### PR TITLE
Always generate pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,16 @@ else()
     )
 endif()
 
+# Configure a pkg-config file
+configure_file(
+  "${PROJECT_SOURCE_DIR}/tools/packaging/debian/precice.pc.in"
+  "lib/pkgconfig/libprecice.pc"
+  @ONLY
+  )
+install(DIRECTORY "${preCICE_BINARY_DIR}/lib/pkgconfig" 
+  DESTINATION lib
+)
+
 
 #
 # CTest

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -84,15 +84,4 @@ install(FILES "${PRECICE_PACKAGING_DIR}/lintian-override"
   RENAME ${CPACK_PACKAGE_NAME}
   )
 
-# Configure a pkg-config file for the debian package
-configure_file(
-  "${PROJECT_SOURCE_DIR}/tools/packaging/debian/precice.pc.in"
-  "${PRECICE_PACKAGING_DIR}/pkgconfig/libprecice.pc"
-  @ONLY
-  )
-install(DIRECTORY "${PRECICE_PACKAGING_DIR}/pkgconfig" 
-  DESTINATION lib
-)
-
-
 include(CPack)


### PR DESCRIPTION
This PR moves the pkgconfig generation from the CPack preparation to the general configuration.
It will now always be generated and installed.