### PR TITLE
Modernize IO and std::endl

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -235,7 +235,7 @@ std::vector<int> BaseCouplingScheme::sendData(m2n::PtrM2N m2n)
   assertion(m2n.get() != nullptr);
   assertion(m2n->isConnected());
   for (const DataMap::value_type &pair : _sendData) {
-    //std::cout<<"\nsend data id="<<pair.first<<": "<<*(pair.second->values)<<std::endl;
+    //std::cout<<"\nsend data id="<<pair.first<<": "<<*(pair.second->values)<<'\n';
     int size = pair.second->values->size();
     m2n->send(pair.second->values->data(), size, pair.second->mesh->getID(), pair.second->dimension);
     sentDataIDs.push_back(pair.first);
@@ -254,7 +254,7 @@ std::vector<int> BaseCouplingScheme::receiveData(
 
   for (DataMap::value_type &pair : _receiveData) {
     int size = pair.second->values->size();
-    //std::cout<<"\nreceive data id="<<pair.first<<": "<<*(pair.second->values)<<std::endl;
+    //std::cout<<"\nreceive data id="<<pair.first<<": "<<*(pair.second->values)<<'\n';
     m2n->receive(pair.second->values->data(), size, pair.second->mesh->getID(), pair.second->dimension);
     receivedDataIDs.push_back(pair.first);
   }
@@ -697,7 +697,7 @@ bool BaseCouplingScheme::measureConvergenceCoarseModelOptimization(
     if (convMeasure.level == 0)
       continue;
 
-    std::cout << "  measure convergence coarse measure, id:" << convMeasure.dataID << std::endl;
+    std::cout << "  measure convergence coarse measure, id:" << convMeasure.dataID << '\n';
     assertion(convMeasure.data != nullptr);
     assertion(convMeasure.measure.get() != nullptr);
     const auto &    oldValues = convMeasure.data->oldValues.col(0);

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -291,7 +291,7 @@ void SerialCouplingScheme::advance()
           //       old fine pressure vals = old coarse pressure vals TODO: find better solution,
           //auto fineIDs = getPostProcessing()->getDataIDs();
           //for(auto id: fineIDs){
-          //  std::cout<<"id: "<<id<<", fineIds.size(): "<<fineIDs.size()<<std::endl;
+          //  std::cout<<"id: "<<id<<", fineIds.size(): "<<fineIDs.size()<<'\n';
           //  getReceiveData(id)->oldValues.column(0) = getReceiveData(id+fineIDs.size())->oldValues.column(0);
           //}
            */

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -928,7 +928,7 @@ bool CouplingSchemeConfiguration::checkIfDataIsCoarse(
   for (int i = 0; i < (int) fineIDs.size(); i++) {
     std::cout << fineIDs.at(i) << ", ";
   }
-  std::cout << "], id: " << id << std::endl;
+  std::cout << "], id: " << id << '\n';
 
   // if id is contained within fine data IDs return with isCoarse = false
   if (not isCoarse)
@@ -944,11 +944,11 @@ bool CouplingSchemeConfiguration::checkIfDataIsCoarse(
       for (auto &coarseID : coarseIDs) {
         std::cout << coarseID << ", ";
       }
-      std::cout << "], id: " << id << std::endl;
+      std::cout << "], id: " << id << '\n';
 
       err = not isCoarse;
     } else {
-      std::cout << "There is no coarse model optkmaiimization defined." << std::endl;
+      std::cout << "There is no coarse model optkmaiimization defined.\n";
       err = true;
     }
   }

--- a/src/cplscheme/impl/BaseQNPostProcessing.cpp
+++ b/src/cplscheme/impl/BaseQNPostProcessing.cpp
@@ -70,13 +70,13 @@ void BaseQNPostProcessing::initialize(
 
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "", "", " << ", ";");
 
-  _debugOut<<"initialization:"<<std::endl;
+  _debugOut<<"initialization:\n";
   for (int id : _dataIDs) {
       const auto& values = *cplData[id]->values;
       const auto& oldValues = cplData[id]->oldValues.col(0);
 
-      _debugOut<<"id: "<<id<<" dim: "<<cplData[id]->dimension<<"     values: "<<values.format(CommaInitFmt)<<std::endl;
-      _debugOut<<"id: "<<id<<" dim: "<<cplData[id]->dimension<<" old values: "<<oldValues.format(CommaInitFmt)<<std::endl;
+      _debugOut<<"id: "<<id<<" dim: "<<cplData[id]->dimension<<"     values: "<<values.format(CommaInitFmt)<<'\n';
+      _debugOut<<"id: "<<id<<" dim: "<<cplData[id]->dimension<<" old values: "<<oldValues.format(CommaInitFmt)<<'\n';
     }
   _debugOut<<"\n";
   */
@@ -128,7 +128,7 @@ void BaseQNPostProcessing::initialize(
     _dimOffsets.resize(utils::MasterSlave::_size + 1);
     _dimOffsets[0] = 0;
     //for (auto & elem : _dataIDs) {
-    //	std::cout<<" Offsets:(vertex) \n"<<cplData[elem]->mesh->getVertexOffsets()<<std::endl;
+    //	std::cout<<" Offsets:(vertex) \n"<<cplData[elem]->mesh->getVertexOffsets()<<'\n';
     //}
     for (size_t i = 0; i < _dimOffsets.size() - 1; i++) {
       int accumulatedNumberOfUnknowns = 0;
@@ -140,14 +140,14 @@ void BaseQNPostProcessing::initialize(
     }
     DEBUG("Number of unknowns at the interface (global): " << _dimOffsets.back());
     if (utils::MasterSlave::_masterMode) {
-      _infostringstream << "\n--------\n DOFs (global): " << _dimOffsets.back() << "\n offsets: " << _dimOffsets << std::endl;
+      _infostringstream << "\n--------\n DOFs (global): " << _dimOffsets.back() << "\n offsets: " << _dimOffsets << '\n';
     }
 
     // test that the computed number of unknown per proc equals the number of entries actually present on that proc
     size_t unknowns = _dimOffsets[utils::MasterSlave::_rank + 1] - _dimOffsets[utils::MasterSlave::_rank];
     assertion(entries == unknowns, entries, unknowns);
   } else {
-    _infostringstream << "\n--------\n DOFs (global): " << entries << std::endl;
+    _infostringstream << "\n--------\n DOFs (global): " << entries << '\n';
   }
 
   // set the number of global rows in the QRFactorization. This is essential for the correctness in master-slave mode!
@@ -310,13 +310,13 @@ void BaseQNPostProcessing::performPostProcessing(
 
   /*
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "", "", " << ", ";");
-  _debugOut<<"iteration: "<<its<<" tStep: "<<tSteps<<"   cplData entry:"<<std::endl;
+  _debugOut<<"iteration: "<<its<<" tStep: "<<tSteps<<"   cplData entry:\n";
   for (int id : _dataIDs) {
       const auto& values = *cplData[id]->values;
       const auto& oldValues = cplData[id]->oldValues.col(0);
 
-      _debugOut<<"id: "<<id<<"     values: "<<values.format(CommaInitFmt)<<std::endl;
-      _debugOut<<"id: "<<id<<" old values: "<<oldValues.format(CommaInitFmt)<<std::endl;
+      _debugOut<<"id: "<<id<<"     values: "<<values.format(CommaInitFmt)<<'\n';
+      _debugOut<<"id: "<<id<<" old values: "<<oldValues.format(CommaInitFmt)<<'\n';
     }
   _debugOut<<"\n";
   */
@@ -445,13 +445,13 @@ void BaseQNPostProcessing::performPostProcessing(
   splitCouplingData(cplData);
 
   /*
-  _debugOut<<"finished update: "<<std::endl;
+  _debugOut<<"finished update: \n";
   for (int id : _dataIDs) {
       const auto& values = *cplData[id]->values;
       const auto& oldValues = cplData[id]->oldValues.col(0);
 
-      _debugOut<<"id: "<<id<<"norm: "<<values.norm()<<"     values: "<<values.format(CommaInitFmt)<<std::endl;
-      _debugOut<<"id: "<<id<<"norm: "<<oldValues.norm()<<" old values: "<<oldValues.format(CommaInitFmt)<<std::endl;
+      _debugOut<<"id: "<<id<<"norm: "<<values.norm()<<"     values: "<<values.format(CommaInitFmt)<<'\n';
+      _debugOut<<"id: "<<id<<"norm: "<<oldValues.norm()<<" old values: "<<oldValues.format(CommaInitFmt)<<'\n';
     }
   _debugOut<<"\n";
   */
@@ -534,7 +534,7 @@ void BaseQNPostProcessing::iterationsConverged(
   
   if (utils::MasterSlave::_masterMode || (not utils::MasterSlave::_masterMode && not utils::MasterSlave::_slaveMode))
     _infostringstream << "# time step " << tSteps << " converged #\n iterations: " << its
-                      << "\n used cols: " << getLSSystemCols() << "\n del cols: " << _nbDelCols << std::endl;
+                      << "\n used cols: " << getLSSystemCols() << "\n del cols: " << _nbDelCols << '\n';
 
   its = 0;
   tSteps++;

--- a/src/cplscheme/impl/MMPostProcessing.cpp
+++ b/src/cplscheme/impl/MMPostProcessing.cpp
@@ -545,7 +545,7 @@ void MMPostProcessing::computeCoarseModelDesignSpecifiaction()
 
       for (int i = 0; i < singularValues.rows(); i++) {
         if (std::abs(singularValues(i)) <= _singularityLimit) {
-          std::cout << "singular value: " << singularValues(i) << std::endl;
+          std::cout << "singular value: " << singularValues(i) << '\n';
 
           // Remove the column from _matrixC and _matrixF
           removeMatrixColumn(i - nbRemoveCols);

--- a/src/cplscheme/impl/MVQNPostProcessing.cpp
+++ b/src/cplscheme/impl/MVQNPostProcessing.cpp
@@ -180,7 +180,7 @@ void MVQNPostProcessing::initialize(
 
   if (utils::MasterSlave::_masterMode || (not utils::MasterSlave::_masterMode && not utils::MasterSlave::_slaveMode))
     _infostringstream << " IMVJ restart mode: " << _imvjRestart << "\n chunk size: " << _chunkSize << "\n trunc eps: " << _svdJ.getThreshold() << "\n R_RS: " << _RSLSreusedTimesteps << "\n--------\n"
-                      << std::endl;
+                      << '\n';
 }
 
 // ==================================================================================
@@ -628,7 +628,7 @@ void MVQNPostProcessing::restartIMVJ()
     //double percentage = 100.0*used_storage/(double)theoreticalJ_storage;
     if (utils::MasterSlave::_masterMode || (not utils::MasterSlave::_masterMode && not utils::MasterSlave::_slaveMode))
       _infostringstream << " - MVJ-RESTART " << _nbRestarts << ", mode= SVD -\n  new modes: " << rankAfter - rankBefore << "\n  rank svd: " << rankAfter << "\n  avg rank: " << _avgRank / _nbRestarts << "\n  truncated modes: " << waste << "\n"
-                        << std::endl;
+                        << '\n';
 
     //        ------------ RESTART LEAST SQUARES ------------
   } else if (_imvjRestartType == MVQNPostProcessing::RS_LS) {
@@ -705,7 +705,7 @@ void MVQNPostProcessing::restartIMVJ()
     DEBUG("MVJ-RESTART, mode=LS. Restart with " << _matrixV_RSLS.cols() << " columns from " << _RSLSreusedTimesteps << " time steps.");
     if (utils::MasterSlave::_masterMode || (not utils::MasterSlave::_masterMode && not utils::MasterSlave::_slaveMode))
       _infostringstream << " - MVJ-RESTART" << _nbRestarts << ", mode= LS -\n  used cols: " << _matrixV_RSLS.cols() << "\n  R_RS: " << _RSLSreusedTimesteps << "\n"
-                        << std::endl;
+                        << '\n';
 
     //            ------------ RESTART ZERO ------------
   } else if (_imvjRestartType == MVQNPostProcessing::RS_ZERO) {
@@ -777,7 +777,7 @@ void MVQNPostProcessing::specializedIterationsConverged(
     _matrixCols_RSLS.push_front(0);
   }
 
-  //_info2<<std::endl;
+  //_info2<<'\n';
 
   // if efficient update of imvj is enabled
   if (not _alwaysBuildJacobian || _imvjRestart) {

--- a/src/cplscheme/impl/QRFactorization.cpp
+++ b/src/cplscheme/impl/QRFactorization.cpp
@@ -524,7 +524,7 @@ int QRFactorization::orthogonalize_stable(
         WARN("The new column is in the range of Q, thus not possible to orthogonalize. Try to insert a unit vector that is orthogonal to the columns space of Q.");
         //DEBUG("[QR-dec] - reorthogonalization");
         if (_fstream_set)
-          (*_infostream) << "[QR-dec] - reorthogonalization" << std::endl;
+          (*_infostream) << "[QR-dec] - reorthogonalization\n";
 
         restart = true;
 
@@ -575,7 +575,7 @@ int QRFactorization::orthogonalize_stable(
             }
           }
           if (_fstream_set)
-            (*_infostream) << "           global u(k):" << global_uk << ",  global k: " << global_k << ",  rank: " << rank << std::endl;
+            (*_infostream) << "           global u(k):" << global_uk << ",  global k: " << global_k << ",  rank: " << rank << '\n';
         }
 
         // take correct action if v is null

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -62,11 +62,11 @@ public:
       const Eigen::VectorXd &designSpecification)
   {
     /*
-     std::cout<<"\n-------"<<std::endl;
-     std::cout<<"   old val: \n"<<oldValues<<std::endl;
-     std::cout<<"   new val: \n"<<newValues<<"\n"<<std::endl;
-     std::cout<<"   design spec: \n"<<designSpecification<<"\n"<<std::endl;
-     std::cout<<"-------\n"<<std::endl;
+     std::cout<<"\n-------\n";
+     std::cout<<"   old val: \n"<<oldValues<<'\n';
+     std::cout<<"   new val: \n"<<newValues<<"\n\n";
+     std::cout<<"   design spec: \n"<<designSpecification<<"\n\n";
+     std::cout<<"-------\n\n";
 */
 
     _normDiff      = utils::MasterSlave::l2norm((newValues - oldValues) - designSpecification);

--- a/src/cplscheme/tests/ParallelMatrixOperationsTest.cpp
+++ b/src/cplscheme/tests/ParallelMatrixOperationsTest.cpp
@@ -140,9 +140,9 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations, * boost::unit_test::fixture<testing::M
   double normVec2   = utils::MasterSlave::l2norm(vec2_local);
   double dotproduct = utils::MasterSlave::dot(vec1_local, vec2_local);
 
-  //  std::cout<<"l2norm vec1: "<<normVec1<<std::endl;
-  //  std::cout<<"l2norm vec2: "<<normVec2<<std::endl;
-  //  std::cout<<"dotproduct: "<<dotproduct<<std::endl;
+  //  std::cout<<"l2norm vec1: "<<normVec1<<'\n';
+  //  std::cout<<"l2norm vec2: "<<normVec2<<'\n';
+  //  std::cout<<"dotproduct: "<<dotproduct<<'\n';
 
   // validate
   BOOST_TEST(testing::equals(normVec1, 1.502540907218387));

--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -7,10 +7,10 @@
 
 void printUsage()
 {
-  std::cout << "Usage:\n' << '\n";
+  std::cout << "Usage:\n\n";
   std::cout << "Run server (deprecated)  :  binprecice server ParticipantName ConfigurationName [LogConfFile]\n";
   std::cout << "Print XML reference      :  binprecice xml\n";
-  std::cout << "Print DTD for XML config :  binprecice dtd\n";
+  std::cout << "Print DTD for XML config :  binprecice dtd" << std::endl;
 }
 
 int main ( int argc, char** argv )
@@ -71,17 +71,17 @@ int main ( int argc, char** argv )
     precice::impl::SolverInterfaceImpl server ( participantName, 0, 1, true );
     server.configure(configFile);
     server.runServer();
-    std::cout << '\n' << '\n' << "...finished running server\n";
+    std::cout << "\n\n...finished running server\n";
   }
   else if (runHelp){
     assertion(not runServer);
     precice::config::Configuration config;
-    std::cout << config.getXMLTag().printDocumentation(0) << '\n' << '\n';
+    std::cout << config.getXMLTag().printDocumentation(0) << "\n\n";
   }
   else if (runDtd) {
 	assertion(not runServer);
     precice::config::Configuration config;
-    std::cout << config.getXMLTag().printDTD(true) << '\n' << '\n';
+    std::cout << config.getXMLTag().printDTD(true) << "\n\n";
   }
   else {
     assertion ( false );

--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -7,10 +7,10 @@
 
 void printUsage()
 {
-  std::cout << "Usage:" << std::endl << std::endl;
-  std::cout << "Run server (deprecated)  :  binprecice server ParticipantName ConfigurationName [LogConfFile]" << std::endl;
-  std::cout << "Print XML reference      :  binprecice xml" << std::endl;
-  std::cout << "Print DTD for XML config :  binprecice dtd" << std::endl;
+  std::cout << "Usage:\n' << '\n";
+  std::cout << "Run server (deprecated)  :  binprecice server ParticipantName ConfigurationName [LogConfFile]\n";
+  std::cout << "Print XML reference      :  binprecice xml\n";
+  std::cout << "Print DTD for XML config :  binprecice dtd\n";
 }
 
 int main ( int argc, char** argv )
@@ -59,37 +59,37 @@ int main ( int argc, char** argv )
 
   if ( runServer ){
     assertion(not runHelp);
-    std::cout << "PreCICE running server..." << std::endl;
+    std::cout << "PreCICE running server...\n";
     std::string participantName ( argv[2] );
     std::string configFile ( argv[3] );
-    std::cout << "  Participant = " << participantName << std::endl;
-    std::cout << "  Configuration = " << configFile << std::endl;
+    std::cout << "  Participant = " << participantName << '\n';
+    std::cout << "  Configuration = " << configFile << '\n';
     int size = precice::utils::Parallel::getCommunicatorSize();
     if ( size != 1 ){
-      std::cerr << "Server can be run with only one process!" << std::endl;
+      std::cerr << "Server can be run with only one process!\n";
     }
     precice::impl::SolverInterfaceImpl server ( participantName, 0, 1, true );
     server.configure(configFile);
     server.runServer();
-    std::cout << std::endl << std::endl << "...finished running server" << std::endl;
+    std::cout << '\n' << '\n' << "...finished running server\n";
   }
   else if (runHelp){
     assertion(not runServer);
     precice::config::Configuration config;
-    std::cout << config.getXMLTag().printDocumentation(0) << std::endl << std::endl;
+    std::cout << config.getXMLTag().printDocumentation(0) << '\n' << '\n';
   }
   else if (runDtd) {
 	assertion(not runServer);
     precice::config::Configuration config;
-    std::cout << config.getXMLTag().printDTD(true) << std::endl << std::endl;
+    std::cout << config.getXMLTag().printDTD(true) << '\n' << '\n';
   }
   else {
     assertion ( false );
   }
   precice::utils::Petsc::finalize();
   //precice::utils::Parallel::synchronizeProcesses();
-  //std::cout << "close: " << precice::utils::Parallel::getProcessRank() << std::endl;
+  //std::cout << "close: " << precice::utils::Parallel::getProcessRank() << '\n';
   precice::utils::Parallel::finalizeMPI();
-  //std::cout << "done" << std::endl;
+  //std::cout << "done\n";
   return 0;
 }

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -58,7 +58,7 @@ void ExportVTK::exportMesh
   TRACE(mesh.getName());
 
   // Plot vertices
-  outFile << "POINTS " << mesh.vertices().size() << " float \n' << '\n";
+  outFile << "POINTS " << mesh.vertices().size() << " float \n\n";
   for (mesh::Vertex& vertex : mesh.vertices()) {
     writeVertex(vertex.getCoords(), outFile);
   }
@@ -67,7 +67,7 @@ void ExportVTK::exportMesh
 
   // Plot edges
   if(mesh.getDimensions() == 2) {
-    outFile << "CELLS " << mesh.edges().size() << " " << mesh.edges().size() * 3
+    outFile << "CELLS " << mesh.edges().size() << ' ' << mesh.edges().size() * 3
             << '\n' << '\n';
     for (mesh::Edge & edge : mesh.edges()) {
       int internalIndices[2];
@@ -75,8 +75,7 @@ void ExportVTK::exportMesh
       internalIndices[1] = edge.vertex(1).getID();
       writeLine(internalIndices, outFile);
     }
-    outFile << '\n' << "CELL_TYPES " << mesh.edges().size()
-            << '\n' << '\n';
+    outFile << "\nCELL_TYPES " << mesh.edges().size() << "\n\n";
     for(size_t i = 0; i < mesh.edges().size(); ++i) {
       outFile << "3\n";
     }
@@ -86,8 +85,8 @@ void ExportVTK::exportMesh
   if(mesh.getDimensions() == 3) {
     size_t sizeTriangles = mesh.triangles().size();
     size_t sizeQuads = mesh.quads().size();
-    outFile << "CELLS " << sizeTriangles + sizeQuads << " "
-            << sizeTriangles * 4 + sizeQuads * 5 << '\n' << '\n';
+    outFile << "CELLS " << sizeTriangles + sizeQuads << ' '
+            << sizeTriangles * 4 + sizeQuads * 5 << "\n\n";
     for (mesh::Triangle& triangle : mesh.triangles()) {
       int internalIndices[3];
       internalIndices[0] = triangle.vertex(0).getID();
@@ -104,8 +103,7 @@ void ExportVTK::exportMesh
       writeQuadrangle(internalIndices, outFile);
     }
 
-    outFile << '\n' << "CELL_TYPES " << sizeTriangles + sizeQuads
-            << '\n' << '\n';
+    outFile << "\nCELL_TYPES " << sizeTriangles + sizeQuads << "\n\n";
     for(size_t i=0; i < sizeTriangles; i++){
       outFile << "5\n";
     }
@@ -115,8 +113,8 @@ void ExportVTK::exportMesh
 
 
     // OLD
-//    outFile << "CELLS " << mesh.triangles().size() << " "
-//            << mesh.triangles().size() * 4  << '\n' << '\n';
+//    outFile << "CELLS " << mesh.triangles().size() << ' '
+//            << mesh.triangles().size() * 4  << "\n\n";
 //    for (mesh::Triangle & triangle : mesh.triangles()){
 //      int internalIndices[3];
 //      internalIndices[0] = triangle.vertex(0).getID();
@@ -124,8 +122,7 @@ void ExportVTK::exportMesh
 //      internalIndices[2] = triangle.vertex(2).getID();
 //      writeTriangle(internalIndices, outFile);
 //    }
-//    outFile << '\n' << "CELL_TYPES " << mesh.triangles().size()
-//            << '\n' << '\n';
+//    outFile << "\nCELL_TYPES " << mesh.triangles().size() << "\n\n";
 //    for(size_t i=0; i < mesh.triangles().size(); i++){
 //      outFile << "5\n";
 //    }
@@ -149,10 +146,10 @@ void ExportVTK:: exportData
     for (mesh::Vertex& vertex : mesh.vertices()) {
       int i = 0;
       for(; i < mesh.getDimensions(); i++){
-        outFile << vertex.getNormal()[i] << " ";
+        outFile << vertex.getNormal()[i] << ' ';
       }
       if(i < 3){
-        outFile << "0";
+        outFile << '0';
       }
       outFile << '\n';
     }
@@ -187,10 +184,10 @@ void ExportVTK:: exportData
         }
         int i = 0;
         for(; i < data->getDimensions(); i++){
-          outFile << viewTemp[i] << " ";
+          outFile << viewTemp[i] << ' ';
         }
         if(i < 3){
-          outFile << "0";
+          outFile << '0';
         }
         outFile << '\n';
       }
@@ -224,9 +221,9 @@ void ExportVTK:: writeHeader
 (
   std::ostream& outFile)
 {
-  outFile << "# vtk DataFile Version 2.0\n' << '\n"
-          << "ASCII\n' << '\n"
-          << "DATASET UNSTRUCTURED_GRID\n' << '\n";
+  outFile << "# vtk DataFile Version 2.0\n\n"
+          << "ASCII\n\n"
+          << "DATASET UNSTRUCTURED_GRID\n\n";
 }
 
 void ExportVTK:: writeVertex
@@ -249,9 +246,9 @@ void ExportVTK:: writeTriangle
   int           vertexIndices[3],
   std::ostream& outFile)
 {
-  outFile << 3 << " ";
+  outFile << 3 << ' ';
   for(int i=0; i < 3; i++) {
-    outFile << vertexIndices[i] << " ";
+    outFile << vertexIndices[i] << ' ';
   }
   outFile << '\n';
 }
@@ -261,9 +258,9 @@ void ExportVTK:: writeQuadrangle
   int           vertexIndices[4],
   std::ostream& outFile)
 {
-  outFile << 4 << " ";
+  outFile << 4 << ' ';
   for(int i=0; i < 4; i++) {
-    outFile << vertexIndices[i] << " ";
+    outFile << vertexIndices[i] << ' ';
   }
   outFile << '\n';
 }
@@ -273,9 +270,9 @@ void ExportVTK:: writeLine
   int           vertexIndices[2],
   std::ostream& outFile)
 {
-  outFile << 2 << " ";
+  outFile << 2 << ' ';
   for(int i=0; i<2; i++) {
-    outFile << vertexIndices[i] << " ";
+    outFile << vertexIndices[i] << ' ';
   }
   outFile << '\n';
 }

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -58,27 +58,27 @@ void ExportVTK::exportMesh
   TRACE(mesh.getName());
 
   // Plot vertices
-  outFile << "POINTS " << mesh.vertices().size() << " float "<< std::endl << std::endl;
+  outFile << "POINTS " << mesh.vertices().size() << " float \n' << '\n";
   for (mesh::Vertex& vertex : mesh.vertices()) {
     writeVertex(vertex.getCoords(), outFile);
   }
-  outFile << std::endl;
+  outFile << '\n';
 
 
   // Plot edges
   if(mesh.getDimensions() == 2) {
     outFile << "CELLS " << mesh.edges().size() << " " << mesh.edges().size() * 3
-            << std::endl << std::endl;
+            << '\n' << '\n';
     for (mesh::Edge & edge : mesh.edges()) {
       int internalIndices[2];
       internalIndices[0] = edge.vertex(0).getID();
       internalIndices[1] = edge.vertex(1).getID();
       writeLine(internalIndices, outFile);
     }
-    outFile << std::endl << "CELL_TYPES " << mesh.edges().size()
-            << std::endl << std::endl;
+    outFile << '\n' << "CELL_TYPES " << mesh.edges().size()
+            << '\n' << '\n';
     for(size_t i = 0; i < mesh.edges().size(); ++i) {
-      outFile << "3" << std::endl;
+      outFile << "3\n";
     }
   }
 
@@ -87,7 +87,7 @@ void ExportVTK::exportMesh
     size_t sizeTriangles = mesh.triangles().size();
     size_t sizeQuads = mesh.quads().size();
     outFile << "CELLS " << sizeTriangles + sizeQuads << " "
-            << sizeTriangles * 4 + sizeQuads * 5 << std::endl << std::endl;
+            << sizeTriangles * 4 + sizeQuads * 5 << '\n' << '\n';
     for (mesh::Triangle& triangle : mesh.triangles()) {
       int internalIndices[3];
       internalIndices[0] = triangle.vertex(0).getID();
@@ -104,19 +104,19 @@ void ExportVTK::exportMesh
       writeQuadrangle(internalIndices, outFile);
     }
 
-    outFile << std::endl << "CELL_TYPES " << sizeTriangles + sizeQuads
-            << std::endl << std::endl;
+    outFile << '\n' << "CELL_TYPES " << sizeTriangles + sizeQuads
+            << '\n' << '\n';
     for(size_t i=0; i < sizeTriangles; i++){
-      outFile << "5" << std::endl;
+      outFile << "5\n";
     }
     for(size_t i=0; i < sizeQuads; i++){
-      outFile << "9" << std::endl;
+      outFile << "9\n";
     }
 
 
     // OLD
 //    outFile << "CELLS " << mesh.triangles().size() << " "
-//            << mesh.triangles().size() * 4  << std::endl << std::endl;
+//            << mesh.triangles().size() * 4  << '\n' << '\n';
 //    for (mesh::Triangle & triangle : mesh.triangles()){
 //      int internalIndices[3];
 //      internalIndices[0] = triangle.vertex(0).getID();
@@ -124,15 +124,15 @@ void ExportVTK::exportMesh
 //      internalIndices[2] = triangle.vertex(2).getID();
 //      writeTriangle(internalIndices, outFile);
 //    }
-//    outFile << std::endl << "CELL_TYPES " << mesh.triangles().size()
-//            << std::endl << std::endl;
+//    outFile << '\n' << "CELL_TYPES " << mesh.triangles().size()
+//            << '\n' << '\n';
 //    for(size_t i=0; i < mesh.triangles().size(); i++){
-//      outFile << "5" << std::endl;
+//      outFile << "5\n";
 //    }
 
   }
 
-  outFile << std::endl;
+  outFile << '\n';
 }
 
 void ExportVTK:: exportData
@@ -140,12 +140,12 @@ void ExportVTK:: exportData
   std::ofstream& outFile,
   mesh::Mesh&    mesh)
 {
-  outFile << "POINT_DATA " << mesh.vertices().size() << std::endl;
-  outFile << std::endl;
+  outFile << "POINT_DATA " << mesh.vertices().size() << '\n';
+  outFile << '\n';
 
   if(_writeNormals) { // Plot vertex normals
-    outFile << "VECTORS VertexNormals float" << std::endl;
-    outFile << std::endl;
+    outFile << "VECTORS VertexNormals float\n";
+    outFile << '\n';
     for (mesh::Vertex& vertex : mesh.vertices()) {
       int i = 0;
       for(; i < mesh.getDimensions(); i++){
@@ -154,9 +154,9 @@ void ExportVTK:: exportData
       if(i < 3){
         outFile << "0";
       }
-      outFile << std::endl;
+      outFile << '\n';
     }
-    outFile << std::endl;
+    outFile << '\n';
 
     // Plot edge normals
 //    if(_plotNormals) {
@@ -179,7 +179,7 @@ void ExportVTK:: exportData
     Eigen::VectorXd& values = data->values();
     if(data->getDimensions() > 1) {
       Eigen::VectorXd viewTemp(data->getDimensions());
-      outFile << "VECTORS " << data->getName() << " float" << std::endl;
+      outFile << "VECTORS " << data->getName() << " float\n";
       for (mesh::Vertex& vertex : mesh.vertices()) {
         int offset = vertex.getID() * data->getDimensions();
         for(int i=0; i < data->getDimensions(); i++){
@@ -192,17 +192,17 @@ void ExportVTK:: exportData
         if(i < 3){
           outFile << "0";
         }
-        outFile << std::endl;
+        outFile << '\n';
       }
-      outFile << std::endl;
+      outFile << '\n';
     }
     else if(data->getDimensions() == 1) {
-      outFile << "SCALARS " << data->getName() << " float" << std::endl;
-      outFile << "LOOKUP_TABLE default" << std::endl;
+      outFile << "SCALARS " << data->getName() << " float\n";
+      outFile << "LOOKUP_TABLE default\n";
       for (mesh::Vertex& vertex : mesh.vertices()) {
-        outFile << values(vertex.getID()) << std::endl;
+        outFile << values(vertex.getID()) << '\n';
       }
-      outFile << std::endl;
+      outFile << '\n';
     }
   }
 }
@@ -224,9 +224,9 @@ void ExportVTK:: writeHeader
 (
   std::ostream& outFile)
 {
-  outFile << "# vtk DataFile Version 2.0" << std::endl << std::endl
-          << "ASCII" << std::endl << std::endl
-          << "DATASET UNSTRUCTURED_GRID" << std::endl << std::endl;
+  outFile << "# vtk DataFile Version 2.0\n' << '\n"
+          << "ASCII\n' << '\n"
+          << "DATASET UNSTRUCTURED_GRID\n' << '\n";
 }
 
 void ExportVTK:: writeVertex
@@ -235,11 +235,11 @@ void ExportVTK:: writeVertex
   std::ostream&           outFile)
 {
   if(position.size() == 2) {
-    outFile << position(0) << "  " << position(1) << "  " << 0.0 << std::endl;
+    outFile << position(0) << "  " << position(1) << "  " << 0.0 << '\n';
   }
   else {
     assertion(position.size() == 3);
-    outFile << position(0) << "  " << position(1) << "  " << position(2) << std::endl;
+    outFile << position(0) << "  " << position(1) << "  " << position(2) << '\n';
   }
 }
 
@@ -253,7 +253,7 @@ void ExportVTK:: writeTriangle
   for(int i=0; i < 3; i++) {
     outFile << vertexIndices[i] << " ";
   }
-  outFile << std::endl;
+  outFile << '\n';
 }
 
 void ExportVTK:: writeQuadrangle
@@ -265,7 +265,7 @@ void ExportVTK:: writeQuadrangle
   for(int i=0; i < 4; i++) {
     outFile << vertexIndices[i] << " ";
   }
-  outFile << std::endl;
+  outFile << '\n';
 }
 
 void ExportVTK:: writeLine
@@ -277,7 +277,7 @@ void ExportVTK:: writeLine
   for(int i=0; i<2; i++) {
     outFile << vertexIndices[i] << " ";
   }
-  outFile << std::endl;
+  outFile << '\n';
 }
 
 }} // namespace precice, io

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -99,12 +99,12 @@ void ExportVTKXML::writeMasterFile
   // write scalar data names
   outMasterFile << "      <PPointData Scalars=\"";
   for (size_t i = 0; i < _scalarDataNames.size(); ++i) {
-    outMasterFile << _scalarDataNames[i] << " ";
+    outMasterFile << _scalarDataNames[i] << ' ';
   }
   // write vector data names
   outMasterFile << "\" Vectors=\"";
   for (size_t i = 0; i < _vectorDataNames.size(); ++i) {
-    outMasterFile << _vectorDataNames[i] << " ";
+    outMasterFile << _vectorDataNames[i] << ' ';
   }
   outMasterFile << "\">\n";
 
