### PR TITLE
Small cleanup in m2n::PointToPointCommunication

### DIFF
--- a/src/m2n/PointToPointCommunication.hpp
+++ b/src/m2n/PointToPointCommunication.hpp
@@ -83,21 +83,26 @@ private:
   
   com::PtrCommunicationFactory _communicationFactory;
 
+  /// Communication class used for this PointToPointCommunication
+  /**
+   * A Communication object represents all connections to all ranks made by this P2P instance.
+   **/
+  com::PtrCommunication _communication;
+  
   /**
    * @brief Defines mapping between:
    *        1. global remote process rank;
    *        2. local data indices, which define a subset of local (for process
    *           rank in the current participant) data to be communicated between
    *           the current process rank and the remote process rank;
-   *        3. communication object (provides point-to-point communication routines).
-   *        5. Appropriatly sized buffer to receive elements
+   *        3. Request holding information about pending communication
+   *        4. Appropriately sized buffer to receive elements
    */
   struct Mapping {
-    int                   remoteRank;
-    std::vector<int>      indices;
-    com::PtrCommunication communication;
-    com::PtrRequest       request;
-    std::vector<double>   recvBuffer;
+    int                 remoteRank;
+    std::vector<int>    indices;
+    com::PtrRequest     request;
+    std::vector<double> recvBuffer;
   };
 
   /**


### PR DESCRIPTION
Should not be problematic, since functionality is untouched. Just wanted to wait for Travis to check it ans will eventually merge it, also without review. Request @uekerman because we planed that change together today.

* Since we hold just one com::Communication instance per P2P object,
move the object out of the mappings vector and save it just once per
class.

* Remove premature resize of vectors. At this point the size of the
indices that are moved into the vector are not yet known. Therefore
the resize will be wrong anyway.

* Reword some of the comments.