### PR TITLE
Make sending and receiving in GatherScatter consistent, fix #451

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. For future 
 
 ## develop
 
+## 1.5.2
+
+- Fixed faulty communication in `master:sockets` leading to crashes.
+
 ## 1.5.1
 
 - Fixed the exposure of `boost::asio` implementation details leading to version incompatibilities

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.9.6)
 
-project(preCICE VERSION 1.5.1 LANGUAGES CXX)
+project(preCICE VERSION 1.5.2 LANGUAGES CXX)
 
 #
 # Overview of this configuration

--- a/SConstruct
+++ b/SConstruct
@@ -106,7 +106,7 @@ env.Append(LIBPATH = [('#' + buildpath)])
 env.Append(CCFLAGS= ['-Wall', '-Wextra', '-Wno-unused-parameter', '-std=c++11'])
 
 # ====== PRECICE_VERSION number ======
-PRECICE_VERSION = "1.5.1"
+PRECICE_VERSION = "1.5.2"
 
 
 # ====== Compiler Settings ======

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -90,7 +90,7 @@ void GatherScatterCommunication::send(
       DEBUG("Slave Size = " << slaveSize);
       if (slaveSize > 0) {
         std::vector<double> valuesSlave(slaveSize);
-        utils::MasterSlave::_communication->receive(valuesSlave, rankSlave);
+        utils::MasterSlave::_communication->receive(valuesSlave.data(), slaveSize, rankSlave);
         for (size_t i = 0; i < vertexDistribution[rankSlave].size(); i++) {
           for (int j = 0; j < valueDimension; j++) {
             globalItemsToSend[vertexDistribution[rankSlave][i] * valueDimension + j] += valuesSlave[i * valueDimension + j];
@@ -155,7 +155,7 @@ void GatherScatterCommunication::receive(
             valuesSlave[i * valueDimension + j] = globalItemsToReceive[vertexDistribution[rankSlave][i] * valueDimension + j];
           }
         }
-        utils::MasterSlave::_communication->send(valuesSlave, rankSlave);
+        utils::MasterSlave::_communication->send(valuesSlave.data(), slaveSize, rankSlave);
         DEBUG("valuesSlave[0] = " << valuesSlave[0]);
       }
     }

--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -11,7 +11,7 @@ from distutils.command.build import build
 
 # name of Interfacing API
 APPNAME = "precice"
-APPVERSION = "1.5.1"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
+APPVERSION = "1.5.2"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
In `GatherScatterCommunication`, we previously sent a vector of doubles but received an array of doubles. This is wrong for any underlying communication, but only had crucial impact when `SocketCommunication` was used. 

closes #451 