@@ -162,7 +162,7 @@ void ExportVTKXML::writeSubFile
     writeVertex(vertex.getCoords(), outSubFile);
   }
   outSubFile << "            </DataArray>\n";
-  outSubFile << "         </Points> \n' << '\n";
+  outSubFile << "         </Points> \n\n";
 
   // Write Mesh
   exportMesh(outSubFile, mesh);
@@ -250,11 +250,11 @@ void ExportVTKXML:: exportData
 {
   outFile << "         <PointData Scalars=\"";
   for (size_t i = 0; i < _scalarDataNames.size(); i++) {
-    outFile << _scalarDataNames[i] << " ";
+    outFile << _scalarDataNames[i] << ' ';
   }
   outFile << "\" Vectors=\"";
   for (size_t i = 0; i < _vectorDataNames.size(); i++) {
-    outFile << _vectorDataNames[i] << " ";
+    outFile << _vectorDataNames[i] << ' ';
   }
   outFile << "\">\n";
 
@@ -294,17 +294,17 @@ void ExportVTKXML:: exportData
           viewTemp[i] = values(offset + i);
         }
         for(int i = 0; i < dataDimensions; i++){
-          outFile << viewTemp[i] << " ";
+          outFile << viewTemp[i] << ' ';
         }
         if(dataDimensions == 2){
-          outFile << "0.0" << " "; //2D data needs to be 3D for vtk
+          outFile << "0.0" << ' '; //2D data needs to be 3D for vtk
         }
