### PR TITLE
Add LGTM configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,11 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - petsc-dev
+        - libboost-all-dev
+        - libopenmpi-dev
+        - lbixml2-dev
+        - libeigen3-dev
+        - python-dev
+        - python-numpy


### PR DESCRIPTION
This is an experimental PR to add support for the static analysis service LGTM.

[preCICE is registered](https://lgtm.com/projects/g/precice/precice/), but the C++ autodetection does not work for PETSc. This PR adds a `.lgtm.yml` file which sets the required packages.

For this to work, we have to activate the [LGTM pull request review](https://lgtm.com/projects/g/precice/precice/ci/). Shall we try this out?