### PR TITLE
Convert all aSend to call by reference

### DIFF
--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -199,33 +199,39 @@ public:
   virtual void send(const int *itemsToSend, int size, int rankReceiver) = 0;
 
   /// Asynchronously sends an array of integer values.
+  /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
   virtual PtrRequest aSend(const int *itemsToSend, int size, int rankReceiver) = 0;
 
   /// Sends an array of double values.
   virtual void send(const double *itemsToSend, int size, int rankReceiver) = 0;
 
   /// Asynchronously sends an array of double values.
+  /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
   virtual PtrRequest aSend(const double *itemsToSend, int size, int rankReceiver) = 0;
 
+  /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
   virtual PtrRequest aSend(std::vector<double> const & itemsToSend, int rankReceiver) = 0;
 
   /// Sends a double to process with given rank.
   virtual void send(double itemToSend, int rankReceiver) = 0;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(double itemToSend, int rankReceiver) = 0;
+  /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
+  virtual PtrRequest aSend(const double & itemToSend, int rankReceiver) = 0;
 
   /// Sends an int to process with given rank.
   virtual void send(int itemToSend, int rankReceiver) = 0;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(int itemToSend, int rankReceiver) = 0;
+  /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
+  virtual PtrRequest aSend(const int & itemToSend, int rankReceiver) = 0;
 
   /// Sends a bool to process with given rank.
   virtual void send(bool itemToSend, int rankReceiver) = 0;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(bool itemToSend, int rankReceiver) = 0;
+  /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
+  virtual PtrRequest aSend( const bool & itemToSend, int rankReceiver) = 0;
 
   /// Receives a std::string from process with given rank.
   virtual void receive(std::string &itemToReceive, int rankSender) = 0;

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -140,7 +140,7 @@ void MPICommunication::send(double itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(double itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const double& itemToSend, int rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
@@ -157,7 +157,7 @@ void MPICommunication::send(int itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(int itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const int& itemToSend, int rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
@@ -174,13 +174,13 @@ void MPICommunication::send(bool itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(bool itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const bool& itemToSend, int rankReceiver)
 {
   TRACE();
   rankReceiver = rankReceiver - _rankOffset;
 
   MPI_Request request;
-  MPI_Isend(&itemToSend,
+  MPI_Isend(const_cast<bool*>(&itemToSend),
             1,
             MPI_BOOL,
             rank(rankReceiver),

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -54,7 +54,7 @@ public:
   virtual void send(double itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(double itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const double& itemToSend, int rankReceiver) override;
 
   /**
    * @brief Sends an int to process with given rank.
@@ -64,7 +64,7 @@ public:
   virtual void send(int itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(int itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const int& itemToSend, int rankReceiver) override;
 
   /**
    * @brief Sends a bool to process with given rank.
@@ -74,7 +74,7 @@ public:
   virtual void send(bool itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(bool itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const bool& itemToSend, int rankReceiver) override;
 
   /**
    * @brief Receives a std::string from process with given rank.

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -480,7 +480,7 @@ void SocketCommunication::send(double itemToSend, int rankReceiver)
   }
 }
 
-PtrRequest SocketCommunication::aSend(double itemToSend, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const double & itemToSend, int rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
@@ -501,7 +501,7 @@ void SocketCommunication::send(int itemToSend, int rankReceiver)
   }
 }
 
-PtrRequest SocketCommunication::aSend(int itemToSend, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const int& itemToSend, int rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
@@ -522,7 +522,7 @@ void SocketCommunication::send(bool itemToSend, int rankReceiver)
   }
 }
 
-PtrRequest SocketCommunication::aSend(bool itemToSend, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const bool & itemToSend, int rankReceiver)
 {
   TRACE(rankReceiver);
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -69,19 +69,19 @@ public:
   virtual void send(double itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(double itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const double & itemToSend, int rankReceiver) override;
 
   /// Sends an int to process with given rank.
   virtual void send(int itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(int itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const int & itemToSend, int rankReceiver) override;
 
   /// Sends a bool to process with given rank.
   virtual void send(bool itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(bool itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const bool & itemToSend, int rankReceiver) override;
 
   /// Receives a std::string from process with given rank.
   virtual void receive(std::string &itemToReceive, int rankSender) override;


### PR DESCRIPTION
This PR fixes the broken design on the bottom level by not taking ownership of the item(s) to send. This is part of the issue #130 

I could not find any lifetime problems in the affected callers in:
https://github.com/precice/precice/blob/b5c939c99379cc297209afdf686b757c53b6e26d/src/com/Communication.cpp#L189
https://github.com/precice/precice/blob/b5c939c99379cc297209afdf686b757c53b6e26d/src/com/Communication.cpp#L231