### PR TITLE
Fix tests resetting log level

### DIFF
--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -173,6 +173,8 @@ void BackendConfiguration::setOption(std::string key, std::string value)
 
 void setupLogging(LoggingConfiguration configs, bool enabled)
 {
+  if (_precice_logging_config_lock) return;
+
   namespace bl = boost::log;
   bl::register_formatter_factory("TimeStamp", boost::make_shared<timestamp_formatter_factory>());
   bl::register_formatter_factory("ColorizedSeverity", boost::make_shared<colorized_severity_formatter_factory>());
@@ -229,6 +231,12 @@ void setupLogging(std::string const & logConfigFile)
 
 void setMPIRank(int const rank) {
   boost::log::attribute_cast<boost::log::attributes::mutable_constant<int>>(boost::log::core::get()->get_global_attributes()["Rank"]).set(rank);
+}
+
+bool _precice_logging_config_lock{false};
+
+void lockConf() {
+    _precice_logging_config_lock = true;
 }
 
 }} // namespace precice, logging

--- a/src/logging/LogConfiguration.hpp
+++ b/src/logging/LogConfiguration.hpp
@@ -39,4 +39,12 @@ void setupLogging(LoggingConfiguration configs, bool enabled = true);
 /// Sets the current MPI rank as a logging attribute
 void setMPIRank(int const rank);
 
+/// Locks the configuration, ignoring any future calls to setupLogging()
+void lockConf();
+
+/** The global lock for the log configuration.
+ * This variable is always initialized to false and can only be modified by calling lockConf()
+ */
+extern bool _precice_logging_config_lock;
+
 }} // namespace precice, logging

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -67,6 +67,7 @@ bool init_unit_test()
   // Initialize either with empty logConfig -> default, configs that are read from file
   // or from the Boost Test log level.
   logging::setupLogging(logConfigs);
+  logging::lockConf();
   
 
   // Sets the default tolerance for floating point comparisions


### PR DESCRIPTION
This PR fixes the Tests resetting the log-level during configuration thus ignoring the log setup from our testing main.

This PR adds:
* `logging::lockConf()` which locks the configuration, turning future calls to `logging:setupConfig()` to no-ops.
* A global `bool _precice_logging_config_lock` which is initialized to `false` and controls this behaviour.  It can only be modified by calling `logging::lockConf()`.

@floli please merge if you approve