### PR TITLE
Add further debug statements during initialization

### DIFF
--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -42,6 +42,7 @@ void M2N::acceptMasterConnection(
   Event e("m2n.acceptMasterConnection", precice::syncMode);
 
   if (not utils::MasterSlave::isSlave()) {
+    PRECICE_DEBUG("Accept master-master connection");
     PRECICE_ASSERT(_masterCom);
     _masterCom->acceptConnection(acceptorName, requesterName, utils::MasterSlave::getRank());
     _isMasterConnected = _masterCom->isConnected();
@@ -60,7 +61,7 @@ void M2N::requestMasterConnection(
 
   if (not utils::MasterSlave::isSlave()) {
     PRECICE_ASSERT(_masterCom);
-
+    PRECICE_DEBUG("Request master-master connection");
     _masterCom->requestConnection(acceptorName, requesterName, 0, 1);
     _isMasterConnected = _masterCom->isConnected();
   }
@@ -77,6 +78,7 @@ void M2N::acceptSlavesConnection(
 
   _areSlavesConnected = true;
   for (const auto &pair : _distComs) {
+    PRECICE_DEBUG("Accept slaves-slaves connections");
     pair.second->acceptConnection(acceptorName, requesterName);
     _areSlavesConnected = _areSlavesConnected && pair.second->isConnected();
   }
@@ -92,6 +94,7 @@ void M2N::requestSlavesConnection(
 
   _areSlavesConnected = true;
   for (const auto &pair : _distComs) {
+    PRECICE_DEBUG("Request slaves connections");
     pair.second->requestConnection(acceptorName, requesterName);
     _areSlavesConnected = _areSlavesConnected && pair.second->isConnected();
   }
@@ -138,6 +141,7 @@ com::PtrCommunication M2N::getMasterCommunication()
 
 void M2N::createDistributedCommunication(mesh::PtrMesh mesh)
 {
+  PRECICE_TRACE();
   DistributedCommunication::SharedPointer distCom = _distrFactory->newDistributedCommunication(mesh);
   _distComs[mesh->getID()]                        = distCom;
 }

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -300,6 +300,7 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
   mesh::Mesh::VertexDistribution  requesterVertexDistribution;
 
   if (utils::MasterSlave::isMaster()) {
+    PRECICE_DEBUG("Exchange vertex distribution between both masters");
     Event e0("m2n.exchangeVertexDistribution");
     // Establish connection between participants' master processes.
     auto c = _communicationFactory->newCommunication();
@@ -313,6 +314,7 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
     PRECICE_ASSERT(utils::MasterSlave::isSlave());
   }
 
+  PRECICE_DEBUG("Broadcast vertex distributions");
   Event e1("m2n.broadcastVertexDistributions", precice::syncMode);
   m2n::broadcast(vertexDistribution);
   m2n::broadcast(requesterVertexDistribution);
@@ -342,11 +344,13 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
 
 // Print `communicationMap'.
 #ifdef P2P_LCM_PRINT
+  PRECICE_DEBUG("Print communication map");
   print(communicationMap);
 #endif
 
 // Print statistics of `communicationMap'.
 #ifdef P2P_LCM_PRINT_STATS
+  PRECICE_DEBUG("Print communication map statistics");
   printCommunicationPartnerCountStats(communicationMap);
   printLocalIndexCountStats(communicationMap);
 #endif
@@ -358,6 +362,7 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
     return;
   }
 
+  PRECICE_DEBUG("Create and connect communication");
   _communication = _communicationFactory->newCommunication();
 
   // Accept point-to-point connections (as server) between the current acceptor
@@ -368,6 +373,7 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
                                            utils::MasterSlave::getRank(),
                                            communicationMap.size());
 
+  PRECICE_DEBUG("Store communication map");
   for (auto const & comMap : communicationMap) {
     int globalRequesterRank = comMap.first;
     auto indices = std::move(communicationMap[globalRequesterRank]);
@@ -391,6 +397,7 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
   mesh::Mesh::VertexDistribution  acceptorVertexDistribution;
 
   if (utils::MasterSlave::isMaster()) {
+    PRECICE_DEBUG("Exchange vertex distribution between both masters");
     Event e0("m2n.exchangeVertexDistribution");
     // Establish connection between participants' master processes.
     auto c = _communicationFactory->newCommunication();
@@ -403,6 +410,7 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
     PRECICE_ASSERT(utils::MasterSlave::isSlave());
   }
 
+  PRECICE_DEBUG("Broadcast vertex distributions");
   Event e1("m2n.broadcastVertexDistributions", precice::syncMode);
   m2n::broadcast(vertexDistribution);
   m2n::broadcast(acceptorVertexDistribution);
@@ -432,11 +440,13 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
 
 // Print `communicationMap'.
 #ifdef P2P_LCM_PRINT
+  PRECICE_DEBUG("Print communication map");
   print(communicationMap);
 #endif
 
 // Print statistics of `communicationMap'.
 #ifdef P2P_LCM_PRINT_STATS
+  PRECICE_DEBUG("Print communication map statistics");
   printCommunicationPartnerCountStats(communicationMap);
   printLocalIndexCountStats(communicationMap);
 #endif
@@ -455,6 +465,7 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
   for (auto &i : communicationMap)
     acceptingRanks.emplace(i.first);
 
+  PRECICE_DEBUG("Create and connect communication");
   _communication = _communicationFactory->newCommunication();
   // Request point-to-point connections (as client) between the current
   // requester process (in the current participant) and (multiple) acceptor
@@ -463,6 +474,7 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
   _communication->requestConnectionAsClient(acceptorName, requesterName,
                                             acceptingRanks, utils::MasterSlave::getRank());
 
+  PRECICE_DEBUG("Store communication map");
   for (auto &i : communicationMap) {
     auto globalAcceptorRank = i.first;
     auto indices            = std::move(i.second);

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -36,7 +36,7 @@ void ReceivedPartition::communicate()
   Event e("partition.receiveGlobalMesh." + _mesh->getName(), precice::syncMode);
   if (not utils::MasterSlave::isSlave()) {
     PRECICE_ASSERT(_mesh->vertices().empty());
-    // a ReceivedPartition can only have one communication, @todo nicer design 
+    // a ReceivedPartition can only have one communication, @todo nicer design
     com::CommunicateMesh(_m2ns[0]->getMasterCommunication()).receiveMesh(*_mesh, 0);
   }
 }
@@ -47,6 +47,7 @@ void ReceivedPartition::compute()
 
   // handle coupling mode first (i.e. serial participant)
   if (not utils::MasterSlave::isSlave() && not utils::MasterSlave::isMaster()) { //coupling mode
+    PRECICE_DEBUG("Handle partition data structures for serial participant");
     _mesh->setGlobalNumberOfVertices(_mesh->vertices().size());
     computeVertexOffsets();
     for (mesh::Vertex &v : _mesh->vertices()) {
@@ -63,12 +64,13 @@ void ReceivedPartition::compute()
   }
 
 
-  // To understand the following steps, it is recommended to look at BU's thesis, especially Figure 69 on page 89 
+  // To understand the following steps, it is recommended to look at BU's thesis, especially Figure 69 on page 89
   // for RBF-based filtering. https://mediatum.ub.tum.de/doc/1320661/document.pdf
 
 
   // (0) set global number of vertices before filtering
   if (utils::MasterSlave::isMaster()) {
+    PRECICE_DEBUG("Set global number of vertices");
     _mesh->setGlobalNumberOfVertices(_mesh->vertices().size());
   }
 
@@ -80,8 +82,10 @@ void ReceivedPartition::compute()
     Event e("partition.preFilterMesh." + _mesh->getName(), precice::syncMode);
 
     if (utils::MasterSlave::isSlave()) {
+      PRECICE_DEBUG("Send bounding box to master");
       prepareBoundingBox();
       com::CommunicateMesh(utils::MasterSlave::_communication).sendBoundingBox(_bb, 0);
+      PRECICE_DEBUG("Receive filtered mesh");
       com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(*_mesh, 0);
 
       if(areProvidedMeshesEmpty()) {
@@ -105,6 +109,7 @@ void ReceivedPartition::compute()
               << ", " << _bb[0].second << " and " << _bb[1].first << ", " << _bb[1].second);
         mesh::Mesh slaveMesh("SlaveMesh", _dimensions, _mesh->isFlipNormals());
         filterMesh(slaveMesh, true);
+        PRECICE_DEBUG("Send filtered mesh to slave: " << rankSlave);
         com::CommunicateMesh(utils::MasterSlave::_communication).sendMesh(slaveMesh, rankSlave);
       }
 
@@ -209,6 +214,7 @@ void ReceivedPartition::compute()
       for (int i = 0; i < numberOfVertices; i++) {
         vertexIDs[i] = _mesh->vertices()[i].getGlobalIndex();
       }
+      PRECICE_DEBUG("Send partition feedback to master");
       utils::MasterSlave::_communication->send(vertexIDs, 0);
     }
     int globalNumberOfVertices = -1;
@@ -229,6 +235,7 @@ void ReceivedPartition::compute()
       PRECICE_ASSERT(numberOfSlaveVertices >= 0);
       std::vector<int> slaveVertexIDs(numberOfSlaveVertices, -1);
       if (numberOfSlaveVertices != 0) {
+        PRECICE_DEBUG("Receive partition feedback from slave rank " << rankSlave);
         utils::MasterSlave::_communication->receive(slaveVertexIDs, rankSlave);
       }
       _mesh->getVertexDistribution()[rankSlave] = std::move(slaveVertexIDs);
@@ -244,6 +251,7 @@ void ReceivedPartition::filterMesh(mesh::Mesh &filteredMesh, const bool filterBy
 {
   PRECICE_TRACE(filterByBB);
 
+  PRECICE_DEBUG("Filter mesh " << _mesh->getName());
   PRECICE_DEBUG("Bounding mesh. #vertices: " << _mesh->vertices().size()
         << ", #edges: " << _mesh->edges().size()
         << ", #triangles: " << _mesh->triangles().size()
@@ -253,8 +261,8 @@ void ReceivedPartition::filterMesh(mesh::Mesh &filteredMesh, const bool filterBy
   std::map<int, mesh::Edge *>   edgeMap;
   int                           vertexCounter = 0;
 
+  PRECICE_DEBUG("Filter vertices");
   for (const mesh::Vertex &vertex : _mesh->vertices()) {
-
     if ((filterByBB && isVertexInBB(vertex)) || (not filterByBB && vertex.isTagged())) {
       mesh::Vertex &v = filteredMesh.createVertex(vertex.getCoords());
       v.setGlobalIndex(vertex.getGlobalIndex());
@@ -267,6 +275,7 @@ void ReceivedPartition::filterMesh(mesh::Mesh &filteredMesh, const bool filterBy
   }
 
   // Add all edges formed by the contributing vertices
+  PRECICE_DEBUG("Add edges to filtered mesh");
   for (mesh::Edge &edge : _mesh->edges()) {
     int vertexIndex1 = edge.vertex(0).getID();
     int vertexIndex2 = edge.vertex(1).getID();
@@ -279,6 +288,7 @@ void ReceivedPartition::filterMesh(mesh::Mesh &filteredMesh, const bool filterBy
 
   // Add all triangles formed by the contributing edges
   if (_dimensions == 3) {
+    PRECICE_DEBUG("Add triangles to filtered mesh");
     for (mesh::Triangle &triangle : _mesh->triangles()) {
       int edgeIndex1 = triangle.edge(0).getID();
       int edgeIndex2 = triangle.edge(1).getID();
@@ -300,6 +310,8 @@ void ReceivedPartition::filterMesh(mesh::Mesh &filteredMesh, const bool filterBy
 void ReceivedPartition::prepareBoundingBox()
 {
   PRECICE_TRACE(_safetyFactor);
+
+  PRECICE_DEBUG("Merge bounding boxes and increase by safety factor");
 
   _bb.resize(_dimensions,
              std::make_pair(std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest()));
@@ -356,6 +368,7 @@ void ReceivedPartition::createOwnerInformation()
     utils::MasterSlave::_communication->send(numberOfVertices, 0);
 
     if (numberOfVertices != 0) {
+      PRECICE_DEBUG("Tag vertices, number of vertices " << numberOfVertices);
       std::vector<int> tags(numberOfVertices, -1);
       std::vector<int> globalIDs(numberOfVertices, -1);
       bool             atInterface = false;
@@ -370,10 +383,12 @@ void ReceivedPartition::createOwnerInformation()
       }
       PRECICE_DEBUG("My tags: " << tags);
       PRECICE_DEBUG("My global IDs: " << globalIDs);
+      PRECICE_DEBUG("Send tags and global IDs");
       utils::MasterSlave::_communication->send(tags, 0);
       utils::MasterSlave::_communication->send(globalIDs, 0);
       utils::MasterSlave::_communication->send(atInterface, 0);
 
+      PRECICE_DEBUG("Receive owner information");
       std::vector<int> ownerVec(numberOfVertices, -1);
       utils::MasterSlave::_communication->receive(ownerVec, 0);
       PRECICE_DEBUG("My owner information: " << ownerVec);
@@ -392,6 +407,7 @@ void ReceivedPartition::createOwnerInformation()
     std::vector<std::vector<int>> slaveTags(utils::MasterSlave::getSize());
 
     // Fill master data
+    PRECICE_DEBUG("Tag master vertices");
     bool masterAtInterface = false;
     slaveOwnerVecs[0].resize(_mesh->vertices().size());
     slaveGlobalIDs[0].resize(_mesh->vertices().size());
@@ -419,10 +435,11 @@ void ReceivedPartition::createOwnerInformation()
       slaveOwnerVecs[rank].resize(localNumberOfVertices, 0);
 
       if (localNumberOfVertices != 0) {
+        PRECICE_DEBUG("Receive tags from slave rank " << rank);
         utils::MasterSlave::_communication->receive(slaveTags[rank], rank);
         utils::MasterSlave::_communication->receive(slaveGlobalIDs[rank], rank);
-        PRECICE_DEBUG("Rank " << rank << " has this tags " << slaveTags[rank]);
-        PRECICE_DEBUG("Rank " << rank << " has this global IDs " << slaveGlobalIDs[rank]);
+        PRECICE_DEBUG("Rank " << rank << " has tags " << slaveTags[rank]);
+        PRECICE_DEBUG("Rank " << rank << " has global IDs " << slaveGlobalIDs[rank]);
         bool atInterface = false;
         utils::MasterSlave::_communication->receive(atInterface, rank);
         if (atInterface)
@@ -431,6 +448,7 @@ void ReceivedPartition::createOwnerInformation()
     }
 
     // Decide upon owners,
+    PRECICE_DEBUG("Decide owners, first round by rough load balancing");
     int localGuess = _mesh->getGlobalNumberOfVertices() / ranksAtInterface; // Guess for a decent load balancing
     // First round: every slave gets localGuess vertices
     for (int rank = 0; rank < utils::MasterSlave::getSize(); rank++) {
@@ -448,6 +466,7 @@ void ReceivedPartition::createOwnerInformation()
     }
 
     // Second round: distribute all other vertices in a greedy way
+    PRECICE_DEBUG("Decide owners, second round in greedy way");
     for (int rank = 0; rank < utils::MasterSlave::getSize(); rank++) {
       for (size_t i = 0; i < slaveOwnerVecs[rank].size(); i++) {
         if (globalOwnerVec[slaveGlobalIDs[rank][i]] == 0 && slaveTags[rank][i] == 1) {
@@ -460,6 +479,7 @@ void ReceivedPartition::createOwnerInformation()
     // Send information back to slaves
     for (int rank = 1; rank < utils::MasterSlave::getSize(); rank++) {
       if (not slaveTags[rank].empty())
+        PRECICE_DEBUG("Send owner information to slave rank " << rank);
         utils::MasterSlave::_communication->send(slaveOwnerVecs[rank], rank);
     }
     // Master data
@@ -472,14 +492,14 @@ void ReceivedPartition::createOwnerInformation()
         PRECICE_DEBUG("The Vertex with global index " << i << " of mesh: " << _mesh->getName()
               << " was completely filtered out, since it has no influence on any mapping.");
       }
-    }    
+    }
 #endif
     auto filteredVertices = std::count(globalOwnerVec.begin(), globalOwnerVec.end(), 0);
     if (filteredVertices)
       PRECICE_WARN(filteredVertices << " of " << _mesh->getGlobalNumberOfVertices()
            << " vertices of mesh " << _mesh->getName() << " have been filtered out "
            << "since they have no influence on the mapping.");
-    
+
   }
 }
 


### PR DESCRIPTION
When using ...
```xml
<log>
    <sink type="stream" output="stdout"  filter= "(%Severity% > debug) or (%Severity% >= debug and %Module% contains SolverInterfaceImpl) or (%Severity% >= debug and %Module% contains partition) or (%Severity% >= debug and %Module% contains PointToPointCommunication)"  enabled="true" />	
</log>
```
(I added this as a further example to the [wiki](https://github.com/precice/precice/wiki/Logging-Configuration)
... you get the following output for Alya Nastin running on 4 ranks.
Should be long enough to find potential problems, but significantly shorter than `TRACE` output. 

```
(2) 20:09:19 [impl::SolverInterfaceImpl]:221 in initialize: Setting up master communication to coupling partner/s
(0) 20:09:19 [impl::SolverInterfaceImpl]:221 in initialize: Setting up master communication to coupling partner/s
(2) 20:09:19 [impl::SolverInterfaceImpl]:224 in initialize: Awaiting master connection from SOLIDZ
(0) 20:09:19 [impl::SolverInterfaceImpl]:224 in initialize: Awaiting master connection from SOLIDZ
(3) 20:09:19 [impl::SolverInterfaceImpl]:221 in initialize: Setting up master communication to coupling partner/s
(1) 20:09:19 [impl::SolverInterfaceImpl]:221 in initialize: Setting up master communication to coupling partner/s
(3) 20:09:19 [impl::SolverInterfaceImpl]:224 in initialize: Awaiting master connection from SOLIDZ
(1) 20:09:19 [impl::SolverInterfaceImpl]:224 in initialize: Awaiting master connection from SOLIDZ
(0) 20:09:28 [impl::SolverInterfaceImpl]:227 in initialize: Established master connection from SOLIDZ
(0) 20:09:28 [impl::SolverInterfaceImpl]:229 in initialize: Masters are connected
(0) 20:09:28 [partition::ReceivedPartition]:35 in communicate: Receive global mesh SOLIDZ_Mesh
(3) 20:09:28 [impl::SolverInterfaceImpl]:227 in initialize: Established master connection from SOLIDZ
(1) 20:09:28 [impl::SolverInterfaceImpl]:227 in initialize: Established master connection from SOLIDZ
(3) 20:09:28 [impl::SolverInterfaceImpl]:229 in initialize: Masters are connected
(1) 20:09:28 [impl::SolverInterfaceImpl]:229 in initialize: Masters are connected
(2) 20:09:28 [impl::SolverInterfaceImpl]:227 in initialize: Established master connection from SOLIDZ
(3) 20:09:28 [partition::ReceivedPartition]:35 in communicate: Receive global mesh SOLIDZ_Mesh
(2) 20:09:28 [impl::SolverInterfaceImpl]:229 in initialize: Masters are connected
(1) 20:09:28 [partition::ReceivedPartition]:35 in communicate: Receive global mesh SOLIDZ_Mesh
(2) 20:09:28 [partition::ReceivedPartition]:35 in communicate: Receive global mesh SOLIDZ_Mesh
(3) 20:09:28 [partition::ProvidedPartition]:79 in compute: Compute partition for mesh NASTIN_Mesh
(1) 20:09:28 [partition::ProvidedPartition]:79 in compute: Compute partition for mesh NASTIN_Mesh
(2) 20:09:28 [partition::ProvidedPartition]:79 in compute: Compute partition for mesh NASTIN_Mesh
(1) 20:09:28 [partition::ProvidedPartition]:87 in compute: Send number of vertices: 10
(2) 20:09:28 [partition::ProvidedPartition]:87 in compute: Send number of vertices: 0
(3) 20:09:28 [partition::ProvidedPartition]:87 in compute: Send number of vertices: 13
(0) 20:09:28 [partition::ProvidedPartition]:79 in compute: Compute partition for mesh NASTIN_Mesh
(0) 20:09:28 [partition::ProvidedPartition]:103 in compute: Add master vertices to vertex distribution
(1) 20:09:28 [partition::ProvidedPartition]:90 in compute: Set global vertex indices
(0) 20:09:28 [partition::ProvidedPartition]:120 in compute: broadcast global number of vertices: 23
(3) 20:09:28 [partition::ProvidedPartition]:90 in compute: Set global vertex indices
(0) 20:09:28 [partition::ProvidedPartition]:129 in compute: Create owner information
(1) 20:09:28 [partition::ProvidedPartition]:129 in compute: Create owner information
(0) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(1) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(0) 20:09:28 [partition::Partition]:30 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(3) 20:09:28 [partition::ProvidedPartition]:129 in compute: Create owner information
(1) 20:09:28 [partition::Partition]:22 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(3) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(0) 20:09:28 [partition::ReceivedPartition]:73 in compute: Set global number of vertices
(3) 20:09:28 [partition::Partition]:22 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(0) 20:09:28 [partition::ReceivedPartition]:135 in compute: Broadcast mesh SOLIDZ_Mesh
(1) 20:09:28 [partition::ReceivedPartition]:135 in compute: Broadcast mesh SOLIDZ_Mesh
(3) 20:09:28 [partition::ReceivedPartition]:135 in compute: Broadcast mesh SOLIDZ_Mesh
(0) 20:09:28 [partition::ReceivedPartition]:150 in compute: Filter mesh SOLIDZ_Mesh by bounding-box
(0) 20:09:28 [partition::ReceivedPartition]:314 in prepareBoundingBox: Merge bounding boxes and increase by safety factor
(0) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 0, first: 1.79769e+308, second: -1.79769e+308
(0) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 1, first: 1.79769e+308, second: -1.79769e+308
(1) 20:09:28 [partition::ReceivedPartition]:150 in compute: Filter mesh SOLIDZ_Mesh by bounding-box
(0) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(1) 20:09:28 [partition::ReceivedPartition]:314 in prepareBoundingBox: Merge bounding boxes and increase by safety factor
(0) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 0
(0) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(1) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 0, first: 1.15, second: 2.05
(0) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(1) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 1, first: -0.45, second: 1.35
(0) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 0, #edges: 0, #triangles: 0, rank: 0
(0) 20:09:28 [partition::ReceivedPartition]:166 in compute: Bounding box filter, filtered from 22 vertices to 0 vertices.
(1) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(1) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 1
(1) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(1) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(1) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 1
(1) 20:09:28 [partition::ReceivedPartition]:166 in compute: Bounding box filter, filtered from 22 vertices to 22 vertices.
(0) 20:09:28 [partition::ReceivedPartition]:177 in compute: Tag vertices for filtering: 1st round.
(3) 20:09:28 [partition::ReceivedPartition]:150 in compute: Filter mesh SOLIDZ_Mesh by bounding-box
(3) 20:09:28 [partition::ReceivedPartition]:314 in prepareBoundingBox: Merge bounding boxes and increase by safety factor
(3) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 0, first: 1, second: 2.1
(3) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 1, first: -0.5, second: 1.5
(3) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(1) 20:09:28 [partition::ReceivedPartition]:177 in compute: Tag vertices for filtering: 1st round.
(3) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 3
(3) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(0) 20:09:28 [partition::ReceivedPartition]:185 in compute: Create owner information.
(0) 20:09:28 [partition::ReceivedPartition]:410 in createOwnerInformation: Tag master vertices
(3) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(0) 20:09:28 [partition::ReceivedPartition]:424 in createOwnerInformation: My tags: []
(3) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 3
(3) 20:09:28 [partition::ReceivedPartition]:166 in compute: Bounding box filter, filtered from 22 vertices to 22 vertices.
(2) 20:09:28 [partition::ProvidedPartition]:90 in compute: Set global vertex indices
(2) 20:09:28 [partition::ProvidedPartition]:129 in compute: Create owner information
(2) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(2) 20:09:28 [partition::Partition]:22 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(2) 20:09:28 [partition::ReceivedPartition]:135 in compute: Broadcast mesh SOLIDZ_Mesh
(1) 20:09:28 [partition::ReceivedPartition]:185 in compute: Create owner information.
(1) 20:09:28 [partition::ReceivedPartition]:371 in createOwnerInformation: Tag vertices, number of vertices 22
(1) 20:09:28 [partition::ReceivedPartition]:384 in createOwnerInformation: My tags: [1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1]
(1) 20:09:28 [partition::ReceivedPartition]:385 in createOwnerInformation: My global IDs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
(1) 20:09:28 [partition::ReceivedPartition]:386 in createOwnerInformation: Send tags and global IDs
(0) 20:09:28 [partition::ReceivedPartition]:434 in createOwnerInformation: Rank 1 has 22 vertices.
(1) 20:09:28 [partition::ReceivedPartition]:391 in createOwnerInformation: Receive owner information
(0) 20:09:28 [partition::ReceivedPartition]:438 in createOwnerInformation: Receive tags from slave rank 1
(0) 20:09:28 [partition::ReceivedPartition]:441 in createOwnerInformation: Rank 1 has tags [1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1]
(0) 20:09:28 [partition::ReceivedPartition]:442 in createOwnerInformation: Rank 1 has global IDs [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
(2) 20:09:28 [partition::ReceivedPartition]:150 in compute: Filter mesh SOLIDZ_Mesh by bounding-box
(2) 20:09:28 [partition::ReceivedPartition]:314 in prepareBoundingBox: Merge bounding boxes and increase by safety factor
(2) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 0, first: 1.79769e+308, second: -1.79769e+308
(2) 20:09:28 [partition::ReceivedPartition]:347 in prepareBoundingBox: Merged BoundingBox, dim: 1, first: 1.79769e+308, second: -1.79769e+308
(2) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(2) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 2
(2) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(2) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(2) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 0, #edges: 0, #triangles: 0, rank: 2
(2) 20:09:28 [partition::ReceivedPartition]:166 in compute: Bounding box filter, filtered from 22 vertices to 0 vertices.
(2) 20:09:28 [partition::ReceivedPartition]:177 in compute: Tag vertices for filtering: 1st round.
(3) 20:09:28 [partition::ReceivedPartition]:177 in compute: Tag vertices for filtering: 1st round.
(2) 20:09:28 [partition::ReceivedPartition]:185 in compute: Create owner information.
(2) 20:09:28 [partition::ReceivedPartition]:189 in compute: Tag vertices for filtering: 2nd round.
(0) 20:09:28 [partition::ReceivedPartition]:434 in createOwnerInformation: Rank 2 has 0 vertices.
(2) 20:09:28 [partition::ReceivedPartition]:196 in compute: Filter mesh SOLIDZ_Mesh by mappings
(2) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(2) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 0, #edges: 0, #triangles: 0, rank: 2
(2) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(2) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(2) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 0, #edges: 0, #triangles: 0, rank: 2
(2) 20:09:28 [partition::ReceivedPartition]:200 in compute: Mapping filter, filtered from 0 vertices to 0 vertices.
(2) 20:09:28 [partition::ReceivedPartition]:207 in compute: Feedback distribution for mesh SOLIDZ_Mesh
(3) 20:09:28 [partition::ReceivedPartition]:185 in compute: Create owner information.
(3) 20:09:28 [partition::ReceivedPartition]:371 in createOwnerInformation: Tag vertices, number of vertices 22
(0) 20:09:28 [partition::ReceivedPartition]:434 in createOwnerInformation: Rank 3 has 22 vertices.
(3) 20:09:28 [partition::ReceivedPartition]:384 in createOwnerInformation: My tags: [0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0]
(0) 20:09:28 [partition::ReceivedPartition]:438 in createOwnerInformation: Receive tags from slave rank 3
(3) 20:09:28 [partition::ReceivedPartition]:385 in createOwnerInformation: My global IDs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
(3) 20:09:28 [partition::ReceivedPartition]:386 in createOwnerInformation: Send tags and global IDs
(3) 20:09:28 [partition::ReceivedPartition]:391 in createOwnerInformation: Receive owner information
(0) 20:09:28 [partition::ReceivedPartition]:441 in createOwnerInformation: Rank 3 has tags [0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0]
(0) 20:09:28 [partition::ReceivedPartition]:442 in createOwnerInformation: Rank 3 has global IDs [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
(0) 20:09:28 [partition::ReceivedPartition]:451 in createOwnerInformation: Decide owners, first round by rough load balancing
(0) 20:09:28 [partition::ReceivedPartition]:469 in createOwnerInformation: Decide owners, second round in greedy way
(0) 20:09:28 [partition::ReceivedPartition]:482 in createOwnerInformation: Send owner information to slave rank 1
(0) 20:09:28 [partition::ReceivedPartition]:482 in createOwnerInformation: Send owner information to slave rank 3
(1) 20:09:28 [partition::ReceivedPartition]:394 in createOwnerInformation: My owner information: [1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1]
(0) 20:09:28 [partition::ReceivedPartition]:486 in createOwnerInformation: My owner information: []
(1) 20:09:28 [partition::ReceivedPartition]:189 in compute: Tag vertices for filtering: 2nd round.
(3) 20:09:28 [partition::ReceivedPartition]:394 in createOwnerInformation: My owner information: [0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0]
(1) 20:09:28 [partition::ReceivedPartition]:196 in compute: Filter mesh SOLIDZ_Mesh by mappings
(0) 20:09:28 [partition::ReceivedPartition]:189 in compute: Tag vertices for filtering: 2nd round.
(3) 20:09:28 [partition::ReceivedPartition]:189 in compute: Tag vertices for filtering: 2nd round.
(0) 20:09:28 [partition::ReceivedPartition]:196 in compute: Filter mesh SOLIDZ_Mesh by mappings
(1) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(0) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(0) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 0, #edges: 0, #triangles: 0, rank: 0
(0) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(1) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 1
(0) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(3) 20:09:28 [partition::ReceivedPartition]:196 in compute: Filter mesh SOLIDZ_Mesh by mappings
(0) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 0, #edges: 0, #triangles: 0, rank: 0
(0) 20:09:28 [partition::ReceivedPartition]:200 in compute: Mapping filter, filtered from 0 vertices to 0 vertices.
(1) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(1) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(1) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 10, #edges: 0, #triangles: 0, rank: 1
(3) 20:09:28 [partition::ReceivedPartition]:254 in filterMesh: Filter mesh SOLIDZ_Mesh
(0) 20:09:28 [partition::ReceivedPartition]:207 in compute: Feedback distribution for mesh SOLIDZ_Mesh
(1) 20:09:28 [partition::ReceivedPartition]:200 in compute: Mapping filter, filtered from 22 vertices to 10 vertices.
(3) 20:09:28 [partition::ReceivedPartition]:258 in filterMesh: Bounding mesh. #vertices: 22, #edges: 0, #triangles: 0, rank: 3
(3) 20:09:28 [partition::ReceivedPartition]:264 in filterMesh: Filter vertices
(3) 20:09:28 [partition::ReceivedPartition]:278 in filterMesh: Add edges to filtered mesh
(3) 20:09:28 [partition::ReceivedPartition]:307 in filterMesh: Filtered mesh. #vertices: 13, #edges: 0, #triangles: 0, rank: 3
(3) 20:09:28 [partition::ReceivedPartition]:200 in compute: Mapping filter, filtered from 22 vertices to 13 vertices.
(1) 20:09:28 [partition::ReceivedPartition]:207 in compute: Feedback distribution for mesh SOLIDZ_Mesh
(1) 20:09:28 [partition::ReceivedPartition]:217 in compute: Send partition feedback to master
(0) 20:09:28 [partition::ReceivedPartition]:238 in compute: Receive partition feedback from slave rank 1
(3) 20:09:28 [partition::ReceivedPartition]:207 in compute: Feedback distribution for mesh SOLIDZ_Mesh
(0) 20:09:28 [partition::ReceivedPartition]:238 in compute: Receive partition feedback from slave rank 3
(3) 20:09:28 [partition::ReceivedPartition]:217 in compute: Send partition feedback to master
(0) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(0) 20:09:28 [partition::Partition]:30 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(1) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(3) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(1) 20:09:28 [partition::Partition]:22 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(3) 20:09:28 [partition::Partition]:22 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(0) 20:09:28 [impl::SolverInterfaceImpl]:233 in initialize: Setting up slaves communication to coupling partner/s
(0) 20:09:28 [impl::SolverInterfaceImpl]:236 in initialize: Awaiting slaves connection from SOLIDZ
(0) 20:09:28 [m2n::PointToPointCommunication]:400 in requestConnection: Exchange vertex distribution between both masters
(1) 20:09:28 [impl::SolverInterfaceImpl]:233 in initialize: Setting up slaves communication to coupling partner/s
(3) 20:09:28 [impl::SolverInterfaceImpl]:233 in initialize: Setting up slaves communication to coupling partner/s
(1) 20:09:28 [impl::SolverInterfaceImpl]:236 in initialize: Awaiting slaves connection from SOLIDZ
(2) 20:09:28 [partition::Partition]:19 in computeVertexOffsets: Generate vertex offsets
(3) 20:09:28 [impl::SolverInterfaceImpl]:236 in initialize: Awaiting slaves connection from SOLIDZ
(1) 20:09:28 [m2n::PointToPointCommunication]:413 in requestConnection: Broadcast vertex distributions
(3) 20:09:28 [m2n::PointToPointCommunication]:413 in requestConnection: Broadcast vertex distributions
(2) 20:09:28 [partition::Partition]:22 in computeVertexOffsets: My vertex offsets: [0, 10, 10, 23]
(2) 20:09:28 [impl::SolverInterfaceImpl]:233 in initialize: Setting up slaves communication to coupling partner/s
(2) 20:09:28 [impl::SolverInterfaceImpl]:236 in initialize: Awaiting slaves connection from SOLIDZ
(2) 20:09:28 [m2n::PointToPointCommunication]:413 in requestConnection: Broadcast vertex distributions
(0) 20:09:28 [m2n::PointToPointCommunication]:413 in requestConnection: Broadcast vertex distributions
(0) 20:09:28 [impl::SolverInterfaceImpl]:239 in initialize: Established slaves connection from SOLIDZ
(0) 20:09:28 [impl::SolverInterfaceImpl]:241 in initialize: Slaves are connected
(0) 20:09:28 [impl::SolverInterfaceImpl]:246 in initialize: Initialize watchpoints
(0) 20:09:28 [impl::SolverInterfaceImpl]:255 in initialize: Initialize coupling schemes
```