### PR TITLE
WIP: Sort out dependencies of python bindings

### DIFF
--- a/src/precice/bindings/python_future/pyproject.toml
+++ b/src/precice/bindings/python_future/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools", "wheel", "Cython>=0.29"]
+requires = ["setuptools", "wheel", "Cython>=0.29", "numpy"]

--- a/src/precice/bindings/python_future/setup.py
+++ b/src/precice/bindings/python_future/setup.py
@@ -7,6 +7,7 @@ from setuptools.command.test import test
 from Cython.Distutils.extension import Extension
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 from Cython.Build import cythonize
+import numpy
 from distutils.command.install import install
 from distutils.command.build import build
 
@@ -77,7 +78,8 @@ def get_extensions(mpi_compiler_wrapper, is_test):
                 libraries=[],
                 language="c++",
                 extra_compile_args=compile_args,
-                extra_link_args=link_args
+                extra_link_args=link_args,
+                include_dirs=[numpy.get_include()]
             ),
         Extension(
                 "test_bindings_module",
@@ -85,15 +87,15 @@ def get_extensions(mpi_compiler_wrapper, is_test):
                 libraries=[],
                 language="c++",
                 extra_compile_args=compile_args,
-                extra_link_args=link_args
+                extra_link_args=link_args,
+                include_dirs=[numpy.get_include()]
             )
     ]
 
 # some global definitions for an additional user input command
 mpicompiler_default = "mpic++"
 add_option = [('mpicompiler=', None, 'specify the mpi compiler wrapper')]
-dependencies = ['cython']
-dependencies.append('mpi4py')  # only needed, if preCICE was compiled with MPI, see https://github.com/precice/precice/issues/311
+dependencies = ['cython', 'numpy', 'mpi4py']  # mpi4py is only needed, if preCICE was compiled with MPI, see https://github.com/precice/precice/issues/311
 
 class my_build_ext(build_ext, object):
     description = "building with optional specification of an alternative mpi compiler wrapper"


### PR DESCRIPTION
setuptools provides a system to properly define and install dependencies of a python package. Currently, the python bindings do not properly implement this system for all the dependencies.

Our preCICE python bindings have the following dependencies:

* cython (for building)
* numpy (needed by cython to be able to deal with numpy arrays, needed for np.ascontigousarray, probably also at some more places)
* more?

Usually installation of the python bindings works (see systemtests). However, if a system is not set up properly, one might run into problems. Some examples:

* user never installed `numpy` using `sudo apt-get` -> `cython` will not be able to find `arrayobject.h` (currently, all our [precice docker baseimages install numpy](https://github.com/precice/systemtests/blob/32fdbbbc7d35f2395ee394dc8113d538b3dd86a1/precice/Dockerfile.Ubuntu1604.home#L13). Therefore, we never actually see this problem)
* user never installed `numpy` using `pip3` -> when we run the bindings, we might get into trouble.

I already added some new dependency checks in this PR. However, we should review these changes thoroughly and also modify the systemtests correspondingly.

Related: https://github.com/precice/systemtests/issues/94