### PR TITLE
Draft constness write functions

### DIFF
--- a/src/precice/bindings/c/SolverInterfaceC.cpp
+++ b/src/precice/bindings/c/SolverInterfaceC.cpp
@@ -137,10 +137,10 @@ int precicec_setMeshVertex
 
 void precicec_getMeshVertices
 (
-  int     meshID,
-  int     size,
-  int*    ids,
-  double* positions )
+  int        meshID,
+  int        size,
+  const int* ids,
+  double*    positions )
 {
   assertion(impl != nullptr);
   impl->getMeshVertices(meshID, size, ids, positions);
@@ -148,10 +148,10 @@ void precicec_getMeshVertices
 
 void precicec_setMeshVertices
 (
-  int     meshID,
-  int     size,
-  double* positions,
-  int*    ids)
+  int           meshID,
+  int           size,
+  const double* positions,
+  int*          ids)
 {
   assertion(impl != nullptr);
   impl->setMeshVertices(meshID, size, positions, ids );
@@ -199,10 +199,10 @@ void precicec_setMeshTriangleWithEdges
 
 void precicec_writeBlockVectorData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int           dataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values )
 {
   assertion(impl != nullptr);
   impl->writeBlockVectorData(dataID, size, valueIndices, values);
@@ -220,10 +220,10 @@ void precicec_writeVectorData
 
 void precicec_writeBlockScalarData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int           dataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values )
 {
   assertion(impl != nullptr);
   impl->writeBlockScalarData(dataID, size, valueIndices, values);
@@ -231,9 +231,9 @@ void precicec_writeBlockScalarData
 
 void precicec_writeScalarData
 (
-  int    dataID,
-  int    valueIndex,
-  double dataValue )
+  int           dataID,
+  int           valueIndex,
+  const double& dataValue )
 {
   assertion ( impl != nullptr );
   impl->writeScalarData ( dataID, valueIndex, dataValue );
@@ -241,10 +241,10 @@ void precicec_writeScalarData
 
 void precicec_readBlockVectorData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   assertion(impl != nullptr);
   impl->readBlockVectorData(dataID, size, valueIndices, values);
@@ -262,10 +262,10 @@ void precicec_readVectorData
 
 void precicec_readBlockScalarData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   assertion(impl != nullptr);
   impl->readBlockScalarData(dataID, size, valueIndices, values);

--- a/src/precice/bindings/c/SolverInterfaceC.h
+++ b/src/precice/bindings/c/SolverInterfaceC.h
@@ -97,16 +97,16 @@ int precicec_setMeshVertex (
   const double* position );
 
 void precicec_getMeshVertices (
-  int     meshID,
-  int     size,
-  int*    ids,
-  double* positions );
+  int        meshID,
+  int        size,
+  const int* ids,
+  double*    positions );
 
 void precicec_setMeshVertices (
-  int     meshID,
-  int     size,
-  double* positions,
-  int*    ids );
+  int           meshID,
+  int           size,
+  const double* positions,
+  int*          ids );
 
 int precicec_getMeshVertexSize ( int meshID );
 
@@ -143,10 +143,10 @@ void precicec_setMeshTriangleWithEdges (
  * @param[in] values Values of the data to be written.
  */
 void precicec_writeBlockVectorData (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values );
+  int           dataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values );
 
 /**
  * @brief Writes vectorial foating point data to the coupling mesh.
@@ -164,10 +164,10 @@ void precicec_writeVectorData (
  * @brief See precice::SolverInterface::writeBlockScalarData().
  */
 void precicec_writeBlockScalarData (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values );
