### PR TITLE
Source Code Modernization

### DIFF
--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -79,7 +79,7 @@ void Participant:: useMesh
   TRACE(_name,  mesh->getName(), mesh->getID() );
   checkDuplicatedUse(mesh);
   assertion ( mesh->getID() < (int)_meshContexts.size() );
-  MeshContext* context = new MeshContext(mesh->getDimensions());
+  auto context = new MeshContext(mesh->getDimensions());
   context->mesh = mesh;
   context->localOffset = localOffset;
   assertion ( mesh->getDimensions() == context->localOffset.size(),
@@ -105,7 +105,7 @@ void Participant:: addWriteData
 {
   checkDuplicatedData ( data );
   assertion ( data->getID() < (int)_dataContexts.size() );
-  DataContext* context = new DataContext ();
+  auto context = new DataContext ();
   context->fromData = data;
   context->mesh = mesh;
   // will be overwritten later if a mapping exists
@@ -121,7 +121,7 @@ void Participant:: addReadData
 {
   checkDuplicatedData ( data );
   assertion ( data->getID() < (int)_dataContexts.size() );
-  DataContext* context = new DataContext ();
+  auto context = new DataContext ();
   context->toData = data;
   context->mesh = mesh;
   // will be overwritten later if a mapping exists

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -301,7 +301,7 @@ void Participant:: setClientServerCommunication
   com::PtrCommunication communication )
 {
   assertion ( communication.use_count() > 0 );
-  _clientServerCommunication = communication;
+  _clientServerCommunication = std::move(communication);
 }
 
 com::PtrCommunication Participant:: getClientServerCommunication() const

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -6,7 +6,7 @@
 #include "WatchPoint.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
 #include "mesh/config/DataConfiguration.hpp"
-#include <utitlity>
+#include <utility>
 
 namespace precice {
 namespace impl {

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -6,6 +6,7 @@
 #include "WatchPoint.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
 #include "mesh/config/DataConfiguration.hpp"
+#include <utitlity>
 
 namespace precice {
 namespace impl {
@@ -19,10 +20,10 @@ void Participant:: resetParticipantCount()
 
 Participant:: Participant
 (
-  const std::string&          name,
+  std::string                 name,
   mesh::PtrMeshConfiguration& meshConfig )
 :
-  _name ( name ),
+  _name (std::move(name)),
   _id ( _participantsSize ),
   _meshContexts ( meshConfig->meshes().size(), nullptr ),
   _dataContexts ( meshConfig->getDataConfiguration()->data().size()*meshConfig->meshes().size(), nullptr )

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -52,7 +52,7 @@ public:
    * @param[in] name Name of the participant. Has to be unique.
    */
   Participant (
-    const std::string&          name,
+    std::string                 name,
     mesh::PtrMeshConfiguration& meshConfig );
 
   virtual ~Participant();

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -582,7 +582,7 @@ void RequestManager:: handleRequestAdvance
   const std::list<int>& clientRanks )
 {
   TRACE();
-  std::list<int>::const_iterator iter = clientRanks.begin();
+  auto iter = clientRanks.begin();
   double oldDt;
   _com->receive(oldDt, *iter);
   iter++;
@@ -891,7 +891,7 @@ void RequestManager:: handleRequestMapWriteDataFrom
   const std::list<int>& clientRanks )
 {
   TRACE();
-  std::list<int>::const_iterator iter = clientRanks.begin();
+  auto iter = clientRanks.begin();
   int ping = 0;
   _com->send(ping, *iter);
   int oldMeshID;
@@ -913,7 +913,7 @@ void RequestManager:: handleRequestMapReadDataTo
   const std::list<int>& clientRanks )
 {
   TRACE();
-  std::list<int>::const_iterator iter = clientRanks.begin();
+  auto iter = clientRanks.begin();
   int ping = 0;
   _com->send(ping, *iter);
   int oldMeshID;

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -662,10 +662,10 @@ void RequestManager:: handleRequestSetMeshVertices
   _com->receive(size, rankSender);
   CHECK(size > 0, "You cannot call setMeshVertices with size=0.");
   std::vector<double> positions(size*_interface.getDimensions());
-  _com->receive(positions.data(), size*_interface.getDimensions(), rankSender);
+  _com->receive(positions, rankSender);
   std::vector<int> ids(size);
   _interface.setMeshVertices(meshID, size, positions.data(), ids.data());
-  _com->send(ids.data(), size, rankSender);
+  _com->send(ids, rankSender);
 }
 
 void RequestManager:: handleRequestGetMeshVertices
@@ -680,9 +680,9 @@ void RequestManager:: handleRequestGetMeshVertices
   assertion(size > 0, size);
   std::vector<int> ids(size);
   std::vector<double> positions(size*_interface.getDimensions());
-  _com->receive(ids.data(), size, rankSender);
+  _com->receive(ids, rankSender);
   _interface.getMeshVertices(meshID, size, ids.data(), positions.data());
-  _com->send(positions.data(), size*_interface.getDimensions(), rankSender);
+  _com->send(positions, rankSender);
 }
 
 void RequestManager:: handleRequestGetMeshVertexIDsFromPositions
@@ -697,9 +697,9 @@ void RequestManager:: handleRequestGetMeshVertexIDsFromPositions
   assertion(size > 0, size);
   std::vector<int> ids(size);
   std::vector<double> positions(size*_interface.getDimensions());
-  _com->receive(positions.data(), size*_interface.getDimensions(), rankSender);
+  _com->receive(positions, rankSender);
   _interface.getMeshVertexIDsFromPositions(meshID, size, positions.data(), ids.data());
-  _com->send(ids.data(), size, rankSender);
+  _com->send(ids, rankSender);
 }
 
 void RequestManager:: handleRequestSetMeshEdge
@@ -777,9 +777,9 @@ void RequestManager:: handleRequestWriteBlockScalarData
   int size = -1;
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
-  _com->receive(indices.data(), size, rankSender);
+  _com->receive(indices, rankSender);
   std::vector<double> data(size);
-  _com->receive(data.data(), size, rankSender);
+  _com->receive(data, rankSender);
   _interface.writeBlockScalarData(dataID, size, indices.data(), data.data());
 }
 
@@ -793,9 +793,9 @@ void RequestManager:: handleRequestWriteBlockVectorData
   int size = -1;
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
-  _com->receive(indices.data(), size, rankSender);
+  _com->receive(indices, rankSender);
   std::vector<double> data(size*_interface.getDimensions());
-  _com->receive(data.data(), size*_interface.getDimensions(), rankSender);
+  _com->receive(data, rankSender);
   _interface.writeBlockVectorData(dataID, size, indices.data(), data.data());
 }
 
@@ -837,10 +837,10 @@ void RequestManager:: handleRequestReadBlockScalarData
   int size = -1;
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
-  _com->receive(indices.data(), size, rankSender);
+  _com->receive(indices, rankSender);
   std::vector<double> data(size);
   _interface.readBlockScalarData(dataID, size, indices.data(), data.data());
-  _com->send(data.data(), size, rankSender);
+  _com->send(data, rankSender);
 }
 
 void RequestManager:: handleRequestReadBlockVectorData
