### PR TITLE
Fix Throws

### DIFF
--- a/src/action/config/ActionConfiguration.cpp
+++ b/src/action/config/ActionConfiguration.cpp
@@ -246,19 +246,19 @@ void ActionConfiguration:: createAction()
     std::ostringstream stream;
     stream << "Data action uses mesh \"" << _configuredAction.mesh
            << "\" which is not configured";
-    throw stream.str();
+    throw std::runtime_error{stream.str()};
   }
   if ((not _configuredAction.sourceData.empty()) && (sourceDataID == -1)){
     std::ostringstream stream;
     stream << "Data action uses source data \"" << _configuredAction.sourceData
            << "\" which is not configured";
-    throw stream.str();
+    throw std::runtime_error{stream.str()};
   }
   if ((not _configuredAction.targetData.empty()) && (targetDataID == -1)){
     std::ostringstream stream;
     stream << "Data action uses target data \"" << _configuredAction.targetData
            << "\" which is not configured";
-    throw stream.str();
+    throw std::runtime_error{stream.str()};
   }
   action::PtrAction action;
   if (_configuredAction.type == NAME_ADD_TO_COORDINATES){

--- a/src/com/config/CommunicationConfiguration.cpp
+++ b/src/com/config/CommunicationConfiguration.cpp
@@ -28,7 +28,7 @@ PtrCommunication CommunicationConfiguration::createCommunication(
     std::ostringstream error;
     error << "Communication type \"mpi\" can only be used "
           << "when preCICE is compiled with argument \"mpi=on\"";
-    throw error.str();
+    throw std::runtime_error{error.str()};
 #else
     com = std::make_shared<com::MPIPortsCommunication>(dir);
 #endif
@@ -38,7 +38,7 @@ PtrCommunication CommunicationConfiguration::createCommunication(
     std::ostringstream error;
     error << "Communication type \"mpi-single\" can only be used "
           << "when preCICE is compiled with argument \"mpi=on\"";
-    throw error.str();
+    throw std::runtime_error{error.str()};
 #else
     com = std::make_shared<com::MPIDirectCommunication>();
 

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -233,7 +233,7 @@ void CouplingSchemeConfiguration::xmlTagCallback(
       std::ostringstream stream;
       stream << "Mesh \"" << nameMesh << "\" with data \"" << nameData
              << "\" not defined at definition of coupling scheme";
-      throw stream.str();
+      throw std::runtime_error{stream.str()};
     }
     _meshConfig->addNeededMesh(nameParticipantFrom, nameMesh);
     _meshConfig->addNeededMesh(nameParticipantTo, nameMesh);

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -827,11 +827,11 @@ void CouplingSchemeConfiguration::addDataToBeExchanged(
     PRECICE_CHECK(to != from, "You cannot define an exchange from and to the same participant");
 
     if (not(utils::contained(from, _config.participants) || from == _config.controller)) {
-      throw std::string("Participant \"" + from + "\" is not configured for coupling scheme");
+      throw std::runtime_error{"Participant \"" + from + "\" is not configured for coupling scheme"};
     }
 
     if (not(utils::contained(to, _config.participants) || to == _config.controller)) {
-      throw std::string("Participant \"" + to + "\" is not configured for coupling scheme");
+      throw std::runtime_error{"Participant \"" + to + "\" is not configured for coupling scheme"};
     }
 
     bool initialize = get<4>(tuple);
@@ -858,11 +858,11 @@ void CouplingSchemeConfiguration::addMultiDataToBeExchanged(
     const std::string &to   = get<3>(tuple);
 
     if (not(utils::contained(from, _config.participants) || from == _config.controller)) {
-      throw std::string("Participant \"" + from + "\" is not configured for coupling scheme");
+      throw std::runtime_error{"Participant \"" + from + "\" is not configured for coupling scheme"};
     }
 
     if (not(utils::contained(to, _config.participants) || to == _config.controller)) {
-      throw std::string("Participant \"" + to + "\" is not configured for coupling scheme");
+      throw std::runtime_error{"Participant \"" + to + "\" is not configured for coupling scheme"};
     }
 
     bool initialize = get<4>(tuple);

--- a/src/cplscheme/config/PostProcessingConfiguration.cpp
+++ b/src/cplscheme/config/PostProcessingConfiguration.cpp
@@ -186,7 +186,7 @@ void PostProcessingConfiguration::xmlTagCallback(
       std::ostringstream stream;
       stream << "Data with name \"" << dataName << "\" associated to mesh \""
              << _meshName << "\" not found on configuration of post-processing";
-      throw stream.str();
+      throw std::runtime_error{stream.str()};
     }
     _neededMeshes.push_back(_meshName);
   } else if (callingTag.getName() == TAG_INIT_RELAX) {

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -134,7 +134,7 @@ m2n::PtrM2N M2NConfiguration::getM2N(const std::string &from, const std::string 
   }
   std::ostringstream error;
   error << "No m2n communication configured between \"" << from << "\" and \"" << to << "\"!";
-  throw error.str();
+  throw std::runtime_error{error.str()};
 }
 
 void M2NConfiguration::xmlTagCallback(xml::XMLTag &tag)
@@ -163,7 +163,7 @@ void M2NConfiguration::xmlTagCallback(xml::XMLTag &tag)
       std::ostringstream error;
       error << "Communication type \"mpi\" can only be used"
             << "when preCICE is compiled with argument \"mpi=on\"";
-      throw error.str();
+      throw std::runtime_error{error.str()};
 #else
       comFactory = std::make_shared<com::MPIPortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
@@ -174,7 +174,7 @@ void M2NConfiguration::xmlTagCallback(xml::XMLTag &tag)
       std::ostringstream error;
       error << "Communication type \"mpi-singleports\" can only be used "
             << "when preCICE is compiled with argument \"mpi=on\"";
-      throw error.str();
+      throw std::runtime_error{error.str()};
 #else
       comFactory = std::make_shared<com::MPISinglePortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
@@ -184,7 +184,7 @@ void M2NConfiguration::xmlTagCallback(xml::XMLTag &tag)
       std::ostringstream error;
       error << "Communication type \"" << "mpi-single" << "\" can only be used "
             << "when preCICE is compiled with argument \"mpi=on\"";
-      throw error.str();
+      throw std::runtime_error{error.str()};
 #else
       com        = std::make_shared<com::MPIDirectCommunication>();
 #endif
@@ -221,7 +221,7 @@ void M2NConfiguration::checkDuplicates(
     std::ostringstream error;
     error << "Multiple communication defined between participant \"" << from
           << "\" and \"" << to << "\"";
-    throw error.str();
+    throw std::runtime_error{error.str()};
   }
 }
 

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -103,7 +103,7 @@ void MeshConfiguration:: xmlTagCallback
       std::ostringstream stream;
       stream << "Data with name \"" << name << "\" is not available during "
              << "configuration of mesh \"" << _meshes.back()->getName() << "\"";
-      throw stream.str();
+      throw std::runtime_error{stream.str()};
     }
   }
 }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -307,7 +307,7 @@ void ParticipantConfiguration:: xmlTagCallback
     if (safetyFactor < 0){
       std::ostringstream stream;
       stream << "Safety Factor must be positive or 0";
-      throw stream.str();
+      throw std::runtime_error{stream.str()};
     }
     bool provide = tag.getBooleanAttributeValue(ATTR_PROVIDE);
     mesh::PtrMesh mesh = _meshConfig->getMesh(name);
