### PR TITLE
Use Error in XML

### DIFF
--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -153,13 +153,13 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(std::map<std::string, std::string> &aA
   TRACE(_name);
   if (_read) {
     std::cout << "Attribute \"" + _name + "\" is defined multiple times\n";
-    throw "Attribute \"" + _name + "\" is defined multiple times";
+    ERROR("Attribute \"" + _name + "\" is defined multiple times");
   }
 
   if (aAttributes.find(getName()) == aAttributes.end()) {
     if (not _hasDefaultValue) {
       std::cout << "Attribute \"" + _name + "\" missing\n";
-      throw "Attribute \"" + _name + "\" missing";
+      ERROR("Attribute \"" + _name + "\" missing");
     }
     set(_value, _defaultValue);
   } else {
@@ -179,7 +179,7 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(std::map<std::string, std::string> &aA
         }
 
         std::cout << stream.str() << '\n';
-        throw stream.str();
+        ERROR(stream.str());
       }
     }
   }
@@ -199,7 +199,7 @@ void XMLAttribute<ATTRIBUTE_T>::readValueSpecific(std::string &rawValue, double 
       value = std::stod(rawValue);
     }
   } catch (...) {
-    throw "String to Double error";
+    ERROR("String to Double error");
   }
 }
 
@@ -209,7 +209,7 @@ void XMLAttribute<ATTRIBUTE_T>::readValueSpecific(std::string &rawValue, int &va
   try {
     value = std::stoi(rawValue);
   } catch (...) {
-    throw "String to Int error";
+    ERROR("String to Int error");
   }
 }
 

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -161,14 +161,8 @@ void XMLTag::readAttributes(std::map<std::string, std::string> &aAttributes)
     auto name = element.first;
 
     if (not utils::contained(name, _attributes)) {
-      std::string error = "Wrong attribute \"" + name + "\"";
-
-      std::cout << error << '\n';
-      throw error;
+      ERROR("Wrong attribute \"" << name << '\"');
     }
-
-    auto value = element.second;
-    //std::cout << name << " :: " << value << '\n';
   }
 
   for (auto &pair : _doubleAttributes) {
@@ -272,8 +266,6 @@ void XMLTag::readAttributes(std::map<std::string, std::string> &aAttributes)
 
 void XMLTag::areAllSubtagsConfigured() const
 {
-  std::ostringstream stream;
-
   for (auto tag : _subtags) {
     std::string ns         = tag->_namespace;
     bool        configured = tag->isConfigured();
@@ -289,11 +281,10 @@ void XMLTag::areAllSubtagsConfigured() const
     if ((not configured) && (occurOnce || occurOnceOrMore)) {
 
       if (tag->getNamespace().empty()) {
-        stream << "Tag <" << tag->getName() << "> is missing";
+        ERROR("Tag <" << tag->getName() << "> is missing");
       } else {
-        stream << "Tag <" << tag->getNamespace() << ":...> is missing";
+        ERROR("Tag <" << tag->getNamespace() << ":...> is missing");
       }
-      throw stream.str();
     }
   }
 }


### PR DESCRIPTION
The XML implementation was still `throw`ing around instead of using `ERROR`.
This PR finally brings the XML code up2date and fixes #346.