-        outFile << " ";
+        outFile << ' ';
       }
     }
     else if(dataDimensions == 1) {
       for (size_t count = 0; count < mesh.vertices().size(); count++) {
-        outFile << values(count) << " ";
+        outFile << values(count) << ' ';
       }
     }
     outFile << '\n' << "            </DataArray>\n";

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -81,20 +81,20 @@ void ExportVTKXML::writeMasterFile
 
   CHECK(outMasterFile, "Could not open master file \"" << outfile.c_str() << "\" for VTKXML export!");
 
-  outMasterFile << "<?xml version=\"1.0\"?>" << std::endl;
+  outMasterFile << "<?xml version=\"1.0\"?>\n";
   outMasterFile << "<VTKFile type=\"PUnstructuredGrid\" version=\"0.1\" byte_order=\"";
-  outMasterFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">")  << std::endl;
-  outMasterFile << "   <PUnstructuredGrid GhostLevel=\"0\">" << std::endl;
+  outMasterFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">")  << '\n';
+  outMasterFile << "   <PUnstructuredGrid GhostLevel=\"0\">\n";
 
-  outMasterFile << "      <PPoints>" << std::endl;
-  outMasterFile << "         <PDataArray type=\"Float32\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>" << std::endl;
-  outMasterFile << "      </PPoints>" << std::endl;
+  outMasterFile << "      <PPoints>\n";
+  outMasterFile << "         <PDataArray type=\"Float32\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>\n";
+  outMasterFile << "      </PPoints>\n";
 
