### PR TITLE
Rewrite Handle Iterators

### DIFF
--- a/src/precice/MeshHandle.cpp
+++ b/src/precice/MeshHandle.cpp
@@ -25,7 +25,8 @@ namespace precice {
 
 // VertexIterator
 
-VertexIterator:: VertexIterator(){}
+VertexIterator::VertexIterator() = default;
+VertexIterator::~VertexIterator() = default;
 
 VertexIterator:: VertexIterator
 (
@@ -100,6 +101,16 @@ int VertexIterator:: vertexID() const
   return (*_impl->iterator).getID();
 }
 
+void VertexIterator::swap(VertexIterator& other) noexcept
+{
+    std::swap(_impl, other._impl);
+}
+
+void swap(VertexIterator& lhs, VertexIterator& rhs) noexcept
+{
+    lhs.swap(rhs);
+}
+
 // VertexHandle
 
 VertexHandle:: VertexHandle
@@ -126,7 +137,9 @@ std::size_t VertexHandle:: size() const
 
 // EdgeIterator
 
-EdgeIterator:: EdgeIterator(){}
+EdgeIterator::EdgeIterator() = default;
+
+EdgeIterator::~EdgeIterator() = default;
 
 EdgeIterator:: EdgeIterator
 (
@@ -198,6 +211,16 @@ int EdgeIterator:: vertexID(int vertexIndex) const
   return (*_impl->iterator).vertex(vertexIndex).getID();
 }
 
+void EdgeIterator::swap(EdgeIterator& other) noexcept
+{
+    std::swap(_impl, other._impl);
+}
+
+void swap(EdgeIterator& lhs, EdgeIterator& rhs) noexcept
+{
+    lhs.swap(rhs);
+}
+
 // EdgeHandle
 
 EdgeHandle:: EdgeHandle
@@ -224,7 +247,9 @@ std::size_t EdgeHandle:: size () const
 
 // TriangleIterator
 
-TriangleIterator:: TriangleIterator(){}
+TriangleIterator::TriangleIterator() = default;
+
+TriangleIterator::~TriangleIterator() = default;
 
 TriangleIterator:: TriangleIterator
 (
@@ -294,6 +319,16 @@ const double* TriangleIterator:: vertexCoords ( int vertexIndex ) const
 int TriangleIterator:: vertexID ( int vertexIndex ) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getID();
+}
+
+void TriangleIterator::swap(TriangleIterator& other) noexcept
+{
+    std::swap(_impl, other._impl);
+}
+
+void swap(TriangleIterator& lhs, TriangleIterator& rhs) noexcept
+{
+    lhs.swap(rhs);
 }
 
 // TriangleHandle

--- a/src/precice/MeshHandle.cpp
+++ b/src/precice/MeshHandle.cpp
@@ -9,108 +9,98 @@ namespace precice {
 
     struct VertexIteratorImplementation {
       mesh::Group::VertexContainer::const_iterator iterator;
-      //double coords[];
-      //int dimensions;
     };
 
     struct EdgeIteratorImplementation {
       mesh::Group::EdgeContainer::const_iterator iterator;
-      //double coords[];
-      //int dimensions;
     };
 
     struct TriangleIteratorImplementation {
       mesh::Group::TriangleContainer::const_iterator iterator;
-      //double coords[];
-      //int dimensions;
     };
   }
 }
 
 namespace precice {
 
+// VertexIterator
+
+VertexIterator:: VertexIterator(){}
+
 VertexIterator:: VertexIterator
 (
   const mesh::Group& content,
   bool               begin )
-:
-  _impl (new impl::VertexIteratorImplementation())
 {
   if ( begin ) {
-    _impl->iterator = content.vertices().begin();
+    _impl= std::unique_ptr<Impl>(new Impl{content.vertices().begin()});
   }
   else  {
-    _impl->iterator = content.vertices().end();
+    _impl= std::unique_ptr<Impl>(new Impl{content.vertices().end()});
   }
-  //_impl->dimensions = content.getDimensions();
 }
 
 VertexIterator:: VertexIterator
 (
   const VertexIterator& toCopy )
-:
-  _impl ( new impl::VertexIteratorImplementation(*toCopy._impl) )
-{}
+{
+    VertexIterator cpy;
+    if (toCopy._impl) {
+        cpy._impl = std::unique_ptr<Impl>(new Impl{toCopy._impl->iterator});
+    }
+    using std::swap;
+    swap(*this, cpy);
+}
 
 VertexIterator & VertexIterator:: operator=
 (
   const VertexIterator& toAssign )
 {
-  _impl->iterator = toAssign._impl->iterator;
-//  assertion ( _impl->dimensions == toAssign._impl->dimensions,
-//               _impl->dimensions, toAssign._impl->dimensions );
-//  for ( int dim=0; dim < _impl->dimensions; dim++ ){
-//    _impl->coords[dim] = toAssign._impl->coords[dim];
-//  }
-  return *this;
+    VertexIterator cpy(toAssign);
+    using std::swap;
+    swap(*this, cpy);
+    return *this;
 }
 
-VertexIterator:: ~VertexIterator()
+VertexIterator VertexIterator:: operator++(int unused)
 {
-  assertion ( _impl != nullptr );
-  delete _impl;
-}
-
-VertexIterator& VertexIterator:: operator++(int unused)
-{
-  auto &result = *this;
-  _impl->iterator++;
-  return result;
+  VertexIterator cpy(*this);
+  this->operator++();
+  return cpy;
 }
 
 VertexIterator& VertexIterator::operator++()
 {
-  _impl->iterator++;
+  _impl->iterator.operator++();
   return *this;
 }
 
-VertexIterator& VertexIterator::operator*()
+const VertexIterator VertexIterator::operator*() const
 {
   return *this;
 }
 
-
-const double* VertexIterator:: vertexCoords()
+bool VertexIterator::operator==(const VertexIterator& other) const
 {
-//  for ( int dim=0; dim < _impl->dimensions; dim++ ){
-//    _impl->coords[dim] = (*_impl->iterator).getCoords()[dim];
-//  }
-//  return _impl->coords;
+  return _impl->iterator == other._impl->iterator;
+}
+
+bool VertexIterator::operator!=(const VertexIterator& other) const
+{
+  return !((*this) == other);
+}
+
+const double* VertexIterator:: vertexCoords() const
+{
   return (*_impl->iterator).getCoords().data();
 }
 
-int VertexIterator:: vertexID()
+int VertexIterator:: vertexID() const
 {
   return (*_impl->iterator).getID();
 }
 
-bool VertexIterator:: operator!=
-(
-  const VertexIterator& vertexIterator )
-{
-  return _impl->iterator != vertexIterator._impl->iterator;
-}
-
+// VertexHandle
 
 VertexHandle:: VertexHandle
 (
@@ -134,55 +124,81 @@ std::size_t VertexHandle:: size() const
   return _content.vertices().size();
 }
 
+// EdgeIterator
+
+EdgeIterator:: EdgeIterator(){}
 
 EdgeIterator:: EdgeIterator
 (
   const mesh::Group& content,
   bool               begin )
-:
-  _impl (new impl::EdgeIteratorImplementation())
 {
   if ( begin ) {
-    _impl->iterator = content.edges().begin();
+    _impl=std::unique_ptr<Impl>(new Impl{content.edges().begin()});
   }
   else  {
-    _impl->iterator = content.edges().end();
+    _impl=std::unique_ptr<Impl>(new Impl{content.edges().end()});
   }
 }
 
-EdgeIterator:: ~EdgeIterator()
+EdgeIterator:: EdgeIterator(const EdgeIterator& toCopy)
 {
-  assertion ( _impl != nullptr );
-  delete _impl;
+    EdgeIterator cpy;
+    if (toCopy._impl) {
+        cpy._impl = std::unique_ptr<Impl>(new Impl{toCopy._impl->iterator});
+    }
+    using std::swap;
+    swap(*this, cpy);
 }
 
-EdgeIterator& EdgeIterator:: operator++(int)
+EdgeIterator & EdgeIterator:: operator=(const EdgeIterator& other)
 {
-  _impl->iterator++;
+    EdgeIterator cpy(other);
+    using std::swap;
+    swap(*this, cpy);
+    return *this;
+}
+
+EdgeIterator EdgeIterator:: operator++(int unused)
+{
+  EdgeIterator cpy(*this);
+  this->operator++();
+  return cpy;
+}
+
+EdgeIterator& EdgeIterator::operator++()
+{
+  _impl->iterator.operator++();
   return *this;
 }
 
-const double* EdgeIterator:: vertexCoords
-(
-  int vertexIndex )
+const EdgeIterator EdgeIterator::operator*() const
+{
+  return *this;
+}
+
+bool EdgeIterator::operator==(const EdgeIterator& other) const
+{
+  return _impl->iterator == other._impl->iterator;
+}
+
+bool EdgeIterator::operator!=(const EdgeIterator& other) const
+{
+  return !((*this) == other);
+}
+
+
+const double* EdgeIterator:: vertexCoords(int vertexIndex) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getCoords().data();
 }
 
