### PR TITLE
Add integration test for setMeshTriangleWithEdges

### DIFF
--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -1374,21 +1374,10 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
 
 }
 
-/**
- * @brief Tests the Nearest Projection Mapping between two participants
- *
- */
-BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string configFile)
 {
-  if (utils::Parallel::getCommunicatorSize() != 2)
-    return;
-
   mesh::Mesh::resetGeometryIDsGlobally();
   using Eigen::Vector3d;
-
-  const std::string configFile = _pathToTests + "mapping-nearest-projection.xml";
 
   const double z = 0.3;
 
@@ -1416,7 +1405,8 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
     SolverInterface cplInterface("SolverOne", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    // namespace is required because we are outside the fixture
+    testing::WhiteboxAccessor::impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     const int meshOneID = cplInterface.getMeshID("MeshOne");
 
     // Setup mesh one.
@@ -1425,14 +1415,21 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
     int idC = cplInterface.setMeshVertex(meshOneID, coordOneC.data());
     int idD = cplInterface.setMeshVertex(meshOneID, coordOneD.data());
 
-    int idAB = cplInterface.setMeshEdge(meshOneID, idA, idB);
-    int idBC = cplInterface.setMeshEdge(meshOneID, idB, idC);
-    int idCD = cplInterface.setMeshEdge(meshOneID, idC, idD);
-    int idDA = cplInterface.setMeshEdge(meshOneID, idD, idA);
-    int idCA = cplInterface.setMeshEdge(meshOneID, idC, idA);
+    if (defineEdgesExplicitly){
 
-    cplInterface.setMeshTriangle(meshOneID, idAB, idBC, idCA);
-    cplInterface.setMeshTriangle(meshOneID, idCD, idDA, idCA);
+      int idAB = cplInterface.setMeshEdge(meshOneID, idA, idB);
+      int idBC = cplInterface.setMeshEdge(meshOneID, idB, idC);
+      int idCD = cplInterface.setMeshEdge(meshOneID, idC, idD);
+      int idDA = cplInterface.setMeshEdge(meshOneID, idD, idA);
+      int idCA = cplInterface.setMeshEdge(meshOneID, idC, idA);
+
+      cplInterface.setMeshTriangle(meshOneID, idAB, idBC, idCA);
+      cplInterface.setMeshTriangle(meshOneID, idCD, idDA, idCA);
+
+    } else {
+      cplInterface.setMeshTriangleWithEdges(meshOneID, idA, idB, idC);
+      cplInterface.setMeshTriangleWithEdges(meshOneID, idC, idD, idA);
+    }
 
     // Initialize, thus sending the mesh.
     double maxDt = cplInterface.initialize();
@@ -1454,7 +1451,8 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
     SolverInterface cplInterface("SolverTwo", 0, 1);
     config::Configuration config;
     xml::configure(config.getXMLTag(), configFile);
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    // namespace is required because we are outside the fixture
+    testing::WhiteboxAccessor::impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
 
     // Setup receiving mesh.
@@ -1482,6 +1480,37 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjection,
     BOOST_TEST(!cplInterface.isCouplingOngoing(), "Receiving participant should have to advance once!");
     cplInterface.finalize();
   }
+}
+
+
+/**
+ * @brief Tests the Nearest Projection Mapping between two participants with explicit definition of edges
+ *
+ */
+BOOST_AUTO_TEST_CASE(testMappingNearestProjectionExplicitEdges,
+                     * testing::MinRanks(2)
+                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+{
+  if (utils::Parallel::getCommunicatorSize() != 2)
+    return;
+  bool defineEdgesExplicitly = true;
+  const std::string configFile = _pathToTests + "mapping-nearest-projection.xml";
+  testMappingNearestProjection(defineEdgesExplicitly, configFile);
+}
+
+/**
+ * @brief Tests the Nearest Projection Mapping between two participants with explicit definition of edges
+ *
+ */
+BOOST_AUTO_TEST_CASE(testMappingNearestProjectionImplicitEdges,
+                     * testing::MinRanks(2)
+                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+{
+  if (utils::Parallel::getCommunicatorSize() != 2)
+    return;
+  bool defineEdgesExplicitly = false;
+  const std::string configFile = _pathToTests + "mapping-nearest-projection.xml";
+  testMappingNearestProjection(defineEdgesExplicitly, configFile);
 }
 
 /**


### PR DESCRIPTION
The new test should catch problems in `setMeshTriangleWithEdges` such as the wrong check we fixed here: https://github.com/precice/precice/commit/7436b9229c7353652ae6034d75c9b49123c9e4a4