### PR TITLE
Use a Rtree query for tagMesh*Round 

### DIFF
--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -772,30 +772,30 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
   // Tags all vertices that are inside otherMesh's bounding box, enlarged by the support radius
   if (
 #if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
-          _basisFunction.hasCompactSupport()
+      _basisFunction.hasCompactSupport()
 #else
-          false
+      false
 #warning "Mesh filtering deactivated, due to PETSc version < 3.8. \
-          preCICE is fully functional, but performance for large cases is degraded."
+      preCICE is fully functional, but performance for large cases is degraded."
 #endif
      )
   {
-      auto rtree = mesh::rtree::getVertexRTree(filterMesh);
-      namespace bgi = boost::geometry::index;
-      auto bb = otherMesh->getBoundingBox();
-      // Enlarge by support radius
-      for (int d = 0; d < otherMesh->getDimensions(); d++){
-        bb[d].first -= _basisFunction.getSupportRadius();
-        bb[d].second += _basisFunction.getSupportRadius();
-      }
-      rtree->query(bgi::within(bb),
-          boost::make_function_output_iterator([&filterMesh](size_t idx){
-            filterMesh->vertices()[idx].tag();
+    auto rtree = mesh::rtree::getVertexRTree(filterMesh);
+    namespace bgi = boost::geometry::index;
+    auto bb = otherMesh->getBoundingBox();
+    // Enlarge by support radius
+    for (int d = 0; d < otherMesh->getDimensions(); d++){
+      bb[d].first -= _basisFunction.getSupportRadius();
+      bb[d].second += _basisFunction.getSupportRadius();
+    }
+    rtree->query(bgi::within(bb),
+        boost::make_function_output_iterator([&filterMesh](size_t idx){
+          filterMesh->vertices()[idx].tag();
           }));
   }
   else {
-      for (auto& vert : filterMesh->vertices())
-        vert.tag();
+    for (auto& vert : filterMesh->vertices())
+      vert.tag();
   }
 }
 

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -773,22 +773,21 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
   auto rtree = mesh::rtree::getVertexRTree(filterMesh);
   mesh::Mesh::VertexContainer insideVerts;
   if (not _basisFunction.hasCompactSupport()) {
-      insideVerts = filterMesh->vertices();
+      for (auto& vert : filterMesh->vertices()){
+        vert.tag();
+      }
   }
   else {
     #if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
       namespace bgi = boost::geometry::index;
       rtree->query(bgi::within(otherMesh->getBoundingBox()),
-          boost::make_function_output_iterator([&filterMesh, &insideVerts](size_t idx){
-            insideVerts.push_back(&filterMesh->vertices()[idx]);
+          boost::make_function_output_iterator([&filterMesh](size_t idx){
+            filterMesh->vertices()[idx].tag();
           }));
     #else
       #warning "Mesh filtering deactivated, due to PETSc version < 3.8. \
 preCICE is fully functional, but performance for large cases is degraded."
     #endif
-  }
-  for (auto& vert : insideVerts){
-    vert.tag();
   }
 }
 
@@ -833,14 +832,10 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshSecondRound()
     bb[d].second += _basisFunction.getSupportRadius();
   }
   auto rtree = mesh::rtree::getVertexRTree(mesh);
-  mesh::Mesh::VertexContainer insideVerts;
   rtree->query(boost::geometry::index::within(bb),
-      boost::make_function_output_iterator([&mesh, &insideVerts](size_t idx){
-        insideVerts.push_back(&mesh->vertices()[idx]);
+      boost::make_function_output_iterator([&mesh](size_t idx){
+        mesh->vertices()[idx].tag();
       }));
-  for (auto& vert : insideVerts){
-    vert.tag();
-  }
 }
 
 

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -633,6 +633,103 @@ BOOST_AUTO_TEST_CASE(testDistributedConservative2DV5)
     );
 }
 
+void testTagging(MeshSpecification inMeshSpec,
+    MeshSpecification outMeshSpec,
+    MeshSpecification shouldTagFirstRound,
+    MeshSpecification shouldTagSecondRound,
+    bool consistent)
+{
+  int meshDimension = inMeshSpec[0].position.size();
+  int valueDimension = inMeshSpec[0].value.size();
+
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false) );
+  mesh::PtrData inData = inMesh->createData("InData", valueDimension);
+  int inDataID = inData->getID();
+  getDistributedMesh(inMeshSpec, inMesh, inData);
+
+  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false) );
+  mesh::PtrData outData = outMesh->createData( "OutData", valueDimension);
+  int outDataID = outData->getID();
+  getDistributedMesh(outMeshSpec, outMesh, outData);
+
+  Gaussian fct(4.5); //Support radius approx. 1
+  Mapping::Constraint constr = consistent? Mapping::CONSISTENT : Mapping::CONSERVATIVE;
+  PetRadialBasisFctMapping<Gaussian> mapping(constr, 2, fct, false, false, false);
+  inMesh->computeState();
+  outMesh->computeState();
+
+  mapping.setMeshes(inMesh, outMesh);
+  mapping.tagMeshFirstRound();
+
+  for (const auto& v : inMesh->vertices()){
+    auto pos = std::find_if(shouldTagFirstRound.begin(), shouldTagFirstRound.end(),
+        [meshDimension, &v](const VertexSpecification& spec){
+          return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
+        });
+    bool found = pos != shouldTagFirstRound.end();
+    BOOST_TEST(found >= v.isTagged(), "FirstRound: Vertex " << v
+        << " is tagged, but should not be.");
+    BOOST_TEST(found <= v.isTagged(), "FirstRound: Vertex " << v
+        << " is not tagged, but should be.");
+  }
+
+  mapping.tagMeshSecondRound();
+
+  for (const auto& v : inMesh->vertices()){
+    auto posFirst = std::find_if(shouldTagFirstRound.begin(), shouldTagFirstRound.end(),
+        [meshDimension, &v](const VertexSpecification& spec){
+          return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
+        });
+    bool foundFirst = posFirst != shouldTagFirstRound.end();
+    auto posSecond = std::find_if(shouldTagSecondRound.begin(), shouldTagSecondRound.end(),
+        [meshDimension, &v](const VertexSpecification& spec){
+          return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
+        });
+    bool foundSecond = posSecond != shouldTagSecondRound.end();
+    BOOST_TEST(foundFirst <= v.isTagged(), "SecondRound: Vertex " << v
+        << " is not tagged, but should be from the first round.");
+    BOOST_TEST(foundSecond <= v.isTagged(), "SecondRound: Vertex " << v
+        << " is not tagged, but should be.");
+    BOOST_TEST((foundSecond or foundFirst)>= v.isTagged(), "SecondRound: Vertex " << v
+        << " is tagged, but should not be.");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testTagFirstRound){
+  using Par = utils::Parallel;
+  assertion(Par::getCommunicatorSize() == 4);
+  //    *
+  //    + <-- owned
+  //* * x * *
+  //    *
+  //    *
+  MeshSpecification outMeshSpec = {
+    {0, -1, {0, 0}, {0}}
+  };
+  MeshSpecification inMeshSpec = {
+    { 0, -1, {-1, 0}, {1}}, //inside
+    { 0, -1, {-2, 0}, {1}}, //outside
+    { 0, 0, {1, 0}, {1}},  //inside, owner
+    { 0, -1, {2, 0}, {1}},  //outside
+    { 0, -1, {0, -1}, {1}}, //inside
+    { 0, -1, {0, -2}, {1}}, //outside
+    { 0, -1, {0, 1}, {1}}, //inside
+    { 0, -1, {0, 2}, {1}}  //outside
+  };
+  MeshSpecification shouldTagFirstRound = {
+    { 0, -1, {-1, 0}, {1}},
+    { 0, -1, {1, 0}, {1}},
+    { 0, -1, {0, -1}, {1}},
+    { 0, -1, {0, 1}, {1}}
+  };
+  MeshSpecification shouldTagSecondRound = {
+    { 0, -1, {2, 0}, {1}}
+  };
+  testTagging(inMeshSpec, outMeshSpec, shouldTagFirstRound, shouldTagSecondRound, true);
+  // For conservative just swap meshes.
+  testTagging(outMeshSpec, inMeshSpec, shouldTagFirstRound, shouldTagSecondRound, false);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 BOOST_AUTO_TEST_SUITE(Serial,

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -11,11 +11,6 @@
 #include <list>
 #include <vector>
 #include <boost/signals2.hpp>
-#include <boost/geometry/geometries/concepts/box_concept.hpp>
-#include <boost/concept/assert.hpp>
-#include <boost/geometry/geometries/box.hpp>
-#include <boost/geometry.hpp>
-
 
 namespace precice {
   namespace mesh {
@@ -350,55 +345,3 @@ private:
 std::ostream& operator<<(std::ostream& os, const Mesh& q);
 
 }} // namespace precice, mesh
-
-//Type traits for Mesh: Make BoundingBox fulfill bg::Box concept
-
-namespace boost { 
-namespace geometry {
-namespace traits {
-using BoundingBox = ::precice::mesh::Mesh::BoundingBox;
-
-template <>
-struct tag<BoundingBox>
-{
-  using type = box_tag;
-};
-
-namespace bg = ::boost::geometry;
-template <>
-struct point_type<BoundingBox>
-{
-  using point_t = bg::model::point<double, 3, bg::cs::cartesian>; //fake point type.
-  using type = point_t; //BoundingBox does not consist of this point type, actually.
-};
-
-template <std::size_t Dimension>
-struct indexed_access<BoundingBox, min_corner, Dimension>
-{
-  static inline double get(const BoundingBox& bb)
-  {
-    return bb[Dimension].first;
-  }
-  static inline void set(BoundingBox& bb, double value)
-  {
-    bb[Dimension].first = value;
-  }
-};
-
-template <std::size_t Dimension>
-struct indexed_access<BoundingBox, max_corner, Dimension>
-{
-  static inline double get(const BoundingBox& bb)
-  {
-    return bb[Dimension].second;
-  }
-  static inline void set(BoundingBox& bb, const double& value)
-  {
-    bb[Dimension].second = value;
-  }
-}; 
-BOOST_CONCEPT_ASSERT( (bg::concepts::Box<BoundingBox>) );
-}}}
-//namespace bg = ::boost::geometry;
-//typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
-//BOOST_CONCEPT_ASSERT( (bg::concepts::Box<bg::model::box<point_t>) );

--- a/src/mesh/impl/RTreeAdapter.hpp
+++ b/src/mesh/impl/RTreeAdapter.hpp
@@ -142,6 +142,54 @@ struct access<Eigen::VectorXd, Dimension>
 
 BOOST_CONCEPT_ASSERT( (concepts::Point<Eigen::VectorXd>));
 
+/// Adapts precice's Mesh::BoundingBox to boost.geometry
+/*
+ * Mesh::BoundingBox should be fulfilling the boost.geometry Box concept
+ */
+using BoundingBox = std::vector<std::pair<double, double>>;
+
+template <>
+struct tag<BoundingBox>
+{
+  using type = box_tag;
+};
+
+namespace bg = ::boost::geometry;
+template <>
+struct point_type<BoundingBox>
+{
+  using point_t = bg::model::point<double, 3, bg::cs::cartesian>; //fake point type.
+  using type = point_t; //BoundingBox does not consist of this point type, actually.
+};
+
+template <std::size_t Dimension>
+struct indexed_access<BoundingBox, min_corner, Dimension>
+{
+  static inline double get(const BoundingBox& bb)
+  {
+    return bb[Dimension].first;
+  }
+  static inline void set(BoundingBox& bb, double value)
+  {
+    bb[Dimension].first = value;
+  }
+};
+
+template <std::size_t Dimension>
+struct indexed_access<BoundingBox, max_corner, Dimension>
+{
+  static inline double get(const BoundingBox& bb)
+  {
+    return bb[Dimension].second;
+  }
+  static inline void set(BoundingBox& bb, const double& value)
+  {
+    bb[Dimension].second = value;
+  }
+};
+
+BOOST_CONCEPT_ASSERT( (bg::concepts::Box<BoundingBox>) );
+
 }}}
 
 namespace precice {

--- a/src/mesh/impl/RTreeAdapter.hpp
+++ b/src/mesh/impl/RTreeAdapter.hpp
@@ -167,10 +167,14 @@ struct indexed_access<BoundingBox, min_corner, Dimension>
 {
   static inline double get(const BoundingBox& bb)
   {
+    if (Dimension >= bb.size())
+        return std::numeric_limits<double>::lowest();
     return bb[Dimension].first;
   }
   static inline void set(BoundingBox& bb, double value)
   {
+    if (Dimension >= bb.size())
+        return;
     bb[Dimension].first = value;
   }
 };
@@ -180,10 +184,14 @@ struct indexed_access<BoundingBox, max_corner, Dimension>
 {
   static inline double get(const BoundingBox& bb)
   {
+    if (Dimension >= bb.size())
+        return std::numeric_limits<double>::max();
     return bb[Dimension].second;
   }
   static inline void set(BoundingBox& bb, const double& value)
   {
+    if (Dimension >= bb.size())
+        return;
     bb[Dimension].second = value;
   }
 };


### PR DESCRIPTION
This PR targets issue #293 by using boost::geometry for lookup.