### PR TITLE
Add check to not call advance when ongoing returns false

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -361,7 +361,7 @@ void BaseCouplingScheme::addComputedTime(
     double timeToAdd)
 {
   PRECICE_TRACE(timeToAdd, _time);
-  PRECICE_CHECK(isCouplingOngoing(), "Invalid call of addComputedTime() after simulation end!");
+  PRECICE_ASSERT(isCouplingOngoing(), "Invalid call of addComputedTime() after simulation end!");
 
   // add time interval that has been computed in the solver to get the correct time remainder
   _computedTimestepPart += timeToAdd;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -335,6 +335,7 @@ double SolverInterfaceImpl:: advance
   utils::ScopedEventPrefix sep("advance/");
 
   PRECICE_CHECK(_couplingScheme->isInitialized(), "initialize() has to be called before advance()");
+  PRECICE_CHECK(isCouplingOngoing(), "advance() cannot be called when isCouplingOngoing() returns false");
   _numberAdvanceCalls++;
   if (_clientMode){
     _requestManager->requestAdvance(computedTimestepLength);


### PR DESCRIPTION
Otherwise, we get
`"Invalid call of addComputedTime() after simulation end!”` which is hard to interpret.
See problem reported by Jun Leng on the mailing list. 