### PR TITLE
Add CMake policy information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required (VERSION 3.5)
 
 project(preCICE VERSION 1.3.0 LANGUAGES CXX)
 
+# CMake Policies
+
+# CMP0074: find_package() uses <PackageName>_ROOT variables.
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+# CMP0075 Include file check macros honor CMAKE_REQUIRED_LIBRARIES
+if(POLICY CMP0075)
+    cmake_policy(SET CMP0075 NEW)
+endif()
+
+
 list (APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/tools/cmake-modules")
 
 set (CMAKE_CXX_STANDARD 11)

--- a/tools/cmake-modules/FindEigen3.cmake
+++ b/tools/cmake-modules/FindEigen3.cmake
@@ -17,8 +17,15 @@
 # This module reads hints about search locations from 
 # the following environment variables:
 #
+# Eigen3_ROOT
 # EIGEN3_ROOT
 # EIGEN3_ROOT_DIR
+#
+# This module reads reads further hints about search locations from 
+# the following CMake variables:
+#
+# Eigen3_ROOT
+#
 
 # Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
 # Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
@@ -79,6 +86,8 @@ else (EIGEN3_INCLUDE_DIR)
   if(NOT EIGEN3_INCLUDE_DIR)
     find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
         HINTS
+        ${Eigen3_ROOT}
+        ENV Eigen3_ROOT 
         ENV EIGEN3_ROOT 
         ENV EIGEN3_ROOT_DIR
         PATHS


### PR DESCRIPTION
Fixes warning regarding unset policies:
* [CMP0074](https://cmake.org/cmake/help/latest/policy/CMP0074.html)
* [CMP0075](https://cmake.org/cmake/help/latest/policy/CMP0075.html)

Further extends the FindEigen3 to support CMP0074. [PR Eigen3 Repo](https://bitbucket.org/eigen/eigen/pull-requests/552/add-findeigen3-support-for-policy-cmp0074/diff)

Fixes #206 