### PR TITLE
Fix find char instead of string

### DIFF
--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -209,7 +209,7 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
 
     DEBUG("Request connection to " << address);
 
-    std::string ipAddress  = address.substr(0, address.find(":"));
+    std::string ipAddress  = address.substr(0, address.find(':'));
     std::string portNumber = address.substr(ipAddress.length() + 1, address.length() - ipAddress.length() - 1);
 
     _portNumber = static_cast<unsigned short>(std::stoi(portNumber));
@@ -276,7 +276,7 @@ void SocketCommunication::requestConnectionAsClient(std::string      const &acce
       Publisher p(addressFileName);
       address = p.read();
       
-      std::string ipAddress  = address.substr(0, address.find(":"));
+      std::string ipAddress  = address.substr(0, address.find(':'));
       std::string portNumber = address.substr(ipAddress.length()+1, address.length() - ipAddress.length()-1);
 
       _portNumber = static_cast<unsigned short>(std::stoi(portNumber));

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -127,8 +127,8 @@ LoggingConfiguration readLogConfFile(std::string const & filename)
     po::store(parsed, vm);
     po::notify(vm);
     for (auto const & opt : parsed.options) {
-      std::string section = opt.string_key.substr(0, opt.string_key.find("."));
-      std::string key = opt.string_key.substr(opt.string_key.find(".")+1);
+      std::string section = opt.string_key.substr(0, opt.string_key.find('.'));
+      std::string key = opt.string_key.substr(opt.string_key.find('.')+1);
       configs[section].setOption(key, opt.value[0]);        
     }
   }

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -190,9 +190,9 @@ template <typename ATTRIBUTE_T>
 void XMLAttribute<ATTRIBUTE_T>::readValueSpecific(std::string &rawValue, double &value)
 {
   try {
-    if (rawValue.find("/") != std::string::npos) {
-      std::string left  = rawValue.substr(0, rawValue.find("/"));
-      std::string right = rawValue.substr(rawValue.find("/") + 1, rawValue.size() - rawValue.find("/") - 1);
+    if (rawValue.find('/') != std::string::npos) {
+      std::string left  = rawValue.substr(0, rawValue.find('/'));
+      std::string right = rawValue.substr(rawValue.find('/') + 1, rawValue.size() - rawValue.find('/') - 1);
 
       value = std::stod(left) / std::stod(right);
     } else {
@@ -237,16 +237,16 @@ void XMLAttribute<ATTRIBUTE_T>::readValueSpecific(std::string &rawValue, Eigen::
     std::string tmp1(rawValue);
     // erase entries before i-th entry
     for (int j = 0; j < i; j++) {
-      if (tmp1.find(";") != std::string::npos) {
-        tmp1.erase(0, tmp1.find(";") + 1);
+      if (tmp1.find(';') != std::string::npos) {
+        tmp1.erase(0, tmp1.find(';') + 1);
       } else {
         componentsLeft = false;
       }
     }
     // if we are not in the last vector component...
-    if (tmp1.find(";") != std::string::npos) {
+    if (tmp1.find(';') != std::string::npos) {
       // ..., erase entries after i-th entry
-      tmp1.erase(tmp1.find(";"), tmp1.size());
+      tmp1.erase(tmp1.find(';'), tmp1.size());
     }
 
     if (componentsLeft) {
@@ -272,17 +272,17 @@ Eigen::VectorXd XMLAttribute<Eigen::VectorXd>::getAttributeValueAsEigenVectorXd(
 	std::string tmp1(rawValue);
 	// erase entries before i-th entry
 	for (int j = 0; j < i; j++){
-	  if (tmp1.find(";") != std::string::npos){
-		tmp1.erase(0,tmp1.find(";")+1);
+	  if (tmp1.find(';') != std::string::npos){
+		tmp1.erase(0,tmp1.find(';')+1);
 	  }
 	  else {
 		componentsLeft = false;
 	  }
 	}
 	// if we are not in the last vector component...
-	if (tmp1.find(";") != std::string::npos){
+	if (tmp1.find(';') != std::string::npos){
 	  // ..., erase entries after i-th entry
-	  tmp1.erase(tmp1.find(";"),tmp1.size());
+	  tmp1.erase(tmp1.find(';'),tmp1.size());
 	}
 	if (componentsLeft){
 	   

--- a/tools/cad_converter/TransformToVRML.cpp
+++ b/tools/cad_converter/TransformToVRML.cpp
@@ -109,7 +109,7 @@ void TransformToVRML:: eliminateRedundancy ()
   while ( fp.getline ( buf, sizeof ( buf ) ) ) {
     std::string str = buf;
     // not last line
-    if ( str.find("]") == std::string::npos ) {
+    if ( str.find(']') == std::string::npos ) {
       str.erase ( str.length()-1 );
       stringCoordinate3.push_back ( str );
     }


### PR DESCRIPTION
The PR replaces uses of `string::find(string)` when the intention is to call `string::find(char)`