### PR TITLE
Bugfix thin plate spline. The log function is used instead of log10

### DIFF
--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -125,7 +125,7 @@ public:
   {
     double result = 0.0;
     if (tarch::la::greater(radius, 0.0)){
-      result = std::log10(radius) * std::pow(radius, 2);
+      result = std::log(radius) * std::pow(radius, 2);
     }
     return result;
   }


### PR DESCRIPTION
See http://mathworld.wolfram.com/ThinPlateSpline.html for the definition of the thin plate spline.