### PR TITLE
Reduce mesh inner state

### DIFF
--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -11,8 +11,7 @@ Edge:: Edge
 :
   _vertices( {&vertexOne, &vertexTwo} ),
   _id ( id ),
-  _normal ( Eigen::VectorXd::Constant(vertexOne.getDimensions(), 0.0) ),
-  _center ( Eigen::VectorXd::Constant(vertexOne.getDimensions(), 0.0) )
+  _normal ( Eigen::VectorXd::Constant(vertexOne.getDimensions(), 0.0) )
 {
   assertion ( vertexOne.getDimensions() == vertexTwo.getDimensions(),
               vertexOne.getDimensions(), vertexTwo.getDimensions() );
@@ -30,9 +29,9 @@ int Edge:: getID () const
   return _id;
 }
 
-const Eigen::VectorXd& Edge::getCenter () const
+const Eigen::VectorXd Edge::getCenter () const
 {
-  return _center;
+  return 0.5 * (_vertices[0]->getCoords() + _vertices[1]->getCoords());
 }
 
 double Edge:: getEnclosingRadius () const

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -17,13 +17,6 @@ Edge:: Edge
               vertexOne.getDimensions(), vertexTwo.getDimensions() );
 }
 
-void Edge:: setEnclosingRadius
-(
-  double radius )
-{
-  _enclosingRadius = radius;
-}
-
 int Edge:: getID () const
 {
   return _id;
@@ -36,7 +29,7 @@ const Eigen::VectorXd Edge::getCenter () const
 
 double Edge:: getEnclosingRadius () const
 {
-  return _enclosingRadius;
+  return (_vertices[0]->getCoords() - getCenter()).norm();
 }
 
 bool Edge::operator==(const Edge& other) const

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -48,10 +48,6 @@ public:
   template<typename VECTOR_T>
   void setNormal ( const VECTOR_T& normal );
 
-  /// Sets the center of the edge.
-  template<typename VECTOR_T>
-  void setCenter ( const VECTOR_T& center );
-
   /// Sets the radius of the circle enclosing the edge.
   void setEnclosingRadius ( double radius );
 
@@ -62,7 +58,7 @@ public:
   const Eigen::VectorXd& getNormal () const;
 
   /// Returns the center of the edge.
-  const Eigen::VectorXd& getCenter () const;
+  const Eigen::VectorXd getCenter () const;
 
   /// Returns the radius of the enclosing circle of the edge.
   double getEnclosingRadius () const;
@@ -88,9 +84,6 @@ private:
 
   /// Normal of the edge.
   Eigen::VectorXd _normal;
-
-  /// Center of the edge.
-  Eigen::VectorXd _center;
 
   /// Radius of the enclosing circle.
   double _enclosingRadius = 0;
@@ -127,16 +120,6 @@ void Edge:: setNormal
   assertion ( normal.size() == _vertices[0]->getDimensions(), normal,
                _vertices[0]->getDimensions() );
   _normal = normal;
-}
-
-template<typename VECTOR_T>
-void Edge:: setCenter
-(
-  const VECTOR_T& center )
-{
-  assertion ( center.size() == _vertices[0]->getDimensions(), center,
-               _vertices[0]->getDimensions() );
-  _center = center;
 }
 
 inline const Eigen::VectorXd& Edge::getNormal () const

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -48,9 +48,6 @@ public:
   template<typename VECTOR_T>
   void setNormal ( const VECTOR_T& normal );
 
-  /// Sets the radius of the circle enclosing the edge.
-  void setEnclosingRadius ( double radius );
-
   /// Returns the (among edges) unique ID of the edge.
   int getID () const;
 
@@ -84,9 +81,6 @@ private:
 
   /// Normal of the edge.
   Eigen::VectorXd _normal;
