### PR TITLE
Add test_install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,13 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/CTestConfig.cmake)
 
 
 #
+# Add test_install
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/TestInstall.cmake)
+
+
+#
 # CPack
 #
 

--- a/cmake/TestInstall.cmake
+++ b/cmake/TestInstall.cmake
@@ -9,7 +9,7 @@ add_custom_target(test_install
   COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/TestInstall/CMakeFiles
   COMMAND ${CMAKE_COMMAND} -Dprecice_DIR=${CMAKE_INSTALL_PREFIX}/lib/cmake/precice ${preCICE_SOURCE_DIR}/tools/solverdummies/cpp
   COMMAND ${CMAKE_COMMAND} --build . --target all
-  COMMAND ${CMAKE_CTEST_COMMAND}
+  COMMAND ${CMAKE_CTEST_COMMAND} -V
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestInstall
   COMMENT "Testing the installation using the C++ solverdummy"
   VERBATIM

--- a/cmake/TestInstall.cmake
+++ b/cmake/TestInstall.cmake
@@ -1,0 +1,16 @@
+#
+# Call the test_install target to test the installation of the library
+#
+# This configures, builds and tests the c++ solverdummy in the TestInstall directory
+#
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestInstall)
+add_custom_target(test_install
+  COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/TestInstall/CMakeCache.txt
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/TestInstall/CMakeFiles
+  COMMAND ${CMAKE_COMMAND} -Dprecice_DIR=${CMAKE_INSTALL_PREFIX}/lib/cmake/precice ${preCICE_SOURCE_DIR}/tools/solverdummies/cpp
+  COMMAND ${CMAKE_COMMAND} --build . --target all
+  COMMAND ${CMAKE_CTEST_COMMAND}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestInstall
+  COMMENT "Testing the installation using the C++ solverdummy"
+  VERBATIM
+  )

--- a/tools/solverdummies/cpp/CMakeLists.txt
+++ b/tools/solverdummies/cpp/CMakeLists.txt
@@ -6,3 +6,13 @@ find_package(precice REQUIRED CONFIG)
 add_executable(solverdummy solverdummy.cpp)
 set_target_properties(solverdummy PROPERTIES CXX_STANDARD 11)
 target_link_libraries(solverdummy PRIVATE precice::precice)
+
+
+enable_testing()
+add_test(NAME precice.solverdummy
+  COMMAND ${CMAKE_COMMAND}
+  -DDUMMY_EXE=$<TARGET_FILE:solverdummy>
+  -DDUMMY_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/../precice-config.xml
+  -V
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/test.cmake
+  )

--- a/tools/solverdummies/cpp/README.md
+++ b/tools/solverdummies/cpp/README.md
@@ -9,6 +9,8 @@ You can use the provided `CMakeLists.txt` to build with CMake.
 1. run `cmake .` in this folder
 2. run `make`
 
+You can now run the test with `ctest -V`.
+
 ## Without CMake (deprecated)
 
 **If you used scons to build preCICE, continue here**

--- a/tools/solverdummies/cpp/test.cmake
+++ b/tools/solverdummies/cpp/test.cmake
@@ -1,0 +1,10 @@
+message("Running Two Solverdummies")
+message("Using executable: ${DUMMY_EXE}")
+message("Using config: ${DUMMY_CONFIG}")
+
+execute_process(
+  COMMAND ${DUMMY_EXE} ${DUMMY_CONFIG} SolverOne MeshOne
+  COMMAND ${DUMMY_EXE} ${DUMMY_CONFIG} SolverTwo MeshTwo
+)
+
+message("Success!")


### PR DESCRIPTION
This PR adds the target `test_install` which tests the installed preCICE library.

It configures the C++ solverdummy using the `CMAKE_INSTALL_PREFIX` to load the installed `preciceConfig.cmake`.
It then attempts to build it and runs the new solverdummy test.