+  int           dataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values );
 
 /**
  * @brief Writes scalar floating point data to the coupling mesh.
@@ -177,9 +177,9 @@ void precicec_writeBlockScalarData (
  * @param[in] dataValue Scalar data value to be written.
  */
 void precicec_writeScalarData (
-  int    dataID,
-  int    valueIndex,
-  double dataValue );
+  int           dataID,
+  int           valueIndex,
+  const double& dataValue );
 
 /**
  * @brief Reads vector data values given as block.
@@ -194,10 +194,10 @@ void precicec_writeScalarData (
  * @param[in] values Values of the data to be read.
  */
 void precicec_readBlockVectorData (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values );
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values );
 
 /**
  * @brief Reads vectorial foating point data from the coupling mesh.
@@ -215,10 +215,10 @@ void precicec_readVectorData (
  * @brief See precice::SolverInterface::readBlockScalarData().
  */
 void precicec_readBlockScalarData (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values );
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values );
 
 /**
  * @brief Reads scalar foating point data from the coupling mesh.

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -311,10 +311,10 @@ void RequestManager:: requestResetMesh
 
 void RequestManager:: requestSetMeshVertices
 (
-  int     meshID,
-  int     size,
-  double* positions,
-  int*    ids )
+  int           meshID,
+  int           size,
+  const double* positions,
+  int*          ids )
 {
   TRACE();
   _com->send(REQUEST_SET_MESH_VERTICES, 0);
@@ -326,10 +326,10 @@ void RequestManager:: requestSetMeshVertices
 
 void RequestManager:: requestGetMeshVertices
 (
-  int     meshID,
-  int     size,
-  int*    ids,
-  double* positions )
+  int        meshID,
+  int        size,
+  const int* ids,
+  double*    positions )
 {
   TRACE();
   _com->send(REQUEST_GET_MESH_VERTICES, 0);
@@ -341,10 +341,10 @@ void RequestManager:: requestGetMeshVertices
 
 void RequestManager:: requestGetMeshVertexIDsFromPositions
 (
-  int     meshID,
-  int     size,
-  double* positions,
-  int*    ids )
+  int           meshID,
+  int           size,
+  const double* positions,
+  int*          ids )
 {
   TRACE(size);
   _com->send(REQUEST_GET_MESH_VERTEX_IDS_FROM_POSITIONS, 0);
@@ -426,10 +426,10 @@ void RequestManager:: requestSetMeshQuadWithEdges
 }
 
 void RequestManager:: requestWriteBlockScalarData (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int           dataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values )
 {
   TRACE(dataID, size);
   _com->send(REQUEST_WRITE_BLOCK_SCALAR_DATA, 0);
@@ -441,9 +441,9 @@ void RequestManager:: requestWriteBlockScalarData (
 
 void RequestManager:: requestWriteScalarData
 (
-  int    dataID,
-  int    valueIndex,
-  double value )
+  int           dataID,
+  int           valueIndex,
+  const double& value )
 {
   TRACE();
   _com->send(REQUEST_WRITE_SCALAR_DATA, 0);
@@ -453,10 +453,10 @@ void RequestManager:: requestWriteScalarData
 }
 
 void RequestManager:: requestWriteBlockVectorData (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int           dataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values )
 {
   TRACE(dataID);
   _com->send(REQUEST_WRITE_BLOCK_VECTOR_DATA, 0);
@@ -468,9 +468,9 @@ void RequestManager:: requestWriteBlockVectorData (
 
 void RequestManager:: requestWriteVectorData
 (
-  int     dataID,
-  int     valueIndex,
-  double* value )
+  int           dataID,
+  int           valueIndex,
+  const double* value )
 {
   TRACE();
   _com->send(REQUEST_WRITE_VECTOR_DATA, 0);
@@ -480,10 +480,10 @@ void RequestManager:: requestWriteVectorData
 }
 
 void RequestManager:: requestReadBlockScalarData (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   TRACE(dataID, size);
   _com->send(REQUEST_READ_BLOCK_SCALAR_DATA, 0);
@@ -508,10 +508,10 @@ void RequestManager:: requestReadScalarData
 
 void RequestManager:: requestReadBlockVectorData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   TRACE(dataID, size);
   _com->send(REQUEST_READ_BLOCK_VECTOR_DATA, 0);

--- a/src/precice/impl/RequestManager.hpp
+++ b/src/precice/impl/RequestManager.hpp
@@ -60,24 +60,24 @@ public:
 
   /// Requests set vertex positions from server.
   void requestSetMeshVertices (
-    int     meshID,
-    int     size,
-    double* positions,
-    int*    ids );
+    int           meshID,
+    int           size,
+    const double* positions,
+    int*          ids );
 
   /// Requests get vertex positions from server.
   void requestGetMeshVertices (
-    int     meshID,
-    int     size,
-    int*    ids,
-    double* positions );
+    int        meshID,
+    int        size,
+    const int* ids,
+    double*    positions );
 
   /// Requests get vertex ids from server.
   void requestGetMeshVertexIDsFromPositions (
-    int     meshID,
-    int     size,
-    double* positions,
-    int*    ids );
+    int           meshID,
+    int           size,
+    const double* positions,
+    int*          ids );
 
   /// Requests set mesh edge from server.
   int requestSetMeshEdge (
@@ -117,36 +117,36 @@ public:
 
   /// Requests write block scalar data from server.
   void requestWriteBlockScalarData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int           dataID,
+    int           size,
+    const int*    valueIndices,
+    const double* values );
 
   /// Requests write scalar data from server.
   void requestWriteScalarData (
-    int    dataID,
-    int    valueIndex,
-    double value );
+    int           dataID,
+    int           valueIndex,
+    const double& value );
 
   /// Requests write block vector data from server.
   void requestWriteBlockVectorData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int           dataID,
+    int           size,
+    const int*    valueIndices,
+    const double* values );
 
   /// Requests write vector data from server.
   void requestWriteVectorData (
-    int     dataID,
-    int     valueIndex,
-    double* value );
+    int           dataID,
+    int           valueIndex,
+    const double* value );
 
   /// Requests read block scalar data from server.
   void requestReadBlockScalarData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int        dataID,
+    int        size,
+    const int* valueIndices,
+    double*    values );
 
   /// Requests read scalar data from server.
   void requestReadScalarData (
@@ -156,10 +156,10 @@ public:
 
   /// Requests read block vector data from server.
   void requestReadBlockVectorData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int        dataID,
+    int        size,
+    const int* valueIndices,
+    double*    values );
 
   /// Requests read vector data from server.
   void requestReadVectorData (

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -671,10 +671,10 @@ int SolverInterfaceImpl:: setMeshVertex
 
 void SolverInterfaceImpl:: setMeshVertices
 (
-  int     meshID,
-  int     size,
-  double* positions,
-  int*    ids )
+  int           meshID,
+  int           size,
+  const double* positions,
+  int*          ids )
 {
   TRACE(meshID, size);
   if (_clientMode){
@@ -698,10 +698,10 @@ void SolverInterfaceImpl:: setMeshVertices
 
 void SolverInterfaceImpl:: getMeshVertices
 (
-  int     meshID,
-  size_t  size,
-  int*    ids,
-  double* positions )
+  int        meshID,
+  size_t     size,
+  const int* ids,
+  double*    positions )
 {
   TRACE(meshID, size);
   if (_clientMode){
@@ -726,10 +726,10 @@ void SolverInterfaceImpl:: getMeshVertices
 }
 
 void SolverInterfaceImpl:: getMeshVertexIDsFromPositions (
-  int     meshID,
-  size_t  size,
-  double* positions,
-  int*    ids )
+  int           meshID,
+  size_t        size,
+  const double* positions,
+  int*          ids )
 {
   TRACE(meshID, size);
   if (_clientMode){
@@ -1153,10 +1153,10 @@ void SolverInterfaceImpl:: mapReadDataTo
 
 void SolverInterfaceImpl:: writeBlockVectorData
 (
-  int     fromDataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int           fromDataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values )
 {
   TRACE(fromDataID, size);
   PRECICE_VALIDATE_DATA_ID(fromDataID);
@@ -1224,10 +1224,10 @@ void SolverInterfaceImpl:: writeVectorData
 
 void SolverInterfaceImpl:: writeBlockScalarData
 (
-  int     fromDataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int           fromDataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values )
 {
   TRACE(fromDataID, size);
   PRECICE_VALIDATE_DATA_ID(fromDataID);
@@ -1254,9 +1254,9 @@ void SolverInterfaceImpl:: writeBlockScalarData
 
 void SolverInterfaceImpl:: writeScalarData
 (
-  int    fromDataID,
-  int    valueIndex,
-  double value )
+  int           fromDataID,
+  int           valueIndex,
+  const double& value )
 {
   TRACE(fromDataID, valueIndex, value );
   PRECICE_VALIDATE_DATA_ID(fromDataID);
@@ -1279,10 +1279,10 @@ void SolverInterfaceImpl:: writeScalarData
 
 void SolverInterfaceImpl:: readBlockVectorData
 (
-  int     toDataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        toDataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   TRACE(toDataID, size);
   PRECICE_VALIDATE_DATA_ID(toDataID);
@@ -1346,10 +1346,10 @@ void SolverInterfaceImpl:: readVectorData
 
 void SolverInterfaceImpl:: readBlockScalarData
 (
-  int     toDataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        toDataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   TRACE(toDataID, size);
   PRECICE_VALIDATE_DATA_ID(toDataID);

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -216,10 +216,10 @@ public:
    * @param[out] ids IDs for data from given positions.
    */
   void setMeshVertices (
-    int     meshID,
-    int     size,
-    double* positions,
-    int*    ids );
+    int           meshID,
+    int           size,
+    const double* positions,
+    int*          ids );
 
   /**
    * @brief Gets spatial positions of vertices for given IDs.
@@ -228,10 +228,10 @@ public:
    * @param[in] positions Positions corresponding to IDs.
    */
   void getMeshVertices (
-    int     meshID,
-    size_t  size,
-    int*    ids,
-    double* positions );
+    int        meshID,
+    size_t     size,
+    const int* ids,
+    double*    positions );
 
   /**
    * @brief Gets vertex data ids from positions.
@@ -241,10 +241,10 @@ public:
    * @param[out] ids IDs corresponding to positions.
    */
   void getMeshVertexIDsFromPositions (
-    int     meshID,
-    size_t  size,
-    double* positions,
-    int*    ids );
+    int           meshID,
+    size_t        size,
+    const double* positions,
+    int*          ids );
 
   /// Returns the number of nodes of a mesh.
   int getMeshVertexSize ( int meshID );
