### PR TITLE
Fix petsc building with 64 bit indices

### DIFF
--- a/tools/travis-install-dependencies.sh
+++ b/tools/travis-install-dependencies.sh
@@ -26,7 +26,7 @@ if [ ! -d $LOCAL_INSTALL/include ]; then
     git clone -b maint https://bitbucket.org/petsc/petsc petsc
     cd petsc
     export PETSC_ARCH=arch-linux2-c-debug
-    python2 configure --with-debugging=1 > ~/petsc.configure
+    python2 configure --with-debugging=1 --with-64-bit-indices > ~/petsc.configure
     make > ~/petsc.make
 fi
 


### PR DESCRIPTION
Build PETSc with 64-bit indices to prevent tests from failing due to overflow.

This already happened to me and leads to crashes with messages along the lines of _"out-of-memory (0 Bytes allocated)"_ and _"Segmentation fault at address 0x0000010"_.