### PR TITLE
Improve CTest from user perspective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to this project will be documented in this file. For future 
   - Extend the displayed information when configuring.
 - Extend `updateSourceFiles.py` to verify the sources using `git ls-files --full-name` if available.
 - Fix the VTK XML exporter not to write VertexNormals
+- Improve the user-friendliness of the tests.
+  - `make test` will run all tests.
+  - `make test_base` only a unproblematic base-set.
+  - A timeout will kill hanging tests.
+  - All tests sets run in isolated working directories.
 
 ## 1.3.0
 - Update of build procedure for python bindings (see [`precice/src/bindings/python/README.md`](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md) for instructions). Note: you do not have to add `PySolverInterface.so` to `PYTHONPATH` manually anymore, if you want to use it in your adapter. Python should be able to find it automatically.   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,40 +269,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/src/tests.cmake)
 
 
 #
-# CTest
-#
-
-enable_testing()
-
-# Register the Base test
-set(PRECICE_TEST_DIR "${preCICE_BINARY_DIR}/TestOutput")
-file(MAKE_DIRECTORY ${PRECICE_TEST_DIR}/Base)
-add_test(NAME precice.Base
-  COMMAND "$<TARGET_FILE:testprecice>"
-  WORKING_DIRECTORY "${PRECICE_TEST_DIR}/Base"
-  )
-if(MPI AND MPIEXEC_EXECUTABLE)
-  # Register the MPI test for 2 Ranks
-  file(MAKE_DIRECTORY "${PRECICE_TEST_DIR}/MPI2")
-  add_test(NAME precice.MPI2
-    COMMAND "${MPIEXEC_EXECUTABLE}" -np 2 "$<TARGET_FILE:testprecice>"
-    WORKING_DIRECTORY "${PRECICE_TEST_DIR}/MPI2"
-    )
-  # Register the MPI test for 4 Ranks
-  file(MAKE_DIRECTORY "${PRECICE_TEST_DIR}/MPI4")
-  add_test(NAME precice.MPI4
-    COMMAND "${MPIEXEC_EXECUTABLE}" -np 4 "$<TARGET_FILE:testprecice>"
-    WORKING_DIRECTORY "${PRECICE_TEST_DIR}/MPI4"
-    )
-  set_tests_properties( precice.MPI2 precice.MPI4
-    PROPERTIES
-    RUN_SERIAL TRUE # Do not run this test in parallel with others
-    TIMEOUT 60 # Set the timeout to 60 seconds on this test
-    )
-endif()
-
-
-#
 # Install Targets for precice
 #
 
@@ -396,6 +362,13 @@ else()
     DESTINATION share/man
     )
 endif()
+
+
+#
+# CTest
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/CTestConfig.cmake)
 
 
 #

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -1,0 +1,75 @@
+#
+# CTest
+#
+
+set(PRECICE_TEST_DIR "${preCICE_BINARY_DIR}/TestOutput")
+mark_as_advanced(PRECICE_TEST_DIR)
+
+function(add_precice_test)
+  cmake_parse_arguments(PARSE_ARGV 0 PAT "MPI;CANFAIL" "NAME;ARGUMENTS" "")
+  if(NOT PAT_NAME)
+    message(FATAL_ERROR "Argument NAME not passed")
+  endif()
+  # We always prefix our tests
+  set(PAT_FULL_NAME "precice.${PAT_NAME}")
+  message(STATUS "Adding Test ${PAT_FULL_NAME}")
+  # Generate working directory
+  set(PAT_WDIR "${PRECICE_TEST_DIR}/${PAT_NAME}")
+  file(MAKE_DIRECTORY "${PAT_WDIR}")
+  # Assemble the command
+  if(PAT_MPI)
+    add_test(NAME ${PAT_FULL_NAME}
+      COMMAND ${MPIEXEC_EXECUTABLE} -np 4 $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS}
+      )
+  else()
+    add_test(NAME ${PAT_FULL_NAME}
+      COMMAND $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS}
+      )
+  endif()
+  set_tests_properties(${PAT_FULL_NAME}
+    PROPERTIES
+    RUN_SERIAL TRUE # Do not run this test in parallel with others
+    TIMEOUT 20 # Set the timeout to 60 seconds on this test
+    WORKING_DIRECTORY "${PAT_WDIR}"
+    )
+  if(PAT_CANFAIL)
+    set_tests_properties(${PAT_FULL_NAME} PROPERTIES LABELS "canfail")
+  endif()
+endfunction(add_precice_test)
+
+enable_testing()
+
+if(MPI AND MPIEXEC_EXECUTABLE)
+  # Configured with MPI
+  # Register the uncritical base-set
+  add_precice_test(
+    NAME Base
+    ARGUMENTS "--run_test=\!@MPI_Ports:\!MappingTests/PetRadialBasisFunctionMapping/Parallel/\*"
+    MPI
+    )
+  add_precice_test(
+    NAME MPI_Ports
+    ARGUMENTS "--run_test=@MPI_Ports"
+    MPI
+    CANFAIL
+    )
+  add_precice_test(
+    NAME PetRBFParallel
+    ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping/Parallel/\*"
+    MPI
+    CANFAIL
+    )
+  add_precice_test(
+    NAME Full
+    MPI
+    CANFAIL
+    )
+  add_precice_test(
+    NAME NoMPI
+    )
+else()
+  # Configured without MPI
+  add_precice_test(
+    NAME NoMPI
+    )
+endif()

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -73,3 +73,13 @@ else()
     NAME Base
     )
 endif()
