### PR TITLE
Cleanup M2N handling in SolverInterfaceImpl::initialize

### DIFF
--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -145,6 +145,16 @@ public:
    */
   virtual void closeConnection() = 0;
 
+  /**
+   * @brief Prepare environment used to establish the communication.
+   */
+  virtual void prepareEstablishment() {}
+
+  /**
+   * @brief Clean-up environment used to establish the communication.
+   */
+  virtual void cleanupEstablishment() {}
+
   /// Performs a reduce summation on the rank given by rankMaster
   virtual void reduceSum(double *itemsToSend, double *itemsToReceive, int size, int rankMaster);
 

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -5,9 +5,13 @@
 namespace precice {
 namespace m2n {
 
+void BoundM2N::prepareEstablishment()
+{
+    m2n->prepareEstablishment();
+}
+
 void BoundM2N::connectMasters()
 {
-    m2n->getMasterCommunication()->prepareEstablishment();
     std::string fullLocalName = localName;
     if (localServer) fullLocalName += "Server";
 
@@ -27,7 +31,11 @@ void BoundM2N::connectSlaves()
     else {
         m2n->acceptSlavesConnection(localName, remoteName);
     }
-    m2n->getMasterCommunication()->cleanupEstablishment();
+}
+
+void BoundM2N::cleanupEstablishment()
+{
+    m2n->prepareEstablishment();
 }
 
 } // namespace m2n

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -16,10 +16,10 @@ void BoundM2N::connectMasters()
     if (localServer) fullLocalName += "Server";
 
     if (isRequesting){
-        m2n->requestMasterConnection(remoteName, localName);
+        m2n->requestMasterConnection(remoteName, fullLocalName);
     }
     else {
-        m2n->acceptMasterConnection(localName, remoteName);
+        m2n->acceptMasterConnection(fullLocalName, remoteName);
     }
 }
 

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -1,11 +1,13 @@
 #include "m2n/BoundM2N.hpp"
 #include "m2n/M2N.hpp"
