### PR TITLE
Add potentially missing SIGXCPU

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -32,6 +32,10 @@
 #include "versions.hpp"
 
 #include <csignal> // used for installing crash handler
+#ifndef SIGXCPU
+#define SIGXCPU 24 /* exceeded CPU time limit */
+#endif
+
 #include <utility>
 
 #include "logging/Logger.hpp"


### PR DESCRIPTION
This PR adds the POSIX signal SIGXCPU if it was not defined prior to invokation.

Alternatively, instead of defining the signal, we could disable the handler registration. 

Fixes #320

@floli Please review and merge if you are ok with defining the signal.