### PR TITLE
Prepend Data Name to Convergence Measure in Log

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -549,10 +549,10 @@ void BaseCouplingScheme::setupDataMatrices(DataMap &data)
   DEBUG("Data size: " << data.size());
   // Reserve storage for convergence measurement of send and receive data values
   for (ConvergenceMeasure &convMeasure : _convergenceMeasures) {
-    assertion(convMeasure.data != nullptr);
-    if (convMeasure.data->oldValues.cols() < 1) {
-      utils::append(convMeasure.data->oldValues,
-                    (Eigen::MatrixXd) Eigen::MatrixXd::Zero(convMeasure.data->values->size(), 1));
+    assertion(convMeasure.couplingData != nullptr);
+    if (convMeasure.couplingData->oldValues.cols() < 1) {
+      utils::append(convMeasure.couplingData->oldValues,
+                    (Eigen::MatrixXd) Eigen::MatrixXd::Zero(convMeasure.couplingData->values->size(), 1));
     }
   }
   // Reserve storage for extrapolation of data values
@@ -593,12 +593,12 @@ void BaseCouplingScheme::setupConvergenceMeasures()
         "At least one convergence measure has to be defined for "
             << "an implicit coupling scheme!");
   for (ConvergenceMeasure &convMeasure : _convergenceMeasures) {
-    int dataID = convMeasure.dataID;
+    int dataID = convMeasure.data->getID();
     if ((getSendData(dataID) != nullptr)) {
-      convMeasure.data = getSendData(dataID);
+      convMeasure.couplingData = getSendData(dataID);
     } else {
-      convMeasure.data = getReceiveData(dataID);
-      assertion(convMeasure.data != nullptr);
+      convMeasure.couplingData = getReceiveData(dataID);
+      assertion(convMeasure.couplingData != nullptr);
     }
   }
 }
@@ -613,17 +613,17 @@ void BaseCouplingScheme::newConvergenceMeasurements()
 }
 
 void BaseCouplingScheme::addConvergenceMeasure(
-    int                         dataID,
+    mesh::PtrData               data,
     bool                        suffices,
     int                         level,
     impl::PtrConvergenceMeasure measure)
 {
   ConvergenceMeasure convMeasure;
-  convMeasure.dataID   = dataID;
-  convMeasure.data     = nullptr;
+  convMeasure.data     = std::move(data);
+  convMeasure.couplingData = nullptr;
   convMeasure.suffices = suffices;
   convMeasure.level    = level;
-  convMeasure.measure  = measure;
+  convMeasure.measure  = std::move(measure);
   _convergenceMeasures.push_back(convMeasure);
   _firstResiduumNorm.push_back(0);
 }
