### PR TITLE
C interface: don't use "extern C" when not in C++.

### DIFF
--- a/src/precice/adapters/c/SolverInterfaceC.h
+++ b/src/precice/adapters/c/SolverInterfaceC.h
@@ -1,7 +1,9 @@
 #ifndef PRECICE_ADAPTERS_C_SOLVERINTERFACEC_H_
 #define PRECICE_ADAPTERS_C_SOLVERINTERFACEC_H_
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
 /**
  * @brief Creates the coupling interface and confiures it.
@@ -249,6 +251,8 @@ void precicec_mapReadDataTo ( int toMeshID );
  */
 void precicec_exportMesh ( const char* filenameSuffix );
 
+#ifdef __cplusplus
 }
+#endif
 
 #endif /* PRECICE_ADAPTERS_C_SOLVERINTERFACEC_H_ */


### PR DESCRIPTION
The header should be able to be included in a C code, compiled with a C compiler. The "extern C" is a C++ statement and triggers an error when trying to compile with a C compiler, while the rest of the code is C. An example is the current CalculiX-adapter.