-
-  /// Radius of the enclosing circle.
-  double _enclosingRadius = 0;
 };
 
 // ------------------------------------------------------ HEADER IMPLEMENTATION

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -298,10 +298,6 @@ void Mesh:: computeState()
   Eigen::VectorXd center(_dimensions);
   Eigen::VectorXd distanceToCenter(_dimensions);
   for (Edge& edge : _content.edges()) {
-    center = edge.vertex(0).getCoords();
-    center += edge.vertex(1).getCoords();
-    center *= 0.5;
-    edge.setCenter(center);
     distanceToCenter = edge.vertex(0).getCoords();
     distanceToCenter -= edge.getCenter();
     edge.setEnclosingRadius(distanceToCenter.norm());
@@ -339,14 +335,6 @@ void Mesh:: computeState()
       assertion(not math::equals(triangle.vertex(2).getCoords(), triangle.vertex(0).getCoords()),
                 triangle.vertex(2).getCoords(),
                 triangle.getID());
-
-      // Compute barycenter by using edge centers, since vertex order is not
-      // guaranteed.
-      auto center = triangle.edge(0).getCenter();
-      center += triangle.edge(1).getCenter();
-      center += triangle.edge(2).getCenter();
-      center /= 3.0;
-      triangle.setCenter(center);
 
       // Compute enclosing radius centered at barycenter
       Eigen::Vector3d toCenter = triangle.getCenter() - triangle.vertex(0).getCoords();
@@ -398,15 +386,6 @@ void Mesh:: computeState()
       assertion(not math::equals(quad.vertex(3).getCoords(), quad.vertex(0).getCoords()),
                 quad.vertex(3).getCoords(),
                 quad.getID());
-
-      // Compute barycenter by using edge centers, since vertex order is not
-      // guaranteed.
-      Eigen::VectorXd center = quad.edge(0).getCenter() +
-        quad.edge(1).getCenter() +
-        quad.edge(2).getCenter() +
-        quad.edge(3).getCenter();
-      center /= 4.0;
-      quad.setCenter(center);
 
       // Compute enclosing radius centered at barycenter
       Eigen::Vector3d toCenter = quad.getCenter() - quad.vertex(0).getCoords();

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -306,7 +306,7 @@ void Mesh:: computeState()
       }
       double length = normal.norm();
       assertion(math::greater(length, 0.0));
-      normal /= length;   // Scale normal vector to length 1
+      normal.normalize();   // Scale normal vector to length 1
       edge.setNormal(normal);
 
       // Accumulate normal in associated vertices
@@ -323,13 +323,11 @@ void Mesh:: computeState()
     // Compute triangle centers, radius, and normals
     for (Triangle& triangle : _content.triangles()) {
       assertion(not math::equals(triangle.vertex(0).getCoords(), triangle.vertex(1).getCoords()),
-                triangle.vertex(0).getCoords(),
-                triangle.getID());
-      assertion(not math::equals(triangle.vertex(1).getCoords(), triangle.vertex(2).getCoords()), triangle.vertex(1).getCoords(),
-                triangle.getID());
+                triangle.vertex(0).getCoords(), triangle.getID());
+      assertion(not math::equals(triangle.vertex(1).getCoords(), triangle.vertex(2).getCoords()),
+                triangle.vertex(1).getCoords(), triangle.getID());
       assertion(not math::equals(triangle.vertex(2).getCoords(), triangle.vertex(0).getCoords()),
-                triangle.vertex(2).getCoords(),
-                triangle.getID());
+                triangle.vertex(2).getCoords(), triangle.getID());
 
       // Compute normals
       if (computeNormals){
@@ -348,9 +346,7 @@ void Mesh:: computeState()
         }
 
         // Normalize triangle normal
-        double length = normal.norm();
-        normal /= length;
-        triangle.setNormal(normal);
+        triangle.setNormal(normal.normalized());
       }
     }
 
@@ -402,20 +398,15 @@ void Mesh:: computeState()
           quad.vertex(i).setNormal(quad.vertex(i).getNormal() + normal);
         }
 
-        // Normalize quad normal
-        normal = normal.normalized();
-        quad.setNormal(normal);
+        quad.setNormal(normal.normalized());
       }
     }
 
     // Normalize edge normals (only done in 3D)
     if (computeNormals){
       for (Edge& edge : _content.edges()) {
-        double length = edge.getNormal().norm();
         // there can be cases when an edge has no adjacent triangle though triangles exist in general (e.g. after filtering)
-        if(math::greater(length,0.0)){
-          edge.setNormal(edge.getNormal() / length);
-        }
+        edge.setNormal(edge.getNormal().normalized());
       }
     }
   }