-  outMasterFile << "      <PCells>" << std::endl;
-  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\"/>" << std::endl;
-  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"offsets\"      NumberOfComponents=\"1\"/>" << std::endl;
-  outMasterFile << "         <PDataArray type=\"UInt8\" Name=\"types\"        NumberOfComponents=\"1\"/>" << std::endl;
-  outMasterFile << "      </PCells>" << std::endl;
+  outMasterFile << "      <PCells>\n";
+  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\"/>\n";
+  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"offsets\"      NumberOfComponents=\"1\"/>\n";
+  outMasterFile << "         <PDataArray type=\"UInt8\" Name=\"types\"        NumberOfComponents=\"1\"/>\n";
+  outMasterFile << "      </PCells>\n";
 
   // write scalar data names
   outMasterFile << "      <PPointData Scalars=\"";
@@ -106,25 +106,25 @@ void ExportVTKXML::writeMasterFile
   for (size_t i = 0; i < _vectorDataNames.size(); ++i) {
     outMasterFile << _vectorDataNames[i] << " ";
   }
-  outMasterFile << "\">" << std::endl;
+  outMasterFile << "\">\n";
 
   for (size_t i = 0; i < _scalarDataNames.size(); ++i) {
-    outMasterFile << "         <PDataArray type=\"Float32\" Name=\""<< _scalarDataNames[i] << "\" NumberOfComponents=\"" << 1 << "\"/>" << std::endl;
+    outMasterFile << "         <PDataArray type=\"Float32\" Name=\""<< _scalarDataNames[i] << "\" NumberOfComponents=\"" << 1 << "\"/>\n";
   }
 
   for (size_t i = 0; i < _vectorDataNames.size(); ++i) {
-    outMasterFile << "         <PDataArray type=\"Float32\" Name=\""<< _vectorDataNames[i] << "\" NumberOfComponents=\"" << 3 << "\"/>" << std::endl;
+    outMasterFile << "         <PDataArray type=\"Float32\" Name=\""<< _vectorDataNames[i] << "\" NumberOfComponents=\"" << 3 << "\"/>\n";
   }
-  outMasterFile << "      </PPointData>" << std::endl;
+  outMasterFile << "      </PPointData>\n";
 
   for (int i = 0; i < utils::MasterSlave::_size; i++) {
     if(mesh.getVertexDistribution()[i].size()>0){ //only non-empty subfiles
-      outMasterFile << "      <Piece Source=\"" << name << "_r" << i << ".vtu\"/>" << std::endl;
+      outMasterFile << "      <Piece Source=\"" << name << "_r" << i << ".vtu\"/>\n";
     }
   }
 
-  outMasterFile << "   </PUnstructuredGrid>" << std::endl;
-  outMasterFile << "</VTKFile>" << std::endl;
+  outMasterFile << "   </PUnstructuredGrid>\n";
+  outMasterFile << "</VTKFile>\n";
 
   outMasterFile.close();
 }
@@ -150,19 +150,19 @@ void ExportVTKXML::writeSubFile
 
   CHECK(outSubFile, "Could not open slave file \"" << outfile.c_str() << "\" for VTKXML export!");
 
-  outSubFile << "<?xml version=\"1.0\"?>" << std::endl;
+  outSubFile << "<?xml version=\"1.0\"?>\n";
   outSubFile << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\" byte_order=\"";
-  outSubFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">")  << std::endl;
+  outSubFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">")  << '\n';
 
-  outSubFile << "   <UnstructuredGrid>" << std::endl;
-  outSubFile << "      <Piece NumberOfPoints=\"" << numPoints << "\" NumberOfCells=\"" << numCells << "\"> " << std::endl;
-  outSubFile << "         <Points> " << std::endl;
-  outSubFile << "            <DataArray type=\"Float32\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\" format=\"ascii\"> " << std::endl;
+  outSubFile << "   <UnstructuredGrid>\n";
+  outSubFile << "      <Piece NumberOfPoints=\"" << numPoints << "\" NumberOfCells=\"" << numCells << "\"> \n";
+  outSubFile << "         <Points> \n";
+  outSubFile << "            <DataArray type=\"Float32\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\" format=\"ascii\"> \n";
   for (mesh::Vertex& vertex : mesh.vertices()) {
     writeVertex(vertex.getCoords(), outSubFile);
   }
-  outSubFile << "            </DataArray>" << std::endl;
-  outSubFile << "         </Points> " << std::endl << std::endl;
+  outSubFile << "            </DataArray>\n";
+  outSubFile << "         </Points> \n' << '\n";
 
   // Write Mesh
   exportMesh(outSubFile, mesh);
@@ -170,9 +170,9 @@ void ExportVTKXML::writeSubFile
   // Write data
   exportData(outSubFile, mesh);
 
-  outSubFile << "      </Piece>" << std::endl;
-  outSubFile << "   </UnstructuredGrid> " << std::endl;
-  outSubFile << "</VTKFile>" << std::endl;
+  outSubFile << "      </Piece>\n";
+  outSubFile << "   </UnstructuredGrid> \n";
+  outSubFile << "</VTKFile>\n";
 
   outSubFile.close();
 }
@@ -183,33 +183,33 @@ void ExportVTKXML::exportMesh
   mesh::Mesh&    mesh)
 {
   if (_meshDimensions == 2) { // write edges as cells
-    outFile << "         <Cells>" << std::endl;
-    outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+    outFile << "         <Cells>\n";
+    outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
     outFile << "               ";
     for (mesh::Edge & edge : mesh.edges()) {
       writeLine(edge, outFile);
     }
-    outFile << std::endl;
-    outFile << "            </DataArray> " << std::endl;
-    outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+    outFile << '\n';
+    outFile << "            </DataArray> \n";
+    outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">\n";
     outFile << "               ";
     for (size_t i = 1; i <= mesh.edges().size(); i++) {
       outFile << 2*i << "  ";
     }
-    outFile << std::endl;
-    outFile << "            </DataArray>" << std::endl;
-    outFile << "            <DataArray type=\"UInt8\"  Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+    outFile << '\n';
+    outFile << "            </DataArray>\n";
+    outFile << "            <DataArray type=\"UInt8\"  Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">\n";
     outFile << "               ";
     for (size_t i = 1; i <= mesh.edges().size(); i++) {
       outFile << 3 << "  ";
     }
-    outFile << std::endl;
-    outFile << "            </DataArray>" << std::endl;
-    outFile << "         </Cells>" << std::endl;
+    outFile << '\n';
+    outFile << "            </DataArray>\n";
+    outFile << "         </Cells>\n";
   } else { // write triangles and quads as cells
 
-    outFile << "         <Cells>" << std::endl;
-    outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+    outFile << "         <Cells>\n";
+    outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
     outFile << "               ";
     for (mesh::Triangle& triangle : mesh.triangles()) {
       writeTriangle(triangle, outFile);
@@ -217,9 +217,9 @@ void ExportVTKXML::exportMesh
     for (mesh::Quad& quad : mesh.quads()) {
       writeQuadrangle(quad, outFile);
     }
-    outFile << std::endl;
-    outFile << "            </DataArray> " << std::endl;
-    outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+    outFile << '\n';
+    outFile << "            </DataArray> \n";
+    outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">\n";
     outFile << "               ";
     for (size_t i = 1; i <= mesh.triangles().size(); i++) {
       outFile << 3*i << "  ";
@@ -227,9 +227,9 @@ void ExportVTKXML::exportMesh
     for (size_t i = 1; i <= mesh.quads().size(); i++) {
       outFile << 4*i << "  ";
     }
-    outFile << std::endl;
-    outFile << "            </DataArray>" << std::endl;
-    outFile << "            <DataArray type=\"UInt8\"  Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+    outFile << '\n';
+    outFile << "            </DataArray>\n";
+    outFile << "            <DataArray type=\"UInt8\"  Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">\n";
     outFile << "               ";
     for (size_t i = 1; i <= mesh.triangles().size(); i++) {
       outFile << 5 << "  ";
@@ -237,9 +237,9 @@ void ExportVTKXML::exportMesh
     for (size_t i = 1; i <= mesh.quads().size(); i++) {
       outFile << 9 << "  ";
     }
-    outFile << std::endl;
-    outFile << "            </DataArray>" << std::endl;
-    outFile << "         </Cells>" << std::endl;
+    outFile << '\n';
+    outFile << "            </DataArray>\n";
+    outFile << "         </Cells>\n";
   }
 }
 
@@ -256,14 +256,14 @@ void ExportVTKXML:: exportData
   for (size_t i = 0; i < _vectorDataNames.size(); i++) {
     outFile << _vectorDataNames[i] << " ";
   }
-  outFile << "\">" << std::endl;
+  outFile << "\">\n";
 
 
   // Print VertexNormals
   if (_writeNormals) {
     const auto dimensions = mesh.getDimensions();
     outFile << "            <DataArray type=\"Float32\" Name=\"VertexNormals\" NumberOfComponents=\"";
-    outFile << std::max(3, dimensions) << "\" format=\"ascii\">" << std::endl;
+    outFile << std::max(3, dimensions) << "\" format=\"ascii\">\n";
     outFile << "               ";
     for (const auto& vertex : mesh.vertices()) {
         const auto normal = vertex.getNormal();
@@ -276,7 +276,7 @@ void ExportVTKXML:: exportData
             outFile << ' ';
         }
     }
-    outFile << std::endl << "            </DataArray>" << std::endl;
+    outFile << '\n' << "            </DataArray>\n";
   }
   for (mesh::PtrData data : mesh.data()) { // Plot vertex data
     Eigen::VectorXd& values = data->values();
@@ -284,7 +284,7 @@ void ExportVTKXML:: exportData
     std::string dataName(data->getName());
     int numberOfComponents = (dataDimensions==2) ? 3 : dataDimensions;
     outFile << "            <DataArray type=\"Float32\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
-    outFile << "\" format=\"ascii\">" << std::endl;
+    outFile << "\" format=\"ascii\">\n";
     outFile << "               ";
     if(dataDimensions > 1) {
       Eigen::VectorXd viewTemp(dataDimensions);
@@ -307,9 +307,9 @@ void ExportVTKXML:: exportData
         outFile << values(count) << " ";
       }
     }
-    outFile << std::endl << "            </DataArray>" << std::endl;
+    outFile << '\n' << "            </DataArray>\n";
   }
-  outFile << "         </PointData> " << std::endl;
+  outFile << "         </PointData> \n";
 }
 
 void ExportVTKXML::writeVertex
@@ -325,7 +325,7 @@ void ExportVTKXML::writeVertex
   {
     outFile << 0.0 << "  ";  //also for 2D scenario, vtk needs 3D data
   }
-  outFile << std::endl;
+  outFile << '\n';
 }
 
 

--- a/src/io/TXTReader.cpp
+++ b/src/io/TXTReader.cpp
@@ -19,12 +19,4 @@ TXTReader:: TXTReader
   //_file << std::setprecision(16);
 }
 