-int EdgeIterator:: vertexID
-(
-  int vertexIndex )
+int EdgeIterator:: vertexID(int vertexIndex) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getID();
 }
 
-bool EdgeIterator:: operator!=
-(
-  const EdgeIterator & edgeIterator )
-{
-  return _impl->iterator != edgeIterator._impl->iterator;
-}
-
+// EdgeHandle
 
 EdgeHandle:: EdgeHandle
 (
@@ -206,54 +222,81 @@ std::size_t EdgeHandle:: size () const
   return _content.edges().size();
 }
 
+// TriangleIterator
+
+TriangleIterator:: TriangleIterator(){}
 
 TriangleIterator:: TriangleIterator
 (
-  const mesh::Group & content,
-  bool                begin )
-:
-  _impl (new impl::TriangleIteratorImplementation())
+  const mesh::Group& content,
+  bool               begin )
 {
   if ( begin ) {
-    _impl->iterator = content.triangles().begin();
+    _impl=std::unique_ptr<Impl>(new Impl{content.triangles().begin()});
   }
   else  {
-    _impl->iterator = content.triangles().end();
+    _impl=std::unique_ptr<Impl>(new Impl{content.triangles().end()});
   }
 }
 
-TriangleIterator:: ~TriangleIterator ()
+TriangleIterator:: TriangleIterator(const TriangleIterator& toCopy)
 {
-  assertion ( _impl != nullptr );
-  delete _impl;
+    TriangleIterator cpy;
+    if (toCopy._impl) {
+        cpy._impl = std::unique_ptr<Impl>(new Impl{toCopy._impl->iterator});
+    }
+    using std::swap;
+    swap(*this, cpy);
 }
 
