### PR TITLE
Fix Interface Checks

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -827,13 +827,13 @@ void SolverInterfaceImpl:: setMeshTriangleWithEdges
     PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  "Given VertexID is invalid!");
     PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), "Given VertexID is invalid!");
     PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  "Given VertexID is invalid!");
-    PRECICE_CHECK(!utils::unique_elements(utils::make_array(firstVertexID, secondVertexID, thirdVertexID)),
+    PRECICE_CHECK(utils::unique_elements(utils::make_array(firstVertexID, secondVertexID, thirdVertexID)),
             "Given VertexIDs must be unique!");
     mesh::Vertex* vertices[3];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];
     vertices[2] = &mesh->vertices()[thirdVertexID];
-    PRECICE_CHECK(!utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
+    PRECICE_CHECK(utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
                 vertices[1]->getCoords(), vertices[2]->getCoords()), utils::ComponentWiseLess{}),
             "The coordinates of the vertices must be unique!");
     mesh::Edge* edges[3];


### PR DESCRIPTION
This PR fixes a critical mistake in the user input validation of some `setMesh` functions.