### PR TITLE
Tooling Page for Doxygen

### DIFF
--- a/docs/documents/020_conventions.dox
+++ b/docs/documents/020_conventions.dox
@@ -25,7 +25,7 @@ Indention & Formatting
 ----------------------
 As a rule of thumb again: Orient yourself on the already written code!
 
-There is a settings file for ```clang-format```. You can use the tool to format your code: ```clang-format -style=file -i FILES```
+There is a settings file for ```clang-format```. See the page on \ref tooling for more information on clang-format.
 
 Regarding indention, we follow the BSD-style.
 
@@ -66,6 +66,8 @@ For a one-line documentation you should use
 void eat(Apple a);
 @endverbatim
 
+For more information, see the page on \ref tooling.
+
 
 Dimension-Ordering
 ==================
@@ -80,10 +82,5 @@ dim 2 |-------|
   |   ---------  
    --> dim 1
 ```
-
-Static Analysis
-==============
-Running a tool like Cppcheck is quick, easy and can detect some errors and bad programming practice. Simply run ```cppcheck --enable=all .``` inside ```precice/src``` or inside the directory you're working.
-
 
 */

--- a/docs/documents/070_tooling.dox
+++ b/docs/documents/070_tooling.dox
@@ -1,0 +1,57 @@
+/**
+
+@page tooling Tooling
+
+This page gives a general overview of the tooling one can use with preCICE.
+
+---
+
+clang-format
+============
+
+The tool [clang-format](https://clang.llvm.org/docs/ClangFormat.html) applies a configured code style to C and C++ files.
+It checks parent directories for a `.clang-format` file and applies the style to a given source file.
+
+Editor integration is available for:
+
+- [Eclipse](https://marketplace.eclipse.org/content/cppstyle)
+- [Emacs](https://clang.llvm.org/docs/ClangFormat.html#emacs-integration)
+- [Vim](https://clang.llvm.org/docs/ClangFormat.html#vim-integration)
+- [Visual Studio](https://clang.llvm.org/docs/ClangFormat.html#visual-studio-integration)
+
+To [disable formatting](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code) for a section of code use comments:
+```
+int formatted_code;
+// clang-format off
+    void    unformatted_code  ;
+// clang-format on
+void formatted_code_again;
+/* clang-format off */
+    void         unformatted_code  ;
+/* clang-format on */
+void formatted_code_yet_again;
+```
+
+clang-tidy
+==========
+
+The tool clang-tidy runs static analysis on C and C++ files and reports warnings in clang error format (i.e. editors can parse them).
+It checks parent directories for a `.clang-tidy` file and uses that configuration.
+
+To prevent the hassle of passing all necessary flags to the tool, it can use a compilation database to look them up.
+To generate this database using CMake, invoke cmake using `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
+Then pass the build directory to clang-tidy using the `-p` flag.
+
+Quick Setup:
+
+- create a build dir `mkdir -p ~/tmp/precice && cd ~/tmp/precice`
+- configure precice using `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $PRICICE_ROOT` (this generates the needed `compile_commands.json`)
+- `cd $PRECICE_ROOT`
+
+How to use:
+- Inspect a single file:  
+    `clang-tidy -p ~/tmp/precice/ src/precice/impl/SolverInterfaceImpl.cpp` ( -p sets the dir where to find the file compile_commands.json)
+-  Inspect the entire source tree or apply fixes:  
+    Use the `run-clang-tidy.py` to prevent header overlap etc.
+    Installed as `/usr/share/clang/run-clang-tidy.py` or from the [mirror](https://github.com/llvm-mirror/clang-tools-extra/blob/master/clang-tidy/tool/run-clang-tidy.py).
+*/

--- a/docs/documents/070_tooling.dox
+++ b/docs/documents/070_tooling.dox
@@ -12,12 +12,18 @@ clang-format
 The tool [clang-format](https://clang.llvm.org/docs/ClangFormat.html) applies a configured code style to C and C++ files.
 It checks parent directories for a `.clang-format` file and applies the style to a given source file.
 
+To use the tool form the shell, run:
+```
+clang-format -style=file -i FILES
+```
+
 Editor integration is available for:
 
 - [Eclipse](https://marketplace.eclipse.org/content/cppstyle)
 - [Emacs](https://clang.llvm.org/docs/ClangFormat.html#emacs-integration)
 - [Vim](https://clang.llvm.org/docs/ClangFormat.html#vim-integration)
 - [Visual Studio](https://clang.llvm.org/docs/ClangFormat.html#visual-studio-integration)
+
 
 To [disable formatting](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code) for a section of code use comments:
 ```
@@ -54,4 +60,41 @@ How to use:
 -  Inspect the entire source tree or apply fixes:  
     Use the `run-clang-tidy.py` to prevent header overlap etc.
     Installed as `/usr/share/clang/run-clang-tidy.py` or from the [mirror](https://github.com/llvm-mirror/clang-tools-extra/blob/master/clang-tidy/tool/run-clang-tidy.py).
+
+Cppcheck
+========
+
+The static analysis tool [Cppcheck](https://github.com/danmar/cppcheck/Cppcheck) can detect some errors and bad programming practice.
+Simply run ```cppcheck --enable=all .``` inside ```precice/src``` or inside the directory you're working.
+
+
+Static Analysis Build
+=====================
+
+CMake can run various static analysis tools on sources after compiling them.
+A quick way of setting up precice looks as follows:
+```
+$ mkdir -p ~/tmp/precice && cd ~/tmp/precice
+$ cmake \
+   -DCMAKE_BUILD_TYPE=Debug \
+   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+   -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-p;." \
+   -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all" \
+   -DCMAKE_CXX_CPPLINT="cpplint.py" \
+   -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="path/to/iwyu;-p;." \
+   -DPYTHON=ON \
+   -DMPI=ON \
+   -DPETSC=ON \
+   $PRECICE_ROOT
+$ make -j $(nproc)
+```
+As this build will run for a very long time, it may be a good idea to save the output to a log file. 
+```
+$ make -j $(nproc) 2>&1 | tee staticanalysis.log
+```
+If the log contains scrambled output, use:
+```
+$ make 2>&1 | tee staticanalysis.log
+```
+
 */


### PR DESCRIPTION
This includes:

* Clang-format
* Clang-tidy
* Cppcheck (moved from conventions)
* CMake static analysis build

![image](https://user-images.githubusercontent.com/13552216/51467228-55858d00-1d6c-11e9-9ed4-b6bf58973c8a.png)
![image](https://user-images.githubusercontent.com/13552216/51467247-6209e580-1d6c-11e9-96f0-1506a092d6e2.png)
