### PR TITLE
Add Accessor Type to access the SolverInterfaceImpl

### DIFF
--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -14,39 +14,8 @@ namespace precice {
   namespace impl {
     class SolverInterfaceImpl;
   }
-}
-
-// Forward declaration to friend the boost test struct
-namespace PreciceTests {
-  namespace Parallel {
-    struct TestFinalize;
-    struct TestMasterSlaveSetup;
-    struct GlobalRBFPartitioning;
-    struct LocalRBFPartitioning;
-    struct TestQN;
-    struct testDistributedCommunications;
-    struct CouplingOnLine;
-  }
-  namespace Serial {
-    struct TestExplicit;
-    struct TestConfiguration;
-    struct testExplicitWithSubcycling;
-    struct testExplicitWithDataExchange;
-    struct testExplicitWithDataInitialization;
-    struct testExplicitWithBlockDataExchange;
-    struct testExplicitWithSolverGeometry;
-    struct testExplicitWithDisplacingGeometry;
-    struct testExplicitWithDataScaling;
-    struct testImplicit;
-    struct testStationaryMappingWithSolverMesh;
-    struct testBug;
-    struct testThreeSolvers;
-    struct testMultiCoupling;
-    struct testMappingNearestProjection;
-  }
-  namespace Server {
-    struct testCouplingModeWithOneServer;
-    struct testCouplingModeParallelWithOneServer;
+  namespace testing {
+      struct WhiteboxFixture;
   }
 }
 
@@ -830,31 +799,7 @@ private:
   SolverInterface& operator= ( const SolverInterface& assign );
 
   // @brief To allow white box tests.
-  friend struct PreciceTests::Parallel::TestFinalize;
-  friend struct PreciceTests::Parallel::TestMasterSlaveSetup;
-  friend struct PreciceTests::Parallel::GlobalRBFPartitioning;
-  friend struct PreciceTests::Parallel::LocalRBFPartitioning;
-  friend struct PreciceTests::Parallel::TestQN;
-  friend struct PreciceTests::Parallel::testDistributedCommunications;
-  friend struct PreciceTests::Parallel::CouplingOnLine;
-  friend struct PreciceTests::Serial::TestExplicit;
-  friend struct PreciceTests::Serial::TestConfiguration;
-  friend struct PreciceTests::Serial::testExplicitWithSubcycling;
-  friend struct PreciceTests::Serial::testExplicitWithDataExchange;
-  friend struct PreciceTests::Serial::testExplicitWithDataInitialization;
-  friend struct PreciceTests::Serial::testExplicitWithBlockDataExchange;
-  friend struct PreciceTests::Serial::testExplicitWithSolverGeometry;
-  friend struct PreciceTests::Serial::testExplicitWithDisplacingGeometry;
-  friend struct PreciceTests::Serial::testExplicitWithDataScaling;
-  friend struct PreciceTests::Serial::testImplicit;
-  friend struct PreciceTests::Serial::testStationaryMappingWithSolverMesh;
-  friend struct PreciceTests::Serial::testBug;
-  friend struct PreciceTests::Serial::testThreeSolvers;
-  friend struct PreciceTests::Serial::testMultiCoupling;
-  friend struct PreciceTests::Serial::testMappingNearestProjection;
-  friend struct PreciceTests::Server::testCouplingModeWithOneServer;
-  friend struct PreciceTests::Server::testCouplingModeParallelWithOneServer;
-
+  friend struct testing::WhiteboxFixture;
 };
 
 } // namespace precice

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -15,7 +15,7 @@ namespace precice {
     class SolverInterfaceImpl;
   }
   namespace testing {
-      struct WhiteboxFixture;
+      struct WhiteboxAccessor;
   }
 }
 
@@ -799,7 +799,7 @@ private:
   SolverInterface& operator= ( const SolverInterface& assign );
 
   // @brief To allow white box tests.
-  friend struct testing::WhiteboxFixture;
+  friend struct testing::WhiteboxAccessor;
 };
 
 } // namespace precice

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -23,7 +23,7 @@ void reset ()
   utils::MasterSlave::reset();
 }
 
