### PR TITLE
Fix constness of SolverInterface member functions

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -48,31 +48,31 @@ int SolverInterface:: getDimensions() const
   return _impl->getDimensions();
 }
 
-bool SolverInterface:: isCouplingOngoing()
+bool SolverInterface:: isCouplingOngoing() const
 {
   return _impl->isCouplingOngoing();
 }
 
-bool SolverInterface:: isReadDataAvailable()
+bool SolverInterface:: isReadDataAvailable() const
 {
   return _impl->isReadDataAvailable();
 }
 
 bool SolverInterface:: isWriteDataRequired
 (
-  double computedTimestepLength )
+  double computedTimestepLength ) const
 {
   return _impl->isWriteDataRequired(computedTimestepLength);
 }
 
-bool SolverInterface:: isTimestepComplete()
+bool SolverInterface:: isTimestepComplete() const
 {
   return _impl->isTimestepComplete();
 }
 
 bool SolverInterface:: isActionRequired
 (
-  const std::string& action )
+  const std::string& action ) const
 {
   return _impl->isActionRequired ( action );
 }
@@ -93,12 +93,12 @@ bool SolverInterface:: hasMesh
 
 int SolverInterface:: getMeshID
 (
-  const std::string& meshName )
+  const std::string& meshName ) const
 {
   return _impl->getMeshID ( meshName );
 }
 
-std::set<int> SolverInterface:: getMeshIDs()
+std::set<int> SolverInterface:: getMeshIDs() const
 {
   return _impl->getMeshIDs();
 }
@@ -112,17 +112,17 @@ bool SolverInterface:: hasData
 
 int SolverInterface:: getDataID
 (
-  const std::string& dataName, int meshID )
+  const std::string& dataName, int meshID ) const
 {
   return _impl->getDataID ( dataName, meshID );
 }
 
-bool SolverInterface::hasToEvaluateSurrogateModel()
+bool SolverInterface::hasToEvaluateSurrogateModel() const
 {
   return _impl->hasToEvaluateSurrogateModel();
 }
 
-bool SolverInterface::hasToEvaluateFineModel()
+bool SolverInterface::hasToEvaluateFineModel() const
 {
   return _impl->hasToEvaluateFineModel();
 }
@@ -145,7 +145,7 @@ int SolverInterface:: setMeshVertex
 
 int SolverInterface:: getMeshVertexSize
 (
-  int meshID)
+  int meshID) const
 {
   return _impl->getMeshVertexSize(meshID);
 }
@@ -165,7 +165,7 @@ void SolverInterface:: getMeshVertices
   int        meshID,
   int        size,
   const int* ids,
-  double*    positions )
+  double*    positions ) const
 {
   _impl->getMeshVertices(meshID, size, ids, positions);
 }
@@ -175,7 +175,7 @@ void SolverInterface:: getMeshVertexIDsFromPositions
   int           meshID,
   int           size,
   const double* positions,
-  int*          ids )
+  int*          ids ) const
 {
   _impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
 }
@@ -290,7 +290,7 @@ void SolverInterface:: readBlockVectorData
   int        dataID,
   int        size,
   const int* valueIndices,
-  double*    values )
+  double*    values ) const
 {
   _impl->readBlockVectorData(dataID, size, valueIndices, values);
 }
@@ -299,7 +299,7 @@ void SolverInterface:: readVectorData
 (
   int     dataID,
   int     valueIndex,
-  double* value )
+  double* value ) const
 {
   return _impl->readVectorData ( dataID, valueIndex, value );
 }
@@ -309,7 +309,7 @@ void SolverInterface:: readBlockScalarData
   int        dataID,
   int        size,
   const int* valueIndices,
-  double*    values )
+  double*    values ) const
 {
   _impl->readBlockScalarData(dataID, size, valueIndices, values);
 }