+
+
+# Add a separate target to test only the base
+add_custom_target(
+  test_base
+  COMMAND ctest -V -R precice.Base
+  DEPENDS testprecice
+  WORKING_DIRECTORY ${preCICE_BINARY_DIR}
+  USES_TERMINAL
+  )

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -65,12 +65,6 @@ if(MPI AND MPIEXEC_EXECUTABLE)
     CANFAIL
     )
   add_precice_test(
-    NAME Full
-    TIMEOUT 180
-    MPI
-    CANFAIL
-    )
-  add_precice_test(
     NAME NoMPI
     )
 else()

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -70,6 +70,6 @@ if(MPI AND MPIEXEC_EXECUTABLE)
 else()
   # Configured without MPI
   add_precice_test(
-    NAME NoMPI
+    NAME Base
     )
 endif()

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -29,7 +29,7 @@ function(add_precice_test)
   set_tests_properties(${PAT_FULL_NAME}
     PROPERTIES
     RUN_SERIAL TRUE # Do not run this test in parallel with others
-    TIMEOUT 20 # Set the timeout to 60 seconds on this test
+    TIMEOUT 60 # Set the timeout to 60 seconds on this test
     WORKING_DIRECTORY "${PAT_WDIR}"
     )
   if(PAT_CANFAIL)

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -6,7 +6,7 @@ set(PRECICE_TEST_DIR "${preCICE_BINARY_DIR}/TestOutput")
 mark_as_advanced(PRECICE_TEST_DIR)
 
 function(add_precice_test)
-  cmake_parse_arguments(PARSE_ARGV 0 PAT "MPI;CANFAIL" "NAME;ARGUMENTS" "")
+  cmake_parse_arguments(PARSE_ARGV 0 PAT "MPI;CANFAIL" "NAME;ARGUMENTS;TIMEOUT" "")
   if(NOT PAT_NAME)
     message(FATAL_ERROR "Argument NAME not passed")
   endif()
@@ -29,9 +29,11 @@ function(add_precice_test)
   set_tests_properties(${PAT_FULL_NAME}
     PROPERTIES
     RUN_SERIAL TRUE # Do not run this test in parallel with others
-    TIMEOUT 60 # Set the timeout to 60 seconds on this test
     WORKING_DIRECTORY "${PAT_WDIR}"
     )
+  if(PAT_TIMEOUT)
+    set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PAT_TIMEOUT} )
+  endif()
   if(PAT_CANFAIL)
     set_tests_properties(${PAT_FULL_NAME} PROPERTIES LABELS "canfail")
   endif()
@@ -45,22 +47,26 @@ if(MPI AND MPIEXEC_EXECUTABLE)
   add_precice_test(
     NAME Base
     ARGUMENTS "--run_test=\!@MPI_Ports:\!MappingTests/PetRadialBasisFunctionMapping/Parallel/\*"
+    TIMEOUT 180
     MPI
     )
   add_precice_test(
     NAME MPI_Ports
     ARGUMENTS "--run_test=@MPI_Ports"
+    TIMEOUT 20
     MPI
     CANFAIL
     )
   add_precice_test(
     NAME PetRBFParallel
     ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping/Parallel/\*"
+    TIMEOUT 20
     MPI
     CANFAIL
     )
   add_precice_test(
     NAME Full
+    TIMEOUT 180
     MPI
     CANFAIL
     )


### PR DESCRIPTION
We currently have a few problematic tests including the `MPI_Ports` and the `PetRBF` Tests.

This PR changes the test suite so that there is a safe base set the user can run.

* If configured without MPI, there is only one test registered running `testprecice`.
* If configured with MPI there are multiple suites:
  * run with `mpiexec -np 4`
    * __Base__ containing all tests except the `MPI_Ports` and the `PetRBF/Paralllel`
    * __MPIPorts__ containing all `@MPI_Ports` tests
    * __PetRBFParallel__ containing the `PetRBF/Parallel` tests
  * run without mpi
    * __NOMPI__ containing all tests

To run:
* all tests: execute `make test`
* the base set: execute `make test_base`

For additional control, use CTest directly `ctest --help`.