### PR TITLE
Fixing relative path

### DIFF
--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -12,7 +12,7 @@ from distutils.command.build import build
 APPNAME = "PySolverInterface"
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
-PRECICE_ROOT = os.path.join(PYTHON_BINDINGS_PATH, "../../../../../precice")
+PRECICE_ROOT = os.path.join(PYTHON_BINDINGS_PATH, "../../../..")
 
 
 class MpiImplementations(Enum):


### PR DESCRIPTION
Before, the relative path assumed that `$PRECICE_ROOT` is called `precice`. However, if the root folder is called differently (e.g. `precice-1.3.0`, if preCICE Version 1.3.0 is used) the compilation of PySolverInterface breaks.