@@ -318,7 +318,7 @@ void SolverInterface:: readScalarData
 (
   int     dataID,
   int     valueIndex,
-  double& value )
+  double& value ) const
 {
   return _impl->readScalarData ( dataID, valueIndex, value );
 }

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -193,7 +193,7 @@ public:
    * @note
    * The user should call finalize() after this function returns false.
    */
-  bool isCouplingOngoing();
+  bool isCouplingOngoing() const;
 
   /**
    * @brief Checks if new data to be read is available.
@@ -213,7 +213,7 @@ public:
    * This is not recommended due to performance reasons.
    * Use this function to prevent unnecessary reads.
    */
-  bool isReadDataAvailable();
+  bool isReadDataAvailable() const;
 
   /**
    * @brief Checks if new data has to be written before calling advance().
@@ -233,7 +233,7 @@ public:
    * This is not recommended due to performance reasons.
    * Use this function to prevent unnecessary writes.
    */
-  bool isWriteDataRequired ( double computedTimestepLength );
+  bool isWriteDataRequired ( double computedTimestepLength ) const;
 
   /**
    * @brief Checks if the current coupling timestep is completed.
@@ -247,7 +247,7 @@ public:
    *
    * @pre initialize() has been called successfully.
    */
-  bool isTimestepComplete();
+  bool isTimestepComplete() const;
 
   /**
    * @brief Returns whether the solver has to evaluate the surrogate model representation.
@@ -262,7 +262,7 @@ public:
    *
    * @see hasToEvaluateFineModel()
    */
-  bool hasToEvaluateSurrogateModel();
+  bool hasToEvaluateSurrogateModel() const;
 
   /**
    * @brief Checks if the solver has to evaluate the fine model representation.
@@ -277,7 +277,7 @@ public:
    *
    * @see hasToEvaluateSurrogateModel()
    */
-  bool hasToEvaluateFineModel();
+  bool hasToEvaluateFineModel() const;
 
   ///@}
 
@@ -299,7 +299,7 @@ public:
    * @see fulfilledAction()
    * @see cplscheme::constants
    */
-  bool isActionRequired ( const std::string& action );
+  bool isActionRequired ( const std::string& action ) const;
 
   /**
    * @brief Indicates preCICE that a required action has been fulfilled by a solver.
@@ -342,14 +342,14 @@ public:
    * @param[in] meshName the name of the mesh
    * @returns the id of the corresponding mesh
    */
-  int getMeshID ( const std::string& meshName );
+  int getMeshID ( const std::string& meshName ) const;
 
   /**
    * @brief Returns a id-set of all used meshes by this participant.
    *
    * @returns the set of ids.
    */
-  std::set<int> getMeshIDs();
+  std::set<int> getMeshIDs() const;
 
   /**
    * @brief Returns a handle to a created mesh.
@@ -383,7 +383,7 @@ public:
    * @param[in] meshID the id of the mesh
    * @returns the amount of the vertices of the mesh
    */
-  int getMeshVertexSize(int meshID);
+  int getMeshVertexSize(int meshID) const;
 
   /**
    * @brief Creates multiple mesh vertices
@@ -427,7 +427,7 @@ public:
     int        meshID,
     int        size,
     const int* ids,
-    double*    positions );
+    double*    positions ) const;
 
   /**
    * @brief Gets mesh vertex IDs from positions.
@@ -448,7 +448,7 @@ public:
     int           meshID,
     int           size,
     const double* positions,
-    int*          ids );
+    int*          ids ) const;
 
   /**
    * @brief Sets mesh edge from vertex IDs, returns edge ID.
@@ -571,7 +571,7 @@ public:
    *
    * @returns the id of the corresponding data
    */
