### PR TITLE
Optimization of initialization bottlenecks

### DIFF
--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -4,6 +4,7 @@
 #include "mesh/RTree.hpp"
 #include <Eigen/Core>
 #include <boost/function_output_iterator.hpp>
+#include <boost/container/flat_set.hpp>
 #include "utils/Event.hpp"
 
 
@@ -139,15 +140,20 @@ void NearestNeighborMapping::tagMeshFirstRound()
 
   computeMapping();
 
+  // Lookup table of all indices used in the mapping
+  const boost::container::flat_set<int> indexSet(_vertexIndices.begin(), _vertexIndices.end());
+
   if (getConstraint() == CONSISTENT){
     for(mesh::Vertex& v : input()->vertices()){
-      if(utils::contained(v.getID(),_vertexIndices)) v.tag();
+      if (indexSet.count(v.getID()) != 0)
+        v.tag();
     }
   }
   else {
     PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
     for(mesh::Vertex& v : output()->vertices()){
-      if(utils::contained(v.getID(),_vertexIndices)) v.tag();
+      if (indexSet.count(v.getID()) != 0)
+        v.tag();
     }
   }
 


### PR DESCRIPTION
This PR optimizes the two most expensive components in the initialization phase for a nearest neighbour mapping with mesh sizes of 400x400 vertices on 2 Ranks.


## 1. `buildCommunicationMap`
I used a two phase scheme to reduce the quadratic complexity down to `O(nlog(n) + m(log(n))`.
The new version is also cache friendly, which could be a reasonable explanation for the dramatic speedup.

<details><summary>Show profiles</summary>

### Develop
![image](https://user-images.githubusercontent.com/13552216/64475654-b344d900-d185-11e9-96f3-042513d51267.png)

### Optimized 1
![image](https://user-images.githubusercontent.com/13552216/64475657-cb1c5d00-d185-11e9-9bbf-e22ab6b131ca.png)

</details>

## 2. `NearestNeightbor::tagFirstFound`
The current implementation of the actual tagging had a quadratic complexity.
I used a `flat_set` to generate a cache-friendly lookup table which reduced the complexity to again `O(nlog(n) + mlog(n))`.

<details><summary>Show profiles</summary>

### Optimized 1
![image](https://user-images.githubusercontent.com/13552216/64475707-7a593400-d186-11e9-9b9c-974270ba4903.png)

### Optimized 1 + 2
![image](https://user-images.githubusercontent.com/13552216/64475715-8c3ad700-d186-11e9-9b76-4631a4833cb9.png)

</details>

## Result

For this scenario, the initialization time was reduced from 25s to 13.7s and finally to 6s.
The initialization time now converges to the generation of the rtree used for spacial queries.
Users are definitely going to feel the improvement when running preCICE, especially in the prototyping phase of their projects.