### PR TITLE
Fix lgtm alerts

### DIFF
--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -28,7 +28,7 @@ void CommunicateMesh::sendMesh(
   int numberOfVertices = mesh.vertices().size();
   _communication->send(numberOfVertices, rankReceiver);
   if (not mesh.vertices().empty()) {
-    std::vector<double> coords(numberOfVertices * dim);
+    std::vector<double> coords(static_cast<size_t>(numberOfVertices) * dim);
     std::vector<int> globalIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
       for (int d = 0; d < dim; d++) {
@@ -172,7 +172,7 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
   int numberOfVertices = mesh.vertices().size();
   _communication->broadcast(numberOfVertices);
   if (numberOfVertices > 0) {
-    std::vector<double> coords(numberOfVertices * dim);
+    std::vector<double> coords(static_cast<size_t>(numberOfVertices) * dim);
     std::vector<int> globalIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
       for (int d = 0; d < dim; d++) {

--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -24,11 +24,11 @@ int main ( int argc, char** argv )
 
   if (argc >= 2) {
     std::string action(argv[1]);
-    if ( action == "dtd" and argc >= 2 ) {
+    if ( action == "dtd" ) {
       wrongParameters = false;
       runDtd = true;
     }
-    if ( action == "xml" and argc >= 2 ) {
+    if ( action == "xml" ) {
       wrongParameters = false;
       runHelp = true;
     }

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -3,6 +3,7 @@
 #include <Eigen/Core>
 #include "utils/Event.hpp"
 #include "mesh/RTree.hpp"
+#include <stdexcept>
 
 namespace precice {
 extern bool syncMode;
@@ -48,7 +49,7 @@ public:
     case (Primitive::Quad):
       return generateInterpolationElements(pos, _mesh.quads()[idx]);
     default:
-      assertion(false, "Primitive is unknown");
+      throw std::invalid_argument{"Primitve is unknown"};
     }
   }
 

--- a/src/mesh/impl/RTree.hpp
+++ b/src/mesh/impl/RTree.hpp
@@ -37,7 +37,7 @@ public:
     case (Primitive::Quad):
       return boost::geometry::return_envelope<AABB>(mesh_.quads()[pi.index]);
     default:
-      assertion(false, "AABB generation for this Primitive is not implemented!")
+      throw std::invalid_argument{"AABB generation for this Primitive is not implemented!"};
     }
   }
 

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -661,7 +661,7 @@ void RequestManager:: handleRequestSetMeshVertices
   int size = -1;
   _com->receive(size, rankSender);
   CHECK(size > 0, "You cannot call setMeshVertices with size=0.");
-  std::vector<double> positions(size*_interface.getDimensions());
+  std::vector<double> positions(static_cast<size_t>(size)*_interface.getDimensions());
   _com->receive(positions, rankSender);
   std::vector<int> ids(size);
   _interface.setMeshVertices(meshID, size, positions.data(), ids.data());
@@ -679,7 +679,7 @@ void RequestManager:: handleRequestGetMeshVertices
   _com->receive(size, rankSender);
   assertion(size > 0, size);
   std::vector<int> ids(size);
-  std::vector<double> positions(size*_interface.getDimensions());
+  std::vector<double> positions(static_cast<size_t>(size)*_interface.getDimensions());
   _com->receive(ids, rankSender);
   _interface.getMeshVertices(meshID, size, ids.data(), positions.data());
   _com->send(positions, rankSender);
@@ -696,7 +696,7 @@ void RequestManager:: handleRequestGetMeshVertexIDsFromPositions
   _com->receive(size, rankSender);
   assertion(size > 0, size);
   std::vector<int> ids(size);
-  std::vector<double> positions(size*_interface.getDimensions());
+  std::vector<double> positions(static_cast<size_t>(size)*_interface.getDimensions());
   _com->receive(positions, rankSender);
   _interface.getMeshVertexIDsFromPositions(meshID, size, positions.data(), ids.data());
   _com->send(ids, rankSender);
@@ -794,7 +794,7 @@ void RequestManager:: handleRequestWriteBlockVectorData
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
   _com->receive(indices, rankSender);
-  std::vector<double> data(size*_interface.getDimensions());
+  std::vector<double> data(static_cast<size_t>(size)*_interface.getDimensions());
   _com->receive(data, rankSender);
   _interface.writeBlockVectorData(dataID, size, indices.data(), data.data());
 }
@@ -854,7 +854,7 @@ void RequestManager:: handleRequestReadBlockVectorData
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
   _com->receive(indices, rankSender);
-  std::vector<double> data(size*_interface.getDimensions());
+  std::vector<double> data(static_cast<size_t>(size)*_interface.getDimensions());
   _interface.readBlockVectorData(dataID, size, indices.data(), data.data());
   _com->send(data, rankSender);
 }

--- a/src/utils/TableWriter.hpp
+++ b/src/utils/TableWriter.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <algorithm>
 #include <chrono>
 #include <iostream>

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -74,7 +74,7 @@ ConfigParser::ConfigParser(const std::string &filePath, std::shared_ptr<precice:
 
   try {
     connectTags(DefTags, SubTags);
-  } catch (std::string error) {
+  } catch (const std::string& error) {
     ERROR(error);
   }
 }

--- a/tools/livegraph/livegraph.py
+++ b/tools/livegraph/livegraph.py
@@ -38,8 +38,10 @@ print 'Plot command:', plotstring
 gnuplot.write ( plotstring )
 gnuplot.write ( 'set autoscale;' )
 gnuplot.flush ()
-while True:
-    time.sleep ( options.interval / 1000.0 )
-    gnuplot.write ( 'replot\n' )
-    gnuplot.flush ()
-gnuplot.close ()
+try:
+    while True:
+        time.sleep ( options.interval / 1000.0 )
+        gnuplot.write ( 'replot\n' )
+        gnuplot.flush ()
+finally:
+    gnuplot.close ()

--- a/tools/plotEventLog.py
+++ b/tools/plotEventLog.py
@@ -1,4 +1,4 @@
-#!env python3
+#!/usr/bin/env python3
 """ Plots Events.log files and shows Events on a timeline for each rank. """
 
 import pandas as pd, numpy as np


### PR DESCRIPTION
This PR fixes the warnings issues by LGTM.

Most prominent was incomplete control-flow in release builds due to our assertion macro getting removed. Those should never be triggered due to the use of the scoped enum though.