### PR TITLE
Refactor Logger

### DIFF
--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -3,6 +3,7 @@
 #include "MPISinglePortsCommunication.hpp"
 #include "utils/assertion.hpp"
 #include "utils/Parallel.hpp"
+#include "utils/MasterSlave.hpp"
 #include "utils/Publisher.hpp"
 
 using precice::utils::Publisher;

--- a/src/com/config/CommunicationConfiguration.hpp
+++ b/src/com/config/CommunicationConfiguration.hpp
@@ -2,6 +2,7 @@
 
 #include "logging/Logger.hpp"
 #include "xml/XMLTag.hpp"
+#include "com/SharedPointer.hpp"
 
 namespace precice
 {

--- a/src/cplscheme/impl/QRFactorization.cpp
+++ b/src/cplscheme/impl/QRFactorization.cpp
@@ -1,6 +1,7 @@
 #include "QRFactorization.hpp"
 #include "com/Communication.hpp"
 #include "cplscheme/impl/BaseQNPostProcessing.hpp"
+#include "utils/MasterSlave.hpp"
 
 #include <algorithm> // std::sort
 #include <cmath>

--- a/src/cplscheme/impl/QRFactorization.hpp
+++ b/src/cplscheme/impl/QRFactorization.hpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 #include <fstream>
+#include <vector>
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 

--- a/src/cplscheme/impl/ResidualPreconditioner.cpp
+++ b/src/cplscheme/impl/ResidualPreconditioner.cpp
@@ -1,4 +1,5 @@
 #include "ResidualPreconditioner.hpp"
+#include "utils/MasterSlave.hpp"
 
 namespace precice
 {

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <boost/filesystem.hpp>
 #include "utils/Helpers.hpp"
+#include "utils/MasterSlave.hpp"
 
 namespace precice {
 namespace io {

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <boost/log/expressions.hpp>
-#include <boost/log/attributes/mutable_constant.hpp>
-
 #include <boost/preprocessor/variadic/to_seq.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/stringize.hpp>
@@ -11,30 +8,18 @@
 #include <boost/vmd/is_empty.hpp>
 
 #include <string>
-#include "utils/MasterSlave.hpp"
+#include "utils/String.hpp"
 #include "utils/prettyprint.hpp" // so that we can put std::vector et. al. on ostream
 #include "utils/SignalHandler.hpp"
 
 #include "Tracer.hpp"
 
+#define WARN(message) _log.warning(LOG_LOCATION, PRECICE_AS_STRING(message))
 
-#define WARN(message) do {                                              \
-    LOG_LOCATION;                                                       \
-    BOOST_LOG_SEV(_log, boost::log::trivial::severity_level::warning)   \
-      << message;                                                       \
-  } while (false)
-
-#define INFO(message)                                                   \
-  if (not precice::utils::MasterSlave::_slaveMode) {                    \
-    LOG_LOCATION;                                                       \
-    BOOST_LOG_SEV(_log, boost::log::trivial::severity_level::info)      \
-      << message;                                                       \
-  }
+#define INFO(message) _log.info(LOG_LOCATION, PRECICE_AS_STRING(message))
 
 #define ERROR(message) do {                                             \
-    LOG_LOCATION;                                                       \
-    BOOST_LOG_SEV(_log, boost::log::trivial::severity_level::error)     \
-    << message;                                                         \
+    _log.error(LOG_LOCATION, PRECICE_AS_STRING(message));               \
     precice::utils::terminationSignalHandler(6);                        \
     std::exit(-1);                                                      \
 } while (false)
@@ -51,11 +36,7 @@
 
 #else // NDEBUG
 
-#define DEBUG(message) do {                                             \
-    LOG_LOCATION;                                                       \
-    BOOST_LOG_SEV(_log, boost::log::trivial::severity_level::debug)     \
-      << message;                                                       \
-  } while (false)
+#define DEBUG(message) _log.debug(LOG_LOCATION, PRECICE_AS_STRING(message))
 
 /// Helper macro, used by TRACE
 #define LOG_ARGUMENT(r, data, i, elem)                                  \
@@ -63,26 +44,18 @@
 
 // Do not put do {...} while (false) here, it will destroy the _tracer_ right after creation
 #define TRACE(...)                                                      \
-  LOG_LOCATION;                                                         \
-  BOOST_LOG_FUNCTION();                                                 \
-  precice::logging::Tracer _tracer_(_log, __func__, __FILE__,__LINE__); \
-  BOOST_LOG_SEV(_log, boost::log::trivial::severity_level::trace) << "Entering " << __func__ \
+  /*BOOST_LOG_FUNCTION();*/                                             \
+  precice::logging::Tracer _tracer_(_log, LOG_LOCATION);                \
+  _log.trace(LOG_LOCATION, PRECICE_AS_STRING("Entering " << __func__    \
   BOOST_PP_IF(BOOST_VMD_IS_EMPTY(__VA_ARGS__),                          \
               BOOST_PP_EMPTY(),                                         \
-              BOOST_PP_SEQ_FOR_EACH_I(LOG_ARGUMENT,, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)));
+              BOOST_PP_SEQ_FOR_EACH_I(LOG_ARGUMENT,, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)))));
 
 
 #endif // ! NDEBUG
 
 