-TriangleIterator & TriangleIterator:: operator++ (int)
+TriangleIterator & TriangleIterator:: operator=(const TriangleIterator& other)
 {
-  _impl->iterator++;
+    TriangleIterator cpy(other);
+    using std::swap;
+    swap(*this, cpy);
+    return *this;
+}
+
+TriangleIterator TriangleIterator:: operator++(int unused)
+{
+  TriangleIterator cpy(*this);
+  this->operator++();
+  return cpy;
+}
+
+TriangleIterator& TriangleIterator::operator++()
+{
+  _impl->iterator.operator++();
   return *this;
 }
 
-const double* TriangleIterator:: vertexCoords
-(
-  int vertexIndex )
+const TriangleIterator TriangleIterator::operator*() const
+{
+  return *this;
+}
+
+bool TriangleIterator::operator==(const TriangleIterator& other) const
+{
+  return _impl->iterator == other._impl->iterator;
+}
+
+bool TriangleIterator::operator!= ( const TriangleIterator& other ) const
+{
+  return !((*this) == other);
+}
+
+
+const double* TriangleIterator:: vertexCoords ( int vertexIndex ) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getCoords().data();
 }
 
-int TriangleIterator:: vertexID
-(
-  int vertexIndex )
+int TriangleIterator:: vertexID ( int vertexIndex ) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getID();
 }
 
-bool TriangleIterator:: operator!=
-(
-  const TriangleIterator & triangleIterator )
-{
-  return _impl->iterator != triangleIterator._impl->iterator;
-}
+// TriangleHandle
 
 TriangleHandle:: TriangleHandle
 (
@@ -278,6 +321,8 @@ std::size_t TriangleHandle:: size () const
 {
   return _content.triangles().size();
 }
+
+// MeshHandle
 
 MeshHandle:: MeshHandle
 (

--- a/src/precice/MeshHandle.cpp
+++ b/src/precice/MeshHandle.cpp
@@ -49,8 +49,7 @@ VertexIterator:: VertexIterator
     if (toCopy._impl) {
         cpy._impl = std::unique_ptr<Impl>(new Impl{toCopy._impl->iterator});
     }
-    using std::swap;
-    swap(*this, cpy);
+    std::swap(*this, cpy);
 }
 
 VertexIterator & VertexIterator:: operator=
@@ -58,8 +57,7 @@ VertexIterator & VertexIterator:: operator=
   const VertexIterator& toAssign )
 {
     VertexIterator cpy(toAssign);
-    using std::swap;
-    swap(*this, cpy);
+    std::swap(*this, cpy);
     return *this;
 }
 
