### PR TITLE
Add Range Interface to Triangle and Quad

### DIFF
--- a/src/mesh/Quad.cpp
+++ b/src/mesh/Quad.cpp
@@ -1,11 +1,17 @@
 #include "Quad.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
+#include <boost/range/concepts.hpp>
 
 namespace precice
 {
 namespace mesh
 {
+
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::iterator>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::const_iterator>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Quad>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Quad>) );
 
 Quad::Quad(
     Edge &edgeOne,

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -4,6 +4,7 @@
 #include "boost/noncopyable.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/PropertyContainer.hpp"
+#include "mesh/RangeAccessor.hpp"
 
 namespace precice
 {
@@ -24,6 +25,12 @@ namespace mesh
 class Quad : public PropertyContainer, private boost::noncopyable
 {
 public:
+  /// Type of the const random access vertex iterator
+  using const_iterator = IndexRangeIterator<const Quad, const Eigen::VectorXd>;
+
+  /// Type of the random access vertex iterator
+  using iterator = const_iterator; //IndexRangeIterator<Quad, Eigen::Vector3d>;
+
   /// Constructor, the order of edges defines the outer normal direction.
   Quad(
       Edge &edgeOne,
@@ -61,6 +68,24 @@ public:
 
   /// Returns const quad edge with index 0, 1, 2, or 3.
   const Edge &edge(int i) const;
+
+  /// Returns a random access iterator to the begin (0) of the vertex range [0,1,2,3]
+  iterator begin();
+
+  /// Returns a random access iterator to the end (4) of the vertex range [0,1,2,3]
+  iterator end();
+
+  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2,3]
+  const_iterator begin() const;
+
+  /// Returns a const random access iterator to the end (4) of the vertex range [0,1,2,3]
+  const_iterator end() const;
+
+  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2,3]
+  const_iterator cbegin() const;
+
+  /// Returns a const random access iterator to the end (4) of the vertex range [0,1,2,3]
+  const_iterator cend() const;
 
   /// Sets the outer normal of the quad.
   template <typename VECTOR_T>
@@ -131,6 +156,36 @@ inline const Vertex &Quad::vertex(int i) const
   return edge(i).vertex(_vertexMap[i]);
 }
 
+inline Quad::iterator Quad::begin()
+{
+  return {this, 0};
+}
+
+inline Quad::iterator Quad::end()
+{
+  return {this, 4};
+}
+
+inline Quad::const_iterator Quad::begin() const
+{
+  return {this, 0};
+}
+
+inline Quad::const_iterator Quad::end() const
+{
+  return {this, 4};
+}
+
+inline Quad::const_iterator Quad::cbegin() const
+{
+    return begin();
+}
+
+inline Quad::const_iterator Quad::cend() const
+{
+    return end();
+}
+
 inline Edge &Quad::edge(int i)
 {
   return *_edges[i];
@@ -159,6 +214,11 @@ inline int Quad::getID() const
 {
   return _id;
 }
+
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::iterator>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::const_iterator>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Quad>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Quad>));
 
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -25,7 +25,12 @@ namespace mesh
 class Quad : public PropertyContainer, private boost::noncopyable
 {
 public:
-  /// Type of the const random access vertex iterator
+  /// Type of the read-only const random-access iterator over Vertex coords
+  /**
+   * This index-based iterator iterates over the vertices of this Quad.
+   * The returned value is the forwarded result of Vertex::getCoords.
+   * It is thus a read-only random-access iterator.
+   */
   using const_iterator = IndexRangeIterator<const Quad, const Eigen::VectorXd>;
 
   /// Type of the random access vertex iterator
@@ -69,23 +74,28 @@ public:
   /// Returns const quad edge with index 0, 1, 2, or 3.
   const Edge &edge(int i) const;
 
-  /// Returns a random access iterator to the begin (0) of the vertex range [0,1,2,3]
+  ///@name Iterators
+  ///@{
+
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2,3]
   iterator begin();
 
