### PR TITLE
Refactor Mesh::computeState

### DIFF
--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -22,6 +22,19 @@ int Edge:: getID () const
   return _id;
 }
 
+const Eigen::VectorXd Edge::computeNormal(bool flip)
+{
+    // Compute normal
+    Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
+    Eigen::VectorXd normal = Eigen::Vector2d(-edgeVector[1], edgeVector[0]);
+    if (not flip){
+        normal *= -1.0; // Invert direction if counterclockwise
+    }
+    _normal = normal.normalized();   // Scale normal vector to length 1
+
+    return normal * getEnclosingRadius() * 2.0; // Weight by length
+}
+
 const Eigen::VectorXd Edge::getCenter () const
 {
   return 0.5 * (_vertices[0]->getCoords() + _vertices[1]->getCoords());

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -48,6 +48,9 @@ public:
   template<typename VECTOR_T>
   void setNormal ( const VECTOR_T& normal );
 
+  /// Computes and sets the normal of the edge, returns the area-weighted normal.
+  const Eigen::VectorXd computeNormal(bool flip = false);
+
   /// Returns the (among edges) unique ID of the edge.
   int getID () const;
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -298,21 +298,12 @@ void Mesh:: computeState()
   // Compute (in 2D) edge normals
   for (Edge& edge : _content.edges()) {
     if (_dimensions == 2 && computeNormals) {
-      // Compute normal
-      Eigen::VectorXd edgeVector = edge.vertex(1).getCoords() - edge.vertex(0).getCoords();
-      Eigen::VectorXd normal = Eigen::Vector2d(-edgeVector[1], edgeVector[0]);
-      if (not _flipNormals){
-        normal *= -1.0; // Invert direction if counterclockwise
-      }
-      assertion(math::greater(normal.norm(), 0.0));
-      normal.normalize();   // Scale normal vector to length 1
-      edge.setNormal(normal);
+      Eigen::VectorXd weightednormal = edge.computeNormal(_flipNormals);
 
       // Accumulate normal in associated vertices
-      normal *= edge.getEnclosingRadius() * 2.0; // Weight by length
       for (int i=0; i < 2; i++){
         Eigen::VectorXd vertexNormal = edge.vertex(i).getNormal();
-        vertexNormal += normal;
+        vertexNormal += weightednormal;
         edge.vertex(i).setNormal(vertexNormal);
       }
     }

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -280,87 +280,75 @@ void Mesh:: computeNormals()
 {
   TRACE(_name);
   // Compute normals only if faces to derive normal information are available
-  bool computeNormals = true;
   size_t size2DFaces = _content.edges().size();
   size_t size3DFaces = _content.triangles().size() + _content.quads().size();
-  if (_dimensions == 2){
-    if (size2DFaces == 0){
-      computeNormals = false;
-    }
+  if (_dimensions == 2 && size2DFaces == 0){
+      return;
   }
-  else if (size3DFaces == 0){
-    assertion(_dimensions == 3, _dimensions);
-    computeNormals = false;
+  if (_dimensions == 3 && size3DFaces == 0){
+    return;
   }
 
   // Compute (in 2D) edge normals
-  for (Edge& edge : _content.edges()) {
-    if (_dimensions == 2 && computeNormals) {
-      Eigen::VectorXd weightednormal = edge.computeNormal(_flipNormals);
+  if (_dimensions == 2) {
+      for (Edge& edge : _content.edges()) {
+          Eigen::VectorXd weightednormal = edge.computeNormal(_flipNormals);
 
-      // Accumulate normal in associated vertices
-      for (int i=0; i < 2; i++){
-        Eigen::VectorXd vertexNormal = edge.vertex(i).getNormal();
-        vertexNormal += weightednormal;
-        edge.vertex(i).setNormal(vertexNormal);
+          // Accumulate normal in associated vertices
+          for (int i=0; i < 2; i++){
+              Eigen::VectorXd vertexNormal = edge.vertex(i).getNormal();
+              vertexNormal += weightednormal;
+              edge.vertex(i).setNormal(vertexNormal);
+          }
       }
-    }
   }
 
   if (_dimensions == 3){
-    // Compute normals
-    for (Triangle& triangle : _content.triangles()) {
-      assertion(triangle.vertex(0) != triangle.vertex(1),
-                triangle.vertex(0), triangle.getID());
-      assertion(triangle.vertex(1) != triangle.vertex(2),
-                triangle.vertex(1), triangle.getID());
-      assertion(triangle.vertex(2) != triangle.vertex(0),
-                triangle.vertex(2), triangle.getID());
-
       // Compute normals
-      if (computeNormals){
-        Eigen::VectorXd weightednormal = triangle.computeNormal(_flipNormals);
+      for (Triangle& triangle : _content.triangles()) {
+          assertion(triangle.vertex(0) != triangle.vertex(1),
+                  triangle.vertex(0), triangle.getID());
+          assertion(triangle.vertex(1) != triangle.vertex(2),
+                  triangle.vertex(1), triangle.getID());
+          assertion(triangle.vertex(2) != triangle.vertex(0),
+                  triangle.vertex(2), triangle.getID());
 
-        // Accumulate area-weighted normal in associated vertices and edges
-        for (int i=0; i < 3; i++){
-          triangle.edge(i).setNormal(triangle.edge(i).getNormal() + weightednormal);
-          triangle.vertex(i).setNormal(triangle.vertex(i).getNormal() + weightednormal);
-        }
+          // Compute normals
+          Eigen::VectorXd weightednormal = triangle.computeNormal(_flipNormals);
+
+          // Accumulate area-weighted normal in associated vertices and edges
+          for (int i=0; i < 3; i++){
+              triangle.edge(i).setNormal(triangle.edge(i).getNormal() + weightednormal);
+              triangle.vertex(i).setNormal(triangle.vertex(i).getNormal() + weightednormal);
+          }
       }
-    }
 
-    // Compute quad normals
-    for (Quad& quad : _content.quads()) {
-      assertion(quad.vertex(0) != quad.vertex(1), quad.vertex(0).getCoords(), quad.getID());
-      assertion(quad.vertex(1) != quad.vertex(2), quad.vertex(1).getCoords(), quad.getID());
-      assertion(quad.vertex(2) != quad.vertex(3), quad.vertex(2).getCoords(), quad.getID());
-      assertion(quad.vertex(3) != quad.vertex(0), quad.vertex(3).getCoords(), quad.getID());
+      // Compute quad normals
+      for (Quad& quad : _content.quads()) {
+          assertion(quad.vertex(0) != quad.vertex(1), quad.vertex(0).getCoords(), quad.getID());
+          assertion(quad.vertex(1) != quad.vertex(2), quad.vertex(1).getCoords(), quad.getID());
+          assertion(quad.vertex(2) != quad.vertex(3), quad.vertex(2).getCoords(), quad.getID());
+          assertion(quad.vertex(3) != quad.vertex(0), quad.vertex(3).getCoords(), quad.getID());
 
-      // Compute normals (assuming all vertices are on same plane)
-      if (computeNormals) {
-        Eigen::VectorXd weightednormal = quad.computeNormal(_flipNormals);
-        // Accumulate area-weighted normal in associated vertices and edges
-        for (int i=0; i < 4; i++){
-          quad.edge(i).setNormal(quad.edge(i).getNormal() + weightednormal);
-          quad.vertex(i).setNormal(quad.vertex(i).getNormal() + weightednormal);
-        }
+          // Compute normals (assuming all vertices are on same plane)
+          Eigen::VectorXd weightednormal = quad.computeNormal(_flipNormals);
+          // Accumulate area-weighted normal in associated vertices and edges
+          for (int i=0; i < 4; i++){
+              quad.edge(i).setNormal(quad.edge(i).getNormal() + weightednormal);
+              quad.vertex(i).setNormal(quad.vertex(i).getNormal() + weightednormal);
+          }
       }
-    }
 
-    // Normalize edge normals (only done in 3D)
-    if (computeNormals){
+      // Normalize edge normals (only done in 3D)
       for (Edge& edge : _content.edges()) {
-        // there can be cases when an edge has no adjacent triangle though triangles exist in general (e.g. after filtering)
-        edge.setNormal(edge.getNormal().normalized());
+          // there can be cases when an edge has no adjacent triangle though triangles exist in general (e.g. after filtering)
+          edge.setNormal(edge.getNormal().normalized());
       }
-    }
   }
 
   for (Vertex& vertex : _content.vertices()) {
-    if (computeNormals) {
       // there can be cases when a vertex has no edge though edges exist in general (e.g. after filtering)
       vertex.setNormal(vertex.getNormal().normalized());
-    }
   }
 }
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -355,18 +355,19 @@ void Mesh:: computeNormals()
 void Mesh:: computeBoundingBox()
 {
   TRACE(_name);
-  _boundingBox = BoundingBox (_dimensions,
+  BoundingBox boundingBox(_dimensions,
                               std::make_pair(std::numeric_limits<double>::max(),
                                              std::numeric_limits<double>::lowest()));
-  for (Vertex& vertex : _content.vertices()) {
+  for (const Vertex& vertex : _content.vertices()) {
     for (int d = 0; d < _dimensions; d++) {
-      _boundingBox[d].first  = std::min(vertex.getCoords()[d], _boundingBox[d].first);
-      _boundingBox[d].second = std::max(vertex.getCoords()[d], _boundingBox[d].second);
+      boundingBox[d].first  = std::min(vertex.getCoords()[d], boundingBox[d].first);
+      boundingBox[d].second = std::max(vertex.getCoords()[d], boundingBox[d].second);
     }
   }
   for (int d = 0; d < _dimensions; d++) {
-    DEBUG("BoundingBox, dim: " << d << ", first: " << _boundingBox[d].first << ", second: " << _boundingBox[d].second);
+    DEBUG("BoundingBox, dim: " << d << ", first: " << boundingBox[d].first << ", second: " << boundingBox[d].second);
   }
+  _boundingBox = std::move(boundingBox);
 }
 
 void Mesh:: computeState()

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -321,22 +321,13 @@ void Mesh:: computeState()
 
       // Compute normals
       if (computeNormals){
-        Eigen::Vector3d vectorA = triangle.edge(1).getCenter() - triangle.edge(0).getCenter(); // edge() is faster than vertex()
-        Eigen::Vector3d vectorB = triangle.edge(2).getCenter() - triangle.edge(0).getCenter();
-        // Compute cross-product of vector A and vector B
-        auto normal = vectorA.cross(vectorB);
-        if ( _flipNormals ){
-          normal *= -1.0; // Invert direction if counterclockwise
-        }
+        Eigen::VectorXd weightednormal = triangle.computeNormal(_flipNormals);
 
         // Accumulate area-weighted normal in associated vertices and edges
         for (int i=0; i < 3; i++){
-          triangle.edge(i).setNormal(triangle.edge(i).getNormal() + normal);
-          triangle.vertex(i).setNormal(triangle.vertex(i).getNormal() + normal);
+          triangle.edge(i).setNormal(triangle.edge(i).getNormal() + weightednormal);
+          triangle.vertex(i).setNormal(triangle.vertex(i).getNormal() + weightednormal);
         }
-
-        // Normalize triangle normal
-        triangle.setNormal(normal.normalized());
       }
     }
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -340,38 +340,12 @@ void Mesh:: computeState()
 
       // Compute normals (assuming all vertices are on same plane)
       if (computeNormals) {
-        // Two triangles are thought by splitting the quad from vertex 0 to 2.
-        // The cross prodcut of the outer edges of the triangles is used to compute
-        // the normal direction and area of the triangles. The direction must be
-        // the same, while the areas differ in general. The normals are added up
-        // and divided by 2 to get the area of the overall quad, since the length
-        // does correspond to the parallelogram spanned by the vectors of the
-        // cross product, which is twice the area of the corresponding triangles.
-        Eigen::Vector3d vectorA = quad.vertex(2).getCoords() - quad.vertex(1).getCoords();
-        Eigen::Vector3d vectorB = quad.vertex(0).getCoords() - quad.vertex(1).getCoords();
-        // Compute cross-product of vector A and vector B
-        auto normal = vectorA.cross(vectorB);
-        
-        vectorA = quad.vertex(0).getCoords() - quad.vertex(3).getCoords();
-        vectorB = quad.vertex(2).getCoords() - quad.vertex(3).getCoords();
-        auto normalSecondPart = vectorA.cross(vectorB);
-        
-        assertion(math::equals(normal.normalized(), normalSecondPart.normalized()),
-                  normal, normalSecondPart);
-        normal += normalSecondPart;
-        normal *= 0.5;
-
-        if ( _flipNormals ){
-          normal *= -1.0; // Invert direction if counterclockwise
-        }
-
+        Eigen::VectorXd weightednormal = quad.computeNormal(_flipNormals);
         // Accumulate area-weighted normal in associated vertices and edges
         for (int i=0; i < 4; i++){
-          quad.edge(i).setNormal(quad.edge(i).getNormal() + normal);
-          quad.vertex(i).setNormal(quad.vertex(i).getNormal() + normal);
+          quad.edge(i).setNormal(quad.edge(i).getNormal() + weightednormal);
+          quad.vertex(i).setNormal(quad.vertex(i).getNormal() + weightednormal);
         }
-
-        quad.setNormal(normal.normalized());
       }
     }
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -276,11 +276,9 @@ void Mesh:: allocateDataValues()
   }
 }
 
-void Mesh:: computeState()
+void Mesh:: computeNormals()
 {
   TRACE(_name);
-  assertion(_dimensions==2 || _dimensions==3, _dimensions);
-
   // Compute normals only if faces to derive normal information are available
   bool computeNormals = true;
   size_t size2DFaces = _content.edges().size();
@@ -358,17 +356,21 @@ void Mesh:: computeState()
     }
   }
 
-  // Normalize vertex normals & compute bounding box
-  _boundingBox = BoundingBox (_dimensions,
-                              std::make_pair(std::numeric_limits<double>::max(),
-                                             std::numeric_limits<double>::lowest()));
-
   for (Vertex& vertex : _content.vertices()) {
     if (computeNormals) {
       // there can be cases when a vertex has no edge though edges exist in general (e.g. after filtering)
       vertex.setNormal(vertex.getNormal().normalized());
     }
-    
+  }
+}
+
+void Mesh:: computeBoundingBox()
+{
+  TRACE(_name);
+  _boundingBox = BoundingBox (_dimensions,
+                              std::make_pair(std::numeric_limits<double>::max(),
+                                             std::numeric_limits<double>::lowest()));
+  for (Vertex& vertex : _content.vertices()) {
     for (int d = 0; d < _dimensions; d++) {
       _boundingBox[d].first  = std::min(vertex.getCoords()[d], _boundingBox[d].first);
       _boundingBox[d].second = std::max(vertex.getCoords()[d], _boundingBox[d].second);
@@ -377,6 +379,15 @@ void Mesh:: computeState()
   for (int d = 0; d < _dimensions; d++) {
     DEBUG("BoundingBox, dim: " << d << ", first: " << _boundingBox[d].first << ", second: " << _boundingBox[d].second);
   }
+}
+
+void Mesh:: computeState()
+{
+  TRACE(_name);
+  assertion(_dimensions==2 || _dimensions==3, _dimensions);
+
+  computeNormals();
+  computeBoundingBox();
 }
 
     

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -282,6 +282,12 @@ public:
 
 private:
 
+  /// Computes the normals for all primitives.
+  void computeNormals();
+
+  /// Computes the boundingBox for the vertices.
+  void computeBoundingBox();
+
   mutable logging::Logger _log{"mesh::Mesh"};
 
   /// Provides unique IDs for all geometry objects

--- a/src/mesh/Quad.cpp
+++ b/src/mesh/Quad.cpp
@@ -98,6 +98,36 @@ Quad::Quad(
   assertion((_vertexMap[2] == 0) || (_vertexMap[2] == 1), _vertexMap[3]);
 }
 
+const Eigen::VectorXd Quad::computeNormal(bool flip)
+{
+    // Two triangles are thought by splitting the quad from vertex 0 to 2.
+    // The cross prodcut of the outer edges of the triangles is used to compute
+    // the normal direction and area of the triangles. The direction must be
+    // the same, while the areas differ in general. The normals are added up
+    // and divided by 2 to get the area of the overall quad, since the length
+    // does correspond to the parallelogram spanned by the vectors of the
+    // cross product, which is twice the area of the corresponding triangles.
+    Eigen::Vector3d vectorA = vertex(2).getCoords() - vertex(1).getCoords();
+    Eigen::Vector3d vectorB = vertex(0).getCoords() - vertex(1).getCoords();
+    // Compute cross-product of vector A and vector B
+    auto normal = vectorA.cross(vectorB);
+
+    vectorA = vertex(0).getCoords() - vertex(3).getCoords();
+    vectorB = vertex(2).getCoords() - vertex(3).getCoords();
+    auto normalSecondPart = vectorA.cross(vectorB);
+
+    assertion(math::equals(normal.normalized(), normalSecondPart.normalized()),
+            normal, normalSecondPart);
+    normal += normalSecondPart;
+    normal *= 0.5;
+
+    if (flip){
+        normal *= -1.0; // Invert direction if counterclockwise
+    }
+    _normal = normal.normalized();
+    return normal;
+}
+
 int Quad::getDimensions() const
 {
   return _edges[0]->getDimensions();

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -95,6 +95,9 @@ public:
   template <typename VECTOR_T>
   void setNormal(const VECTOR_T &normal);
 
+  /// Computes and sets the normal of the triangle, returns the area-weighted normal.
+  const Eigen::VectorXd computeNormal(bool flip = false);
+
   /// Returns a among quads globally unique ID.
   int getID() const;
 

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -71,6 +71,19 @@ Triangle::Triangle(
   assertion((_vertexMap[2] == 0) || (_vertexMap[2] == 1), _vertexMap[0]);
 }
 
+const Eigen::VectorXd Triangle::computeNormal(bool flip)
+{
+    Eigen::Vector3d vectorA = edge(1).getCenter() - edge(0).getCenter();
+    Eigen::Vector3d vectorB = edge(2).getCenter() - edge(0).getCenter();
+    // Compute cross-product of vector A and vector B
+    auto normal = vectorA.cross(vectorB);
+    if (flip){
+      normal *= -1.0; // Invert direction if counterclockwise
+    }
+    _normal = normal.normalized();
+    return normal;
+}
+
 int Triangle::getDimensions() const
 {
   return _edges[0]->getDimensions();

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -108,6 +108,9 @@ public:
   template <typename VECTOR_T>
   void setNormal(const VECTOR_T &normal);
 
+  /// Computes and sets the normal of the triangle, returns the area-weighted normal.
+  const Eigen::VectorXd computeNormal(bool flip = false);
+
   /// Returns a among triangles globally unique ID.
   int getID() const;
 


### PR DESCRIPTION
This PR refactors `Mesh::computeState` by:
1) Moving the normal computation into the primitive classes e.g. `Edge::computeNormal()`.
2) Splitting `computeState` up into `computeNormals` and `computeBoundingBox`
3) Dramatically reducing the branching in `computeNormals`

Further Idea:
`computeState` asserts that the vertices of edges, triangles and quads are distinct. Shouldn't this be asserted directly in the `Mesh::createEdge` functions?