### PR TITLE
Moved version logging to configure

### DIFF
--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -218,11 +218,6 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
     sink->set_filter(boost::log::parse_filter(config.filter));
     boost::log::core::get()->add_sink(sink);
   }
-
-  // Printing PRECICE_VERSION as first line of the log
-  auto t = std::time(nullptr);
-  BOOST_LOG_TRIVIAL(info)
-    << "This is preCICE version " << PRECICE_VERSION << ". Starting " << std::put_time(std::localtime(&t), "%F %T");
 }
 
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -88,8 +88,8 @@ void SolverInterfaceImpl:: configure
   config::Configuration config;
   xml::configure(config.getXMLTag(), configurationFileName);
   if(_accessorProcessRank==0){
-    INFO("Configuring preCICE with configuration: \"" << configurationFileName << "\"" );
     INFO("This is preCICE version " << PRECICE_VERSION);
+    INFO("Configuring preCICE with configuration: \"" << configurationFileName << "\"" );
   }
   configure(config.getSolverInterfaceConfiguration());
 }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -29,6 +29,7 @@
 #include <Eigen/Core>
 #include "partition/ReceivedPartition.hpp"
 #include "partition/ProvidedPartition.hpp"
+#include "versions.hpp"
 
 #include <csignal> // used for installing crash handler
 #include <utility>
@@ -88,6 +89,7 @@ void SolverInterfaceImpl:: configure
   xml::configure(config.getXMLTag(), configurationFileName);
   if(_accessorProcessRank==0){
     INFO("Configuring preCICE with configuration: \"" << configurationFileName << "\"" );
+    INFO("This is preCICE version " << PRECICE_VERSION);
   }
   configure(config.getSolverInterfaceConfiguration());
 }


### PR DESCRIPTION
This solves the issue that we always got a "This is preCICE version ..." for every rank and not yet formatted properly. 
See issue #269 