### PR TITLE
Refactor SolverInterfaceImpl

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -8,6 +8,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include "RTree.hpp"
+#include <array>
+#include <algorithm>
 
 namespace precice {
 namespace mesh {
@@ -123,6 +125,26 @@ Edge& Mesh:: createEdge
   newEdge->addParent(*this);
   _content.add(newEdge);
   return *newEdge;
+}
+
+Edge& Mesh::createUniqueEdge
+(
+    Vertex& vertexOne,
+    Vertex& vertexTwo
+)
+{ 
+    const std::array<int, 2> vids{vertexOne.getID(), vertexTwo.getID()};
+    const auto eend = edges().end();
+    auto pos = std::find_if(edges().begin(), eend,
+            [&vids](const Edge& e) -> bool {
+                const std::array<int, 2> eids{e.vertex(0).getID(), e.vertex(1).getID()};
+                return std::is_permutation(vids.begin(), vids.end(), eids.begin());
+            });
+    if (pos != eend) {
+        return *pos;
+    } else {
+        return createEdge(vertexOne, vertexTwo);
+    }
 }
 
 Triangle& Mesh:: createTriangle
@@ -265,12 +287,12 @@ int Mesh:: getID() const
 
 bool Mesh::isValidVertexID(int vertexID) const
 {
-    return (0 <= vertexID) && ( vertexID < vertices().size());
+    return (0 <= vertexID) && (static_cast<size_t>(vertexID) < vertices().size());
 }
 
 bool Mesh::isValidEdgeID(int edgeID) const
 {
-    return (0 <= edgeID) && ( edgeID < edges().size());
+    return (0 <= edgeID) && (static_cast<size_t>(edgeID) < edges().size());
 }
 
 void Mesh:: allocateDataValues()

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -263,6 +263,16 @@ int Mesh:: getID() const
   return iter->second;
 }
 