@@ -160,15 +158,13 @@ EdgeIterator:: EdgeIterator(const EdgeIterator& toCopy)
     if (toCopy._impl) {
         cpy._impl = std::unique_ptr<Impl>(new Impl{toCopy._impl->iterator});
     }
-    using std::swap;
-    swap(*this, cpy);
+    std::swap(*this, cpy);
 }
 
 EdgeIterator & EdgeIterator:: operator=(const EdgeIterator& other)
 {
     EdgeIterator cpy(other);
-    using std::swap;
-    swap(*this, cpy);
+    std::swap(*this, cpy);
     return *this;
 }
 
@@ -270,15 +266,13 @@ TriangleIterator:: TriangleIterator(const TriangleIterator& toCopy)
     if (toCopy._impl) {
         cpy._impl = std::unique_ptr<Impl>(new Impl{toCopy._impl->iterator});
     }
-    using std::swap;
-    swap(*this, cpy);
+    std::swap(*this, cpy);
 }
 
 TriangleIterator & TriangleIterator:: operator=(const TriangleIterator& other)
 {
     TriangleIterator cpy(other);
-    using std::swap;
-    swap(*this, cpy);
+    std::swap(*this, cpy);
     return *this;
 }
 

--- a/src/precice/MeshHandle.hpp
+++ b/src/precice/MeshHandle.hpp
@@ -75,7 +75,7 @@ class VertexHandle
 {
 public:
 
-  typedef VertexIterator const_iterator;
+  using const_iterator = VertexIterator;
 
   /// Constructor, reference to mesh object holding vertices required.
   VertexHandle ( const mesh::Group& content );
@@ -146,8 +146,7 @@ class EdgeHandle
 {
 public:
 
-   // @brief Necessary to be used by boost::foreach.
-   typedef EdgeIterator const_iterator;
+  using const_iterator = EdgeIterator;
 
    /**
     * @brief Constructor, reference to mesh object holding edges required.
@@ -223,7 +222,7 @@ class TriangleHandle
 {
 public:
 
-   typedef TriangleIterator const_iterator;
+  using const_iterator = TriangleIterator;
 
    /**
     * @brief Constructor, reference to mesh object holding triangles required.
@@ -244,7 +243,7 @@ public:
 
 private:
 
-   // @brief Mesh instance holding triangles.
+   /// Mesh instance holding triangles.
    const mesh::Group& _content;
 };
 
@@ -270,7 +269,7 @@ public:
    /**
     * @brief Standard constructor, not meant to be used by a solver.
     *
-    * @param mesh [IN] The mesh representing the geometry.
+    * @param[in] mesh The mesh representing the geometry.
     */
    MeshHandle ( const mesh::Group& content );
 
@@ -291,13 +290,13 @@ public:
 
 private:
 
-   // @brief Handle for vertices.
+   /// Handle for vertices.
    VertexHandle _vertexHandle;
 
-   // @brief Handle for edges.
+   /// Handle for edges.
    EdgeHandle _edgeHandle;
 
-   // @brief Handle for triangles.
+   /// Handle for triangles.
    TriangleHandle _triangleHandle;
 };
 

--- a/src/precice/MeshHandle.hpp
+++ b/src/precice/MeshHandle.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 #include <cstddef>
+#include <iterator>
+#include <memory>
 
 namespace precice {
   namespace mesh {
@@ -25,34 +27,41 @@ namespace precice {
 class VertexIterator
 {
 public:
+  using value_type        = VertexIterator;
+  using reference         = VertexIterator &;
+  using pointer           = VertexIterator *;
+  using difference_type   = std::size_t;
+  using iterator_category = std::forward_iterator_tag;
+
+  VertexIterator();
 
   VertexIterator (
     const mesh::Group& content,
     bool               begin );
 
-  VertexIterator ( const VertexIterator& toCopy );
+  VertexIterator ( const VertexIterator& other );
 
-  VertexIterator& operator= ( const VertexIterator& toAssign );
-
-  ~VertexIterator();
+  VertexIterator& operator= ( const VertexIterator& other );
 
   /// Postfix operator
-  VertexIterator& operator++(int unused);
+  VertexIterator operator++(int unused);
 
   /// Prefix operator
   VertexIterator& operator++();
 
-  VertexIterator& operator*();
+  const VertexIterator operator*() const;
 
-  int vertexID();
+  int vertexID() const;
 
-  const double* vertexCoords();
+  const double* vertexCoords() const;
 
-  bool operator!= ( const VertexIterator& vertexIterator );
+  bool operator== ( const VertexIterator& other ) const;
+
+  bool operator!= ( const VertexIterator& other ) const;
 
 private:
-
-  impl::VertexIteratorImplementation* _impl;
+  using Impl = impl::VertexIteratorImplementation;
+  std::unique_ptr<Impl> _impl;
 };
 
 /// Offers methods begin() and end() to iterate over all vertices.
@@ -82,24 +91,40 @@ private:
 class EdgeIterator
 {
 public:
+  using value_type        = EdgeIterator;
+  using reference         = EdgeIterator &;
+  using pointer           = EdgeIterator *;
+  using difference_type   = std::size_t;
+  using iterator_category = std::forward_iterator_tag;
+
+  EdgeIterator ();
 
   EdgeIterator (
     const mesh::Group& mesh,
     bool              begin );
 
-  ~EdgeIterator();
 
-  EdgeIterator& operator++(int);
+  EdgeIterator (const EdgeIterator& other);
 
-  const double* vertexCoords ( int vertexIndex );
+  EdgeIterator& operator=(const EdgeIterator& other);
 
-  int vertexID ( int vertexIndex );
+  EdgeIterator operator++(int);
 
-  bool operator!= ( const EdgeIterator& edgeIterator );
+  EdgeIterator& operator++();
+
+  const EdgeIterator operator*() const;
+
+  const double* vertexCoords ( int vertexIndex ) const;
+
+  int vertexID ( int vertexIndex ) const;
+
+  bool operator== ( const EdgeIterator& other ) const;
+
+  bool operator!= ( const EdgeIterator& other ) const;
 
 private:
-
-  impl::EdgeIteratorImplementation* _impl;
+  using Impl = impl::EdgeIteratorImplementation;
+  std::unique_ptr<Impl> _impl;
 };
 
 /**
@@ -138,24 +163,39 @@ private:
 class TriangleIterator
 {
 public:
+  using value_type        = TriangleIterator;
+  using reference         = TriangleIterator &;
+  using pointer           = TriangleIterator *;
+  using difference_type   = std::size_t;
+  using iterator_category = std::forward_iterator_tag;
+
+  TriangleIterator();
 
   TriangleIterator (
     const mesh::Group& content,
     bool               begin );
 
-  ~TriangleIterator();
+  TriangleIterator (const TriangleIterator& other);
 
-  TriangleIterator& operator++(int);
+  TriangleIterator& operator=(const TriangleIterator& other);
 
-  const double* vertexCoords ( int vertexIndex );
+  TriangleIterator operator++(int);
 
-  int vertexID ( int vertexIndex );
+  TriangleIterator& operator++();
 
-  bool operator!= ( const TriangleIterator& triangleIterator );
+  const TriangleIterator operator*() const;
+
+  const double* vertexCoords ( int vertexIndex ) const;
+
+  int vertexID ( int vertexIndex ) const;
+
+  bool operator== ( const TriangleIterator& other ) const;
+
+  bool operator!= ( const TriangleIterator& other ) const;
 
 private:
-
-  impl::TriangleIteratorImplementation* _impl;
+  using Impl = impl::TriangleIteratorImplementation;
+  std::unique_ptr<Impl> _impl;
 };
 
 /**

--- a/src/precice/MeshHandle.hpp
+++ b/src/precice/MeshHandle.hpp
@@ -35,6 +35,8 @@ public:
 
   VertexIterator();
 
+  ~VertexIterator();
+
   VertexIterator (
     const mesh::Group& content,
     bool               begin );
@@ -59,10 +61,14 @@ public:
 
   bool operator!= ( const VertexIterator& other ) const;
 
+  void swap(VertexIterator& other) noexcept;
+
 private:
   using Impl = impl::VertexIteratorImplementation;
   std::unique_ptr<Impl> _impl;
 };
+
+void swap(VertexIterator& lhs, VertexIterator& rhs) noexcept;
 
 /// Offers methods begin() and end() to iterate over all vertices.
 class VertexHandle
@@ -99,6 +105,8 @@ public:
 
   EdgeIterator ();
 
+  ~EdgeIterator ();
+
   EdgeIterator (
     const mesh::Group& mesh,
     bool              begin );
@@ -122,10 +130,14 @@ public:
 
   bool operator!= ( const EdgeIterator& other ) const;
 
+  void swap(EdgeIterator& other) noexcept;
+
 private:
   using Impl = impl::EdgeIteratorImplementation;
   std::unique_ptr<Impl> _impl;
 };
+
+void swap(EdgeIterator& lhs, EdgeIterator& rhs) noexcept;
 
 /**
  * @brief Offers methods begin() and end() to iterate over all edges.
@@ -171,6 +183,8 @@ public:
 
   TriangleIterator();
 
+  ~TriangleIterator();
+
   TriangleIterator (
     const mesh::Group& content,
     bool               begin );
@@ -193,10 +207,14 @@ public:
 
   bool operator!= ( const TriangleIterator& other ) const;
 
+  void swap(TriangleIterator& other) noexcept;
+
 private:
   using Impl = impl::TriangleIteratorImplementation;
   std::unique_ptr<Impl> _impl;
 };
+
+void swap(TriangleIterator& lhs, TriangleIterator& rhs) noexcept;
 
 /**
  * @brief Offers methods begin() and end() to iterate over all triangles.

--- a/src/precice/tests/MeshHandleTest.cpp
+++ b/src/precice/tests/MeshHandleTest.cpp
@@ -1,0 +1,86 @@
+#include "precice/MeshHandle.hpp"
+#include "testing/Testing.hpp"
+#include "mesh/Mesh.hpp"
+#include <Eigen/Core>
+#include <vector>
+#include <algorithm>
+
+using namespace precice;
+
+struct MeshFixture {
+    MeshFixture() : mesh("MyMesh", 3, false), handle(mesh.content()) {
+        auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+        auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+        auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
+        auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+        // Quad Borders
+        auto & e1 = mesh.createEdge(v1, v2);
+        auto & e2 = mesh.createEdge(v2, v3);
+        auto & e3 = mesh.createEdge(v3, v4);
+        auto & e4 = mesh.createEdge(v4, v1);
+        // Diagonal
+        auto & e5 = mesh.createEdge(v2, v4);
+        // Triangles
+        mesh.createTriangle(e1, e5, e4);
+        mesh.createTriangle(e2, e3, e5);
+        // Quad
+        mesh.createQuad(e1, e2, e3, e4);
+        // Check the Mesh
+        BOOST_TEST(mesh.vertices().size() == 4);
+        BOOST_TEST(mesh.edges().size() == 5);
+        BOOST_TEST(mesh.triangles().size() == 2);
+        BOOST_TEST(mesh.quads().size() == 1);
+    }
+
+    mesh::Mesh mesh;
+    MeshHandle handle;
+    const int vertex_cnt = 4;
+    const int edge_cnt = 5;
+    const int triangle_cnt = 2;
+    const int quad_cnt = 1;
+    const int primitive_cnt = 4+5+2+1;
+};
+
+
+BOOST_FIXTURE_TEST_SUITE(PreciceTests, MeshFixture)
+
+BOOST_AUTO_TEST_CASE(VertexHandle)
+{
+    const auto& vertices = handle.vertices();
+    BOOST_TEST(std::distance(vertices.begin(), vertices.end()) == vertex_cnt);
+    BOOST_TEST(vertices.size() == vertex_cnt);
+    std::set<int> vs;
+    for(const auto & v : vertices) {
+        vs.insert(v.vertexID());
+    }
+    BOOST_TEST(vs.size() == vertex_cnt);
+}
+
+BOOST_AUTO_TEST_CASE(EdgeHandle)
+{
+    const auto& edges = handle.edges();
+    BOOST_TEST(std::distance(edges.begin(), edges.end()) == edge_cnt);
+    BOOST_TEST(edges.size() == edge_cnt);
+    std::set<int> vs;
+    for(const auto & e : handle.edges()) {
+        vs.insert(e.vertexID(0));
+        vs.insert(e.vertexID(1));
+    }
+    BOOST_TEST(vs.size() == vertex_cnt);
+}
+
+BOOST_AUTO_TEST_CASE(TriangleHandle)
+{
+    const auto& triangles = handle.triangles();
+    BOOST_TEST(std::distance(triangles.begin(), triangles.end()) == triangle_cnt);
+    BOOST_TEST(triangles.size() == triangle_cnt);
+    std::set<int> vs;
+    for(const auto & t : handle.triangles()) {
+        vs.insert(t.vertexID(0));
+        vs.insert(t.vertexID(1));
+        vs.insert(t.vertexID(2));
+    }
+    BOOST_TEST(vs.size() == vertex_cnt);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a rewrite of the MeshHandle Iterators. They now fulfil the concept of [ForwardIterator](https://en.cppreference.com/w/cpp/named_req/ForwardIterator).

Closes #80 

## TODO
* [x] Add tests