### PR TITLE
Generate ENV file to similify working with custom install prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://github.com/precice/precice/wiki/Roadmap).
 
 ## develop
+- Generate an env file that can be sourced after installing the library
 - The python module for the preCICE bindings `PySolverInterface` is renamed to `precice`. This change does not break old code. Please refer to [`precice/src/precice/bindings/python/README.md`](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md) for more informaiton.
 - Use boost stacktrace for cross platform stacktrace printing. This requires Boost 1.65.1
 - Add explicit linking to `libdl` for `boost::stacktrace`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ list (APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 list (APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 
 include(CopyTargetProperty)
+include(EnvFile)
 
 # CMake Policies
 
@@ -278,6 +279,14 @@ install(TARGETS precice binprecice
   PUBLIC_HEADER DESTINATION include/precice
   INCLUDES DESTINATION include/precice
   )
+
+write_env_file(
+  FILE "${preCICE_BINARY_DIR}/precice.env"
+  PREFIX "${CMAKE_INSTALL_PREFIX}"
+  LIBRARY lib
+  RUNTIME bin
+  INTERFACE include 
+)
 
 if(PRECICE_InstallTest)
   # Install the testprecice target

--- a/cmake/EnvFile.cmake
+++ b/cmake/EnvFile.cmake
@@ -1,0 +1,30 @@
+# This function writes an env file to be sourced by a shell.
+# 
+# Mandatory Arguments:
+#   FILE      - The file to write
+#   PREFIX    - The prefix for the options below
+#
+# Options:
+#   LIBRARY   - The library dir, usually lib
+#   RUNTIME   - The runtime dir, usually bin
+#   INTERFACE - The interface dir, usually include
+#
+function(write_env_file)
+  cmake_parse_arguments(PARSE_ARGV 0 WEF "" "FILE;LIBRARY;INTERFACE;RUNTIME" "")
+  if(NOT WEF_FILE)
+    message(FATAL_ERROR "The argument FILE is missing!")
+  endif()
+  if(NOT WEF_PREFIX)
+    message(FATAL_ERROR "The argument PREFIX is missing!")
+  endif()
+  if(WEF_LIBRARY)
+    file(APPEND ${WEF_FILE} "export LD_LIBRARY_PATH=\"${WEF_PREFIX}/${WEF_LIBRARY}:\$LD_LIBRARY_PATH\"\n")
+    file(APPEND ${WEF_FILE} "export LIBRARY_PATH=\"${WEF_PREFIX}/${WEF_LIBRARY}:\$LIBRARY_PATH\"\n")
+  endif()
+  if(WEF_INTERFACE)
+    file(APPEND ${WEF_FILE} "export CPATH=\"${WEF_PREFIX}/${WEF_INTERFACE}:\$CPATH\"\n")
+  endif()
+  if(WEF_RUNTIME)
+    file(APPEND ${WEF_FILE} "export PATH=\"${WEF_PREFIX}/${WEF_RUNTIME}:\$PATH\"\n")
+  endif()
+endfunction(write_env_file)


### PR DESCRIPTION
This PR generates the file `precice.env` in the binary directory which sets environment variables to the location of the install prefix. It extends `LD_LIBRARY_PATH`, `LIBRARY_PATH`,  `PATH` and `CPATH`.

Scenario:
```console
$ cmake -DCMAKE_INSTALL_PREFIX=~/software/bugfree/precice/ $PRECICE_ROOT
$ make install
$ . precice.env
$ echo $CPATH
/home/precicefan/software/bugfree/precice/:
```
A user could then either paste the file content into the `.bashrc` or source it from there.