+bool Mesh::isValidVertexID(int vertexID) const
+{
+    return (0 <= vertexID) && ( vertexID < vertices().size());
+}
+
+bool Mesh::isValidEdgeID(int edgeID) const
+{
+    return (0 <= edgeID) && ( edgeID < edges().size());
+}
+
 void Mesh:: allocateDataValues()
 {
   TRACE(_content.vertices().size());

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -206,6 +206,12 @@ public:
   /// Returns the base ID of the mesh.
   int getID() const;
 
+  /// Returns true if the given vertexID is valid
+  bool isValidVertexID(int vertexID) const;
+
+  /// Returns true if the given edgeID is valid
+  bool isValidEdgeID(int edgeID) const;
+
   /// Allocates memory for the vertex data values.
   void allocateDataValues();
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -135,6 +135,16 @@ public:
     Vertex& vertexTwo );
 
   /**
+   * @brief Creates and initializes an Edge object or returns an already existing one.
+   *
+   * @param[in] vertexOne Reference to first Vertex defining the Edge.
+   * @param[in] vertexTwo Reference to second Vertex defining the Edge.
+   */
+  Edge& createUniqueEdge (
+    Vertex& vertexOne,
+    Vertex& vertexTwo );
+
+  /**
    * @brief Creates and initializes a Triangle object.
    *
    * @param[in] edgeOne Reference to first edge defining the Triangle.

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -500,5 +500,34 @@ BOOST_AUTO_TEST_CASE(MeshWKTPrint)
     BOOST_TEST(reference == sstream.str());
 }
 
+BOOST_AUTO_TEST_CASE(CreateUniqueEdge)
+{
+    int dim = 3;
+    Mesh mesh1 ( "Mesh1", dim, false );
+    auto& mesh = mesh1;
+    Eigen::VectorXd coords0(dim);
+    Eigen::VectorXd coords1(dim);
+    Eigen::VectorXd coords2(dim);
+    coords0 << 0.0, 0.0, 0.0;
+    coords1 << 1.0, 0.0, 0.0;
+    coords2 << 0.0, 0.0, 1.0;
+    Vertex& v0 = mesh.createVertex(coords0);
+    Vertex& v1 = mesh.createVertex(coords1);
+    Vertex& v2 = mesh.createVertex(coords2);
+
+    Edge& e01a = mesh.createEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
+    Edge& e01b = mesh.createEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
+    BOOST_TEST(mesh.edges().size() == 2);
+
+    Edge& e01c = mesh.createUniqueEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
+    BOOST_TEST(mesh.edges().size() == 2);
+    BOOST_TEST(e01a == e01c);
+
+    Edge& e12a = mesh.createUniqueEdge ( v1, v2 ); // LINESTRING (0 0 0, 1 0 0)
+    BOOST_TEST(mesh.edges().size() == 3);
+    Edge& e12b = mesh.createUniqueEdge ( v1, v2 ); // LINESTRING (0 0 0, 1 0 0)
+    BOOST_TEST(mesh.edges().size() == 3);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Mesh
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1130,14 +1130,7 @@ void SolverInterfaceImpl:: mapReadDataTo
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       assertion(mappingContext.mapping==context.mappingContext.mapping);
       mappingContext.mapping->map(inDataID, outDataID);
-#     ifndef NDEBUG
-      int max = context.toData->values().size();
-      std::ostringstream stream;
-      for (int i=0; (i < max) && (i < 10); i++){
-        stream << context.toData->values()[i] << " ";
-      }
-      DEBUG("First mapped values = " << stream.str());
-#     endif
+      DEBUG("First mapped values = " << context.toData->values());
     }
   }
   mappingContext.hasMappedData = true;
@@ -1594,14 +1587,7 @@ void SolverInterfaceImpl:: mapWrittenData()
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       DEBUG("Map from dataID " << inDataID << " to dataID: " << outDataID);
       context.mappingContext.mapping->map(inDataID, outDataID);
-#     ifndef NDEBUG
-      int max = context.toData->values().size();
-      std::ostringstream stream;
-      for (int i=0; (i < max) && (i < 10); i++){
-        stream << context.toData->values()[i] << " ";
-      }
-      DEBUG("First mapped values = " << stream.str() );
-#     endif
+      DEBUG("First mapped values = " << context.toData->values());
     }
   }
 
@@ -1651,14 +1637,7 @@ void SolverInterfaceImpl:: mapReadData()
       DEBUG("Map read data \"" << context.fromData->getName()
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       context.mappingContext.mapping->map(inDataID, outDataID);
-#     ifndef NDEBUG
-      int max = context.toData->values().size();
-      std::ostringstream stream;
-      for (int i=0; (i < max) && (i < 10); i++){
-        stream << context.toData->values()[i] << " ";
-      }
-      DEBUG("First mapped values = " << stream.str());
-#     endif
+      DEBUG("First mapped values = " << context.toData->values());
     }
   }
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -838,62 +838,9 @@ void SolverInterfaceImpl:: setMeshTriangleWithEdges
     vertices[1] = &mesh->vertices()[secondVertexID];
     vertices[2] = &mesh->vertices()[thirdVertexID];
     mesh::Edge* edges[3];
-    edges[0] = nullptr;
-    edges[1] = nullptr;
-    edges[2] = nullptr;
-    for (mesh::Edge& edge : mesh->edges()) {
-      // Check edge 0
-      bool foundEdge = edge.vertex(0).getID() == vertices[0]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[1]->getID();
-      if (foundEdge){
-        edges[0] = &edge;
-        continue;
-      }
-      foundEdge = edge.vertex(0).getID() == vertices[1]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[0]->getID();
-      if (foundEdge){
-        edges[0] = &edge;
-        continue;
-      }
-
-      // Check edge 1
-      foundEdge = edge.vertex(0).getID() == vertices[1]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[2]->getID();
-      if (foundEdge){
-        edges[1] = &edge;
-        continue;
-      }
-      foundEdge = edge.vertex(0).getID() == vertices[2]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[1]->getID();
-      if (foundEdge){
-        edges[1] = &edge;
-        continue;
-      }
-
-      // Check edge 2
-      foundEdge = edge.vertex(0).getID() == vertices[2]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[0]->getID();
-      if (foundEdge){
-        edges[2] = &edge;
-        continue;
-      }
-      foundEdge = edge.vertex(0).getID() == vertices[0]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[2]->getID();
-      if (foundEdge){
-        edges[2] = &edge;
-        continue;
-      }
-    }
-    // Create missing edges
-    if (edges[0] == nullptr){
-      edges[0] = & mesh->createEdge(*vertices[0], *vertices[1]);
-    }
-    if (edges[1] == nullptr){
-      edges[1] = & mesh->createEdge(*vertices[1], *vertices[2]);
-    }
-    if (edges[2] == nullptr){
-      edges[2] = & mesh->createEdge(*vertices[2], *vertices[0]);
-    }
+    edges[0] = & mesh->createUniqueEdge(*vertices[0], *vertices[1]);
+    edges[1] = & mesh->createUniqueEdge(*vertices[1], *vertices[2]);
+    edges[2] = & mesh->createUniqueEdge(*vertices[2], *vertices[0]);
 
     mesh->createTriangle(*edges[0], *edges[1], *edges[2]);
   }
@@ -960,80 +907,10 @@ void SolverInterfaceImpl:: setMeshQuadWithEdges
     vertices[2] = &mesh->vertices()[thirdVertexID];
     vertices[3] = &mesh->vertices()[fourthVertexID];
     mesh::Edge* edges[4];
-    edges[0] = nullptr;
-    edges[1] = nullptr;
-    edges[2] = nullptr;
-    edges[3] = nullptr;
-    for (mesh::Edge& edge : mesh->edges()) {
-      // Check edge 0
-      bool foundEdge = edge.vertex(0).getID() == vertices[0]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[1]->getID();
-      if ( foundEdge ){
-        edges[0] = &edge;
-        continue;
-      }
-      foundEdge = edge.vertex(0).getID() == vertices[1]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[0]->getID();
-      if (foundEdge){
-        edges[0] = &edge;
-        continue;
-      }
-
-      // Check edge 1
-      foundEdge = edge.vertex(0).getID() == vertices[1]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[2]->getID();
-      if ( foundEdge ){
-        edges[1] = &edge;
-        continue;
-      }
-      foundEdge = edge.vertex(0).getID() == vertices[2]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[1]->getID();
-      if ( foundEdge ){
-        edges[1] = &edge;
-        continue;
-      }
-
-      // Check edge 2
-      foundEdge = edge.vertex(0).getID() == vertices[2]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[3]->getID();
-      if ( foundEdge ){
-        edges[2] = &edge;
-        continue;
-      }
-      foundEdge = edge.vertex(0).getID() == vertices[3]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[2]->getID();
-      if ( foundEdge ){
-        edges[2] = &edge;
-        continue;
-      }
-
-      // Check edge 3
-      foundEdge = edge.vertex(0).getID() == vertices[3]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[0]->getID();
-      if ( foundEdge ){
-        edges[3] = &edge;
-        continue;
-      }
-      foundEdge = edge.vertex(0).getID() == vertices[0]->getID();
-      foundEdge &= edge.vertex(1).getID() == vertices[3]->getID();
-      if ( foundEdge ){
-        edges[3] = &edge;
-        continue;
-      }
-    }
-    // Create missing edges
-    if (edges[0] == nullptr){
-      edges[0] = & mesh->createEdge(*vertices[0], *vertices[1]);
-    }
-    if (edges[1] == nullptr){
-      edges[1] = & mesh->createEdge(*vertices[1], *vertices[2]);
-    }
-    if (edges[2] == nullptr){
-      edges[2] = & mesh->createEdge(*vertices[2], *vertices[3]);
-    }
-    if (edges[3] == nullptr){
-      edges[3] = & mesh->createEdge(*vertices[3], *vertices[0]);
-    }
+    edges[0] = & mesh->createUniqueEdge(*vertices[0], *vertices[1]);
+    edges[1] = & mesh->createUniqueEdge(*vertices[1], *vertices[2]);
+    edges[2] = & mesh->createUniqueEdge(*vertices[2], *vertices[3]);
+    edges[3] = & mesh->createUniqueEdge(*vertices[3], *vertices[0]);
 
     mesh->createQuad(*edges[0], *edges[1], *edges[2], *edges[3]);
   }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -26,6 +26,7 @@
 #include "utils/Parallel.hpp"
 #include "utils/Petsc.hpp"
 #include "utils/MasterSlave.hpp"
+#include "utils/EigenHelperFunctions.hpp"
 #include "mapping/Mapping.hpp"
 #include <Eigen/Core>
 #include "partition/ReceivedPartition.hpp"
@@ -982,7 +983,7 @@ void SolverInterfaceImpl:: mapReadDataTo
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       assertion(mappingContext.mapping==context.mappingContext.mapping);
       mappingContext.mapping->map(inDataID, outDataID);
-      DEBUG("First mapped values = " << context.toData->values());
+      DEBUG("First mapped values = " << utils::firstN(context.toData->values(), 10));
     }
   }
   mappingContext.hasMappedData = true;
@@ -1439,7 +1440,7 @@ void SolverInterfaceImpl:: mapWrittenData()
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       DEBUG("Map from dataID " << inDataID << " to dataID: " << outDataID);
       context.mappingContext.mapping->map(inDataID, outDataID);
-      DEBUG("First mapped values = " << context.toData->values());
+      DEBUG("First mapped values = " << utils::firstN(context.toData->values(), 10));
     }
   }
 
@@ -1489,7 +1490,7 @@ void SolverInterfaceImpl:: mapReadData()
       DEBUG("Map read data \"" << context.fromData->getName()
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       context.mappingContext.mapping->map(inDataID, outDataID);
-      DEBUG("First mapped values = " << context.toData->values());
+      DEBUG("First mapped values = " << utils::firstN(context.toData->values(), 10));
     }
   }
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1090,7 +1090,6 @@ void SolverInterfaceImpl:: mapWriteDataFrom
       int inDataID = context.fromData->getID();
       int outDataID = context.toData->getID();
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-      //assign(context.toData->values()) = 0.0;
       DEBUG("Map data \"" << context.fromData->getName()
                    << "\" from mesh \"" << context.mesh->getName() << "\"");
       assertion(mappingContext.mapping==context.mappingContext.mapping);
@@ -1127,7 +1126,6 @@ void SolverInterfaceImpl:: mapReadDataTo
       int inDataID = context.fromData->getID();
       int outDataID = context.toData->getID();
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-      //assign(context.toData->values()) = 0.0;
       DEBUG("Map data \"" << context.fromData->getName()
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       assertion(mappingContext.mapping==context.mappingContext.mapping);
@@ -1600,7 +1598,6 @@ void SolverInterfaceImpl:: mapWrittenData()
       DEBUG("Map data \"" << context.fromData->getName()
                    << "\" from mesh \"" << context.mesh->getName() << "\"");
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-      //assign(context.toData->values()) = 0.0;
       DEBUG("Map from dataID " << inDataID << " to dataID: " << outDataID);
       context.mappingContext.mapping->map(inDataID, outDataID);
 #     ifndef NDEBUG
@@ -1657,7 +1654,6 @@ void SolverInterfaceImpl:: mapReadData()
       int inDataID = context.fromData->getID();
       int outDataID = context.toData->getID();
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-      //assign(context.toData->values()) = 0.0;
       DEBUG("Map read data \"" << context.fromData->getName()
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       context.mappingContext.mapping->map(inDataID, outDataID);
@@ -1740,10 +1736,8 @@ void SolverInterfaceImpl:: resetWrittenData()
   TRACE();
   for (DataContext& context : _accessor->writeDataContexts()) {
     context.fromData->values() = Eigen::VectorXd::Zero(context.fromData->values().size());
-    //assign(context.fromData->values()) = 0.0;
     if (context.toData != context.fromData){
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-      //assign(context.toData->values()) = 0.0;
     }
   }
 }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -772,12 +772,8 @@ int SolverInterfaceImpl:: setMeshEdge
     if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
       DEBUG("Full mesh required.");
       mesh::PtrMesh& mesh = context.mesh;
-      assertion(firstVertexID >= 0, firstVertexID);
-      assertion(secondVertexID >= 0, secondVertexID);
-      assertion(firstVertexID < (int)mesh->vertices().size(),
-                 firstVertexID, mesh->vertices().size());
-      assertion(secondVertexID < (int)mesh->vertices().size(),
-                 secondVertexID, mesh->vertices().size());
+      CHECK(mesh->isValidVertexID(firstVertexID),  " Given VertexID is invalid!");
+      CHECK(mesh->isValidVertexID(secondVertexID), " Given VertexID is invalid!");
       mesh::Vertex& v0 = mesh->vertices()[firstVertexID];
       mesh::Vertex& v1 = mesh->vertices()[secondVertexID];
       return mesh->createEdge(v0, v1).getID ();
@@ -803,12 +799,9 @@ void SolverInterfaceImpl:: setMeshTriangle
     MeshContext& context = _accessor->meshContext(meshID);
     if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
       mesh::PtrMesh& mesh = context.mesh;
-      assertion ( firstEdgeID >= 0 );
-      assertion ( secondEdgeID >= 0 );
-      assertion ( thirdEdgeID >= 0 );
-      assertion ( (int)mesh->edges().size() > firstEdgeID );
-      assertion ( (int)mesh->edges().size() > secondEdgeID );
-      assertion ( (int)mesh->edges().size() > thirdEdgeID );
+      CHECK(mesh->isValidEdgeID(firstEdgeID),  " Given EdgeID is invalid!");
+      CHECK(mesh->isValidEdgeID(secondEdgeID), " Given EdgeID is invalid!");
+      CHECK(mesh->isValidEdgeID(thirdEdgeID),  " Given EdgeID is invalid!");
       mesh::Edge& e0 = mesh->edges()[firstEdgeID];
       mesh::Edge& e1 = mesh->edges()[secondEdgeID];
       mesh::Edge& e2 = mesh->edges()[thirdEdgeID];
@@ -837,15 +830,9 @@ void SolverInterfaceImpl:: setMeshTriangleWithEdges
   MeshContext& context = _accessor->meshContext(meshID);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
     mesh::PtrMesh& mesh = context.mesh;
-    assertion(firstVertexID >= 0, firstVertexID);
-    assertion(secondVertexID >= 0, secondVertexID);
-    assertion(thirdVertexID >= 0, thirdVertexID);
-    assertion((int)mesh->vertices().size() > firstVertexID,
-                mesh->vertices().size(), firstVertexID);
-    assertion((int)mesh->vertices().size() > secondVertexID,
-                mesh->vertices().size(), secondVertexID);
-    assertion((int)mesh->vertices().size() > thirdVertexID,
-                 mesh->vertices().size(), thirdVertexID);
+    CHECK(mesh->isValidVertexID(firstVertexID),  " Given VertexID is invalid!");
+    CHECK(mesh->isValidVertexID(secondVertexID), " Given VertexID is invalid!");
+    CHECK(mesh->isValidVertexID(thirdVertexID),  " Given VertexID is invalid!");
     mesh::Vertex* vertices[3];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];
@@ -931,14 +918,10 @@ void SolverInterfaceImpl:: setMeshQuad
     MeshContext& context = _accessor->meshContext(meshID);
     if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
       mesh::PtrMesh& mesh = context.mesh;
-      assertion(firstEdgeID >= 0);
-      assertion(secondEdgeID >= 0);
-      assertion(thirdEdgeID >= 0);
-      assertion(fourthEdgeID >= 0);
-      assertion((int)mesh->edges().size() > firstEdgeID);
-      assertion((int)mesh->edges().size() > secondEdgeID);
-      assertion((int)mesh->edges().size() > thirdEdgeID);
-      assertion((int)mesh->quads().size() > fourthEdgeID);
+      CHECK(mesh->isValidEdgeID(firstEdgeID),  " Given EdgeID is invalid!");
+      CHECK(mesh->isValidEdgeID(secondEdgeID), " Given EdgeID is invalid!");
+      CHECK(mesh->isValidEdgeID(thirdEdgeID),  " Given EdgeID is invalid!");
+      CHECK(mesh->isValidEdgeID(fourthEdgeID), " Given EdgeID is invalid!");
       mesh::Edge& e0 = mesh->edges()[firstEdgeID];
       mesh::Edge& e1 = mesh->edges()[secondEdgeID];
       mesh::Edge& e2 = mesh->edges()[thirdEdgeID];
@@ -967,18 +950,10 @@ void SolverInterfaceImpl:: setMeshQuadWithEdges
   MeshContext& context = _accessor->meshContext(meshID);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
     mesh::PtrMesh& mesh = context.mesh;
-    assertion(firstVertexID >= 0, firstVertexID);
-    assertion(secondVertexID >= 0, secondVertexID);
-    assertion(thirdVertexID >= 0, thirdVertexID);
-    assertion(fourthVertexID >= 0, fourthVertexID);
-    assertion((int)mesh->vertices().size() > firstVertexID,
-                 mesh->vertices().size(), firstVertexID);
-    assertion((int)mesh->vertices().size() > secondVertexID,
-                 mesh->vertices().size(), secondVertexID);
-    assertion((int)mesh->vertices().size() > thirdVertexID,
-                 mesh->vertices().size(), thirdVertexID);
-    assertion((int)mesh->vertices().size() > fourthVertexID,
-                 mesh->vertices().size(), fourthVertexID);
+    CHECK(mesh->isValidVertexID(firstVertexID),  " Given VertexID is invalid!");
+    CHECK(mesh->isValidVertexID(secondVertexID), " Given VertexID is invalid!");
+    CHECK(mesh->isValidVertexID(thirdVertexID),  " Given VertexID is invalid!");
+    CHECK(mesh->isValidVertexID(fourthVertexID), " Given VertexID is invalid!");
     mesh::Vertex* vertices[4];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1186,10 +1186,7 @@ void SolverInterfaceImpl:: writeVectorData
 {
   TRACE(fromDataID, valueIndex );
   PRECICE_VALIDATE_DATA_ID(fromDataID);
-# ifndef NDEBUG
-  if (_dimensions == 2) DEBUG("value = " << Eigen::Map<const Eigen::Vector2d>(value));
-  if (_dimensions == 3) DEBUG("value = " << Eigen::Map<const Eigen::Vector3d>(value));
-# endif
+  DEBUG("value = " << Eigen::Map<const Eigen::VectorXd>(value, _dimensions));
   CHECK(valueIndex >= -1, "Invalid value index (" << valueIndex << ") when writing vector data!" );
   if (_clientMode){
     _requestManager->requestWriteVectorData(fromDataID, valueIndex, value);
@@ -1326,10 +1323,7 @@ void SolverInterfaceImpl:: readVectorData
     }
 
   }
-# ifndef NDEBUG
-  if (_dimensions == 2) DEBUG("read value = " << Eigen::Map<const Eigen::Vector2d>(value));
-  if (_dimensions == 3) DEBUG("read value = " << Eigen::Map<const Eigen::Vector3d>(value));
-# endif
+  DEBUG("read value = " << Eigen::Map<const Eigen::VectorXd>(value, _dimensions));
 }
 
 void SolverInterfaceImpl:: readBlockScalarData

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -67,6 +67,7 @@ target_sources(testprecice
     src/testing/main.cpp
     src/testing/tests/ExampleTests.cpp
     src/utils/tests/DimensionsTest.cpp
+    src/utils/tests/EigenHelperFunctionsTest.cpp
     src/utils/tests/ManageUniqueIDsTest.cpp
     src/utils/tests/MultiLockTest.cpp
     src/utils/tests/ParallelTest.cpp

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -47,4 +47,15 @@ void append(
   }
 }
 
+/** Maps the first at most n values of an Eigen object to a row vector
+ *
+ * @param[in] val the Eigen object to map from
+ * @returns the mapped const row vector
+ */
+template<typename Derived>
+auto firstN(const Eigen::PlainObjectBase<Derived>& val, unsigned n) -> const Eigen::Map<const Eigen::Matrix<typename Derived::Scalar, 1, Eigen::Dynamic>> 
+{
+    return {val.data(), std::min<Eigen::Index>(n,val.size())};
+}
+
 }}

