### PR TITLE
Add ccache caching in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
       compiler: clang
       env: BUILD_TYPE=SCONS MPI=off PETSC=off
 cache:
+  ccache: true
   directories:
     - $LOCAL_INSTALL
 

--- a/tools/travis-build-test.sh
+++ b/tools/travis-build-test.sh
@@ -17,7 +17,7 @@ if [ "$BUILD_TYPE" = "SCONS" ]; then
 else
     # CMake build
     mkdir $TRAVIS_BUILD_DIR/build && cd $TRAVIS_BUILD_DIR/build
-    cmake -DPETSC=$PETSC -DMPI=$MPI -DPYTHON=on -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug $TRAVIS_BUILD_DIR
+    cmake -DPETSC=$PETSC -DMPI=$MPI -DPYTHON=on -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache $TRAVIS_BUILD_DIR
     cmake --build . -- -j $(nproc)
     ctest --output-on-failure -O $TRAVIS_BUILD_DIR/tests/boost-test-output
 fi


### PR DESCRIPTION
This PR adds object file caching using CMake and ccache for travis builds.
[Travis directly supports this.](https://docs.travis-ci.com/user/caching/)