### PR TITLE
SCons cannot find PETSc if PETSC_ARCH is needed for full path to PETSc.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -186,7 +186,7 @@ if env["petsc"]:
     else:
         checkAdd("petsc")
     # Set PETSC_VERSION to correct values 
-    with open(join(PETSC_DIR, "include/petscversion.h"), "r") as versionfile:
+    with open(join( join(PETSC_DIR, PETSC_ARCH), "include/petscversion.h"), "r") as versionfile:
         for line in versionfile:
             tokens = line.split()
             try:

--- a/SConstruct
+++ b/SConstruct
@@ -185,8 +185,15 @@ if env["petsc"]:
         checkAdd("craypetsc_gnu_real")
     else:
         checkAdd("petsc")
+        
+    petsc_path = []
+    if ( FindFile( "petscversion.h", join( PETSC_DIR, PETSC_ARCH, "include/" ) ) == None ):
+      petsc_path = PETSC_DIR
+    else:
+      petsc_path = join( PETSC_DIR, PETSC_ARCH )
+
     # Set PETSC_VERSION to correct values 
-    with open(join( PETSC_DIR, PETSC_ARCH, "include/petscversion.h"), "r") as versionfile:
+    with open(join( petsc_path, "include/petscversion.h"), "r") as versionfile:
         for line in versionfile:
             tokens = line.split()
             try:

--- a/SConstruct
+++ b/SConstruct
@@ -186,7 +186,7 @@ if env["petsc"]:
     else:
         checkAdd("petsc")
     # Set PETSC_VERSION to correct values 
-    with open(join( join(PETSC_DIR, PETSC_ARCH), "include/petscversion.h"), "r") as versionfile:
+    with open(join( PETSC_DIR, PETSC_ARCH, "include/petscversion.h"), "r") as versionfile:
         for line in versionfile:
             tokens = line.split()
             try:


### PR DESCRIPTION
I am on Ubuntu 18.04 and have installed PETSc through the package manager. This installs PETSc into `/usr/lib/petscdir/3.7.7/x86_64-linux-gnu-real/`. Following the guide in the wiki, see [wiki page](https://github.com/precice/precice/wiki/Dependencies#petsc-optional), I set

```bash
export PETSC_DIR=/usr/lib/petscdir/3.7.7
export PETSC_ARCH=x86_64-linux-gnu-real
```

However, SCons fails to build preCICE since it does not find PETSc. Line 189 of the `SConstruct` file reads:

```
with open(join(PETSC_DIR, "include/petscversion.h"), "r") as versionfile:
```

This means that it expects that `PETSC_DIR` would point to the full path `/usr/lib/petscdir/3.7.7/x86_64-linux-gnu-real`. This is not an issue when following the other instruction in the wiki, see [wiki page](https://github.com/precice/precice/wiki/Dependencies#ubuntu-1804). There it is suggested to set 

```
export PETSC_DIR=/usr/lib/petscdir/3.7/
```

If one follows this part of the manuels, it works since `/usr/lib/petscdir/3.7/` is a symlink to `/usr/lib/petscdir/3.7.7/x86_64-linux-gnu-real/` on Ubuntu 18.04.

I propose to change line 189 of the SConstruct to (since SCons is still supported):

```python
with open(join( join(PETSC_DIR, PETSC_ARCH), "include/petscversion.h"), "r") as versionfile:
```

*Edit*: I changed it to avoid the double `join` as suggested below.

This will work if `PETSC_ARCH` is empty and `PETSC_DIR` points directly to the PETSc dir and if the full path is given by `$PETSC_DIR/$PETSC_ARCH`. I think both options (`PETSC_ARCH` empty and set) are allowed by newer versions of PETSc.

**Error message**

```
scons: Reading SConscript files ...

(default)  builddir   = build      Directory holding build files. ( /path/to/builddir )
(default)  build      = Debug      Build type (release|debug|Release|Debug)
(default)  libprefix  = /usr       Path prefix for libraries ( /path/to/libprefix )
(default)  compiler   = mpicxx     Compiler to use.
(default)  mpi        = True       Enables MPI-based communication and running coupling tests. (yes|no)
(modified) petsc      = True       Enable use of the PETSc linear algebra library. (yes|no)
(modified) python     = True       Used for Python scripted solver actions. (yes|no)
(default)  gprof      = False      Used in detailed performance analysis. (yes|no)
(default)  platform   = none       Special configuration for certain platforms (none|supermuc|hazelhen)

Checking whether the C++ compiler works... yes
Checking for C++ library pthread... yes
(modified) PETSC_DIR  = /usr/lib/petscdir/3.7.7
(modified) PETSC_ARCH = x86_64-linux-gnu-real
Checking for C++ library petsc... yes
IOError: [Errno 2] No such file or directory: '/usr/lib/petscdir/3.7.7/include/petscversion.h':
  File "/home/jaustar/precice-test/precice-git/SConstruct", line 189:
    with open(join(PETSC_DIR, "include/petscversion.h"), "r") as versionfile:
```

**How to reproduce**
- Under the assumption that you run Ubuntu 18.04 an have installed PETSc through the package manager you can run the following script. It will checkout preCICE and try build it using SCons.

```bash
#/bin/bash -l

precice_ver="git"
nworkers=8
target_dir="precice-git"


if [[ ! -d ${target_dir} ]]; then
  git clone git@github.com:precice/precice.git ${target_dir}
fi

cd ${target_dir}
export PRECICE_ROOT=${PWD}

# Important to reproduce the bug
export PETSC_DIR=/usr/lib/petscdir/3.7.7
export PETSC_ARCH=x86_64-linux-gnu-real

scons petsc=yes python=yes -j ${nworkers}

./tools/compileAndTest.py -t
```