### PR TITLE
Adding network socket option for macOS on reference XML

### DIFF
--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -40,7 +40,8 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     doc = "Interface name to be used for socket communiation. ";
     doc += "Default is \"lo\", i.e., the local host loopback. ";
     doc += "Might be different on supercomputing systems, e.g. \"ib0\" ";
-    doc += "for the InfiniBand on SuperMUC";
+    doc += "for the InfiniBand on SuperMUC. ";
+    doc += "For macOS use \"lo0\". ";
     attrNetwork.setDocumentation(doc);
     attrNetwork.setDefaultValue("lo");
     tag.addAttribute(attrNetwork);


### PR DESCRIPTION
macOS uses different network socket option to Ubuntu. How about we add a comment about this on reference XML (like how SuperMUC socket option is there now)? 