### PR TITLE
C solver dummy: add package name in the preCICE include

### DIFF
--- a/tools/solverdummies/c/solverdummy.c
+++ b/tools/solverdummies/c/solverdummy.c
@@ -1,5 +1,5 @@
-#include "SolverInterfaceC.h"
-#include "Constants.h"
+#include "precice/SolverInterfaceC.h"
+#include "precice/Constants.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
While both ways work (with preCICE installed via make install or package), this is the way we use in our adapters, in the C++ solver dummy, and in our documentation.

Closes #392.

Reviewers: please check that this does not break your workflows.