### PR TITLE
Migrate stacktrace to boost::stacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. For future 
 - Actions can now specify a `MeshRequirement`, such as the `ScaleByAreaAction`.
 - Many events have been reworked and are now uniformly named. 
 - There is a `syncMode` for events (for detailed performance measurements), configurable and off by default. 
+- Use boost stacktrace for cross platform stacktrace printing. This requires Boost 1.65
 
 ## 1.2.0
 - Make `polynomial=separate` the default setting for PetRBF.

--- a/SConstruct
+++ b/SConstruct
@@ -228,6 +228,7 @@ checkAdd("boost_unit_test_framework")
 checkAdd(header = 'boost/vmd/is_empty.hpp', usage = 'Boost Variadic Macro Data Library')
 checkAdd(header = 'boost/geometry.hpp', usage = 'Boost Geometry Library')
 checkAdd(header = 'boost/signals2.hpp', usage = 'Boost Signals2')
+checkAdd(lib = 'dl', usage = 'Boost Stacktrace Requirement')
 
 # ====== MPI ======
 if env["mpi"]:

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -6,6 +6,7 @@
 #include "mesh/Quad.hpp"
 #include "Constants.hpp"
 #include <Eigen/Core>
+#include <iomanip>
 #include <iostream>
 #include <fstream>
 #include <boost/filesystem.hpp>

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -1,4 +1,5 @@
 #include "PointToPointCommunication.hpp"
+#include <iomanip>
 #include <vector>
 #include <thread>
 #include "com/Communication.hpp"

--- a/src/utils/stacktrace.cpp
+++ b/src/utils/stacktrace.cpp
@@ -1,0 +1,10 @@
+#include <boost/stacktrace.hpp>
+#include <sstream>
+#include <string>
+
+std::string getStacktrace()
+{
+  std::ostringstream strm;
+  strm << boost::stacktrace::stacktrace();
+  return strm.str();
+}

--- a/src/utils/stacktrace.hpp
+++ b/src/utils/stacktrace.hpp
@@ -1,62 +1,6 @@
 #pragma once
 
-#include <execinfo.h>	// for backtrace
-#include <cxxabi.h>	// for __cxa_demangle
-
 #include <string>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
 
-/// Prints a demangled stack backtrace of the caller function
-static inline std::string getStacktrace()
-{
-  std::ostringstream strm;
-  const int max_frames = 100;
-  strm << "Stack Trace:" << std::endl;
-
-  // Storage array for stack trace address data
-  void* addrlist[max_frames+1];
-
-  // Retrieve current stack addresses
-  int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
-
-  if (addrlen == 0) {
-    strm << "  <empty, possibly corrupt>" << std::endl;
-    return strm.str();
-  }
-
-  // Resolve addresses into strings containing "filename(function+address)", this array must be free()-ed
-  char** symbollist = backtrace_symbols(addrlist, addrlen);
-
-  // Allocate string which will be filled with the demangled function name
-  size_t funcnamesize = 256;
-  char* funcname = new char[funcnamesize];
-  
-  // Iterate over the returned symbol lines. skip the first, it is the address of this function.
-  for (int i = 1; i < addrlen; i++) {
-    std::string strSymbols(symbollist[i]);
-    auto op = strSymbols.find("(");
-    auto cp = strSymbols.find(")");
-    auto plus = strSymbols.find("+");
-    std::string strSymbol = strSymbols.substr(op+1, plus-op-1);
-    std::string strOffset = strSymbols.substr(plus+1, cp-plus-1);
-
-    int status;
-    char* ret = abi::__cxa_demangle(strSymbol.c_str(), funcname, &funcnamesize, &status);
-    strm << "  (" << std::setw(2) << addrlen-i << ")";
-    if (status == 0) {
-      funcname = ret; // Use possibly realloc()-ed string
-      strm << "  " << strSymbols.substr(0, op) << " : " << funcname << "+" << strOffset <<  std::endl;
-    }
-    else {
-      // Demangling failed. Output function name as a C function with no arguments.
-      strm << "  " << strSymbols.substr(0, op) << " : " << strSymbol << "()+" << strOffset <<  std::endl;
-    }
-  }
-
-  delete[] funcname;
-  free(symbollist);
-  
-  return strm.str();
-}
+/// Returns a demangled stack backtrace of the caller function
+std::string getStacktrace();


### PR DESCRIPTION
Migrates `utils/stacktrace.hpp` to `boost::stacktrace`.
I moved the implementation to a separate cpp to decouple the compile time overhead of the boost header from the widely used assertion header.

I had to fix missing `<iomanip>`includes in other headers.

Fixes #201 

### TODO

* [ ] Add stacktrace to [wiki](https://github.com/precice/precice/wiki/Dependencies#boost)