### PR TITLE
Fix Eigen Includes

### DIFF
--- a/src/action/ComputeCurvatureAction.cpp
+++ b/src/action/ComputeCurvatureAction.cpp
@@ -1,5 +1,6 @@
 #include "ComputeCurvatureAction.hpp"
 #include <Eigen/Dense>
+#include <Eigen/Geometry>
 #include "mesh/Edge.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Triangle.hpp"

--- a/src/math/geometry.cpp
+++ b/src/math/geometry.cpp
@@ -1,5 +1,6 @@
 #include "geometry.hpp"
 #include <Eigen/Dense>
+#include <Eigen/Geometry>
 #include "math/math.hpp"
 #include "utils/Helpers.hpp"
 

--- a/src/mesh/Quad.cpp
+++ b/src/mesh/Quad.cpp
@@ -2,6 +2,8 @@
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
 #include <boost/range/concepts.hpp>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
 
 namespace precice
 {

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -2,6 +2,8 @@
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
 #include <boost/range/concepts.hpp>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
 
 namespace precice
 {


### PR DESCRIPTION
According to the [documentation](http://eigen.tuxfamily.org/dox/group__Geometry__Module.html#ga0024b44eca99cb7135887c2aaf319d28) the `cross` function requires us to include `Eigen/Geometry`.