### PR TITLE
Replaces ID management with a flat_set

### DIFF
--- a/src/utils/ManageUniqueIDs.cpp
+++ b/src/utils/ManageUniqueIDs.cpp
@@ -9,21 +9,22 @@ int ManageUniqueIDs::getFreeID()
 {
   bool notFound = true;
   while (notFound) {
-    if (_ids.count(_lowerLimit) == 0) {
+    if (!_ids.contains(_lowerLimit)) {
       notFound = false;
     }
     _lowerLimit++;
   }
-  _ids.insert(_lowerLimit - 1);
+  _ids.insert(_ids.end(), _lowerLimit - 1);
   return _lowerLimit - 1;
 }
 
 bool ManageUniqueIDs::insertID(int id)
 {
-  if (_ids.count(id) != 0)
+  if (_ids.contains(id)) {
     return false;
-  else
-    _ids.insert(id);
+  }
+
+  _ids.insert(_ids.end(), id);
   return true;
 }
 

--- a/src/utils/ManageUniqueIDs.cpp
+++ b/src/utils/ManageUniqueIDs.cpp
@@ -9,7 +9,7 @@ int ManageUniqueIDs::getFreeID()
 {
   bool notFound = true;
   while (notFound) {
-    if (!_ids.contains(_lowerLimit)) {
+    if (_ids.find(_lowerLimit) == _ids.end()) {
       notFound = false;
     }
     _lowerLimit++;
@@ -20,7 +20,7 @@ int ManageUniqueIDs::getFreeID()
 
 bool ManageUniqueIDs::insertID(int id)
 {
-  if (_ids.contains(id)) {
+  if (_ids.find(id) != _ids.end()) {
     return false;
   }
 

--- a/src/utils/ManageUniqueIDs.hpp
+++ b/src/utils/ManageUniqueIDs.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <set>
+#include <boost/container/flat_set.hpp>
 
 namespace precice
 {
@@ -27,7 +27,7 @@ public:
 
 private:
   /// Stores all used IDs.
-  std::set<int> _ids;
+  boost::container::flat_set<int> _ids;
 
   /// Marks next ID to be given, from lower to higher values.
   int _lowerLimit = 0;


### PR DESCRIPTION
This PR replaces the set used by `precice::utils::ManageUniqueIDs` with a `boost::container::flat_set`.

Rational:
* `getFreeId()` is called for adding a primitive to a `precice::mesh::Mesh`.
* It is used extensively when calling `setMeshXXX` via the SolverInterface.
* It is used extensively when computing the partitions. (Memory peak due to gathering.)
* `std::set` and `std::unordered_set` are allocation-heavy containers.
* `boost::container::flat_map` is essentially an ordered vector, thus compact and cache-friendly. Insertions are `O(n)` but we always insert a new id bigger than the already indexed ids. Thus we can use the end of the container as a hint to shortcut the search and achieve constant complexity.

Result for [this setup](https://github.com/precice/precice/issues/483#issuecomment-520494968) (boost 1.70.0)
* 250 instead of 823000 allocations
* 1.6 MB (1.2%) instead of 11.6 MB (8%) peak memory consumption

Downside:
* Additional dependency on a boost header-only library