### PR TITLE
Modernize Non-Copyable Base Classes

### DIFF
--- a/src/action/Action.hpp
+++ b/src/action/Action.hpp
@@ -46,6 +46,8 @@ public:
   {
   }
 
+  Action& operator=(Action &&) = delete;
+
   /// Destructor, empty.
   virtual ~Action() {}
 

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <boost/core/noncopyable.hpp>
 #include "Request.hpp"
 #include "logging/Logger.hpp"
 
@@ -42,10 +41,13 @@ namespace com
  * sized appropriatly. Asynchronous receive methods also expect the vector
  * be sized correctly.
  */
-class Communication: private boost::noncopyable
+class Communication
 {
 
 public:
+
+  Communication& operator=(Communication &&) = delete;
+
   /// Destructor, empty.
   virtual ~Communication()
   {

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -49,6 +49,8 @@ public:
   /// To be used, when the coupling timestep length is determined dynamically during the coupling.
   static const double UNDEFINED_TIMESTEP_LENGTH;
 
+  CouplingScheme& operator=(CouplingScheme &&) = delete;
+
   virtual ~CouplingScheme() {}
 
   /**

--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -14,6 +14,8 @@ namespace io {
 /// Abstract base class of all classes exporting container data structures.
 class Export {
 public:
+  Export& operator=(Export &&) = delete;
+
   virtual ~Export() {}
 
   /// Returns the export type ID.

--- a/src/io/Import.hpp
+++ b/src/io/Import.hpp
@@ -24,6 +24,8 @@ class Import {
 public:
   Import(const std::string &location);
 
+  Import& operator=(Import &&) = delete;
+
   virtual ~Import() {}
 
   /**

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -46,6 +46,8 @@ public:
   /// Constructor, takes mapping constraint.
   Mapping ( Constraint constraint, int dimensions );
 
+  Mapping& operator=(Mapping &&) = delete;
+
   /// Destructor, empty.
   virtual ~Mapping() {}
 

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -5,7 +5,6 @@
 
 #include "mesh/PropertyContainer.hpp"
 #include "mesh/Vertex.hpp"
-#include "boost/noncopyable.hpp"
 #include "math/differences.hpp"
 
 namespace precice {
@@ -16,7 +15,7 @@ struct EdgeIteratorTypes;
 template<typename Types> class EdgeIterator;
 
 /// Linear edge of a mesh, defined by two Vertex objects.
-class Edge : public PropertyContainer, private boost::noncopyable
+class Edge : public PropertyContainer
 {
 public:
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -6,7 +6,6 @@
 #include "mesh/Vertex.hpp"
 #include "utils/PointerVector.hpp"
 #include "utils/ManageUniqueIDs.hpp"
-#include <boost/noncopyable.hpp>
 #include <map>
 #include <list>
 #include <vector>
@@ -36,7 +35,7 @@ namespace mesh {
  *
  * Usage example: precice::mesh::tests::MeshTest::testDemonstration()
  */
-class Mesh : public PropertyContainer, private boost::noncopyable
+class Mesh : public PropertyContainer
 {
 public:
 

--- a/src/mesh/PropertyContainer.hpp
+++ b/src/mesh/PropertyContainer.hpp
@@ -32,6 +32,7 @@ namespace mesh
 class PropertyContainer
 {
 public:
+  PropertyContainer& operator=(PropertyContainer &&) = delete;
 
   virtual ~PropertyContainer(){};
 

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <algorithm>
-#include "boost/noncopyable.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/PropertyContainer.hpp"
 #include "mesh/RangeAccessor.hpp"
@@ -13,7 +12,7 @@ namespace mesh
 {
 
 /// Quadrilateral (or Quadrangle) geometric primitive.
-class Quad : public PropertyContainer, private boost::noncopyable
+class Quad : public PropertyContainer
 {
 public:
   /// Type of the read-only const random-access iterator over Vertex coords

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <boost/noncopyable.hpp>
 #include <iostream>
 #include <algorithm>
 
@@ -27,7 +26,7 @@ namespace mesh
 {
 
 /// Triangle of a mesh, defined by three edges (and vertices).
-class Triangle : public PropertyContainer, private boost::noncopyable
+class Triangle : public PropertyContainer
 {
 public:
   /// Type of the read-only const random-access iterator over Vertex coords

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <boost/noncopyable.hpp>
 #include <iostream>
 
 #include "math/differences.hpp"
@@ -13,7 +12,7 @@ namespace mesh
 {
 
 /// Vertex of a mesh.
-class Vertex : public PropertyContainer, private boost::noncopyable
+class Vertex : public PropertyContainer
 {
 public:
   /// Constructor for vertex

--- a/src/partition/Partition.hpp
+++ b/src/partition/Partition.hpp
@@ -35,6 +35,8 @@ public:
   /// Constructor.
   Partition(mesh::PtrMesh mesh);
 
+  Partition& operator=(Partition &&) = delete;
+
   virtual ~Partition() {}
 
   /// The mesh is communicated between both master ranks (if required)

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -37,7 +37,7 @@ namespace precice {
 namespace impl {
 
 /// Implementation of solver interface.
-class SolverInterfaceImpl : private boost::noncopyable
+class SolverInterfaceImpl
 {
 public:
 
@@ -57,6 +57,18 @@ public:
     int         accessorProcessRank,
     int         accessorCommunicatorSize,
     bool        serverMode );
+
+  /// Deleted copy constructor
+  SolverInterfaceImpl(SolverInterfaceImpl const &) = delete;
+
+  /// Deleted copy assignment
+  SolverInterfaceImpl& operator=(SolverInterfaceImpl const &) = delete;
+  
+  /// Deleted move constructor
+  SolverInterfaceImpl(SolverInterfaceImpl &&) = delete;
+
+  /// Deleted move assignment
+  SolverInterfaceImpl& operator=(SolverInterfaceImpl &&) = delete;
 
   /**
    * @brief Configures the coupling interface from the given xml file.

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -29,6 +29,9 @@ class XMLTag
 public:
   /// Callback interface for configuration classes using XMLTag.
   struct Listener {
+
+    Listener& operator=(Listener &&) = delete;
+
     virtual ~Listener(){};
     /**
      * @brief Callback at begin of XML tag.


### PR DESCRIPTION
This PR modernizes the virtual base classes used in preCICE.

It uses the [DesDeMovA method by Peter Sommerlad](https://www.youtube.com/watch?v=fs4lIN3_IlA) to make the classes implicitly non-copyable.
This protects future users from unintended slicing and removes `boost::noncopyable`.