-TXTReader:: ~TXTReader()
-{
-  if (_file){
-    _file.close();
-  }
-}
-
-
 }} // namespace precice, io

--- a/src/io/TXTReader.hpp
+++ b/src/io/TXTReader.hpp
@@ -20,9 +20,6 @@ public:
   /// Constructor, opens file and sets format.
   explicit TXTReader(const std::string& filename);
 
-  /// Destructor, closes file.
-  ~TXTReader();
-
   /// Reads the Eigen::Matrix from the file.
   template<typename Scalar, int Rows, int Cols>
   void read(Eigen::Matrix<Scalar, Rows, Cols>& matrix)

--- a/src/io/TXTWriter.cpp
+++ b/src/io/TXTWriter.cpp
@@ -32,4 +32,14 @@ void TXTWriter::flush()
     _file.flush();
 }
 
+void TXTWriter::write(const Eigen::MatrixXd& matrix)
+{
+  for (long i = 0; i < matrix.rows(); i++) {
+    for (long j = 0; j < matrix.cols(); j++) {
+      _file << matrix(i, j) << ' ';
+    }
+  }
+  _file << '\n';
+}
+
 }} // namespace precice, io

--- a/src/io/TXTWriter.cpp
+++ b/src/io/TXTWriter.cpp
@@ -20,13 +20,6 @@ TXTWriter:: TXTWriter
   _file << std::setprecision(16);
 }
 
-TXTWriter:: ~TXTWriter()
-{
-  if (_file){
-    _file.close ();
-  }
-}
-
 void TXTWriter::flush()
 {
     _file.flush();

--- a/src/io/TXTWriter.cpp
+++ b/src/io/TXTWriter.cpp
@@ -27,4 +27,9 @@ TXTWriter:: ~TXTWriter()
   }
 }
 
+void TXTWriter::flush()
+{
+    _file.flush();
+}
+
 }} // namespace precice, io

--- a/src/io/TXTWriter.hpp
+++ b/src/io/TXTWriter.hpp
@@ -26,15 +26,7 @@ public:
   ~TXTWriter();
 
   ///Writes (appends) the matrix to the file.
-  void write(const Eigen::MatrixXd& matrix)
-  {
-    for (long i = 0; i < matrix.rows(); i++) {
-      for (long j = 0; j < matrix.cols(); j++) {
-        _file << matrix(i, j) << ' ';
-      }
-    }
-    _file << '\n';
-  }
+  void write(const Eigen::MatrixXd& matrix);
 
   ///Flush the buffer to file
   void flush();

--- a/src/io/TXTWriter.hpp
+++ b/src/io/TXTWriter.hpp
@@ -20,11 +20,6 @@ public:
    */
   explicit TXTWriter(const std::string& filename);
 
-  /**
-   * @brief Destructor, closes file.
-   */
-  ~TXTWriter();
-
   ///Writes (appends) the matrix to the file.
   void write(const Eigen::MatrixXd& matrix);
 

--- a/src/io/TXTWriter.hpp
+++ b/src/io/TXTWriter.hpp
@@ -36,6 +36,9 @@ public:
     _file << '\n';
   }
 
+  ///Flush the buffer to file
+  void flush();
+
   
 private:
   logging::Logger _log{"io::TXTWriter"};

--- a/src/io/TXTWriter.hpp
+++ b/src/io/TXTWriter.hpp
@@ -30,10 +30,10 @@ public:
   {
     for (long i = 0; i < matrix.rows(); i++) {
       for (long j = 0; j < matrix.cols(); j++) {
-        _file << matrix(i, j) << " ";
+        _file << matrix(i, j) << ' ';
       }
     }
-    _file << std::endl;
+    _file << '\n';
   }
 
   

--- a/src/io/tests/TXTWriterReaderTest.cpp
+++ b/src/io/tests/TXTWriterReaderTest.cpp
@@ -13,6 +13,7 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
     Eigen::Matrix<double, 1, 2> output(1, 2);
     TXTWriter                   txtWriter("io-TXTWriterReaderTest-matrix-1by2.log");
     txtWriter.write(output);
+    txtWriter.flush();
     Eigen::Matrix<double, 1, 2> input(1, 2);
     TXTReader                   txtReader("io-TXTWriterReaderTest-matrix-1by2.log");
     txtReader.read(input);
@@ -23,6 +24,7 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
     Eigen::Matrix<double, 2, 1> output(1, 2);
     TXTWriter                   txtWriter("io-TXTWriterReaderTest-matrix-2by1.log");
     txtWriter.write(output);
+    txtWriter.flush();
     Eigen::Matrix<double, 2, 1> input(1, 2);
     TXTReader                   txtReader("io-TXTWriterReaderTest-matrix-2by1.log");
     txtReader.read(input);
@@ -37,6 +39,7 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
 
     Eigen::VectorXd vecOutput = Eigen::VectorXd::Constant(1, 1);
     txtWriter.write(vecOutput);
+    txtWriter.flush();
 
     Eigen::Matrix<double, 3, 3> matInput;
     TXTReader                   txtReader("io-TXTWriterReaderTest-matrix-3by3.log");
@@ -52,6 +55,7 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
     Eigen::Vector3d output(1, 2, 3);
     TXTWriter       txtWriter("io-TXTWriterReaderTest-vector-3.log");
     txtWriter.write(output);
+    txtWriter.flush();
 
     Eigen::Vector3d input;
     TXTReader       txtReader("io-TXTWriterReaderTest-vector-3.log");

--- a/src/io/tests/TXTWriterReaderTest.cpp
+++ b/src/io/tests/TXTWriterReaderTest.cpp
@@ -11,9 +11,10 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
 {
   {
     Eigen::Matrix<double, 1, 2> output(1, 2);
-    TXTWriter                   txtWriter("io-TXTWriterReaderTest-matrix-1by2.log");
-    txtWriter.write(output);
-    txtWriter.flush();
+    {
+        TXTWriter txtWriter("io-TXTWriterReaderTest-matrix-1by2.log");
+        txtWriter.write(output);
+    }
     Eigen::Matrix<double, 1, 2> input(1, 2);
     TXTReader                   txtReader("io-TXTWriterReaderTest-matrix-1by2.log");
     txtReader.read(input);
@@ -22,9 +23,10 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
 
   {
     Eigen::Matrix<double, 2, 1> output(1, 2);
-    TXTWriter                   txtWriter("io-TXTWriterReaderTest-matrix-2by1.log");
-    txtWriter.write(output);
-    txtWriter.flush();
+    {
+        TXTWriter txtWriter("io-TXTWriterReaderTest-matrix-2by1.log");
+        txtWriter.write(output);
+    }
     Eigen::Matrix<double, 2, 1> input(1, 2);
     TXTReader                   txtReader("io-TXTWriterReaderTest-matrix-2by1.log");
     txtReader.read(input);
@@ -34,12 +36,13 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
   {
     Eigen::Matrix<double, 3, 3> matOutput;
     matOutput << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-    TXTWriter txtWriter("io-TXTWriterReaderTest-matrix-3by3.log");
-    txtWriter.write(matOutput);
-
     Eigen::VectorXd vecOutput = Eigen::VectorXd::Constant(1, 1);
-    txtWriter.write(vecOutput);
-    txtWriter.flush();
+
+    {
+        TXTWriter txtWriter("io-TXTWriterReaderTest-matrix-3by3.log");
+        txtWriter.write(matOutput);
+        txtWriter.write(vecOutput);
+    }
 
     Eigen::Matrix<double, 3, 3> matInput;
     TXTReader                   txtReader("io-TXTWriterReaderTest-matrix-3by3.log");
@@ -53,9 +56,10 @@ BOOST_AUTO_TEST_CASE(TXTWriterReaderTest, * testing::OnMaster())
 
   {
     Eigen::Vector3d output(1, 2, 3);
-    TXTWriter       txtWriter("io-TXTWriterReaderTest-vector-3.log");
-    txtWriter.write(output);
-    txtWriter.flush();
+    {
+        TXTWriter txtWriter("io-TXTWriterReaderTest-vector-3.log");
+        txtWriter.write(output);
+    }
 
     Eigen::Vector3d input;
     TXTReader       txtReader("io-TXTWriterReaderTest-vector-3.log");

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -107,7 +107,7 @@ public:
   
   void consume(boost::log::record_view const& rec, string_type const& formatted_record)
   {
-    *_ostream << formatted_record << std::endl << std::flush;
+    *_ostream << formatted_record << '\n' << std::flush;
   }
 };
 

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -59,7 +59,7 @@
 
 /// Helper macro, used by TRACE
 #define LOG_ARGUMENT(r, data, i, elem)                                  \
-  << std::endl << "  Argument " << i << ": " << BOOST_PP_STRINGIZE(elem) << " == " << elem
+  << '\n' << "  Argument " << i << ": " << BOOST_PP_STRINGIZE(elem) << " == " << elem
 
 // Do not put do {...} while (false) here, it will destroy the _tracer_ right after creation
 #define TRACE(...)                                                      \

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -95,7 +95,7 @@ void print(std::map<int, std::vector<int>> const &m)
 
   for (auto &i : m) {
     for (auto &j : i.second) {
-      oss << i.first << ":" << j << std::endl; // prints rank:index
+      oss << i.first << ":" << j << '\n'; // prints rank:index
     }
   }
 
@@ -157,7 +157,7 @@ void printCommunicationPartnerCountStats(std::map<int, std::vector<int>> const &
               << "  Minimum: " << minimum << "\n"
               << "  Average: " << average << "\n"
               << "Number of Interface Processes: " << count << "\n"
-              << std::endl;
+              << '\n';
   } else {
     assertion(utils::MasterSlave::_slaveMode);
     utils::MasterSlave::_communication->send(size, 0);
@@ -211,7 +211,7 @@ void printLocalIndexCountStats(std::map<int, std::vector<int>> const &m)
               << "  Minimum: " << minimum << "\n"
               << "  Average: " << average << "\n"
               << "Number of Interface Processes: " << count << "\n"
-              << std::endl;
+              << '\n';
   } else {
     assertion(utils::MasterSlave::_slaveMode);
 

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -1008,12 +1008,12 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computePreallocationMatr
   }
 
   if (utils::Parallel::getCommunicatorSize() == 1) {
-    // std::cout << "Computed Preallocation C Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << std::endl;
+    // std::cout << "Computed Preallocation C Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
     ierr = MatSeqSBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data()); CHKERRV(ierr);
   }
   else {
     // std::cout << "Computed Preallocation C MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    // << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << std::endl;
+    // << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
     ierr = MatMPISBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data(), 0, o_nnz.data()); CHKERRV(ierr);
   }
   MatSetOption(_matrixC, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
@@ -1085,12 +1085,12 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computePreallocationMatr
     }
   }
   if (utils::Parallel::getCommunicatorSize() == 1) {
-    // std::cout << "Preallocation A Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << std::endl;
+    // std::cout << "Preallocation A Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
     ierr = MatSeqAIJSetPreallocation(_matrixA, 0, d_nnz.data()); CHKERRV(ierr);
   }
   else {
     // std::cout << "Preallocation A MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    // << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << std::endl;
+    // << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
     ierr = MatMPIAIJSetPreallocation(_matrixA, 0, d_nnz.data(), 0, o_nnz.data()); CHKERRV(ierr);
   }
   MatSetOption(_matrixA, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
@@ -1162,12 +1162,12 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::savedPreallocationMatrixC(mes
   }
 
   if (utils::Parallel::getCommunicatorSize() == 1) {
-    // std::cout << "Computed Preallocation C Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << std::endl;
+    // std::cout << "Computed Preallocation C Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
     MatSeqSBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data());
   }
   else {
     // std::cout << "Computed Preallocation C MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    //           << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << std::endl;
+    //           << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
     MatMPISBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data(), 0, o_nnz.data());
   }
   MatSetOption(_matrixC, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
@@ -1245,12 +1245,12 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::savedPreallocationMatrixA(mes
     }
   }
   if (utils::Parallel::getCommunicatorSize() == 1) {
-    // std::cout << "Preallocation A Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << std::endl;
+    // std::cout << "Preallocation A Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
     MatSeqAIJSetPreallocation(_matrixA, 0, d_nnz.data());
   }
   else {
     // std::cout << "Preallocation A MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    //           << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << std::endl;
+    //           << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
     MatMPIAIJSetPreallocation(_matrixA, 0, d_nnz.data(), 0, o_nnz.data());
   }
   MatSetOption(_matrixA, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);

