### PR TITLE
Hotfix 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://github.com/precice/precice/wiki/Roadmap).
 
-## develop
+## 1.6.1
+
+- Fixed a platform-dependant issue with boost.
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. For future 
 
 ## develop
 
-## v1.6.0
+## 1.6.0
 
 - Added CMake target to uninstall the project.
 - Added `INFO` log output of the connection build-up during the instantiation. This dramatically simplifies the identification of connection-related problems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. For future 
 
 ## 1.6.1
 
-- Fixed a platform-dependant issue with boost.
+- Fixed a platform-dependent issue with boost.
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. For future 
 
 ## develop
 
+## v1.6.0
+
 - Added CMake target to uninstall the project.
 - Added `INFO` log output of the connection build-up during the instantiation. This dramatically simplifies the identification of connection-related problems.
 - Added `precice::getVersionInformation()` to the interface. This returns a semicolon separated list of information containing the version, configuration, compiler and flags used to compile the library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10.2)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/XSDKCompilerDetect.cmake)
 
-project(preCICE VERSION 1.6.0 LANGUAGES CXX)
+project(preCICE VERSION 1.6.1 LANGUAGES CXX)
 
 #
 # Overview of this configuration

--- a/SConstruct
+++ b/SConstruct
@@ -106,7 +106,7 @@ env.Append(LIBPATH = [('#' + buildpath)])
 env.Append(CCFLAGS= ['-Wall', '-Wextra', '-Wno-unused-parameter', '-std=c++11'])
 
 # ====== PRECICE_VERSION number ======
-PRECICE_VERSION = "1.6.0"
+PRECICE_VERSION = "1.6.1"
 
 
 # ====== Compiler Settings ======

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -34,7 +34,7 @@ rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh& mesh)
   RTreeParameters params;
   vertex_traits::IndexGetter ind(mesh->vertices());
   auto tree = std::make_shared<vertex_traits::RTree>(
-          boost::irange(0lu, mesh->vertices().size()), params, ind);
+          boost::irange<std::size_t>(0lu, mesh->vertices().size()), params, ind);
 
   cache.vertices = tree;
   return tree;
@@ -55,7 +55,7 @@ rtree::edge_traits::Ptr rtree::getEdgeRTree(const PtrMesh& mesh)
   RTreeParameters params;
   edge_traits::IndexGetter ind(mesh->edges());
   auto tree = std::make_shared<edge_traits::RTree>(
-          boost::irange(0lu, mesh->edges().size()), params, ind);
+          boost::irange<std::size_t>(0lu, mesh->edges().size()), params, ind);
 
   cache.edges = tree;
   return tree;

--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='precice',
-    version='1.6.0',
+    version='1.6.1',
     description='Python language bindings for preCICE coupling library',
     url='https://github.com/precice/precice',
     author='the preCICE developers',

--- a/src/precice/bindings/python_future/setup.py
+++ b/src/precice/bindings/python_future/setup.py
@@ -12,7 +12,7 @@ from distutils.command.build import build
 
 # name of Interfacing API
 APPNAME = "precice_future"
-APPVERSION = "1.6.0"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
+APPVERSION = "1.6.1"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
This release fixes a platform-dependant compilation error due to a potential inconsistency in parameter types to `boost::irange`.

Fixes #510 