--- a/src/utils/tests/EigenHelperFunctionsTest.cpp
+++ b/src/utils/tests/EigenHelperFunctionsTest.cpp
@@ -1,0 +1,17 @@
+#include "testing/Testing.hpp"
+#include "utils/EigenHelperFunctions.hpp"
+
+using namespace precice::utils;
+
+BOOST_AUTO_TEST_SUITE(UtilsTests)
+
+BOOST_AUTO_TEST_CASE(FirstN)
+{
+    Eigen::VectorXd a(7);
+    a << 1, 2, 3, 4, 5, 6, 7;
+    Eigen::RowVectorXd b(3);
+    b << 1, 2, 3;
+    BOOST_TEST(firstN(a, 3) == b);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Applying this PR will:
* clean up the use Eigen in the SolverInterfaceImpl (fixes #356)
* Use `Eigen::Map<Eigen::MatrixXd>` to interact with raw buffers from the interface.
* Merge unnecessary repetitions of debug statements
* Refactor the validation of Vertex and Edge IDs into the `Mesh` class as `isValidVertexID()` / `isValidEdgeID()`.
* Refactor check and create for edges into the `Mesh` class as `createUniqueEdge()`
* Removes a few leftover comments

@uekerman please have a look at the mesh interface extension and accept if ok.