### PR TITLE
Fix build with PETSc below 3.7 

### DIFF
--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -17,7 +17,7 @@ PetscErrorCode PetscOptionsSetValueWrapper(const char name [], const char value[
     typename std::enable_if<std::is_same<Func, PetscErrorCode(PetscOptions,const char [],const char[])>::value, Func>::type PetscOptionsSetValueImpl =
                            PetscOptionsSetValue)
 {
-  PetscOptionsSetValueImpl(nullptr, name, value);
+  return PetscOptionsSetValueImpl(nullptr, name, value);
 };
 
 template <typename Func = decltype(PetscOptionsSetValue)>
@@ -25,7 +25,7 @@ PetscErrorCode PetscOptionsSetValueWrapper(const char name[], const char value[]
     typename std::enable_if<std::is_same<Func, PetscErrorCode(const char[], const char[])>::value, Func>::type PetscOptionsSetValueImpl =
                             PetscOptionsSetValue)
 {
-  PetscOptionsSetValueImpl(name, value);
+  return PetscOptionsSetValueImpl(name, value);
 };
 
 }

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -9,6 +9,28 @@
 namespace precice {
 namespace utils {
 
+#ifndef PRECICE_NO_PETSC
+namespace {
+
+template< typename Func = decltype(PetscOptionsSetValue)>
+PetscErrorCode PetscOptionsSetValueWrapper(const char name [], const char value[],
+    typename std::enable_if<std::is_same<Func, PetscErrorCode(PetscOptions,const char [],const char[])>::value, Func>::type PetscOptionsSetValueImpl =
+                           PetscOptionsSetValue)
+{
+  PetscOptionsSetValueImpl(nullptr, name, value);
+};
+
+template <typename Func = decltype(PetscOptionsSetValue)>
+PetscErrorCode PetscOptionsSetValueWrapper(const char name[], const char value[],
+    typename std::enable_if<std::is_same<Func, PetscErrorCode(const char[], const char[])>::value, Func>::type PetscOptionsSetValueImpl =
+                            PetscOptionsSetValue)
+{
+  PetscOptionsSetValueImpl(name, value);
+};
+
+}
+#endif
+
 logging::Logger Petsc::_log("utils::Petsc");
 
 bool Petsc::weInitialized = false;
@@ -38,7 +60,7 @@ void Petsc::finalize()
   PetscBool petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
   if (petscIsInitialized and weInitialized) {
-    PetscOptionsSetValue(nullptr, "-options_left", "no"); 
+    PetscOptionsSetValueWrapper("-options_left", "no"); 
     PetscFinalize();
   }
 #endif // not PRECICE_NO_PETSC

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -11,20 +11,36 @@ namespace utils {
 
 #ifndef PRECICE_NO_PETSC
 
-// Fix for compatibility with PETSc < 3.7 to call PetscOptionsSetValue with proper number of args
 namespace {
 
-template< typename Func = decltype(PetscOptionsSetValue)>
+using new_signature = PetscErrorCode(PetscOptions, const char [], const char[]);
+using old_signature = PetscErrorCode(const char [], const char[]);
+
+/**
+ * @brief Fix for compatibility with PETSc < 3.7. 
+ * 
+ * This enables to call PetscOptionsSetValue with proper number of arguments.
+ * This instantiates only the template, that specifies correct function signature, whilst 
+ * the other one is discarded ( https://en.cppreference.com/w/cpp/language/sfinae )
+ */
+template< typename curr_signature = decltype(PetscOptionsSetValue) >
 PetscErrorCode PetscOptionsSetValueWrapper(const char name [], const char value[],
-    typename std::enable_if<std::is_same<Func, PetscErrorCode(PetscOptions,const char [],const char[])>::value, Func>::type PetscOptionsSetValueImpl =
+    typename std::enable_if<std::is_same<curr_signature, new_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
                            PetscOptionsSetValue)
 {
   return PetscOptionsSetValueImpl(nullptr, name, value);
 };
 
-template <typename Func = decltype(PetscOptionsSetValue)>
+/**
+ * @brief Fix for compatibility with PETSc < 3.7. 
+ * 
+ * This enables to call PetscOptionsSetValue with proper number of arguments.
+ * This instantiates only the template, that specifies correct function signature, whilst 
+ * the other one is discarded ( https://en.cppreference.com/w/cpp/language/sfinae )
+ */
+template <typename curr_signature = decltype(PetscOptionsSetValue)>
 PetscErrorCode PetscOptionsSetValueWrapper(const char name[], const char value[],
-    typename std::enable_if<std::is_same<Func, PetscErrorCode(const char[], const char[])>::value, Func>::type PetscOptionsSetValueImpl =
+    typename std::enable_if<std::is_same<curr_signature, old_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
                             PetscOptionsSetValue)
 {
   return PetscOptionsSetValueImpl(name, value);

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -10,6 +10,8 @@ namespace precice {
 namespace utils {
 
 #ifndef PRECICE_NO_PETSC
+
+// Fix for compatibility with PETSc < 3.7 to call PetscOptionsSetValue with proper number of args
 namespace {
 
 template< typename Func = decltype(PetscOptionsSetValue)>


### PR DESCRIPTION
In 3.7 they changed number of arguments in certain functions ( see [here](https://www.mcs.anl.gov/petsc/documentation/changes/37.html) ), leading to build failure on e.g Ubuntu 16.04 with packaged PETSc. This fixes it by introducing a wrapper that determines number of arguments to to `PetscOptionsSetValue` on compile time, and calls corresponding function. 
I tested on Ubuntu 16.04  (PETSc 3.6.2 ) and Ubuntu 18.04 . 