@@ -647,14 +647,14 @@ bool BaseCouplingScheme::measureConvergence(
     if (convMeasure.level > 0)
       continue;
 
-    assertion(convMeasure.data != nullptr);
+    assertion(convMeasure.couplingData != nullptr);
     assertion(convMeasure.measure.get() != nullptr);
-    const auto &    oldValues = convMeasure.data->oldValues.col(0);
-    Eigen::VectorXd q         = Eigen::VectorXd::Zero(convMeasure.data->values->size());
-    if (designSpecifications.find(convMeasure.dataID) != designSpecifications.end())
-      q = designSpecifications.at(convMeasure.dataID);
+    const auto &    oldValues = convMeasure.couplingData->oldValues.col(0);
+    Eigen::VectorXd q         = Eigen::VectorXd::Zero(convMeasure.couplingData->values->size());
+    if (designSpecifications.find(convMeasure.data->getID()) != designSpecifications.end())
+      q = designSpecifications.at(convMeasure.data->getID());
 
-    convMeasure.measure->measure(oldValues, *convMeasure.data->values, q);
+    convMeasure.measure->measure(oldValues, *convMeasure.couplingData->values, q);
 
     if (not utils::MasterSlave::isSlave()) {
       std::stringstream sstm;
@@ -697,22 +697,22 @@ bool BaseCouplingScheme::measureConvergenceCoarseModelOptimization(
     if (convMeasure.level == 0)
       continue;
 
-    std::cout << "  measure convergence coarse measure, id:" << convMeasure.dataID << '\n';
-    assertion(convMeasure.data != nullptr);
+    std::cout << "  measure convergence coarse measure, data:" << convMeasure.data->getName() << '\n';
+    assertion(convMeasure.couplingData != nullptr);
     assertion(convMeasure.measure.get() != nullptr);
-    const auto &    oldValues = convMeasure.data->oldValues.col(0);
-    Eigen::VectorXd q         = Eigen::VectorXd::Zero(convMeasure.data->values->size());
-    if (designSpecifications.find(convMeasure.dataID) != designSpecifications.end())
-      q = designSpecifications.at(convMeasure.dataID);
+    const auto &    oldValues = convMeasure.couplingData->oldValues.col(0);
+    Eigen::VectorXd q         = Eigen::VectorXd::Zero(convMeasure.couplingData->values->size());
+    if (designSpecifications.find(convMeasure.data->getID()) != designSpecifications.end())
+      q = designSpecifications.at(convMeasure.data->getID());
 
-    convMeasure.measure->measure(oldValues, *convMeasure.data->values, q);
+    convMeasure.measure->measure(oldValues, *convMeasure.couplingData->values, q);
 
     if (not convMeasure.measure->isConvergence()) {
       allConverged = false;
     } else if (convMeasure.suffices == true) {
       oneSuffices = true;
     }
-    INFO(convMeasure.measure->printState());
+    INFO('<' << convMeasure.data->getName() << '<' << convMeasure.measure->printState());
   }
 
   if (allConverged) {

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -252,7 +252,7 @@ public:
 
   /// Adds a measure to determine the convergence of coupling iterations.
   void addConvergenceMeasure(
-      int                         dataID,
+      mesh::PtrData               data,
       bool                        suffices,
       int                         level,
       impl::PtrConvergenceMeasure measure);
@@ -435,8 +435,8 @@ protected:
 
   /// Holds relevant variables to perform a convergence measurement.
   struct ConvergenceMeasure {
-    int                         dataID;
-    CouplingData *              data;
+    mesh::PtrData               data;
+    CouplingData *              couplingData;
     bool                        suffices;
     int                         level;
     impl::PtrConvergenceMeasure measure;

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -298,9 +298,9 @@ void MultiCouplingScheme::setupConvergenceMeasures()
   CHECK(not _convergenceMeasures.empty(),
         "At least one convergence measure has to be defined for an implicit coupling scheme!");
   for (ConvergenceMeasure& convMeasure : _convergenceMeasures) {
-    int dataID = convMeasure.dataID;
-    convMeasure.data = getData(dataID);
-    assertion(convMeasure.data != nullptr);
+    int dataID = convMeasure.data->getID();
+    convMeasure.couplingData = getData(dataID);
+    assertion(convMeasure.couplingData != nullptr);
   }
 }
 

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -559,8 +559,7 @@ void CouplingSchemeConfiguration::addAbsoluteConvergenceMeasure(
 {
   TRACE();
   impl::PtrConvergenceMeasure measure(new impl::AbsoluteConvergenceMeasure(limit));
-  int                         dataID = getData(dataName, meshName)->getID();
-  _config.convMeasures.push_back(std::make_tuple(dataID, suffices, meshName, level, measure));
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, level, measure));
 }
 
 void CouplingSchemeConfiguration::addRelativeConvergenceMeasure(
@@ -573,8 +572,7 @@ void CouplingSchemeConfiguration::addRelativeConvergenceMeasure(
   TRACE();
   impl::PtrConvergenceMeasure measure(
       new impl::RelativeConvergenceMeasure(limit));
-  int dataID = getData(dataName, meshName)->getID();
-  _config.convMeasures.push_back(std::make_tuple(dataID, suffices, meshName, level, measure));
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, level, measure));
 }
 
 void CouplingSchemeConfiguration::addResidualRelativeConvergenceMeasure(
@@ -587,8 +585,7 @@ void CouplingSchemeConfiguration::addResidualRelativeConvergenceMeasure(
   TRACE();
   impl::PtrConvergenceMeasure measure(
       new impl::ResidualRelativeConvergenceMeasure(limit));
-  int dataID = getData(dataName, meshName)->getID();
-  _config.convMeasures.push_back(std::make_tuple(dataID, suffices, meshName, level, measure));
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, level, measure));
 }
 
 void CouplingSchemeConfiguration::addMinIterationConvergenceMeasure(
@@ -601,8 +598,7 @@ void CouplingSchemeConfiguration::addMinIterationConvergenceMeasure(
   TRACE();
   impl::PtrConvergenceMeasure measure(
       new impl::MinIterationConvergenceMeasure(minIterations));
-  int dataID = getData(dataName, meshName)->getID();
-  _config.convMeasures.push_back(std::make_tuple(dataID, suffices, meshName, level, measure));
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, level, measure));
 }
 
 mesh::PtrData CouplingSchemeConfiguration::getData(
@@ -672,15 +668,15 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
   // Add convergence measures
   using std::get;
   for (auto &elem : _config.convMeasures) {
-    int                         dataID     = get<0>(elem);
+    mesh::PtrData               data       = get<0>(elem);
     bool                        suffices   = get<1>(elem);
     std::string                 neededMesh = get<2>(elem);
     int                         level      = get<3>(elem);
     impl::PtrConvergenceMeasure measure    = get<4>(elem);
     _meshConfig->addNeededMesh(_config.participants[1], neededMesh);
-    checkIfDataIsExchanged(dataID);
+    checkIfDataIsExchanged(data->getID());
     //bool isCoarse = checkIfDataIsCoarse(dataID);
-    scheme->addConvergenceMeasure(dataID, suffices, level, measure);
+    scheme->addConvergenceMeasure(data, suffices, level, measure);
   }
 
   // Set relaxation parameters
@@ -713,15 +709,15 @@ PtrCouplingScheme CouplingSchemeConfiguration::createParallelImplicitCouplingSch
   // Add convergence measures
   using std::get;
   for (auto &elem : _config.convMeasures) {
-    int                         dataID     = get<0>(elem);
+    mesh::PtrData               data       = get<0>(elem);
     bool                        suffices   = get<1>(elem);
     std::string                 neededMesh = get<2>(elem);
     int                         level      = get<3>(elem);
     impl::PtrConvergenceMeasure measure    = get<4>(elem);
     _meshConfig->addNeededMesh(_config.participants[1], neededMesh);
-    checkIfDataIsExchanged(dataID);
+    checkIfDataIsExchanged(data->getID());
     //bool isCoarse = checkIfDataIsCoarse(dataID);
-    scheme->addConvergenceMeasure(dataID, suffices, level, measure);
+    scheme->addConvergenceMeasure(data, suffices, level, measure);
   }
 
   // Set relaxation parameters
@@ -774,15 +770,15 @@ PtrCouplingScheme CouplingSchemeConfiguration::createMultiCouplingScheme(
   // Add convergence measures
   using std::get;
   for (auto &elem : _config.convMeasures) {
-    int                         dataID     = get<0>(elem);
+    mesh::PtrData               data       = get<0>(elem);
     bool                        suffices   = get<1>(elem);
     std::string                 neededMesh = get<2>(elem);
     int                         level      = get<3>(elem);
     impl::PtrConvergenceMeasure measure    = get<4>(elem);
     _meshConfig->addNeededMesh(_config.controller, neededMesh);
-    checkIfDataIsExchanged(dataID);
+    checkIfDataIsExchanged(data->getID());
     // bool isCoarse = checkIfDataIsCoarse(dataID);
-    scheme->addConvergenceMeasure(dataID, suffices, level, measure);
+    scheme->addConvergenceMeasure(data, suffices, level, measure);
   }
 
   // Set relaxation parameters

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -140,7 +140,7 @@ private:
     typedef std::tuple<mesh::PtrData, mesh::PtrMesh, std::string, std::string, bool> Exchange;
     std::vector<Exchange>                                                            exchanges;
     /// Tuples of data ID, mesh ID, and convergence measure.
-    std::vector<std::tuple<int, bool, std::string, int, impl::PtrConvergenceMeasure>> convMeasures;
+    std::vector<std::tuple<mesh::PtrData, bool, std::string, int, impl::PtrConvergenceMeasure>> convMeasures;
     int                                                                               maxIterations = -1;
     int                                                                               extrapolationOrder = 0;
 

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -323,10 +323,8 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations) );
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure2 (
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations) );
-  cplScheme.addConvergenceMeasure (
-      mesh->data()[1]->getID(), false, false, minIterationConvMeasure1 );
-  cplScheme.addConvergenceMeasure (
-      mesh->data()[0]->getID(), false, false, minIterationConvMeasure2 );
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1 );
+  cplScheme.addConvergenceMeasure(mesh->data()[0], false, false, minIterationConvMeasure2 );
 
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -566,8 +566,7 @@ BOOST_FIXTURE_TEST_CASE(testAbsConvergenceMeasureSynchronized, testing::M2NFixtu
   double convergenceLimit1 = sqrt(3.0); // when diff_vector = (1.0, 1.0, 1.0)
   cplscheme::impl::PtrConvergenceMeasure absoluteConvMeasure1 (
       new cplscheme::impl::AbsoluteConvergenceMeasure(convergenceLimit1));
-  cplScheme.addConvergenceMeasure (
-      mesh->data()[1]->getID(), false, false, absoluteConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, absoluteConvMeasure1);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {5, 5, 5};
@@ -679,8 +678,7 @@ BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronized, testing::M2NF
   int minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1 (
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure (
-      mesh->data()[1]->getID(), false, false, minIterationConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {3, 3, 3};
@@ -745,8 +743,7 @@ BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling,
   int minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1 (
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure (
-      mesh->data()[1]->getID(), false, false, minIterationConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1);
   runCouplingWithSubcycling (
       cplScheme, nameLocalParticipant, meshConfig, validIterations);
 }
@@ -810,8 +807,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
   int minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1 (
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure (
-      mesh->data()[1]->getID(), false, false, minIterationConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1);
 
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());


### PR DESCRIPTION
This required to expose the whole pointer to `Data` instead of only the `dataID`.