### PR TITLE
Output of filtered vertices only as aggregated count.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://github.com/precice/precice/wiki/Roadmap).
 
+## Post 1.5
+- Only the total number of filtered vertices are printed, not each one separately, unless debug output is enabled.
+
 ## develop
 - The SolverInterface is now hardened against invalid IDs and misconfiguration using a consitent mechanism to express requirements.
 - The SolverInterface now keeps track of the Mesh states, which results more informative error messages for mesh related functions.

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -467,11 +467,17 @@ void ReceivedPartition::createOwnerInformation()
 #ifndef NDEBUG
     for (size_t i = 0; i < globalOwnerVec.size(); i++) {
       if (globalOwnerVec[i] == 0) {
-        WARN("The Vertex with global index " << i << " of mesh: " << _mesh->getName()
-             << " was completely filtered out, since it has no influence on any mapping.");
+        DEBUG("The Vertex with global index " << i << " of mesh: " << _mesh->getName()
+              << " was completely filtered out, since it has no influence on any mapping.");
       }
-    }
+    }    
 #endif
+    auto filteredVertices = std::count(globalOwnerVec.begin(), globalOwnerVec.end(), 0);
+    if (filteredVertices)
+      WARN(filteredVertices << " of " << _mesh->vertices().size()
+           << " vertices of mesh " << _mesh->getName() << " have been filtered out "
+           << "since they have no influence on the mapping.");
+    
   }
 }
 


### PR DESCRIPTION
+ Output as INFO level, because it's happens quite often and is not
critical.
+ All filtered vertices can still be printed when activating debug log output.