### PR TITLE
Fix NP Mapping

### DIFF
--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -35,7 +35,7 @@ void NearestNeighborMapping:: computeMapping()
   
   if (getConstraint() == CONSISTENT){
     DEBUG("Compute consistent mapping");
-    mesh::rtree::PtrVertexRTree rtree = mesh::rtree::getVertexRTree(input());
+    auto rtree = mesh::rtree::getVertexRTree(input());
     size_t verticesSize = output()->vertices().size();
     _vertexIndices.resize(verticesSize);
     const mesh::Mesh::VertexContainer& outputVertices = output()->vertices();
@@ -51,7 +51,7 @@ void NearestNeighborMapping:: computeMapping()
   else {
     assertion(getConstraint() == CONSERVATIVE, getConstraint());
     DEBUG("Compute conservative mapping");
-    mesh::rtree::PtrVertexRTree rtree = mesh::rtree::getVertexRTree(output());
+    auto rtree = mesh::rtree::getVertexRTree(output());
     size_t verticesSize = input()->vertices().size();
     _vertexIndices.resize(verticesSize);
     const mesh::Mesh::VertexContainer& inputVertices = input()->vertices();

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -72,7 +72,9 @@ void NearestProjectionMapping::computeMapping()
   constexpr int nnearest = 4;
 
   if (getDimensions() == 2) {
-    //CHECK(fVertices.empty() || !tEdges.empty(), "Mesh \"" << to->getName() << "\" does not contain Edges to project onto.");
+    if(!fVertices.empty() && tEdges.empty()) {
+        WARN("2D Mesh \"" << to->getName() << "\" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.");
+    }
 
     auto indexEdges    = mesh::rtree::getEdgeRTree(to);
     auto indexVertices = mesh::rtree::getVertexRTree(to);
@@ -108,7 +110,9 @@ void NearestProjectionMapping::computeMapping()
     }
   } else {
     const auto &tTriangles = to->triangles();
-    //CHECK(fVertices.empty() || !tTriangles.empty(), "Mesh \"" << to->getName() << "\" does not contain Triangles to project onto.");
+    if(!fVertices.empty() && tTriangles.empty()) {
+         WARN("3D Mesh \"" << to->getName() << "\" does not contain triangles. Nearest projection mapping will map to primitives of lower dimension.");
+    }
 
     auto indexTriangles = mesh::rtree::getTriangleRTree(to);
     auto indexEdges     = mesh::rtree::getEdgeRTree(to);

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -3,6 +3,9 @@
 #include <Eigen/Core>
 #include "utils/Event.hpp"
 
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+
 namespace precice {
 extern bool syncMode;
 
@@ -26,42 +29,135 @@ NearestProjectionMapping:: NearestProjectionMapping
   }
 }
 
+namespace{
+    struct MatchType {
+        double distance;
+        int index;
+
+        MatchType() = default;
+        MatchType(double d, int i):distance(d), index(i) {};
+        constexpr bool operator<(MatchType const & other) const { return distance < other.distance; };
+    };
+}
+
 void NearestProjectionMapping:: computeMapping()
 {
-  TRACE(input()->vertices().size(), output()->vertices().size());
+    TRACE(input()->vertices().size(), output()->vertices().size());
+    precice::utils::Event e("map.np.computeMapping.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
-  precice::utils::Event e("map.np.computeMapping.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
+    // Setup Direction of Mapping
+    mesh::PtrMesh from, to;
+    if (getConstraint() == CONSISTENT){
+        DEBUG("Compute consistent mapping");
+        from = output();
+        to   = input();
+    } else {
+        DEBUG("Compute conservative mapping");
+        from = input();
+        to   = output();
+    }
 
-  if (getConstraint() == CONSISTENT){
-    DEBUG("Compute consistent mapping");
-    _weights.resize(output()->vertices().size());
-    for ( size_t i=0; i < output()->vertices().size(); i++ ){
-      query::FindClosest findClosest(output()->vertices()[i].getCoords());
-      findClosest(*input()); // Search inside the input mesh for the output vertex
-      assertion(findClosest.hasFound());
-      const query::ClosestElement& closest = findClosest.getClosest();
-      _weights[i].clear();
-      for (const query::InterpolationElement& elem : closest.interpolationElements) {
-        _weights[i].push_back(elem);
-      }
+    const auto &fVertices = from->vertices();
+    const auto &tVertices = to->vertices();
+    const auto &tEdges    = to->edges();
+
+    _weights.resize(fVertices.size());
+
+    constexpr int nnearest = 4;
+
+    if (getDimensions() == 2) {
+        //CHECK(fVertices.empty() || !tEdges.empty(), "Mesh \"" << to->getName() << "\" does not contain Edges to project onto.");
+
+        auto indexEdges = mesh::rtree::getEdgeRTree(to);
+        auto indexVertices = mesh::rtree::getVertexRTree(to);
+
+        std::vector<MatchType> matches;
+        matches.reserve(nnearest);
+        for (size_t i = 0; i < fVertices.size(); i++) {
+            const Eigen::VectorXd &coords = fVertices[i].getCoords();
+            // Search for the from vertex inside the destination meshes edges
+            matches.clear();
+            indexEdges->query(bg::index::nearest(coords, nnearest),
+                    boost::make_function_output_iterator([&](int match) {
+                        matches.emplace_back(bg::distance(coords, tEdges[match]), match);
+                        }));
+            std::sort(matches.begin(), matches.end());
+            bool found = false;
+            for (const auto& match: matches) {
+                auto weights = query::generateInterpolationElements(fVertices[i], tEdges[match.index]);
+                if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const & elem){ return elem.weight >= 0.0; })) {
+                    _weights[i] = std::move(weights);
+                    found = true;
+                    break;
+                }
+            }
+
+            if (not found) {
+                // Search for the from vertex inside the destination meshes vertices
+                indexVertices->query(bg::index::nearest(coords, 1), 
+                        boost::make_function_output_iterator([&](int match) {
+                            _weights[i] = query::generateInterpolationElements(fVertices[i], tVertices[match]);
+                            }));
+            }
+        }
+    } else {
+        const auto &tTriangles = to->triangles();
+        //CHECK(fVertices.empty() || !tTriangles.empty(), "Mesh \"" << to->getName() << "\" does not contain Triangles to project onto.");
+
+        auto indexTriangles = mesh::rtree::getTriangleRTree(to);
+        auto indexEdges     = mesh::rtree::getEdgeRTree(to);
+        auto indexVertices  = mesh::rtree::getVertexRTree(to);
+
+        std::vector<MatchType> matches;
+        matches.reserve(nnearest);
+        for (size_t i = 0; i < fVertices.size(); i++) {
+            const Eigen::VectorXd &coords = fVertices[i].getCoords();
+
+            // Search for the vertex inside the destination meshes triangles
+            matches.clear();
+            indexTriangles->query(bg::index::nearest(coords, nnearest),
+                    boost::make_function_output_iterator([&](mesh::rtree::triangle_traits::IndexType const & match) {
+                        matches.emplace_back(bg::distance(coords, tTriangles[match.second]), match.second);
+                        }));
+            std::sort(matches.begin(), matches.end());
+            bool found = false;
+            for (const auto& match: matches) {
+                auto weights = query::generateInterpolationElements(fVertices[i], tTriangles[match.index]);
+                if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const & elem){ return elem.weight >= 0.0; })) {
+                    _weights[i] = std::move(weights);
+                    found = true;
+                    break;
+                }
+            }
+
+            if (not found) {
+                // Search for the vertex inside the destination meshes edges
+                matches.clear();
+                indexEdges->query(bg::index::nearest(coords, nnearest),
+                        boost::make_function_output_iterator([&](int match) {
+                            matches.emplace_back(bg::distance(coords, tEdges[match]), match);
+                            }));
+                std::sort(matches.begin(), matches.end());
+                for (const auto& match: matches) {
+                    auto weights = query::generateInterpolationElements(fVertices[i], tEdges[match.index]);
+                    if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const & elem){ return elem.weight >= 0.0; })) {
+                        _weights[i] = std::move(weights);
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if (not found) {
+                // Search for the vertex inside the destination meshes vertices
+                indexVertices->query(bg::index::nearest(coords, 1), 
+                        boost::make_function_output_iterator([&](int match) {
+                            _weights[i] = query::generateInterpolationElements(fVertices[i], tVertices[match]);
+                            }));
+            }
+        }
     }
-  }
-  else {
-    assertion(getConstraint() == CONSERVATIVE, getConstraint());
-    DEBUG("Compute conservative mapping");
-    _weights.resize(input()->vertices().size());
-    for ( size_t i=0; i < input()->vertices().size(); i++ ){
-      query::FindClosest findClosest(input()->vertices()[i].getCoords());
-      findClosest(*output());
-      assertion(findClosest.hasFound());
-      const query::ClosestElement& closest = findClosest.getClosest();
-      _weights[i].clear();
-      for (const query::InterpolationElement& elem : closest.interpolationElements) {
-        _weights[i].push_back(elem);
-      }
-    }
-  }
-  _hasComputedMapping = true;
+    _hasComputedMapping = true;
 }
 
 bool NearestProjectionMapping:: hasComputedMapping() const