--- a/src/precice/bindings/fortran/SolverInterfaceFASTEST.cpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFASTEST.cpp
@@ -41,8 +41,8 @@ void precice_fastest_create_
   string stringAccessorNameFluid(participantNameFluid, strippedLength);
   strippedLength = precice::impl::strippedLength(configFileName,lengthConfigFileName);
   string stringConfigFileName(configFileName, strippedLength);
-  //cout << "Accessor: " << stringAccessorName << "!" << endl;
-  //cout << "Config  : " << stringConfigFileName << "!" << endl;
+  //cout << "Accessor: " << stringAccessorName << "!" << '\n';
+  //cout << "Config  : " << stringConfigFileName << "!" << '\n';
   if(isAcousticUsed){
     implAcoustic = new precice::impl::SolverInterfaceImpl (stringAccessorNameAcoustic,
            *solverProcessIndex, *solverProcessSize, false);

--- a/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
@@ -30,16 +30,16 @@ void precicef_create_
   int   lengthAccessorName,
   int   lengthConfigFileName )
 {
-  //cout << "lengthAccessorName: " << lengthAccessorName << endl;
-  //cout << "lengthConfigFileName: " << lengthConfigFileName << endl;
-  //cout << "solverProcessIndex: " << *solverProcessIndex << endl;
-  //cout << "solverProcessSize: " << *solverProcessSize << endl;
+  //cout << "lengthAccessorName: " << lengthAccessorName << '\n';
+  //cout << "lengthConfigFileName: " << lengthConfigFileName << '\n';
+  //cout << "solverProcessIndex: " << *solverProcessIndex << '\n';
+  //cout << "solverProcessSize: " << *solverProcessSize << '\n';
   int strippedLength = precice::impl::strippedLength(participantName,lengthAccessorName);
   string stringAccessorName(participantName, strippedLength);
   strippedLength = precice::impl::strippedLength(configFileName,lengthConfigFileName);
   string stringConfigFileName(configFileName, strippedLength);
-  //cout << "Accessor: " << stringAccessorName << "!" << endl;
-  //cout << "Config  : " << stringConfigFileName << "!" << endl;
+  //cout << "Accessor: " << stringAccessorName << "!" << '\n';
+  //cout << "Config  : " << stringConfigFileName << "!" << '\n';
   impl = new precice::impl::SolverInterfaceImpl (stringAccessorName,
          *solverProcessIndex, *solverProcessSize, false);
   impl->configure(stringConfigFileName);
@@ -166,14 +166,14 @@ void precicef_action_required_
 {
   CHECK(impl != nullptr,errormsg);
   //assertion(lengthAction > 1);
-  //std::cout << "lengthAction: " << lengthAction << std::endl;
+  //std::cout << "lengthAction: " << lengthAction << '\n';
   //std::cout << "Action:";
   //for (int i=0; i < lengthAction; i++){
   //  std::cout << " a[" << i << "]=\"" << action[i] << "\"";
   //}
-  //std::cout << std::endl;
+  //std::cout << '\n';
   int strippedLength = precice::impl::strippedLength(action, lengthAction);
-  //std::cout << "strippedLength: " << strippedLength << std::endl;
+  //std::cout << "strippedLength: " << strippedLength << '\n';
   //assertion(strippedLength > 1);
   string stringAction(action, strippedLength);
   if (impl->isActionRequired(stringAction)){

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
     double values[2];
     interface.advance(1.0);
     interface.readBlockScalarData(dataID, 2, vertexIDs, values);
-//    std::cout << utils::Parallel::getProcessRank() <<": " << values << std::endl;
+//    std::cout << utils::Parallel::getProcessRank() <<": " << values << '\n';
     interface.finalize();
   }
   else {

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -45,7 +45,7 @@ bool init_unit_test()
   
   if (logConfigs.empty()) { // nothing has been read from log.conf
     #if BOOST_VERSION == 106900
-    std::cerr << "Boost 1.69 get log_level is broken, preCICE log level set to debug." << std::endl;
+    std::cerr << "Boost 1.69 get log_level is broken, preCICE log level set to debug.\n";
     auto logLevel = log_successful_tests;
     #else
     auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);
@@ -97,11 +97,11 @@ int main(int argc, char* argv[])
     
   if (utils::Parallel::getCommunicatorSize() < 4) {
     if (utils::Parallel::getProcessRank() == 0)
-      std::cerr << "Running tests on less than four processors. Not all tests are executed." << std::endl;
+      std::cerr << "Running tests on less than four processors. Not all tests are executed.\n";
   }
   if (utils::Parallel::getCommunicatorSize() > 4) {
     if (utils::Parallel::getProcessRank() == 0)
-      std::cerr << "Running tests on more than 4 processors is not supported. Aborting." << std::endl;
+      std::cerr << "Running tests on more than 4 processors is not supported. Aborting.\n";
     std::exit(-1);
   }
 

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -297,6 +297,7 @@ void EventRegistry::writeSummary(std::ostream &out)
   MPI_Comm_size(comm, &size);
 
   if (rank == 0) {
+    using std::endl;
     { // Print per event stats
       std::time_t ts = sys_clk::to_time_t(localRankData.finalizedAt);
       double const duration = std::chrono::duration_cast<std::chrono::milliseconds>(localRankData.getDuration()).count();
@@ -305,9 +306,9 @@ void EventRegistry::writeSummary(std::ostream &out)
 
       out << "Global runtime       = "
           << duration << "ms / "
-          << duration / 1000 << "s\n"
-          << "Number of processors = " << size << '\n'
-          << "# Rank: " << rank << "\n\n";
+          << duration / 1000 << "s" << endl
+          << "Number of processors = " << size << endl
+          << "# Rank: " << rank << endl << endl;
 
       Table table(out);
       table.addColumn("Event", getMaxNameWidth());
@@ -325,7 +326,7 @@ void EventRegistry::writeSummary(std::ostream &out)
                        ev.getTotal() / duration);
       }
     }
-    out << '\n' << '\n';
+    out << endl << endl;
     { // Print aggregated states
       Table t(out);
       t.addColumn("Name", getMaxNameWidth());
@@ -393,7 +394,7 @@ void EventRegistry::writeJSON(std::ostream & out)
       });
   }
   
-  out << std::setw(2) << js << '\n';
+  out << std::setw(2) << js << std::endl;
 }
 
 

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -297,7 +297,6 @@ void EventRegistry::writeSummary(std::ostream &out)
   MPI_Comm_size(comm, &size);
 
   if (rank == 0) {
-    using std::endl;
     { // Print per event stats
       std::time_t ts = sys_clk::to_time_t(localRankData.finalizedAt);
       double const duration = std::chrono::duration_cast<std::chrono::milliseconds>(localRankData.getDuration()).count();
@@ -306,9 +305,9 @@ void EventRegistry::writeSummary(std::ostream &out)
 
       out << "Global runtime       = "
           << duration << "ms / "
-          << duration / 1000 << "s" << endl
-          << "Number of processors = " << size << endl
-          << "# Rank: " << rank << endl << endl;
+          << duration / 1000 << "s\n"
+          << "Number of processors = " << size << '\n'
+          << "# Rank: " << rank << "\n\n";
 
       Table table(out);
       table.addColumn("Event", getMaxNameWidth());
@@ -326,7 +325,7 @@ void EventRegistry::writeSummary(std::ostream &out)
                        ev.getTotal() / duration);
       }
     }
-    out << endl << endl;
+    out << '\n' << '\n';
     { // Print aggregated states
       Table t(out);
       t.addColumn("Name", getMaxNameWidth());
@@ -394,7 +393,7 @@ void EventRegistry::writeJSON(std::ostream & out)
       });
   }
   
-  out << std::setw(2) << js << std::endl;
+  out << std::setw(2) << js << '\n';
 }
 
 

--- a/src/utils/String.cpp
+++ b/src/utils/String.cpp
@@ -18,21 +18,21 @@ std::string wrapText (
   std::string wrapped;
   int length = 0;
   while (text[length] == ' '){
-    wrapped += " ";
+    wrapped += ' ';
     length++;
   }
   for (int i=0; i < (int)tokens.size()-1; i++){
     length += (int)tokens[i].length();
     wrapped += tokens[i];
     if (length + (int)tokens[i+1].length() + 1 > linewidth){
-      wrapped += "\n";
+      wrapped += '\n';
       for (int ws=0; ws < indentation; ws++){
-        wrapped += " ";
+        wrapped += ' ';
       }
       length = indentation;
     }
     else {
-      wrapped += " ";
+      wrapped += ' ';
       length += 1;
     }
   }

--- a/src/utils/TableWriter.cpp
+++ b/src/utils/TableWriter.cpp
@@ -50,10 +50,10 @@ void Table::printHeader()
     out << padding << setw(h.width) << h.name << padding << sepChar;
   }
 
-  out << endl;
+  out << '\n';
   int headerLength = std::accumulate(cols.begin(), cols.end(), 0, [this](int count, Column col){
     return count + col.width + sepChar.size() + 2;
     });
   std::string sepLine(headerLength, '-');
-  out << sepLine << endl;
+  out << sepLine << '\n';
 }

--- a/src/utils/TableWriter.hpp
+++ b/src/utils/TableWriter.hpp
@@ -74,7 +74,7 @@ public:
   void printRow(size_t index, T a)
   {
     out << padding << std::setw(cols[index].width) << std::setprecision(cols[index].precision)
-         << a << padding << sepChar << std::endl;
+         << a << padding << sepChar << '\n';
   }
 
 

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -18,18 +18,18 @@
 
 /// Helper macro, used by assertion.
 #define PRINT_ARGUMENT(r, data, i, elem)                        \
-  std::cerr << "  Argument " << i << ": " << elem << std::endl;
+  std::cerr << "  Argument " << i << ": " << elem << '\n';
 
 /// Asserts that expr evaluates to true, prints all other arguments and calls assert(false).
 #define assertion(...) if (not (BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__))) { \
-    std::cerr << "ASSERTION FAILED" << std::endl \
-              << "  Location:          " << BOOST_CURRENT_FUNCTION << std::endl \
-              << "  File:              " << __FILE__ << ":" << __LINE__ << std::endl \
-              << "  Rank:              " << precice::utils::Parallel::getProcessRank()  << std::endl \
+    std::cerr << "ASSERTION FAILED\n" \
+              << "  Location:          " << BOOST_CURRENT_FUNCTION << '\n' \
+              << "  File:              " << __FILE__ << ":" << __LINE__ << '\n' \
+              << "  Rank:              " << precice::utils::Parallel::getProcessRank()  << '\n' \
               << "  Failed expression: " << BOOST_PP_STRINGIZE(BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__)) \
-              <<  std::endl;                                            \
+              <<  '\n';                                            \
     BOOST_PP_SEQ_FOR_EACH_I(PRINT_ARGUMENT,, BOOST_PP_SEQ_TAIL(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))); \
-    std::cerr << getStacktrace() << std::endl;                          \
+    std::cerr << getStacktrace() << '\n';                          \
     std::cerr.flush();                                                  \
     std::cout.flush();                                                  \
     assert(false);                                                      \

--- a/src/utils/prettyprint.hpp
+++ b/src/utils/prettyprint.hpp
@@ -362,7 +362,7 @@ namespace pretty_print
 
 
     // A wrapper for a C-style array given as pointer-plus-size.
-    // Usage: std::cout << pretty_print_array(arr, n) << '\n';
+    // Usage: std::cout << pretty_print_array(arr, n) << std::endl;
 
     template<typename T>
     struct array_wrapper_n
@@ -381,7 +381,7 @@ namespace pretty_print
 
 
     // A wrapper for hash-table based containers that offer local iterators to each bucket.