@@ -315,14 +315,14 @@ void ParticipantConfiguration:: xmlTagCallback
       std::ostringstream stream;
       stream << "Participant \"" << _participants.back()->getName()
              << "\" uses mesh \"" << name << "\" which is not defined";
-      throw stream.str();
+      throw std::runtime_error{stream.str()};
     }
     if ((geoFilter != partition::ReceivedPartition::GeometricFilter::BROADCAST_FILTER || safetyFactor != 0.5) && from==""){
       std::ostringstream stream;
       stream << "Participant \"" << _participants.back()->getName()
              << "\" uses mesh \"" << name << "\" which is not received (no \"from\"), but has a geometric-filter and/or"
              << " a safety factor defined. This is not valid.";
-      throw stream.str();
+      throw std::runtime_error{stream.str()};
     }
     _participants.back()->useMesh ( mesh, offset, false, from, safetyFactor, provide, geoFilter );
   }

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -197,7 +197,7 @@ void XMLTag::readAttributes(std::map<std::string, std::string> &aAttributes)
     std::string name = xmlReader->getAttributeName(i);
     if (not utils::contained(name, _attributes)){
       std::string error = "Wrong attribute \"" + name + "\"";
-      throw error;
+      throw std::runtime_error{error};
     }
 //    else if (contained(name, _doubleAttributes)){
 //      XMLAttribute<double>& attr = _doubleAttributes[name];
@@ -228,7 +228,7 @@ void XMLTag::readAttributes(std::map<std::string, std::string> &aAttributes)
 //      attr.readValue(xmlReader);
 //    }
 //    else {
-//      throw "Internal error in readAttributes";
+//      throw std::runtime_error{"Internal error in readAttributes"};
 //    }
 //    readNames.insert(name);
   }
@@ -239,7 +239,7 @@ void XMLTag::readAttributes(std::map<std::string, std::string> &aAttributes)
 //
 //      std::ostringstream stream;
 //      stream << "Attribute \"" << name << "\" is not defined";
-//      throw stream.str();
+//      throw std::runtime_error{stream.str()};
 //    }
 //  }
 


### PR DESCRIPTION
There were still placed in the code-base `throw`ing strings directly.
This PR wraps the remaining occurrences in `std::runtime_error`.

This should at least make issue #488 less confusing.