@@ -133,20 +229,26 @@ void NearestProjectionMapping:: map
 void NearestProjectionMapping::tagMeshFirstRound()
 {
   TRACE();
+  DEBUG("Compute Mapping for Tagging");
 
   computeMapping();
+  DEBUG("Tagging First Round");
+
+  std::set<int> tagged;
 
   if (getConstraint() == CONSISTENT){
     for(mesh::Vertex& v : input()->vertices()){
       for (size_t i=0; i < output()->vertices().size(); i++) {
         const InterpolationElements& elems = _weights[i];
         for (const query::InterpolationElement& elem : elems) {
-          if (elem.element->getID()==v.getID() && elem.weight!=0.0) {
+          if (elem.element->getID()==v.getID() && !math::equals(elem.weight,0.0)) {
             v.tag();
+            tagged.insert(v.getID());
           }
         }
       }
     }
+    DEBUG("First Round Tagged " << tagged.size() << "/" << input()->vertices().size() << " Vertices");
   }
   else {
     assertion(getConstraint() == CONSERVATIVE, getConstraint());
@@ -154,12 +256,14 @@ void NearestProjectionMapping::tagMeshFirstRound()
       for (size_t i=0; i < input()->vertices().size(); i++) {
         const InterpolationElements& elems = _weights[i];
         for (const query::InterpolationElement& elem : elems) {
-          if (elem.element->getID()==v.getID() && elem.weight!=0.0) {
+          if (elem.element->getID()==v.getID() && !math::equals(elem.weight,0.0)) {
             v.tag();
+            tagged.insert(v.getID());
           }
         }
       }
     }
+    DEBUG("First Round Tagged " << tagged.size() << "/" << output()->vertices().size() << " Vertices");
   }
 
   clear();

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -1,10 +1,10 @@
-#include "NearestProjectionMapping.hpp"
-#include "query/FindClosest.hpp"
 #include <Eigen/Core>
-#include "utils/Event.hpp"
+#include "NearestProjectionMapping.hpp"
 #include "mesh/RTree.hpp"
+#include "query/FindClosest.hpp"
+#include "utils/Event.hpp"
 
-namespace bg = boost::geometry;
+namespace bg  = boost::geometry;
 namespace bgi = boost::geometry::index;
 
 namespace precice {
@@ -12,214 +12,213 @@ extern bool syncMode;
 
 namespace mapping {
 
-NearestProjectionMapping:: NearestProjectionMapping
-(
-  Constraint constraint,
-  int        dimensions)
-:
-  Mapping(constraint, dimensions)
+NearestProjectionMapping::NearestProjectionMapping(
+    Constraint constraint,
+    int        dimensions)
+    : Mapping(constraint, dimensions)
 {
-  if (constraint == CONSISTENT){
+  if (constraint == CONSISTENT) {
     setInputRequirement(Mapping::MeshRequirement::FULL);
     setOutputRequirement(Mapping::MeshRequirement::VERTEX);
-  }
-  else {
+  } else {
     assertion(constraint == CONSERVATIVE, constraint);
     setInputRequirement(Mapping::MeshRequirement::VERTEX);
     setOutputRequirement(Mapping::MeshRequirement::FULL);
   }
 }
 
-namespace{
-    struct MatchType {
-        double distance;
-        int index;
+namespace {
+struct MatchType {
+  double distance;
+  int    index;
 
-        MatchType() = default;
-        MatchType(double d, int i):distance(d), index(i) {};
-        constexpr bool operator<(MatchType const & other) const { return distance < other.distance; };
-    };
-}
+  MatchType() = default;
+  MatchType(double d, int i)
+      : distance(d), index(i){};
+  constexpr bool operator<(MatchType const &other) const
+  {
+    return distance < other.distance;
+  };
+};
+} // namespace
 
-void NearestProjectionMapping:: computeMapping()
+void NearestProjectionMapping::computeMapping()
 {
-    TRACE(input()->vertices().size(), output()->vertices().size());
-    precice::utils::Event e("map.np.computeMapping.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
+  TRACE(input()->vertices().size(), output()->vertices().size());
+  precice::utils::Event e("map.np.computeMapping.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
-    // Setup Direction of Mapping
-    mesh::PtrMesh from, to;
-    if (getConstraint() == CONSISTENT){
-        DEBUG("Compute consistent mapping");
-        from = output();
-        to   = input();
-    } else {
-        DEBUG("Compute conservative mapping");
-        from = input();
-        to   = output();
-    }
+  // Setup Direction of Mapping
+  mesh::PtrMesh from, to;
+  if (getConstraint() == CONSISTENT) {
+    DEBUG("Compute consistent mapping");
+    from = output();
+    to   = input();
+  } else {
+    DEBUG("Compute conservative mapping");
+    from = input();
+    to   = output();
+  }
 
-    const auto &fVertices = from->vertices();
-    const auto &tVertices = to->vertices();
-    const auto &tEdges    = to->edges();
+  const auto &fVertices = from->vertices();
+  const auto &tVertices = to->vertices();
+  const auto &tEdges    = to->edges();
 
-    _weights.resize(fVertices.size());
+  _weights.resize(fVertices.size());
 
-    constexpr int nnearest = 4;
+  constexpr int nnearest = 4;
 
-    if (getDimensions() == 2) {
-        //CHECK(fVertices.empty() || !tEdges.empty(), "Mesh \"" << to->getName() << "\" does not contain Edges to project onto.");
+  if (getDimensions() == 2) {
+    //CHECK(fVertices.empty() || !tEdges.empty(), "Mesh \"" << to->getName() << "\" does not contain Edges to project onto.");
 
-        auto indexEdges = mesh::rtree::getEdgeRTree(to);
-        auto indexVertices = mesh::rtree::getVertexRTree(to);
+    auto indexEdges    = mesh::rtree::getEdgeRTree(to);
+    auto indexVertices = mesh::rtree::getVertexRTree(to);
 
-        std::vector<MatchType> matches;
-        matches.reserve(nnearest);
-        for (size_t i = 0; i < fVertices.size(); i++) {
-            const Eigen::VectorXd &coords = fVertices[i].getCoords();
-            // Search for the from vertex inside the destination meshes edges
-            matches.clear();
-            indexEdges->query(bg::index::nearest(coords, nnearest),
-                    boost::make_function_output_iterator([&](int match) {
-                        matches.emplace_back(bg::distance(coords, tEdges[match]), match);
-                        }));
-            std::sort(matches.begin(), matches.end());
-            bool found = false;
-            for (const auto& match: matches) {
-                auto weights = query::generateInterpolationElements(fVertices[i], tEdges[match.index]);
-                if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const & elem){ return elem.weight >= 0.0; })) {
-                    _weights[i] = std::move(weights);
-                    found = true;
-                    break;
-                }
-            }
-
-            if (not found) {
-                // Search for the from vertex inside the destination meshes vertices
-                indexVertices->query(bg::index::nearest(coords, 1), 
+    std::vector<MatchType> matches;
+    matches.reserve(nnearest);
+    for (size_t i = 0; i < fVertices.size(); i++) {
+      const Eigen::VectorXd &coords = fVertices[i].getCoords();
+      // Search for the from vertex inside the destination meshes edges
+      matches.clear();
+      indexEdges->query(bg::index::nearest(coords, nnearest),
                         boost::make_function_output_iterator([&](int match) {
-                            _weights[i] = query::generateInterpolationElements(fVertices[i], tVertices[match]);
-                            }));
-            }
+                          matches.emplace_back(bg::distance(coords, tEdges[match]), match);
+                        }));
+      std::sort(matches.begin(), matches.end());
+      bool found = false;
+      for (const auto &match : matches) {
+        auto weights = query::generateInterpolationElements(fVertices[i], tEdges[match.index]);
+        if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const &elem) { return elem.weight >= 0.0; })) {
+          _weights[i] = std::move(weights);
+          found       = true;
+          break;
         }
-    } else {
-        const auto &tTriangles = to->triangles();
-        //CHECK(fVertices.empty() || !tTriangles.empty(), "Mesh \"" << to->getName() << "\" does not contain Triangles to project onto.");
+      }
 
-        auto indexTriangles = mesh::rtree::getTriangleRTree(to);
-        auto indexEdges     = mesh::rtree::getEdgeRTree(to);
-        auto indexVertices  = mesh::rtree::getVertexRTree(to);
+      if (not found) {
+        // Search for the from vertex inside the destination meshes vertices
+        indexVertices->query(bg::index::nearest(coords, 1),
+                             boost::make_function_output_iterator([&](int match) {
+                               _weights[i] = query::generateInterpolationElements(fVertices[i], tVertices[match]);
+                             }));
+      }
+    }
+  } else {
+    const auto &tTriangles = to->triangles();
+    //CHECK(fVertices.empty() || !tTriangles.empty(), "Mesh \"" << to->getName() << "\" does not contain Triangles to project onto.");
 
-        std::vector<MatchType> matches;
-        matches.reserve(nnearest);
-        for (size_t i = 0; i < fVertices.size(); i++) {
-            const Eigen::VectorXd &coords = fVertices[i].getCoords();
+    auto indexTriangles = mesh::rtree::getTriangleRTree(to);
+    auto indexEdges     = mesh::rtree::getEdgeRTree(to);
+    auto indexVertices  = mesh::rtree::getVertexRTree(to);
 
-            // Search for the vertex inside the destination meshes triangles
-            matches.clear();
-            indexTriangles->query(bg::index::nearest(coords, nnearest),
-                    boost::make_function_output_iterator([&](mesh::rtree::triangle_traits::IndexType const & match) {
-                        matches.emplace_back(bg::distance(coords, tTriangles[match.second]), match.second);
-                        }));
-            std::sort(matches.begin(), matches.end());
-            bool found = false;
-            for (const auto& match: matches) {
-                auto weights = query::generateInterpolationElements(fVertices[i], tTriangles[match.index]);
-                if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const & elem){ return elem.weight >= 0.0; })) {
-                    _weights[i] = std::move(weights);
-                    found = true;
-                    break;
-                }
-            }
+    std::vector<MatchType> matches;
+    matches.reserve(nnearest);
+    for (size_t i = 0; i < fVertices.size(); i++) {
+      const Eigen::VectorXd &coords = fVertices[i].getCoords();
 
-            if (not found) {
-                // Search for the vertex inside the destination meshes edges
-                matches.clear();
-                indexEdges->query(bg::index::nearest(coords, nnearest),
-                        boost::make_function_output_iterator([&](int match) {
+      // Search for the vertex inside the destination meshes triangles
+      matches.clear();
+      indexTriangles->query(bg::index::nearest(coords, nnearest),
+                            boost::make_function_output_iterator([&](mesh::rtree::triangle_traits::IndexType const &match) {
+                              matches.emplace_back(bg::distance(coords, tTriangles[match.second]), match.second);
+                            }));
+      std::sort(matches.begin(), matches.end());
+      bool found = false;
+      for (const auto &match : matches) {
+        auto weights = query::generateInterpolationElements(fVertices[i], tTriangles[match.index]);
+        if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const &elem) { return elem.weight >= 0.0; })) {
+          _weights[i] = std::move(weights);
+          found       = true;
+          break;
+        }
+      }
+
+      if (not found) {
+        // Search for the vertex inside the destination meshes edges
+        matches.clear();
+        indexEdges->query(bg::index::nearest(coords, nnearest),
+                          boost::make_function_output_iterator([&](int match) {
                             matches.emplace_back(bg::distance(coords, tEdges[match]), match);
-                            }));
-                std::sort(matches.begin(), matches.end());
-                for (const auto& match: matches) {
-                    auto weights = query::generateInterpolationElements(fVertices[i], tEdges[match.index]);
-                    if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const & elem){ return elem.weight >= 0.0; })) {
-                        _weights[i] = std::move(weights);
-                        found = true;
-                        break;
-                    }
-                }
-            }
-
-            if (not found) {
-                // Search for the vertex inside the destination meshes vertices
-                indexVertices->query(bg::index::nearest(coords, 1), 
-                        boost::make_function_output_iterator([&](int match) {
-                            _weights[i] = query::generateInterpolationElements(fVertices[i], tVertices[match]);
-                            }));
-            }
+                          }));
+        std::sort(matches.begin(), matches.end());
+        for (const auto &match : matches) {
+          auto weights = query::generateInterpolationElements(fVertices[i], tEdges[match.index]);
+          if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const &elem) { return elem.weight >= 0.0; })) {
+            _weights[i] = std::move(weights);
+            found       = true;
+            break;
+          }
         }
+      }
+
+      if (not found) {
+        // Search for the vertex inside the destination meshes vertices
+        indexVertices->query(bg::index::nearest(coords, 1),
+                             boost::make_function_output_iterator([&](int match) {
+                               _weights[i] = query::generateInterpolationElements(fVertices[i], tVertices[match]);
+                             }));
+      }
     }
-    _hasComputedMapping = true;
+  }
+  _hasComputedMapping = true;
 }
 
-bool NearestProjectionMapping:: hasComputedMapping() const
+bool NearestProjectionMapping::hasComputedMapping() const
 {
   return _hasComputedMapping;
 }
 
-void NearestProjectionMapping:: clear()
+void NearestProjectionMapping::clear()
 {
   TRACE();
   _weights.clear();
   _hasComputedMapping = false;
 }
 
