### PR TITLE
Turn Python Bindings into proper packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://github.com/precice/precice/wiki/Roadmap).
 
 ## develop
+- The python modules are now proper packages tracking dependecies etc
 - The python module for the preCICE bindings `PySolverInterface` is renamed to `precice`. This change does not break old code. Please refer to [`precice/src/precice/bindings/python/README.md`](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md) for more informaiton.
 - Use boost stacktrace for cross platform stacktrace printing. This requires Boost 1.65.1
 - Add explicit linking to `libdl` for `boost::stacktrace`

--- a/src/precice/bindings/PySolverInterface/README.md
+++ b/src/precice/bindings/PySolverInterface/README.md
@@ -1,68 +1,37 @@
 **DEPRECATED!!!**
 
-`PySolverInterface` are the old python language bindings for preCICE and will be removed in version 2.0.0. Please use the new python language bindings [`precice`](https://github.com/precice/precice/tree/changingNameOfPySolverInterface/src/precice/bindings/python), if possible. If you still want to use the syntax related to the old `PySolverInterface` bindings and you do not want to change your code, refer to the instructions below.
+`PySolverInterface` are the old python language bindings for preCICE and will be removed in version 2.0.0. Please use the new python language bindings [`precice`](../python/README.md).
 
 Python language bindings for preCICE
 ----------------------------
 
 # Dependencies
 
-* Download and install Cython from http://cython.org/#download or install it using your package manager (e.g. `pip install --user Cython` or `pip3 install --user Cython`). 
-* Only necessary, if your are using python2: Install Enum using your package manager (e.g. `sudo apt install python-enum34`)
+Install the [precice python bindings](../python/README.md).
 
-*Note:* If you installed Cython using `apt install Cython` under Ubuntu 16.04, you might face problems. Try installing using `pip2/3` instead.
+# Installation
 
-# Building
-
-1. Install the new language bindings `precice` following the instructions [here](https://github.com/precice/precice/tree/changingNameOfPySolverInterface/src/precice/bindings/python).
-2. Open terminal in this folder.
-3. Execute the following command:
-
+In this directory, run:
 ```
-$ python3 setup.py build
-```
-This creates a folder `build` with the binaries.
-
-4. Run 
-```
-$ python3 setup.py install --user
-```
-to install the module on your system. You might need `sudo`, depending on the how you have installed Python. You can use the option `--prefix=your/default/path` to install the module at an arbitrary path of your choice (for example, if you cannot or don't want to use `sudo`).
-
-5. Clean
-```
-$ python3 setup.py clean --all
-```
-again: depending on you system, you might need `sudo`.
-
-It is recommended to use preCICE as a shared library here. `mpic++` is used as default compiler, if you want to use a different compiler, this can be done with the option `--mpicompiler=<yourcompiler>`. Example:
-```
-$ python3 setup.py build --mpicompiler=mpicc
+$ pip3 install --user .
 ```
 
 # Using
 
-1. Import `PySolverInterface` into your code:
+1. Import `PySolverInterface` in your code:
 
-```
+```python
 import PySolverInterface
 from PySolverInterface import *
 ```
 
-2. If you use preCICE with MPI, you also have to add
-   
+2. If you compiled preCICE with MPI, you also have to install mpi4py:
+
 ```   
-from mpi4py import MPI
+$ pip3 install --user mpi4py
+```   
+
+Then add the following import to your python file:
+```python
+from mpi4py import MPI # Initialize MPI
 ```
-
-To install mpi4py, you can e.g. (you need MPI already installed, e.g. libopenmpi-dev) 
-
-```
-sudo apt-get install python-pip
-sudo pip install mpi4py
-```
-
-
-**NOTE:**
-- For an example of how the `PySolverInterface` can be used, refer to the [1D elastic tube example](https://github.com/precice/precice/wiki/1D-elastic-tube-using-the-Python-API).
-- In case the compilation fails with `shared_ptr.pxd not found` messages, check if you use the latest version of Cython.

--- a/src/precice/bindings/PySolverInterface/setup.py
+++ b/src/precice/bindings/PySolverInterface/setup.py
@@ -1,8 +1,15 @@
 from setuptools import setup
 
 setup(
-    name="PySolverInterface",
-    packages=['PySolverInterface'],
+    name='PySolverInterface',
+    version='0.1',
     description='Python language bindings for preCICE coupling library',
-    python_requires='>=3'
+    url='https://github.com/precice/precice',
+    author='the preCICE developers',
+    author_email='info@precice.org',
+    license='LGPL-3.0',
+    python_requires='>=3',
+    install_requires=[
+        'precice'
+    ]
 )

--- a/src/precice/bindings/PySolverInterface/setup.py
+++ b/src/precice/bindings/PySolverInterface/setup.py
@@ -9,6 +9,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
+    packages=['PySolverInterface'],
     install_requires=[
         'precice'
     ]

--- a/src/precice/bindings/python/README.md
+++ b/src/precice/bindings/python/README.md
@@ -1,69 +1,85 @@
 Python language bindings for preCICE
 ------------------------------------
 
-# Dependencies
+These are the python bindings for preCICE.
 
-* Download and install Cython from http://cython.org/#download or install it using your package manager (e.g. `pip install Cython` or `pip3 install Cython`). 
-* Only necessary, if your are using python2: Install Enum using your package manager (e.g. `sudo apt install python-enum34`)
+# Installing the package
 
-*Note:* If you installed Cython using `apt install Cython` under Ubuntu 16.04, you might face problems. Try installing using `pip2/3` instead.
+We recommend using `pip3 install --user` for the sake of simplicity.
 
-*Note:* If you have both Python 2 and Python 3 in your system, make sure that you use the correct version with `python2` or `python3` (the default `python` command may invoke the wrong version, giving you errors such as  not being able to find packages). You may actually want to change your default python version to Python 3 e.g. by setting up an alias (it has already been a while since Python 3 is around, that's probably a good idea!).
+For system installs of preCICE, this works out of the box.
 
-# Building
+If preCICE was installed in a custom prefix, or not installed at all, you have to extend the following environment variables:
+- `LIBRARY_PATH`, `LD_LIBRARY_PATH` to the library location, or `$prefix/lib`
+- `CPATH` either to the `src` directory or the `$prefix/include`
 
-1. Open terminal in this folder.
-2. Execute the following command:
+## Using pip3
+
+In this directory, execute:
+```
+$ pip3 install --user .
+```
+
+This will fetch cython, compile the bindings and finally install the precice package.
+
+## With explicit include path, library path, or mpicompiler
+
+1. Install cython via pip3
+```
+$ pip3 install --user cython
+```
+2. Open terminal in this folder.
+3. Build the bindings
 
 ```
-$ python3 setup.py build_ext --include-dirs=$PRECICE_ROOT/src --library-dirs=$PRECICE_ROOT/build/last
+$ python3 setup.py build_ext --mpicompiler=mpicc --include-dirs=$PRECICE_ROOT/src --library-dirs=$PRECICE_ROOT/build/last 
 ```
-This creates a folder `build` with the binaries.
-If you build preCICE using CMake, you can pass the path to the CMake binary directory using `--library-dirs`.
 
-3. Run 
+**Options:**
+- `--include-dirs=`, default: `''`   
+  Path to the headers of preCICE, point to the sources `$PRECICE_ROOT/src`, or the your custom install prefix `$prefix/include`.
+- `--library-dirs=`, default: `''`  
+  Path to the libary of preCICE, point to the build directory (scons: `$PRECICE_ROOT/build/last`, cmake: wherever you configured the build), or to the custom install prefix `$prefix/lib`.
+- `--mpicompiler=`, default: `mpic++`  
+  MPI compiler wrapper of choice.
+
+**NOTES:**
+
+- If you build preCICE using CMake, you can pass the path to the CMake binary directory using `--library-dirs`.
+- It is recommended to use preCICE as a shared library here.
+- If you used scons for building precice and `PRECICE_ROOT` is defined, you can also use the script `build_and_install.sh`.
+
+4. Install the bindings
 ```
 $ python3 setup.py install --user
 ```
-to install the module on your system. You might need `sudo`, depending on the how you have installed Python. You can use the option `--prefix=your/default/path` to install the module at an arbitrary path of your choice (for example, if you cannot or don't want to use `sudo`).
 
-4. Clean
+4. Clean-up _optional_
 ```
 $ python3 setup.py clean --all
 ```
-This will clean the (user's) build directory (you probably don't need these files as you already installed them elsewhere).
 
-It is recommended to use preCICE as a shared library here. `mpic++` is used as default compiler, if you want to use a different compiler, this can be done with the option `--mpicompiler=<yourcompiler>`. Example:
+# Test the installation
+
+Run the following to test the installation:
 ```
-$ python3 setup.py build --mpicompiler=mpicc
-```
-
-**NOTE:** If you used scons for building precice and `PRECICE_ROOT` is defined, you can also use the script `build_and_install.sh`.
-
-# Using
-
-1. Import `precice` into your code:
-
-```
-import precice
-from precice import *
+$ python3 -c "import precice"
 ```
 
-2. If you use preCICE with MPI, you also have to add
-   
-```   
-from mpi4py import MPI
-```
+# Using with MPI
 
-To install mpi4py, you can e.g. (you need MPI already installed, e.g. libopenmpi-dev) 
+If precice was compiled with MPI, you have to initialize MPI prior to configuring a SolverInterface.
+To do so, install the package `mpi4py` and import `MPI` in your python module.
 
 ```
-sudo apt-get install python-pip
-sudo pip install mpi4py
+$ pip3 install --user mpi4py
 ```
 
+```python
+from mpi4py import MPI # Initialize MPI 
+```
 
 **NOTE:**
 - For an example of how the `precice` can be used, refer to the [1D elastic tube example](https://github.com/precice/precice/wiki/1D-elastic-tube-using-the-Python-API).
 - In case the compilation fails with `shared_ptr.pxd not found` messages, check if you use the latest version of Cython.
-- If you want to use the old interface (precice version < 1.4.0), please also install the corresponding wrapper [`PySolverInterface`](https://github.com/precice/precice/tree/changingNameOfPySolverInterface/src/precice/bindings/PySolverInterface) using `setup.py install`.
+- If you want to use the old interface (precice version < 1.4.0), please also install the corresponding wrapper [`PySolverInterface`](https://github.com/precice/precice/tree/changingNameOfPySolverInterface/src/precice/bindings/PySolverInterface).

--- a/src/precice/bindings/python/build_and_install.sh
+++ b/src/precice/bindings/python/build_and_install.sh
@@ -1,3 +1,19 @@
+#! /bin/env sh
+set -e
+echo "Building and installing precice bindings from a scons-build"
+if [[ -z "$PRECICE_ROOT" ]]; then
+    echo "ERROR: PRECICE_ROOT not set!"
+    exit 1
+fi
+if [[ ! -d "$PRECICE_ROOT/src" ]]; then
+    echo "ERROR: no source directory found! \"$PRECICE_ROOT/\""
+    exit 1
+fi
+if [[ ! -d "$PRECICE_ROOT/build/last" ]]; then
+    echo "ERROR: no scons build found! \"$PRECICE_ROOT/build/last\""
+    exit 1
+fi
 python3 setup.py build_ext --library-dirs=$PRECICE_ROOT/build/last --include-dirs=$PRECICE_ROOT/src
 python3 setup.py install --user
 python3 setup.py clean --all
+exit 0

--- a/src/precice/bindings/python/pyproject.toml
+++ b/src/precice/bindings/python/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]

--- a/src/precice/bindings/python/pyproject.toml
+++ b/src/precice/bindings/python/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+# PEP 518 - minimum build system requirements
+requires = ["setuptools", "wheel", "Cython>=0.29"]

--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -10,7 +10,7 @@ from distutils.command.build import build
 
 # name of Interfacing API
 APPNAME = "precice"
-APPVERSION = "1.0"
+APPVERSION = "1.3"
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -10,7 +10,7 @@ from distutils.command.build import build
 
 # name of Interfacing API
 APPNAME = "precice"
-APPVERSION = "1.3"
+APPVERSION = "1.3"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -10,6 +10,7 @@ from distutils.command.build import build
 
 # name of Interfacing API
 APPNAME = "precice"
+APPVERSION = "1.0"
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -127,9 +128,17 @@ class my_build(build, object):
 # build precice.so python extension to be added to "PYTHONPATH" later
 setup(
     name=APPNAME,
+    version=APPVERSION,
     description='Python language bindings for preCICE coupling library',
+    url='https://github.com/precice/precice',
+    author='the preCICE developers',
+    author_email='info@precice.org',
+    license='LGPL-3.0',
+    python_requires='>=3',
+    install_requires=[
+        'cython'
+    ],
     cmdclass={'build_ext': my_build_ext,
               'build': my_build,
               'install': my_install},
-    python_requires='>=3'
 )

--- a/tools/solverdummies/python/README.md
+++ b/tools/solverdummies/python/README.md
@@ -1,12 +1,17 @@
-# Compilation
+# Install Dependencies
 
-Don't forget to build the Python bindings! Go [here](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md) for instructions.
+Run in this directory:
+```
+pip3 install --user -r requirements.txt
+```
+
+Don't forget to install the precice [python bindings](../../../src/precice/bindings/python/README.md).
 
 # Run
 
 You can test the dummy solver by coupling two instances with each other. Open two terminals and run
- * `python solverdummy.py precice-config.xml SolverOne MeshOne`
- * `python solverdummy.py precice-config.xml SolverTwo MeshTwo`
+ * `python3 solverdummy.py precice-config.xml SolverOne MeshOne`
+ * `python3 solverdummy.py precice-config.xml SolverTwo MeshTwo`
 
 # Next Steps
 

--- a/tools/solverdummies/python/requirements.txt
+++ b/tools/solverdummies/python/requirements.txt
@@ -1,0 +1,4 @@
+precice>=1.3
+argparse>=1.4
+numpy>=1.16
+mpi4py>=3


### PR DESCRIPTION
The python bindings are now packages:

* `PySolverinterface` depends on `precice>=1.3.0`
* `precice` installs `cython` prior to setup
* Readmes explain how to install everything

The python solverdummy now has the following requirements-file:
```
precice
numpy
mpi4py
```

# Result

```
$ pip3 install --user src/precice/bindings/python
$ pip3 install --user src/precice/bindings/PySolverdummy
$ pip3 install --user -r tools/solverdummies/python/requirements.txt
$ // run solver dummies
```

Reviewers: please give feedback