### PR TITLE
Fix m2n indices left in undefined state after move

### DIFF
--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -428,7 +428,8 @@ void PointToPointCommunication::acceptConnection(std::string const &nameAcceptor
 
     c->receive(globalRequesterRank, localRequesterRank);
 
-    auto indices = std::move(communicationMap[globalRequesterRank]);
+    std::vector<int> indices;
+    indices.swap(communicationMap[globalRequesterRank]);
     _totalIndexCount += indices.size();
 
     // NOTE:


### PR DESCRIPTION
This `std::move()` moves the `std::vector<int>` from the map key and thus leaves it in an undefined state.
This change swaps an empty vector in-place, leaving the map in a altered, but defined state.