### PR TITLE
Silence PETSc warnings about unused arguments

### DIFF
--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -37,6 +37,7 @@ void Petsc::finalize()
   PetscBool petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
   if (petscIsInitialized and weInitialized) {
+    PetscOptionsSetValue(nullptr, "-options_left", "no"); 
     PetscFinalize();
   }
 #endif // not PRECICE_NO_PETSC


### PR DESCRIPTION
Tells PETSc not to complain about unused options passed via `argv`.