-  int getDataID ( const std::string& dataName, int meshID );
+  int getDataID ( const std::string& dataName, int meshID ) const;
 
   /**
    * @brief Computes and maps all read data mapped to the mesh with given ID.
@@ -713,7 +713,7 @@ public:
     int        dataID,
     int        size,
     const int* valueIndices,
-    double*    values );
+    double*    values ) const;
 
   /**
    * @brief Reads vector data form a vertex
@@ -738,7 +738,7 @@ public:
   void readVectorData (
     int     dataID,
     int     valueIndex,
-    double* value );
+    double* value ) const;
 
   /**
    * @brief Reads scalar data as a block.
@@ -764,7 +764,7 @@ public:
     int        dataID,
     int        size,
     const int* valueIndices,
-    double*    values );
+    double*    values ) const;
 
   /**
    * @brief Reads scalar data of a vertex.
@@ -784,7 +784,7 @@ public:
   void readScalarData (
     int     dataID,
     int     valueIndex,
-    double& value );
+    double& value ) const;
 
   ///@}
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -496,13 +496,13 @@ int SolverInterfaceImpl:: getDimensions() const
   return _dimensions;
 }
 
-bool SolverInterfaceImpl:: isCouplingOngoing()
+bool SolverInterfaceImpl:: isCouplingOngoing() const
 {
   TRACE();
   return _couplingScheme->isCouplingOngoing();
 }
 
-bool SolverInterfaceImpl:: isReadDataAvailable()
+bool SolverInterfaceImpl:: isReadDataAvailable() const
 {
   TRACE();
   return _couplingScheme->hasDataBeenExchanged();
@@ -510,13 +510,13 @@ bool SolverInterfaceImpl:: isReadDataAvailable()
 
 bool SolverInterfaceImpl:: isWriteDataRequired
 (
-  double computedTimestepLength )
+  double computedTimestepLength ) const
 {
   TRACE(computedTimestepLength);
   return _couplingScheme->willDataBeExchanged(computedTimestepLength);
 }
 
-bool SolverInterfaceImpl:: isTimestepComplete()
+bool SolverInterfaceImpl:: isTimestepComplete() const
 {
   TRACE();
   return _couplingScheme->isCouplingTimestepComplete();
@@ -524,7 +524,7 @@ bool SolverInterfaceImpl:: isTimestepComplete()
 
 bool SolverInterfaceImpl:: isActionRequired
 (
-  const std::string& action )
+  const std::string& action ) const
 {
   TRACE(action, _couplingScheme->isActionRequired(action));
   return _couplingScheme->isActionRequired(action);
@@ -541,13 +541,13 @@ void SolverInterfaceImpl:: fulfilledAction
   _couplingScheme->performedAction(action);
 }
 
-bool SolverInterfaceImpl::hasToEvaluateSurrogateModel()
+bool SolverInterfaceImpl::hasToEvaluateSurrogateModel() const
 {
  // std::cout<<"_isCoarseModelOptimizationActive() = "<<_couplingScheme->isCoarseModelOptimizationActive();
   return _couplingScheme->isCoarseModelOptimizationActive();
 }
 
-bool SolverInterfaceImpl::hasToEvaluateFineModel()
+bool SolverInterfaceImpl::hasToEvaluateFineModel() const
 {
   return not _couplingScheme->isCoarseModelOptimizationActive();
 }
@@ -562,14 +562,15 @@ bool SolverInterfaceImpl:: hasMesh
 
 int SolverInterfaceImpl:: getMeshID
 (
-  const std::string& meshName )
+  const std::string& meshName ) const
 {
   TRACE(meshName);
-  CHECK( utils::contained(meshName, _meshIDs), "Mesh with name \""<< meshName << "\" is not defined!" );
-  return _meshIDs[meshName];
+  const auto pos = _meshIDs.find(meshName);
+  CHECK(pos != _meshIDs.end(), "Mesh with name \""<< meshName << "\" is not defined!" );
+  return pos->second;
 }
 
-std::set<int> SolverInterfaceImpl:: getMeshIDs()
+std::set<int> SolverInterfaceImpl:: getMeshIDs() const
 {
   TRACE();
   std::set<int> ids;
@@ -581,28 +582,28 @@ std::set<int> SolverInterfaceImpl:: getMeshIDs()
 
 bool SolverInterfaceImpl:: hasData
 (
-  const std::string& dataName, int meshID )
+  const std::string& dataName, int meshID ) const
 {
   TRACE(dataName, meshID );
   PRECICE_VALIDATE_MESH_ID(meshID);
-  std::map<std::string,int>& sub_dataIDs =  _dataIDs[meshID];
+  const auto & sub_dataIDs = _dataIDs.at(meshID);
   return sub_dataIDs.find(dataName)!= sub_dataIDs.end();
 }
 
 int SolverInterfaceImpl:: getDataID
 (
-  const std::string& dataName, int meshID )
+  const std::string& dataName, int meshID ) const
 {
   TRACE(dataName, meshID );
   PRECICE_VALIDATE_MESH_ID(meshID);
   CHECK(hasData(dataName, meshID),
         "Data with name \"" << dataName << "\" is not defined on mesh with ID \"" << meshID << "\".");
-  return _dataIDs[meshID][dataName];
+  return _dataIDs.at(meshID).at(dataName);
 }
 
 int SolverInterfaceImpl:: getMeshVertexSize
 (
-  int meshID )
+  int meshID ) const
 {
   TRACE(meshID);
   int size = 0;
@@ -701,7 +702,7 @@ void SolverInterfaceImpl:: getMeshVertices
   int        meshID,
   size_t     size,
   const int* ids,
-  double*    positions )
+  double*    positions ) const
 {
   TRACE(meshID, size);
   if (_clientMode){
@@ -728,7 +729,7 @@ void SolverInterfaceImpl:: getMeshVertexIDsFromPositions (
   int           meshID,
   size_t        size,
   const double* positions,
-  int*          ids )
+  int*          ids ) const
 {
   TRACE(meshID, size);
   if (_clientMode){
@@ -1115,7 +1116,7 @@ void SolverInterfaceImpl:: readBlockVectorData
   int        toDataID,
   int        size,
   const int* valueIndices,
-  double*    values )
+  double*    values ) const
 {
   TRACE(toDataID, size);
   PRECICE_VALIDATE_DATA_ID(toDataID);
@@ -1149,7 +1150,7 @@ void SolverInterfaceImpl:: readVectorData
 (
   int     toDataID,
   int     valueIndex,
-  double* value )
+  double* value ) const
 {
   TRACE(toDataID, valueIndex);
   PRECICE_VALIDATE_DATA_ID(toDataID);
@@ -1179,7 +1180,7 @@ void SolverInterfaceImpl:: readBlockScalarData
   int        toDataID,
   int        size,
   const int* valueIndices,
-  double*    values )
+  double*    values ) const
 {
   TRACE(toDataID, size);
   PRECICE_VALIDATE_DATA_ID(toDataID);
@@ -1210,7 +1211,7 @@ void SolverInterfaceImpl:: readScalarData
 (
   int     toDataID,
   int     valueIndex,
-  double& value )
+  double& value ) const
 {
   TRACE(toDataID, valueIndex, value);
   PRECICE_VALIDATE_DATA_ID(toDataID);
@@ -1234,7 +1235,7 @@ void SolverInterfaceImpl:: readScalarData
 void SolverInterfaceImpl:: exportMesh
 (
   const std::string& filenameSuffix,
-  int                exportType )
+  int                exportType ) const
 {
   TRACE(filenameSuffix, exportType );
   // Export meshes

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -133,36 +133,36 @@ public:
    * is retreived in the function initializeCoupling and updated in the
    * function exchangeData.
    */