-    // Usage: std::cout << bucket_print(m, 4) << '\n';  (Prints bucket 5 of container m.)
+    // Usage: std::cout << bucket_print(m, 4) << std::endl;  (Prints bucket 5 of container m.)
 
     template <typename T>
     struct bucket_print_wrapper

--- a/src/utils/prettyprint.hpp
+++ b/src/utils/prettyprint.hpp
@@ -362,7 +362,7 @@ namespace pretty_print
 
 
     // A wrapper for a C-style array given as pointer-plus-size.
-    // Usage: std::cout << pretty_print_array(arr, n) << std::endl;
+    // Usage: std::cout << pretty_print_array(arr, n) << '\n';
 
     template<typename T>
     struct array_wrapper_n
@@ -381,7 +381,7 @@ namespace pretty_print
 
 
     // A wrapper for hash-table based containers that offer local iterators to each bucket.
-    // Usage: std::cout << bucket_print(m, 4) << std::endl;  (Prints bucket 5 of container m.)
+    // Usage: std::cout << bucket_print(m, 4) << '\n';  (Prints bucket 5 of container m.)
 
     template <typename T>
     struct bucket_print_wrapper

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -152,13 +152,13 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(std::map<std::string, std::string> &aA
 {
   TRACE(_name);
   if (_read) {
-    std::cout << "Attribute \"" + _name + "\" is defined multiple times" << std::endl;
+    std::cout << "Attribute \"" + _name + "\" is defined multiple times\n";
     throw "Attribute \"" + _name + "\" is defined multiple times";
   }
 
   if (aAttributes.find(getName()) == aAttributes.end()) {
     if (not _hasDefaultValue) {
-      std::cout << "Attribute \"" + _name + "\" missing" << std::endl;
+      std::cout << "Attribute \"" + _name + "\" missing\n";
       throw "Attribute \"" + _name + "\" missing";
     }
     set(_value, _defaultValue);
@@ -178,7 +178,7 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(std::map<std::string, std::string> &aA
             stream << " or value must be \"" << *first << '"';
         }
 
-        std::cout << stream.str() << std::endl;
+        std::cout << stream.str() << '\n';
         throw stream.str();
       }
     }
@@ -306,7 +306,7 @@ std::string XMLAttribute<ATTRIBUTE_T>::printDTD(const std::string &ElementName) 
     dtd << "#REQUIRED";
   }
 
-  dtd << ">" << std::endl;
+  dtd << ">\n";
 
   return dtd.str();
 }

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -501,13 +501,13 @@ std::string XMLTag::printDocumentation(int indentation) const
   doc << utils::wrapText(tagHead.str(), linewidth, indentation + 3);
 
   if (not _subtags.empty()) {
-    doc << ">\n' << '\n";
+    doc << ">\n\n";
     for (auto const subtag : _subtags) {
       doc << subtag->printDocumentation(indentation + 3);
     }
-    doc << indent << "</" << _fullName << ">\n' << '\n";
+    doc << indent << "</" << _fullName << ">\n\n";
   } else {
-    doc << "/>\n' << '\n";
+    doc << "/>\n\n";
   }
 
   return doc.str();

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -163,12 +163,12 @@ void XMLTag::readAttributes(std::map<std::string, std::string> &aAttributes)
     if (not utils::contained(name, _attributes)) {
       std::string error = "Wrong attribute \"" + name + "\"";
 
-      std::cout << error << std::endl;
+      std::cout << error << '\n';
       throw error;
     }
 
     auto value = element.second;
-    //std::cout << name << " :: " << value << std::endl;
+    //std::cout << name << " :: " << value << '\n';
   }
 
   for (auto &pair : _doubleAttributes) {
@@ -346,7 +346,7 @@ std::string XMLTag::printDTD(const bool start) const
   std::ostringstream dtd;
 
   if (start)
-    dtd << "<!DOCTYPE " << _fullName << " [" << std::endl;
+    dtd << "<!DOCTYPE " << _fullName << " [\n";
 
   dtd << "<!ELEMENT " << _fullName << " ";
 
@@ -372,9 +372,9 @@ std::string XMLTag::printDTD(const bool start) const
       first = false;
     }
 
-    dtd << ")>" << std::endl;
+    dtd << ")>\n";
   } else {
-    dtd << "EMPTY>" << std::endl;
+    dtd << "EMPTY>\n";
   }
 
   for (const auto &pair : _doubleAttributes) {
@@ -403,10 +403,10 @@ std::string XMLTag::printDTD(const bool start) const
     }
   }
 
-  dtd << std::endl;
+  dtd << '\n';
 
   if (start)
-    dtd << "]>" << std::endl;
+    dtd << "]>\n";
 
   return dtd.str();
 }
@@ -421,17 +421,17 @@ std::string XMLTag::printDocumentation(int indentation) const
   }
 
   std::ostringstream doc;
