### PR TITLE
WIP: Fix Flush Cache on Mapping clear

### DIFF
--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -78,6 +78,11 @@ void NearestNeighborMapping:: clear()
   TRACE();
   _vertexIndices.clear();
   _hasComputedMapping = false;
+  if (getConstraint() == CONSISTENT){
+    mesh::rtree::clear(*input()); 
+  } else {
+    mesh::rtree::clear(*output()); 
+  }
 }
 
 void NearestNeighborMapping:: map

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -125,6 +125,11 @@ void NearestProjectionMapping:: clear()
   TRACE();
   _weights.clear();
   _hasComputedMapping = false;
+  if (getConstraint() == CONSISTENT){
+    mesh::rtree::clear(*input()); 
+  } else {
+    mesh::rtree::clear(*output()); 
+  }
 }
 
 void NearestProjectionMapping:: map


### PR DESCRIPTION
Fixes `mapping::clear()` not to clear the underlying mesh-caches.