### PR TITLE
Add bulk methods for setting Triangles and Edges

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -190,6 +190,16 @@ int SolverInterface:: setMeshEdge
   return _impl->setMeshEdge ( meshID, firstVertexID, secondVertexID );
 }
 
+void SolverInterface:: setMeshEdges
+(
+  int meshID,
+  int size,
+  const int* vertexIDs,
+  int* edgeIDs )
+{
+    _impl->setMeshEdges(meshID, size, vertexIDs, edgeIDs);
+}
+
 void SolverInterface:: setMeshTriangle
 (
   int meshID,
@@ -198,6 +208,15 @@ void SolverInterface:: setMeshTriangle
   int thirdEdgeID )
 {
   _impl->setMeshTriangle ( meshID, firstEdgeID, secondEdgeID, thirdEdgeID );
+}
+
+void SolverInterface:: setMeshTriangles
+(
+  int meshID,
+  int size,
+  const int* edgeIDs )
+{
+    _impl->setMeshTriangles(meshID, size, edgeIDs);
 }
 
 void SolverInterface:: setMeshTriangleWithEdges

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -466,6 +466,26 @@ public:
     int secondVertexID );
 
   /**
+   * @brief Sets multiple mesh edges from vertexIDs and writes the resulting ids to edgeIDs
+   *
+   * @param[in] meshID ID of the mesh to add the edges to
+   * @param[in] size amount of edges to add
+   * @param[in] vertexIDs IDs of the vertices of the edges
+   * @param[out] edgeIDs IDs of the resulting edges
+   *
+   * The format of vertexIDs is (e0A, e0B, e1A, e1B, ... )
+   *
+   * @pre vertices in vertexIDs were added to the mesh with the ID meshID
+   * @pre count of available elements at vertexIDs is at least size*2
+   * @pre count of available elements at edgeIDs is at least size
+   */
+  void setMeshEdges (
+    int meshID,
+    int size,
+    const int* vertexIDs,
+    int* edgeIDs );
+
+  /**
    * @brief Sets mesh triangle from edge IDs
    *
    * @param[in] meshID ID of the mesh to add the triangle to
@@ -480,6 +500,23 @@ public:
     int firstEdgeID,
     int secondEdgeID,
     int thirdEdgeID );
+
+  /**
+   * @brief Sets multiple mesh triangles from edgeIDs
+   *
+   * @param[in] meshID ID of the mesh to add the triangles to
+   * @param[in] size amount of triangles to add
+   * @param[in] edgeIDs IDs of the edges of the triangles
+   *
+   * The format of edgeIDs is (t0A, e0B, t0C, e1A, e1B, e1C, ... )
+   *
+   * @pre edges in edgeIDs were added to the mesh with the ID meshID
+   * @pre count of available elements at edgeIDs is at least size*3
+   */
+  void setMeshTriangles (
+    int meshID,
+    int size,
+    const int* edgeIDs );
 
   /**
    * @brief Sets mesh triangle from vertex IDs.

--- a/src/precice/impl/RequestManager.hpp
+++ b/src/precice/impl/RequestManager.hpp
@@ -85,12 +85,25 @@ public:
     int firstVertexID,
     int secondVertexID );
 
+  /// Requests set mesh edges from server.
+  void requestSetMeshEdges (
+    int meshID,
+    int size,
+    const int* vertexIDs,
+    int* edgeIDs );
+
   /// Requests set mesh triangle from server.
   void requestSetMeshTriangle (
     int meshID,
     int firstEdgeID,
     int secondEdgeID,
     int thirdEdgeID );
+
+  /// Requests set mesh triangles from server.
+  void requestSetMeshTriangles (
+    int meshID,
+    int size,
+    const int* edgeIDs );
 
   /// Requests set mesh triangle with edges from server.
   void requestSetMeshTriangleWithEdges (
@@ -189,7 +202,9 @@ private:
     REQUEST_GET_MESH_VERTICES,
     REQUEST_GET_MESH_VERTEX_IDS_FROM_POSITIONS,
     REQUEST_SET_MESH_EDGE,
+    REQUEST_SET_MESH_EDGES,
     REQUEST_SET_MESH_TRIANGLE,
+    REQUEST_SET_MESH_TRIANGLES,
     REQUEST_SET_MESH_TRIANGLE_WITH_EDGES,
     REQUEST_SET_MESH_QUAD,
     REQUEST_SET_MESH_QUAD_WITH_EDGES,
@@ -250,8 +265,14 @@ private:
   /// Handles request set mesh edge from client.
   void handleRequestSetMeshEdge ( int rankSender );
 
+  /// Handles request set mesh edge from client.
+  void handleRequestSetMeshEdges ( int rankSender );
+
   /// Handles request set mesh triangle from client.
   void handleRequestSetMeshTriangle ( int rankSender );
+
+  /// Handles request set mesh triangle from client.
+  void handleRequestSetMeshTriangles ( int rankSender );
 
   /// Handles request set mesh triangle with edges from client.
   void handleRequestSetMeshTriangleWithEdges ( int rankSender );

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -281,12 +281,25 @@ public:
     int firstVertexID,
     int secondVertexID );
 
+  /// Set multiple edges of a solver mesh.
+  void setMeshEdges (
+    int meshID,
+    int size,
+    const int* vertexIDs,
+    int* edgeIDs );
+
   /// Set a triangle of a solver mesh.
   void setMeshTriangle (
     int meshID,
     int firstEdgeID,
     int secondEdgeID,
     int thirdEdgeID );
+
+  /// Set multiple triangles of a solver mesh.
+  void setMeshTriangles (
+    int meshID,
+    int size,
+    const int* edgeIDs );
 
   /// Sets a triangle and creates/sets edges automatically of a solver mesh.
   void setMeshTriangleWithEdges (


### PR DESCRIPTION
This PR adds bulk counterparts for `setMeshTriangle` and `setMeshEdge`.

Closes #465

Reviewers, please check the changes to the SolverInterface as well as the implementation especially in the server parts.

# TODO
* [ ] Add tests
* [ ] Extend bindings