@@ -427,11 +418,8 @@ void Mesh:: computeState()
 
   for (Vertex& vertex : _content.vertices()) {
     if (computeNormals) {
-      double length = vertex.getNormal().norm();
       // there can be cases when a vertex has no edge though edges exist in general (e.g. after filtering)
-      if(math::greater(length,0.0)){
-        vertex.setNormal(vertex.getNormal() / length);
-      }
+      vertex.setNormal(vertex.getNormal().normalized());
     }
     
     for (int d = 0; d < _dimensions; d++) {

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -295,12 +295,7 @@ void Mesh:: computeState()
   }
 
   // Compute edge centers, enclosing radius, and (in 2D) edge normals
-  Eigen::VectorXd center(_dimensions);
-  Eigen::VectorXd distanceToCenter(_dimensions);
   for (Edge& edge : _content.edges()) {
-    distanceToCenter = edge.vertex(0).getCoords();
-    distanceToCenter -= edge.getCenter();
-    edge.setEnclosingRadius(distanceToCenter.norm());
     if (_dimensions == 2 && computeNormals){
       // Compute normal
       Eigen::VectorXd vectorA = edge.vertex(1).getCoords();
@@ -335,19 +330,6 @@ void Mesh:: computeState()
       assertion(not math::equals(triangle.vertex(2).getCoords(), triangle.vertex(0).getCoords()),
                 triangle.vertex(2).getCoords(),
                 triangle.getID());
-
-      // Compute enclosing radius centered at barycenter
-      Eigen::Vector3d toCenter = triangle.getCenter() - triangle.vertex(0).getCoords();
-      double distance0 = toCenter.norm();
-      toCenter = triangle.getCenter() - triangle.vertex(1).getCoords();
-      double distance1 = toCenter.norm();
-      toCenter = triangle.getCenter() - triangle.vertex(2).getCoords();
-      double distance2 = toCenter.norm();
-      double maxDistance = std::max( {distance0, distance1, distance2} );
-      // maxDistance = distance1 > maxDistance ? distance1 : maxDistance;
-      // maxDistance = distance2 > maxDistance ? distance2 : maxDistance;
-      
-      triangle.setEnclosingRadius(maxDistance);
 
       // Compute normals
       if (computeNormals){
@@ -387,22 +369,6 @@ void Mesh:: computeState()
                 quad.vertex(3).getCoords(),
                 quad.getID());
 
-      // Compute enclosing radius centered at barycenter
-      Eigen::Vector3d toCenter = quad.getCenter() - quad.vertex(0).getCoords();
-      double distance0 = toCenter.norm();
-      toCenter = quad.getCenter() - quad.vertex(1).getCoords();
-      double distance1 = toCenter.norm();
-      toCenter = quad.getCenter() - quad.vertex(2).getCoords();
-      double distance2 = toCenter.norm();
-      toCenter = quad.getCenter() - quad.vertex(3).getCoords();
-      double distance3 = toCenter.norm();
-      double maxDistance = std::max( {distance0, distance1, distance2, distance3} );
-      // maxDistance = distance1 > maxDistance ? distance1 : maxDistance;
-      // maxDistance = distance2 > maxDistance ? distance2 : maxDistance;
-      // maxDistance = distance3 > maxDistance ? distance3 : maxDistance;
-      quad.setEnclosingRadius(maxDistance);
-
-
       // Compute normals (assuming all vertices are on same plane)
       if (computeNormals){
         // Two triangles are thought by splitting the quad from vertex 0 to 2.
@@ -437,8 +403,6 @@ void Mesh:: computeState()
         }
 
         // Normalize quad normal
-        // double length = normal.norm();
-        // normal /= length;
         normal = normal.normalized();
         quad.setNormal(normal);
       }

--- a/src/mesh/Quad.cpp
+++ b/src/mesh/Quad.cpp
@@ -21,8 +21,7 @@ Quad::Quad(
     int   id)
   : _edges({&edgeOne, &edgeTwo, &edgeThree, &edgeFour}),
     _id(id),
-    _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions())),
-    _center(edgeOne.getDimensions())
+    _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions()))
 {
   assertion(edgeOne.getDimensions() == edgeTwo.getDimensions(),
             edgeOne.getDimensions(), edgeTwo.getDimensions());
@@ -114,9 +113,9 @@ const Eigen::VectorXd &Quad::getNormal() const
   return _normal;
 }
 
