### PR TITLE
Fix problem with boost test during building

### DIFF
--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -27,6 +27,9 @@ public:
   /// Type of the random access vertex iterator
   using iterator = const_iterator; //IndexRangeIterator<Quad, Eigen::Vector3d>;
 
+  /// Fix for the Boost.Test versions 1.65 - 1.67.1
+  using value_type = Eigen::VectorXd;
+
   /// Constructor, the order of edges defines the outer normal direction.
   Quad(
       Edge &edgeOne,

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -41,6 +41,8 @@ public:
   /// Type of the read-only random access vertex iterator
   using iterator = const_iterator;
 
+  /// Fix for the Boost.Test versions 1.65.1 - 1.67
+  using value_type = Eigen::VectorXd;
 
   /// Constructor, the order of edges defines the outer normal direction.
   Triangle(


### PR DESCRIPTION
As explained in this [comment](https://github.com/precice/precice/issues/176#issuecomment-435618022), this should resolve #176 related to Boost.Test. 
I tested it by successfully installing preCICE in ubuntu 18.04 container with 
apt-get obtained Boost 1.65.1. Travis build on older boost version is working also.