### PR TITLE
Set the logging level from the boost test logging level (--log_level=...)

### DIFF
--- a/src/logging/LogConfiguration.hpp
+++ b/src/logging/LogConfiguration.hpp
@@ -27,6 +27,9 @@ struct BackendConfiguration
 /// Holds the configuration of the logging system
 using LoggingConfiguration = std::vector<BackendConfiguration>;
 
+/// Reads a log configuration file, returns vector of BackEndConfiguration
+LoggingConfiguration readLogConfFile(std::string const & filename);
+
 /// Configures the logging from a log file
 void setupLogging(std::string const & logConfigFile = "log.conf");
 

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -1,4 +1,5 @@
 #include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_parameters.hpp>
 #include <boost/filesystem.hpp>
 #include "utils/Parallel.hpp"
 #include "utils/Petsc.hpp"
@@ -12,13 +13,59 @@ extern bool syncMode;
 }
 
 
-/// Boost test Initialization function:
+/// Boost test Initialization function
+/**
+Boost Test Log Levels and corresponding command line arguments to --log_level
+as of Boost 1.68:
+
+\code
+type = enum boost::unit_test::log_level : int {
+  boost::unit_test::invalid_log_level = -1,
+  boost::unit_test::log_successful_tests = 0, all
+  boost::unit_test::log_test_units = 1, unit_scope, test_suite
+  boost::unit_test::log_messages = 2, message
+  boost::unit_test::log_warnings = 3, warning
+  boost::unit_test::log_all_errors = 4, error (default log level)
+  boost::unit_test::log_cpp_exception_errors = 5, cpp_exception
+  boost::unit_test::log_system_errors = 6, system_error
+  boost::unit_test::log_fatal_errors, fatal_error
+  boost::unit_test::log_nothing, nothing
+}
+\endcode
+**/
 bool init_unit_test()
 {
   using namespace boost::unit_test;
-  auto & master_suite = framework::master_test_suite();
+  using namespace precice;
   
+  auto & master_suite = framework::master_test_suite();
   master_suite.p_name.value = "preCICE Tests";
+
+  auto logConfigs = logging::readLogConfFile("log.conf");
+  
+  if (logConfigs.empty()) { // nothing has been read from log.conf
+    #if BOOST_VERSION >= 106400
+    auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);
+    #else
+    auto logLevel = runtime_config::get<log_level>(runtime_config::LOG_LEVEL);
+    #endif
+    logging::BackendConfiguration config;
+    if (logLevel == log_successful_tests or logLevel == log_test_units)
+      config.filter = "%Severity% >= debug";
+    if (logLevel == log_messages)
+      config.filter = "%Severity% >= info";
+    if (logLevel == log_warnings)
+      config.filter = "%Severity% >= warning";
+    if (logLevel >= log_all_errors)
+      config.filter = "%Severity% >= warning"; // log warnings in any case
+    
+    logConfigs.push_back(config);
+  }
+
+  // Initialize either with empty logConfig -> default, configs that are read from file
+  // or from the Boost Test log level.
+  logging::setupLogging(logConfigs);
+  
 
   // Sets the default tolerance for floating point comparisions
   // Can be overwritten on a per-test or per-suite basis using decators
@@ -36,7 +83,7 @@ int main(int argc, char* argv[])
 
   precice::testMode = true;
   precice::syncMode = false;
-  logging::setupLogging();
+  logging::setupLogging(); // first logging initalization, as early as possible
   utils::Parallel::initializeMPI(&argc, &argv);
   logging::setMPIRank(utils::Parallel::getProcessRank());
   utils::Petsc::initialize(&argc, &argv);


### PR DESCRIPTION
Only if no log.conf exists in the current working directory.

The mapping boost test level -> log level is, of course, open to debate. Currently it's:

```
--log_level=X`

X == all or success or test_suite or unit_scope => "%Severity% >= debug"
X == message => "%Severity% >= info"
X == warning => "%Severity% >= warning"
X == error or cpp_exception or system_error or fatal_error, nothing) => "%Severity% >= warning"
```