### PR TITLE
Add M2N and Communication cleanup

### DIFF
--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -145,6 +145,11 @@ public:
    */
   virtual void closeConnection() = 0;
 
+  /**
+   * @brief Clean-up artefacts used to establish the communication.
+   */
+  virtual void cleanup() {}
+
   /// Performs a reduce summation on the rank given by rankMaster
   virtual void reduceSum(double *itemsToSend, double *itemsToReceive, int size, int rankMaster);
 

--- a/src/m2n/DistributedCommunication.hpp
+++ b/src/m2n/DistributedCommunication.hpp
@@ -44,6 +44,13 @@ public:
   virtual bool isConnected() = 0;
 
   /**
+   * @brief Request the communication objects to cleanup
+   *
+   * @see com::Communication::cleanup()
+   */
+  virtual void cleanup() {};
+
+  /**
    * @brief Connects to another participant, which has to call requestConnection().
    *
    * @param[in] acceptorName Name of calling participant.

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -120,6 +120,15 @@ void M2N::closeConnection()
   }
 }
 
+void M2N::cleanup()
+{
+  TRACE();
+  _masterCom->cleanup();
+  for (auto &pair : _distComs) {
+      pair.second->cleanup();
+  }
+}
+
 com::PtrCommunication M2N::getMasterCommunication()
 {
   assertion(not utils::MasterSlave::_slaveMode);

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -71,6 +71,13 @@ public:
    */
   void closeConnection();
 
+  /**
+   * @brief Request the communication objects to cleanup
+   *
+   * @see com::Communication::cleanup()
+   */
+  void cleanup();
+
   /// Get the basic communication between the 2 masters.
   com::PtrCommunication getMasterCommunication();
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -247,6 +247,10 @@ double SolverInterfaceImpl:: initialize()
         m2n->acceptSlavesConnection(localName, remoteName);
       }
     }
+    DEBUG("Cleaning up" );
+    for (auto& m2nPair : _m2ns) {
+        m2nPair.second.m2n->cleanup();
+    }
     INFO("Slaves are connected" );
 
     std::set<action::Action::Timing> timings;


### PR DESCRIPTION
This PR adds `cleanup()` functionality to:
* `SolverInterfaceImpl::initilalize` calling `cleanup()` for all `m2ns` after it connected all slaves
* `m2n::M2N::cleanup()` calling cleanup on the master comm and distributed comms
* `virtual com::Communication::cleanup()` doing nothing by default
* `virtual com::DistributedCommunication::cleanup()` doing nothing by default

This forms the base for the various Communication back-ends to specify cleanup functionality if necessary.