### PR TITLE
Improve Doxygen Namespace Documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -816,7 +816,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = MappingTests MeshTests CplSchemeTests PreciceTests
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/docs/documents/namespaces.dox
+++ b/docs/documents/namespaces.dox
@@ -1,0 +1,71 @@
+/** @namespace precice
+ *  @brief main namespace of the precice library
+ */
+
+/** @namespace precice::action
+ *  @brief contains actions to modify exchanged data
+ */
+
+/** @namespace precice::com
+ *  @brief contains the data communication abstraction layer
+ */
+
+/** @namespace precice::constants
+ *  @brief contains names for files and common value types
+ */
+
+/** @namespace precice::cplscheme
+ *  @brief contains implementations of coupling schemes for coupled simulations.
+ */
+
+/** @namespace precice::io
+ *  @brief provides import and export of the coupling mesh and data.
+ *  
+ *  @see preice::mesh
+ */
+
+/** @namespace precice::logging
+ *  @brief contains the logging framework
+ */
+
+/** @namespace precice::m2n
+ *  @brief contains the logic of the parallel communication between participants.
+ */
+
+/** @namespace precice::mapping
+ *  @brief contains data mapping from points to meshes
+ *
+ *  @see precice::query
+ *  @see precice::mesh
+ */
+
+/** @namespace precice::math
+ *  @brief provides general mathematical constants and functions.
+ */
+
+/** @namespace precice::mesh
+ *  @brief provides Mesh and primitives
+ *
+ */
+
+/** @namespace precice::partition
+ *  @brief contains the partitioning of distributed meshes
+ */
+
+/** @namespace precice::query
+ *  @brief contains geometrical queries
+ */
+
+/** @namespace precice::testing
+ *  @brief contains the testing framework
+ */
+
+/** @namespace precice::utils
+ *  @brief contains precice-related utilites
+ */
+
+/** @namespace precice::xml
+ *  @brief contains the XML configuration parser
+ */
+
+// vim: ft=cpp

--- a/docs/documents/namespaces.dox
+++ b/docs/documents/namespaces.dox
@@ -1,17 +1,17 @@
 /** @namespace precice
- *  @brief main namespace of the precice library
+ *  @brief Main namespace of the precice library.
  */
 
 /** @namespace precice::action
- *  @brief contains actions to modify exchanged data
+ *  @brief contains actions to modify exchanged data.
  */
 
 /** @namespace precice::com
- *  @brief contains the data communication abstraction layer
+ *  @brief contains the data communication abstraction layer.
  */
 
 /** @namespace precice::constants
- *  @brief contains names for files and common value types
+ *  @brief contains names for files and common value types.
  */
 
 /** @namespace precice::cplscheme
@@ -19,13 +19,11 @@
  */
 
 /** @namespace precice::io
- *  @brief provides import and export of the coupling mesh and data.
- *  
- *  @see preice::mesh
+ *  @brief provides Import and Export of the coupling \ref mesh::Mesh "mesh" and \ref mesh::Data "data".
  */
 
 /** @namespace precice::logging
- *  @brief contains the logging framework
+ *  @brief contains the logging framework.
  */
 
 /** @namespace precice::m2n
@@ -33,10 +31,7 @@
  */
 
 /** @namespace precice::mapping
- *  @brief contains data mapping from points to meshes
- *
- *  @see precice::query
- *  @see precice::mesh
+ *  @brief contains data mapping from \ref mesh::Vertex "points" to \ref mesh::Mesh "meshes".
  */
 
 /** @namespace precice::math
@@ -44,28 +39,27 @@
  */
 
 /** @namespace precice::mesh
- *  @brief provides Mesh and primitives
- *
+ *  @brief provides Mesh, Data and primitives.
  */
 
 /** @namespace precice::partition
- *  @brief contains the partitioning of distributed meshes
+ *  @brief contains the partitioning of distributed meshes.
  */
 
 /** @namespace precice::query
- *  @brief contains geometrical queries
+ *  @brief contains geometrical queries.
  */
 
 /** @namespace precice::testing
- *  @brief contains the testing framework
+ *  @brief contains the testing framework.
  */
 
 /** @namespace precice::utils
- *  @brief contains precice-related utilites
+ *  @brief contains precice-related utilites.
  */
 
 /** @namespace precice::xml
- *  @brief contains the XML configuration parser
+ *  @brief contains the XML configuration parser.
  */
 
 // vim: ft=cpp

--- a/docs/documents/namespaces.dox
+++ b/docs/documents/namespaces.dox
@@ -61,5 +61,3 @@
 /** @namespace precice::xml
  *  @brief contains the XML configuration parser.
  */
-
-// vim: ft=cpp

--- a/src/math/barycenter.hpp
+++ b/src/math/barycenter.hpp
@@ -8,6 +8,7 @@ namespace precice
 {
 namespace math
 {
+/// Provides operations to calculate barycentric coordinates and projection from a point to a primitive.
 namespace barycenter
 {
 

--- a/src/utils/Petsc.hpp
+++ b/src/utils/Petsc.hpp
@@ -45,6 +45,7 @@ private:
 
 namespace precice {
 namespace utils {
+/// PETSc related utilities
 namespace petsc {
 
 enum VIEWERFORMAT { ASCII, BINARY };


### PR DESCRIPTION
* Adds missing documentation of main namespaces as a separate file.
* Adds missing namespace comments for _sub-namespaces_