-void NearestProjectionMapping:: map
-(
-  int inputDataID,
-  int outputDataID )
+void NearestProjectionMapping::map(
+    int inputDataID,
+    int outputDataID)
 {
   TRACE(inputDataID, outputDataID);
 
   precice::utils::Event e("map.np.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
-  mesh::PtrData inData = input()->data(inputDataID);
-  mesh::PtrData outData = output()->data(outputDataID);
-  const Eigen::VectorXd& inValues = inData->values();
-  Eigen::VectorXd& outValues = outData->values();
+  mesh::PtrData          inData    = input()->data(inputDataID);
+  mesh::PtrData          outData   = output()->data(outputDataID);
+  const Eigen::VectorXd &inValues  = inData->values();
+  Eigen::VectorXd &      outValues = outData->values();
   //assign(outValues) = 0.0;
   int dimensions = inData->getDimensions();
   assertion(dimensions == outData->getDimensions());
 
-  if (getConstraint() == CONSISTENT){
+  if (getConstraint() == CONSISTENT) {
     DEBUG("Map consistent");
     assertion(_weights.size() == output()->vertices().size(),
-               _weights.size(), output()->vertices().size());
-    for (size_t i=0; i < output()->vertices().size(); i++){
-      InterpolationElements& elems = _weights[i];
-      size_t outOffset = i * dimensions;
-      for (query::InterpolationElement& elem : elems) {
-        size_t inOffset = (size_t)elem.element->getID() * dimensions;
-        for (int dim=0; dim < dimensions; dim++){
-          assertion(outOffset + dim < (size_t)outValues.size());
-          assertion(inOffset + dim < (size_t)inValues.size());
+              _weights.size(), output()->vertices().size());
+    for (size_t i = 0; i < output()->vertices().size(); i++) {
+      InterpolationElements &elems     = _weights[i];
+      size_t                 outOffset = i * dimensions;
+      for (query::InterpolationElement &elem : elems) {
+        size_t inOffset = (size_t) elem.element->getID() * dimensions;
+        for (int dim = 0; dim < dimensions; dim++) {
+          assertion(outOffset + dim < (size_t) outValues.size());
+          assertion(inOffset + dim < (size_t) inValues.size());
           outValues(outOffset + dim) += elem.weight * inValues(inOffset + dim);
         }
       }
     }
-  }
-  else {
+  } else {
     assertion(getConstraint() == CONSERVATIVE, getConstraint());
     DEBUG("Map conservative");
     assertion(_weights.size() == input()->vertices().size(),
-               _weights.size(), input()->vertices().size());
-    for (size_t i=0; i < input()->vertices().size(); i++){
-      size_t inOffset = i * dimensions;
-      InterpolationElements& elems = _weights[i];
-      for (query::InterpolationElement& elem : elems) {
-        size_t outOffset = (size_t)elem.element->getID() * dimensions;
-        for ( int dim=0; dim < dimensions; dim++ ){
-          assertion(outOffset + dim < (size_t)outValues.size());
-          assertion(inOffset + dim < (size_t)inValues.size());
+              _weights.size(), input()->vertices().size());
+    for (size_t i = 0; i < input()->vertices().size(); i++) {
+      size_t                 inOffset = i * dimensions;
+      InterpolationElements &elems    = _weights[i];
+      for (query::InterpolationElement &elem : elems) {
+        size_t outOffset = (size_t) elem.element->getID() * dimensions;
+        for (int dim = 0; dim < dimensions; dim++) {
+          assertion(outOffset + dim < (size_t) outValues.size());
+          assertion(inOffset + dim < (size_t) inValues.size());
           outValues(outOffset + dim) += elem.weight * inValues(inOffset + dim);
         }
       }
@@ -235,37 +234,39 @@ void NearestProjectionMapping::tagMeshFirstRound()
   computeMapping();
   DEBUG("Tagging First Round");
 
-  std::set<int> tagged;
-
-  if (getConstraint() == CONSISTENT){
-    for(mesh::Vertex& v : input()->vertices()){
-      for (size_t i=0; i < output()->vertices().size(); i++) {
-        const InterpolationElements& elems = _weights[i];
-        for (const query::InterpolationElement& elem : elems) {
-          if (elem.element->getID()==v.getID() && !math::equals(elem.weight,0.0)) {
-            v.tag();
-            tagged.insert(v.getID());
-          }
-        }
-      }
-    }
-    DEBUG("First Round Tagged " << tagged.size() << "/" << input()->vertices().size() << " Vertices");
-  }
-  else {
+  // Determine the Mesh to Tag
+  mesh::PtrMesh from{nullptr};
+  if (getConstraint() == CONSISTENT) {
+    from = input();
+  } else {
     assertion(getConstraint() == CONSERVATIVE, getConstraint());
-    for(mesh::Vertex& v : output()->vertices()){
-      for (size_t i=0; i < input()->vertices().size(); i++) {
-        const InterpolationElements& elems = _weights[i];
-        for (const query::InterpolationElement& elem : elems) {
-          if (elem.element->getID()==v.getID() && !math::equals(elem.weight,0.0)) {
-            v.tag();
-            tagged.insert(v.getID());
-          }
-        }
+    from = output();
+  }
+
+  // Gather all vertices to be tagged in a first phase.
+  // max_count is used to shortcut if all vertices have been tagged.
+  std::unordered_set<mesh::Vertex const *> tagged;
+  const std::size_t max_count = from->vertices().size();
+
+  for (const InterpolationElements &elems : _weights) {
+    for (const query::InterpolationElement &elem : elems) {
+      if (!math::equals(elem.weight, 0.0)) {
+        tagged.insert(elem.element);
       }
     }
-    DEBUG("First Round Tagged " << tagged.size() << "/" << output()->vertices().size() << " Vertices");
+    // Shortcut if all vertices are tagged
+    if (tagged.size() == max_count) {
+      break;
+    }
   }
+
+  // Now tag all vertices to be tagged in the second phase.
+  for (auto& v : from->vertices()) {
+      if(tagged.count(&v) == 1) {
+          v.tag();
+      }
+  }
+  DEBUG("First Round Tagged " << tagged.size() << "/" << max_count << " Vertices");
 
   clear();
 }
@@ -276,4 +277,5 @@ void NearestProjectionMapping::tagMeshSecondRound()
   // for NP mapping no operation needed here
 }
 
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -2,6 +2,7 @@
 #include "query/FindClosest.hpp"
 #include <Eigen/Core>
 #include "utils/Event.hpp"
+#include "mesh/RTree.hpp"
 
 namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -65,6 +65,10 @@ void NearestProjectionMapping::computeMapping()
 
   _weights.resize(fVertices.size());
 
+  // Amount of nearest elements to fetch for detailed comparison.
+  // This safety margin results in a candidate set which forms the base for the
+  // local nearest projection and counters the loss of detail due to bounding box generation.
+  // @TODO Add a configuration option for this factor
   constexpr int nnearest = 4;
 
   if (getDimensions() == 2) {

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -25,8 +25,6 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   outMesh->computeState();
   outMesh->allocateDataValues();
 
-  BOOST_TEST_MESSAGE(*outMesh);
-
   // Base-value for tests
   double value = 1.0;
 

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -197,6 +197,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 }
 
 
+/// @TODO FIX broken test
+#if 0
 BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
 {
   using namespace mesh;
@@ -281,6 +283,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   BOOST_TEST ( outData->values()[1] == valueVertex2 );
   BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
 {

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -25,53 +25,83 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   outMesh->computeState();
   outMesh->allocateDataValues();
 
-  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false) );
-  PtrData inData = inMesh->createData ( "Data", 1 );
-  int inDataID = inData->getID();
+  BOOST_TEST_MESSAGE(*outMesh);
 
-  // Setup mapping with mapping coordinates and geometry used
-  mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-  mapping.setMeshes(inMesh, outMesh);
-
-  // Map value 1.0 from middle of edge to geometry. Expect half of the
-  // value to be added to vertex1 and half of it to vertex2.
-  Vertex& inv1 = inMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
-  // Map value 1.0 from below edge to geometry. Expect vertex1 to get the
-  // full data value, i.e. 1.0 and in addition the value from before. In total
-  // v1 should have 1.5 * dataValue then.
-  Vertex& inv2 = inMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
-  // Do the same thing from above, expect vertex2 to get the full value now.
-  Vertex& inv3 = inMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
-  inMesh->allocateDataValues();
-
+  // Base-value for tests
   double value = 1.0;
-  //assign(inData->values()) = value;
-  inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
-  mapping.computeMapping();
-  mapping.map(inDataID, outDataID);
-  Eigen::VectorXd& values = outData->values();
-  BOOST_TEST(values(0) == value * 1.5);
-  BOOST_TEST(values(1) == value * 1.5);
 
-  // Change in-vertex coordinates and recompute mapping
-  inv1.setCoords (Eigen::Vector2d(-1.0, -1.0));
-  inv2.setCoords (Eigen::Vector2d(-1.0, -1.0));
-  inv3.setCoords (Eigen::Vector2d(1.0, 1.0));
-  //assign(values) = 0.0;
-  values = Eigen::VectorXd::Constant(values.size(), 0.0);
+  {
+      // Setup mapping with mapping coordinates and geometry used
+      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
+      PtrMesh inMesh ( new Mesh("InMesh0", dimensions, false) );
+      PtrData inData = inMesh->createData ( "Data0", 1 );
+      int inDataID = inData->getID();
 
-  mapping.computeMapping();
-  mapping.map(inDataID, outDataID);
-  BOOST_TEST(values(0) == value * 2.0);
-  BOOST_TEST(values(1) == value * 1.0);
+      // Map value 1.0 from middle of edge to geometry. Expect half of the
+      // value to be added to vertex1 and half of it to vertex2.
+      Vertex& inv1 = inMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
+      // Map value 1.0 from below edge to geometry. Expect vertex1 to get the
+      // full data value, i.e. 1.0 and in addition the value from before. In total
+      // v1 should have 1.5 * dataValue then.
+      Vertex& inv2 = inMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
+      // Do the same thing from above, expect vertex2 to get the full value now.
+      Vertex& inv3 = inMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
 
-  // reset output value and remap
-  //assign(values) = 0.0;
-  values = Eigen::VectorXd::Constant(values.size(), 0.0);
+      inMesh->allocateDataValues();
+      inMesh->computeState();
 
-  mapping.map(inDataID, outDataID);
-  BOOST_TEST(values(0) == value * 2.0);
-  BOOST_TEST(values(1) == value * 1.0);
+      //assign(inData->values()) = value;
+      inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
+      //assign(values) = 0.0;
+      Eigen::VectorXd& values = outData->values();
+      values = Eigen::VectorXd::Constant(values.size(), 0.0);
+
+      mapping.setMeshes(inMesh, outMesh);
+      mapping.computeMapping();
+      mapping.map(inDataID, outDataID);
+      BOOST_TEST_CONTEXT(*inMesh) {
+          BOOST_TEST(values(0) == value * 1.5);
+          BOOST_TEST(values(1) == value * 1.5);
+      }
+  }
+  {
+      // Setup mapping with mapping coordinates and geometry used
+      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
+      PtrMesh inMesh ( new Mesh("InMesh1", dimensions, false) );
+      PtrData inData = inMesh->createData ( "Data1", 1 );
+      int inDataID = inData->getID();
+
+      Vertex& inv1 = inMesh->createVertex(Eigen::Vector2d(-1.0, -1.0));
+      Vertex& inv2 = inMesh->createVertex(Eigen::Vector2d(-1.0, -1.0));
+      Vertex& inv3 = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+
+      inMesh->allocateDataValues();
+      inMesh->computeState();
+
+      //assign(inData->values()) = value;
+      inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
+      //assign(values) = 0.0;
+      Eigen::VectorXd& values = outData->values();
+      values = Eigen::VectorXd::Constant(values.size(), 0.0);
+
+      mapping.setMeshes(inMesh, outMesh);
+      mapping.computeMapping();
+      mapping.map(inDataID, outDataID);
+      BOOST_TEST_CONTEXT(*inMesh) {
+          BOOST_TEST(values(0) == value * 2.0);
+          BOOST_TEST(values(1) == value * 1.0);
+      }
+
+      // reset output value and remap
+      //assign(values) = 0.0;
+      values = Eigen::VectorXd::Constant(values.size(), 0.0);
+
+      mapping.map(inDataID, outDataID);
+      BOOST_TEST_CONTEXT(*inMesh) {
+          BOOST_TEST(values(0) == value * 2.0);
+          BOOST_TEST(values(1) == value * 1.0);
+      }
+  }
 }
 
 BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
@@ -94,61 +124,76 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   values(0) = valueVertex1;
   values(1) = valueVertex2;
 
-  // Create mesh to map to
-  PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false) );
-  PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
+  {
+      // Create mesh to map to
+      PtrMesh outMesh ( new Mesh("OutMesh0", dimensions, false) );
+      PtrData outData = outMesh->createData ( "OutData", 1 );
+      int outDataID = outData->getID();
 
-  // Setup mapping with mapping coordinates and geometry used
-  mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+      // Setup mapping with mapping coordinates and geometry used
+      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+      mapping.setMeshes ( inMesh, outMesh );
+      BOOST_TEST ( mapping.hasComputedMapping() == false );
 
-  Vertex& outv0 = outMesh->createVertex ( Eigen::Vector2d(0.5, 0.5) );
-  Vertex& outv1 = outMesh->createVertex ( Eigen::Vector2d(-0.5, -0.5) );
-  Vertex& outv2 = outMesh->createVertex ( Eigen::Vector2d(1.5, 1.5) );
-  outMesh->allocateDataValues();
+      Vertex& outv0 = outMesh->createVertex ( Eigen::Vector2d(0.5, 0.5) );
+      Vertex& outv1 = outMesh->createVertex ( Eigen::Vector2d(-0.5, -0.5) );
+      Vertex& outv2 = outMesh->createVertex ( Eigen::Vector2d(1.5, 1.5) );
+      outMesh->allocateDataValues();
 
-  // Compute and perform mapping
-  mapping.computeMapping();
-  mapping.map ( inDataID, outDataID );
+      // Compute and perform mapping
+      mapping.computeMapping();
+      mapping.map ( inDataID, outDataID );
 
-  // Validate results
-  BOOST_TEST ( mapping.hasComputedMapping() == true );
-  BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-  BOOST_TEST ( outData->values()[1] == valueVertex1 );
-  BOOST_TEST ( outData->values()[2] == valueVertex2 );
+      // Validate results
+      BOOST_TEST ( mapping.hasComputedMapping() == true );
+      BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
+      BOOST_TEST ( outData->values()[1] == valueVertex1);
+      BOOST_TEST ( outData->values()[2] == valueVertex2);
 
-  // Redo mapping, results should be
-  //assign(outData->values()) = 0.0;
-  outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+      // Redo mapping, results should be
+      //assign(outData->values()) = 0.0;
+      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-  BOOST_TEST ( outData->values()[1] == valueVertex1 );
-  BOOST_TEST ( outData->values()[2] == valueVertex2 );
+      mapping.map ( inDataID, outDataID );
+      BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
+      BOOST_TEST ( outData->values()[1] == valueVertex1);
+      BOOST_TEST ( outData->values()[2] == valueVertex2);
+  }
 
-  // Change vertex coordinates and redo mapping
-  outv0.setCoords ( Eigen::Vector2d(-0.5, -0.5) );
-  outv1.setCoords ( Eigen::Vector2d(1.5, 1.5) );
-  outv2.setCoords ( Eigen::Vector2d(0.5, 0.5) );
-  //assign(outData->values()) = 0.0;
-  outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+  {
+      // Create mesh to map to
+      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false) );
+      PtrData outData = outMesh->createData ( "OutData", 1 );
+      int outDataID = outData->getID();
 
-  mapping.computeMapping();
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST ( outData->values()[0] == valueVertex1 );
-  BOOST_TEST ( outData->values()[1] == valueVertex2 );
-  BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+      // Setup mapping with mapping coordinates and geometry used
+      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+      mapping.setMeshes ( inMesh, outMesh );
+      BOOST_TEST ( mapping.hasComputedMapping() == false );
 
-  // Reset output data to zero and redo the mapping
-  //assign(outData->values()) = 0.0;
-  outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+      Vertex& outv0 = outMesh->createVertex ( Eigen::Vector2d(-0.5, -0.5) );
+      Vertex& outv1 = outMesh->createVertex ( Eigen::Vector2d(1.5, 1.5) );
+      Vertex& outv2 = outMesh->createVertex ( Eigen::Vector2d(0.5, 0.5) );
+      outMesh->allocateDataValues();
 
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST ( outData->values()[0] == valueVertex1 );
-  BOOST_TEST ( outData->values()[1] == valueVertex2 );
-  BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+      //assign(outData->values()) = 0.0;
+      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+
+      mapping.computeMapping();
+      mapping.map ( inDataID, outDataID );
+      BOOST_TEST ( outData->values()[0] == valueVertex1);
+      BOOST_TEST ( outData->values()[1] == valueVertex2);
+      BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+
+      // Reset output data to zero and redo the mapping
+      //assign(outData->values()) = 0.0;
+      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+
+      mapping.map ( inDataID, outDataID );
+      BOOST_TEST ( outData->values()[0] == valueVertex1);
+      BOOST_TEST ( outData->values()[1] == valueVertex2);
+      BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+  }
 }
 
 

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -195,8 +195,6 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 }
 
 
-/// @TODO FIX broken test
-#if 0
 BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
 {
   using namespace mesh;
@@ -224,64 +222,85 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   values(1) = valueVertex2;
   values(2) = valueVertex3;
 
-  // Create mesh to map to
-  PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false) );
-  PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
+  {
+      // Create mesh to map to
+      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false) );
+      PtrData outData = outMesh->createData ( "OutData1", 1 );
+      int outDataID = outData->getID();
 
-  // Setup mapping with mapping coordinates and geometry used
-  mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+      // Setup mapping with mapping coordinates and geometry used
+      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+      mapping.setMeshes ( inMesh, outMesh );
+      BOOST_TEST ( mapping.hasComputedMapping() == false );
 
-  Vertex& outv0 = outMesh->createVertex ( Eigen::Vector3d(0.5, 0.5, 0.0) );
-  Vertex& outv1 = outMesh->createVertex ( Eigen::Vector3d(-0.5, -0.5, 0.0) );
-  Vertex& outv2 = outMesh->createVertex ( Eigen::Vector3d(1.5, 1.5, 0.0) );
-  outMesh->allocateDataValues();
+      Vertex& outv0 = outMesh->createVertex ( Eigen::Vector3d(0.5, 0.5, 0.0) );
+      Vertex& outv1 = outMesh->createVertex ( Eigen::Vector3d(-0.5, -0.5, 0.0) );
+      Vertex& outv2 = outMesh->createVertex ( Eigen::Vector3d(1.5, 1.5, 0.0) );
+      outMesh->allocateDataValues();
 
-  // Compute and perform mapping
-  mapping.computeMapping();
-  mapping.map ( inDataID, outDataID );
+      // Compute and perform mapping
+      mapping.computeMapping();
+      mapping.map ( inDataID, outDataID );
 
-  // Validate results
-  BOOST_TEST ( mapping.hasComputedMapping() == true );
-  BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-  BOOST_TEST ( outData->values()[1] == valueVertex1 );
-  BOOST_TEST ( outData->values()[2] == valueVertex2 );
+      // Validate results
+      BOOST_TEST ( mapping.hasComputedMapping() == true );
+      BOOST_TEST_CONTEXT(*inMesh) {
+          BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
+          BOOST_TEST ( outData->values()[1] ==  valueVertex1 );
+          BOOST_TEST ( outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5 );
+      }
 
-  // Redo mapping, results should be
-  //assign(outData->values()) = 0.0;
-  outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+      // Redo mapping, results should be
+      //assign(outData->values()) = 0.0;
+      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-  BOOST_TEST ( outData->values()[1] == valueVertex1 );
-  BOOST_TEST ( outData->values()[2] == valueVertex2 );
+      mapping.map ( inDataID, outDataID );
+      BOOST_TEST_CONTEXT(*inMesh) {
+          BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
+          BOOST_TEST ( outData->values()[1] ==  valueVertex1 );
+          BOOST_TEST ( outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5 );
+      }
+  }
+  {
+      // Create mesh to map to
+      PtrMesh outMesh ( new Mesh("OutMesh2", dimensions, false) );
+      PtrData outData = outMesh->createData ( "OutData2", 1 );
+      int outDataID = outData->getID();
 
-  // Change vertex coordinates and redo mapping
-  outv0.setCoords ( Eigen::Vector3d(-0.5, -0.5, 0.0) );
-  outv1.setCoords ( Eigen::Vector3d(1.5, 1.5, 0.0) );
-  outv2.setCoords ( Eigen::Vector3d(0.5, 0.5, 0.0) );
-  //assign(outData->values()) = 0.0;
-  outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+      // Setup mapping with mapping coordinates and geometry used
+      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+      mapping.setMeshes ( inMesh, outMesh );
+      BOOST_TEST ( mapping.hasComputedMapping() == false );
 
-  mapping.clear();
-  mapping.computeMapping();
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST ( outData->values()[0] == valueVertex1 );
-  BOOST_TEST ( outData->values()[1] == valueVertex2 );
-  BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+      Vertex& outv0 = outMesh->createVertex ( Eigen::Vector3d(-0.5, -0.5, 0.0) );
+      Vertex& outv1 = outMesh->createVertex ( Eigen::Vector3d(1.5, 1.5, 0.0) );
+      Vertex& outv2 = outMesh->createVertex ( Eigen::Vector3d(0.5, 0.5, 0.0) );
+      outMesh->allocateDataValues();
 
-  // Reset output data to zero and redo the mapping
-  //assign(outData->values()) = 0.0;
-  outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+      //assign(outData->values()) = 0.0;
+      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST ( outData->values()[0] == valueVertex1 );
-  BOOST_TEST ( outData->values()[1] == valueVertex2 );
-  BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+      mapping.clear();
+      mapping.computeMapping();
+      mapping.map ( inDataID, outDataID );
+      BOOST_TEST_CONTEXT(*inMesh) {
+          BOOST_TEST ( outData->values()[0] == valueVertex1 );
+          BOOST_TEST ( outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5 );
+          BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+      }
+
+      // Reset output data to zero and redo the mapping
+      //assign(outData->values()) = 0.0;
+      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+
+      mapping.map ( inDataID, outDataID );
+      BOOST_TEST_CONTEXT(*inMesh) {
+          BOOST_TEST ( outData->values()[0] == valueVertex1 );
+          BOOST_TEST ( outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5 );
+          BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+      }
+  }
 }