-#define LOG_LOCATION do {                                               \
-    boost::log::attribute_cast<boost::log::attributes::mutable_constant<int>>( \
-      boost::log::core::get()->get_global_attributes()["Line"]).set(__LINE__); \
-    boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>( \
-      boost::log::core::get()->get_global_attributes()["File"]).set(__FILE__); \
-    boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>( \
-      boost::log::core::get()->get_global_attributes()["Function"]).set(__func__); \
-  } while (false)
+#define LOG_LOCATION precice::logging::LogLocation{__FILE__,  __LINE__, __func__}
 
   
 

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -50,6 +50,8 @@ Logger::Logger(const Logger& other)
 {
 }
 
+Logger::Logger(Logger&& other) = default;
+
 Logger& Logger::operator=(Logger other)
 {
     swap(other);

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -12,9 +12,16 @@
 namespace precice {
 namespace logging {
 
+/** The implementation of logging::Logger
+ *
+ * @note The point of using a pimpl for the logger is to remove boost::log from logger.hpp
+ */
 class Logger::LoggerImpl : public boost::log::sources::severity_logger<boost::log::trivial::severity_level>
 {
 public:
+  /** Creates a Boost logger for the said module.
+   * @param[in] module the name of the module.
+   */
   explicit LoggerImpl(std::string module);
 };
 
@@ -34,8 +41,10 @@ Logger::LoggerImpl::LoggerImpl(std::string module)
 
 Logger::Logger(std::string module) : _impl(new LoggerImpl{std::move(module)}) {}
 
+// This is required for the std::unique_ptr.
 Logger::~Logger() = default;
 
+// Extracts the name saved in the attribute "Module"
 Logger::Logger(const Logger& other)
     : Logger{other._impl->get_attributes().find("Module")->second.get_value().extract_or_throw<std::string>()}
 {

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -4,11 +4,21 @@
 #include <boost/log/attributes/named_scope.hpp>
 #include <boost/log/attributes/constant.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/trivial.hpp>
+
+#include <boost/log/expressions.hpp>
+#include <boost/log/attributes/mutable_constant.hpp>
 
 namespace precice {
 namespace logging {
 
-Logger::Logger(std::string module)
+class Logger::LoggerImpl : public boost::log::sources::severity_logger<boost::log::trivial::severity_level>
+{
+public:
+  explicit LoggerImpl(std::string module);
+};
+
+Logger::LoggerImpl::LoggerImpl(std::string module)
 {
   add_attribute("Module", boost::log::attributes::constant<std::string>(module));
   
@@ -22,4 +32,65 @@ Logger::Logger(std::string module)
   log::core::get()->add_global_attribute("Function", attrs::mutable_constant<std::string>(""));
 }
 
+Logger::Logger(std::string module) : _impl(new LoggerImpl{std::move(module)}) {}
+
+Logger::~Logger() = default;
+
+Logger::Logger(const Logger& other)
+    : Logger{other._impl->get_attributes().find("Module")->second.get_value().extract_or_throw<std::string>()}
+{
+}
+
+Logger& Logger::operator=(Logger other)
+{
+    swap(other);
+    return *this;
+}
+
+void Logger::swap(Logger& other) noexcept
+{ 
+    _impl.swap(other._impl);
+}
+
+
+namespace {
+    /// Sets the log location in the boost core
+    void setLogLocation(LogLocation loc) {
+        boost::log::attribute_cast<boost::log::attributes::mutable_constant<int>>(boost::log::core::get()->get_global_attributes()["Line"]).set(loc.line);
+        boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["File"]).set(loc.file);
+        boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["Function"]).set(loc.func);
+    }
+}
+
+void Logger::error(LogLocation loc, const std::string& mess)
+{
+    setLogLocation(loc);
+    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::error) << mess;
+}
+
+void Logger::warning(LogLocation loc, const std::string& mess)
+{
+    setLogLocation(loc);
+    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::warning) << mess;
+}
+
+void Logger::info(LogLocation loc, const std::string& mess)
+{
+    setLogLocation(loc);
+    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::info) << mess;
+}
+
+void Logger::debug(LogLocation loc, const std::string& mess)
+{
+    setLogLocation(loc);
+    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::debug) << mess;
+}
+
+void Logger::trace(LogLocation loc, const std::string& mess)
+{
+    setLogLocation(loc);
+    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::trace) << mess;
+}
+
 }}
