### PR TITLE
WIP Add oversubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For future 
 - More "pythonic" python bindings `precice_future` are introduced. The python bindings `precice` are deprecated and will be removed in preCICE Version 2.0.0. If you still want to use them, please install `precice` and `precice_future`. Our recommendation, if you want to use the new bindings: Use `import precice_future as precice`.
 - Added CMake target to uninstall the project.
 - Only the total number of filtered vertices are printed, not each one separately, unless debug output is enabled.
+- Added `-oversubscribe` to the tests allowing them to run on dual-core processors.
 
 ## 1.5.1
 

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -19,7 +19,7 @@ function(add_precice_test)
   # Assemble the command
   if(PAT_MPI)
     add_test(NAME ${PAT_FULL_NAME}
-      COMMAND ${MPIEXEC_EXECUTABLE} -np 4 $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS}
+      COMMAND ${MPIEXEC_EXECUTABLE} -oversubscribe -np 4 $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS}
       )
   else()
     add_test(NAME ${PAT_FULL_NAME}


### PR DESCRIPTION
This PR adds ` -oversubscribe` to the MPI tests allowing the tests to run on dual-core processors.

Reviewers: Is this option supported by all major MPI implementations? If yes, please merge.