### PR TITLE
Add Mapping Distance Info

### DIFF
--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -292,6 +292,7 @@ target_sources(precice
     src/utils/Petsc.cpp
     src/utils/Petsc.hpp
     src/utils/PointerVector.hpp
+    src/utils/Statistics.hpp
     src/utils/String.cpp
     src/utils/String.hpp
     src/utils/TableWriter.cpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -76,6 +76,7 @@ target_sources(testprecice
     src/utils/tests/MultiLockTest.cpp
     src/utils/tests/ParallelTest.cpp
     src/utils/tests/PointerVectorTest.cpp
+    src/utils/tests/StatisticsTest.cpp
     src/utils/tests/StringTest.cpp
     src/xml/tests/ParserTest.cpp
     src/xml/tests/XMLTest.cpp

--- a/src/utils/Statistics.hpp
+++ b/src/utils/Statistics.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <iosfwd>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+
+namespace precice {
+namespace utils {
+namespace statistics {
+
+/**
+ * Accunulates distance measures and provides statistics based on them.
+ */
+class DistanceAccumulator {
+public:
+  /// Accumulates value
+  void operator()(double value)
+  {
+    _acc(value);
+  }
+
+  /// Returns the minimum of all accumulated values
+  double min() const
+  {
+    return boost::accumulators::extract::min(_acc);
+  }
+
+  /// Returns the maximum of all accumulated values
+  double max() const
+  {
+    return boost::accumulators::extract::max(_acc);
+  }
+
+private:
+  boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::min, boost::accumulators::tag::max>> _acc;
+};
+
+inline std::ostream &operator<<(std::ostream &out, const DistanceAccumulator &accumulator)
+{
+  return out << "min:" << accumulator.min() << " max:" << accumulator.max();
+};
+
+} // namespace statistics
+} // namespace utils
+} // namespace precice

--- a/src/utils/Statistics.hpp
+++ b/src/utils/Statistics.hpp
@@ -5,6 +5,9 @@
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+#include <boost/accumulators/statistics/count.hpp>
 
 namespace precice {
 namespace utils {
@@ -33,13 +36,41 @@ public:
     return boost::accumulators::extract::max(_acc);
   }
 
+  /// Returns the mean of all accumulated values
+  double mean() const
+  {
+    return boost::accumulators::extract::mean(_acc);
+  }
+
+  /// Returns how many values have been accumulated
+  std::size_t count() const
+  {
+      return boost::accumulators::extract::count(_acc);
+  }
+
+  /// Returns the sample variance based on all accumulated values
+  double variance() const
+  {
+    return boost::accumulators::extract::variance(_acc);
+  }
+
 private:
-  boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::min, boost::accumulators::tag::max>> _acc;
+  boost::accumulators::accumulator_set<double, boost::accumulators::stats<
+      boost::accumulators::tag::min,
+      boost::accumulators::tag::max,
+      boost::accumulators::tag::mean,
+      boost::accumulators::tag::lazy_variance
+          >> _acc;
 };
 
 inline std::ostream &operator<<(std::ostream &out, const DistanceAccumulator &accumulator)
 {
-  return out << "min:" << accumulator.min() << " max:" << accumulator.max();
+  out << "min:" << accumulator.min()
+      << " max:" << accumulator.max()
+      << " avg: " << accumulator.mean()
+      << " var: " << accumulator.variance()
+      << " cnt: " << accumulator.count();
+  return out;
 };
 
 } // namespace statistics

--- a/src/utils/tests/StatisticsTest.cpp
+++ b/src/utils/tests/StatisticsTest.cpp
@@ -1,0 +1,25 @@
+#include "testing/Testing.hpp"
+#include "utils/Statistics.hpp"
+#include <Eigen/Core>
+
+namespace pu = precice::utils;
+
+BOOST_AUTO_TEST_SUITE(UtilsTests)
+
+BOOST_AUTO_TEST_CASE(DistanceAccumulator)
+{
+    pu::statistics::DistanceAccumulator acc;
+    acc(0);
+    BOOST_TEST(acc.min() == 0);
+    BOOST_TEST(acc.max() == 0);
+
+    acc(1);
+    acc(-1);
+    acc(23);
+    acc(11);
+    BOOST_TEST(acc.min() == -1);
+    BOOST_TEST(acc.min() != 0);
+    BOOST_TEST(acc.max() == 23);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds an info log which displays the minimum and maximum distance between projections for NN/NP mappings.
This is easily extensible to any other features of [boost accumulator](https://www.boost.org/doc/libs/1_65_1/doc/html/accumulators/user_s_guide.html#accumulators.user_s_guide.the_statistical_accumulators_library).
I implemented a wrapper class `precice::utils::statistics::DistanceAccumulator` which makes it simpler to print and extend.

This is a non-intrusive way of giving the user a hint for mismatching meshes without making assumptions of the units of the coordinate systems.

**Test output:**
```
(0) 11:59:01 [mapping::NearestProjectionMapping]:122 in computeMapping: Mapping distance min:0 max:0.707107
```


Closes #160 