### PR TITLE
Fix Interface constness

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -152,30 +152,30 @@ int SolverInterface:: getMeshVertexSize
 
 void SolverInterface:: setMeshVertices
 (
-  int     meshID,
-  int     size,
-  double* positions,
-  int*    ids )
+  int           meshID,
+  int           size,
+  const double* positions,
+  int*          ids )
 {
   _impl->setMeshVertices(meshID, size, positions, ids);
 }
 
 void SolverInterface:: getMeshVertices
 (
-  int     meshID,
-  int     size,
-  int*    ids,
-  double* positions )
+  int        meshID,
+  int        size,
+  const int* ids,
+  double*    positions )
 {
   _impl->getMeshVertices(meshID, size, ids, positions);
 }
 
 void SolverInterface:: getMeshVertexIDsFromPositions
 (
-  int     meshID,
-  int     size,
-  double* positions,
-  int*    ids )
+  int           meshID,
+  int           size,
+  const double* positions,
+  int*          ids )
 {
   _impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
 }
@@ -251,8 +251,8 @@ void SolverInterface:: writeBlockVectorData
 (
   int     dataID,
   int     size,
-  int*    valueIndices,
-  double* values )
+  const int*    valueIndices,
+  const double* values )
 {
   _impl->writeBlockVectorData(dataID, size, valueIndices, values);
 }
@@ -268,10 +268,10 @@ void SolverInterface:: writeVectorData
 
 void SolverInterface:: writeBlockScalarData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int           dataID,
+  int           size,
+  const int*    valueIndices,
+  const double* values )
 {
   _impl->writeBlockScalarData(dataID, size, valueIndices, values);
 }
@@ -287,10 +287,10 @@ void SolverInterface:: writeScalarData
 
 void SolverInterface:: readBlockVectorData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   _impl->readBlockVectorData(dataID, size, valueIndices, values);
 }
@@ -306,10 +306,10 @@ void SolverInterface:: readVectorData
 
 void SolverInterface:: readBlockScalarData
 (
-  int     dataID,
-  int     size,
-  int*    valueIndices,
-  double* values )
+  int        dataID,
+  int        size,
+  const int* valueIndices,
+  double*    values )
 {
   _impl->readBlockScalarData(dataID, size, valueIndices, values);
 }

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -403,10 +403,10 @@ public:
    * @see getDimensions()
    */
   void setMeshVertices (
-    int     meshID,
-    int     size,
-    double* positions,
-    int*    ids );
+    int           meshID,
+    int           size,
+    const double* positions,
+    int*          ids );
 
   /**
    * @brief Get vertex positions for multiple vertex ids from a given mesh
@@ -424,10 +424,10 @@ public:
    * @see getDimensions()
    */
   void getMeshVertices (
-    int     meshID,
-    int     size,
-    int*    ids,
-    double* positions );
+    int        meshID,
+    int        size,
+    const int* ids,
+    double*    positions );
 
   /**
    * @brief Gets mesh vertex IDs from positions.
@@ -445,10 +445,10 @@ public:
    * @note prefer to reuse the IDs returned from calls to setMeshVertex() and setMeshVertices().
    */
   void getMeshVertexIDsFromPositions (
-    int     meshID,
-    int     size,
-    double* positions,
-    int*    ids );
+    int           meshID,
+    int           size,
+    const double* positions,
+    int*          ids );
 
   /**
    * @brief Sets mesh edge from vertex IDs, returns edge ID.
@@ -615,10 +615,10 @@ public:
    * @see SolverInterface::setMeshVertex()
    */
   void writeBlockVectorData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int           dataID,
+    int           size,
+    const int*    valueIndices,
+    const double* values );
 
   /**
    * @brief Writes vector data to a vertex
@@ -663,10 +663,10 @@ public:
    * @see SolverInterface::setMeshVertex()
    */
   void writeBlockScalarData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int           dataID,
+    int           size,
+    const int*    valueIndices,
+    const double* values );
 
   /**
    * @brief Writes scalar data to a vertex
@@ -710,10 +710,10 @@ public:
    * @see SolverInterface::setMeshVertex()
    */
   void readBlockVectorData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int        dataID,
+    int        size,
+    const int* valueIndices,
+    double*    values );
 
   /**
    * @brief Reads vector data form a vertex
@@ -761,10 +761,10 @@ public:
    * @see SolverInterface::setMeshVertex()
    */
   void readBlockScalarData (
-    int     dataID,
-    int     size,
-    int*    valueIndices,
-    double* values );
+    int        dataID,
+    int        size,
+    const int* valueIndices,
+    double*    values );
 
   /**
    * @brief Reads scalar data of a vertex.

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -441,9 +441,9 @@ void RequestManager:: requestWriteBlockScalarData (
 
 void RequestManager:: requestWriteScalarData
 (
-  int           dataID,
-  int           valueIndex,
-  const double& value )
+  int    dataID,
+  int    valueIndex,
+  double value )
 {
   TRACE();
   _com->send(REQUEST_WRITE_SCALAR_DATA, 0);

--- a/src/precice/impl/RequestManager.hpp
+++ b/src/precice/impl/RequestManager.hpp
@@ -124,9 +124,9 @@ public:
 
   /// Requests write scalar data from server.
   void requestWriteScalarData (
-    int           dataID,
-    int           valueIndex,
-    const double& value );
+    int    dataID,
+    int    valueIndex,
+    double value );
 
   /// Requests write block vector data from server.
   void requestWriteBlockVectorData (

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1254,9 +1254,9 @@ void SolverInterfaceImpl:: writeBlockScalarData
 
 void SolverInterfaceImpl:: writeScalarData
 (
-  int           fromDataID,
-  int           valueIndex,
-  const double& value )
+  int    fromDataID,
+  int    valueIndex,
+  double value)
 {
   TRACE(fromDataID, valueIndex, value );
   PRECICE_VALIDATE_DATA_ID(fromDataID);

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -201,6 +201,9 @@ public:
   /// Returns data id corresponding to the given name (from configuration) and mesh.
   int getDataID ( const std::string& dataName, int meshID );
 
+  /// Returns the number of nodes of a mesh.
+  int getMeshVertexSize ( int meshID );
+
   /**
    * @brief Resets mesh with given ID.
    *
@@ -209,6 +212,15 @@ public:
    * non-incremental.
    */
   void resetMesh ( int meshID );
+
+  /**
+   * @brief Set the position of a solver mesh vertex.
+   *
+   * @return Vertex ID to be used when setting an edge.
+   */
+  int setMeshVertex (
+    int           meshID,
+    const double* position );
 
   /**
    * @brief Sets several spatial positions for a mesh.
@@ -245,18 +257,6 @@ public:
     size_t        size,
     const double* positions,
     int*          ids );
-
-  /// Returns the number of nodes of a mesh.
-  int getMeshVertexSize ( int meshID );
-
-  /**
-   * @brief Set the position of a solver mesh vertex.
-   *
-   * @return Vertex ID to be used when setting an edge.
-   */
-  int setMeshVertex (
-    int           meshID,
-    const double* position );
 
   /**
    * @brief Set an edge of a solver mesh.
@@ -363,9 +363,9 @@ public:
    * @param dataValue    [IN] Value of the data to be written
    */
   void writeScalarData(
-    int           fromDataID,
-    int           valueIndex,
-    const double& value );
+    int    fromDataID,
+    int    valueIndex,
+    double value);
 
   /**
    * @brief Reads vector data values given as block.


### PR DESCRIPTION
This PR fixes the constness of the SolverInterface including the SolverInterfaceImpl, and RequestManager.

This change boils down to marking pointers of `[in]` parameters `const`.