### PR TITLE
Fix use of Variable Length Arrays

### DIFF
--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -559,9 +559,9 @@ void SocketCommunication::receive(std::string &itemToReceive, int rankSender)
 
   try {
     asio::read(*_sockets[rankSender], asio::buffer(&size, sizeof(size_t)));
-    char msg[size];
-    asio::read(*_sockets[rankSender], asio::buffer(msg, size));
-    itemToReceive = msg;
+    std::vector<char> msg(size);
+    asio::read(*_sockets[rankSender], asio::buffer(msg.data(), size));
+    itemToReceive = msg.data();
   } catch (std::exception &e) {
     ERROR("Receive failed: " << e.what());
   }

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -623,9 +623,9 @@ void RequestManager:: handleRequestSetMeshVertex
   TRACE(rankSender);
   int meshID = -1;
   _com->receive(meshID, rankSender);
-  double position[_interface.getDimensions()];
-  _com->receive(position, _interface.getDimensions(), rankSender);
-  int index = _interface.setMeshVertex(meshID, position);
+  std::vector<double> position(_interface.getDimensions());
+  _com->receive(position.data(), _interface.getDimensions(), rankSender);
+  int index = _interface.setMeshVertex(meshID, position.data());
   _com->send(index, rankSender);
 }
 
@@ -808,9 +808,9 @@ void RequestManager:: handleRequestWriteVectorData
   _com->receive(dataID, rankSender);
   int index = -1;
   _com->receive( index, rankSender);
-  double data[_interface.getDimensions()];
-  _com->receive(data, _interface.getDimensions(), rankSender);
-  _interface.writeVectorData(dataID, index, data);
+  std::vector<double> data(_interface.getDimensions());
+  _com->receive(data.data(), _interface.getDimensions(), rankSender);
+  _interface.writeVectorData(dataID, index, data.data());
 }
 
 void RequestManager:: handleRequestReadScalarData
@@ -868,9 +868,9 @@ void RequestManager:: handleRequestReadVectorData
   _com->receive(dataID, rankSender);
   int index = -1;
   _com->receive(index, rankSender);
-  double data[_interface.getDimensions()];
-  _interface.readVectorData(dataID, index, data);
-  _com->send(data, _interface.getDimensions(), rankSender);
+  std::vector<double> data(_interface.getDimensions());
+  _interface.readVectorData(dataID, index, data.data());
+  _com->send(data.data(), _interface.getDimensions(), rankSender);
 }
 
 void RequestManager:: handleRequestMapWriteDataFrom


### PR DESCRIPTION
Variable length array are supported by many C++ compilers, but actually forbidden in standard C++.

This PR replaces variable length array with `std::vector` or `std::string`.

Together with #334, our codebase now compiles __warning-free__ with:
`-Wall -Wextra -Wpedantic -Wno-unused-parameter` and `gcc 5.4.0` | `clang 7.0.1`