@@ -320,10 +320,10 @@ public:
    * @param[in] values Values of the data to be written.
    */
   void writeBlockVectorData (
-    int     fromDataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int           fromDataID,
+    int           size,
+    const int*    valueIndices,
+    const double* values );
 
 
   /**
@@ -348,10 +348,10 @@ public:
    * @param values [IN] Values of the data to be written.
    */
   void writeBlockScalarData (
-    int     fromDataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int           fromDataID,
+    int           size,
+    const int*    valueIndices,
+    const double* values );
 
   /**
    * @brief Write scalar data to the interface mesh
@@ -363,9 +363,9 @@ public:
    * @param dataValue    [IN] Value of the data to be written
    */
   void writeScalarData(
-    int    fromDataID,
-    int    valueIndex,
-    double value );
+    int           fromDataID,
+    int           valueIndex,
+    const double& value );
 
   /**
    * @brief Reads vector data values given as block.
@@ -380,10 +380,10 @@ public:
    * @param values [IN] Values of the data to be read.
    */
   void readBlockVectorData (
-    int     toDataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int        toDataID,
+    int        size,
+    const int* valueIndices,
+    double*    values );
 
   /**
    * @brief Reads vector data from the coupling mesh.
@@ -405,10 +405,10 @@ public:
    * @param[in] values Values of the data to be written.
    */
   void readBlockScalarData (
-    int     toDataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int        toDataID,
+    int        size,
+    const int* valueIndices,
+    double*    values );
 
   /**
    * @brief Read scalar data from the interface mesh.


### PR DESCRIPTION
As discussed in [this issue](https://github.com/Dominanz/precice/issues/1), the value arguments of the write functions in were changed into `const` pointers in this branch, since access to them is read-only inside this functions. This allows for safer code and better optimizations in programs that use preCICE, because they are now guaranteed that values are accessed read-only in the write functions.