### PR TITLE
Add the build directory to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .sconf_temp
 \#*#
 core
+build


### PR DESCRIPTION
For the OpenFOAM implementation of the preCICE adapter, a git submodule is used. After the compilation, the directory is "dirty" due to the build directory.