### PR TITLE
Optimize the index generation

### DIFF
--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -2,6 +2,7 @@
 #include "mesh/impl/RTreeAdapter.hpp"
 
 #include "mesh/RTree.hpp"
+#include <boost/range/irange.hpp>
 
 namespace precice {
 namespace mesh {
@@ -27,12 +28,13 @@ rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh& mesh)
       return cache.vertices;
   }
 
+  // Generating the rtree is expensive, so passing everything in the ctor is
+  // the best we can do. Even passing an index range instead of calling 
+  // tree->insert repeatedly is about 10x faster.
   RTreeParameters params;
   vertex_traits::IndexGetter ind(mesh->vertices());
-  auto tree = std::make_shared<vertex_traits::RTree>(params, ind);
-  for (size_t i = 0; i < mesh->vertices().size(); ++i) {
-      tree->insert(i);
-  }
+  auto tree = std::make_shared<vertex_traits::RTree>(
+          boost::irange(0lu, mesh->vertices().size()), params, ind);
 
   cache.vertices = tree;
   return tree;
@@ -47,12 +49,13 @@ rtree::edge_traits::Ptr rtree::getEdgeRTree(const PtrMesh& mesh)
       return cache.edges;
   }
 
+  // Generating the rtree is expensive, so passing everything in the ctor is
+  // the best we can do. Even passing an index range instead of calling 
+  // tree->insert repeatedly is about 10x faster.
   RTreeParameters params;
   edge_traits::IndexGetter ind(mesh->edges());
-  auto tree = std::make_shared<edge_traits::RTree>(params, ind);
-  for (size_t i = 0; i < mesh->edges().size(); ++i) {
-      tree->insert(i);
-  }
+  auto tree = std::make_shared<edge_traits::RTree>(
+          boost::irange(0lu, mesh->edges().size()), params, ind);
 
   cache.edges = tree;
   return tree;
@@ -67,14 +70,21 @@ rtree::triangle_traits::Ptr rtree::getTriangleRTree(const PtrMesh& mesh)
       return cache.triangles;
   }
 
-  RTreeParameters params;
-  triangle_traits::IndexGetter ind;
-  auto tree = std::make_shared<triangle_traits::RTree>(params, ind);
+  // We first generate the values for the triangle rtree.
+  // The resulting vector is a random access range, which can be passed to the
+  // constructor of the rtree for more efficient indexing.
+  std::vector<triangle_traits::IndexType> elements;
+  elements.reserve(mesh->triangles().size());
   for (size_t i = 0; i < mesh->triangles().size(); ++i) {
       auto box = bg::return_envelope<RTreeBox>(mesh->triangles()[i]);
-      tree->insert(std::make_pair(std::move(box) , i));
+      elements.emplace_back(std::move(box) , i);
   }
 
+  // Generating the rtree is expensive, so passing everything in the ctor is
+  // the best we can do.
+  RTreeParameters params;
+  triangle_traits::IndexGetter ind;
+  auto tree = std::make_shared<triangle_traits::RTree>(elements, params, ind);
   cache.triangles = tree;
   return tree;
 }


### PR DESCRIPTION
This PR optimized the index generation by passing all information to the constructor of the rtree.

For vertices and edges, this PR essentially removes the `for (int i ...) tree->insert(i)` loop and passes an index range [`boost::irange`](https://www.boost.org/doc/libs/1_65_1/libs/range/doc/html/range/reference/ranges/irange.html) directly in the constructor.

For triangles, this PR first creates a vector of items to insert into the index tree (pair of bounding-box and index). This range is then passed to the constructor.

## Profiles
A: 500x500 vertices fully triangulated on 2 ranks
B: 400x400 vertices fully triangulated on 2 ranks


<details><summary>Profile conservative mapping</summary>

### Old

![image](https://user-images.githubusercontent.com/13552216/64624981-be00a780-d3eb-11e9-8829-6c2046e975ac.png)

### New

![image](https://user-images.githubusercontent.com/13552216/64625022-ceb11d80-d3eb-11e9-9357-47c4f61c12f9.png)

</details>

<details><summary>Profile consistent mapping</summary>

### Old

![image](https://user-images.githubusercontent.com/13552216/64625141-f56f5400-d3eb-11e9-938b-cccad7d6c59e.png)

### New

![image](https://user-images.githubusercontent.com/13552216/64625229-1df74e00-d3ec-11e9-9ff6-0d160e99890b.png)


</details>

## Results

For this scenario, these changes improve the runtime of:

* **vertex** index generation by x10
* **edge** index generation by x15
* **triangle** index generation by x20

The next bottlenecks are:
* `Mesh::addMesh()`
* `*Parition::filterPartition()`