### PR TITLE
SCons: Fix versions

### DIFF
--- a/src/SConscript-linux
+++ b/src/SConscript-linux
@@ -81,7 +81,7 @@ sourcesXml = [
 ]
 
 sourcesVersion = [
-    File('versions.cpp')
+    File('precice/impl/versions.cpp')
 ]
 
 sourcesAllNoMain = [

--- a/src/SConscript-windows-1
+++ b/src/SConscript-windows-1
@@ -49,7 +49,7 @@ sourcesCom = [
    ]
 
 sourcesVersion = [
-    File('versions.cpp')
+    File('precice/impl/versions.cpp')
 ]
    
 sourcesAll = [ 

--- a/src/SConscript-windows-2
+++ b/src/SConscript-windows-2
@@ -24,7 +24,7 @@ sourcesPrecice = [
    ]
 
 sourcesVersion = [
-    File('versions.cpp')
+    File('precice/impl/versions.cpp')
 ]
    
 sourcesAll = [ 

--- a/src/precice/impl/versions.cpp.in
+++ b/src/precice/impl/versions.cpp.in
@@ -1,4 +1,4 @@
 #include "precice/impl/versions.hpp"
 
-const char * precice::preciceRevision = "@preCICE_REVISION@";
-const char * precice::versionInformation = "@preCICE_VERSION@;@preCICE_REVISION@;@preCICE_VERSION_INFORMATION@";
+char const * const precice::preciceRevision = "@preCICE_REVISION@";
+char const * const precice::versionInformation = "@preCICE_VERSION@;@preCICE_REVISION@;@preCICE_VERSION_INFORMATION@";

--- a/src/precice/impl/versions.hpp.in
+++ b/src/precice/impl/versions.hpp.in
@@ -8,6 +8,6 @@
 #endif
 
 namespace precice {
-    extern const char * preciceRevision;
-    extern const char * versionInformation;
+    extern char const * const preciceRevision;
+    extern char const * const versionInformation;
 }


### PR DESCRIPTION
I am trying to revive the SCons build (as we have not yet officially abandoned it), which currently fails due to problems with the versions info.

This PR currently updates the SConscript files to look for the moved versions.cpp file (from `src/versions.cpp` to `src/precice/impl/versions.cpp`).

However, it still fails with the following error and I am quite puzzled why:

```
build/debug/precice/impl/versions.os:(.data.rel.local+0x0): multiple definition of `precice::preciceRevision'
build/debug/precice/impl/versions.os:(.data.rel.local+0x0): first defined here
build/debug/precice/impl/versions.os:(.data.rel.local+0x8): multiple definition of `precice::versionInformation'
build/debug/precice/impl/versions.os:(.data.rel.local+0x8): first defined here
collect2: error: ld returned 1 exit status
```

I tried deleting the `src/precice/impl/versions.[cpp|hpp]` files, but it did not have any effect. Here is their content:

<details>
<summary>
Here are the result files:
</summary>
<p>

* `src/precice/impl/versions.hpp`:
```c++
#pragma once

#define PRECICE_VERSION "1.5.2"

#ifndef PRECICE_NO_PETSC
  #define PETSC_MAJOR 3
  #define PETSC_MINOR 9
#endif

namespace precice {
    extern const char * preciceRevision;
    extern const char * versionInformation;
}
```

* `src/precice/impl/versions.cpp`:
```c++
#include "precice/impl/versions.hpp"

const char * precice::preciceRevision = "no-info [SCons]";
const char * precice::versionInformation = "1.5.2;no-info [SCons];MPI=Y;PETSC=Y;PYTHON=Y";
```
</p>
</details>

@fsimonis any idea?