### PR TITLE
WIP Add a Git verification step to updateSourceFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file. For future 
   - CPack configuration of target `package` to generate binary debian, tar and zip packages.
   - Add `CMakeLists.txt` to `tools/solverdummy/cpp`. It is an example of how to link to precice with CMake.
   - Extend the displayed information when configuring.
+- Extend `updateSourceFiles.py` to verify the sources using `git ls-files --full-name` if available.
 
 ## 1.3.0
 - Update of build procedure for python bindings (see [`precice/src/bindings/python/README.md`](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md) for instructions). Note: you do not have to add `PySolverInterface.so` to `PYTHONPATH` manually anymore, if you want to use it in your adapter. Python should be able to find it automatically.   

--- a/tools/updateSourceFiles.py
+++ b/tools/updateSourceFiles.py
@@ -6,7 +6,7 @@ import sys
 import subprocess
 
 """ Files matching this pattern will be filtered out """
-IGNORE_PATTERNS = ["drivers", "PySolverInterface"]
+IGNORE_PATTERNS = ["drivers", "bindings/python"]
 
 """ Configured files, which should be ignored by git """
 CONFIGURED_SOURCES = ["src/versions.hpp"]
@@ -67,6 +67,7 @@ def get_file_lists(root):
             tests += files
         else:
             sources += files
+    sources += CONFIGURED_SOURCES
 
     # Remove bindings from the sources
     sources = [source for source in sources if source not in bindings]
@@ -118,7 +119,7 @@ def main():
         print("Current dir {} is not the root of the precice repository!".format(root))
         return 1
     sources, public, tests = get_file_lists(root)
-    print("Detected:\n sources: {}\n public: {}\n tests: {}".format(len(sources), len(public), len(tests)))
+    print("Detected:\n  sources: {}\n  public: {}\n  tests: {}".format(len(sources), len(public), len(tests)))
 
     gitfiles = get_gitfiles()
     if gitfiles:
@@ -134,12 +135,12 @@ def main():
             print("Files:")
             for file in not_tracked:
                 print("  {}".format(file))
-            print("VERIFICATION FAILED")
-            return 1
+            print("Verification FAILED")
         else:
-            print("Verification with git succeeded.")
+            print("Verification SUCCEEDED")
     else:
-        print("Git did not run successfully.\nThese sources are UNVERIFIED!")
+        print("Git did not run successfully.")
+        print("Verification SKIPPED")
 
     print("Generating CMake files")
     sources_file, tests_file = get_cmake_file_paths(root)


### PR DESCRIPTION
This PR adds:
* A verification step to the source generation
* IGNORE_PATTERNS to ignore bindings etc.
* CONFIGURED_SOURCES to add the result of `.in` files such as `src/versions.hpp.in`

```console
$ tools/updateSourceFiles.py
Detected:
 sources: 296
 public: 5
 tests: 70
The source tree contains files not tracked by git.
Please do one of the following with these files:
  - track them using 'git add'
  - add them to IGNORE_PATTERNS in this script
  - add them to CONFIGURED_SOURCES in this script!
Files:
  src/precice/bindings/python/BadPythonBoy.hpp
  src/precice/bindings/python/BadPythonBoy.cpp
  src/precice/BadBoy.cpp
VERIFICATION FAILED
```


```console
$ tools/updateSourceFiles.py         
Detected:
 sources: 296
 public: 5
 tests: 70
Git did not run successfully.
These sources are UNVERIFIED!
Generating CMake files
Writing Files
 ./src/sources.cmake
 ./src/tests.cmake
done
```