### PR TITLE
Add PR quality checks on travis and a bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,13 @@ matrix:
         - lcov --remove coverage.info '/usr/*' "$LOCAL_INSTALL/*" --output-file coverage.info # filter system-files and local-dependencies
         - lcov --list coverage.info # debug info
         - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
+    # Additional checks of code quality, etc
+    - name: "Pull request check"
+      if: type = pull_request
+      include:
+      script: bash tools/travis-pr-check.sh
+      after_success:
+      after_failure:
 
 
 cache:

--- a/tools/travis-pr-check.sh
+++ b/tools/travis-pr-check.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Checks pull request to match certain style and post in the
+# pull request thread if this style is not matched
+
+# Checks code style with clang-tidy
+check_code_style()
+{
+  not_tidy='   '
+  # check results with clang-tidy
+  cd $TRAVIS_BUILD_DIR
+  cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $PRECICE_ROOT > /dev/null
+  for file in ${files_changed}; do
+    # clang-tidy onyl reports on files that are compiled
+    if [ ${file##*.} == 'cpp' ]; then
+      clang-tidy -p $TRAVIS_BUILD_DIR $file
+      if [ "$?" -eq 0 ]; then
+        not_tidy+="\n    * \`$file\` "
+        pr_invalid=1
+      fi
+    fi
+  done
+
+  if [ -n "$not_tidy" ]; then
+    bot_msg+="\n* Clang-tidy complained on the following files: "
+    bot_msg+="${not_tidy}"
+    bot_msg+="\n Consider running clang-tidy on them ( or browsing [Travis log](https://api.travis-ci.org/v3/job/${TRAVIS_JOB_ID}/log.txt ) ) and fixing reported issues"
+  fi
+}
+
+
+# Checks code formatting with clang-format
+check_code_format()
+{
+  not_formatted='   '
+  # Get diff from this commit and filter filetypes that are needed
+  if [ -n "${files_changed}" ]; then
+    for file in ${files_changed}; do
+      clang-format -style=file -output-replacements-xml $file  | grep -c "<replacement " > /dev/null
+      if [ "$?" -eq 0 ]; then
+        not_formatted+="\n    * \`$file\` "
+        pr_invalid=1
+      fi
+    done
+  fi
+
+  if [ -n "$not_formatted" ]; then
+    bot_msg+="\n* Your code formatting did not follow our clang-format style in following files: "
+    bot_msg+="$not_formatted"
+  fi
+}
+
+# Checks if something was added to the changelog, if certain threshold
+# of lines  was changed
+check_changelog()
+{
+  # perform merge and get the number of lines changed
+  lines_changed=$(git log | sed -n '2p' | awk '{print $2, $3}' | xargs git diff --numstat | awk '{ sum+= $1 + $2 ; } END { print sum; }')
+  if [ $lines_changed -gt 100 ]; then
+    git log | sed -n '2p' | awk '{print $2, $3}' | xargs git diff --numstat | grep 'CHANGELOG.md'
+    if [ "$?" -eq 1 ]; then
+      pr_invalid=1
+      bot_msg+="\n* It seems like you  forgot to update \`CHANGELOG.md\`"
+    fi
+  fi
+}
+
+# Get list of files that were changed
+files_changed=$( git log | sed -n '2p' | awk '{print $2, $3}' | xargs git diff --name-only | grep '.cpp\|.hpp' | xargs )
+pr_invalid=0
+# generic bot message start
+bot_msg="Thank you for your contribution.\n"
+
+# perform necessary checks
+check_changelog
+check_code_format
+check_code_style
+
+# Send message to github API to post in the PR thread if we failed
+if [[ "$pr_invalid" -eq 1 ]]; then
+   curl -s -H "Authorization: token $TRAVIS_ACCESS_TOKEN" -X POST -d "{\"body\": \"$bot_msg\"}" \
+     "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments" > /dev/null
+   exit 1
+fi


### PR DESCRIPTION
This adds several checks, that are performed on Travis for pull requests
For now it means that for all changed files following checks are done:
* **Code formatting**
  It will check full file, so at some point the source code should be reformated, so this check does not get triggered with every PR
* **Warnings from clang-tidy**

And if there are enough total lines changed in the code (I am not sure what metric should be set here so now it is magical number of 100 lines, I am open to suggestions ), check whether something added to the `CHANGELOG`.

If some check fails @precice-bot will post a message (e.g. see [ this dummy PR ]( https://github.com/shkodm/precice/pull/5 ) on my fork ), with the reasons of failure. 

This is not the final state, more demonstration of the possibilities, so I am encouraging to propose some ideas of what other checks can be useful or about improvement of the current state. 

