### PR TITLE
Add MeshRequirement to Actions

### DIFF
--- a/src/action/Action.hpp
+++ b/src/action/Action.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mesh/SharedPointer.hpp"
+#include "mapping/Mapping.hpp"
 
 namespace precice
 {
@@ -28,7 +29,18 @@ public:
 
   Action(
       Timing               timing,
-      const mesh::PtrMesh &mesh)
+      const mesh::PtrMesh &mesh,
+      mapping::Mapping::MeshRequirement requirement)
+      : _timing(timing),
+        _mesh(mesh),
+        _meshRequirement(requirement)
+  {
+  }
+
+  Action(
+      Timing               timing,
+      const mesh::PtrMesh &mesh
+      )
       : _timing(timing),
         _mesh(mesh)
   {
@@ -62,12 +74,21 @@ public:
     return _mesh;
   }
 
+  /// Returns the mesh requirement of this action
+  mapping::Mapping::MeshRequirement getMeshRequirement() const
+  {
+    return _meshRequirement;
+  }
+
 private:
   /// Determines when the action will be executed.
   Timing _timing;
 
   /// Mesh carrying the data used in the action.
   mesh::PtrMesh _mesh;
+
+  /// The mesh requirements for the mesh
+  mapping::Mapping::MeshRequirement _meshRequirement = mapping::Mapping::MeshRequirement::UNDEFINED;
 };
 
 } // namespace action

--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -13,7 +13,7 @@ ScaleByAreaAction::ScaleByAreaAction(
     int                  targetDataID,
     const mesh::PtrMesh &mesh,
     Scaling              scaling)
-    : Action(timing, mesh),
+    : Action(timing, mesh, mapping::Mapping::MeshRequirement::FULL),
       _targetData(mesh->data(targetDataID)),
       _scaling(scaling)
 {

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -77,5 +77,16 @@ int Mapping:: getDimensions() const
   return _dimensions;
 }
 
+bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs) {
+    switch(lhs) {
+        case(Mapping::MeshRequirement::UNDEFINED):
+            return rhs != Mapping::MeshRequirement::UNDEFINED;
+        case(Mapping::MeshRequirement::VERTEX):
+            return rhs == Mapping::MeshRequirement::FULL;
+        case(Mapping::MeshRequirement::FULL):
+                return false;
+    };
+}
+
 }} // namespace precice, mapping
 

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -141,4 +141,12 @@ private:
   int _dimensions;
 };
 
+
+/** Defines an ordering for MeshRequirement in terms of specificality
+* @param[in] lhs the left-hand side of the binary operator
+* @param[in] rhs the right-hand side of the binary operator
+*/
+bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs);
+
+
 }} // namespace precice, mapping

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -515,12 +515,10 @@ void ParticipantConfiguration:: finishParticipantConfiguration
       participant->addReadMappingContext(mappingContext);
     }
 
-    if (map->getInputRequirement() > fromMeshContext.meshRequirement){
-      fromMeshContext.meshRequirement = map->getInputRequirement();
-    }
-    if (map->getOutputRequirement() > toMeshContext.meshRequirement){
-      toMeshContext.meshRequirement = map->getOutputRequirement();
-    }
+    fromMeshContext.meshRequirement = std::max(
+            fromMeshContext.meshRequirement, map->getInputRequirement());
+    toMeshContext.meshRequirement = std::max(
+            toMeshContext.meshRequirement, map->getOutputRequirement());
 
     fromMeshContext.fromMappingContext = *mappingContext;
     toMeshContext.toMappingContext = *mappingContext;

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -19,6 +19,11 @@ struct MeshContext
    :
     localOffset ( Eigen::VectorXd::Zero(dimensions) )
   {}
+
+   /** Upgrades the mesh requirement to a more specific level.
+    * @param[in] requirement The requirement to upgrade to.
+    */
+   void require(mapping::Mapping::MeshRequirement requirement);
   
    /// Mesh holding the geometry data structure.
    mesh::PtrMesh mesh;
@@ -54,5 +59,9 @@ struct MeshContext
    MappingContext toMappingContext;
    
 };
+
+inline void MeshContext::require(mapping::Mapping::MeshRequirement requirement) {
+    meshRequirement = std::max(meshRequirement, requirement);
+}
 
 }} // namespace precice, impl

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -243,6 +243,8 @@ void Participant:: addAction
   const action::PtrAction& action )
 {
   _actions.push_back ( action );
+  auto& context = meshContext(action->getMesh()->getID());
+  context.require(action->getMeshRequirement());
 }
 
 std::vector<action::PtrAction>& Participant:: actions()


### PR DESCRIPTION
This adds a `MeshRequirement` to actions with a default of UNDEFINED.
Adding an Action to a participant upgrades the `MeshRequirement` of the targeted mesh if needed.

This PR fixed #81 