### PR TITLE
Generate the build dir from CMake to fix symlink failing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ target_link_libraries(testprecice Threads::Threads)
 target_link_libraries(testprecice precice)
 
 # Create a symlink to the last build from build/last directory.
+file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/build")
 add_custom_target(symlink ALL
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/build/last)
 


### PR DESCRIPTION
Alternative would be to create the build-dir during configuration via
`file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/build)`