### PR TITLE
Silence Travis warnings from OpenMPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - LD_LIBRARY_PATH="$PETSC_DIR/$PETSC_ARCH/lib:$LOCAL_INSTALL/lib:$LD_LIBRARY_PATH"
     - LIBRARY_PATH="$PETSC_DIR/$PETSC_ARCH/lib:$LOCAL_INSTALL/lib:$LIBRARY_PATH"
     - PYTHONPATH="$PETSC_DIR/$PETSC_ARCH/lib:/usr/lib/python2.7:/usr/lib/python2.7/dist-packages:/usr/lib/python2.7/plat-x86_64-linux-gnu"
+    - CXXFLAGS="-Wall -Wextra -Wno-unused-parameter"
 
   matrix:
     - MPI=on PETSC=on
@@ -40,7 +41,7 @@ cache:
     - $LOCAL_INSTALL
 
 before_install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-6" && export CC="gcc-6"; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-6" && export CC="gcc-6" && export CXXFLAGS="$CXXFLAGS -Wno-literal-suffix"; fi
   - export OMPI_CXX=$CXX
   - if [ "$MPI" = "on" ]; then export CXX="mpicxx"; fi
 

--- a/SConstruct
+++ b/SConstruct
@@ -123,16 +123,16 @@ PRECICE_VERSION = "1.3.0"
 env.Append(CCFLAGS = ['-fPIC'])
 
 real_compiler = get_real_compiler(env["compiler"])
-if real_compiler == 'icc':
+if real_compiler.startswith('icc'):
     env.AppendUnique(LIBPATH = ['/usr/lib/'])
     env.Append(LIBS = ['stdc++'])
     if env["build"] == 'debug':
         env.Append(CCFLAGS = ['-align'])
     elif env["build"] == 'release':
         env.Append(CCFLAGS = ['-w', '-fast', '-align', '-ansi-alias'])
-elif real_compiler == 'g++':
+elif real_compiler.startswith('g++'):
     env.Append(CCFLAGS= ['-Wno-literal-suffix'])
-elif real_compiler == "clang++":
+elif real_compiler.startswith("clang++"):
     env.Append(CCFLAGS= ['-Wsign-compare']) # sign-compare not enabled in Wall with clang.
 elif real_compiler == "g++-mp-4.9":
     # Some special treatment that seems to be necessary for Mac OS.

--- a/SConstruct
+++ b/SConstruct
@@ -131,7 +131,7 @@ if real_compiler == 'icc':
     elif env["build"] == 'release':
         env.Append(CCFLAGS = ['-w', '-fast', '-align', '-ansi-alias'])
 elif real_compiler == 'g++':
-    pass
+    env.Append(CCFLAGS= ['-Wno-literal-suffix'])
 elif real_compiler == "clang++":
     env.Append(CCFLAGS= ['-Wsign-compare']) # sign-compare not enabled in Wall with clang.
 elif real_compiler == "g++-mp-4.9":


### PR DESCRIPTION
Our Travis log is currently flooded with warnings from the OpenMPI headers.
This PR silences these warnings by appending `-Wno-literal-suffix` to the `CXXFLAGS`.

One example from [here](https://travis-ci.org/precice/precice/jobs/499187815#L791):
```
/usr/lib/openmpi/include/mpi_portable_platform.h:374:34: warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]
              _STRINGIFY(__GNUC__)"."_STRINGIFY(__GNUC_MINOR__)"."_STRINGIFY(__GNUC_PATCHLEVEL__)
```

@floli please review and merge