### PR TITLE
Check Repeated Configuration of CPLSchemes for same Participants

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -416,6 +416,11 @@ std::vector<std::string> BaseCouplingScheme::getCouplingPartners() const
   return partnerNames;
 }
 
+std::set<std::string> BaseCouplingScheme::getParticipants() const
+{
+    return {_firstParticipant, _secondParticipant};
+}
+
 double BaseCouplingScheme::getThisTimestepRemainder() const
 {
   TRACE();

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -148,6 +148,9 @@ public:
   /// returns list of all coupling partners
   virtual std::vector<std::string> getCouplingPartners() const;
 
+  /// returns list of all coupling partners
+  virtual std::set<std::string> getParticipants() const;
+
   /**
    * @brief Returns the remaining timestep length of the current time step.
    *

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -119,6 +119,17 @@ std::vector<std::string> CompositionalCouplingScheme:: getCouplingPartners() con
   return partners;
 }
 
+std::set<std::string> CompositionalCouplingScheme:: getParticipants() const
+{
+  TRACE();
+  std::set<std::string> participants;
+  for (Scheme scheme : _couplingSchemes) {
+    const auto& subparticipants = scheme.scheme->getParticipants();
+    participants.insert(subparticipants.begin(), subparticipants.end());
+  }
+  return participants;
+}
+
 bool CompositionalCouplingScheme::willDataBeExchanged(double lastSolverTimestepLength) const
 {
   TRACE(lastSolverTimestepLength);

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -103,6 +103,9 @@ public:
   /// Returns list of all coupling partners
   virtual std::vector<std::string> getCouplingPartners() const;
 
+  /// Returns list of all coupled participants
+  virtual std::set<std::string> getParticipants() const;
+
   /**
    * @brief Returns true, if data will be exchanged when calling advance().
    *

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <set>
 
 namespace precice {
 namespace cplscheme {
@@ -94,6 +95,9 @@ public:
 
   /// Returns list of all coupling partners.
   virtual std::vector<std::string> getCouplingPartners() const =0;
+
+  /// Returns list of all participants.
+  virtual std::set<std::string> getParticipants() const =0;
 
   /*
    * @brief Returns true, if data will be exchanged when calling advance().

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -314,6 +314,11 @@ void CouplingSchemeConfiguration::addCouplingScheme(
   TRACE(participantName);
   if (utils::contained(participantName, _couplingSchemes)) {
     DEBUG("Coupling scheme exists already for participant");
+    const auto participants = cplScheme->getParticipants();
+    CHECK(std::none_of(_couplingSchemes.begin(), _couplingSchemes.end(),
+                [&participants](const typename decltype(_couplingSchemes)::value_type& kv){
+                    return participants == kv.second->getParticipants();
+                }), "A coupling scheme already exists for these participants!");
     if (utils::contained(participantName, _couplingSchemeCompositions)) {
       DEBUG("Coupling scheme composition exists already for participant");
       // Fetch the composition and add the new scheme.

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -67,6 +67,11 @@ public:
    */
   virtual std::vector<std::string> getCouplingPartners() const { assertion(false); return std::vector<std::string>(); }
 
+  /*
+   * @brief Not implemented.
+   */
+  virtual std::set<std::string> getParticipants() const { return {}; }
+
   /**
    * @brief Not implemented.
    */


### PR DESCRIPTION
This PR:
* Adds `std::set<std::string> getParticipants() const` to the coupling schemes.
* Checks at configuration whether a coupling scheme was already defined for a set of participants.

This produces an error on repeated configuration of a coupling scheme between the same participants and thus fixes #155 

Reviewers: please comment if you are ok with the interface extension.