-const Eigen::VectorXd &Quad::getCenter() const
+const Eigen::VectorXd Quad::getCenter() const
 {
-  return _center;
+  return (_edges[0]->getCenter() + _edges[1]->getCenter() + _edges[2]->getCenter() + _edges[3]->getCenter()) / 4;
 }
 
 double Quad::getEnclosingRadius() const

--- a/src/mesh/Quad.cpp
+++ b/src/mesh/Quad.cpp
@@ -103,11 +103,6 @@ int Quad::getDimensions() const
   return _edges[0]->getDimensions();
 }
 
-void Quad::setEnclosingRadius(double radius)
-{
-  _enclosingRadius = radius;
-}
-
 const Eigen::VectorXd &Quad::getNormal() const
 {
   return _normal;
@@ -120,7 +115,11 @@ const Eigen::VectorXd Quad::getCenter() const
 
 double Quad::getEnclosingRadius() const
 {
-  return _enclosingRadius;
+  auto center = getCenter();
+  return std::max({(center - vertex(0).getCoords()).norm(),
+                   (center - vertex(1).getCoords()).norm(),
+                   (center - vertex(2).getCoords()).norm(),
+                   (center - vertex(3).getCoords()).norm()});
 }
 
 bool Quad::operator==(const Quad& other) const

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -92,9 +92,6 @@ public:
   template <typename VECTOR_T>
   void setNormal(const VECTOR_T &normal);
 
-  /// Sets the radius of the circle enclosing the quad.
-  void setEnclosingRadius(double radius);
-
   /// Returns a among quads globally unique ID.
   int getID() const;
 
@@ -108,11 +105,7 @@ public:
   /// Returns the barycenter of the quad.
   const Eigen::VectorXd getCenter() const;
 
-  /**
-   * @brief Returns the radius of the circle enclosing the quad.
-   *
-   * @pre The radius has to be computed and set from outside before.
-   */
+  /// Returns the radius of the circle enclosing the quad.
   double getEnclosingRadius() const;
 
   /**
@@ -138,9 +131,6 @@ private:
 
   /// Normal vector of the quad.
   Eigen::VectorXd _normal;
-
-  /// Minimal radius of circle enclosing the quad.
-  double _enclosingRadius = 0;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -92,10 +92,6 @@ public:
   template <typename VECTOR_T>
   void setNormal(const VECTOR_T &normal);
 
-  /// Sets the center of the quad.
-  template <typename VECTOR_T>
-  void setCenter(const VECTOR_T &center);
-
   /// Sets the radius of the circle enclosing the quad.
   void setEnclosingRadius(double radius);
 
@@ -109,12 +105,8 @@ public:
    */
   const Eigen::VectorXd &getNormal() const;
 
-  /**
-   * @brief Returns the barycenter of the quad.
-   *
-   * @pre The center has to be computed and set from outside before.
-   */
-  const Eigen::VectorXd &getCenter() const;
+  /// Returns the barycenter of the quad.
+  const Eigen::VectorXd getCenter() const;
 
   /**
    * @brief Returns the radius of the circle enclosing the quad.
@@ -146,9 +138,6 @@ private:
 
   /// Normal vector of the quad.
   Eigen::VectorXd _normal;
-
-  /// Center point of the quad.
-  Eigen::VectorXd _center;
 
   /// Minimal radius of circle enclosing the quad.
   double _enclosingRadius = 0;
@@ -213,13 +202,6 @@ void Quad::setNormal(const VECTOR_T &normal)
 {
   assertion(normal.size() == getDimensions(), normal.size(), getDimensions());
   _normal = normal;
-}
-
-template <typename VECTOR_T>
-void Quad::setCenter(const VECTOR_T &center)
-{
-  assertion(center.size() == getDimensions(), center.size(), getDimensions());
-  _center = center;
 }
 
 inline int Quad::getID() const

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -21,8 +21,7 @@ Triangle::Triangle(
     : PropertyContainer(),
       _edges({&edgeOne, &edgeTwo, &edgeThree}),
       _id(id),
-      _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions())),
-      _center(edgeOne.getDimensions())
+      _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions()))
 {
   assertion(edgeOne.getDimensions() == edgeTwo.getDimensions(),
             edgeOne.getDimensions(), edgeTwo.getDimensions());
@@ -88,9 +87,9 @@ const Eigen::VectorXd &Triangle::getNormal() const
   return _normal;
 }
 
-const Eigen::VectorXd &Triangle::getCenter() const
+const Eigen::VectorXd Triangle::getCenter() const
 {
-  return _center;
+  return (_edges[0]->getCenter() +_edges[1]->getCenter() + _edges[2]->getCenter()) / 3.0;
 }
 
 double Triangle::getEnclosingRadius() const

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -76,12 +76,6 @@ int Triangle::getDimensions() const
   return _edges[0]->getDimensions();
 }
 
-void Triangle::setEnclosingRadius(
-    double radius)
-{
-  _enclosingRadius = radius;
-}
-
 const Eigen::VectorXd &Triangle::getNormal() const
 {
   return _normal;
@@ -94,7 +88,10 @@ const Eigen::VectorXd Triangle::getCenter() const
 
 double Triangle::getEnclosingRadius() const
 {
-  return _enclosingRadius;
+  auto center = getCenter();
+  return std::max({(center - vertex(0).getCoords()).norm(),
+                   (center - vertex(1).getCoords()).norm(),
+                   (center - vertex(2).getCoords()).norm()});
 }
 
 bool Triangle::operator==(const Triangle& other) const

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -106,10 +106,6 @@ public:
   template <typename VECTOR_T>
   void setNormal(const VECTOR_T &normal);
 
-  /// Sets the barycenter of the triangle.
-  template <typename VECTOR_T>
-  void setCenter(const VECTOR_T &center);
-
   /// Sets the radius of the circle enclosing the triangle.
   void setEnclosingRadius(double radius);
 
@@ -123,12 +119,8 @@ public:
    */
   const Eigen::VectorXd &getNormal() const;
 
-  /**
-   * @brief Returns the barycenter of the triangle.
-   *
-   * @pre The center has to be computed and set from outside before.
-   */
-  const Eigen::VectorXd &getCenter() const;
+  /// Returns the barycenter of the triangle.
+  const Eigen::VectorXd getCenter() const;
 
   /**
    * @brief Returns the radius of the circle enclosing the triangle.
@@ -161,9 +153,6 @@ private:
 
   /// Normal vector of the triangle.
   Eigen::VectorXd _normal;
-
-  /// Center point of the triangle.
-  Eigen::VectorXd _center;
 
   /// Minimal radius of circle enclosing the triangle.
   double _enclosingRadius = 0;
@@ -231,13 +220,6 @@ void Triangle::setNormal(
   _normal = normal;
 }
 
-template <typename VECTOR_T>
-void Triangle::setCenter(
-    const VECTOR_T &center)
-{
-  assertion(center.size() == getDimensions(), center.size(), getDimensions());
-  _center = center;
-}
 
 inline int Triangle::getID() const
 {

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -106,9 +106,6 @@ public:
   template <typename VECTOR_T>
   void setNormal(const VECTOR_T &normal);
 
-  /// Sets the radius of the circle enclosing the triangle.
-  void setEnclosingRadius(double radius);
-
   /// Returns a among triangles globally unique ID.
   int getID() const;
 
@@ -122,11 +119,7 @@ public:
   /// Returns the barycenter of the triangle.
   const Eigen::VectorXd getCenter() const;
 
-  /**
-   * @brief Returns the radius of the circle enclosing the triangle.
-   *
-   * @pre The radius has to be computed and set from outside before.
-   */
+  /// Returns the radius of the circle enclosing the triangle.
   double getEnclosingRadius() const;
 
   /**
@@ -153,9 +146,6 @@ private:
 
   /// Normal vector of the triangle.
   Eigen::VectorXd _normal;
-
-  /// Minimal radius of circle enclosing the triangle.
-  double _enclosingRadius = 0;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS


### PR DESCRIPTION
The _enclosingRadius_ and the _center_ of each mesh primitive (Edge, Triangle, Quad) were computed explicitly in `Mesh::computeState`.

Now each primitive computes it inside `getCenter` / `getEnclosingRadius` from its geometry.

This greatly reduces the complexity of  `Mesh::computeState`. It also reduces the inner state of the primitives, and therefore the danger of inconsistencies, e.g. when someone changes coordinates but does not recalculate the center. Last but not least, it's just the right thing to do.

The only possibly downside I see, is that the performance of `getCenter` / `getEnclosingRadius` is somewhat lower, because it's computed upon each request. Still, it's not an expensive computation and it's only used in performance insensitive parts of precice.