### PR TITLE
Use const double& for writeScalarData

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -290,9 +290,9 @@ void SolverInterface:: writeBlockScalarData
 
 void SolverInterface:: writeScalarData
 (
-  int    dataID,
-  int    valueIndex,
-  double value )
+  int           dataID,
+  int           valueIndex,
+  const double& value )
 {
   _impl->writeScalarData ( dataID, valueIndex, value );
 }

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -697,9 +697,9 @@ public:
    * @see SolverInterface::setMeshVertex()
    */
   void writeScalarData (
-    int    dataID,
-    int    valueIndex,
-    double value );
+    int           dataID,
+    int           valueIndex,
+    const double& value );
 
   /**
    * @brief Reads vector data into a provided block.


### PR DESCRIPTION
This change was introduced in https://github.com/precice/precice/commit/be65dcec131ac7f249b82146dd6a75ec8aeba7ad. I first assumed that it was just forgotten in https://github.com/precice/precice/pull/348. However, in https://github.com/precice/precice/commit/e480aef4e3a74ccd405f03a2770bee18cdb548e9 it was intentionally removed.

In any case we should avoid reintroducing this change via #494. And, if we want to introduce the change, introduce it independently. @fsimonis can you enlighten me?