### PR TITLE
Add Index for all Mesh Primitives

### DIFF
--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -1,3 +1,5 @@
+#include "impl/RTree.hpp"
+
 #include "RTree.hpp"
 
 namespace precice {
@@ -64,6 +66,18 @@ Box3d getEnclosingBox(Vertex const & middlePoint, double sphereRadius)
   return box;
 }
 
+PrimitiveRTree indexMesh(const Mesh &mesh)
+{
+  using namespace impl;
+
+  AABBGenerator  gen{mesh};
+  PrimitiveRTree tree;
+  indexPrimitive(tree, gen, mesh.vertices());
+  indexPrimitive(tree, gen, mesh.edges());
+  indexPrimitive(tree, gen, mesh.triangles());
+  indexPrimitive(tree, gen, mesh.quads());
+  return tree;
+}
 
 std::ostream &operator<<(std::ostream &out, Primitive val)
 {

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -32,13 +32,12 @@ PtrPrimitiveRTree rtree::getPrimitiveRTree(PtrMesh mesh)
   auto iter = _primitive_trees.find(mesh->getID());
   if (iter != _primitive_trees.end()) {
     return iter->second;
-  } else {
-    auto treeptr = std::make_shared<PrimitiveRTree>(indexMesh(*mesh));
-    _primitive_trees.insert(std::make_pair(
-        mesh->getID(),
-        treeptr));
-    return treeptr;
   }
+  auto treeptr = std::make_shared<PrimitiveRTree>(indexMesh(*mesh));
+  _primitive_trees.emplace(std::piecewise_construct,
+          std::forward_as_tuple(mesh->getID()),
+          std::forward_as_tuple(treeptr));
+  return treeptr;
 }
 
 void rtree::clear(Mesh &mesh)

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -6,7 +6,7 @@ namespace precice {
 namespace mesh {
 
 // Initialize static member
-std::map<int, rtree::PtrRTree> precice::mesh::rtree::trees;
+std::map<int, rtree::PtrRTree> precice::mesh::rtree::_vertex_trees;
 // Initialize static member
 std::map<int, PtrPrimitiveRTree> precice::mesh::rtree::_primitive_trees;
 
@@ -15,7 +15,7 @@ rtree::PtrRTree rtree::getVertexRTree(PtrMesh mesh)
   RTreeParameters params;
   VertexIndexGetter ind(mesh->vertices());
     
-  auto result = trees.emplace(std::piecewise_construct,
+  auto result = _vertex_trees.emplace(std::piecewise_construct,
                               std::forward_as_tuple(mesh->getID()),
                               std::forward_as_tuple(std::make_shared<VertexRTree>(params, ind)));
     
@@ -44,7 +44,7 @@ PtrPrimitiveRTree rtree::getPrimitiveRTree(PtrMesh mesh)
 
 void rtree::clear(Mesh &mesh)
 {
-  trees.erase(mesh.getID());
+  _vertex_trees.erase(mesh.getID());
   _primitive_trees.erase(mesh.getID());
 }
 

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -10,7 +10,7 @@ std::map<int, rtree::PtrRTree> precice::mesh::rtree::_vertex_trees;
 // Initialize static member
 std::map<int, PtrPrimitiveRTree> precice::mesh::rtree::_primitive_trees;
 
-rtree::PtrRTree rtree::getVertexRTree(PtrMesh mesh)
+rtree::PtrRTree rtree::getVertexRTree(const PtrMesh& mesh)
 {
   RTreeParameters params;
   VertexIndexGetter ind(mesh->vertices());
@@ -28,7 +28,7 @@ rtree::PtrRTree rtree::getVertexRTree(PtrMesh mesh)
   return tree;
 }
 
-PtrPrimitiveRTree rtree::getPrimitiveRTree(PtrMesh mesh)
+PtrPrimitiveRTree rtree::getPrimitiveRTree(const PtrMesh& mesh)
 {
   assertion(mesh, "Empty meshes are not allowed.");
   auto iter = _primitive_trees.find(mesh->getID());

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -102,13 +102,13 @@ public:
   /*
    * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
    */
-  static PtrRTree getVertexRTree(PtrMesh mesh);
+  static PtrRTree getVertexRTree(const PtrMesh& mesh);
   
   /// Returns the pointer to boost::geometry::rtree for the given mesh primitives
   /*
    * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
    */
-  static PtrPrimitiveRTree getPrimitiveRTree(PtrMesh mesh);
+  static PtrPrimitiveRTree getPrimitiveRTree(const PtrMesh& mesh);
 
   /// Only clear the trees of that specific mesh
   static void clear(Mesh & mesh);

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include "mesh/impl/RTreeAdapter.hpp"
 #include "mesh/Mesh.hpp"
 #include <boost/geometry.hpp>
-
+#include "mesh/Triangle.hpp"
+#include "mesh/Quad.hpp"
 
 // Forward declaration to friend the boost test struct
 namespace MeshTests {
@@ -12,9 +14,147 @@ namespace RTree {
 struct CacheClearing;
 }}
 
-
 namespace precice {
 namespace mesh {
+
+/** The enumeration of various primitive types.
+ * \see PrimitiveIndex
+ * \see as_primitve_enum
+ */
+enum class Primitive {
+  Vertex,
+  Edge,
+  Triangle,
+  Quad
+};
+
+/// A standard print operator for Primitive
+std::ostream& operator<<(std::ostream& out, Primitive val);
+
+/// The type traits to return the enum value of a primitive type.
+template <class T>
+struct as_primitive_enum {
+};
+template <>
+struct as_primitive_enum<mesh::Vertex> {
+  static constexpr Primitive value = Primitive::Vertex;
+};
+template <>
+struct as_primitive_enum<mesh::Edge> {
+  static constexpr Primitive value = Primitive::Edge;
+};
+template <>
+struct as_primitive_enum<mesh::Triangle> {
+  static constexpr Primitive value = Primitive::Triangle;
+};
+template <>
+struct as_primitive_enum<mesh::Quad> {
+  static constexpr Primitive value = Primitive::Quad;
+};
+
+/** Binds an Index and Primitive into a type
+ * \see AABBGenerator
+ * \see indexPrimitives
+ */
+struct PrimitiveIndex {
+  Primitive type;
+  size_t    index;
+};
+
+/// Standard equality test for PrimitiveIndex
+bool operator==(const PrimitiveIndex& lhs, const PrimitiveIndex& rhs);
+
+/// Standard non-equality test for PrimitiveIndex
+bool operator!=(const PrimitiveIndex& lhs, const PrimitiveIndex& rhs);
+
+/// A standard print operator for PrimitiveIndex
+std::ostream& operator<<(std::ostream& out, PrimitiveIndex val);
+
+/// The axis aligned bounding box based on the Vertex Type
+using AABB = boost::geometry::model::box<Eigen::VectorXd>;
+
+/** Holding a reference to a Mesh it is a functor for packing
+ *  PrimitiveIndex into AABBs.
+ */
+class AABBGenerator
+{
+public:
+  /// Constructs a generator for a given mesh
+  explicit AABBGenerator(const mesh::Mesh &mesh)
+      : mesh_(mesh){};
+
+  /** constructs a AABB of a PrimitiveIndex.
+   *
+   * This operator takes a PrimitiveIndex and fetches the actual primitive from the mesh.
+   * It then constructs an AABB using boost::geometry::return_envelope() and returns it.
+   *
+   * \param pi the index to build the AABB for
+   * \returns a AABB for the primitive
+   */
+  AABB operator()(const PrimitiveIndex &pi) const
+  {
+    switch (pi.type) {
+    case (Primitive::Vertex):
+      return boost::geometry::return_envelope<AABB>(mesh_.vertices()[pi.index]);
+    case (Primitive::Edge):
+      return boost::geometry::return_envelope<AABB>(mesh_.edges()[pi.index]);
+    case (Primitive::Triangle):
+      return boost::geometry::return_envelope<AABB>(mesh_.triangles()[pi.index]);
+    case (Primitive::Quad):
+      return boost::geometry::return_envelope<AABB>(mesh_.quads()[pi.index]);
+    default:
+      assertion(false, "AABB generation for this Primitive is not implemented!")
+    }
+  }
+
+private:
+  /// The mesh used look the primitives up
+  const mesh::Mesh &mesh_;
+};
+
+/// The rtree capable of indexing primitives of an entire Mesh
+using PrimitiveRTree = boost::geometry::index::rtree<std::pair<AABB, PrimitiveIndex>, boost::geometry::index::rstar<16>>;
+
+/// The shared_ptr convenience type for PrimitiveRTree
+using PtrPrimitiveRTree = std::shared_ptr<PrimitiveRTree>;
+
+/** indexes a container of primitives into an rtree.
+ *
+ * The algorithm indexes every primitive of the given container using the passed generator.
+ * It inserts its result and the PrimitiveIndex into the rtree as a std::pair.
+ *
+ * \param[inout] rtree the rtree to index into
+ * \param gen the Generator generating something to index rtree::value_type.
+ * \param conti the Container to index
+ */
+template <typename Container, typename Generator = AABBGenerator>
+void indexPrimitive(PrimitiveRTree &rtree, const Generator& gen, const Container &conti)
+{
+  using ValueType = typename std::remove_reference<typename std::remove_cv<typename Container::value_type>::type>::type;
+  for (size_t i = 0; i < conti.size(); ++i) {
+    PrimitiveIndex index{as_primitive_enum<ValueType>::value, i};
+    rtree.insert(std::make_pair(gen(index), index));
+  }
+}
+
+/** Indexes a given mesh and returns a PrimitiveRTree holding the index
+ *
+ * This indexes the vertices, edges, triangles, and quads of a given Mesh and retrurns the index tree
+ *
+ * \param mesh the mesh to index
+ *
+ * \return the tree containing the indexed primitives descibed above
+ */
+inline PrimitiveRTree indexMesh(const Mesh &mesh)
+{
+  AABBGenerator  gen{mesh};
+  PrimitiveRTree tree;
+  indexPrimitive(tree, gen, mesh.vertices());
+  indexPrimitive(tree, gen, mesh.edges());
+  indexPrimitive(tree, gen, mesh.triangles());
+  indexPrimitive(tree, gen, mesh.quads());
+  return tree;
+}
 
 class rtree {
 public:
@@ -25,19 +165,26 @@ public:
                                                           VertexIndexGetter>;
   using PtrRTree = std::shared_ptr<VertexRTree>;
 
-  /// Returns the pointer to boost::geometry::rtree for the given mesh
+  /// Returns the pointer to boost::geometry::rtree for the given mesh vertices
   /*
    * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
    */
   static PtrRTree getVertexRTree(PtrMesh mesh);
   
-  /// Only clear the tree of that specific mesh
+  /// Returns the pointer to boost::geometry::rtree for the given mesh primitives
+  /*
+   * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
+   */
+  static PtrPrimitiveRTree getPrimitiveRTree(PtrMesh mesh);
+
+  /// Only clear the trees of that specific mesh
   static void clear(Mesh & mesh);
 
   friend struct MeshTests::RTree::CacheClearing;
   
 private:
-  static std::map<int, PtrRTree> trees;
+  static std::map<int, PtrPrimitiveRTree> _primitive_trees; ///< Cache for the primitive trees
+  static std::map<int, PtrRTree>          trees; ///< Cache for the vertex trees
 };
 
 

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -117,7 +117,7 @@ public:
   
 private:
   static std::map<int, PtrPrimitiveRTree> _primitive_trees; ///< Cache for the primitive trees
-  static std::map<int, PtrRTree>          trees; ///< Cache for the vertex trees
+  static std::map<int, PtrRTree>          _vertex_trees; ///< Cache for the vertex trees
 };
 
 

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -73,69 +73,11 @@ std::ostream& operator<<(std::ostream& out, PrimitiveIndex val);
 /// The axis aligned bounding box based on the Vertex Type
 using AABB = boost::geometry::model::box<Eigen::VectorXd>;
 
-/** Holding a reference to a Mesh it is a functor for packing
- *  PrimitiveIndex into AABBs.
- */
-class AABBGenerator
-{
-public:
-  /// Constructs a generator for a given mesh
-  explicit AABBGenerator(const mesh::Mesh &mesh)
-      : mesh_(mesh){};
-
-  /** constructs a AABB of a PrimitiveIndex.
-   *
-   * This operator takes a PrimitiveIndex and fetches the actual primitive from the mesh.
-   * It then constructs an AABB using boost::geometry::return_envelope() and returns it.
-   *
-   * \param pi the index to build the AABB for
-   * \returns a AABB for the primitive
-   */
-  AABB operator()(const PrimitiveIndex &pi) const
-  {
-    switch (pi.type) {
-    case (Primitive::Vertex):
-      return boost::geometry::return_envelope<AABB>(mesh_.vertices()[pi.index]);
-    case (Primitive::Edge):
-      return boost::geometry::return_envelope<AABB>(mesh_.edges()[pi.index]);
-    case (Primitive::Triangle):
-      return boost::geometry::return_envelope<AABB>(mesh_.triangles()[pi.index]);
-    case (Primitive::Quad):
-      return boost::geometry::return_envelope<AABB>(mesh_.quads()[pi.index]);
-    default:
-      assertion(false, "AABB generation for this Primitive is not implemented!")
-    }
-  }
-
-private:
-  /// The mesh used look the primitives up
-  const mesh::Mesh &mesh_;
-};
-
 /// The rtree capable of indexing primitives of an entire Mesh
 using PrimitiveRTree = boost::geometry::index::rtree<std::pair<AABB, PrimitiveIndex>, boost::geometry::index::rstar<16>>;
 
 /// The shared_ptr convenience type for PrimitiveRTree
 using PtrPrimitiveRTree = std::shared_ptr<PrimitiveRTree>;
-
-/** indexes a container of primitives into an rtree.
- *
- * The algorithm indexes every primitive of the given container using the passed generator.
- * It inserts its result and the PrimitiveIndex into the rtree as a std::pair.
- *
- * \param[inout] rtree the rtree to index into
- * \param gen the Generator generating something to index rtree::value_type.
- * \param conti the Container to index
- */
-template <typename Container, typename Generator = AABBGenerator>
-void indexPrimitive(PrimitiveRTree &rtree, const Generator& gen, const Container &conti)
-{
-  using ValueType = typename std::remove_reference<typename std::remove_cv<typename Container::value_type>::type>::type;
-  for (size_t i = 0; i < conti.size(); ++i) {
-    PrimitiveIndex index{as_primitive_enum<ValueType>::value, i};
-    rtree.insert(std::make_pair(gen(index), index));
-  }
-}
 
 /** Indexes a given mesh and returns a PrimitiveRTree holding the index
  *
@@ -145,16 +87,7 @@ void indexPrimitive(PrimitiveRTree &rtree, const Generator& gen, const Container
  *
  * \return the tree containing the indexed primitives descibed above
  */
-inline PrimitiveRTree indexMesh(const Mesh &mesh)
-{
-  AABBGenerator  gen{mesh};
-  PrimitiveRTree tree;
-  indexPrimitive(tree, gen, mesh.vertices());
-  indexPrimitive(tree, gen, mesh.edges());
-  indexPrimitive(tree, gen, mesh.triangles());
-  indexPrimitive(tree, gen, mesh.quads());
-  return tree;
-}
+PrimitiveRTree indexMesh(const Mesh &mesh);
 
 class rtree {
 public:

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -31,9 +31,19 @@ public:
   template<typename VECTOR_T>
   void setCoords ( const VECTOR_T& coordinates );
 
+  /// Sets the coordinates of the vertex.
+  /// RValue variant
+  template<typename VECTOR_T>
+  void setCoords ( VECTOR_T&& coordinates );
+
   /// Sets the normal of the vertex.
   template<typename VECTOR_T>
   void setNormal ( const VECTOR_T& normal );
+
+  /// Sets the normal of the vertex.
+  /// RValue variant
+  template<typename VECTOR_T>
+  void setNormal ( VECTOR_T&& normal );
 
   /// Returns the unique (among vertices of one mesh) ID of the vertex.
   int getID() const;
@@ -105,12 +115,30 @@ void Vertex:: setCoords
 }
 
 template<typename VECTOR_T>
+void Vertex:: setCoords
+(
+  VECTOR_T&& coordinates )
+{
+  assertion ( coordinates.size() == _coords.size(), coordinates.size(), _coords.size() );
+  _coords = std::forward<VECTOR_T>(coordinates);
+}
+
+template<typename VECTOR_T>
 void Vertex:: setNormal
 (
   const VECTOR_T& normal )
 {
   assertion ( normal.size() == _normal.size(), normal.size(), _normal.size() );
   _normal = normal;
+}
+
+template<typename VECTOR_T>
+void Vertex:: setNormal
+(
+  VECTOR_T&& normal )
+{
+  assertion ( normal.size() == _normal.size(), normal.size(), _normal.size() );
+  _normal = std::forward<VECTOR_T>(normal);
 }
 
 inline int Vertex:: getID() const

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -31,8 +31,7 @@ public:
   template<typename VECTOR_T>
   void setCoords ( const VECTOR_T& coordinates );
 
-  /// Sets the coordinates of the vertex.
-  /// RValue variant
+  /// Sets the coordinates of the vertex, rvalue variant
   template<typename VECTOR_T>
   void setCoords ( VECTOR_T&& coordinates );
 
@@ -40,8 +39,7 @@ public:
   template<typename VECTOR_T>
   void setNormal ( const VECTOR_T& normal );
 
-  /// Sets the normal of the vertex.
-  /// RValue variant
+  /// Sets the normal of the vertex, rvalue variant
   template<typename VECTOR_T>
   void setNormal ( VECTOR_T&& normal );
 

--- a/src/mesh/impl/RTree.hpp
+++ b/src/mesh/impl/RTree.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "mesh/RTree.hpp"
+
+namespace precice {
+namespace mesh {
+namespace impl {
+
+
+/** Holding a reference to a Mesh it is a functor for packing
+ *  PrimitiveIndex into AABBs.
+ */
+class AABBGenerator
+{
+public:
+  /// Constructs a generator for a given mesh
+  explicit AABBGenerator(const mesh::Mesh &mesh)
+      : mesh_(mesh){};
+
+  /** constructs a AABB of a PrimitiveIndex.
+   *
+   * This operator takes a PrimitiveIndex and fetches the actual primitive from the mesh.
+   * It then constructs an AABB using boost::geometry::return_envelope() and returns it.
+   *
+   * @param pi the index to build the AABB for
+   * @returns a AABB for the primitive
+   */
+  AABB operator()(const PrimitiveIndex &pi) const
+  {
+    switch (pi.type) {
+    case (Primitive::Vertex):
+      return boost::geometry::return_envelope<AABB>(mesh_.vertices()[pi.index]);
+    case (Primitive::Edge):
+      return boost::geometry::return_envelope<AABB>(mesh_.edges()[pi.index]);
+    case (Primitive::Triangle):
+      return boost::geometry::return_envelope<AABB>(mesh_.triangles()[pi.index]);
+    case (Primitive::Quad):
+      return boost::geometry::return_envelope<AABB>(mesh_.quads()[pi.index]);
+    default:
+      assertion(false, "AABB generation for this Primitive is not implemented!")
+    }
+  }
+
+private:
+  /// The mesh used look the primitives up
+  const mesh::Mesh &mesh_;
+};
+
+/** indexes a container of primitives into an rtree.
+ *
+ * The algorithm indexes every primitive of the given container using the passed generator.
+ * It inserts its result and the PrimitiveIndex into the rtree as a std::pair.
+ *
+ * @param[IN, OUT] rtree the rtree to index into
+ * @param gen the Generator generating something to index rtree::value_type.
+ * @param conti the Container to index
+ */
+template <typename Container, typename Generator = AABBGenerator>
+void indexPrimitive(PrimitiveRTree &rtree, const Generator& gen, const Container &conti)
+{
+  using ValueType = typename std::remove_reference<typename std::remove_cv<typename Container::value_type>::type>::type;
+  for (size_t i = 0; i < conti.size(); ++i) {
+    PrimitiveIndex index{as_primitive_enum<ValueType>::value, i};
+    rtree.insert(std::make_pair(gen(index), index));
+  }
+}
+
+}}}

--- a/src/mesh/impl/RTreeAdapter.hpp
+++ b/src/mesh/impl/RTreeAdapter.hpp
@@ -3,7 +3,18 @@
 #include <boost/geometry.hpp>
 #include <Eigen/Core>
 #include "mesh/Vertex.hpp"
+#include "mesh/Edge.hpp"
 
+namespace precice {
+namespace mesh {
+class Triangle;
+class Quad;
+} // namespace mesh
+} // namespace precice
+
+using precice::mesh::Edge;
+using precice::mesh::Quad;
+using precice::mesh::Triangle;
 using precice::mesh::Vertex;
 
 namespace boost {
@@ -38,6 +49,65 @@ struct access<Vertex, Dimension>
   }
 };
 
+/** @brief Provides the necessary template specialisations to adapt precice's Edge to boost.geometry
+*
+* This adapts every Edge to the segment concept of boost.geometry.
+* Include impl/RangeAdapter.hpp for full support.
+*/
+template <>
+struct tag<Edge> {
+  using type = segment_tag;
+};
+template <>
+struct point_type<Edge> {
+  using type = Eigen::VectorXd;
+};
+
+template <size_t Index, size_t Dimension>
+struct indexed_access<Edge, Index, Dimension> {
+  static_assert((Index <= 1), "Valid Indices are {0, 1}");
+  static_assert((Dimension <= 2), "Valid Dimensions are {0, 1, 2}");
+
+  static double get(Edge const &e)
+  {
+    return access<Eigen::VectorXd, Dimension>::get(e.vertex(Index).getCoords());
+  }
+
+  static void set(Edge &e, double const &value)
+  {
+    Eigen::VectorXd v = e.vertex(Index).getCoords();
+    access<Eigen::VectorXd, Dimension>::set(v, value);
+    e.vertex(Index).setCoords(std::move(v));
+  }
+};
+
+/** @brief Provides the necessary template specialisations to adapt precice's Triangle to boost.geometry
+*
+* This adapts every Triangle to the ring concept (filled planar polygone) of boost.geometry.
+* Include impl/RangeAdapter.hpp for full support.
+*/
+template <>
+struct tag<Triangle> {
+  using type = ring_tag;
+};
+template <>
+struct closure<Triangle> {
+  static const closure_selector value = closed;
+};
+
+/** @brief Provides the necessary template specialisations to adapt precice's Quad to boost.geometry
+*
+* This adapts every Quad to the ring concept (filled planar polygone) of boost.geometry.
+*/
+template <>
+struct tag<Quad> {
+  using type = ring_tag;
+};
+template <>
+struct closure<Quad> {
+  static const closure_selector value = closed;
+};
+
 /// Adapts Eigen::VectorXd to boost.geometry
 /*
  * This adapts every VectorXd to a 3d point. For non-existing dimensions, zero is returned.
@@ -60,6 +130,10 @@ struct access<Eigen::VectorXd, Dimension>
   
   static void set(Eigen::VectorXd& p, double const& value)
   {
+    // This handles default initialized VectorXd
+    if (p.size() == 0) {
+        p.resize(3);
+    }
     p[Dimension] = value;
   }
 };

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -1,6 +1,7 @@
 #include "testing/Testing.hpp"
 #include "mesh/RTree.hpp"
 #include "mesh/impl/RTreeAdapter.hpp"
+#include "math/geometry.hpp"
 
 using namespace precice::mesh;
 
@@ -119,7 +120,6 @@ BOOST_AUTO_TEST_CASE(QueryWithBox)
   }
 }
 
-
 BOOST_AUTO_TEST_CASE(VertexAdapter)
 {
   precice::mesh::Mesh mesh("MyMesh", 2, false);
@@ -129,6 +129,70 @@ BOOST_AUTO_TEST_CASE(VertexAdapter)
   BOOST_TEST(bg::get<2>(v) == 0);
   bg::set<1>(v, 5);
   BOOST_TEST(bg::get<1>(v) == 5);
+}
+
+BOOST_AUTO_TEST_CASE(EdgeAdapter)
+{
+  precice::mesh::Mesh mesh("MyMesh", 2, false);
+  auto & v1 = mesh.createVertex(Eigen::Vector2d(1, 2));
+  auto & v2 = mesh.createVertex(Eigen::Vector2d(3, 4));
+  auto & e = mesh.createEdge(v1, v2);
+  BOOST_TEST((bg::get<0,0>(e)) == 1.0);
+  BOOST_TEST((bg::get<0,1>(e)) == 2.0);
+  BOOST_TEST((bg::get<0,2>(e)) == 0.0);
+  BOOST_TEST((bg::get<1,0>(e)) == 3.0);
+  BOOST_TEST((bg::get<1,1>(e)) == 4.0);
+  BOOST_TEST((bg::get<1,2>(e)) == 0.0);
+  bg::set<1,1>(e, 5.0);
+  BOOST_TEST((bg::get<1,1>(e)) == 5.0);
+}
+
+BOOST_AUTO_TEST_CASE(TriangleAdapter)
+{
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+  auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+  auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto & e1 = mesh.createEdge(v1, v2);
+  auto & e2 = mesh.createEdge(v2, v3);
+  auto & e3 = mesh.createEdge(v3, v1);
+  auto & t = mesh.createTriangle(e1, e2, e3);
+
+  std::vector<Eigen::VectorXd> vertices(t.begin(), t.end());
+  std::vector<Eigen::VectorXd> refs{ v1.getCoords(), v2.getCoords(), v3.getCoords()};
+  BOOST_TEST(vertices.size() == refs.size());
+  BOOST_TEST((std::is_permutation(
+                  vertices.begin(), vertices.end(),
+                  refs.begin(),
+                  []( const Eigen::VectorXd& lhs, const Eigen::VectorXd& rhs) {
+                     return precice::math::equals(lhs, rhs);
+                  }
+            )));
+}
+
+BOOST_AUTO_TEST_CASE(QuadAdapter)
+{
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+  auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+  auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
+  auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto & e1 = mesh.createEdge(v1, v2);
+  auto & e2 = mesh.createEdge(v2, v3);
+  auto & e3 = mesh.createEdge(v3, v4);
+  auto & e4 = mesh.createEdge(v4, v1);
+  auto & t = mesh.createQuad(e1, e2, e3, e4);
+
+  std::vector<Eigen::VectorXd> vertices(t.begin(), t.end());
+  std::vector<Eigen::VectorXd> refs{ v1.getCoords(), v2.getCoords(), v3.getCoords(), v4.getCoords()};
+  BOOST_TEST(vertices.size() == refs.size());
+  BOOST_TEST((std::is_permutation(
+                  vertices.begin(), vertices.end(),
+                  refs.begin(),
+                  []( const Eigen::VectorXd& lhs, const Eigen::VectorXd& rhs) {
+                     return precice::math::equals(lhs, rhs);
+                  }
+            )));
 }
 
 BOOST_AUTO_TEST_CASE(VectorAdapter)

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -310,19 +310,19 @@ BOOST_AUTO_TEST_CASE(CacheClearing)
   // The Cache should clear whenever a mesh changes
   auto vTree1 = rtree::getVertexRTree(mesh);
   auto pTree1 = rtree::getPrimitiveRTree(mesh);
-  BOOST_TEST(rtree::trees.size() == 1);
+  BOOST_TEST(rtree::_vertex_trees.size() == 1);
   BOOST_TEST(rtree::_primitive_trees.size() == 1);
   mesh->meshChanged(*mesh); // Emit signal, that mesh has changed
-  BOOST_TEST(rtree::trees.size() == 0);
+  BOOST_TEST(rtree::_vertex_trees.size() == 0);
   BOOST_TEST(rtree::_primitive_trees.size() == 0);
 
   // The Cache should clear whenever we destroy the Mesh
   auto vTree2 = rtree::getVertexRTree(mesh);
   auto pTree2 = rtree::getPrimitiveRTree(mesh);
-  BOOST_TEST(rtree::trees.size() == 1);
+  BOOST_TEST(rtree::_vertex_trees.size() == 1);
   BOOST_TEST(rtree::_primitive_trees.size() == 1);
   mesh.reset(); // Destroy mesh object, signal is emitted to clear cache
-  BOOST_TEST(rtree::trees.size() == 0);
+  BOOST_TEST(rtree::_vertex_trees.size() == 0);
   BOOST_TEST(rtree::_primitive_trees.size() == 0);
 }
 

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -1,5 +1,6 @@
 #include "testing/Testing.hpp"
 #include "mesh/RTree.hpp"
+#include "mesh/impl/RTree.hpp"
 #include "mesh/impl/RTreeAdapter.hpp"
 #include "math/geometry.hpp"
 
@@ -339,8 +340,9 @@ BOOST_AUTO_TEST_CASE(PrimitveIndexComparison) {
 
 BOOST_FIXTURE_TEST_CASE(IndexSinglePrimitiveType, MeshFixture) {
   PrimitiveRTree rtree;
-  AABBGenerator gen{mesh};
+  impl::AABBGenerator gen{mesh};
 
+  using impl::indexPrimitive;
   BOOST_TEST(rtree.empty());
   indexPrimitive(rtree, gen, mesh.vertices());
   BOOST_TEST(rtree.size() == vertex_cnt);

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -99,25 +99,80 @@ BOOST_AUTO_TEST_CASE(QuadAdapter)
 
 BOOST_AUTO_TEST_SUITE_END() // BG Adapters
 
+struct MeshFixture {
+  MeshFixture() : mesh("MyMesh", 3, false) {
+    auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+    auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+    auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
+    auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+    // Quad Borders
+    auto & e1 = mesh.createEdge(v1, v2);
+    auto & e2 = mesh.createEdge(v2, v3);
+    auto & e3 = mesh.createEdge(v3, v4);
+    auto & e4 = mesh.createEdge(v4, v1);
+    // Diagonal
+    auto & e5 = mesh.createEdge(v2, v4);
+    // Triangles
+    mesh.createTriangle(e1, e5, e4);
+    mesh.createTriangle(e2, e3, e5);
+    // Quad
+    mesh.createQuad(e1, e2, e3, e4);
+
+    // Check the Mesh
+    BOOST_TEST(mesh.vertices().size() == 4);
+    BOOST_TEST(mesh.edges().size() == 5);
+    BOOST_TEST(mesh.triangles().size() == 2);
+    BOOST_TEST(mesh.quads().size() == 1);
+  }
+
+  Mesh mesh;
+
+  const int vertex_cnt = 4;
+  const int edge_cnt = 5;
+  const int triangle_cnt = 2;
+  const int quad_cnt = 1;
+  const int primitive_cnt = 4+5+2+1;
+};
+
 BOOST_AUTO_TEST_CASE(Query_2D)
 {
   PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false));
   mesh->createVertex(Eigen::Vector2d(0, 0));
   mesh->createVertex(Eigen::Vector2d(0, 1));
-  mesh->createVertex(Eigen::Vector2d(1, 0));
-  mesh->createVertex(Eigen::Vector2d(1, 1));
+  auto& v1 = mesh->createVertex(Eigen::Vector2d(1, 0));
+  auto& v2 = mesh->createVertex(Eigen::Vector2d(1, 1));
+  mesh->createEdge(v1, v2);
   
-  auto tree = rtree::getVertexRTree(mesh);
+  {
+    auto tree = rtree::getVertexRTree(mesh);
 
-  BOOST_TEST(tree->size() == 4);
+    BOOST_TEST(tree->size() == 4);
 
-  Eigen::VectorXd searchVector(Eigen::Vector2d(0.2, 0.8));
-  std::vector<size_t> results;
+    Eigen::VectorXd searchVector(Eigen::Vector2d(0.2, 0.8));
+    std::vector<size_t> results;
 
-  tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
+    tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
 
-  BOOST_TEST(results.size() == 1);
-  BOOST_TEST( mesh->vertices()[results[0]].getCoords() == Eigen::Vector2d(0, 1) );
+    BOOST_TEST(results.size() == 1);
+    BOOST_TEST( mesh->vertices()[results[0]].getCoords() == Eigen::Vector2d(0, 1) );
+  }
+
+  {
+    auto tree = rtree::getPrimitiveRTree(mesh);
+
+    BOOST_TEST(tree->size() == 5);
+
+    Eigen::VectorXd searchVector(Eigen::Vector2d(0.2, 0.8));
+    std::vector<PrimitiveRTree::value_type> results;
+
+    tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
+
+    BOOST_TEST(results.size() == 1);
+    auto pi = results.front().second;
+    BOOST_TEST(pi.type == Primitive::Vertex);
+    BOOST_TEST(pi.index < mesh->vertices().size());
+    BOOST_TEST(mesh->vertices()[pi.index].getCoords() == Eigen::Vector2d(0, 1) );
+  }
 }
 
 BOOST_AUTO_TEST_CASE(Query_3D)
@@ -129,20 +184,57 @@ BOOST_AUTO_TEST_CASE(Query_3D)
   mesh->createVertex(Eigen::Vector3d(0, 1, 1));
   mesh->createVertex(Eigen::Vector3d(1, 0, 0));
   mesh->createVertex(Eigen::Vector3d(1, 0, 1));
-  mesh->createVertex(Eigen::Vector3d(1, 1, 0));
-  mesh->createVertex(Eigen::Vector3d(1, 1, 1));
+  auto& v1 = mesh->createVertex(Eigen::Vector3d(1, 1, 0));
+  auto& v2 = mesh->createVertex(Eigen::Vector3d(1, 1, 1));
+  mesh->createEdge(v1, v2);
 
-  auto tree = rtree::getVertexRTree(mesh);
+  {
+    auto tree = rtree::getVertexRTree(mesh);
 
-  BOOST_TEST(tree->size() == 8);
+    BOOST_TEST(tree->size() == 8);
 
-  Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 0.0, 0.8));
-  std::vector<size_t> results;
+    Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 0.0, 0.8));
+    std::vector<size_t> results;
 
-  tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
+    tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
 
-  BOOST_TEST(results.size() == 1);
-  BOOST_TEST( mesh->vertices()[results[0]].getCoords() == Eigen::Vector3d(1, 0, 1) );
+    BOOST_TEST(results.size() == 1);
+    BOOST_TEST( mesh->vertices()[results[0]].getCoords() == Eigen::Vector3d(1, 0, 1) );
+  }
+
+  {
+    auto tree = rtree::getPrimitiveRTree(mesh);
+
+    BOOST_TEST(tree->size() == 9);
+
+    Eigen::VectorXd searchVector(Eigen::Vector3d(1.8, 0.0, 0.8));
+    std::vector<PrimitiveRTree::value_type> results;
+
+    tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
+
+    BOOST_TEST(results.size() == 1);
+    auto pi = results.front().second;
+    BOOST_TEST(pi.type == Primitive::Vertex);
+    BOOST_TEST(pi.index < mesh->vertices().size());
+    BOOST_TEST(mesh->vertices()[pi.index].getCoords() == Eigen::Vector3d(1, 0, 1) );
+  }
+
+  {
+    auto tree = rtree::getPrimitiveRTree(mesh);
+
+    BOOST_TEST(tree->size() == 9);
+
+    Eigen::VectorXd searchVector((v1.getCoords()+v2.getCoords())/2);
+    searchVector += Eigen::Vector3d(0.001, -0.03, 0.005); // "noise"
+    std::vector<PrimitiveRTree::value_type> results;
+
+    tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
+
+    BOOST_TEST(results.size() == 1);
+    auto pi = results.front().second;
+    BOOST_TEST(pi.type == Primitive::Edge);
+    BOOST_TEST(pi.index == 0);
+  }
 }
 
 /// Resembles how boost geometry is used inside the PetRBF
@@ -212,17 +304,69 @@ BOOST_AUTO_TEST_CASE(CacheClearing)
 {
   PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false));
   mesh->createVertex(Eigen::Vector2d(0, 0));
+
   
-  auto tree1 = rtree::getVertexRTree(mesh);
+  // The Cache should clear whenever a mesh changes
+  auto vTree1 = rtree::getVertexRTree(mesh);
+  auto pTree1 = rtree::getPrimitiveRTree(mesh);
   BOOST_TEST(rtree::trees.size() == 1);
+  BOOST_TEST(rtree::_primitive_trees.size() == 1);
   mesh->meshChanged(*mesh); // Emit signal, that mesh has changed
   BOOST_TEST(rtree::trees.size() == 0);
-  
-  auto tree2 = rtree::getVertexRTree(mesh);
+  BOOST_TEST(rtree::_primitive_trees.size() == 0);
+
+  // The Cache should clear whenever we destroy the Mesh
+  auto vTree2 = rtree::getVertexRTree(mesh);
+  auto pTree2 = rtree::getPrimitiveRTree(mesh);
   BOOST_TEST(rtree::trees.size() == 1);
+  BOOST_TEST(rtree::_primitive_trees.size() == 1);
   mesh.reset(); // Destroy mesh object, signal is emitted to clear cache
   BOOST_TEST(rtree::trees.size() == 0);
-  
+  BOOST_TEST(rtree::_primitive_trees.size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(PrimitveIndexComparison) {
+  PrimitiveIndex a{Primitive::Vertex, 2lu};
+  PrimitiveIndex b{Primitive::Vertex, 2lu};
+  PrimitiveIndex c{Primitive::Edge, 2lu};
+  PrimitiveIndex d{Primitive::Edge, 0lu};
+
+  BOOST_TEST(a == b);
+  BOOST_TEST(a != c);
+  BOOST_TEST(b != c);
+  BOOST_TEST(c != d);
+}
+
+BOOST_FIXTURE_TEST_CASE(IndexSinglePrimitiveType, MeshFixture) {
+  PrimitiveRTree rtree;
+  AABBGenerator gen{mesh};
+
+  BOOST_TEST(rtree.empty());
+  indexPrimitive(rtree, gen, mesh.vertices());
+  BOOST_TEST(rtree.size() == vertex_cnt);
+  indexPrimitive(rtree, gen, mesh.edges());
+  BOOST_TEST(rtree.size() == vertex_cnt+edge_cnt);
+  indexPrimitive(rtree, gen, mesh.triangles());
+  BOOST_TEST(rtree.size() == vertex_cnt+edge_cnt+triangle_cnt);
+  indexPrimitive(rtree, gen, mesh.quads());
+  BOOST_TEST(rtree.size() == primitive_cnt);
+}
+
+BOOST_FIXTURE_TEST_CASE(IndexMesh, MeshFixture) {
+  auto tree = indexMesh(mesh);
+  BOOST_TEST(tree.size() == primitive_cnt);
+}
+
+BOOST_FIXTURE_TEST_CASE(CacheFunctionality, MeshFixture) {
+    PtrMesh ptr{&mesh, [](Mesh*){}}; // Use an empty deleter to prevent double-free
+
+    auto vt1 = rtree::getVertexRTree(ptr);
+    auto vt2 = rtree::getVertexRTree(ptr);
+    BOOST_TEST(vt1 == vt2);
+
+    auto pt1 = rtree::getPrimitiveRTree(ptr);
+    auto pt2 = rtree::getPrimitiveRTree(ptr);
+    BOOST_TEST(pt1 == pt2);
 }
 
 


### PR DESCRIPTION
This PR adds the `PrimitiveRTree` to `precice::mesh::rtree`.

It can be generated using `precice::mesh::rtree::getPrimitiveRTree()` and gets cached just like the `rtree:VertexRTree`.

It is a bit more verbose than the VertexRTree as it needs to index Vertex, Edge, Triangle and Quad at the same time.
For each primitive, it needs to generate an axis-aligned bounding box (AABB) as an Indexable and a `PrimitiveIndex` as Value.
The struct `PrimitiveIndex` contains the index and type of the primitive as an enum for latter lookup.

The functor-like class `AABBGenerator` (parameterised with a `Mesh`) can generate an `AABB` for a given primitive.

This PR is a fragment of #156