-  bool isCouplingOngoing();
+  bool isCouplingOngoing() const;
 
   /**
    * @brief Returns true, if new data to be read is available.
    */
-  bool isReadDataAvailable();
+  bool isReadDataAvailable() const;
 
   /**
    * @brief Returns true, if new data has to be written.
    */
-  bool isWriteDataRequired ( double computedTimestepLength );
+  bool isWriteDataRequired ( double computedTimestepLength ) const;
 
   /**
    * @brief Returns true, if a global timestep is completed.
    */
-  bool isTimestepComplete();
+  bool isTimestepComplete() const;
 
   /**
    * @brief Returns whether the solver has to evaluate the surrogate model representation
    *        It does not automatically imply, that the solver does not have to evaluate the
    *        fine model representation
    */
-  bool hasToEvaluateSurrogateModel();
+  bool hasToEvaluateSurrogateModel() const;
 
   /**
    * @brief Returns whether the solver has to evaluate the fine model representation
    *        It does not automatically imply, that the solver does not have to evaluate the
    *        surrogate model representation
    */
-  bool hasToEvaluateFineModel();
+  bool hasToEvaluateFineModel() const;
 
   /**
    * @brief Returns true, if provided name of action is required.
@@ -173,7 +173,7 @@ public:
    * performing them on demand, and calling fulfilledAction() to signalize
    * preCICE the correct behavior of the solver.
    */
