### PR TITLE
Improve the clang-format support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BraceWrapping:
   BeforeElse:      false
   IndentBraces:    false
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Linux
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakAfterJavaFieldAnnotations: false
@@ -87,6 +87,6 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11
-TabWidth:        8
+TabWidth:        2
 UseTab:          Never
 ...

--- a/tools/formatting/README.md
+++ b/tools/formatting/README.md
@@ -1,0 +1,15 @@
+# Formatting Tools
+
+## check-format
+
+This bash-script checks the format of every c(pp) & h(pp) file in the current and parent directories against the clang-format style defined in a parent `.clang-format` file.
+It returns 0 if everything is formatted correctly.
+Otherwise, it displays the list of files that do not match the format and returns 1.
+
+_This script is meant to be called in a CI environment._
+
+## format-all
+
+This bash-script applies the format of a parent `.clang-format` to every c(pp) & h(pp) file in the current and parent directories.
+
+This script returns 0 on success.

--- a/tools/formatting/README.md
+++ b/tools/formatting/README.md
@@ -6,8 +6,6 @@ This bash-script checks the format of every c(pp) & h(pp) file in the current an
 It returns 0 if everything is formatted correctly.
 Otherwise, it displays the list of files that do not match the format and returns 1.
 
-_This script is meant to be called in a CI environment._
-
 ## format-all
 
 This bash-script applies the format of a parent `.clang-format` to every c(pp) & h(pp) file in the current and parent directories.

--- a/tools/formatting/check-format
+++ b/tools/formatting/check-format
@@ -1,0 +1,26 @@
+#! /bin/bash
+# Call this script to check the format every c[pp] & h[pp] file
+# in the current and parent directories against the defined clang-format style.
+#
+# Returns 1 on an incorrect format
+
+FILES="$(find . -type f -name \*.hpp -or -name \*.h -or -name \*.cpp -or -name \*.c)"
+
+DIFFS=""
+for cfile in $FILES; do
+    DIFF=$(diff "$cfile" <(clang-format -style=file $cfile))
+    if [[ -n "$DIFF" ]]; then
+        DIFFS="$DIFFS $cfile"
+    fi
+done
+
+if [[ -n "$DIFFS" ]]; then
+    echo "The following files are not formatted correctly:"
+    for cfile in $DIFFS; do
+        echo "$cfile"
+    done
+    exit 1
+else
+    echo "All files are formatted correctly"
+    exit 0
+fi

--- a/tools/formatting/format-all
+++ b/tools/formatting/format-all
@@ -1,0 +1,14 @@
+#! /bin/bash
+# Call this script to format every c[pp] & h[pp] file
+# in the parent directory using clang-format
+
+FILES="$(find . -type f -name \*.hpp -or -name \*.h -or -name \*.cpp -or -name \*.c)"
+SPIN=0
+echo "Formatting files"
+for cfile in $FILES
+do
+    clang-format -style=file -i $cfile
+    echo -n "."
+done
+echo -e "\nDone"
+exit 0


### PR DESCRIPTION
Adjusted the clang-format.

Added two scripts to
1) check the formatting and
2) format all files

Both scripts reside in `/tools/formatting/`.