### PR TITLE
Add Travis coverage report using codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,8 @@ matrix:
       env: BUILD_TYPE=SCONS MPI=off PETSC=off
 
     # Test coverage
-    - compiler: gcc
+    - name: "Test Coverage"
+      compiler: gcc
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,24 @@ matrix:
     - if: type = cron or branch = master
       compiler: clang
       env: BUILD_TYPE=SCONS MPI=off PETSC=off
+
+    # Test coverage
+    - compiler: gcc
+      addons:
+        apt:
+          packages:
+            - lcov
+
+      script:
+        - $TRAVIS_BUILD_DIR/tools/travis-coverage.sh
+
+      after_success:
+        - lcov --capture --directory "$TRAVIS_BUILD_DIR/build" --output-file coverage.info
+        - lcov --remove coverage.info '/usr/*' "$LOCAL_INSTALL/*" --output-file coverage.info # filter system-files and local-dependencies
+        - lcov --list coverage.info # debug info
+        - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
+
+
 cache:
   directories:
     - $LOCAL_INSTALL

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
       - python-numpy
       - libblas-dev
       - liblapack-dev
+      - lcov
 
 env:
   global:
@@ -65,14 +66,8 @@ matrix:
     # Test coverage
     - name: "Test Coverage"
       compiler: gcc
-      addons:
-        apt:
-          packages:
-            - lcov
-
       script:
         - $TRAVIS_BUILD_DIR/tools/travis-coverage.sh
-
       after_success:
         - lcov --capture --directory "$TRAVIS_BUILD_DIR/build" --output-file coverage.info
         - lcov --remove coverage.info '/usr/*' "$LOCAL_INSTALL/*" --output-file coverage.info # filter system-files and local-dependencies

--- a/tools/travis-coverage.sh
+++ b/tools/travis-coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# CMake build
+mkdir $TRAVIS_BUILD_DIR/build && cd $TRAVIS_BUILD_DIR/build
+CXX=g++
+CXXFLAGS="--coverage"
+LDFLAGS="--coverage"
+cmake -DPETSC=on -DMPI=on -DPYTHON=on -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=mpicxx $TRAVIS_BUILD_DIR
+cmake --build . -- -j $(nproc)
+ctest


### PR DESCRIPTION
This PR adds a Travis job which creates a coverage report using gcc and uploads it to codecov.io 

Closes #307