### PR TITLE
Fix Eigen Format

### DIFF
--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -1,4 +1,5 @@
 #include "Edge.hpp"
+#include "utils/EigenIO.hpp"
 
 namespace precice {
 namespace mesh {
@@ -57,13 +58,12 @@ bool Edge::operator!=(const Edge& other) const
 }
 
 std::ostream& operator<<(std::ostream& stream, const Edge& edge){
-    stream << "LINESTRING (";
-    for (int i = 0; i < 2; i++){
-        stream << edge.vertex(i).getCoords().transpose();
-        if (i < 1)
-            stream << ", ";
-    }
-    return stream << ")";
+    using utils::eigenio::wkt;
+    return stream << "LINESTRING ("
+                  << edge.vertex(0).getCoords().transpose().format(wkt())
+                  << ", "
+                  << edge.vertex(1).getCoords().transpose().format(wkt())
+                  << ')';
 }
 
 }} // namespace precice, mesh

--- a/src/mesh/Quad.cpp
+++ b/src/mesh/Quad.cpp
@@ -1,6 +1,7 @@
 #include "Quad.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
+#include "utils/EigenIO.hpp"
 #include <boost/range/concepts.hpp>
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
@@ -168,13 +169,13 @@ bool Quad::operator!=(const Quad& other) const
 
 std::ostream& operator<<(std::ostream& os, const Quad& q)
 {
-    os << "POLYGON ((";
-    for (int i = 0; i < 4; i++){
-        os << q.vertex(i).getCoords().transpose();
-        if (i < 3)
-            os << ", ";
-    }
-    return os <<", " << q.vertex(0).getCoords().transpose() << "))";
+    using utils::eigenio::wkt;
+    return os << "POLYGON (("
+              << q.vertex(0).getCoords().transpose().format(wkt()) << ", "
+              << q.vertex(1).getCoords().transpose().format(wkt()) << ", "
+              << q.vertex(2).getCoords().transpose().format(wkt()) << ", "
+              << q.vertex(3).getCoords().transpose().format(wkt()) << ", "
+              << q.vertex(0).getCoords().transpose().format(wkt()) << "))";
 }
 
 } // namespace mesh

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -1,6 +1,7 @@
 #include "Triangle.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
+#include "utils/EigenIO.hpp"
 #include <boost/range/concepts.hpp>
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
@@ -123,13 +124,12 @@ bool Triangle::operator!=(const Triangle& other) const
 
 std::ostream& operator<<(std::ostream& os, const Triangle& t)
 {
-    os << "POLYGON ((";
-    for (int i = 0; i < 3; i++){
-        os << t.vertex(i).getCoords().transpose();
-        if (i < 2)
-            os << ", ";
-    }
-    return os <<", " << t.vertex(0).getCoords().transpose() << "))";
+    using utils::eigenio::wkt;
+    return os << "POLYGON (("
+              << t.vertex(0).getCoords().transpose().format(wkt()) << ", "
+              << t.vertex(1).getCoords().transpose().format(wkt()) << ", "
+              << t.vertex(2).getCoords().transpose().format(wkt()) << ", "
+              << t.vertex(0).getCoords().transpose().format(wkt()) << "))";
 }
 
 } // namespace mesh

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -1,4 +1,5 @@
 #include "Vertex.hpp"
+#include "utils/EigenIO.hpp"
 
 namespace precice
 {
@@ -47,7 +48,7 @@ void Vertex::tag()
 
 std::ostream &operator<<(std::ostream &os, Vertex const &v)
 {
-  return os << "POINT (" << v.getCoords().transpose() << ")";
+  return os << "POINT (" << v.getCoords().transpose().format(utils::eigenio::wkt()) << ')';
 }
 
 } // namespace mesh

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -266,6 +266,7 @@ target_sources(precice
     src/utils/Dimensions.hpp
     src/utils/EigenHelperFunctions.cpp
     src/utils/EigenHelperFunctions.hpp
+    src/utils/EigenIO.hpp
     src/utils/Event.cpp
     src/utils/Event.hpp
     src/utils/EventUtils.cpp
@@ -295,7 +296,6 @@ target_sources(precice
     src/utils/prettyprint.hpp
     src/utils/stacktrace.cpp
     src/utils/stacktrace.hpp
-    src/versions.hpp
     src/versions.hpp
     src/xml/ConfigParser.cpp
     src/xml/ConfigParser.hpp

--- a/src/utils/EigenIO.hpp
+++ b/src/utils/EigenIO.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Eigen/Core>
+
+namespace precice {
+namespace utils {
+namespace eigenio {
+
+inline Eigen::IOFormat wkt()
+{
+  return Eigen::IOFormat(
+      Eigen::StreamPrecision,
+      Eigen::DontAlignCols,
+      " ", // Coeff separator
+      ","  // Row separator
+  );
+}
+
+} // namespace eigenio
+} // namespace utils
+} // namespace precice

--- a/src/utils/prettyprint.hpp
+++ b/src/utils/prettyprint.hpp
@@ -38,7 +38,8 @@ namespace pretty_print
         struct has_const_iterator : private sfinae_base
         {
         private:
-            template <typename C> static yes & test(typename C::const_iterator*);
+            template <typename C>
+            static typename std::enable_if<!std::is_void<typename std::iterator_traits<typename C::const_iterator>::value_type>::value, yes &>::type test(typename C::const_iterator*);
             template <typename C> static no  & test(...);
         public:
             static const bool value = sizeof(test<T>(nullptr)) == sizeof(yes);


### PR DESCRIPTION
This PR fixes a bug in the prettyprint library when used together with an `Eigen::Matrix` from the current development version of eigen3.

preCICE now uses an [`Eigen::IOFormat`](http://eigen.tuxfamily.org/dox/structEigen_1_1IOFormat.html) object to format the vectors according to the WKT specification.

I created a PR to fix the prettyprint bug upstream (https://github.com/louisdx/cxx-prettyprint/pull/28).

Fixes #456