-  /// Returns a random access iterator to the end (4) of the vertex range [0,1,2,3]
+  /// Returns a read-only random-access iterator to the end (4) of the vertex range [0,1,2,3]
   iterator end();
 
-  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2,3]
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2,3]
   const_iterator begin() const;
 
-  /// Returns a const random access iterator to the end (4) of the vertex range [0,1,2,3]
+  /// Returns a read-only random-access iterator to the end (4) of the vertex range [0,1,2,3]
   const_iterator end() const;
 
-  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2,3]
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2,3]
   const_iterator cbegin() const;
 
-  /// Returns a const random access iterator to the end (4) of the vertex range [0,1,2,3]
+  /// Returns a read-only random-access iterator to the end (4) of the vertex range [0,1,2,3]
   const_iterator cend() const;
+
+  ///@}
 
   /// Sets the outer normal of the quad.
   template <typename VECTOR_T>

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -215,10 +215,5 @@ inline int Quad::getID() const
   return _id;
 }
 
-BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::iterator>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::const_iterator>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Quad>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Quad>));
-
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/RangeAccessor.hpp
+++ b/src/mesh/RangeAccessor.hpp
@@ -8,10 +8,10 @@ namespace mesh
 {
 /** random access iterator over an indexable Source.
  * 
- * \tparam Source the underlying container to intex into
- * \tparam Value the resulting value
+ * @tparam Source the underlying container to intex into
+ * @tparam Value the resulting value
  *
- *  @note This version currently only supports Sources with a const `src.vertex(index).getCoords()` access.
+ * @note This version currently only supports Sources with a const `src.vertex(index).getCoords()` access.
  */
 template <typename Source, typename Value>
 class IndexRangeIterator : public boost::iterator_facade<

--- a/src/mesh/RangeAccessor.hpp
+++ b/src/mesh/RangeAccessor.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <boost/iterator/iterator_facade.hpp>
+
+namespace precice
+{
+namespace mesh
+{
+/** random access iterator over an indexable Source.
+ * 
+ * \tparam Source the underlying container to intex into
+ * \tparam Value the resulting value
+ *
+ *  @note This version currently only supports Sources with a const `src.vertex(index).getCoords()` access.
+ */
+template <typename Source, typename Value>
+class IndexRangeIterator : public boost::iterator_facade<
+                               IndexRangeIterator<Source, const Value>,
+                               const Value,
+                               boost::random_access_traversal_tag>
+{
+public:
+  IndexRangeIterator() = default;
+  IndexRangeIterator(Source *src, size_t index)
+      : src_(src), idx_(index) {}
+
+  const Value &dereference() const
+  {
+    using Coord = decltype(src_->vertex(idx_).getCoords());
+    static_assert(
+            std::is_reference<Coord>::value,
+            "Coordinate type must be a reference!");
+    static_assert(
+            std::is_convertible<Coord, Value>::value,
+            "Exposed and accessed types must match!");
+    return static_cast<const Value &>(src_->vertex(idx_).getCoords());
+  }
+
+  size_t equal(const IndexRangeIterator<Source, Value> &other) const
+  {
+    return other.idx_ == idx_ && other.src_ == src_;
+  }
+  void increment()
+  {
+    ++idx_;
+  }
+  void decrement()
+  {
+    --idx_;
+  }
+  void advance(size_t n)
+  {
+    idx_ += n;
+  }
+  size_t distance_to(const IndexRangeIterator<Source, Value> &other) const
+  {
+    return other.idx_ - idx_;
+  }
+
+private:
+  Source *src_{nullptr}; ///< the source to access
+  size_t  idx_{0}; ///< the current index to access
+};
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/RangeAccessor.hpp
+++ b/src/mesh/RangeAccessor.hpp
@@ -6,9 +6,9 @@ namespace precice
 {
 namespace mesh
 {
-/** random access iterator over an indexable Source.
+/** random-access iterator over an indexable Source.
  * 
- * @tparam Source the underlying container to intex into
+ * @tparam Source the underlying container to index into
  * @tparam Value the resulting value
  *
  * @note This version currently only supports Sources with a const `src.vertex(index).getCoords()` access.
@@ -40,18 +40,22 @@ public:
   {
     return other.idx_ == idx_ && other.src_ == src_;
   }
+
   void increment()
   {
     ++idx_;
   }
+
   void decrement()
   {
     --idx_;
   }
+
   void advance(size_t n)
   {
     idx_ += n;
   }
+
   size_t distance_to(const IndexRangeIterator<Source, Value> &other) const
   {
     return other.idx_ - idx_;

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -1,11 +1,17 @@
 #include "Triangle.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
+#include <boost/range/concepts.hpp>
 
 namespace precice
 {
 namespace mesh
 {
+
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::iterator>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::const_iterator>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Triangle>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>));
 
 Triangle::Triangle(
     Edge &edgeOne,

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -3,7 +3,6 @@
 #include <Eigen/Core>
 #include <array>
 #include <boost/noncopyable.hpp>
-#include <boost/range/concepts.hpp>
 #include "mesh/Edge.hpp"
 #include "mesh/PropertyContainer.hpp"
 #include "mesh/RangeAccessor.hpp"
@@ -28,11 +27,11 @@ namespace mesh
 class Triangle : public PropertyContainer, private boost::noncopyable
 {
 public:
-  /// Type of the const random access vertex iterator
+  /// Type of the read-only random access vertex iterator
   using const_iterator = IndexRangeIterator<const Triangle, const Eigen::VectorXd>;
 
-  /// Type of the random access vertex iterator
-  using iterator = const_iterator; // IndexRangeIterator<Triangle, Eigen::VectorXd>;
+  /// Type of the read-only random access vertex iterator
+  using iterator = const_iterator;
 
 
   /// Constructor, the order of edges defines the outer normal direction.

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -221,11 +221,5 @@ inline int Triangle::getID() const
   return _id;
 }
 
-
-BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::iterator>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::const_iterator>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Triangle>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>));
-
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -3,8 +3,10 @@
 #include <Eigen/Core>
 #include <array>
 #include <boost/noncopyable.hpp>
+#include <boost/range/concepts.hpp>
 #include "mesh/Edge.hpp"
 #include "mesh/PropertyContainer.hpp"
+#include "mesh/RangeAccessor.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice
@@ -26,6 +28,13 @@ namespace mesh
 class Triangle : public PropertyContainer, private boost::noncopyable
 {
 public:
+  /// Type of the const random access vertex iterator
+  using const_iterator = IndexRangeIterator<const Triangle, const Eigen::VectorXd>;
+
+  /// Type of the random access vertex iterator
+  using iterator = const_iterator; // IndexRangeIterator<Triangle, Eigen::VectorXd>;
+
+
   /// Constructor, the order of edges defines the outer normal direction.
   Triangle(
       Edge &edgeOne,
@@ -62,6 +71,24 @@ public:
 
   /// Returns const triangle edge with index 0, 1 or 2.
   const Edge &edge(int i) const;
+
+  /// Returns a random access iterator to the begin (0) of the vertex range [0,1,2]
+  iterator begin();
+
+  /// Returns a random access iterator to the end (3) of the vertex range [0,1,2]
+  iterator end();
+
+  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2]
+  const_iterator begin() const;
+
+  /// Returns a const random access iterator to the end (3) of the vertex range [0,1,2]
+  const_iterator end() const;
+
+  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2]
+  const_iterator cbegin() const;
+
+  /// Returns a const random access iterator to the end (3) of the vertex range [0,1,2]
+  const_iterator cend() const;
 
   /// Sets the outer normal of the triangle.
   template <typename VECTOR_T>
@@ -143,6 +170,36 @@ inline const Edge &Triangle::edge(int i) const
   return *_edges[i];
 }
 
+inline Triangle::iterator Triangle::begin()
+{
+  return {this, 0};
+}
+
+inline Triangle::iterator Triangle::end()
+{
+  return {this, 3};
+}
+
+inline Triangle::const_iterator Triangle::begin() const
+{
+  return {this, 0};
+}
+
+inline Triangle::const_iterator Triangle::end() const
+{
+  return {this, 3};
+}
+
+inline Triangle::const_iterator Triangle::cbegin() const
+{
+  return begin();
+}
+
+inline Triangle::const_iterator Triangle::cend() const
+{
+  return end();
+}
+
 template <typename VECTOR_T>
 void Triangle::setNormal(
     const VECTOR_T &normal)
@@ -163,6 +220,12 @@ inline int Triangle::getID() const
 {
   return _id;
 }
+
+
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::iterator>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::const_iterator>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Triangle>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>));
 
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -27,7 +27,12 @@ namespace mesh
 class Triangle : public PropertyContainer, private boost::noncopyable
 {
 public:
-  /// Type of the read-only random access vertex iterator
+  /// Type of the read-only const random-access iterator over Vertex coords
+  /**
+   * This index-based iterator iterates over the vertices of this Quad.
+   * The returned value is the forwarded result of Vertex::getCoords.
+   * It is thus a read-only random-access iterator.
+   */
   using const_iterator = IndexRangeIterator<const Triangle, const Eigen::VectorXd>;
 
   /// Type of the read-only random access vertex iterator
@@ -71,23 +76,28 @@ public:
   /// Returns const triangle edge with index 0, 1 or 2.
   const Edge &edge(int i) const;
 
-  /// Returns a random access iterator to the begin (0) of the vertex range [0,1,2]
+  ///@name Iterators
+  ///@{
+
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2]
   iterator begin();
 
-  /// Returns a random access iterator to the end (3) of the vertex range [0,1,2]
+  /// Returns a read-only random-access iterator to the end (3) of the vertex range [0,1,2]
   iterator end();
 
-  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2]
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2]
   const_iterator begin() const;
 
-  /// Returns a const random access iterator to the end (3) of the vertex range [0,1,2]
+  /// Returns a read-only random access iterator to the end (3) of the vertex range [0,1,2]
   const_iterator end() const;
 
-  /// Returns a const random access iterator to the begin (0) of the vertex range [0,1,2]
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2]
   const_iterator cbegin() const;
 
-  /// Returns a const random access iterator to the end (3) of the vertex range [0,1,2]
+  /// Returns a read-only random access iterator to the end (3) of the vertex range [0,1,2]
   const_iterator cend() const;
+
+  ///@}
 
   /// Sets the outer normal of the triangle.
   template <typename VECTOR_T>

--- a/src/mesh/tests/QuadTest.cpp
+++ b/src/mesh/tests/QuadTest.cpp
@@ -9,13 +9,6 @@ using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
-BOOST_AUTO_TEST_CASE(QuadCompileTimeAsserts)
-{
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::iterator>));
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::const_iterator>));
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Quad>));
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Quad>));
-}
 
 BOOST_AUTO_TEST_CASE(Quads)
 {

--- a/src/mesh/tests/QuadTest.cpp
+++ b/src/mesh/tests/QuadTest.cpp
@@ -9,6 +9,14 @@ using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
+BOOST_AUTO_TEST_CASE(QuadCompileTimeAsserts)
+{
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::iterator>));
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::const_iterator>));
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Quad>));
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Quad>));
+}
+
 BOOST_AUTO_TEST_CASE(Quads)
 {
   using Eigen::Vector3d;

--- a/src/mesh/tests/QuadTest.cpp
+++ b/src/mesh/tests/QuadTest.cpp
@@ -3,6 +3,8 @@
 #include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
 
+#include <vector>
+
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
@@ -115,6 +117,65 @@ BOOST_AUTO_TEST_CASE(Quads)
 
     int id = quad.getID();
     BOOST_TEST(id == 0);
+  }
+  {
+    Vertex v0(coords0, 0);
+    Vertex v1(coords1, 1);
+    Vertex v2(coords2, 2);
+    Vertex v3(coords3, 3);
+
+    Edge e0(v0, v1, 0);
+    Edge e1(v1, v2, 1);
+    Edge e2(v2, v3, 2);
+    Edge e3(v3, v0, 3);
+
+    Quad quad(e0, e1, e2, e3, 0);
+    {
+      // Test begin(), end()
+      auto       ibegin = quad.begin();
+      const auto iend   = quad.end();
+      BOOST_TEST(std::distance(ibegin, iend) == 4);
+      BOOST_TEST(*ibegin == v0.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v1.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v2.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v3.getCoords());
+      ++ibegin;
+      BOOST_TEST((ibegin == iend));
+    }
+    {
+      // Test begin(), end() for const
+      const Quad &cquad = quad;
+      auto            ibegin    = cquad.begin();
+      const auto      iend      = cquad.end();
+      BOOST_TEST(std::distance(ibegin, iend) == 4);
+      BOOST_TEST(*ibegin == v0.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v1.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v2.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v3.getCoords());
+      ++ibegin;
+      BOOST_TEST((ibegin == iend));
+    }
+    {
+      // Test cbegin(), cend()
+      auto       ibegin = quad.cbegin();
+      const auto iend   = quad.cend();
+      BOOST_TEST(std::distance(ibegin, iend) == 4);
+      BOOST_TEST(*ibegin == v0.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v1.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v2.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v3.getCoords());
+      ++ibegin;
+      BOOST_TEST((ibegin == iend));
+    }
   }
 }
 

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -3,6 +3,8 @@
 #include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
 
