### PR TITLE
Add LibDL to CMake Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,11 @@ find_package (Threads REQUIRED)
 find_package(Boost 1.65.1 REQUIRED
   COMPONENTS filesystem log log_setup program_options system thread unit_test_framework)
 
+if (UNIX OR APPLE OR MINGW)
+  # Used for boost stacktrace on POSIX and MINGW
+  find_package(DL REQUIRED)
+endif()
+
 find_package(Eigen3 3.2 REQUIRED)
 
 find_package(LibXml2 REQUIRED)
@@ -145,6 +150,9 @@ set_target_properties(precice PROPERTIES
 target_compile_definitions(precice PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES)
 target_link_libraries(precice PRIVATE ${Boost_LIBRARIES})
 target_include_directories(precice PRIVATE ${Boost_INCLUDE_DIRS})
+if(UNIX OR APPLE OR MINGW)
+  target_link_libraries(precice PRIVATE DL::DL)
+endif()
 
 # Setup Eigen3
 target_link_libraries(precice PRIVATE Eigen3::Eigen)

--- a/cmake/modules/FindDL.cmake
+++ b/cmake/modules/FindDL.cmake
@@ -1,0 +1,34 @@
+# This module defines the following variables:
+#
+# DL_FOUND
+#   True if libdl found.
+#
+# DL_LIBRARIES
+#   The library libdl
+#
+# This module exports the following IMPORTED target:
+#
+# DL::DL
+#
+
+find_library(DL_LIBRARY
+    NAMES dl libdl
+    HINTS ${DL_ROOT} $ENV{DL_ROOT})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(DL
+    REQUIRED_VARS DL_LIBRARY)
+
+if(DL_FOUND)
+    set(DL_LIBRARIES ${DL_LIBRARY})
+
+    if(NOT TARGET DL::DL)
+        add_library(DL::DL UNKNOWN IMPORTED)
+        set_target_properties(DL::DL PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${DL_LIBRARY}"
+            )
+        set_property(TARGET DL::DL APPEND PROPERTY IMPORTED_LOCATION "${DL_LIBRARY}")
+    endif()
+endif()
+
+mark_as_advanced(DL_LIBRARIES)


### PR DESCRIPTION
This adds a simplistic CMake find module for the `libdl` library.
CMake will require it for POSIX and MINGW environments. This library is a subset `libc` and get installed alongside it.
Ubuntu installs it as part of `essentials` -> `libc-bin` -> [flibc6](https://packages.ubuntu.com/bionic/amd64/libc6/filelist).

Fixes #254 