+#include "com/Communication.hpp"
 
 namespace precice {
 namespace m2n {
 
 void BoundM2N::connectMasters()
 {
+    m2n->getMasterCommunication()->prepareEstablishment();
     std::string fullLocalName = localName;
     if (localServer) fullLocalName += "Server";
 
@@ -25,6 +27,7 @@ void BoundM2N::connectSlaves()
     else {
         m2n->acceptSlavesConnection(localName, remoteName);
     }
+    m2n->getMasterCommunication()->cleanupEstablishment();
 }
 
 } // namespace m2n

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -1,0 +1,31 @@
+#include "m2n/BoundM2N.hpp"
+#include "m2n/M2N.hpp"
+
+namespace precice {
+namespace m2n {
+
+void BoundM2N::connectMasters()
+{
+    std::string fullLocalName = localName;
+    if (localServer) fullLocalName += "Server";
+
+    if (isRequesting){
+        m2n->requestMasterConnection(remoteName, localName);
+    }
+    else {
+        m2n->acceptMasterConnection(localName, remoteName);
+    }
+}
+
+void BoundM2N::connectSlaves()
+{
+    if (isRequesting){
+        m2n->requestSlavesConnection(remoteName, localName);
+    }
+    else {
+        m2n->acceptSlavesConnection(localName, remoteName);
+    }
+}
+
+} // namespace m2n
+} // namespace precice

--- a/src/m2n/BoundM2N.hpp
+++ b/src/m2n/BoundM2N.hpp
@@ -6,10 +6,19 @@
 namespace precice {
 namespace m2n {
     
+/// An M2N between participants with a configured direction
 struct BoundM2N {
+    /// Prepare to establish the connection
+    void prepareEstablishment();
+
+    /// Connect the Masters of the M2N
     void connectMasters();
 
+    /// Connect the Slaves of the M2N
     void connectSlaves();
+
+    /// Cleanup after having established the connection
+    void cleanupEstablishment();
 
     PtrM2N m2n;
     std::string localName;

--- a/src/m2n/BoundM2N.hpp
+++ b/src/m2n/BoundM2N.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "m2n/SharedPointer.hpp"
+#include <string>
+
+namespace precice {
+namespace m2n {
+    
+struct BoundM2N {
+    void connectMasters();
+
+    void connectSlaves();
+
+    PtrM2N m2n;
+    std::string localName;
+    std::string remoteName;
+    bool isRequesting;
+    bool localServer;
+};
+
+} // namespace m2n
+} // namespace precice

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -100,6 +100,18 @@ void M2N::requestSlavesConnection(
   assertion(_areSlavesConnected);
 }
 
+void M2N::prepareEstablishment()
+{
+  TRACE();
+  _masterCom->prepareEstablishment();
+}
+
+void M2N::cleanupEstablishment()
+{
+  TRACE();
+  _masterCom->cleanupEstablishment();
+}
+
 void M2N::closeConnection()
 {
   TRACE();

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -65,6 +65,28 @@ public:
                                const std::string &requesterName);
 
   /**
+   * @brief prepares to establish the connections
+   *
+   * This should be called before calling the accept and request methods.
+   * Calling this function forwards the call to the configured master communication.
+   *
+   * @see com::Communication::prepareEstablishment()
+   * @see cleanupEstablishment()
+   */
+  void prepareEstablishment();
+
+  /**
+   * @brief cleans-up to establish the connections
+   *
+   * This should be called after calling the accept and request methods.
+   * Calling this function forwards the call to the configured master communication.
+   *
+   * @see com::Communication::cleanupEstablishment()
+   * @see prepareEstablishment()
+   */
+  void cleanupEstablishment();
+
+  /**
    * @brief Disconnects from communication space, i.e. participant.
    *
    * This method is called on destruction.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -209,23 +209,21 @@ double SolverInterfaceImpl:: initialize()
   else {
     // Setup communication
 
-    INFO("Setting up master communication to coupling partner/s " );
+    INFO("Setting up master communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
+        m2nPair.second.prepareEstablishment();
         m2nPair.second.connectMasters();
     }
-    INFO("Coupling partner/s are connected " );
-
-
-    DEBUG("Perform initializations");
-
+    INFO("Masters are connected");
 
     computePartitions();
 
-    INFO("Setting up slaves communication to coupling partner/s " );
+    INFO("Setting up slaves communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
       m2nPair.second.connectSlaves();
+      m2nPair.second.cleanupEstablishment();
     }
-    INFO("Slaves are connected" );
+    INFO("Slaves are connected");
 
     std::set<action::Action::Timing> timings;
     double dt = 0.0;

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -11,6 +11,7 @@
 #include "cplscheme/SharedPointer.hpp"
 #include "com/Communication.hpp"
 #include "m2n/config/M2NConfiguration.hpp"
+#include "m2n/BoundM2N.hpp"
 #include "utils/MultiLock.hpp"
 #include <string>
 #include <vector>
@@ -464,11 +465,6 @@ public:
 
 private:
 
-  struct M2NWrap {
-    m2n::PtrM2N m2n;
-    bool isRequesting;
-  };
-
   mutable logging::Logger _log{"impl::SolverInterfaceImpl"};
 
   std::string _accessorName;
@@ -502,7 +498,7 @@ private:
   /// For plotting of used mesh neighbor-relations
   query::ExportVTKNeighbors _exportVTKNeighbors;
 
-  std::map<std::string,M2NWrap> _m2ns;
+  std::map<std::string,m2n::BoundM2N> _m2ns;
 
   /// Holds information about solvers participating in the coupled simulation.
   std::vector<impl::PtrParticipant> _participants;

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -142,6 +142,8 @@ target_sources(precice
     src/logging/Tracer.hpp
     src/logging/config/LogConfiguration.cpp
     src/logging/config/LogConfiguration.hpp
+    src/m2n/BoundM2N.cpp
+    src/m2n/BoundM2N.hpp
     src/m2n/DistributedComFactory.hpp
     src/m2n/DistributedCommunication.hpp
     src/m2n/GatherScatterComFactory.cpp


### PR DESCRIPTION
This PR:
* Adds handlers for preparing and cleaning-up the establishment of the communication to `com::Communication`.  
  The Communication classes can use this to create directories and remove them.
* Replaces `SolverinterfaceImpl::M2NWrap` with `m2n::BoundM2N`  
  This will become simpler/redundant once we refactor the configuration and remove the server
* Refactors the communication establishment from `SolverInterfaceImpl::initialize()` into `M2N::BoundM2N`
* Clarifies some logging

Reviewers: please give feedback