### PR TITLE
Fix VTKXMLExporter not writing VertexNormals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file. For future 
   - CPack configuration of target `package` to generate binary debian, tar and zip packages.
   - Add `CMakeLists.txt` to `tools/solverdummy/cpp`. It is an example of how to link to precice with CMake.
   - Extend the displayed information when configuring.
+- Fix the VTK XML exporter not to write VertexNormals
 
 ## 1.3.0
 - Update of build procedure for python bindings (see [`precice/src/bindings/python/README.md`](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md) for instructions). Note: you do not have to add `PySolverInterface.so` to `PYTHONPATH` manually anymore, if you want to use it in your adapter. Python should be able to find it automatically.   

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -54,7 +54,7 @@ void ExportVTKXML::processDataNamesAndDimensions
   _vectorDataNames.clear();
   _scalarDataNames.clear();
   if (_writeNormals) {
-    _vectorDataNames.push_back("VertexNormals ");
+    _vectorDataNames.push_back("VertexNormals");
   }
   for (mesh::PtrData data : mesh.data()) {
     int dataDimensions = data->getDimensions();
@@ -258,6 +258,26 @@ void ExportVTKXML:: exportData
   }
   outFile << "\">" << std::endl;
 
+
+  // Print VertexNormals
+  if (_writeNormals) {
+    const auto dimensions = mesh.getDimensions();
+    outFile << "            <DataArray type=\"Float32\" Name=\"VertexNormals\" NumberOfComponents=\"";
+    outFile << std::max(3, dimensions) << "\" format=\"ascii\">" << std::endl;
+    outFile << "               ";
+    for (const auto& vertex : mesh.vertices()) {
+        const auto normal = vertex.getNormal();
+        for(int i=0; i < std::max(3, dimensions); i++){
+            if (i < dimensions) {
+                outFile << normal[i] << ' ';
+            } else {
+                outFile << "0.0 ";
+            }
+            outFile << ' ';
+        }
+    }
+    outFile << std::endl << "            </DataArray>" << std::endl;
+  }
   for (mesh::PtrData data : mesh.data()) { // Plot vertex data
     Eigen::VectorXd& values = data->values();
     int dataDimensions = data->getDimensions();

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 
   mesh.computeState();
 
-  bool             exportNormals = false;
+  bool             exportNormals = true;
   io::ExportVTKXML exportVTKXML(exportNormals);
   std::string      filename = "io-ExportVTKXMLTest-testExportPolygonalMesh";
   std::string      location = "";


### PR DESCRIPTION
The following are the newly created files: [test.zip](https://github.com/precice/precice/files/2860613/test.zip).

@MakisH can you check them in paraview please?

Fixes #227 