-#endif
 
 BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
 {

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -208,14 +208,21 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   int inDataID = inData->getID ();
   Vertex& v1 = inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
   Vertex& v2 = inMesh->createVertex ( Eigen::Vector3d(1.0, 1.0, 0.0) );
-  inMesh->createEdge ( v1, v2 );
+  Vertex& v3 = inMesh->createVertex ( Eigen::Vector3d(2.0, 2.0, 0.0) );
+  Edge & e12 = inMesh->createEdge ( v1, v2 );
+  Edge & e23 = inMesh->createEdge ( v2, v3 );
+  Edge & e31 = inMesh->createEdge ( v3, v1 );
+  inMesh->createTriangle(e12, e23, e31);
+
   inMesh->computeState();
   inMesh->allocateDataValues();
   double valueVertex1 = 1.0;
   double valueVertex2 = 2.0;
+  double valueVertex3 = 3.0;
   Eigen::VectorXd& values = inData->values();
   values(0) = valueVertex1;
   values(1) = valueVertex2;
+  values(2) = valueVertex3;
 
   // Create mesh to map to
   PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false) );
@@ -258,6 +265,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   //assign(outData->values()) = 0.0;
   outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
+  mapping.clear();
   mapping.computeMapping();
   mapping.map ( inDataID, outDataID );
   BOOST_TEST ( outData->values()[0] == valueVertex1 );

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -282,6 +282,110 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
 }
 
+BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
+{
+  using namespace precice::mesh;
+  constexpr int dimensions = 3;
+
+  // Create mesh to map from with Triangles ABD and BDC
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false));
+  PtrData inData = inMesh->createData("InData", 1);
+  Vertex& inVA = inMesh->createVertex(Eigen::Vector3d{0,0,0});
+  Vertex& inVB = inMesh->createVertex(Eigen::Vector3d{0,1,0});
+  Vertex& inVC = inMesh->createVertex(Eigen::Vector3d{1,1,0});
+  Vertex& inVD = inMesh->createVertex(Eigen::Vector3d{1,0,0});
+
+  Edge& inEDA = inMesh->createEdge(inVD, inVA);
+  Edge& inEAB = inMesh->createEdge(inVA, inVB);
+  Edge& inEBD = inMesh->createEdge(inVB, inVD);
+  Edge& inEDC = inMesh->createEdge(inVD, inVC);
+  Edge& inECB = inMesh->createEdge(inVC, inVB);
+
+  inMesh->createTriangle(inEAB, inEBD, inEDA);
+  inMesh->createTriangle(inEBD, inEDC, inECB);
+  inMesh->allocateDataValues();
+  inMesh->computeState();
+  inData->values() << 1.0, 1.0, 1.0, 1.0;
+
+  // Create mesh to map to with one vertex per defined traingle
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false));
+  PtrData outData = outMesh->createData("OutData", 1);
+  outMesh->createVertex(Eigen::Vector3d{0.33, 0.33, 0});
+  outMesh->createVertex(Eigen::Vector3d{0.66, 0.66, 0});
+  outMesh->allocateDataValues();
+  outMesh->computeState();
+  outData->values() << 0.0, 0.0;
+
+  // Setup mapping with mapping coordinates and geometry used
+  precice::mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  mapping.computeMapping();
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST_INFO("In Data:" << inData->values());
+  BOOST_TEST_INFO("Out Data before Mapping:" << outData->values());
+  mapping.map(inData->getID(), outData->getID());
+  BOOST_TEST_INFO("Out Data after Mapping:" << outData->values());
+  BOOST_TEST(outData->values() == outData->values().cwiseAbs());
+}
+
+BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
+{
+  using namespace precice::mesh;
+  constexpr int dimensions = 3;
+
+  PtrMesh inMesh(new precice::mesh::Mesh("InMesh", 3, false));
+  PtrData inData = inMesh->createData("InData", 1);
+  const double z1 = 0.1;
+  const double z2 = -0.1;
+  auto& v00 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
+  auto& v01 = inMesh->createVertex(Eigen::Vector3d(0, 1, 0));
+  auto& v10 = inMesh->createVertex(Eigen::Vector3d(1, 0, z1));
+  auto& v11 = inMesh->createVertex(Eigen::Vector3d(1, 1, z1));
+  auto& v20 = inMesh->createVertex(Eigen::Vector3d(2, 0, z2));
+  auto& v21 = inMesh->createVertex(Eigen::Vector3d(2, 1, z2));
+  auto& ell = inMesh->createEdge(v00, v01);
+  auto& elt = inMesh->createEdge(v01, v11);
+  auto& elr = inMesh->createEdge(v11, v10);
+  auto& elb = inMesh->createEdge(v10, v00);
+  auto& eld = inMesh->createEdge(v00, v11);
+  auto& erl = elr;
+  auto& ert = inMesh->createEdge(v11, v21);
+  auto& err = inMesh->createEdge(v21, v20);
+  auto& erb = inMesh->createEdge(v20, v10);
+  auto& erd = inMesh->createEdge(v10, v21);
+  auto& tlt = inMesh->createTriangle(ell, elt, eld);
+  auto& tlb = inMesh->createTriangle(eld, elb, elr);
+  auto& trt = inMesh->createTriangle(erl, ert, erd);
+  auto& trb = inMesh->createTriangle(erd, erb, err);
+
+  inMesh->allocateDataValues();
+  inMesh->computeState();
+  inData->values() = Eigen::VectorXd::Constant(6, 1.0);
+
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false));
+  PtrData outData = outMesh->createData("OutData", 1);
+  outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
+  outMesh->allocateDataValues();
+  outMesh->computeState();
+  outData->values() = Eigen::VectorXd::Constant(1, 0.0);
+
+  // Setup mapping with mapping coordinates and geometry used
+  precice::mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  mapping.computeMapping();
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+
+  BOOST_TEST_INFO("In Data:" << inData->values());
+  BOOST_TEST_INFO("Out Data before Mapping:" << outData->values());
+  mapping.map(inData->getID(), outData->getID());
+  BOOST_TEST_INFO("Out Data after Mapping:" << outData->values());
+  BOOST_TEST(outData->values()[0] == 1.0);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -41,8 +41,8 @@ Mesh:: Mesh
   _nameIDPairs[_name] = _managePropertyIDs->getFreeID ();
   setProperty(INDEX_GEOMETRY_ID, _nameIDPairs[_name]);
 
-  meshChanged.connect(&rtree::clear);
-  meshDestroyed.connect(&rtree::clear);
+  meshChanged.connect([](Mesh & m){rtree::clear(m);});
+  meshDestroyed.connect([](Mesh & m){rtree::clear(m);});
 }
 
 Mesh:: ~Mesh()

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -304,7 +304,7 @@ void Mesh:: allocateDataValues()
     if (leftToAllocate > 0){
       utils::append(data->values(), (Eigen::VectorXd) Eigen::VectorXd::Zero(leftToAllocate));
     }
-    DEBUG("Data " << data->getName() << " no has " << data->values().size() << " values");
+    DEBUG("Data " << data->getName() << " now has " << data->values().size() << " values");
   }
 }
 

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -1,32 +1,84 @@
-#include "impl/RTree.hpp"
+#include "mesh/impl/RTree.hpp"
+#include "mesh/impl/RTreeAdapter.hpp"
 
