### PR TITLE
Hotfix 1.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ env:
     - LOCAL_INSTALL="$HOME/local"
     - PETSC_ARCH=arch-linux2-c-debug
     - PETSC_DIR=$LOCAL_INSTALL/petsc
-    - CPLUS_INCLUDE_PATH="$PETSC_DIR/include:$PETSC_DIR/$PETSC_ARCH/include:$LOCAL_INSTALL/include:$CPLUS_INCLUDE_PATH"
+    - EIGEN3_ROOT_DIR=${LOCAL_INSTALL}/eigen3
+    - CPLUS_INCLUDE_PATH="$PETSC_DIR/include:$PETSC_DIR/$PETSC_ARCH/include:$LOCAL_INSTALL/include:$EIGEN3_ROOT_DIR:$CPLUS_INCLUDE_PATH"
     - LD_LIBRARY_PATH="$PETSC_DIR/$PETSC_ARCH/lib:$LOCAL_INSTALL/lib:$LD_LIBRARY_PATH"
     - LIBRARY_PATH="$PETSC_DIR/$PETSC_ARCH/lib:$LOCAL_INSTALL/lib:$LIBRARY_PATH"
     - PYTHONPATH="$PETSC_DIR/$PETSC_ARCH/lib:/usr/lib/python2.7:/usr/lib/python2.7/dist-packages:/usr/lib/python2.7/plat-x86_64-linux-gnu"
-    - EIGEN3_ROOT_DIR=${LOCAL_INSTALL}/eigen3
     - BOOST_ROOT=${LOCAL_INSTALL}
     - BUILD_TYPE=CMAKE
     - CXXFLAGS="-Wall -Wextra -Wno-unused-parameter"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. For future 
 
 ## develop
 
+## 1.5.1
+
+- Fixed the exposure of `boost::asio` implementation details leading to version incompatibilities
+- Fixed the CMake linkage of Boost to become compatible with the generated CMake config of Boost 1.70.0
+
 ## 1.5.0
 
 - Added CMake alias `precice::precice` which mimics the namespaced library name after calling `find_package(precice)`. This allows seamless use as a subproject.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,8 +143,16 @@ set_target_properties(precice PROPERTIES
 
 # Setup Boost
 target_compile_definitions(precice PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES)
-target_link_libraries(precice PRIVATE ${Boost_LIBRARIES})
-target_include_directories(precice PRIVATE ${Boost_INCLUDE_DIRS})
+target_link_libraries(precice PRIVATE
+  Boost::boost
+  Boost::filesystem
+  Boost::log
+  Boost::log_setup
+  Boost::program_options
+  Boost::system
+  Boost::thread
+  Boost::unit_test_framework
+  )
 if(UNIX OR APPLE OR MINGW)
   target_link_libraries(precice PRIVATE ${CMAKE_DL_LIBS})
 endif()
@@ -210,7 +218,14 @@ target_link_libraries(binprecice
   Threads::Threads
   precice
   Eigen3::Eigen
-  ${Boost_LIBRARIES}
+  Boost::boost
+  Boost::filesystem
+  Boost::log
+  Boost::log_setup
+  Boost::program_options
+  Boost::system
+  Boost::thread
+  Boost::unit_test_framework
   )
 set_target_properties(binprecice PROPERTIES
   # precice is a C++11 project
@@ -239,7 +254,14 @@ target_link_libraries(testprecice
   Threads::Threads
   precice
   Eigen3::Eigen
-  ${Boost_LIBRARIES}
+  Boost::boost
+  Boost::filesystem
+  Boost::log
+  Boost::log_setup
+  Boost::program_options
+  Boost::system
+  Boost::thread
+  Boost::unit_test_framework
   )
 set_target_properties(testprecice PROPERTIES
   # precice is a C++11 project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.9.6)
 
-project(preCICE VERSION 1.5.0 LANGUAGES CXX)
+project(preCICE VERSION 1.5.1 LANGUAGES CXX)
 
 #
 # Overview of this configuration

--- a/SConstruct
+++ b/SConstruct
@@ -106,7 +106,7 @@ env.Append(LIBPATH = [('#' + buildpath)])
 env.Append(CCFLAGS= ['-Wall', '-Wextra', '-Wno-unused-parameter', '-std=c++11'])
 
 # ====== PRECICE_VERSION number ======
-PRECICE_VERSION = "1.5.0"
+PRECICE_VERSION = "1.5.1"
 
 
 # ====== Compiler Settings ======

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -139,9 +139,7 @@ private:
   std::string _addressDirectory;
 
   using IOService     = boost::asio::io_service;
-  using TCP           = boost::asio::ip::tcp;
-  using SocketService = boost::asio::stream_socket_service<TCP>;
-  using Socket        = boost::asio::basic_stream_socket<TCP, SocketService>;
+  using Socket        = boost::asio::ip::tcp::socket;
   using Work          = boost::asio::io_service::work;
   
   std::shared_ptr<IOService> _ioService;

--- a/src/com/SocketSendQueue.hpp
+++ b/src/com/SocketSendQueue.hpp
@@ -17,9 +17,7 @@ class SocketSendQueue
 {
 public:
 
-  using TCP           = boost::asio::ip::tcp;
-  using SocketService = boost::asio::stream_socket_service<TCP>;
-  using Socket        = boost::asio::basic_stream_socket<TCP, SocketService>;
+  using Socket = boost::asio::ip::tcp::socket;
 
   SocketSendQueue() = default;
   ~SocketSendQueue();

--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -11,7 +11,7 @@ from distutils.command.build import build
 
 # name of Interfacing API
 APPNAME = "precice"
-APPVERSION = "1.5.0"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
+APPVERSION = "1.5.1"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
This Hotfix address compatibility issues

    between the boost::asio versions and
    between the CMake Config generated by Boost 1.70.0 and the FindBoost module.

Closes #426

It also fixes #423
Local version of #429 