-  doc << indent << "<!-- TAG " << _fullName << std::endl;
+  doc << indent << "<!-- TAG " << _fullName << '\n';
   if (not _doc.empty()) {
     std::string indentedDoc = indent + "         " + _doc;
     doc << utils::wrapText(indentedDoc, linewidth, indentation + 9);
-    doc << std::endl;
+    doc << '\n';
   }
   doc << indent << "         (can occur " << getOccurrenceString(_occurrence) << " times)";
 
   for (const auto &pair : _doubleAttributes) {
     std::ostringstream attrDoc;
-    doc << std::endl;
+    doc << '\n';
     attrDoc << indent << "     ATTR " << pair.first << ": "
             << pair.second.getUserDocumentation();
     doc << utils::wrapText(attrDoc.str(), linewidth, indentation + 10);
@@ -439,7 +439,7 @@ std::string XMLTag::printDocumentation(int indentation) const
 
   for (const auto &pair : _intAttributes) {
     std::ostringstream attrDoc;
-    doc << std::endl;
+    doc << '\n';
     attrDoc << indent << "     ATTR " << pair.first << ": "
             << pair.second.getUserDocumentation();
     doc << utils::wrapText(attrDoc.str(), linewidth, indentation + 10);
@@ -447,7 +447,7 @@ std::string XMLTag::printDocumentation(int indentation) const
 
   for (const auto &pair : _stringAttributes) {
     std::ostringstream attrDoc;
-    doc << std::endl;
+    doc << '\n';
     attrDoc << indent << "     ATTR " << pair.first << ": "
             << pair.second.getUserDocumentation();
     doc << utils::wrapText(attrDoc.str(), linewidth, indentation + 10);
@@ -455,7 +455,7 @@ std::string XMLTag::printDocumentation(int indentation) const
 
   for (const auto &pair : _booleanAttributes) {
     std::ostringstream attrDoc;
-    doc << std::endl;
+    doc << '\n';
     attrDoc << indent << "     ATTR " << pair.first << ": "
             << pair.second.getUserDocumentation();
     doc << utils::wrapText(attrDoc.str(), linewidth, indentation + 10);
@@ -463,13 +463,13 @@ std::string XMLTag::printDocumentation(int indentation) const
 
   for (const auto &pair : _eigenVectorXdAttributes) {
     std::ostringstream attrDoc;
-    doc << std::endl;
+    doc << '\n';
     attrDoc << indent << "     ATTR " << pair.first << ": "
             << pair.second.getUserDocumentation();
     doc << utils::wrapText(attrDoc.str(), linewidth, indentation + 10);
   }
 
-  doc << " -->" << std::endl;
+  doc << " -->\n";
   std::ostringstream tagHead;
   tagHead << indent << "<" << _fullName;
 
@@ -501,13 +501,13 @@ std::string XMLTag::printDocumentation(int indentation) const
   doc << utils::wrapText(tagHead.str(), linewidth, indentation + 3);
 
   if (not _subtags.empty()) {
-    doc << ">" << std::endl << std::endl;
+    doc << ">\n' << '\n";
     for (auto const subtag : _subtags) {
       doc << subtag->printDocumentation(indentation + 3);
     }
-    doc << indent << "</" << _fullName << ">" << std::endl << std::endl;
+    doc << indent << "</" << _fullName << ">\n' << '\n";
   } else {
-    doc << "/>" << std::endl << std::endl;
+    doc << "/>\n' << '\n";
   }
 
   return doc.str();

--- a/tools/cad_converter/DataConverter.cpp
+++ b/tools/cad_converter/DataConverter.cpp
@@ -12,7 +12,7 @@
 int main ( int argc, char** argv )
 {
   if ( argc != 3 ) {
-    std::cout << " Usage: ./DataConverter inputFileName outputFilename" << std::endl;
+    std::cout << " Usage: ./DataConverter inputFileName outputFilename\n";
     abort ();
   }
 
@@ -23,14 +23,14 @@ int main ( int argc, char** argv )
 
   if ( myTransformer.parseFileType () ) {
     if ( myTransformer.doTransform() ) {
-      std::cout << " Transform to VRML succeed!" << std::endl;
+      std::cout << " Transform to VRML succeed!\n";
     }
     else {
-      std::cout << " Transform to VRML failed!" << std::endl;
+      std::cout << " Transform to VRML failed!\n";
     }
   }
   else {
-    std::cout << "Input file type must be one of: .stp .step .igs .iges" << std::endl;
+    std::cout << "Input file type must be one of: .stp .step .igs .iges\n";
     return 0;
   }
   return 1;

--- a/tools/cad_converter/IGES2Vrml.cpp
+++ b/tools/cad_converter/IGES2Vrml.cpp
@@ -29,7 +29,7 @@ bool IGES2Vrml:: readFile (  const std::string & inputFileName )
 void IGES2Vrml:: loadReport ( void )
 {
    if ( !myIGESFileName || ( myIGESFileName [0] == '\0' ) ) {
-      std::cout << "no input file" << endl;
+      std::cout << "no input file" << '\n';
       return;
    }
 

--- a/tools/cad_converter/STEP2Vrml.cpp
+++ b/tools/cad_converter/STEP2Vrml.cpp
@@ -26,7 +26,7 @@ bool STEP2Vrml:: readFile ( const std::string & inputFileName )
 void STEP2Vrml:: loadReport ( void )
 {
    if ( !mySTEPFileName || ( mySTEPFileName [0] == '\0' ) ) {
-      cout << "no input Filename" << endl;
+      cout << "no input Filename" << '\n';
       return;
    }
 

--- a/tools/cad_converter/TransformToVRML.cpp
+++ b/tools/cad_converter/TransformToVRML.cpp
@@ -129,7 +129,7 @@ void TransformToVRML:: eliminateRedundancy ()
   std::vector<int> deleteList;
 
   std::cout << "before elemination: " << stringCoordinate3.size() << " points "
-            << std::endl;
+            << '\n';
 
   size_t j = 0;
   for ( size_t i=0; i < stringCoordinate3.size (); i++ ) {
@@ -145,7 +145,7 @@ void TransformToVRML:: eliminateRedundancy ()
     }
   }
 
-  std::cout << "after elemination: " << oneMap.size() << " points " << std::endl;
+  std::cout << "after elemination: " << oneMap.size() << " points \n";
 
   // eliminate redundancy
   for ( size_t i=deleteList.size ()-1; i >= 0; i-- ) {
@@ -186,39 +186,39 @@ void TransformToVRML:: eliminateRedundancy ()
   fp.open ( _outputFileName.c_str(), std::ios_base::out );
 
   for ( size_t i=0; i < vrmlText.size(); i++ ) {
-    fp << vrmlText [ i ] << endl;
+    fp << vrmlText [ i ] << '\n';
   }
 
   for ( size_t i=0; i < stringCoordinate3.size()-1; i++ ) {
-    fp << stringCoordinate3[i] << "," << std::endl;
+    fp << stringCoordinate3[i] << ",\n";
   }
 
-  fp << stringCoordinate3[stringCoordinate3.size()-1] << " ]" << std::endl;
+  fp << stringCoordinate3[stringCoordinate3.size()-1] << " ]\n";
 
-  fp << "}"                 << std::endl;
-  fp << "ShapeHints {"      << std::endl;
-  fp << "}"                 << std::endl;
-  fp << "IndexedFaceSet {"  << std::endl;
-  fp << "coordIndex ["      << std::endl;
+  fp << "}\n";
+  fp << "ShapeHints {\n";
+  fp << "}\n";
+  fp << "IndexedFaceSet {\n";
+  fp << "coordIndex [\n";
 
   for ( size_t i=0; i < vectorFaceIndices.size() - 1; i += 3 ) {
     fp << vectorFaceIndices [ i + 0 ] << ","
     << vectorFaceIndices [ i + 1 ] << ","
     << vectorFaceIndices [ i + 2 ] << ","
-    << "-1," << std::endl;
+    << "-1,\n";
   }
 
   fp << vectorFaceIndices [ vectorFaceIndices.size() - 3 ] << ","
   << vectorFaceIndices [ vectorFaceIndices.size() - 2 ] << ","
   << vectorFaceIndices [ vectorFaceIndices.size() - 1 ] << ","
-  << "-1" << std::endl;
+  << "-1\n";
 
-  fp << "]"  << std::endl;
-  fp << "}"  << std::endl;
-  fp << "}"  << std::endl;
-  fp << "}"  << std::endl;
-  fp << "}"  << std::endl;
-  fp << "}"  << std::endl;
+  fp << "]\n";
+  fp << "}\n";
+  fp << "}\n";
+  fp << "}\n";
+  fp << "}\n";
+  fp << "}\n";
 
   return;
 }

--- a/tools/communication_dummies/mainA.cpp
+++ b/tools/communication_dummies/mainA.cpp
@@ -147,8 +147,7 @@ main(int argc, char** argv) {
 
     c.requestConnection("B", "A");
 
-    cout << utils::MasterSlave::_rank << ": "
-         << "Connected!" << '\n';
+    cout << utils::MasterSlave::_rank << ": " << "Connected!\n";
 
     std::vector<double> data = getData();
 
@@ -157,13 +156,11 @@ main(int argc, char** argv) {
     c.receive(data.data(), data.size());
 
     if (validate(data))
-      cout << utils::MasterSlave::_rank << ": "
-           << "Success!" << '\n';
+      cout << utils::MasterSlave::_rank << ": " << "Success!\n";
     else
-      cout << utils::MasterSlave::_rank << ": "
-           << "Failure!" << '\n';
+      cout << utils::MasterSlave::_rank << ": " << "Failure!\n";
 
-    cout << "----------" << '\n';
+    cout << "----------\n";
   }
 
   utils::MasterSlave::_communication.reset();

--- a/tools/communication_dummies/mainA.cpp
+++ b/tools/communication_dummies/mainA.cpp
@@ -13,7 +13,6 @@
 using namespace precice;
 
 using std::cout;
-using std::endl;
 using std::vector;
 
 vector<double>
@@ -66,7 +65,7 @@ validate(vector<double> const& data) {
 
 int
 main(int argc, char** argv) {
-  std::cout << "Running communication dummy" << std::endl;
+  std::cout << "Running communication dummy\n";
 
   int provided;
 
@@ -76,7 +75,7 @@ main(int argc, char** argv) {
   MPI_Comm_rank(MPI_COMM_WORLD, &utils::MasterSlave::_rank);
 
   if (utils::MasterSlave::_size != 3) {
-    std::cout << "Please run with 3 mpi processes" << std::endl;
+    std::cout << "Please run with 3 mpi processes\n";
     return 1;
   }
 
@@ -149,7 +148,7 @@ main(int argc, char** argv) {
     c.requestConnection("B", "A");
 
     cout << utils::MasterSlave::_rank << ": "
-         << "Connected!" << endl;
+         << "Connected!" << '\n';
 
     std::vector<double> data = getData();
 
@@ -159,17 +158,17 @@ main(int argc, char** argv) {
 
     if (validate(data))
       cout << utils::MasterSlave::_rank << ": "
-           << "Success!" << endl;
+           << "Success!" << '\n';
     else
       cout << utils::MasterSlave::_rank << ": "
-           << "Failure!" << endl;
+           << "Failure!" << '\n';
 
-    cout << "----------" << endl;
+    cout << "----------" << '\n';
   }
 
   utils::MasterSlave::_communication.reset();
 
   MPI_Finalize();
 
-  std::cout << "Stop communication dummy" << std::endl;
+  std::cout << "Stop communication dummy\n";
 }

--- a/tools/communication_dummies/mainB.cpp
+++ b/tools/communication_dummies/mainB.cpp
@@ -13,7 +13,6 @@
 using namespace precice;
 
 using std::cout;
-using std::endl;
 using std::vector;
 using std::rand;
 
@@ -82,7 +81,7 @@ process(vector<double>& data) {
 
 int
 main(int argc, char** argv) {
-  std::cout << "Running communication dummy" << std::endl;
+  std::cout << "Running communication dummy\n";
 
   int provided;
 
@@ -92,7 +91,7 @@ main(int argc, char** argv) {
   MPI_Comm_rank(MPI_COMM_WORLD, &utils::MasterSlave::_rank);
 
   if (utils::MasterSlave::_size != 5) {
-    std::cout << "Please run with 5 mpi processes" << std::endl;
+    std::cout << "Please run with 5 mpi processes\n";
     return 1;
   }
 
@@ -168,7 +167,7 @@ main(int argc, char** argv) {
     c.acceptConnection("B", "A");
 
     cout << utils::MasterSlave::_rank << ": "
-         << "Connected!" << endl;
+         << "Connected!" << '\n';
 
     std::vector<double> data = getData();
 
@@ -176,21 +175,21 @@ main(int argc, char** argv) {
 
     if (validate(data))
       cout << utils::MasterSlave::_rank << ": "
-           << "Success!" << endl;
+           << "Success!" << '\n';
     else
       cout << utils::MasterSlave::_rank << ": "
-           << "Failure!" << endl;
+           << "Failure!" << '\n';
 
     process(data);
 
     c.send(data.data(), data.size());
 
-    cout << "----------" << endl;
+    cout << "----------" << '\n';
   }
 
   utils::MasterSlave::_communication.reset();
 
   MPI_Finalize();
 
-  std::cout << "Stop communication dummy" << std::endl;
+  std::cout << "Stop communication dummy\n";
 }

--- a/tools/mpi/acceptor/main.cpp
+++ b/tools/mpi/acceptor/main.cpp
@@ -32,7 +32,6 @@
 #include <iostream>
 
 using std::cout;
-using std::endl;
 using std::ofstream;
 using std::remove;
 using std::rename;
@@ -51,7 +50,7 @@ struct Sentinel {
     if (::rank != 0)
       return;
 
-    cout << "Acceptor: " << (::ack == 4 ? "Success!" : "Failure!") << endl;
+    cout << "Acceptor: " << (::ack == 4 ? "Success!" : "Failure!") << '\n';
   }
 } sentinel;
 
@@ -77,7 +76,7 @@ main(int argc, char** argv) {
 
     rename((address_file_name + "~").c_str(), address_file_name.c_str());
 
-    cout << "Address: " << port_name << endl;
+    cout << "Address: " << port_name << '\n';
 
     MPI_Comm communicator;
 

--- a/tools/mpi/requester/main.cpp
+++ b/tools/mpi/requester/main.cpp
@@ -32,7 +32,6 @@
 #include <iostream>
 
 using std::cout;
-using std::endl;
 using std::ifstream;
 using std::remove;
 using std::rename;
@@ -51,7 +50,7 @@ struct Sentinel {
     if (::rank != 0)
       return;
 
-    cout << "Requester: " << (::ack == 4 ? "Success!" : "Failure!") << endl;
+    cout << "Requester: " << (::ack == 4 ? "Success!" : "Failure!") << '\n';
   }
 } sentinel;
 
@@ -77,7 +76,7 @@ main(int argc, char** argv) {
       ifs.getline(port_name, MPI_MAX_PORT_NAME);
     }
 
-    cout << "Address: " << port_name << endl;
+    cout << "Address: " << port_name << '\n';
 
     MPI_Comm communicator;
 

--- a/tools/solverdummies/cpp/solverdummy.cpp
+++ b/tools/solverdummies/cpp/solverdummy.cpp
@@ -8,7 +8,7 @@
 
 int main (int argc, char **argv)
 {
-  std::cout << "Starting SolverDummy..." << std::endl;
+  std::cout << "Starting SolverDummy...\n";
   int commRank = 0;
   int commSize = 1;
 
@@ -16,12 +16,12 @@ int main (int argc, char **argv)
   using namespace precice::constants;
 
   if (argc != 4){
-    std::cout << "Usage: ./solverdummy configFile solverName meshName" << std::endl;
-    std::cout << std::endl;
-    std::cout << "Parameter description" << std::endl;
-    std::cout << "  configurationFile: Path and filename of preCICE configuration" << std::endl;
-    std::cout << "  solverName:        SolverDummy participant name in preCICE configuration" << std::endl;
-    std::cout << "  meshName:          Mesh in preCICE configuration that carries read and write data" << std::endl;
+    std::cout << "Usage: ./solverdummy configFile solverName meshName\n";
+    std::cout << '\n';
+    std::cout << "Parameter description\n";
+    std::cout << "  configurationFile: Path and filename of preCICE configuration\n";
+    std::cout << "  solverName:        SolverDummy participant name in preCICE configuration\n";
+    std::cout << "  meshName:          Mesh in preCICE configuration that carries read and write data\n";
     return 1;
 }
 
@@ -47,23 +47,23 @@ int main (int argc, char **argv)
   while (interface.isCouplingOngoing()){
 
     if (interface.isActionRequired(actionWriteIterationCheckpoint())){
-      std::cout << "DUMMY: Writing iteration checkpoint" << std::endl;
+      std::cout << "DUMMY: Writing iteration checkpoint\n";
       interface.fulfilledAction(actionWriteIterationCheckpoint());
     }
 
     dt = interface.advance(dt);
 
     if (interface.isActionRequired(actionReadIterationCheckpoint())){
-      std::cout << "DUMMY: Writing iteration checkpoint" << std::endl;
+      std::cout << "DUMMY: Writing iteration checkpoint\n";
       interface.fulfilledAction(actionReadIterationCheckpoint());
     }
     else{
-      std::cout << "DUMMY: Advancing in time" << std::endl;
+      std::cout << "DUMMY: Advancing in time\n";
     }
   }
 
   interface.finalize();
-  std::cout << "DUMMY: Closing C++ solver dummy..." << std::endl;
+  std::cout << "DUMMY: Closing C++ solver dummy...\n";
 
   return 0;
 }

--- a/tools/structure0815/Globals.hpp
+++ b/tools/structure0815/Globals.hpp
@@ -11,7 +11,7 @@
    { \
       std::ostringstream conv; \
       conv << message; \
-      std::cout << conv.str() << std::endl; \
+      std::cout << conv.str() << '\n'; \
    }
 #else
 #define STRUCTURE_DEBUG(message)
@@ -21,7 +21,7 @@
    { \
       std::ostringstream conv; \
       conv << message; \
-      std::cout << conv.str() << std::endl; \
+      std::cout << conv.str() << '\n'; \
    }
 
 #endif /* GLOBALS_HPP_ */

--- a/tools/structure0815/Tests.cpp
+++ b/tools/structure0815/Tests.cpp
@@ -6,11 +6,11 @@
 using precice::math::equals;
 
 #define validate(booleanExpr, msg) if (!(booleanExpr)) { \
-    std::cerr << "  boolean test failed " << std::endl \
-              << "  file: " << __FILE__ << " \t line: " << __LINE__ << std::endl \
+    std::cerr << "  boolean test failed \n" \
+              << "  file: " << __FILE__ << " \t line: " << __LINE__ << '\n' \
               << "  statement: " << #booleanExpr \
               << "  msg: " << msg \
-              << std::endl; \
+              << '\n'; \
     return;\
   }
 


### PR DESCRIPTION
This PR:
* Replaces `std::endl` with newline characters and merges them into adjacent strings is possible.
* Removes `io::TXTWriter`and `io::TXTReader` destructors as the destructor of the streams closes them anyhow.
* Adds `void TXTWriter::flush()`
* Fixes the Tests, which relied on a hidden flush instead of closing the stream by destroying the writer (or calling flush).