### PR TITLE
Add events for mapping internals 

### DIFF
--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -31,11 +31,14 @@ void NearestNeighborMapping:: computeMapping()
   assertion(input().get() != nullptr);
   assertion(output().get() != nullptr);
 
-  precice::utils::Event e("map.nn.computeMapping.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
+  const std::string baseEvent = "map.nn.computeMapping.From" + input()->getName() + "To" + output()->getName();
+  precice::utils::Event e(baseEvent, precice::syncMode);
   
   if (getConstraint() == CONSISTENT){
     DEBUG("Compute consistent mapping");
+    precice::utils::Event e2(baseEvent+".getIndex", precice::syncMode);
     auto rtree = mesh::rtree::getVertexRTree(input());
+    e2.stop();
     size_t verticesSize = output()->vertices().size();
     _vertexIndices.resize(verticesSize);
     const mesh::Mesh::VertexContainer& outputVertices = output()->vertices();
@@ -51,7 +54,9 @@ void NearestNeighborMapping:: computeMapping()
   else {
     assertion(getConstraint() == CONSERVATIVE, getConstraint());
     DEBUG("Compute conservative mapping");
+    precice::utils::Event e2(baseEvent+".getIndex", precice::syncMode);
     auto rtree = mesh::rtree::getVertexRTree(output());
+    e2.stop();
     size_t verticesSize = input()->vertices().size();
     _vertexIndices.resize(verticesSize);
     const mesh::Mesh::VertexContainer& inputVertices = input()->vertices();
@@ -130,6 +135,7 @@ void NearestNeighborMapping:: map
 void NearestNeighborMapping::tagMeshFirstRound()
 {
   TRACE();
+  precice::utils::Event e("map.nn.tagMeshFirstRound.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
   computeMapping();
 

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -45,7 +45,8 @@ struct MatchType {
 void NearestProjectionMapping::computeMapping()
 {
   TRACE(input()->vertices().size(), output()->vertices().size());
-  precice::utils::Event e("map.np.computeMapping.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
+  const std::string baseEvent = "map.np.computeMapping.From" + input()->getName() + "To" + output()->getName();
+  precice::utils::Event e(baseEvent, precice::syncMode);
 
   // Setup Direction of Mapping
   mesh::PtrMesh origins, search_space;
@@ -76,8 +77,10 @@ void NearestProjectionMapping::computeMapping()
         WARN("2D Mesh \"" << search_space->getName() << "\" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.");
     }
 
+    precice::utils::Event e2(baseEvent+".getIndex2D", precice::syncMode);
     auto indexEdges    = mesh::rtree::getEdgeRTree(search_space);
     auto indexVertices = mesh::rtree::getVertexRTree(search_space);
+    e2.stop();
 
     std::vector<MatchType> matches;
     matches.reserve(nnearest);
@@ -114,9 +117,11 @@ void NearestProjectionMapping::computeMapping()
          WARN("3D Mesh \"" << search_space->getName() << "\" does not contain triangles. Nearest projection mapping will map to primitives of lower dimension.");
     }
 
+    precice::utils::Event e2(baseEvent+".getIndex3D", precice::syncMode);
     auto indexTriangles = mesh::rtree::getTriangleRTree(search_space);
     auto indexEdges     = mesh::rtree::getEdgeRTree(search_space);
     auto indexVertices  = mesh::rtree::getVertexRTree(search_space);
+    e2.stop();
 
     std::vector<MatchType> matches;
     matches.reserve(nnearest);
@@ -237,6 +242,7 @@ void NearestProjectionMapping::map(
 void NearestProjectionMapping::tagMeshFirstRound()
 {
   TRACE();
+  precice::utils::Event e("map.np.tagMeshFirstRound.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
   DEBUG("Compute Mapping for Tagging");
 
   computeMapping();

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -348,6 +348,7 @@ bool ReceivedPartition::isVertexInBB(const mesh::Vertex &vertex)
 void ReceivedPartition::createOwnerInformation()
 {
   TRACE();
+  Event e("partition.createOwnerInformation." + _mesh->getName(), precice::syncMode);
 
   if (utils::MasterSlave::isSlave()) {
     int numberOfVertices = _mesh->vertices().size();


### PR DESCRIPTION
This PR adds events to simplify the inspection of mappings:

* Nearest Neighbor Mapping:
    *`map.nn.computeMapping.FromAToB`
    *`map.nn.tagMeshFirstRound.FromAToB.getIndex`
* Nearest Projection Mapping: 
    *`map.np.tagMeshFirstRound.FromAToB`
    * `map.np.computeMapping.FromAToB.getIndex2D`
    * `map.np.computeMapping.FromAToB.getIndex3D`
* `ReceivedPartition`:
    * `partition.createOwnerInformation.A`