+#include <iterator>
+
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
@@ -108,6 +110,58 @@ BOOST_AUTO_TEST_CASE(Triangles)
 
     int id = triangle.getID();
     BOOST_TEST(id == 0);
+  }
+  {
+    Vertex v0(coords1, 0);
+    Vertex v1(coords2, 1);
+    Vertex v2(coords3, 2);
+
+    Edge e0(v0, v1, 0);
+    Edge e1(v1, v2, 1);
+    Edge e2(v2, v0, 2);
+
+    Triangle triangle(e0, e1, e2, 0);
+
+    {
+      // Test begin(), end()
+      auto       ibegin = triangle.begin();
+      const auto iend   = triangle.end();
+      BOOST_TEST(std::distance(ibegin, iend) == 3);
+      BOOST_TEST(*ibegin == v0.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v1.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v2.getCoords());
+      ++ibegin;
+      BOOST_TEST((ibegin == iend));
+    }
+    {
+      // Test begin(), end() for const
+      const Triangle &ctriangle = triangle;
+      auto            ibegin    = ctriangle.begin();
+      const auto      iend      = ctriangle.end();
+      BOOST_TEST(std::distance(ibegin, iend) == 3);
+      BOOST_TEST(*ibegin == v0.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v1.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v2.getCoords());
+      ++ibegin;
+      BOOST_TEST((ibegin == iend));
+    }
+    {
+      // Test cbegin(), cend()
+      auto       ibegin = triangle.cbegin();
+      const auto iend   = triangle.cend();
+      BOOST_TEST(std::distance(ibegin, iend) == 3);
+      BOOST_TEST(*ibegin == v0.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v1.getCoords());
+      ++ibegin;
+      BOOST_TEST(*ibegin == v2.getCoords());
+      ++ibegin;
+      BOOST_TEST((ibegin == iend));
+    }
   }
 }
 

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -9,15 +9,6 @@ using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
-BOOST_AUTO_TEST_CASE(TriangleCompileTimeAsserts)
-{
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::iterator>));
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::const_iterator>));
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Triangle>));
-  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>));
-}
-
-
 BOOST_AUTO_TEST_CASE(Triangles)
 {
   using Eigen::Vector3d;

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -9,6 +9,15 @@ using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
+BOOST_AUTO_TEST_CASE(TriangleCompileTimeAsserts)
+{
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::iterator>));
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::const_iterator>));
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Triangle>));
+  BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>));
+}
+
+
 BOOST_AUTO_TEST_CASE(Triangles)
 {
   using Eigen::Vector3d;


### PR DESCRIPTION
This will change Triangle and Quad so that they fulfil the requirements of the RandomAccessRange model.
The iterators provide access to the vertex coordinates and are all implemented as ReadIterators.