### PR TITLE
Fortran77 bindings: Fix the missing const declaration of an input var…

### DIFF
--- a/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
@@ -97,8 +97,8 @@ void precicef_ongoing_
 
 void precicef_write_data_required_
 (
-  double* computedTimestepLength,
-  int*    isRequired )
+  const double* computedTimestepLength,
+  int*          isRequired )
 {
   CHECK(impl != nullptr,errormsg);
   if (impl->isWriteDataRequired(*computedTimestepLength)){


### PR DESCRIPTION
…iable in the precicef_write_data_required interface. This caused the routine to not be available to the Fortran codes that use the library.