+

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -1,15 +1,35 @@
 #pragma once
 
 #include <string>
-#include <boost/log/trivial.hpp>
+#include <memory>
 
 namespace precice {
 namespace logging {
 
-class Logger : public boost::log::sources::severity_logger<boost::log::trivial::severity_level>
-{
+struct LogLocation {
+    const char * file;
+    int line;
+    const char * func;
+};
+
+class Logger {
 public:
   explicit Logger(std::string module);
+  Logger(const Logger& other);
+  Logger& operator=(Logger other);
+  ~Logger();
+
+  void swap(Logger& other) noexcept;
+
+  void error(LogLocation loc, const std::string& mess);
+  void warning(LogLocation loc, const std::string& mess);
+  void info(LogLocation loc, const std::string& mess);
+  void debug(LogLocation loc, const std::string& mess);
+  void trace(LogLocation loc, const std::string& mess);
+
+private:
+  class LoggerImpl;
+  std::unique_ptr<LoggerImpl> _impl;
 };
 
 }} // namespace precice, logging

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -22,6 +22,7 @@ public:
   explicit Logger(std::string module);
 
   Logger(const Logger& other);
+  Logger(Logger&& other) = default;
   Logger& operator=(Logger other);
   ~Logger();
 

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -22,7 +22,7 @@ public:
   explicit Logger(std::string module);
 
   Logger(const Logger& other);
-  Logger(Logger&& other) = default;
+  Logger(Logger&& other);
   Logger& operator=(Logger other);
   ~Logger();
 

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -6,29 +6,39 @@
 namespace precice {
 namespace logging {
 
+/// Struct used to capture the original location of a log request
 struct LogLocation {
     const char * file;
     int line;
     const char * func;
 };
 
+/// This class provides a leightweight logger.
 class Logger {
 public:
+  /** creates a logger for a given module.
+   * @param[in] the name of the module 
+   */
   explicit Logger(std::string module);
+
   Logger(const Logger& other);
   Logger& operator=(Logger other);
   ~Logger();
 
   void swap(Logger& other) noexcept;
 
+  ///@name Logging operations
+  ///@{
   void error(LogLocation loc, const std::string& mess);
   void warning(LogLocation loc, const std::string& mess);
   void info(LogLocation loc, const std::string& mess);
   void debug(LogLocation loc, const std::string& mess);
   void trace(LogLocation loc, const std::string& mess);
-
+  ///@}
 private:
+  /// Forward declaration of the implementation of the logger
   class LoggerImpl;
+  /// Pimpl to the logger implementation
   std::unique_ptr<LoggerImpl> _impl;
 };
 

--- a/src/logging/Tracer.cpp
+++ b/src/logging/Tracer.cpp
@@ -7,28 +7,16 @@ namespace logging {
 Tracer::Tracer
 (
   Logger &log,
-  std::string function,
-  std::string file,
-  long line
+  LogLocation loc
   )
   :
   _log(log),
-  _function(function),
-  _file(file),
-  _line(line)
+  _loc(std::move(loc))
 {}
 
 Tracer::~Tracer()
 {
-  using namespace boost::log;
-
-  attribute_cast<attributes::mutable_constant<int>>(core::get()->get_global_attributes()["Line"]).set(_line);
-
-  attribute_cast<attributes::mutable_constant<std::string>>(core::get()->get_global_attributes()["File"]).set(_file);
-
-  attribute_cast<attributes::mutable_constant<std::string>>(core::get()->get_global_attributes()["Function"]).set(_function);
-
-  BOOST_LOG_SEV(_log, trivial::severity_level::trace) << "Leaving " << _function;
+  _log.trace(_loc, std::string{"Leaving "}.append(_loc.func));
 }
 
 }} // namespace precice,logging

--- a/src/logging/Tracer.hpp
+++ b/src/logging/Tracer.hpp
@@ -8,19 +8,14 @@ class Tracer
 {
 public:  
   
-  Tracer (Logger &log, std::string function, std::string file, long line);
+  Tracer (Logger &log, LogLocation loc);
   ~Tracer();
 
 private:
 
   Logger _log;
 
-  std::string _function;
-
-  std::string _file;
-
-  long _line;
-
+  LogLocation _loc;
 };
 
 }} // namespace precice, logging