-  bool isActionRequired (	const std::string& action );
+  bool isActionRequired (	const std::string& action ) const;
 
   /**
    * @brief Tells preCICE that a required action has been fulfilled by a solver.
@@ -190,19 +190,19 @@ public:
    *
    * The existing names are determined from the configuration.
    */
-  int getMeshID (	const std::string& meshName );
+  int getMeshID (	const std::string& meshName ) const;
 
   /// Returns all mesh IDs (besides sub-ids).
-  std::set<int> getMeshIDs();
+  std::set<int> getMeshIDs() const;
 
   /// Returns true, if the data with given name is used in the given mesh.
-  bool hasData ( const std::string& dataName, int meshID );
+  bool hasData ( const std::string& dataName, int meshID ) const;
 
   /// Returns data id corresponding to the given name (from configuration) and mesh.
-  int getDataID ( const std::string& dataName, int meshID );
+  int getDataID ( const std::string& dataName, int meshID ) const;
 
   /// Returns the number of nodes of a mesh.
-  int getMeshVertexSize ( int meshID );
+  int getMeshVertexSize ( int meshID ) const;
 
   /**
    * @brief Resets mesh with given ID.
@@ -243,7 +243,7 @@ public:
     int        meshID,
     size_t     size,
     const int* ids,
-    double*    positions );
+    double*    positions ) const;
 
   /**
    * @brief Gets vertex data ids from positions.
@@ -256,7 +256,7 @@ public:
     int           meshID,
     size_t        size,
     const double* positions,
-    int*          ids );
+    int*          ids ) const;
 
   /**
    * @brief Set an edge of a solver mesh.
@@ -383,7 +383,7 @@ public:
     int        toDataID,
     int        size,
     const int* valueIndices,
-    double*    values );
+    double*    values ) const;
 
   /**
    * @brief Reads vector data from the coupling mesh.
@@ -395,7 +395,7 @@ public:
   void readVectorData (
     int     toDataID,
     int     valueIndex,
-    double* value );
+    double* value ) const;
 
   /**
    * @brief Reads scalar data values given as block.
@@ -408,7 +408,7 @@ public:
     int        toDataID,
     int        size,
     const int* valueIndices,
-    double*    values );
+    double*    values ) const;
 
   /**
    * @brief Read scalar data from the interface mesh.
@@ -422,7 +422,7 @@ public:
   void readScalarData (
     int     toDataID,
     int     valueIndex,
-    double& value );
+    double& value ) const;
 
   /**
    * @brief Sets the location for all output of preCICE.
@@ -444,7 +444,7 @@ public:
    */
   void exportMesh (
     const std::string& filenameSuffix,
-    int                exportType = constants::exportAll() );
+    int                exportType = constants::exportAll() ) const;
 
 
   /**
@@ -554,7 +554,7 @@ private:
   void addMeshesToCouplingScheme();
 
   /// Returns true, if the accessor uses the mesh with given name.
-  bool isUsingMesh ( const std::string& meshName );
+  bool isUsingMesh ( const std::string& meshName ) const;
 
   /// Determines participants providing meshes to other participants.
   void configurePartitions (


### PR DESCRIPTION
This PR fixes the SolverInterface constness by adding `const` to appropriate member functions.