-#include "RTree.hpp"
+#include "mesh/RTree.hpp"
 
 namespace precice {
 namespace mesh {
 
+namespace bg = boost::geometry;
+
 // Initialize static member
-std::map<int, rtree::PtrVertexRTree> precice::mesh::rtree::_vertex_trees;
-// Initialize static member
+std::map<int, rtree::MeshIndices> precice::mesh::rtree::_cached_trees;
 std::map<int, PtrPrimitiveRTree> precice::mesh::rtree::_primitive_trees;
 
-rtree::PtrVertexRTree rtree::getVertexRTree(const PtrMesh& mesh)
+rtree::MeshIndices& rtree::cacheEntry(int meshID)
 {
+    auto result = _cached_trees.emplace(std::make_pair(meshID, rtree::MeshIndices{}));
+    return result.first->second;
+}
+
+
+rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh& mesh)
+{
+  assertion(mesh);
+  auto& cache = cacheEntry(mesh->getID());
+  if (cache.vertices) {
+      return cache.vertices;
+  }
+
   RTreeParameters params;
-  VertexIndexGetter ind(mesh->vertices());
-    
-  auto result = _vertex_trees.emplace(std::piecewise_construct,
-                              std::forward_as_tuple(mesh->getID()),
-                              std::forward_as_tuple(std::make_shared<VertexRTree>(params, ind)));
-    
-  PtrVertexRTree tree = std::get<0>(result)->second;
-    
-  if (std::get<1>(result)) // insertion took place, fill tree
-    for (size_t i = 0; i < mesh->vertices().size(); ++i)
+  vertex_traits::IndexGetter ind(mesh->vertices());
+  auto tree = std::make_shared<vertex_traits::RTree>(params, ind);
+  for (size_t i = 0; i < mesh->vertices().size(); ++i) {
       tree->insert(i);
-    
+  }
+
+  cache.vertices = tree;
   return tree;
 }
+
+
+rtree::edge_traits::Ptr rtree::getEdgeRTree(const PtrMesh& mesh)
+{
+  assertion(mesh);
+  auto& cache = cacheEntry(mesh->getID());
+  if (cache.edges) {
+      return cache.edges;
+  }
+
+  RTreeParameters params;
+  edge_traits::IndexGetter ind(mesh->edges());
+  auto tree = std::make_shared<edge_traits::RTree>(params, ind);
+  for (size_t i = 0; i < mesh->edges().size(); ++i) {
+      tree->insert(i);
+  }
+
+  cache.edges = tree;
+  return tree;
+}
+
+
+rtree::triangle_traits::Ptr rtree::getTriangleRTree(const PtrMesh& mesh)
+{
+  assertion(mesh);
+  auto& cache = cacheEntry(mesh->getID());
+  if (cache.triangles) {
+      return cache.triangles;
+  }
+
+  RTreeParameters params;
+  triangle_traits::IndexGetter ind;
+  auto tree = std::make_shared<triangle_traits::RTree>(params, ind);
+  for (size_t i = 0; i < mesh->triangles().size(); ++i) {
+      auto box = bg::return_envelope<RTreeBox>(mesh->triangles()[i]);
+      tree->insert(std::make_pair(std::move(box) , i));
+  }
+
+  cache.triangles = tree;
+  return tree;
+}
+
 
 PtrPrimitiveRTree rtree::getPrimitiveRTree(const PtrMesh& mesh)
 {
@@ -42,12 +94,18 @@ PtrPrimitiveRTree rtree::getPrimitiveRTree(const PtrMesh& mesh)
   return treeptr;
 }
 
+
 void rtree::clear(Mesh &mesh)
 {
-  _vertex_trees.erase(mesh.getID());
+  _cached_trees.erase(mesh.getID());
   _primitive_trees.erase(mesh.getID());
 }
 
+void rtree::clear()
+{
+  _cached_trees.clear();
+  _primitive_trees.clear();
+}
 
 Box3d getEnclosingBox(Vertex const & middlePoint, double sphereRadius)
 {
@@ -65,6 +123,7 @@ Box3d getEnclosingBox(Vertex const & middlePoint, double sphereRadius)
   
   return box;
 }
+
 
 PrimitiveRTree indexMesh(const Mesh &mesh)
 {

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -90,7 +90,7 @@ using PtrPrimitiveRTree = std::shared_ptr<PrimitiveRTree>;
 PrimitiveRTree indexMesh(const Mesh &mesh);
 
 /// The RTree box type
-using RTreeBox = bg::model::box<Eigen::VectorXd>;
+using RTreeBox = boost::geometry::model::box<Eigen::VectorXd>;
 
 /// Type trait to extract information based on the type of a Primitive
 template<class T>

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -89,20 +89,108 @@ using PtrPrimitiveRTree = std::shared_ptr<PrimitiveRTree>;
  */
 PrimitiveRTree indexMesh(const Mesh &mesh);
 
+/// The RTree box type
+using RTreeBox = bg::model::box<Eigen::VectorXd>;
+
+/// Type trait to extract information based on the type of a Primitive
+template<class T>
+struct PrimitiveTraits;
+
+template<>
+struct PrimitiveTraits<pm::Vertex> {
+    using MeshContainer = Mesh::VertexContainer;
+};
+
+template<>
+struct PrimitiveTraits<pm::Edge> {
+    using MeshContainer = Mesh::EdgeContainer;
+};
+
+template<>
+struct PrimitiveTraits<pm::Triangle> {
+    using MeshContainer = Mesh::TriangleContainer;
+};
+
+template<>
+struct PrimitiveTraits<pm::Quad> {
+    using MeshContainer = Mesh::VertexContainer;
+};
+
+/// The general rtree parameter type used in precice
+using RTreeParameters = boost::geometry::index::rstar<16>;
+
+
+namespace impl {
+template <typename Primitive>
+class IsDirectIndexableHelper {
+private:
+  template <typename T, typename = typename std::enable_if<
+                            std::is_same<
+                                typename boost::geometry::traits::tag<T>::type,
+                                boost::geometry::point_tag>::value,
+                            std::nullptr_t>::type>
+  static std::true_type test(char *);
+  template <typename T, typename = typename std::enable_if<
+                            std::is_same<
+                                typename boost::geometry::traits::tag<T>::type,
+                                boost::geometry::segment_tag>::value,
+                            std::nullptr_t>::type>
+  static std::true_type test(int *);
+  template <typename T, typename = typename std::enable_if<
+                            std::is_same<
+                                typename boost::geometry::traits::tag<T>::type,
+                                boost::geometry::box_tag>::value,
+                            std::nullptr_t>::type>
+  static std::true_type test(void *);
+
+  template <typename T>
+  static std::false_type test(...);
+
+public:
+  using type = decltype(test<Primitive>(nullptr));
+};
+} // impl
+
+template <class Primitive>
+struct IsDirectIndexable : impl::IsDirectIndexableHelper<Primitive>::type {};
+
+
+/// The type traits of a rtree based on a Primitive
+template <class Primitive>
+struct RTreeTraits {
+  using MeshContainer = typename PrimitiveTraits<Primitive>::MeshContainer;
+  using MeshContainerIndex = typename MeshContainer::size_type;
+
+  using IndexType = typename std::conditional<
+      IsDirectIndexable<Primitive>::value,
+      MeshContainerIndex,
+      std::pair<RTreeBox, MeshContainerIndex>>::type;
+
+  using IndexGetter = typename std::conditional<
+      IsDirectIndexable<Primitive>::value,
+      impl::PtrVectorIndexable<MeshContainer>,
+      boost::geometry::index::indexable<IndexType>>::type;
+
+  using RTree = boost::geometry::index::rtree<IndexType, RTreeParameters, IndexGetter>;
+  using Ptr   = std::shared_ptr<RTree>;
+};
+
+
 class rtree {
 public:
-  using VertexIndexGetter = impl::PtrVectorIndexable<Mesh::VertexContainer>;
-  using RTreeParameters   = boost::geometry::index::rstar<16>;
-  using VertexRTree       = boost::geometry::index::rtree<Mesh::VertexContainer::container::size_type,
-                                                          RTreeParameters,
-                                                          VertexIndexGetter>;
-  using PtrVertexRTree = std::shared_ptr<VertexRTree>;
+  using vertex_traits   = RTreeTraits<Vertex>;
+  using edge_traits     = RTreeTraits<Edge>;
+  using triangle_traits = RTreeTraits<Triangle>;
 
   /// Returns the pointer to boost::geometry::rtree for the given mesh vertices
   /*
    * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
    */
-  static PtrVertexRTree getVertexRTree(const PtrMesh& mesh);
+  static vertex_traits::Ptr getVertexRTree(const PtrMesh& mesh);
+
+  static edge_traits::Ptr getEdgeRTree(const PtrMesh& mesh);
+
+  static triangle_traits::Ptr getTriangleRTree(const PtrMesh& mesh);
   
   /// Returns the pointer to boost::geometry::rtree for the given mesh primitives
   /*
@@ -113,11 +201,21 @@ public:
   /// Only clear the trees of that specific mesh
   static void clear(Mesh & mesh);
 
+  /// Clear the complete cache
+  static void clear();
+
   friend struct MeshTests::RTree::CacheClearing;
-  
 private:
+  struct MeshIndices {
+      vertex_traits::Ptr vertices;
+      edge_traits::Ptr edges;
+      triangle_traits::Ptr triangles;
+  };
+
+  static MeshIndices& cacheEntry(int MeshID);
+
+  static std::map<int, MeshIndices> _cached_trees; ///< Cache for all index trees
   static std::map<int, PtrPrimitiveRTree> _primitive_trees; ///< Cache for the primitive trees
-  static std::map<int, PtrVertexRTree>    _vertex_trees; ///< Cache for the vertex trees
 };
 
 

--- a/src/mesh/impl/RTreeAdapter.hpp
+++ b/src/mesh/impl/RTreeAdapter.hpp
@@ -12,10 +12,8 @@ class Quad;
 } // namespace mesh
 } // namespace precice
 
-using precice::mesh::Edge;
-using precice::mesh::Quad;
-using precice::mesh::Triangle;
-using precice::mesh::Vertex;
+namespace pm = precice::mesh;
+namespace bg = boost::geometry;
 
 namespace boost {
 namespace geometry {
@@ -57,15 +55,15 @@ BOOST_CONCEPT_ASSERT( (bg::concepts::Point<Eigen::VectorXd>));
 /*
 * This adapts every Vertex to a 3d point. For non-existing dimensions, zero is returned.
 */
-template<> struct tag<Vertex>               { using type = point_tag; };
-template<> struct coordinate_type<Vertex>   { using type = double; };
-template<> struct coordinate_system<Vertex> { using type = cs::cartesian; };
-template<> struct dimension<Vertex> : boost::mpl::int_<3> {};
+template<> struct tag<pm::Vertex>               { using type = point_tag; };
+template<> struct coordinate_type<pm::Vertex>   { using type = double; };
+template<> struct coordinate_system<pm::Vertex> { using type = cs::cartesian; };
+template<> struct dimension<pm::Vertex> : boost::mpl::int_<3> {};
 
 template<size_t Dimension>
-struct access<Vertex, Dimension>
+struct access<pm::Vertex, Dimension>
 {
-  static double get(Vertex const& p)
+  static double get(pm::Vertex const& p)
   {
     if (Dimension > static_cast<size_t>(p.getDimensions())-1)
       return 0;
@@ -73,7 +71,7 @@ struct access<Vertex, Dimension>
     return p.getCoords()[Dimension];
   }
   
-  static void set(Vertex& p, double const& value)
+  static void set(pm::Vertex& p, double const& value)
   {
     Eigen::VectorXd vec = p.getCoords();
     vec[Dimension] = value;
@@ -81,7 +79,7 @@ struct access<Vertex, Dimension>
   }
 };
 
-BOOST_CONCEPT_ASSERT( (concepts::Point<Vertex>));
+BOOST_CONCEPT_ASSERT( (concepts::Point<pm::Vertex>));
 
 /** @brief Provides the necessary template specialisations to adapt precice's Edge to boost.geometry
 *
@@ -89,25 +87,25 @@ BOOST_CONCEPT_ASSERT( (concepts::Point<Vertex>));
 * Include impl/RangeAdapter.hpp for full support.
 */
 template <>
-struct tag<Edge> {
+struct tag<pm::Edge> {
   using type = segment_tag;
 };
 template <>
-struct point_type<Edge> {
+struct point_type<pm::Edge> {
   using type = Eigen::VectorXd;
 };
 
 template <size_t Index, size_t Dimension>
-struct indexed_access<Edge, Index, Dimension> {
+struct indexed_access<pm::Edge, Index, Dimension> {
   static_assert((Index <= 1), "Valid Indices are {0, 1}");
   static_assert((Dimension <= 2), "Valid Dimensions are {0, 1, 2}");
 
-  static double get(Edge const &e)
+  static double get(pm::Edge const &e)
   {
     return access<Eigen::VectorXd, Dimension>::get(e.vertex(Index).getCoords());
   }
 
-  static void set(Edge &e, double const &value)
+  static void set(pm::Edge &e, double const &value)
   {
     Eigen::VectorXd v = e.vertex(Index).getCoords();
     access<Eigen::VectorXd, Dimension>::set(v, value);
@@ -121,7 +119,7 @@ struct indexed_access<Edge, Index, Dimension> {
 * Include impl/RangeAdapter.hpp for full support.
 */
 template <>
-struct tag<Triangle> {
+struct tag<pm::Triangle> {
   using type = ring_tag;
 };
 template <>
@@ -140,7 +138,7 @@ struct closure<pm::Triangle> {
 * This adapts every Quad to the ring concept (filled planar polygone) of boost.geometry.
 */
 template <>
-struct tag<Quad> {
+struct tag<pm::Quad> {
   using type = ring_tag;
 };
 template <>

--- a/src/mesh/impl/RTreeAdapter.hpp
+++ b/src/mesh/impl/RTreeAdapter.hpp
@@ -21,6 +21,38 @@ namespace boost {
 namespace geometry {
 namespace traits {
 
+/// Adapts Eigen::VectorXd to boost.geometry
+/*
+ * This adapts every VectorXd to a 3d point. For non-existing dimensions, zero is returned.
+ */
+template<> struct tag<Eigen::VectorXd>               { using type = point_tag; };
+template<> struct coordinate_type<Eigen::VectorXd>   { using type = double; };
+template<> struct coordinate_system<Eigen::VectorXd> { using type = cs::cartesian; };
+template<> struct dimension<Eigen::VectorXd> : boost::mpl::int_<3> {};
+
+template<size_t Dimension>
+struct access<Eigen::VectorXd, Dimension>
+{
+  static double get(Eigen::VectorXd const& p)
+  {
+    if (Dimension > static_cast<size_t>(p.rows())-1)
+      return 0;
+   
+    return p[Dimension];
+  }
+  
+  static void set(Eigen::VectorXd& p, double const& value)
+  {
+    // This handles default initialized VectorXd
+    if (p.size() == 0) {
+        p = Eigen::VectorXd::Zero(3);
+    }
+    p[Dimension] = value;
+  }
+};
+
+BOOST_CONCEPT_ASSERT( (bg::concepts::Point<Eigen::VectorXd>));
+
 /// Provides the necessary template specialisations to adapt precice's Vertex to boost.geometry
 /*
 * This adapts every Vertex to a 3d point. For non-existing dimensions, zero is returned.
@@ -93,9 +125,15 @@ struct tag<Triangle> {
   using type = ring_tag;
 };
 template <>
-struct closure<Triangle> {
-  static const closure_selector value = closed;
+struct point_order<pm::Triangle> {
+  static const order_selector value = clockwise;
 };
+template <>
+struct closure<pm::Triangle> {
+  static const closure_selector value = open;
+};
+
+// BOOST_CONCEPT_ASSERT( (bg::concepts::Ring<pm::Triangle>));
 
 /** @brief Provides the necessary template specialisations to adapt precice's Quad to boost.geometry
 *
@@ -106,41 +144,15 @@ struct tag<Quad> {
   using type = ring_tag;
 };
 template <>
-struct closure<Quad> {
-  static const closure_selector value = closed;
+struct point_order<pm::Quad> {
+  static const order_selector value = clockwise;
+};
+template <>
+struct closure<pm::Quad> {
+  static const closure_selector value = open;
 };
 
-/// Adapts Eigen::VectorXd to boost.geometry
-/*
- * This adapts every VectorXd to a 3d point. For non-existing dimensions, zero is returned.
- */
-template<> struct tag<Eigen::VectorXd>               { using type = point_tag; };
-template<> struct coordinate_type<Eigen::VectorXd>   { using type = double; };
-template<> struct coordinate_system<Eigen::VectorXd> { using type = cs::cartesian; };
-template<> struct dimension<Eigen::VectorXd> : boost::mpl::int_<3> {};
-
-template<size_t Dimension>
-struct access<Eigen::VectorXd, Dimension>
-{
-  static double get(Eigen::VectorXd const& p)
-  {
-    if (Dimension > static_cast<size_t>(p.rows())-1)
-      return 0;
-   
-    return p[Dimension];
-  }
-  
-  static void set(Eigen::VectorXd& p, double const& value)
-  {
-    // This handles default initialized VectorXd
-    if (p.size() == 0) {
-        p.resize(3);
-    }
-    p[Dimension] = value;
-  }
-};
-
-BOOST_CONCEPT_ASSERT( (concepts::Point<Eigen::VectorXd>));
+// BOOST_CONCEPT_ASSERT( (bg::concepts::Ring<pm::Quad>));
 
 /// Adapts precice's Mesh::BoundingBox to boost.geometry
 /*

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -98,6 +98,156 @@ BOOST_AUTO_TEST_CASE(QuadAdapter)
             )));
 }
 
+BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
+{
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
+  auto & v2 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
+  auto & v5 = mesh.createVertex(Eigen::Vector3d(0.2, 0.2, 0));
+  auto & e1 = mesh.createEdge(v1, v2);
+  auto & e2 = mesh.createEdge(v2, v3);
+  auto & e3 = mesh.createEdge(v3, v1);
+  auto & t = mesh.createTriangle(e1, e2, e3);
+
+  BOOST_TEST(bg::comparable_distance(v1, v2) > 0.5);
+  BOOST_TEST(bg::comparable_distance(v1, v1) < 0.01);
+  BOOST_TEST(bg::comparable_distance(e1, v2) < 0.01);
+  BOOST_TEST(bg::comparable_distance(e1, v3) > 0.2);
+  BOOST_TEST(bg::comparable_distance(t, v3) < 0.1);
+  BOOST_TEST(bg::comparable_distance(t, v4) > 0.2);
+  BOOST_TEST(bg::comparable_distance(t, v5) < 0.01);
+}
+
+BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
+{
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & lv1 = mesh.createVertex(Eigen::Vector3d(-1, 1, 0.1));
+  auto & lv2 = mesh.createVertex(Eigen::Vector3d( 0,-1, 0));
+  auto & lv3 = mesh.createVertex(Eigen::Vector3d(-2, 0,-0.1));
+  auto & le1 = mesh.createEdge(lv1, lv2);
+  auto & le2 = mesh.createEdge(lv2, lv3);
+  auto & le3 = mesh.createEdge(lv3, lv1);
+  auto & lt = mesh.createTriangle(le1, le2, le3);
+
+  auto & rv1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0.1));
+  auto & rv2 = mesh.createVertex(Eigen::Vector3d(2, 0,-0.1));
+  auto & rv3 = mesh.createVertex(Eigen::Vector3d(1,-1, 0));
+  auto & re1 = mesh.createEdge(rv1, rv2);
+  auto & re2 = mesh.createEdge(rv2, rv3);
+  auto & re3 = mesh.createEdge(rv3, rv1);
+  auto & rt = mesh.createTriangle(re1, re2, re3);
+
+  auto & v1 = mesh.createVertex(Eigen::Vector3d(-2, 1, 0));
+  auto & v2 = mesh.createVertex(Eigen::Vector3d( 2,-1, 0));
+  auto & v3 = mesh.createVertex(Eigen::Vector3d( 0, 0, 0));
+
+  auto lt_v1 = bg::comparable_distance(lt, v1);
+  auto lt_v2 = bg::comparable_distance(lt, v2);
+
+  auto rt_v1 = bg::comparable_distance(rt, v1);
+  auto rt_v3 = bg::comparable_distance(rt, v3);
+
+  BOOST_TEST(precice::testing::equals(lt_v1, 0.5));
+  BOOST_TEST(lt_v2 > 0);
+  BOOST_TEST(rt_v1 > 1);
+  BOOST_TEST(rt_v3 > 0);
+}
+
+BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
+{
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & a = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
+  auto & b = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto & c = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
+  auto & d = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+
+  auto & ab = mesh.createEdge(a, b);
+  auto & bd = mesh.createEdge(b, d);
+  auto & da = mesh.createEdge(d, a);
+  auto & dc = mesh.createEdge(d, c);
+  auto & cb = mesh.createEdge(c, b);
+
+  auto & lt = mesh.createTriangle(ab, bd, da);
+  auto & rt = mesh.createTriangle(bd, dc, cb);
+  BOOST_TEST_MESSAGE("Left  Triangle:" << lt);
+  BOOST_TEST_MESSAGE("Right Triangle:" << rt);
+
+  auto & lv = mesh.createVertex(Eigen::Vector3d(.25,.25,0));
+  auto & rv = mesh.createVertex(Eigen::Vector3d(.75,.75,0));
+
+  auto lv_lt = bg::comparable_distance(lv, lt);
+  auto lv_rt = bg::comparable_distance(lv, rt);
+  BOOST_TEST( precice::testing::equals(lv_lt, 0.0), lv_lt << " == 0.0");
+  BOOST_TEST(!precice::testing::equals(lv_rt, 0.0), lv_rt << " != 0.0");
+
+  auto rv_lt = bg::comparable_distance(rv, lt);
+  auto rv_rt = bg::comparable_distance(rv, rt);
+  BOOST_TEST(!precice::testing::equals(rv_lt, 0.0), rv_lt << " != 0.0");
+  BOOST_TEST( precice::testing::equals(rv_rt, 0.0), rv_rt << " == 0.0");
+}
+
+BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
+{
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
+  auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
+  auto & v4 = mesh.createVertex(Eigen::Vector3d(0, 1, 1));
+  auto & v5 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto & e1 = mesh.createEdge(v1, v2);
+  auto & e2 = mesh.createEdge(v2, v3);
+  auto & e3 = mesh.createEdge(v3, v1);
+  auto & t = mesh.createTriangle(e1, e2, e3);
+
+  auto t_v4 = bg::comparable_distance(t, v4);
+  auto v4_t = bg::comparable_distance(v4, t);
+  BOOST_TEST(t_v4 > 0.01);
+  BOOST_TEST(v4_t > 0.01);
+  BOOST_TEST(v4_t == t_v4);
+
+  auto t_v5 = bg::comparable_distance(t, v5);
+  auto v5_t = bg::comparable_distance(v5, t);
+  BOOST_TEST(t_v5 > 0.01);
+  BOOST_TEST(v5_t > 0.01);
+  BOOST_TEST(v5_t == t_v5);
+
+  BOOST_TEST(v4_t < t_v5);
+}
+
+BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
+{
+  using precice::testing::equals;
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
+  auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
+  auto & e1 = mesh.createEdge(v1, v2);
+  auto & e2 = mesh.createEdge(v2, v3);
+  auto & e3 = mesh.createEdge(v3, v1);
+  auto & t = mesh.createTriangle(e1, e2, e3);
+  auto box = bg::return_envelope<precice::mesh::RTreeBox>(t);
+  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0,0,0}));
+  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1,1,1}));
+}
+
+BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
+{
+  using precice::testing::equals;
+  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
+  auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
+  auto & e1 = mesh.createEdge(v1, v3);
+  auto & e2 = mesh.createEdge(v3, v2);
+  auto & e3 = mesh.createEdge(v2, v1);
+  auto & t = mesh.createTriangle(e1, e2, e3);
+  auto box = bg::return_envelope<precice::mesh::RTreeBox>(t);
+  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0,0,0}));
+  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1,1,1}));
+}
+
 BOOST_AUTO_TEST_SUITE_END() // BG Adapters
 
 struct MeshFixture {
@@ -238,6 +388,88 @@ BOOST_AUTO_TEST_CASE(Query_3D)
   }
 }
 
+BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
+{
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false));
+  const double z1 = 0.1;
+  const double z2 = -0.1;
+  auto& v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
+  auto& v01 = mesh->createVertex(Eigen::Vector3d(0, 1, 0));
+  auto& v10 = mesh->createVertex(Eigen::Vector3d(1, 0, z1));
+  auto& v11 = mesh->createVertex(Eigen::Vector3d(1, 1, z1));
+  auto& v20 = mesh->createVertex(Eigen::Vector3d(2, 0, z2));
+  auto& v21 = mesh->createVertex(Eigen::Vector3d(2, 1, z2));
+  auto& ell = mesh->createEdge(v00, v01);
+  auto& elt = mesh->createEdge(v01, v11);
+  auto& elr = mesh->createEdge(v11, v10);
+  auto& elb = mesh->createEdge(v10, v00);
+  auto& eld = mesh->createEdge(v00, v11);
+  auto& erl = elr;
+  auto& ert = mesh->createEdge(v11, v21);
+  auto& err = mesh->createEdge(v21, v20);
+  auto& erb = mesh->createEdge(v20, v10);
+  auto& erd = mesh->createEdge(v10, v21);
+  auto& tlt = mesh->createTriangle(ell, elt, eld);
+  auto& tlb = mesh->createTriangle(eld, elb, elr);
+  auto& trt = mesh->createTriangle(erl, ert, erd);
+  auto& trb = mesh->createTriangle(erd, erb, err);
+
+  {
+    auto tree = rtree::getVertexRTree(mesh);
+
+    BOOST_TEST(tree->size() == 6);
+
+    Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 0.0, 0.8));
+    std::vector<size_t> results;
+
+    tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
+
+    BOOST_TEST_INFO(results);
+    BOOST_TEST(results.size() == 1);
+  }
+  {
+    auto tree = rtree::getEdgeRTree(mesh);
+
+    BOOST_TEST(tree->size() == 9);
+
+    Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 0.5, 0.0));
+    std::set<size_t> results;
+
+    tree->query(bgi::nearest(searchVector, 2), std::inserter(results, results.begin()));
+
+    BOOST_TEST_INFO(results);
+    BOOST_TEST(results.size() == 2);
+    BOOST_TEST(results.count(eld.getID()) == 1);
+    BOOST_TEST(results.count(elr.getID()) == 1);
+  }
+  {
+    auto tree = rtree::getTriangleRTree(mesh);
+
+    BOOST_TEST(tree->size() == 4);
+
+    Eigen::VectorXd searchVector(Eigen::Vector3d(0.7, 0.5, 0.0));
+    std::vector<std::pair<double, size_t>> results;
+
+    tree->query(bgi::nearest(searchVector, 3), boost::make_function_output_iterator([&](const precice::mesh::rtree::triangle_traits::IndexType & val){
+                results.push_back(std::make_pair(
+                            boost::geometry::distance(
+                                searchVector,
+                                mesh->triangles()[val.second]
+                                ),
+                            val.second));
+                }));
+
+    std::sort(results.begin(), results.end());
+    BOOST_TEST_INFO(results);
+    BOOST_TEST(results.size() == 3);
+    BOOST_TEST(results[0].second == tlb.getID());
+    BOOST_TEST(results[1].second == tlt.getID());
+    BOOST_TEST(results[2].second == trt.getID());
+    BOOST_TEST(results[2].second != trb.getID());
+  }
+}
+
+
 /// Resembles how boost geometry is used inside the PetRBF
 BOOST_AUTO_TEST_CASE(QueryWithBox)
 {
@@ -310,19 +542,19 @@ BOOST_AUTO_TEST_CASE(CacheClearing)
   // The Cache should clear whenever a mesh changes
   auto vTree1 = rtree::getVertexRTree(mesh);
   auto pTree1 = rtree::getPrimitiveRTree(mesh);
-  BOOST_TEST(rtree::_vertex_trees.size() == 1);
+  BOOST_TEST(rtree::_cached_trees.size() == 1);
   BOOST_TEST(rtree::_primitive_trees.size() == 1);
   mesh->meshChanged(*mesh); // Emit signal, that mesh has changed
-  BOOST_TEST(rtree::_vertex_trees.empty());
+  BOOST_TEST(rtree::_cached_trees.empty());
   BOOST_TEST(rtree::_primitive_trees.empty());
 
   // The Cache should clear whenever we destroy the Mesh
   auto vTree2 = rtree::getVertexRTree(mesh);
   auto pTree2 = rtree::getPrimitiveRTree(mesh);
-  BOOST_TEST(rtree::_vertex_trees.size() == 1);
+  BOOST_TEST(rtree::_cached_trees.size() == 1);
   BOOST_TEST(rtree::_primitive_trees.size() == 1);
   mesh.reset(); // Destroy mesh object, signal is emitted to clear cache
-  BOOST_TEST(rtree::_vertex_trees.empty());
+  BOOST_TEST(rtree::_cached_trees.empty());
   BOOST_TEST(rtree::_primitive_trees.empty());
 }
 

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -96,6 +96,9 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
   for(std::string configurationFileName : configs){
 
     reset();
+
+    BOOST_TEST_MESSAGE("Config: " << configurationFileName);
+
     std::string solverName;
     int timesteps = 0;
     double time = 0.0;

--- a/src/precice/tests/explicit-mpi-single-non-inc.xml
+++ b/src/precice/tests/explicit-mpi-single-non-inc.xml
@@ -28,9 +28,9 @@
       <participant name="SolverOne">
          <use-mesh name="Test-Square" from="SolverTwo"/>
          <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-projection direction="write" from="MeshOne" to="Test-Square"
+         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
                   constraint="conservative" timing="onadvance"/>
-         <mapping:nearest-projection direction="read" from="Test-Square" to="MeshOne"
+         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
                   constraint="consistent" timing="ondemand"/>
          <write-data name="Forces"       mesh="MeshOne"/>
          <write-data name="Pressures"    mesh="MeshOne"/>

--- a/src/precice/tests/explicit-mpi-single.xml
+++ b/src/precice/tests/explicit-mpi-single.xml
@@ -19,9 +19,9 @@
       <participant name="SolverOne">
          <use-mesh name="Test-Square" from="SolverTwo" />
          <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-projection direction="write" from="MeshOne" to="Test-Square"
+         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
                   constraint="conservative" timing="onadvance"/>
-         <mapping:nearest-projection direction="read" from="Test-Square" to="MeshOne"
+         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
                   constraint="consistent" timing="onadvance" />
          <write-data name="Forces"     mesh="MeshOne" />
          <read-data  name="Velocities" mesh="MeshOne" />

--- a/src/precice/tests/explicit-mpi.xml
+++ b/src/precice/tests/explicit-mpi.xml
@@ -19,9 +19,9 @@
       <participant name="SolverOne">
          <use-mesh name="Test-Square" from="SolverTwo"  />
          <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-projection direction="write" from="MeshOne" to="Test-Square"
+         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
                   constraint="conservative"/>
-         <mapping:nearest-projection direction="read" from="Test-Square" to="MeshOne"
+         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
                   constraint="consistent" timing="onadvance" />
          <write-data name="Forces"     mesh="Test-Square" />
          <read-data  name="Velocities" mesh="Test-Square" />

--- a/src/precice/tests/explicit-sockets.xml
+++ b/src/precice/tests/explicit-sockets.xml
@@ -20,9 +20,9 @@
       <participant name="SolverOne">
          <use-mesh name="Test-Square" from="SolverTwo" />
          <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-projection direction="write" from="MeshOne" to="Test-Square"
+         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
                   constraint="conservative"/>
-         <mapping:nearest-projection direction="read" from="Test-Square" to="MeshOne"
+         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
                   constraint="consistent" timing="onadvance" />
          <write-data name="Forces"     mesh="Test-Square" />
          <read-data  name="Velocities" mesh="Test-Square" />

--- a/src/precice/tests/explicit-solvergeometry.xml
+++ b/src/precice/tests/explicit-solvergeometry.xml
@@ -24,9 +24,9 @@
       <participant name="SolverOne">
          <use-mesh name="MeshOne" provide="yes"/>
          <use-mesh name="SolverGeometry" from="SolverTwo" />
-         <mapping:nearest-projection direction="write" from="MeshOne" to="SolverGeometry"
+         <mapping:nearest-neighbor direction="write" from="MeshOne" to="SolverGeometry"
                   constraint="conservative" timing="initial" />
-         <mapping:nearest-projection direction="read" from="SolverGeometry" to="MeshOne"
+         <mapping:nearest-neighbor direction="read" from="SolverGeometry" to="MeshOne"
                   constraint="consistent" timing="initial" />
          <write-data name="Forces"        mesh="MeshOne" />
          <read-data  name="Velocities"    mesh="MeshOne" />

--- a/src/query/FindClosest.cpp
+++ b/src/query/FindClosest.cpp
@@ -11,6 +11,12 @@
 namespace precice {
 namespace query {
 
+std::ostream& operator<<(std::ostream& out, const InterpolationElement& val)
+{
+    out << '(' << *val.element << ", w:" << val.weight << ')';
+    return out;
+}
+
 InterpolationElements generateInterpolationElements(
     const mesh::Vertex& /*location*/,
     const mesh::Vertex& element)

--- a/src/query/FindClosest.hpp
+++ b/src/query/FindClosest.hpp
@@ -30,6 +30,8 @@ struct InterpolationElement
   InterpolationElement(const mesh::Vertex& element_, double weight_): element(&element_), weight(weight_) {}
 };
 
+std::ostream& operator<<(std::ostream& out, const InterpolationElement& val);
+
 /// A vector of InterpolationElement
 using InterpolationElements = std::vector<InterpolationElement>;
 

--- a/src/query/tests/FindClosestTest.cpp
+++ b/src/query/tests/FindClosestTest.cpp
@@ -384,5 +384,79 @@ BOOST_AUTO_TEST_CASE(WeigthsOfVertices)
   BOOST_TEST(closest.interpolationElements[1].weight == 0.3);
 }
 
+
+struct MeshFixture {
+    int dimension = 3;
+    double z = 0.0;
+    mesh::Mesh mesh;
+    mesh::Vertex *v1, *v2, *v3, *vinside, *voutside;
+    mesh::Edge *e12, *e23, *e31;
+    mesh::Triangle* t;
+    MeshFixture() : mesh("Mesh", dimension, true)
+    {
+        v1 = &mesh.createVertex(Eigen::Vector3d(0.0, 0.0, z));
+        v2 = &mesh.createVertex(Eigen::Vector3d(1.0, 0.0, z));
+        v3 = &mesh.createVertex(Eigen::Vector3d(0.5, 0.5, z));
+        vinside = &mesh.createVertex(Eigen::Vector3d(0.1, 0.1, z));
+        voutside = &mesh.createVertex(Eigen::Vector3d(1.0, 1.0, z));
+        e12 = &mesh.createEdge(*v1, *v2);
+        e23= &mesh.createEdge(*v2, *v3);
+        e31= &mesh.createEdge(*v3, *v1);
+        t=&mesh.createTriangle(*e12, *e23, *e31);
+        mesh.computeState();
+    }
+    ~MeshFixture(){}
+};
+
+BOOST_FIXTURE_TEST_SUITE(InterpolationElements, MeshFixture)
+
+BOOST_AUTO_TEST_CASE(Vertex)
+{
+  auto elems = query::generateInterpolationElements(*vinside, *v1);
+  BOOST_TEST(elems.size() == 1);
+  BOOST_TEST(elems.front().element == v1);
+  BOOST_TEST(elems.front().weight == 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(Edge)
+{
+  auto elems = query::generateInterpolationElements(*vinside, *e12);
+  BOOST_TEST(elems.size() == 2);
+  BOOST_TEST(elems.front().element == v1);
+  BOOST_TEST(elems.front().weight == 0.9);
+  BOOST_TEST(elems.back().element == v2);
+  BOOST_TEST(elems.back().weight == 0.1);
+}
+
+BOOST_AUTO_TEST_CASE(TriangleInside)
+{
+  auto elems = query::generateInterpolationElements(*vinside, *t);
+  BOOST_TEST(elems.size() == 3);
+  std::map<mesh::Vertex const *, double> weights;
+  for(const auto& elem : elems) {
+      weights[elem.element] = elem.weight;
+  }
+  BOOST_TEST(weights.at(v1) == 0.8);
+  BOOST_TEST(weights.at(v2) == 0.0);
+  BOOST_TEST(weights.at(v3) == 0.2);
+}
+
+BOOST_AUTO_TEST_CASE(TriangleOutside)
+{
+  auto elems = query::generateInterpolationElements(*voutside, *t);
+  BOOST_TEST(elems.size() == 3);
+  std::map<mesh::Vertex const *, double> weights;
+  for(const auto& elem : elems) {
+      weights[elem.element] = elem.weight;
+  }
+  // Extrapolating
+  BOOST_TEST(weights.at(v1) == -1.0);
+  BOOST_TEST(weights.at(v2) == 0.0);
+  BOOST_TEST(weights.at(v3) == 2.0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // InterpolationElements
+
+
 BOOST_AUTO_TEST_SUITE_END() // FindClosestTests
 BOOST_AUTO_TEST_SUITE_END() // QueryTests

--- a/src/utils/PointerVector.hpp
+++ b/src/utils/PointerVector.hpp
@@ -18,6 +18,9 @@ public:
    typedef std::vector<CONTENT_T*> container;
    typedef CONTENT_T value_type; // necessary to be standard conform
 
+   // The size_type of the wrapped vector
+   using size_type = typename container::size_type;
+
    /// Type of iterator hiding pointers.
    typedef boost::indirect_iterator<
               typename container::iterator,


### PR DESCRIPTION
This PR fixes the NP mapping bug and is based on the Hotfix 1.5.1.

This PR will:
* Fix the openness and direction of boost geometry adapters.
* Add tests to the boost geometry adapters, and the generation of interpolation elements.
* Fix the tests of the NP mapping by removing vertex coordinate modification.
* Add additional tests to failing edge cases of the NP mapping.
* Replace the general primitive index by one index per primitive.
  The new version does not require to wrap primitives in bounding boxes, which fixes the encountered bugs.
* The NP mapping now uses the _nearest_ projection instead of using extrapolation.


Fixes #371
Closes #373 