--- a/src/m2n/PointToPointCommunication.hpp
+++ b/src/m2n/PointToPointCommunication.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "DistributedCommunication.hpp"
 #include <list>
+#include <vector>
+#include <string>
+
+#include "DistributedCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"

--- a/src/utils/String.hpp
+++ b/src/utils/String.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <sstream>
 
 namespace precice {
 namespace utils {
@@ -23,6 +24,13 @@ std::string & checkAppendExtension(std::string& filename, const std::string& ext
  * This function is case-insensitive.
  */
 bool convertStringToBool(std::string const & value);
+
+
+#define PRECICE_AS_STRING(message) [&]{ \
+        std::ostringstream oss;        \
+        oss << message;                \
+        return oss.str();              \
+    }()
 
 
 }} // namespace precice, utils

--- a/src/utils/String.hpp
+++ b/src/utils/String.hpp
@@ -25,7 +25,7 @@ std::string & checkAppendExtension(std::string& filename, const std::string& ext
  */
 bool convertStringToBool(std::string const & value);
 
-
+/// Turns stream-like code into a std::string.
 #define PRECICE_AS_STRING(message) [&]{ \
         std::ostringstream oss;        \
         oss << message;                \

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -6,6 +6,7 @@
 #include <boost/preprocessor/variadic/to_seq.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/stringize.hpp>
+#include <boost/current_function.hpp>
 
 #include "stacktrace.hpp"
 #include "Parallel.hpp"


### PR DESCRIPTION
This PR refactors the current logger.

## Problem:
* Due to the Boost dependencies, the cost of including `Logger.hpp` is around 2.6 seconds, including:
   * 1500ms for `boost/log/expressions.hpp`via `LogMacros.hpp`
   * 810ms for `boost/log/trivial.hpp` aka the actual logger
   * ~250ms for `MasterSlave.hpp`
   * 100ms for `prettyprint.hpp` (Depends strongly on the call-site)
* This header is included in nearly every translation unit, which slows the entire build process down.

## My Approach:
* Use a pimpl to move the boost dependencies into a single translation unit `Logger.cpp`
* Use a minimal struct to forward the log location to the impl.
* Materialize passed log message to a string and pass that to the impl.
* Use functions for the log levels to prevent a boost dependency for the log-level in the interface.

## Side-Effects:
* The Logger itself is now a mere pointer, thus doesn't bloat up the class it is member of.
* Accessing the logger is always an indirection.

## Result:
* The cost of including `Logger.hpp` now converges against `prettyprint.hpp`.
* The build runs notably faster (Debug + `make -j4` on i7-7700 in tempfs):

|  | Real | User | Sys |
| --- | --- | --- | --- |
Before | 3m43s |  11m29s | 0m37s
After | 2m6s | 6m25s | 0m20s