### PR TITLE
Change main references to namespaces and fix inconsistencies

### DIFF
--- a/docs/documents/000_main.dox
+++ b/docs/documents/000_main.dox
@@ -5,26 +5,27 @@
 The directory $src$ contains the sources of preCICE. The library API of preCICE
 is contained in the directory $precice$, which brings together the functionalities
 contained in the other components of preCICE. Every component has its own
-directory, and the following components exist currently:
+directory and namespace.
+The following components currently exist:
 
-- \ref src/action "action" -- Actions that can be executed to modify the exchanged data, can be written in Python.
-- \ref src/com "com" defines a data communication abstraction layer and implementations.
-- \ref src/cplscheme "cplscheme" takes coupling data and communication objects and implements coupling schemes for coupled simulations.
-- \ref src/drivers "drivers "holds the main function for building the ```binprecice``` executable.
-- \ref src/io "io" implements import and export of the coupling mesh and data.
-- \ref src/logging "logging" Contains the code for the logging framework, based on boost logging.
-- \ref src/m2n "m2n" define the logical part of the parallel communication between participants
-- \ref src/mesh "mesh" holds the coupling mesh and coupling data classes, which form the base of all other components.
-- \ref src/math "math" -- General mathematical constants and functions.
-- \ref src/mapping "mapping" defines data mapping from points to meshes by using geometrical queries.
-- \ref src/partition "partition" computes the partitioning of distributed meshes at initialization.  
-- \ref src/query "query" holds classes to perform geometrical queries on geometries.
-- \ref src/testing "testing" holds the code that configure the boost testing framework and the main function for the testprecice executable.
-- \ref src/utils "utils" contains functionality serving as technical basis for all other components.
-- \ref src/xml "xml" -- The XML configuration parser.
+- \ref precice::action "action" contains actions that can be executed to modify the exchanged data, can be written in Python.
+- \ref precice::com "com" defines a data communication abstraction layer and implementations.
+- \ref precice::cplscheme "cplscheme" takes coupling data and communication objects and implements coupling schemes for coupled simulations.
+- \ref src/drivers "drivers" holds the main function for building the ```binprecice``` executable.
+- \ref precice::io "io" implements import and export of the coupling mesh and data.
+- \ref precice::logging "logging" contains the code for the logging framework, based on boost logging.
+- \ref precice::m2n "m2n" defines the logical part of the parallel communication between participants.
+- \ref precice::mesh "mesh" holds the coupling mesh and coupling data classes, which form the base of all other components.
+- \ref precice::math "math" provides general mathematical constants and functions.
+- \ref precice::mapping "mapping" defines data mapping from points to meshes by using geometrical queries.
+- \ref precice::partition "partition" computes the partitioning of distributed meshes at initialization.
+- \ref precice::query "query" holds classes to perform geometrical queries on geometries.
+- \ref precice::testing "testing" holds the code that configure the boost testing framework and the main function for the testprecice executable.
+- \ref precice::utils "utils" contains functionality serving as technical basis for all other components.
+- \ref precice::xml "xml" contains the XML configuration parser.
 
 
-The components of preCICE have some common subdirectory structure. Some typical directories appearing are ```tests```, ```config```, and ```impl```.
+The components of preCICE have some common subdirectory/namespace structure. Some typical directories appearing are ```tests```, ```config```, and ```impl```.
 - ```tests``` holds classes for automated testing of the corresponding component.
 - ```config``` provides functionality to configure the classes of a component from xml files.
 - ```impl``` contains implementation of a component which is not part of its interface and used only internally.


### PR DESCRIPTION
* Fix inconsistent style in list
* Add mention that folder is consistent with namespace structure
* Links now redirect to the namespace instead of the folder.
  Exception is the link to `src/drivers`.
  Rational: The namespace view provides more information about the _what_ instead of the _where_.