### PR TITLE
Redesign Triangle Checks

### DIFF
--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -46,6 +46,14 @@ double Edge:: getEnclosingRadius () const
   return (_vertices[0]->getCoords() - getCenter()).norm();
 }
 
+bool Edge::connectedTo(const Edge& other) const
+{
+    return _vertices[0] == other._vertices[0]
+        || _vertices[0] == other._vertices[1]
+        || _vertices[1] == other._vertices[0]
+        || _vertices[1] == other._vertices[1];
+}
+
 bool Edge::operator==(const Edge& other) const
 {
     return math::equals(_normal, other._normal) &&

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -62,7 +62,7 @@ public:
   /// Returns the radius of the enclosing circle of the edge.
   double getEnclosingRadius () const;
 
-  /// Checks weather both eadges share a vertex.
+  /// Checks whether both edges share a vertex.
   bool connectedTo(const Edge& other) const;
 
   /**

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -62,6 +62,9 @@ public:
   /// Returns the radius of the enclosing circle of the edge.
   double getEnclosingRadius () const;
 
+  /// Checks weather both eadges share a vertex.
+  bool connectedTo(const Edge& other) const;
+
   /**
    * @brief Compares two Edges for equality
    *

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -153,6 +153,11 @@ Triangle& Mesh:: createTriangle
   Edge& edgeTwo,
   Edge& edgeThree )
 {
+  PRECICE_CHECK(
+          edgeOne.connectedTo(edgeTwo) &&
+          edgeTwo.connectedTo(edgeThree) &&
+          edgeThree.connectedTo(edgeOne),
+          "Edges are not connected!");
   Triangle* newTriangle = new Triangle (
       edgeOne, edgeTwo, edgeThree, _manageTriangleIDs.getFreeID());
   newTriangle->addParent(*this);

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -66,12 +66,12 @@ Triangle::Triangle(
       _vertexMap[2] = 1;
     }
   }
-  PRECICE_ASSERT(&edge(0).vertex(_vertexMap[0]) != &edge(1).vertex(_vertexMap[1]));
-  PRECICE_ASSERT(&edge(0).vertex(_vertexMap[0]) != &edge(2).vertex(_vertexMap[2]));
-  PRECICE_ASSERT(&edge(1).vertex(_vertexMap[1]) != &edge(2).vertex(_vertexMap[2]));
-  PRECICE_ASSERT((_vertexMap[0] == 0) || (_vertexMap[0] == 1), _vertexMap[0]);
-  PRECICE_ASSERT((_vertexMap[1] == 0) || (_vertexMap[1] == 1), _vertexMap[0]);
-  PRECICE_ASSERT((_vertexMap[2] == 0) || (_vertexMap[2] == 1), _vertexMap[0]);
+
+  PRECICE_ASSERT(
+          (&edge(0).vertex(_vertexMap[0]) != &edge(1).vertex(_vertexMap[1])) &&
+          (&edge(0).vertex(_vertexMap[0]) != &edge(2).vertex(_vertexMap[2])) &&
+          (&edge(1).vertex(_vertexMap[1]) != &edge(2).vertex(_vertexMap[2])),
+          "Triangle vertices are not unique!");
 }
 
 const Eigen::VectorXd Triangle::computeNormal(bool flip)

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -51,4 +51,25 @@ BOOST_AUTO_TEST_CASE(EdgeWKTPrint)
     std::string e2str("LINESTRING (1 2 3, 3 2 1)");
     BOOST_TEST(e2str == e2stream.str());
 }
+
+BOOST_AUTO_TEST_CASE(EdgeConnectedTo)
+{
+   Vertex v1 (Eigen::Vector3d(0,0,1), 0);
+   Vertex v2 (Eigen::Vector3d(0,0,2), 0);
+   Vertex v3 (Eigen::Vector3d(0,0,3), 0);
+   Vertex v4 (Eigen::Vector3d(0,0,4), 0);
+
+   Edge edge1(v1, v2, 0);
+   Edge edge2(v2, v3, 0);
+   BOOST_TEST(edge1.connectedTo(edge2));
+   BOOST_TEST(edge2.connectedTo(edge1));
+
+   Edge edge3(v3, v4, 0);
+   BOOST_TEST(!edge1.connectedTo(edge3));
+   BOOST_TEST(!edge3.connectedTo(edge1));
+   BOOST_TEST(edge2.connectedTo(edge3));
+   BOOST_TEST(edge3.connectedTo(edge2));
+}
+
+
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -764,8 +764,8 @@ int SolverInterfaceImpl:: setMeshEdge
     if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
       PRECICE_DEBUG("Full mesh required.");
       mesh::PtrMesh& mesh = context.mesh;
-      PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  " Given VertexID is invalid!");
-      PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), " Given VertexID is invalid!");
+      PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  "Given VertexID is invalid!");
+      PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), "Given VertexID is invalid!");
       mesh::Vertex& v0 = mesh->vertices()[firstVertexID];
       mesh::Vertex& v1 = mesh->vertices()[secondVertexID];
       return mesh->createEdge(v0, v1).getID ();
@@ -791,11 +791,11 @@ void SolverInterfaceImpl:: setMeshTriangle
     MeshContext& context = _accessor->meshContext(meshID);
     if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
       mesh::PtrMesh& mesh = context.mesh;
-      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID),  " Given EdgeID is invalid!");
-      PRECICE_CHECK(mesh->isValidEdgeID(secondEdgeID), " Given EdgeID is invalid!");
-      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID),  " Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID),  "Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(secondEdgeID), "Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID),  "Given EdgeID is invalid!");
       PRECICE_CHECK(utils::unique_elements(utils::make_array(firstEdgeID, secondEdgeID, thirdEdgeID)),
-              " Given EdgeIDs must be unique!");
+              "Given EdgeIDs must be unique!");
       mesh::Edge& e0 = mesh->edges()[firstEdgeID];
       mesh::Edge& e1 = mesh->edges()[secondEdgeID];
       mesh::Edge& e2 = mesh->edges()[thirdEdgeID];
@@ -824,18 +824,18 @@ void SolverInterfaceImpl:: setMeshTriangleWithEdges
   MeshContext& context = _accessor->meshContext(meshID);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
     mesh::PtrMesh& mesh = context.mesh;
-    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  " Given VertexID is invalid!");
-    PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), " Given VertexID is invalid!");
-    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  " Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  "Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), "Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  "Given VertexID is invalid!");
     PRECICE_CHECK(!utils::unique_elements(utils::make_array(firstVertexID, secondVertexID, thirdVertexID)),
-            " Given VertexIDs must be unique!");
+            "Given VertexIDs must be unique!");
     mesh::Vertex* vertices[3];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];
     vertices[2] = &mesh->vertices()[thirdVertexID];
     PRECICE_CHECK(!utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
                 vertices[1]->getCoords(), vertices[2]->getCoords()), utils::ComponentWiseLess{}),
-            " The coordinates of the vertices must be unique!");
+            "The coordinates of the vertices must be unique!");
     mesh::Edge* edges[3];
     edges[0] = & mesh->createUniqueEdge(*vertices[0], *vertices[1]);
     edges[1] = & mesh->createUniqueEdge(*vertices[1], *vertices[2]);
@@ -864,10 +864,10 @@ void SolverInterfaceImpl:: setMeshQuad
     MeshContext& context = _accessor->meshContext(meshID);
     if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
       mesh::PtrMesh& mesh = context.mesh;
-      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID),  " Given EdgeID is invalid!");
-      PRECICE_CHECK(mesh->isValidEdgeID(secondEdgeID), " Given EdgeID is invalid!");
-      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID),  " Given EdgeID is invalid!");
-      PRECICE_CHECK(mesh->isValidEdgeID(fourthEdgeID), " Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID),  "Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(secondEdgeID), "Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID),  "Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(fourthEdgeID), "Given EdgeID is invalid!");
       mesh::Edge& e0 = mesh->edges()[firstEdgeID];
       mesh::Edge& e1 = mesh->edges()[secondEdgeID];
       mesh::Edge& e2 = mesh->edges()[thirdEdgeID];
@@ -896,10 +896,10 @@ void SolverInterfaceImpl:: setMeshQuadWithEdges
   MeshContext& context = _accessor->meshContext(meshID);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
     mesh::PtrMesh& mesh = context.mesh;
-    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  " Given VertexID is invalid!");
-    PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), " Given VertexID is invalid!");
-    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  " Given VertexID is invalid!");
-    PRECICE_CHECK(mesh->isValidVertexID(fourthVertexID), " Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  "Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), "Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  "Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(fourthVertexID), "Given VertexID is invalid!");
     mesh::Vertex* vertices[4];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -27,6 +27,7 @@
 #include "utils/Petsc.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/EigenHelperFunctions.hpp"
+#include "utils/algorithm.hpp"
 #include "mapping/Mapping.hpp"
 #include <Eigen/Core>
 #include "partition/ReceivedPartition.hpp"
@@ -793,6 +794,8 @@ void SolverInterfaceImpl:: setMeshTriangle
       PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID),  " Given EdgeID is invalid!");
       PRECICE_CHECK(mesh->isValidEdgeID(secondEdgeID), " Given EdgeID is invalid!");
       PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID),  " Given EdgeID is invalid!");
+      PRECICE_CHECK(utils::unique_elements(utils::make_array(firstEdgeID, secondEdgeID, thirdEdgeID)),
+              " Given EdgeIDs must be unique!");
       mesh::Edge& e0 = mesh->edges()[firstEdgeID];
       mesh::Edge& e1 = mesh->edges()[secondEdgeID];
       mesh::Edge& e2 = mesh->edges()[thirdEdgeID];
@@ -824,10 +827,15 @@ void SolverInterfaceImpl:: setMeshTriangleWithEdges
     PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  " Given VertexID is invalid!");
     PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), " Given VertexID is invalid!");
     PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  " Given VertexID is invalid!");
+    PRECICE_CHECK(!utils::unique_elements(utils::make_array(firstVertexID, secondVertexID, thirdVertexID)),
+            " Given VertexIDs must be unique!");
     mesh::Vertex* vertices[3];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];
     vertices[2] = &mesh->vertices()[thirdVertexID];
+    PRECICE_CHECK(!utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
+                vertices[1]->getCoords(), vertices[2]->getCoords()), utils::ComponentWiseLess{}),
+            " The coordinates of the vertices must be unique!");
     mesh::Edge* edges[3];
     edges[0] = & mesh->createUniqueEdge(*vertices[0], *vertices[1]);
     edges[1] = & mesh->createUniqueEdge(*vertices[1], *vertices[2]);

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -290,6 +290,7 @@ target_sources(precice
     src/utils/TableWriter.cpp
     src/utils/TableWriter.hpp
     src/utils/TypeNames.hpp
+    src/utils/algorithm.hpp
     src/utils/assertion.hpp
     src/utils/json.hpp
     src/utils/prettyprint.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -67,6 +67,7 @@ target_sources(testprecice
     src/testing/Testing.hpp
     src/testing/main.cpp
     src/testing/tests/ExampleTests.cpp
+    src/utils/tests/AlgorithmTest.cpp
     src/utils/tests/DimensionsTest.cpp
     src/utils/tests/EigenHelperFunctionsTest.cpp
     src/utils/tests/ManageUniqueIDsTest.cpp

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 #include "utils/assertion.hpp"
+#include "utils/algorithm.hpp"
 
 namespace precice {
 namespace utils {
@@ -57,5 +58,33 @@ auto firstN(const Eigen::PlainObjectBase<Derived>& val, unsigned n) -> const Eig
 {
     return {val.data(), std::min<Eigen::Index>(n,val.size())};
 }
+
+
+template<typename DerivedLHS, typename DerivedRHS>
+bool componentWiseLess(const Eigen::PlainObjectBase<DerivedLHS>& lhs, const Eigen::PlainObjectBase<DerivedRHS>& rhs)
+{
+    const auto lhs_begin = lhs.data();
+    const auto lhs_end   = lhs.data()+lhs.size();
+    const auto rhs_begin = rhs.data();
+    const auto rhs_end   = rhs.data()+rhs.size();
+    
+    auto mismatch = utils::mismatch(lhs_begin, lhs_end, rhs_begin, rhs_end);
+
+    if (mismatch.first == lhs_end) {
+        return true;
+    }
+    if (mismatch.second == rhs_end) {
+        return false;
+    }
+    return *mismatch.first < *mismatch.second;
+}
+
+struct ComponentWiseLess {
+    template<typename DerivedLHS, typename DerivedRHS>
+    bool operator()(const Eigen::PlainObjectBase<DerivedLHS>& lhs, const Eigen::PlainObjectBase<DerivedRHS>& rhs) const
+    {
+        return componentWiseLess(lhs, rhs);
+    }
+};
 
 }}

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include<algorithm>
+#include<array>
+#include<functional>
+#include<type_traits>
+
+namespace precice {
+namespace utils {
+
+/// Function that generates an array from given elements.
+template<typename... Elements>
+auto make_array(Elements&&... elements) -> std::array<typename std::common_type<Elements...>::type, sizeof...(Elements)> {
+    return { std::forward<Elements>(elements)... };
+}
+
+/** Checks weather the given elements contains no duplicates.
+ *
+ * \tparam Container type of the passed container.
+ * \tparam Compare type of the comparator.
+ * \param c the container to check for unique elements.
+ * \param comp the comparator to use for the elements.
+ * \returns weather all elements in c are unique.
+ */
+template <typename Container, typename Compare>
+bool unique_elements(const Container& c, Compare comp)
+{
+  // This algorithm runs on small containers, so the O(n^2) does not hurt.
+  auto cbegin = c.begin();
+  auto cend   = c.end();
+  // An empty set has unique elements
+  if (cbegin == cend) {
+    return true;
+  }
+  auto cstart = cbegin + 1;
+  for (; cstart < cend; ++cbegin, ++cstart) {
+    if (std::find_if(cstart, cend,
+                [&comp, cbegin](const typename Container::value_type &v) -> bool {
+                    return comp(*cbegin, v); 
+                }) != cend) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Checks weather the given elements contains no duplicates.
+ *
+ * \tparam T type of items to check
+ * \param c the elements to compare
+ * \returns weather all elements are unique.
+ */
+template <typename Container>
+bool unique_elements(const Container& c)
+{
+  using Comp = std::equal_to<typename Container::value_type>;
+  return unique_elements<Container, Comp>(c, Comp{});
+}
+
+
+/** std::mismatch
+ * @todo{Remove when migrating to c++14}
+ */
+template<class InputIt1, class InputIt2>
+std::pair<InputIt1, InputIt2>
+    mismatch(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
+{
+    while (first1 != last1 && first2 != last2 && *first1 == *first2) {
+        ++first1, ++first2;
+    }
+    return std::make_pair(first1, first2);
+}
+
+
+} // namespace utils
+} // namespace precice

--- a/src/utils/tests/AlgorithmTest.cpp
+++ b/src/utils/tests/AlgorithmTest.cpp
@@ -1,0 +1,55 @@
+#include "testing/Testing.hpp"
+#include "utils/algorithm.hpp"
+
+namespace pu = precice::utils;
+
+BOOST_AUTO_TEST_SUITE(UtilsTests)
+
+BOOST_AUTO_TEST_CASE(MakeArray)
+{
+    auto a = pu::make_array(1,2,3);
+    BOOST_TEST(a.size() == 3);
+    BOOST_TEST(a[0] == 1);
+    BOOST_TEST(a[1] == 2);
+    BOOST_TEST(a[2] == 3);
+}
+
+BOOST_AUTO_TEST_CASE(UniqueElements)
+{
+    std::vector<int> y{1,2,3,4,5,6,7,8,9};
+    BOOST_TEST(pu::unique_elements(y));
+    BOOST_TEST(pu::unique_elements(y, [](int l, int r){ return l == r; }));
+
+    std::vector<int> n1{1,2,3,4,5,6,7,8,9,9};
+    BOOST_TEST(!pu::unique_elements(n1));
+    BOOST_TEST(!pu::unique_elements(n1, [](int l, int r){ return l == r; }));
+
+    std::vector<int> n2{1,1,3,4,5,6,7,8,9};
+    BOOST_TEST(!pu::unique_elements(n2));
+    BOOST_TEST(!pu::unique_elements(n2, [](int l, int r){ return l == r; }));
+
+    std::vector<int> e;
+    BOOST_TEST(pu::unique_elements(e));
+    BOOST_TEST(pu::unique_elements(e, [](int l, int r){ return l == r; }));
+}
+
+BOOST_AUTO_TEST_CASE(Mismatch)
+{
+    std::vector<int> a{1,2,3,4,5,6,7,8,9};
+    std::vector<int> b{1,2,3,4,5,0,9};
+
+    auto aa = pu::mismatch(
+            a.begin(), a.end(),
+            a.begin(), a.end());
+    BOOST_TEST((aa.first == aa.second));
+    BOOST_TEST((aa.first == a.end()));
+
+    auto ab = pu::mismatch(
+            a.begin(), a.end(),
+            b.begin(), b.end());
+    BOOST_TEST((ab.first != a.end()));
+    BOOST_TEST(*ab.first == 6);
+    BOOST_TEST(*ab.second == 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/EigenHelperFunctionsTest.cpp
+++ b/src/utils/tests/EigenHelperFunctionsTest.cpp
@@ -14,4 +14,28 @@ BOOST_AUTO_TEST_CASE(FirstN)
     BOOST_TEST(firstN(a, 3) == b);
 }
 
+BOOST_AUTO_TEST_CASE(ComponentWiseLess)
+{
+    precice::utils::ComponentWiseLess cwl;
+
+    Eigen::VectorXd a(8);
+    a << 1, 2, 3, 4, 5, 6, 7, 9;
+
+    Eigen::VectorXd b(8);
+    b << 1, 2, 3, 4, 5, 6, 8, 0;
+
+    BOOST_TEST(componentWiseLess(a, b));
+    BOOST_TEST(!componentWiseLess(b, a));
+    BOOST_TEST(cwl(a, b));
+    BOOST_TEST(!cwl(b, a));
+
+    Eigen::VectorXd c = b;
+
+    BOOST_TEST(componentWiseLess(c, b));
+    BOOST_TEST(componentWiseLess(b, c));
+    BOOST_TEST(cwl(c, b));
+    BOOST_TEST(cwl(b, c));
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR will:
* Turn triangle assertions into checks
* Check uniqueness of edgeIDs in SolverInterface
* Check uniqueness of vertices in SolverInterface
* Check edge connectivity in Mesh::createTriangle

Fixes #372