### PR TITLE
Change MeshRequirement to enum class

### DIFF
--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -9,8 +9,8 @@ Mapping:: Mapping
   int             dimensions)
 :
   _constraint(constraint),
-  _inputRequirement(UNDEFINED),
-  _outputRequirement(UNDEFINED),
+  _inputRequirement(MeshRequirement::UNDEFINED),
+  _outputRequirement(MeshRequirement::UNDEFINED),
   _input(),
   _output(),
   _dimensions(dimensions)
@@ -86,6 +86,21 @@ bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs) {
         case(Mapping::MeshRequirement::FULL):
                 return false;
     };
+}
+
+std::ostream &operator<<(std::ostream &out, Mapping::MeshRequirement val) {
+    switch (val) {
+        case (Mapping::MeshRequirement::UNDEFINED):
+            out << "UNDEFINED";
+            break;
+        case (Mapping::MeshRequirement::VERTEX):
+            out << "VERTEX";
+            break;
+        case (Mapping::MeshRequirement::FULL):
+            out << "FULL";
+            break;
+    };
+    return out;
 }
 
 }} // namespace precice, mapping

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -35,7 +35,7 @@ public:
    * connected by edges and faces. VERTEX requires a mesh consisting of vertices
    * only.
    */
-  enum MeshRequirement {
+  enum class MeshRequirement {
     UNDEFINED = 0,
     /// Vertices only.
     VERTEX = 1,
@@ -148,5 +148,10 @@ private:
 */
 bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs);
 
+/** Defines the output operation to streams
+* @param[inout] out stream to output to.
+* @param[in] val the value to output.
+*/
+std::ostream& operator<<(std::ostream& out, Mapping::MeshRequirement val);
 
 }} // namespace precice, mapping

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -20,8 +20,8 @@ NearestNeighborMapping:: NearestNeighborMapping
 :
   Mapping(constraint, dimensions)
 {
-  setInputRequirement(VERTEX);
-  setOutputRequirement(VERTEX);
+  setInputRequirement(Mapping::MeshRequirement::VERTEX);
+  setOutputRequirement(Mapping::MeshRequirement::VERTEX);
 }
 
 void NearestNeighborMapping:: computeMapping()

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -16,13 +16,13 @@ NearestProjectionMapping:: NearestProjectionMapping
   Mapping(constraint, dimensions)
 {
   if (constraint == CONSISTENT){
-    setInputRequirement(FULL);
-    setOutputRequirement(VERTEX);
+    setInputRequirement(Mapping::MeshRequirement::FULL);
+    setOutputRequirement(Mapping::MeshRequirement::VERTEX);
   }
   else {
     assertion(constraint == CONSERVATIVE, constraint);
-    setInputRequirement(VERTEX);
-    setOutputRequirement(FULL);
+    setInputRequirement(Mapping::MeshRequirement::VERTEX);
+    setOutputRequirement(Mapping::MeshRequirement::FULL);
   }
 }
 

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -202,8 +202,8 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping
   _polynomial(polynomial),
   _preallocation(preallocation)
 {
-  setInputRequirement(VERTEX);
-  setOutputRequirement(VERTEX);
+  setInputRequirement(Mapping::MeshRequirement::VERTEX);
+  setOutputRequirement(Mapping::MeshRequirement::VERTEX);
   _deadAxis = new bool[dimensions];
 
   if (getDimensions()==2) {

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -119,8 +119,8 @@ RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: RadialBasisFctMapping
   Mapping ( constraint, dimensions ),
   _basisFunction ( function )
 {
-  setInputRequirement(VERTEX);
-  setOutputRequirement(VERTEX);
+  setInputRequirement(Mapping::MeshRequirement::VERTEX);
+  setOutputRequirement(Mapping::MeshRequirement::VERTEX);
   setDeadAxis(xDead, yDead, zDead);
 }
 

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -32,7 +32,7 @@ struct MeshContext
    std::vector<int> associatedData;
 
    /// Determines which mesh type has to be provided by the accessor.
-   mapping::Mapping::MeshRequirement meshRequirement = mapping::Mapping::UNDEFINED;
+   mapping::Mapping::MeshRequirement meshRequirement = mapping::Mapping::MeshRequirement::UNDEFINED;
 
    /// Name of participant that creats the mesh.
    std::string receiveMeshFrom;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -754,7 +754,7 @@ int SolverInterfaceImpl:: setMeshEdge
   else {
     CHECK(not _couplingScheme->isInitialized(), "Edges can only be defined before initialize() is called");
     MeshContext& context = _accessor->meshContext(meshID);
-    if ( context.meshRequirement == mapping::Mapping::FULL ){
+    if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
       DEBUG("Full mesh required.");
       mesh::PtrMesh& mesh = context.mesh;
       assertion(firstVertexID >= 0, firstVertexID);
@@ -786,7 +786,7 @@ void SolverInterfaceImpl:: setMeshTriangle
   else {
     CHECK(not _couplingScheme->isInitialized(), "Triangles can only be defined before initialize() is called");
     MeshContext& context = _accessor->meshContext(meshID);
-    if ( context.meshRequirement == mapping::Mapping::FULL ){
+    if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
       mesh::PtrMesh& mesh = context.mesh;
       assertion ( firstEdgeID >= 0 );
       assertion ( secondEdgeID >= 0 );
@@ -820,7 +820,7 @@ void SolverInterfaceImpl:: setMeshTriangleWithEdges
   }
   CHECK(not _couplingScheme->isInitialized(), "Triangles can only be defined before initialize() is called");
   MeshContext& context = _accessor->meshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::FULL){
+  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
     mesh::PtrMesh& mesh = context.mesh;
     assertion(firstVertexID >= 0, firstVertexID);
     assertion(secondVertexID >= 0, secondVertexID);
@@ -914,7 +914,7 @@ void SolverInterfaceImpl:: setMeshQuad
   else {
     CHECK(not _couplingScheme->isInitialized(), "Quads can only be defined before initialize() is called");
     MeshContext& context = _accessor->meshContext(meshID);
-    if (context.meshRequirement == mapping::Mapping::FULL){
+    if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
       mesh::PtrMesh& mesh = context.mesh;
       assertion(firstEdgeID >= 0);
       assertion(secondEdgeID >= 0);
@@ -950,7 +950,7 @@ void SolverInterfaceImpl:: setMeshQuadWithEdges
   }
   CHECK(not _couplingScheme->isInitialized(), "Quads can only be defined before initialize() is called");
   MeshContext& context = _accessor->meshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::FULL){
+  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
     mesh::PtrMesh& mesh = context.mesh;
     assertion(firstVertexID >= 0, firstVertexID);
     assertion(secondVertexID >= 0, secondVertexID);


### PR DESCRIPTION
This PR: 
* fixes unscoped access of the enum values, 
* turns the enum to a enum class,
* adds `operator<<` for debugging purposes