-struct ParallelTestFixture : testing::WhiteboxFixture {
+struct ParallelTestFixture : testing::WhiteboxAccessor {
 
   std::string _pathToTests;
 

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -23,7 +23,7 @@ void reset ()
   utils::MasterSlave::reset();
 }
 
-struct ParallelTestFixture {
+struct ParallelTestFixture : testing::WhiteboxFixture {
 
   std::string _pathToTests;
 
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup, * testing::OnSize(4))
   std::string configFilename = _pathToTests + "config1.xml";
   config::Configuration config;
   xml::configure(config.getXMLTag(), configFilename);
-  interface._impl->configure(config.getSolverInterfaceConfiguration());
+  impl(interface).configure(config.getSolverInterfaceConfiguration());
 
   BOOST_TEST ( interface.getDimensions() == 3 );
 
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
   xml::configure(config.getXMLTag(), configFilename);
   if(utils::Parallel::getProcessRank()<=1){
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 2 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("MeshOne");
     double xCoord = 0.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
   }
   else {
     SolverInterface interface ( "SolverTwo", utils::Parallel::getProcessRank()-2, 2 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("MeshTwo");
     double xCoord = -2.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
     xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
     xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
     xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
     xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "Ateles", utils::Parallel::getProcessRank(), 3 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("Ateles_Mesh");
 
     int vertexIDs[4];
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "FASTEST", 0, 1 );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID("FASTEST_Mesh");
     int vertexIDs[10];
     double xCoord = -0.0001;
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
     xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( solverName, rank, size );
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     int meshID = interface.getMeshID(meshName);
     int writeDataID = interface.getDataID(writeDataName, meshID);
     int readDataID = interface.getDataID(readDataName, meshID);
@@ -450,7 +450,7 @@ BOOST_AUTO_TEST_CASE(testDistributedCommunications, * testing::OnSize(4))
     SolverInterface precice(solverName, rank, size);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + fileName);
-    precice._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(precice).configure(config.getSolverInterfaceConfiguration());
     int meshID = precice.getMeshID(meshName);
     int forcesID = precice.getDataID("Forces", meshID);
     int velocID = precice.getDataID("Velocities", meshID);

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -16,7 +16,7 @@
 using namespace precice;
 
 
-struct SerialTestFixture : testing::WhiteboxFixture {
+struct SerialTestFixture : testing::WhiteboxAccessor {
 
   std::string _pathToTests;
 

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -16,7 +16,7 @@
 using namespace precice;
 
 
-struct SerialTestFixture {
+struct SerialTestFixture : testing::WhiteboxFixture {
 
   std::string _pathToTests;
 
@@ -46,12 +46,12 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   SolverInterface interfacePeano ("Peano", 0, 1);
   config::Configuration config;
   xml::configure(config.getXMLTag(), filename);
-  interfacePeano._impl->configure(config.getSolverInterfaceConfiguration());
+  impl(interfacePeano).configure(config.getSolverInterfaceConfiguration());
 
-  BOOST_TEST(interfacePeano._impl->_participants.size() == 2);
+  BOOST_TEST(impl(interfacePeano)._participants.size() == 2);
   BOOST_TEST(interfacePeano.getDimensions() == 2);
 
-  impl::PtrParticipant peano = interfacePeano._impl->_participants[0];
+  impl::PtrParticipant peano = impl(interfacePeano)._participants[0];
   BOOST_TEST(peano);
   BOOST_TEST(peano->getName() == "Peano");
   BOOST_TEST(peano->getID() == 0);
@@ -65,11 +65,11 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
 
   // Test configuration for accessor "Comsol"
   SolverInterface interfaceComsol ("Comsol", 0, 1);
-  interfaceComsol._impl->configure(config.getSolverInterfaceConfiguration());
-  BOOST_TEST(interfaceComsol._impl->_participants.size() == 2);
+  impl(interfaceComsol).configure(config.getSolverInterfaceConfiguration());
+  BOOST_TEST(impl(interfaceComsol)._participants.size() == 2);
   BOOST_TEST(interfaceComsol.getDimensions() == 2);
 
-  impl::PtrParticipant comsol = interfaceComsol._impl->_participants[1];
+  impl::PtrParticipant comsol = impl(interfaceComsol)._participants[1];
   BOOST_TEST(comsol);
   BOOST_TEST(comsol->getName() == "Comsol");
   BOOST_TEST(comsol->getID()== 1);
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
 
     config::Configuration config;
     xml::configure(config.getXMLTag(), configurationFileName);
-    couplingInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
 
     //was necessary to replace pre-defined geometries
     if(solverName=="SolverOne" && couplingInterface.hasMesh("MeshOne")){
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
     SolverInterface precice("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    precice._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(precice).configure(config.getSolverInterfaceConfiguration());
 
     double maxDt = precice.initialize();
     int timestep = 0;
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
     SolverInterface precice("SolverTwo", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    precice._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(precice).configure(config.getSolverInterfaceConfiguration());
     int meshID = precice.getMeshID("Test-Square");
     precice.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
     precice.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
     SolverInterface cplInterface("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     /* int squareID = */ cplInterface.getMeshID("Test-Square");
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
 
     VertexHandle vertices = cplInterface.getMeshHandle("Test-Square").vertices();
     while (cplInterface.isCouplingOngoing()){
-      cplInterface._impl->resetMesh(meshOneID);
+      impl(cplInterface).resetMesh(meshOneID);
       i = 0;
       for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
         int index = cplInterface.setMeshVertex(meshOneID, it.vertexCoords());
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
     SolverInterface cplInterface("SolverTwo", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int meshID = cplInterface.getMeshID("Test-Square");
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
     SolverInterface cplInterface("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-data-init.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int meshOneID = cplInterface.getMeshID("MeshOne");
     cplInterface.setMeshVertex(meshOneID, Vector3d(1.0,2.0,3.0).data());
     double maxDt = cplInterface.initialize();
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
     SolverInterface cplInterface("SolverTwo", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-data-init.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
     Vector3d pos = Vector3d::Zero();
     cplInterface.setMeshVertex(meshTwoID, pos.data());
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
     SolverInterface cplInterface("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single-non-inc.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int meshOneID = cplInterface.getMeshID("MeshOne");
     double maxDt = cplInterface.initialize();
     int forcesID = cplInterface.getDataID("Forces", meshOneID);
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
     Eigen::VectorXi getReadIDs(size);
 
     while (cplInterface.isCouplingOngoing()){
-      cplInterface._impl->resetMesh(meshOneID);
+      impl(cplInterface).resetMesh(meshOneID);
       for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
         for (int dim=0; dim < 3; dim++){
           writePositions[it.vertexID()*3 + dim] = it.vertexCoords()[dim];
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
           }
           expectedTemperatures[it.vertexID()] = counter + it.vertexCoords()[0];
         }
-        cplInterface._impl->resetMesh(meshOneID);
+        impl(cplInterface).resetMesh(meshOneID);
         cplInterface.setMeshVertices(meshOneID, size, readPositions.data(), readIDs.data());
         cplInterface.mapReadDataTo(meshOneID);
         cplInterface.readBlockVectorData(velocitiesID, size, readIDs.data(),
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single-non-inc.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int squareID = cplInterface.getMeshID("Test-Square");
     int forcesID = cplInterface.getDataID ( "Forces", squareID );
     int pressuresID = cplInterface.getDataID("Pressures", squareID );
@@ -525,7 +525,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
     SolverInterface couplingInterface("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    couplingInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
 
     //was necessary to replace pre-defined geometries
     int meshID = couplingInterface.getMeshID("MeshOne");
@@ -545,7 +545,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     BOOST_TEST(cplInterface.getDimensions() == 3);
     int meshID = cplInterface.getMeshID ( "SolverGeometry" );
     int i0 = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
@@ -592,7 +592,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDisplacingGeometry,
     SolverInterface cplInterface ( "SolverOne", 0, 1 );
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     double dt = cplInterface.initialize();
 
     int meshID = cplInterface.getMeshID("SolverGeometry");
@@ -628,7 +628,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDisplacingGeometry,
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int meshID = cplInterface.getMeshID("SolverGeometry");
     int i0 = cplInterface.setMeshVertex(meshID, zero.data());
     int i1 = cplInterface.setMeshVertex(meshID, one.data());
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
     SolverInterface cplInterface ( "SolverOne", 0, 1 );
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-datascaling.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     BOOST_TEST ( cplInterface.getDimensions() == 2 );
 
     int meshID = cplInterface.getMeshID("Test-Square");
@@ -719,7 +719,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "explicit-datascaling.xml");
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     BOOST_TEST ( cplInterface.getDimensions() == 2 );
     dt = cplInterface.initialize();
     int meshID = cplInterface.getMeshID("Test-Square");
@@ -759,7 +759,7 @@ BOOST_AUTO_TEST_CASE(testImplicit,
     SolverInterface couplingInterface("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "implicit.xml");
-    couplingInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
 
     int meshID = couplingInterface.getMeshID("Square");
     double pos[3];
@@ -799,7 +799,7 @@ BOOST_AUTO_TEST_CASE(testImplicit,
     SolverInterface couplingInterface("SolverTwo", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "implicit.xml");
-    couplingInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
     double maxDt = couplingInterface.initialize();
     while (couplingInterface.isCouplingOngoing()){
       if (couplingInterface.isActionRequired(actionWriteIterationCheckpoint())){
@@ -851,12 +851,12 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
     if (dim == 2){
       config::Configuration config;
       xml::configure(config.getXMLTag(), config2D);
-      interface._impl->configure(config.getSolverInterfaceConfiguration());
+      impl(interface).configure(config.getSolverInterfaceConfiguration());
     }
     else {
       config::Configuration config;
       xml::configure(config.getXMLTag(), config3D);
-      interface._impl->configure(config.getSolverInterfaceConfiguration());
+      impl(interface).configure(config.getSolverInterfaceConfiguration());
     }
     BOOST_TEST(interface.getDimensions() == dim);
 
@@ -1020,7 +1020,7 @@ BOOST_AUTO_TEST_CASE(testBug,
     SolverInterface precice("Flite", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configName);
-    precice._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(precice).configure(config.getSolverInterfaceConfiguration());
     int meshID = precice.getMeshID("FliteNodes");
     int forcesID = precice.getDataID(precice::constants::dataForces(), meshID);
     int displacementsID = precice.getDataID(precice::constants::dataDisplacements(), meshID);
@@ -1053,7 +1053,7 @@ BOOST_AUTO_TEST_CASE(testBug,
     SolverInterface precice("Calculix", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configName);
-    precice._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(precice).configure(config.getSolverInterfaceConfiguration());
     int meshID = precice.getMeshID("CalculixNodes");
     for (Vector3d& coord : coords){
       precice.setMeshVertex(meshID, coord.data());
@@ -1127,7 +1127,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       SolverInterface precice(solverName, 0, 1);
       config::Configuration config;
       xml::configure(config.getXMLTag(), configs[k]);
-      precice._impl->configure(config.getSolverInterfaceConfiguration());
+      impl(precice).configure(config.getSolverInterfaceConfiguration());
       int meshAID = precice.getMeshID("MeshA");
       int meshBID = precice.getMeshID("MeshB");
       precice.setMeshVertex(meshAID, Eigen::Vector2d(0, 0).data());
@@ -1156,7 +1156,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       SolverInterface precice(solverName, 0, 1);
       config::Configuration config;
       xml::configure(config.getXMLTag(), configs[k]);
-      precice._impl->configure(config.getSolverInterfaceConfiguration());
+      impl(precice).configure(config.getSolverInterfaceConfiguration());
       int meshID = precice.getMeshID("MeshC");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
@@ -1184,7 +1184,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       SolverInterface precice(solverName, 0, 1);
       config::Configuration config;
       xml::configure(config.getXMLTag(), configs[k]);
-      precice._impl->configure(config.getSolverInterfaceConfiguration());
+      impl(precice).configure(config.getSolverInterfaceConfiguration());
       int meshID = precice.getMeshID("MeshD");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
@@ -1258,7 +1258,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
     SolverInterface precice(participant, 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "/multi.xml");
-    precice._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(precice).configure(config.getSolverInterfaceConfiguration());
     BOOST_TEST(precice.getDimensions() == 2);
 
     if (utils::Parallel::getProcessRank() == 0){
@@ -1319,7 +1319,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
     SolverInterface precice("NASTIN", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "/multi.xml");
-    precice._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(precice).configure(config.getSolverInterfaceConfiguration());
     BOOST_TEST(precice.getDimensions() == 2);
     int meshID1 = precice.getMeshID("NASTIN_Mesh1");
     int meshID2 = precice.getMeshID("NASTIN_Mesh2");
@@ -1409,7 +1409,7 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
     SolverInterface cplInterface("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     const int meshOneID = cplInterface.getMeshID("MeshOne");
 
     // Setup mesh one.
@@ -1447,7 +1447,7 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
     SolverInterface cplInterface("SolverTwo", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    cplInterface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
 
     // Setup receiving mesh.

--- a/src/precice/tests/ServerTests.cpp
+++ b/src/precice/tests/ServerTests.cpp
@@ -15,7 +15,7 @@ extern bool testMode;
 }
 
 
-struct ServerTestFixture {
+struct ServerTestFixture : testing::WhiteboxFixture {
   std::string _pathToTests;
 
   void reset(){
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     SolverInterface interface("ParticipantA", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
 
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     SolverInterface interface("ParticipantB", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
     double dt = interface.initialize();
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     SolverInterface interface("ParticipantA", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
 
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     SolverInterface interface("ParticipantB", rank-1, 2);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    interface._impl->configure(config.getSolverInterfaceConfiguration());
+    impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
     double dt = interface.initialize();

--- a/src/precice/tests/ServerTests.cpp
+++ b/src/precice/tests/ServerTests.cpp
@@ -15,7 +15,7 @@ extern bool testMode;
 }
 
 
-struct ServerTestFixture : testing::WhiteboxFixture {
+struct ServerTestFixture : testing::WhiteboxAccessor {
   std::string _pathToTests;
 
   void reset(){

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -190,6 +190,21 @@ private:
 };
 
 
+/// Fixture giving access to the impl of a befriended class
+struct WhiteboxFixture {
+    /** Returns the impl of the obj by reference.
+     *
+     * Returns a reference to the object pointed to by the _impl of a class.
+     * This class needs to be friend of T.
+     *
+     * @param[in] obj The object to fetch the impl from.
+     * @returns a lvalue reference to the impl object.
+     */
+    template<typename T>
+    static auto impl(T& obj) -> typename std::add_lvalue_reference<decltype(*(obj._impl))>::type {
+        return *obj._impl;
+    }
+};
 
 
 /// equals to be used in tests. Prints both operatorans on failure

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -190,8 +190,8 @@ private:
 };
 
 
-/// Fixture giving access to the impl of a befriended class
-struct WhiteboxFixture {
+/// struct giving access to the impl of a befriended class or struct
+struct WhiteboxAccessor {
     /** Returns the impl of the obj by reference.
      *
      * Returns a reference to the object pointed to by the _impl of a class.


### PR DESCRIPTION
This PR:
* adds the fixture `WhiteboxFixture`. This fixture is a friend of `SolverInterface`.
* adds method `impl(T& obj)` which fetches the `_impl` of obj and returns a lvalue reference to it.

Tests can now access the `SolverInterfaceImpl` by using the `WhiteboxFixture` as a test fixture and by writing `impl(interface).configure(...)` instead of `interface._impl->configure(...)`.
Existing fixtures can simply inherit from `WhiteboxFixture`.
There is no extra friend statement necessary.