### PR TITLE
README.md: make Releases more prominent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@
 
 preCICE stands for Precise Code Interaction Coupling Environment. Its main component is a library that can be used by simulation programs to be coupled together in a partitioned way, enabling multi-physics simulations, such as fluid-structure interaction.
 
-If you are new to preCICE, please have a look at our [wiki (documentation)](https://github.com/precice/precice/wiki) and at [precice.org](https://www.precice.org).
+If you are new to preCICE, please have a look at our [wiki (documentation)](https://github.com/precice/precice/wiki) and at [precice.org](https://www.precice.org). You may also prefer to [get and install a binary package for the latest release](https://github.com/precice/precice/releases/latest) ([master branch](https://github.com/precice/precice/tree/master)).
 
 <div align="center" style="margin-bottom:30px">
 <img src="https://www.precice.org/assets/precice_overview.png" alt="preCICE overview" style="max-height: 100%; max-width: 100%">


### PR DESCRIPTION
We want that new users:
* get a package for the latest release or
* build preCICE from `master` (not from `develop`)
* but avoid the "Download zip" button, which we cannot control. (see #424 and #446 ).

With this, I am trying to make Releases more prominent. Any ideas?