@@ -853,10 +853,10 @@ void RequestManager:: handleRequestReadBlockVectorData
   int size = -1;
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
-  _com->receive(indices.data(), size, rankSender);
+  _com->receive(indices, rankSender);
   std::vector<double> data(size*_interface.getDimensions());
   _interface.readBlockVectorData(dataID, size, indices.data(), data.data());
-  _com->send(data.data(), size*_interface.getDimensions(), rankSender);
+  _com->send(data, rankSender);
 }
 
 void RequestManager:: handleRequestReadVectorData

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -3,6 +3,7 @@
 #include "cplscheme/CouplingScheme.hpp"
 #include "precice/impl/SolverInterfaceImpl.hpp"
 #include <algorithm>
+#include <utility>
 
 namespace precice {
 namespace impl {
@@ -14,8 +15,8 @@ RequestManager:: RequestManager
   cplscheme::PtrCouplingScheme couplingScheme)
 :
   _interface(solverInterfaceImpl),
-  _com(clientServerCommunication),
-  _couplingScheme(couplingScheme)
+  _com(std::move(clientServerCommunication)),
+  _couplingScheme(std::move(couplingScheme))
 {}
 
 void RequestManager:: handleRequests()

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -4,6 +4,7 @@
 #include "precice/impl/SolverInterfaceImpl.hpp"
 #include <algorithm>
 #include <utility>
+#include <vector>
 
 namespace precice {
 namespace impl {
@@ -660,13 +661,11 @@ void RequestManager:: handleRequestSetMeshVertices
   int size = -1;
   _com->receive(size, rankSender);
   CHECK(size > 0, "You cannot call setMeshVertices with size=0.");
-  double* positions = new double[size*_interface.getDimensions()];
-  _com->receive(positions, size*_interface.getDimensions(), rankSender);
-  int* ids = new int[size];
-  _interface.setMeshVertices(meshID, size, positions, ids);
-  _com->send(ids, size, rankSender);
-  delete[] positions;
-  delete[] ids;
+  std::vector<double> positions(size*_interface.getDimensions());
+  _com->receive(positions.data(), size*_interface.getDimensions(), rankSender);
+  std::vector<int> ids(size);
+  _interface.setMeshVertices(meshID, size, positions.data(), ids.data());
+  _com->send(ids.data(), size, rankSender);
 }
 
 void RequestManager:: handleRequestGetMeshVertices
@@ -679,13 +678,11 @@ void RequestManager:: handleRequestGetMeshVertices
   _com->receive(meshID, rankSender);
   _com->receive(size, rankSender);
   assertion(size > 0, size);
-  int* ids = new int[size];
-  double* positions = new double[size*_interface.getDimensions()];
-  _com->receive(ids, size, rankSender);
-  _interface.getMeshVertices(meshID, size, ids, positions);
-  _com->send(positions, size*_interface.getDimensions(), rankSender);
-  delete[] ids;
-  delete[] positions;
+  std::vector<int> ids(size);
+  std::vector<double> positions(size*_interface.getDimensions());
+  _com->receive(ids.data(), size, rankSender);
+  _interface.getMeshVertices(meshID, size, ids.data(), positions.data());
+  _com->send(positions.data(), size*_interface.getDimensions(), rankSender);
 }
 
 void RequestManager:: handleRequestGetMeshVertexIDsFromPositions
@@ -698,13 +695,11 @@ void RequestManager:: handleRequestGetMeshVertexIDsFromPositions
   _com->receive(meshID, rankSender);
   _com->receive(size, rankSender);
   assertion(size > 0, size);
-  int* ids = new int[size];
-  double* positions = new double[size*_interface.getDimensions()];
-  _com->receive(positions, size*_interface.getDimensions(), rankSender);
-  _interface.getMeshVertexIDsFromPositions(meshID, size, positions, ids);
-  _com->send(ids, size, rankSender);
-  delete[] ids;
-  delete[] positions;
+  std::vector<int> ids(size);
+  std::vector<double> positions(size*_interface.getDimensions());
+  _com->receive(positions.data(), size*_interface.getDimensions(), rankSender);
+  _interface.getMeshVertexIDsFromPositions(meshID, size, positions.data(), ids.data());
+  _com->send(ids.data(), size, rankSender);
 }
 
 void RequestManager:: handleRequestSetMeshEdge
