### PR TITLE
Add additional info in the connection stage

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -213,8 +213,10 @@ double SolverInterfaceImpl:: initialize()
 
     INFO("Setting up master communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
-        m2nPair.second.prepareEstablishment();
-        m2nPair.second.connectMasters();
+        auto& bm2n = m2nPair.second;
+        INFO("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " master of " << bm2n.remoteName);
+        bm2n.prepareEstablishment();
+        bm2n.connectMasters();
     }
     INFO("Masters are connected");
 
@@ -222,8 +224,10 @@ double SolverInterfaceImpl:: initialize()
 
     INFO("Setting up slaves communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
-      m2nPair.second.connectSlaves();
-      m2nPair.second.cleanupEstablishment();
+      auto& bm2n = m2nPair.second;
+      INFO("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " slaves of " << bm2n.remoteName);
+      bm2n.connectSlaves();
+      bm2n.cleanupEstablishment();
     }
     INFO("Slaves are connected");
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -214,9 +214,10 @@ double SolverInterfaceImpl:: initialize()
     INFO("Setting up master communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
         auto& bm2n = m2nPair.second;
-        DEBUG("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " master of " << bm2n.remoteName);
+        DEBUG((bm2n.isRequesting?"Awaiting master connection from ":"Establishing master connection to ") << bm2n.remoteName);
         bm2n.prepareEstablishment();
         bm2n.connectMasters();
+        DEBUG("Established master connection " << (bm2n.isRequesting?"from ":"to ") << bm2n.remoteName);
     }
     INFO("Masters are connected");
 
@@ -225,9 +226,10 @@ double SolverInterfaceImpl:: initialize()
     INFO("Setting up slaves communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
       auto& bm2n = m2nPair.second;
-      DEBUG("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " slaves of " << bm2n.remoteName);
+      DEBUG((bm2n.isRequesting?"Awaiting slaves connection from ":"Establishing slaves connection to ") << bm2n.remoteName);
       bm2n.connectSlaves();
       bm2n.cleanupEstablishment();
+      DEBUG("Established slaves connection " << (bm2n.isRequesting?"from ":"to ") << bm2n.remoteName);
     }
     INFO("Slaves are connected");
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -214,7 +214,7 @@ double SolverInterfaceImpl:: initialize()
     INFO("Setting up master communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
         auto& bm2n = m2nPair.second;
-        INFO("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " master of " << bm2n.remoteName);
+        DEBUG("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " master of " << bm2n.remoteName);
         bm2n.prepareEstablishment();
         bm2n.connectMasters();
     }
@@ -225,7 +225,7 @@ double SolverInterfaceImpl:: initialize()
     INFO("Setting up slaves communication to coupling partner/s" );
     for (auto& m2nPair : _m2ns) {
       auto& bm2n = m2nPair.second;
-      INFO("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " slaves of " << bm2n.remoteName);
+      DEBUG("Establishing " << (bm2n.isRequesting?"incoming connection from ":"outgoing connection to") <<  " slaves of " << bm2n.remoteName);
       bm2n.connectSlaves();
       bm2n.cleanupEstablishment();
     }


### PR DESCRIPTION
This PR adds some more information in the connection stage of the preCICE initialization.

Here is the log from running the solverdummies:

New | SolverOne | SolverTwo 
| --- | --- | --- |
|| Setting up master communication to coupling partner/s | Setting up master communication to coupling partner/s |
:star: | Establishing incoming connection from  master of SolverTwo | Establishing outgoing connection to master of SolverOne |
|| Masters are connected | Masters are connected |
|| Gather mesh MeshOne  | Receive global mesh MeshOne |
|| Send global mesh MeshOne | |
|| Compute partition for mesh MeshOne | Compute partition for mesh MeshTwo|
|| Setting up slaves communication to coupling partner/s | Setting up slaves communication to coupling partner/s|
|:star: | Establishing incoming connection from  slaves of SolverTwo | Establishing outgoing connection to slaves of SolverOne|
|| Slaves are connected | Slaves are connected |

Closes #444