### PR TITLE
compileAndTest: abort if args.root is not defined.

### DIFF
--- a/tools/compileAndTest.py
+++ b/tools/compileAndTest.py
@@ -50,7 +50,11 @@ if len(sys.argv) < 2:
     
 args, remainder = parser.parse_known_args()
 
-os.chdir(args.root)
+if (args.root):
+    os.chdir(args.root)
+else:
+    print("The preCICE root directory is not defined. Have you set the $PRECICE_ROOT environment variable?")
+    sys.exit(1)
 
 if args.compile:
     if args.remove_build:


### PR DESCRIPTION
This is a common problem among new users.
`args.root` defaults to `PRECICE_ROOT`.
If `PRECICE_ROOT` is not defined, the `os.chdir(args.root)` crashes wildly.
This commit checks if it is other than `None` before changing the directory.