### PR TITLE
Replace assertion with BOOST_TEST

### DIFF
--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
                      * testing::MinRanks(2))
 {
   utils::Parallel::synchronizeProcesses();
-  P_ASSERT(utils::Parallel::getCommunicatorSize() > 1);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
   mesh::PropertyContainer::resetPropertyIDCounter();
 
   std::string participant0("rank0");
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
                      * testing::MinRanks(2))
 {
   utils::Parallel::synchronizeProcesses();
-  P_ASSERT(utils::Parallel::getCommunicatorSize() > 1);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
   mesh::PropertyContainer::resetPropertyIDCounter();
 
   std::string participant0("rank0");
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
                      * testing::MinRanks(2))
 {
   utils::Parallel::synchronizeProcesses();
-  P_ASSERT(utils::Parallel::getCommunicatorSize() > 1);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
   mesh::PropertyContainer::resetPropertyIDCounter();
 
   std::string participant0("rank0");

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -36,7 +36,7 @@ struct CompositionalCouplingSchemeFixture
   {
     using namespace mesh;
     utils::Parallel::synchronizeProcesses();
-    P_ASSERT(utils::Parallel::getCommunicatorSize() > 1);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
     mesh::PropertyContainer::resetPropertyIDCounter();
 
     std::string configurationPath(configFilename);
@@ -74,7 +74,7 @@ struct CompositionalCouplingSchemeFixture
       connect(nameParticipant1, nameParticipant2, localParticipant, m2n1);
     }
     else {
-      P_ASSERT(utils::Parallel::getProcessRank() == 2,
+      BOOST_TEST(utils::Parallel::getProcessRank() == 2,
           utils::Parallel::getProcessRank());
       localParticipant = nameParticipant2;
       connect(nameParticipant1, nameParticipant2, localParticipant, m2n1);
@@ -162,7 +162,7 @@ struct CompositionalCouplingSchemeFixture
       BOOST_TEST(cplScheme->getNextTimestepMaxLength() > 0.0); // ??
     }
     else {
-      P_ASSERT(participantName == std::string("Participant2"), participantName);
+      BOOST_TEST(participantName == std::string("Participant2"), participantName);
       cplScheme->initialize(0.0, 1);
       BOOST_TEST(cplScheme->hasDataBeenExchanged());
       BOOST_TEST(not cplScheme->isCouplingTimestepComplete());
@@ -200,14 +200,14 @@ struct CompositionalCouplingSchemeFixture
                const std::string&     localParticipant,
                m2n::PtrM2N communication ) const
   {
-    P_ASSERT( communication );
-    P_ASSERT( not communication->isConnected() );
+    BOOST_TEST ( communication );
+    BOOST_TEST ( not communication->isConnected() );
     utils::Parallel::splitCommunicator( localParticipant );
     if ( participant0 == localParticipant ) {
       communication->requestMasterConnection ( participant1, participant0 );
     }
     else {
-      P_ASSERT( participant1 == localParticipant );
+      BOOST_TEST ( participant1 == localParticipant );
       communication->acceptMasterConnection ( participant1, participant0 );
     }
   }

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -146,8 +146,8 @@ void runExplicitCouplingWithSubcycling(
   int computedTimesteps = 0;
   std::string nameParticipant0 ( "Participant0" );
   std::string nameParticipant1 ( "Participant1" );
-  P_ASSERT( (participantName == nameParticipant0) ||
-              (participantName == nameParticipant1) );
+  BOOST_TEST ( (participantName == nameParticipant0) ||
+               (participantName == nameParticipant1) );
   if ( participantName == nameParticipant0 ) {
     cplScheme.initialize ( 0.0, 1 );
     double dtDesired = cplScheme.getNextTimestepMaxLength() / 2.0;
@@ -257,14 +257,14 @@ struct ExplicitCouplingSchemeFixture
       const std::string&      localParticipant,
       m2n::PtrM2N& communication )
   {
-    P_ASSERT(communication);
-    P_ASSERT(not communication->isConnected());
+    BOOST_TEST(communication);
+    BOOST_TEST(not communication->isConnected());
     utils::Parallel::splitCommunicator( localParticipant );
     if ( participant0 == localParticipant ) {
       communication->requestMasterConnection ( participant1, participant0);
     }
     else {
-      P_ASSERT( participant1 == localParticipant );
+      BOOST_TEST ( participant1 == localParticipant );
       communication->acceptMasterConnection ( participant1, participant0);
     }
   }
@@ -330,7 +330,7 @@ BOOST_AUTO_TEST_CASE(testConfiguredSimpleExplicitCoupling,
     return;
 
   using namespace mesh;
-  P_ASSERT( utils::Parallel::getCommunicatorSize() > 1 );
+  BOOST_TEST ( utils::Parallel::getCommunicatorSize() > 1 );
   mesh::PropertyContainer::resetPropertyIDCounter ();
 
   std::string configurationPath ( _pathToTests + "explicit-coupling-scheme-1.xml" );
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
     BOOST_TEST(not cplScheme.isCouplingOngoing());
   }
   else {
-    P_ASSERT( nameLocalParticipant == std::string(nameParticipant1), nameLocalParticipant );
+    BOOST_TEST ( nameLocalParticipant == std::string(nameParticipant1), nameLocalParticipant );
     cplScheme.initialize ( 0.0, 1 );
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -146,8 +146,7 @@ void runExplicitCouplingWithSubcycling(
   int computedTimesteps = 0;
   std::string nameParticipant0 ( "Participant0" );
   std::string nameParticipant1 ( "Participant1" );
-  BOOST_TEST ( (participantName == nameParticipant0) ||
-               (participantName == nameParticipant1) );
+  BOOST_TEST ( ((participantName == nameParticipant0) || (participantName == nameParticipant1)) );
   if ( participantName == nameParticipant0 ) {
     cplScheme.initialize ( 0.0, 1 );
     double dtDesired = cplScheme.getNextTimestepMaxLength() / 2.0;

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -352,7 +352,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
     }
   }
   else {
-    P_ASSERT(nameLocalParticipant == nameParticipant1);
+    BOOST_TEST(nameLocalParticipant == nameParticipant1);
     auto& values = mesh->data(dataID0)->values();
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
     Eigen::VectorXd v(3); v << 1.0, 2.0, 3.0;

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -48,7 +48,7 @@ void runCoupling(
   int computedTimesteps = 0;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
-  P_ASSERT((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1));
+  BOOST_TEST ((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1));
   int iterationCount = 0;
   std::vector<int>::const_iterator iterValidIterations = validIterations.begin();
 
@@ -213,7 +213,11 @@ void runCouplingWithSubcycling
   int computedTimesteps = 0;
   std::string nameParticipant0 ( "Participant0");
   std::string nameParticipant1 ( "Participant1");
+<<<<<<< HEAD
   P_ASSERT((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1));
+=======
+  BOOST_TEST((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1));
+>>>>>>> Replace assertion with BOOST_TEST
   int iterationCount = 0;
   std::vector<int>::const_iterator iterValidIterations =
       validIterations.begin();
@@ -832,7 +836,11 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
     }
   }
   else {
+<<<<<<< HEAD
     P_ASSERT(nameLocalParticipant == nameParticipant1);
+=======
+    BOOST_TEST(nameLocalParticipant == nameParticipant1);
+>>>>>>> Replace assertion with BOOST_TEST
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
     cplScheme.performedAction(constants::actionWriteInitialData());
     auto& values = mesh->data(dataID0)->values();

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -48,7 +48,7 @@ void runCoupling(
   int computedTimesteps = 0;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
-  BOOST_TEST ((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1));
+  BOOST_TEST (((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1)));
   int iterationCount = 0;
   std::vector<int>::const_iterator iterValidIterations = validIterations.begin();
 
@@ -213,11 +213,7 @@ void runCouplingWithSubcycling
   int computedTimesteps = 0;
   std::string nameParticipant0 ( "Participant0");
   std::string nameParticipant1 ( "Participant1");
-<<<<<<< HEAD
-  P_ASSERT((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1));
-=======
-  BOOST_TEST((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1));
->>>>>>> Replace assertion with BOOST_TEST
+  BOOST_TEST(((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1)));
   int iterationCount = 0;
   std::vector<int>::const_iterator iterValidIterations =
       validIterations.begin();
@@ -836,11 +832,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
     }
   }
   else {
-<<<<<<< HEAD
-    P_ASSERT(nameLocalParticipant == nameParticipant1);
-=======
     BOOST_TEST(nameLocalParticipant == nameParticipant1);
->>>>>>> Replace assertion with BOOST_TEST
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
     cplScheme.performedAction(constants::actionWriteInitialData());
     auto& values = mesh->data(dataID0)->values();

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -34,7 +34,7 @@ using namespace precice;
 struct SetupMasterSlaveFixture {
   SetupMasterSlaveFixture()
   {
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
     auto masterSlaveCom                = std::make_shared<com::MPIDirectCommunication>();
     utils::MasterSlave::_communication = masterSlaveCom;

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -18,7 +18,7 @@ using namespace m2n;
 
 BOOST_AUTO_TEST_CASE(GatherScatterTest, *testing::OnSize(4))
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   utils::MasterSlave::reset();
 
   com::PtrCommunication participantCom = com::PtrCommunication(new com::MPIDirectCommunication());

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -28,7 +28,7 @@ void process(vector<double> &data)
 
 void P2PComTest1(com::PtrCommunicationFactory cf)
 {
-  P_ASSERT(Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(Parallel::getCommunicatorSize() == 4);
 
   MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
 
@@ -143,7 +143,7 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
 /// a very similar test, but with a vertex that has been completely filtered out
 void P2PComTest2(com::PtrCommunicationFactory cf)
 {
-  P_ASSERT(Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(Parallel::getCommunicatorSize() == 4);
 
   MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
 

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -98,7 +98,7 @@ void testDistributed(Mapping& mapping,
                      int inGlobalIndexOffset = 0)
 {
   using Par = utils::Parallel;
-  P_ASSERT(Par::getCommunicatorSize() == 4);
+  BOOST_TEST(Par::getCommunicatorSize() == 4);
   int meshDimension = inMeshSpec[0].position.size();
   int valueDimension = inMeshSpec[0].value.size();
 
@@ -140,7 +140,7 @@ void testDistributed(Mapping& mapping,
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV1)
 {
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getRestrictedCommunicator({0,1,2,3}));
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   Gaussian fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV1)
 /// Using a more heterogenous distributon of vertices and owner
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV2)
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   Gaussian fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV2)
 /// Test with a very heterogenous distributed and non-continues ownership
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3)
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   Gaussian fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
 // same as 2DV4, but all ranks have vertices
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   ThinPlateSplines fct;
   PetRadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV6,
                      * boost::unit_test::tolerance(1e-7))
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   ThinPlateSplines fct;
   PetRadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV6,
 /// Test with a homogenous distribution of mesh amoung ranks
 BOOST_AUTO_TEST_CASE(DistributedConservative2DV1)
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   Gaussian fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSERVATIVE, 2, fct, false, false, false);
 
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV1)
 /// Using a more heterogenous distribution of vertices and owner
 BOOST_AUTO_TEST_CASE(DistributedConservative2DV2)
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   Gaussian fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSERVATIVE, 2, fct, false, false, false);
 
@@ -694,7 +694,7 @@ void testTagging(MeshSpecification inMeshSpec,
 }
 
 BOOST_AUTO_TEST_CASE(testTagFirstRound){
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   //    *
   //    + <-- owned
   //* * x * *

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_SUITE(ProvidedPartitionTests)
 
 void setupParallelEnvironment(m2n::PtrM2N m2n)
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
   com::PtrCommunication masterSlaveCom = com::PtrCommunication(new com::MPIDirectCommunication());
   utils::MasterSlave::_communication   = masterSlaveCom;

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_SUITE(ReceivedPartitionTests)
 
 void setupParallelEnvironment(m2n::PtrM2N m2n)
 {
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
   com::PtrCommunication masterSlaveCom = com::PtrCommunication(new com::MPIDirectCommunication());
   utils::MasterSlave::_communication   = masterSlaveCom;
@@ -69,8 +69,8 @@ void tearDownParallelEnvironment()
 void createSolidzMesh2D(mesh::PtrMesh pSolidzMesh)
 {
   int dimensions = 2;
-  P_ASSERT(pSolidzMesh);
-  P_ASSERT(pSolidzMesh->getDimensions() == dimensions);
+  BOOST_TEST(pSolidzMesh);
+  BOOST_TEST(pSolidzMesh->getDimensions() == dimensions);
   Eigen::VectorXd position(dimensions);
 
   position << 0.0, 0.0;
@@ -101,8 +101,8 @@ void createSolidzMesh2D(mesh::PtrMesh pSolidzMesh)
 void createSolidzMesh2DSmall(mesh::PtrMesh pSolidzMesh)
 {
   int dimensions = 2;
-  P_ASSERT(pSolidzMesh);
-  P_ASSERT(pSolidzMesh->getDimensions() == dimensions);
+  BOOST_TEST(pSolidzMesh);
+  BOOST_TEST(pSolidzMesh->getDimensions() == dimensions);
   Eigen::VectorXd position(dimensions);
 
   position << 0.0, 0.0;
@@ -118,8 +118,8 @@ void createSolidzMesh2DSmall(mesh::PtrMesh pSolidzMesh)
 void createNastinMesh2D(mesh::PtrMesh pNastinMesh)
 {
   int dimensions = 2;
-  P_ASSERT(pNastinMesh);
-  P_ASSERT(pNastinMesh->getDimensions() == dimensions);
+  BOOST_TEST(pNastinMesh);
+  BOOST_TEST(pNastinMesh->getDimensions() == dimensions);
 
   if (utils::Parallel::getProcessRank() == 1) {
 
@@ -144,8 +144,8 @@ void createSolidzMesh3D(mesh::PtrMesh pSolidzMesh)
 {
   int             dimensions = 3;
   Eigen::VectorXd position(dimensions);
-  P_ASSERT(pSolidzMesh);
-  P_ASSERT(pSolidzMesh->getDimensions() == dimensions);
+  BOOST_TEST(pSolidzMesh);
+  BOOST_TEST(pSolidzMesh->getDimensions() == dimensions);
 
   position << 0.0, 0.0, -0.1;
   mesh::Vertex &v1 = pSolidzMesh->createVertex(position);
@@ -175,8 +175,8 @@ void createSolidzMesh3D(mesh::PtrMesh pSolidzMesh)
 void createNastinMesh3D(mesh::PtrMesh pNastinMesh)
 {
   int dimensions = 3;
-  P_ASSERT(pNastinMesh);
-  P_ASSERT(pNastinMesh->getDimensions() == dimensions);
+  BOOST_TEST(pNastinMesh);
+  BOOST_TEST(pNastinMesh->getDimensions() == dimensions);
 
   if (utils::Parallel::getProcessRank() == 1) { //Master
 

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -31,7 +31,7 @@ struct ParallelTestFixture : testing::WhiteboxAccessor {
     reset();
     _pathToTests = testing::getPathToSources() + "/precice/tests/";
     utils::Parallel::restrictGlobalCommunicator({0,1,2,3});
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   }
 
   ~ParallelTestFixture()
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "SolverOne" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator()); //needed since this test uses PETSc
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 3);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
 
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
   else {
     utils::Parallel::splitCommunicator( "SolverTwo" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 1);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
 
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "SolverOne" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 3);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
 
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
   else {
     utils::Parallel::splitCommunicator( "SolverTwo" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 1);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
 
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "Ateles" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 3);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "Ateles", utils::Parallel::getProcessRank(), 3 );
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
   else {
     utils::Parallel::splitCommunicator( "FASTEST" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 1);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "FASTEST", 0, 1 );
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
 
   utils::Parallel::splitCommunicator( solverName );
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
-  P_ASSERT(utils::Parallel::getCommunicatorSize() == size);
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == size);
   utils::Parallel::clearGroups();
 
   for(int k=0; k<numberOfTests; k++){
@@ -595,7 +595,7 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, * testing::OnSize(4))
   else {
     utils::Parallel::splitCommunicator( "SolidSolver" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
-    P_ASSERT(utils::Parallel::getCommunicatorSize() == 1);
+    BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
     xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "SolidSolver", 0, 1 );

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
       solverName = "SolverOne";
     }
     else {
-      P_ASSERT(utils::Parallel::getProcessRank() == 1);
+      BOOST_TEST(utils::Parallel::getProcessRank() == 1);
       solverName = "SolverTwo";
     }
 
@@ -837,7 +837,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
   std::string config2D = _pathToTests + "mapping-without-geo-2D.xml";
   std::string config3D = _pathToTests + "mapping-without-geo-3D.xml";
   int rank = utils::Parallel::getProcessRank();
-  P_ASSERT((rank == 0) || (rank == 1), rank);
+  BOOST_TEST((rank == 0) || (rank == 1), rank);
   std::string solverName = rank == 0 ? "SolverA" : "SolverB";
   std::string meshForcesA = "MeshForcesA";
   std::string meshDisplA = "MeshDisplacementsA";
@@ -938,7 +938,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
       interface.finalize();
     }
     else {
-      P_ASSERT(rank == 1, rank);
+      BOOST_TEST(rank == 1, rank);
       int meshForcesID = interface.getMeshID(meshForcesB);
       int meshDisplID = interface.getMeshID(meshDisplB);
       int dataForcesID = interface.getDataID(dataForces, meshForcesID);
@@ -1021,7 +1021,7 @@ BOOST_AUTO_TEST_CASE(testBug,
   }
 
   int rank = utils::Parallel::getProcessRank();
-  P_ASSERT((rank == 0) || (rank == 1), rank);
+  BOOST_TEST((rank == 0) || (rank == 1), rank);
   std::string solverName = rank == 0 ? "Flite" : "Calculix";
   if (solverName == std::string("Flite")){
     SolverInterface precice("Flite", 0, 1);
@@ -1056,7 +1056,7 @@ BOOST_AUTO_TEST_CASE(testBug,
     precice.finalize();
   }
   else {
-    P_ASSERT(solverName == std::string("Calculix"), solverName);
+    BOOST_TEST(solverName == std::string("Calculix"), solverName);
     SolverInterface precice("Calculix", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configName);
@@ -1118,7 +1118,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     reset();
 
     int rank = utils::Parallel::getProcessRank();
-    P_ASSERT((rank == 0) || (rank == 1) || (rank == 2), rank);
+    BOOST_TEST((rank == 0) || (rank == 1) || (rank == 2), rank);
 
     std::string writeIterCheckpoint(constants::actionWriteIterationCheckpoint());
     std::string readIterCheckpoint(constants::actionReadIterationCheckpoint());
@@ -1187,7 +1187,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[k][1]);
     }
     else {
-      P_ASSERT(solverName == std::string("SolverThree"), solverName);
+      BOOST_TEST(solverName == std::string("SolverThree"), solverName);
       SolverInterface precice(solverName, 0, 1);
       config::Configuration config;
       xml::configure(config.getXMLTag(), configs[k]);
@@ -1322,7 +1322,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
 
   }
   else {
-    P_ASSERT(utils::Parallel::getProcessRank() == 3);
+    BOOST_TEST(utils::Parallel::getProcessRank() == 3);
     SolverInterface precice("NASTIN", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), _pathToTests + "/multi.xml");

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -837,7 +837,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
   std::string config2D = _pathToTests + "mapping-without-geo-2D.xml";
   std::string config3D = _pathToTests + "mapping-without-geo-3D.xml";
   int rank = utils::Parallel::getProcessRank();
-  BOOST_TEST((rank == 0) || (rank == 1), rank);
+  BOOST_TEST(((rank == 0) || (rank == 1)), rank);
   std::string solverName = rank == 0 ? "SolverA" : "SolverB";
   std::string meshForcesA = "MeshForcesA";
   std::string meshDisplA = "MeshDisplacementsA";
@@ -1021,7 +1021,7 @@ BOOST_AUTO_TEST_CASE(testBug,
   }
 
   int rank = utils::Parallel::getProcessRank();
-  BOOST_TEST((rank == 0) || (rank == 1), rank);
+  BOOST_TEST(((rank == 0) || (rank == 1)), rank);
   std::string solverName = rank == 0 ? "Flite" : "Calculix";
   if (solverName == std::string("Flite")){
     SolverInterface precice("Flite", 0, 1);
@@ -1118,7 +1118,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     reset();
 
     int rank = utils::Parallel::getProcessRank();
-    BOOST_TEST((rank == 0) || (rank == 1) || (rank == 2), rank);
+    BOOST_TEST(((rank == 0) || (rank == 1) || (rank == 2)), rank);
 
     std::string writeIterCheckpoint(constants::actionWriteIterationCheckpoint());
     std::string readIterCheckpoint(constants::actionReadIterationCheckpoint());

--- a/src/precice/tests/ServerTests.cpp
+++ b/src/precice/tests/ServerTests.cpp
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     BOOST_TEST(timesteps == 5);
   }
   else {
-    P_ASSERT(rank == 2, rank);
+    BOOST_TEST (rank == 2, rank);
     bool isServer = true;
     impl::SolverInterfaceImpl server("ParticipantB", 0, 1, isServer);
 
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     BOOST_TEST(timesteps == 5);
   }
   else {
-    P_ASSERT(rank == 3, rank);
+    BOOST_TEST(rank == 3, rank);
     bool isServer = true;
     impl::SolverInterfaceImpl server("ParticipantB", 0, 1, isServer);
 

--- a/src/query/tests/FindVoxelContentTest.cpp
+++ b/src/query/tests/FindVoxelContentTest.cpp
@@ -19,8 +19,8 @@ void performTestVertices(
     const Eigen::VectorXd &offset)
 {
   int dim = offset.size();
-  P_ASSERT(not math::oneGreater(offset, Eigen::VectorXd::Constant(dim, 1.0)));
-  P_ASSERT(math::allGreater(offset, Eigen::VectorXd::Constant(dim, -1.0)));
+  BOOST_TEST(not math::oneGreater(offset, Eigen::VectorXd::Constant(dim, 1.0)));
+  BOOST_TEST(math::allGreater(offset, Eigen::VectorXd::Constant(dim, -1.0)));
   bool            flipNormals = false;
   mesh::Mesh      mesh("TestMesh", dim, flipNormals);
   Eigen::VectorXd coords(offset);
@@ -33,8 +33,8 @@ void performTestVertices(
   query::FindVoxelContent             findIncluded(center, halflengths, includeBounds);
   query::FindVoxelContent             findExcluded(center, halflengths, excludeBounds);
 
-  P_ASSERT(testDim >= 0);
-  P_ASSERT(testDim < dim);
+  BOOST_TEST(testDim >= 0);
+  BOOST_TEST(testDim < dim);
 
   double sign = positive ? 1.0 : -1.0;
   int    size = 0;
@@ -126,8 +126,8 @@ void performTestEdges(
     const Eigen::VectorXd &offset)
 {
   int dim = offset.size();
-  P_ASSERT(not math::oneGreater(offset, Eigen::VectorXd::Constant(dim, 1.0)));
-  P_ASSERT(math::allGreater(offset, Eigen::VectorXd::Constant(dim, -1.0)));
+  BOOST_TEST(not math::oneGreater(offset, Eigen::VectorXd::Constant(dim, 1.0)));
+  BOOST_TEST(math::allGreater(offset, Eigen::VectorXd::Constant(dim, -1.0)));
   bool            flipNormals = false;
   mesh::Mesh      mesh("TestMesh", dim, flipNormals);
   Eigen::VectorXd coords0(offset);
@@ -143,8 +143,8 @@ void performTestEdges(
   query::FindVoxelContent             findIncluded(center, halflengths, includeBounds);
   query::FindVoxelContent             findExcluded(center, halflengths, excludeBounds);
 
-  P_ASSERT(testDim >= 0);
-  P_ASSERT(testDim < dim);
+  BOOST_TEST(testDim >= 0);
+  BOOST_TEST(testDim < dim);
 
   double sign = positive ? 1.0 : -1.0;
 
@@ -246,7 +246,7 @@ void performTestTriangles(
     bool positive)
 {
   int dim = 3;
-  P_ASSERT(testDim != secondDimension);
+  BOOST_TEST(testDim != secondDimension);
   bool            flipNormals = false;
   mesh::Mesh      mesh("TestMesh", dim, flipNormals);
   Eigen::Vector3d coords0 = Eigen::Vector3d::Zero();
@@ -267,8 +267,8 @@ void performTestTriangles(
   query::FindVoxelContent             findIncluded(center, halflengths, includeBounds);
   query::FindVoxelContent             findExcluded(center, halflengths, excludeBounds);
 
-  P_ASSERT(testDim >= 0);
-  P_ASSERT(testDim < dim);
+  BOOST_TEST(testDim >= 0);
+  BOOST_TEST(testDim < dim);
 
   double sign = positive ? 1.0 : -1.0;
 

--- a/src/testing/tests/ExampleTests.cpp
+++ b/src/testing/tests/ExampleTests.cpp
@@ -137,7 +137,7 @@ BOOST_FIXTURE_TEST_CASE(IntegrationTestsWithTwoParticipants, testing::SplitParti
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 2);
   }
   else {
-    P_ASSERT(participantID==2);
+    BOOST_TEST(participantID==2);
 
     // Put here your preCICE API code for the second participant
 

--- a/src/utils/tests/ParallelTest.cpp
+++ b/src/utils/tests/ParallelTest.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(Parallel, *testing::MinRanks{3})
     if ((rank == 0) || (rank == 1)) {
       group = "GroupOne";
     } else {
-      P_ASSERT(rank == 2, rank);
+      BOOST_TEST(rank == 2, rank);
       group = "GroupTwo";
     }
     Par::splitCommunicator(group);


### PR DESCRIPTION
If we do not build preCICE in debug mode, `assertion` will be ignored. Therefore, we should use `BOOST_TEST` in our tests.