### PR TITLE
Initial commit to add empty string assertion in Cbindings

### DIFF
--- a/src/precice/bindings/c/SolverInterfaceC.cpp
+++ b/src/precice/bindings/c/SolverInterfaceC.cpp
@@ -14,9 +14,11 @@ void precicec_createSolverInterface
   int         solverProcessIndex,
   int         solverProcessSize )
 {
+  assertion (participantName == '\0');
   std::string stringAccessorName ( participantName );
   impl = new precice::impl::SolverInterfaceImpl ( stringAccessorName,
       solverProcessIndex, solverProcessSize, false );
+  assertion (configFileName == '\0');
   std::string stringConfigFileName ( configFileName );
   impl->configure ( stringConfigFileName );
 }


### PR DESCRIPTION
User needs to be warned if the adapter passes empty strings in place of `participantName` and `configFileName` in the C bindings. This was observed as an issue in the fluent_adapter because FLUENT does not proceed in the event of such a case of SolverInterface initialization. 