### PR TITLE
Add Nearest Projection Test

### DIFF
--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -42,6 +42,7 @@ namespace PreciceTests {
     struct testBug;
     struct testThreeSolvers;
     struct testMultiCoupling;
+    struct testMappingNearestProjection;
   }
   namespace Server {
     struct testCouplingModeWithOneServer;
@@ -612,6 +613,7 @@ private:
   friend struct PreciceTests::Serial::testBug;
   friend struct PreciceTests::Serial::testThreeSolvers;
   friend struct PreciceTests::Serial::testMultiCoupling;
+  friend struct PreciceTests::Serial::testMappingNearestProjection;
   friend struct PreciceTests::Server::testCouplingModeWithOneServer;
   friend struct PreciceTests::Server::testCouplingModeParallelWithOneServer;
 

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -1366,8 +1366,6 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
 /**
  * @brief Tests the Nearest Projection Mapping between two participants
  *
- * A mapping is employed for the second solver, i.e., at the end of
- * initializeData(), the mapping needs to be invoked.
  */
 BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
                      * testing::MinRanks(2)

--- a/src/precice/tests/mapping-nearest-projection.xml
+++ b/src/precice/tests/mapping-nearest-projection.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+   <solver-interface dimensions="3" >   
+      <data:scalar name="DataOne"/>
+   
+      <mesh name="MeshOne">
+         <use-data name="DataOne"/>
+      </mesh>
+      
+      <mesh name="MeshTwo">
+         <use-data name="DataOne"/>
+      </mesh>
+      
+      <participant name="SolverOne">
+         <use-mesh name="MeshOne" provide="on"/>
+         <write-data name="DataOne" mesh="MeshOne"/>
+      </participant>
+      
+      <participant name="SolverTwo">
+         <use-mesh name="MeshOne" from="SolverOne"/>
+         <use-mesh name="MeshTwo" provide="on"/>
+         <mapping:nearest-projection direction="read" from="MeshOne" to="MeshTwo"
+                  constraint="consistent" timing="initial"/>
+         <read-data  name="DataOne" mesh="MeshTwo"/>
+      </participant>
+      
+      <m2n:mpi-single from="SolverOne" to="SolverTwo" />
+      
+      <coupling-scheme:serial-explicit> 
+         <participants first="SolverOne" second="SolverTwo"/> 
+         <max-timesteps value="1"/>
+         <timestep-length value="1.0"/>
+         <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      </coupling-scheme:serial-explicit>                           
+                  
+   </solver-interface>
+
+</precice-configuration>


### PR DESCRIPTION
Adds an integration test for the nearest projection mapping.

Note that I created the branch prior to the merge of #156.
Travis thus checks both the old and the new implementation of nearest projection.