@@ -781,13 +776,11 @@ void RequestManager:: handleRequestWriteBlockScalarData
   _com->receive(dataID, rankSender);
   int size = -1;
   _com->receive(size, rankSender);
-  int* indices = new int[size];
-  _com->receive(indices, size, rankSender);
-  double* data = new double[size];
-  _com->receive(data, size, rankSender);
-  _interface.writeBlockScalarData(dataID, size, indices, data);
-  delete[] indices;
-  delete[] data;
+  std::vector<int> indices(size);
+  _com->receive(indices.data(), size, rankSender);
+  std::vector<double> data(size);
+  _com->receive(data.data(), size, rankSender);
+  _interface.writeBlockScalarData(dataID, size, indices.data(), data.data());
 }
 
 void RequestManager:: handleRequestWriteBlockVectorData
@@ -799,13 +792,11 @@ void RequestManager:: handleRequestWriteBlockVectorData
   _com->receive(dataID, rankSender);
   int size = -1;
   _com->receive(size, rankSender);
-  int* indices = new int[size];
-  _com->receive(indices, size, rankSender);
-  double* data = new double[size*_interface.getDimensions()];
-  _com->receive(data, size*_interface.getDimensions(), rankSender);
-  _interface.writeBlockVectorData(dataID, size, indices, data);
-  delete[] indices;
-  delete[] data;
+  std::vector<int> indices(size);
+  _com->receive(indices.data(), size, rankSender);
+  std::vector<double> data(size*_interface.getDimensions());
+  _com->receive(data.data(), size*_interface.getDimensions(), rankSender);
+  _interface.writeBlockVectorData(dataID, size, indices.data(), data.data());
 }
 
 void RequestManager:: handleRequestWriteVectorData
