### PR TITLE
Fix preCICE on Boost 1.69

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ set(headers
   src/precice/bindings/c/Constants.h)
 set_target_properties(precice PROPERTIES PUBLIC_HEADER "${headers}")
 
+target_include_directories(precice PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(precice PRIVATE ${PYTHON_LIBRARIES})
 target_link_libraries(precice PUBLIC ${MPI_LIBRARIES})
 target_link_libraries(precice PUBLIC ${Boost_LIBRARIES})

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -44,8 +44,13 @@ bool init_unit_test()
   auto logConfigs = logging::readLogConfFile("log.conf");
   
   if (logConfigs.empty()) { // nothing has been read from log.conf
-    auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);
     logging::BackendConfiguration config;
+#if BOOST_VERSION == 106900
+    std::cerr << "Boost Version 1.69 log_level is broken, set to debug." << std::endl;
+    auto logLevel = log_successful_tests;
+#else
+    auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);
+#endif
     if (logLevel == log_successful_tests or logLevel == log_test_units)
       config.filter = "%Severity% >= debug";
     if (logLevel == log_messages)
@@ -54,7 +59,6 @@ bool init_unit_test()
       config.filter = "%Severity% >= warning";
     if (logLevel >= log_all_errors)
       config.filter = "%Severity% >= warning"; // log warnings in any case
-    
     logConfigs.push_back(config);
   }
 

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -67,8 +67,11 @@ bool init_unit_test()
   // Can be overwritten on a per-test or per-suite basis using decators
   // boost::unit_test::decorator::collector::instance() * boost::unit_test::tolerance(0.001);
   * tolerance(1e-9); // Stores the decorator in the collector singleton
+#if BOOST_VERSION >= 106900
+  decorator::collector_t::instance().store_in(master_suite);
+#else
   decorator::collector::instance().store_in(master_suite);
-  
+#endif
   return true;
 }
 


### PR DESCRIPTION
Boost.Test 1.69 is broken on preCICE. There are two issues:

1.  `collector` became `collector_t`
Fixed by this PR with a simple `#if` preprocessor directive.
2. At runtime `testprecice` fails at:
https://github.com/precice/precice/blob/d601da73c78bf684fa986bb4e2d81861fc96b982/src/testing/main.cpp#L47
This is caused by a bug in Boost.Test, which is discussed [there](https://github.com/boostorg/test/issues/199). It only affects preCICE in boost version 1.69, as the author already fixed it. This does, however, pose the question of how we should handle it. Suggestions are welcome :).