### PR TITLE
Added check for correct mapping direction to prevent ugly FPE

### DIFF
--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -470,6 +470,19 @@ void ParticipantConfiguration:: finishParticipantConfiguration
     impl::MeshContext& fromMeshContext = participant->meshContext(fromMeshID);
     impl::MeshContext& toMeshContext = participant->meshContext(toMeshID);
 
+    if(confMapping.direction == mapping::MappingConfiguration::READ){
+      CHECK(toMeshContext.provideMesh, "A read mapping needs to map to a provided mesh. "
+          "Mesh " << confMapping.toMesh->getName() << " is not provided.");
+      CHECK(not fromMeshContext.receiveMeshFrom.empty(), "A read mapping needs to map from a received mesh. "
+          "Mesh " << confMapping.fromMesh->getName() << " is not received.");
+    }
+    else{
+      CHECK(fromMeshContext.provideMesh, "A write mapping needs to map from a provided mesh. "
+          "Mesh " << confMapping.fromMesh->getName() << " is not provided.");
+      CHECK(not toMeshContext.receiveMeshFrom.empty(), "A write mapping needs to map to a received mesh. "
+          "Mesh " << confMapping.toMesh->getName() << " is not received.");
+    }
+
     if(confMapping.isRBF){
       fromMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
       toMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -1157,6 +1157,8 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       config::Configuration config;
       xml::configure(config.getXMLTag(), configs[k]);
       precice._impl->configure(config.getSolverInterfaceConfiguration());
+      int meshID = precice.getMeshID("MeshC");
+      precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
 
       if (precice.isActionRequired(writeInitData)){
@@ -1183,6 +1185,8 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       config::Configuration config;
       xml::configure(config.getXMLTag(), configs[k]);
       precice._impl->configure(config.getSolverInterfaceConfiguration());
+      int meshID = precice.getMeshID("MeshD");
+      precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
 
       if (precice.isActionRequired(writeInitData)){

--- a/src/precice/tests/three-solver-explicit-explicit.xml
+++ b/src/precice/tests/three-solver-explicit-explicit.xml
@@ -29,14 +29,14 @@
       <participant name="SolverTwo">
          <use-mesh name="MeshA" from="SolverOne"/>
          <use-mesh name="MeshC" provide="yes"/>
-         <read-data name="Data" mesh="MeshA" />
-         <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshA" constraint="conservative" />
+         <read-data name="Data" mesh="MeshC" />
+         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
       </participant>
       
       <participant name="SolverThree">
          <use-mesh name="MeshB" from="SolverOne"/>
          <use-mesh name="MeshD" provide="yes"/>
-         <read-data name="Data" mesh="MeshB" />
+         <read-data name="Data" mesh="MeshD" />
          <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
       </participant>
       

--- a/src/precice/tests/three-solver-explicit-implicit.xml
+++ b/src/precice/tests/three-solver-explicit-implicit.xml
@@ -40,18 +40,18 @@
       
       <participant name="SolverTwo">
          <use-mesh name="MeshA" from="SolverOne"/>
+         <write-data name="Data1" mesh="MeshC"/>
+         <read-data  name="Data0" mesh="MeshC"/>
          <use-mesh name="MeshC" provide="yes"/>
-         <write-data name="Data1" mesh="MeshA"/>
-         <read-data  name="Data0" mesh="MeshA"/>
-         <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshA" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
       </participant>
       
       <participant name="SolverThree">
          <use-mesh name="MeshB" from="SolverOne"/>
+         <write-data name="Data2" mesh="MeshD"/>
+         <read-data  name="Data0" mesh="MeshD"/>
          <use-mesh name="MeshD" provide="yes"/>
-         <write-data name="Data2" mesh="MeshB"/>
-         <read-data  name="Data0" mesh="MeshB"/>
-         <mapping:nearest-neighbor direction="read" from="MeshD" to="MeshB" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
       </participant>
       
       <m2n:mpi-single from="SolverOne" to="SolverTwo"/>

--- a/src/precice/tests/three-solver-implicit-explicit.xml
+++ b/src/precice/tests/three-solver-implicit-explicit.xml
@@ -40,18 +40,18 @@
       
       <participant name="SolverTwo">
          <use-mesh name="MeshA" from="SolverOne"/>
-         <write-data name="Data1" mesh="MeshA"/>
-         <read-data  name="Data0" mesh="MeshA"/>
+         <write-data name="Data1" mesh="MeshC"/>
+         <read-data  name="Data0" mesh="MeshC"/>
          <use-mesh name="MeshC" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshA" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
       </participant>
       
       <participant name="SolverThree">
          <use-mesh name="MeshB" from="SolverOne"/>
-         <write-data name="Data2" mesh="MeshB"/>
-         <read-data  name="Data0" mesh="MeshB"/>
+         <write-data name="Data2" mesh="MeshD"/>
+         <read-data  name="Data0" mesh="MeshD"/>
          <use-mesh name="MeshD" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshD" to="MeshB" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
       </participant>
       
       <m2n:mpi-single from="SolverOne" to="SolverTwo"/>

--- a/src/precice/tests/three-solver-implicit-implicit.xml
+++ b/src/precice/tests/three-solver-implicit-implicit.xml
@@ -40,18 +40,18 @@
       
       <participant name="SolverTwo">
          <use-mesh name="MeshA" from="SolverOne"/>
-         <write-data name="Data1" mesh="MeshA"/>
-         <read-data  name="Data0" mesh="MeshA"/>
+         <write-data name="Data1" mesh="MeshC"/>
+         <read-data  name="Data0" mesh="MeshC"/>
          <use-mesh name="MeshC" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshA" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
       </participant>
       
       <participant name="SolverThree">
          <use-mesh name="MeshB" from="SolverOne"/>
-         <write-data name="Data2" mesh="MeshB"/>
-         <read-data  name="Data0" mesh="MeshB"/>
+         <write-data name="Data2" mesh="MeshD"/>
+         <read-data  name="Data0" mesh="MeshD"/>
          <use-mesh name="MeshD" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshD" to="MeshB" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
       </participant>
       
       <m2n:mpi-single from="SolverOne" to="SolverTwo"/>

--- a/src/precice/tests/three-solver-parallel.xml
+++ b/src/precice/tests/three-solver-parallel.xml
@@ -40,18 +40,18 @@
       
       <participant name="SolverTwo">
          <use-mesh name="MeshA" from="SolverOne"/>
-         <write-data name="Data1" mesh="MeshA"/>
-         <read-data  name="Data0" mesh="MeshA"/>
+         <write-data name="Data1" mesh="MeshC"/>
+         <read-data  name="Data0" mesh="MeshC"/>
          <use-mesh name="MeshC" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshA" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
       </participant>
       
       <participant name="SolverThree">
          <use-mesh name="MeshB" from="SolverOne"/>
-         <write-data name="Data2" mesh="MeshB"/>
-         <read-data  name="Data0" mesh="MeshB"/>
+         <write-data name="Data2" mesh="MeshD"/>
+         <read-data  name="Data0" mesh="MeshD"/>
          <use-mesh name="MeshD" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshD" to="MeshB" constraint="conservative" />
+         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
       </participant>
       
       <m2n:mpi-single from="SolverOne" to="SolverTwo"/>


### PR DESCRIPTION
This should prevent the ugly FPE that @threimann ran into when coupling FASTEST and Ateles.

**Not** allowed is: 
```
    <participant name="Ateles">
      <use-mesh name="Ateles_Acoustics" provide="yes" />
      <use-mesh name="AcousticSurfaceFASTEST" from="FASTEST"/>
     ...
      <mapping:nearest-neighbor direction="read" to="AcousticSurfaceFASTEST" from="Ateles_Acoustics" constraint="consistent" timing="initial"/>
    </participant>
```

but should be:
```
      <mapping:nearest-neighbor direction="read" from="AcousticSurfaceFASTEST" to="Ateles_Acoustics" constraint="consistent" timing="initial"/>
```