@@ -845,13 +836,11 @@ void RequestManager:: handleRequestReadBlockScalarData
   _com->receive(dataID, rankSender);
   int size = -1;
   _com->receive(size, rankSender);
-  int* indices = new int[size];
-  _com->receive(indices, size, rankSender);
-  double* data = new double[size];
-  _interface.readBlockScalarData(dataID, size, indices, data);
-  _com->send(data, size, rankSender);
-  delete[] indices;
-  delete[] data;
+  std::vector<int> indices(size);
+  _com->receive(indices.data(), size, rankSender);
+  std::vector<double> data(size);
+  _interface.readBlockScalarData(dataID, size, indices.data(), data.data());
+  _com->send(data.data(), size, rankSender);
 }
 
 void RequestManager:: handleRequestReadBlockVectorData
@@ -863,13 +852,11 @@ void RequestManager:: handleRequestReadBlockVectorData
   _com->receive(dataID, rankSender);
   int size = -1;
   _com->receive(size, rankSender);
-  int* indices = new int[size];
-  _com->receive(indices, size, rankSender);
-  double* data = new double[size*_interface.getDimensions()];
-  _interface.readBlockVectorData(dataID, size, indices, data);
-  _com->send(data, size*_interface.getDimensions(), rankSender);
-  delete[] indices;
-  delete[] data;
+  std::vector<int> indices(size);
+  _com->receive(indices.data(), size, rankSender);
+  std::vector<double> data(size*_interface.getDimensions());
+  _interface.readBlockVectorData(dataID, size, indices.data(), data.data());
+  _com->send(data.data(), size*_interface.getDimensions(), rankSender);
 }
 
 void RequestManager:: handleRequestReadVectorData

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1738,8 +1738,7 @@ PtrParticipant SolverInterfaceImpl:: determineAccessingParticipant
 (
    const config::SolverInterfaceConfiguration& config )
 {
-  config::PtrParticipantConfiguration partConfig =
-      config.getParticipantConfiguration ();
+  const auto& partConfig = config.getParticipantConfiguration();
   for (const PtrParticipant& participant : partConfig->getParticipants()) {
     if ( participant->getName() == _accessorName ) {
       return participant;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -30,7 +30,7 @@
 #include "partition/ReceivedPartition.hpp"
 #include "partition/ProvidedPartition.hpp"
 
-#include <signal.h> // used for installing crash handler
+#include <csignal> // used for installing crash handler
 
 #include "logging/Logger.hpp"
 #include "logging/LogConfiguration.hpp"

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -31,6 +31,7 @@
 #include "partition/ProvidedPartition.hpp"
 
 #include <csignal> // used for installing crash handler
+#include <utility>
 
 #include "logging/Logger.hpp"
 #include "logging/LogConfiguration.hpp"
@@ -51,12 +52,12 @@ namespace impl {
 
 SolverInterfaceImpl:: SolverInterfaceImpl
 (
-  const std::string& participantName,
-  int                accessorProcessRank,
-  int                accessorCommunicatorSize,
-  bool               serverMode )
+  std::string participantName,
+  int         accessorProcessRank,
+  int         accessorCommunicatorSize,
+  bool        serverMode )
 :
-  _accessorName(participantName),
+  _accessorName(std::move(participantName)),
   _accessorProcessRank(accessorProcessRank),
   _accessorCommunicatorSize(accessorCommunicatorSize),
   _serverMode(serverMode)

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1715,7 +1715,7 @@ void SolverInterfaceImpl:: handleExports()
 
   if (_couplingScheme->isCouplingTimestepComplete()){
     // Export watch point data
-    for (PtrWatchPoint watchPoint : _accessor->watchPoints()) {
+    for (const PtrWatchPoint& watchPoint : _accessor->watchPoints()) {
       watchPoint->exportPointData(_couplingScheme->getTime());
     }
   }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -143,7 +143,7 @@ void SolverInterfaceImpl:: configure
   }
 
   // Add meshIDs and data IDs
-  for (MeshContext* meshContext : _accessor->usedMeshContexts()) {
+  for (const MeshContext* meshContext : _accessor->usedMeshContexts()) {
     const mesh::PtrMesh& mesh = meshContext->mesh;
     for (std::pair<std::string,int> nameID : mesh->getNameIDPairs()) {
       assertion(not utils::contained(nameID.first, _meshIDs));
@@ -191,9 +191,8 @@ double SolverInterfaceImpl:: initialize()
   else {
     // Setup communication
 
-    typedef std::map<std::string,M2NWrap>::value_type M2NPair;
     INFO("Setting up master communication to coupling partner/s " );
-    for (M2NPair& m2nPair : _m2ns) {
+    for (auto& m2nPair : _m2ns) {
       m2n::PtrM2N& m2n = m2nPair.second.m2n;
       std::string localName = _accessorName;
       if (_serverMode) localName += "Server";
@@ -216,9 +215,8 @@ double SolverInterfaceImpl:: initialize()
 
     computePartitions();
 
-    typedef std::map<std::string,M2NWrap>::value_type M2NPair;
     INFO("Setting up slaves communication to coupling partner/s " );
-    for (M2NPair& m2nPair : _m2ns) {
+    for (const auto& m2nPair : _m2ns) {
       m2n::PtrM2N& m2n = m2nPair.second.m2n;
       std::string localName = _accessorName;
       std::string remoteName(m2nPair.first);
@@ -1392,7 +1390,7 @@ void SolverInterfaceImpl:: exportMesh
     bool exportAll = exportType == constants::exportAll();
     bool exportThis = context.exporter->getType() == exportType;
     if ( exportAll || exportThis ){
-      for (MeshContext* meshContext : _accessor->usedMeshContexts()) {
+      for (const MeshContext* meshContext : _accessor->usedMeshContexts()) {
         std::string name = meshContext->mesh->getName() + "-" + filenameSuffix;
         DEBUG ( "Exporting mesh to file \"" << name << "\" at location \"" << context.location << "\"" );
         context.exporter->doExport ( name, context.location, *(meshContext->mesh) );
@@ -1429,8 +1427,7 @@ void SolverInterfaceImpl:: configureM2Ns
   const m2n::M2NConfiguration::SharedPointer& config )
 {
   TRACE();
-  typedef m2n::M2NConfiguration::M2NTuple M2NTuple;
-  for (M2NTuple m2nTuple : config->m2ns()) {
+  for (const auto& m2nTuple : config->m2ns()) {
     std::string comPartner("");
     bool isRequesting = false;
     if (std::get<1>(m2nTuple) == _accessorName){
@@ -1473,8 +1470,8 @@ void SolverInterfaceImpl:: configurePartitions
       bool hasToSend = false; /// @todo multiple sends
       m2n::PtrM2N m2n;
 
-      for (PtrParticipant receiver : _participants ) {
-        for (MeshContext* receiverContext : receiver->usedMeshContexts()) {
+      for (auto& receiver : _participants ) {
+        for (auto& receiverContext : receiver->usedMeshContexts()) {
           if(receiverContext->receiveMeshFrom == _accessorName && receiverContext->mesh->getName() == context->mesh->getName()){
             CHECK( not hasToSend, "Mesh " << context->mesh->getName() << " can currently only be received once.")
             hasToSend = true;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1408,7 +1408,7 @@ MeshHandle SolverInterfaceImpl:: getMeshHandle
   assertion(not _clientMode);
   for (MeshContext* context : _accessor->usedMeshContexts()){
     if (context->mesh->getName() == meshName){
-      return MeshHandle(context->mesh->content());
+      return {context->mesh->content()};
     }
   }
   ERROR("Participant \"" << _accessorName

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -216,7 +216,7 @@ double SolverInterfaceImpl:: initialize()
     computePartitions();
 
     INFO("Setting up slaves communication to coupling partner/s " );
-    for (const auto& m2nPair : _m2ns) {
+    for (auto& m2nPair : _m2ns) {
       m2n::PtrM2N& m2n = m2nPair.second.m2n;
       std::string localName = _accessorName;
       std::string remoteName(m2nPair.first);

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -51,10 +51,10 @@ public:
    *                            xml configuration file.
    */
   SolverInterfaceImpl (
-    const std::string& participantName,
-    int                accessorProcessRank,
-    int                accessorCommunicatorSize,
-    bool               serverMode );
+    std::string participantName,
+    int         accessorProcessRank,
+    int         accessorCommunicatorSize,
+    bool        serverMode );
 
   /**
    * @brief Configures the coupling interface from the given xml file.

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -16,12 +16,12 @@ namespace impl {
 
 WatchPoint:: WatchPoint
 (
-  const Eigen::VectorXd&  pointCoords,
-  const mesh::PtrMesh&    meshToWatch,
-  const std::string&      exportFilename )
+  Eigen::VectorXd    pointCoords,
+  mesh::PtrMesh      meshToWatch,
+  const std::string& exportFilename )
 :
-  _point ( pointCoords ),
-  _mesh ( meshToWatch ),
+  _point(std::move(pointCoords)),
+  _mesh(std::move(meshToWatch)),
   _txtWriter ( exportFilename )
 {
   assertion ( _mesh.use_count() > 0 );

--- a/src/precice/impl/WatchPoint.hpp
+++ b/src/precice/impl/WatchPoint.hpp
@@ -27,9 +27,9 @@ public:
    * @param[in] meshToWatch Mesh to be watched, can be empty on construction.
    */
   WatchPoint (
-    const Eigen::VectorXd& pointCoords,
-    const mesh::PtrMesh&   meshToWatch,
-    const std::string&     exportFilename );
+    Eigen::VectorXd    pointCoords,
+    mesh::PtrMesh      meshToWatch,
+    const std::string& exportFilename );
 
   const mesh::PtrMesh& mesh() const;
   


### PR DESCRIPTION
I modernised various parts of the code by fixing the warnings from compiling some core classes with `-Wall -Wextra -Wpedantic` and additionally running `clang-tidy`.

Main changes include:
* const correctness especially in loops
* replacing `new X[s]`-`delete X[];` pairs with `std::vector`
* using `auto` with `new`
* Pass by value and move instead of pass by const ref and copy-construct
* Fix c style header `<signal.h>`-> `<csignal>`