### PR TITLE
Add configuration context to callback

### DIFF
--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -151,6 +151,7 @@ PtrAccelerationConfiguration AccelerationConfiguration::getCoarseModelOptimizati
 }
 
 void AccelerationConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext& context,
     xml::XMLTag &callingTag)
 {
   PRECICE_TRACE(callingTag.getFullName());
@@ -247,6 +248,7 @@ void AccelerationConfiguration::xmlTagCallback(
 }
 
 void AccelerationConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext& context,
     xml::XMLTag &callingTag)
 {
   PRECICE_TRACE(callingTag.getName());

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -28,10 +28,10 @@ public:
   PtrAccelerationConfiguration getCoarseModelOptimizationConfig();
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlTagCallback(xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlEndTagCallback(xml::XMLTag &callingTag);
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
 
   /// Removes configured acceleration.
   void clear();

--- a/src/action/config/ActionConfiguration.cpp
+++ b/src/action/config/ActionConfiguration.cpp
@@ -164,7 +164,8 @@ ActionConfiguration:: ActionConfiguration
 }
 
 void ActionConfiguration:: xmlTagCallback
-(
+( 
+  const xml::ConfigurationContext& context,
   xml::XMLTag& callingTag )
 {
   PRECICE_TRACE(callingTag.getName());
@@ -198,6 +199,7 @@ void ActionConfiguration:: xmlTagCallback
 
 void ActionConfiguration:: xmlEndTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& callingTag )
 {
   if (callingTag.getNamespace() == TAG){

--- a/src/action/config/ActionConfiguration.hpp
+++ b/src/action/config/ActionConfiguration.hpp
@@ -27,14 +27,14 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag);
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag);
 
   /**
    * @brief Returns the id of the mesh used in the data action.

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
     meshConfig->setDimensions(3);
     action::ActionConfiguration config(tag, meshConfig);
-    xml::configure(tag, filename);
+    xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
     action::PtrAction action = config.actions().front();
     BOOST_TEST(action);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
     meshConfig->setDimensions(3);
     action::ActionConfiguration config(tag, meshConfig);
-    xml::configure(tag, filename);
+    xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
     action::PtrAction action = config.actions().front();
     BOOST_TEST(action);
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
     meshConfig->setDimensions(3);
     action::ActionConfiguration config(tag, meshConfig);
-    xml::configure(tag, filename);
+    xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
     action::PtrAction action = config.actions().front();
     BOOST_TEST(action);
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
     meshConfig->setDimensions(3);
     action::ActionConfiguration config(tag, meshConfig);
-    xml::configure(tag, filename);
+    xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
     action::PtrAction action = config.actions().front();
     BOOST_TEST(action);

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -145,6 +145,7 @@ const PtrCouplingScheme &CouplingSchemeConfiguration::getCouplingScheme(
 }
 
 void CouplingSchemeConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext& context,
     xml::XMLTag &tag)
 {
   PRECICE_TRACE(tag.getFullName());
@@ -249,6 +250,7 @@ void CouplingSchemeConfiguration::xmlTagCallback(
 }
 
 void CouplingSchemeConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext& context,
     xml::XMLTag &tag)
 {
   PRECICE_TRACE(tag.getFullName());

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -72,10 +72,10 @@ public:
   const std::string &getDataToExchange(int index) const;
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlTagCallback(xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlEndTagCallback(xml::XMLTag &callingTag);
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
 
   /// Adds a manually configured coupling scheme for a participant.
   void addCouplingScheme(PtrCouplingScheme cplScheme, const std::string &participantName);

--- a/src/cplscheme/tests/AbsoluteConvergenceMeasureTest.cpp
+++ b/src/cplscheme/tests/AbsoluteConvergenceMeasureTest.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_CASE(AbsoluteConvergenceMeasureTest)
   using Eigen::Vector3d;
   // Create convergence measure for Vector data
   double                           convergenceLimit = 9.0;
-  impl::AbsoluteConvergenceMeasure measure(convergenceLimit);
+  cplscheme::impl::AbsoluteConvergenceMeasure measure(convergenceLimit);
 
   // Create data sets for old state of data and new state of data
   Vector3d oldValues0(-2, -1, 0);

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -53,7 +53,21 @@ struct CompositionalCouplingSchemeFixture
     m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
     CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig );
 
-    xml::configure(root, configurationPath);
+    if (utils::Parallel::getProcessRank() == 0){
+      localParticipant = nameParticipant0;
+    }
+    else if (utils::Parallel::getProcessRank() == 1){
+      localParticipant = nameParticipant1;
+    }
+    else {
+      BOOST_TEST(utils::Parallel::getProcessRank() == 2,
+          utils::Parallel::getProcessRank());
+      localParticipant = nameParticipant2;
+    }
+
+    xml::ConfigurationContext context{localParticipant, 0, 1};
+    xml::configure(root, context, configurationPath);
+
     meshConfig->setMeshSubIDs();
     m2n::PtrM2N m2n0 = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
     m2n::PtrM2N m2n1 = m2nConfig->getM2N(nameParticipant1, nameParticipant2);
@@ -65,18 +79,13 @@ struct CompositionalCouplingSchemeFixture
     meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
 
     if (utils::Parallel::getProcessRank() == 0){
-      localParticipant = nameParticipant0;
       connect(nameParticipant0, nameParticipant1, localParticipant, m2n0);
     }
     else if (utils::Parallel::getProcessRank() == 1){
-      localParticipant = nameParticipant1;
       connect(nameParticipant0, nameParticipant1, localParticipant, m2n0);
       connect(nameParticipant1, nameParticipant2, localParticipant, m2n1);
     }
     else {
-      BOOST_TEST(utils::Parallel::getProcessRank() == 2,
-          utils::Parallel::getProcessRank());
-      localParticipant = nameParticipant2;
       connect(nameParticipant1, nameParticipant2, localParticipant, m2n1);
     }
 

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -344,6 +344,8 @@ BOOST_AUTO_TEST_CASE(testConfiguredSimpleExplicitCoupling,
   else if ( utils::Parallel::getProcessRank() == 1 ) {
     nameLocalParticipant = nameParticipant1;
   }
+  xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
+
   xml::XMLTag root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(3);
@@ -352,7 +354,7 @@ BOOST_AUTO_TEST_CASE(testConfiguredSimpleExplicitCoupling,
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, configurationPath);
+  xml::configure(root, context, configurationPath);
   meshConfig->setMeshSubIDs();
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
@@ -387,6 +389,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
   else if ( utils::Parallel::getProcessRank() == 1 ){
     nameLocalParticipant = nameParticipant1;
   }
+  xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
 
   xml::XMLTag root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
@@ -396,7 +399,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, configurationPath);
+  xml::configure(root, context, configurationPath);
   meshConfig->setMeshSubIDs();
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
@@ -481,6 +484,8 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization,
   else if (utils::Parallel::getProcessRank() == 1){
     nameLocalParticipant = nameParticipant1;
   }
+  xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
+
   xml::XMLTag root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(2);
@@ -489,7 +494,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization,
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, configurationPath);
+  xml::configure(root, context, configurationPath);
   meshConfig->setMeshSubIDs();
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
@@ -559,6 +564,8 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization,
   else if (utils::Parallel::getProcessRank() == 1){
     nameLocalParticipant = nameParticipant1;
   }
+  xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
+
   xml::XMLTag root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(2);
@@ -567,7 +574,7 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization,
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, configurationPath);
+  xml::configure(root, context, configurationPath);
   meshConfig->setMeshSubIDs();
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
@@ -692,6 +699,7 @@ BOOST_AUTO_TEST_CASE(testConfiguredExplicitCouplingWithSubcycling,
   else if ( utils::Parallel::getProcessRank() == 1 ) {
     nameLocalParticipant = nameParticipant1;
   }
+  xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
 
   xml::XMLTag root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
@@ -701,7 +709,7 @@ BOOST_AUTO_TEST_CASE(testConfiguredExplicitCouplingWithSubcycling,
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, configurationPath);
+  xml::configure(root, context, configurationPath);
   meshConfig->setMeshSubIDs();
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
   // some dummy mesh

--- a/src/cplscheme/tests/MinIterationConvergenceMeasureTest.cpp
+++ b/src/cplscheme/tests/MinIterationConvergenceMeasureTest.cpp
@@ -8,7 +8,7 @@ using namespace cplscheme;
 
 BOOST_AUTO_TEST_CASE(MinIterationConvergenceMeasureTest)
 {
-  impl::MinIterationConvergenceMeasure measure(5);
+  cplscheme::impl::MinIterationConvergenceMeasure measure(5);
   Eigen::VectorXd                      emptyValues; // No values needed for min-iter
 
   for (int iSeries = 0; iSeries < 3; iSeries++) {

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(testParseConfigurationWithRelaxation)
       new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, path);
+  xml::configure(root, xml::ConfigurationContext{}, path);
   BOOST_CHECK(cplSchemeConfig._accelerationConfig->getAcceleration().get());
   meshConfig->setMeshSubIDs();
 }

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(testParseConfigurationWithRelaxation)
       new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, path);
+  xml::configure(root, xml::ConfigurationContext{}, path);
   BOOST_CHECK(cplSchemeConfig._accelerationConfig->getAcceleration().get()); // no nullptr
   meshConfig->setMeshSubIDs();
 }
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(testConfiguredAbsConvergenceMeasureSynchronized,
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
   CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
 
-  xml::configure(root, configurationPath);
+  xml::configure(root, xml::ConfigurationContext{}, configurationPath);
   meshConfig->setMeshSubIDs();
   m2n::PtrM2N m2n = m2nConfig->getM2N("Participant0", "Participant1");
 

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -46,6 +46,7 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
 }
 
 void ExportConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext& context,
     xml::XMLTag &tag)
 {
   if (tag.getNamespace() == TAG) {

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -24,10 +24,10 @@ public:
     return _contexts;
   }
 
-  virtual void xmlTagCallback(xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
 
   /// Callback from automatic configuration. Not utilitzed here.
-  virtual void xmlEndTagCallback(xml::XMLTag &callingTag) {}
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag) {}
 
   void resetExports()
   {

--- a/src/io/tests/ExportConfigurationTest.cpp
+++ b/src/io/tests/ExportConfigurationTest.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
   XMLTag tag = xml::getRootTag();
   {
     io::ExportConfiguration config(tag);
-    xml::configure(tag, testing::getPathToSources() + "/io/tests/config1.xml");
+    xml::configure(tag, xml::ConfigurationContext{}, testing::getPathToSources() + "/io/tests/config1.xml");
     BOOST_TEST(config.exportContexts().size() == 1);
     const io::ExportContext &context = config.exportContexts().front();
     BOOST_TEST(context.type == "vtk");
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
   {
     tag.clear();
     io::ExportConfiguration config(tag);
-    xml::configure(tag, testing::getPathToSources() + "/io/tests/config2.xml");
+    xml::configure(tag, xml::ConfigurationContext{}, testing::getPathToSources() + "/io/tests/config2.xml");
     BOOST_TEST(config.exportContexts().size() == 1);
     const io::ExportContext &context = config.exportContexts().front();
     BOOST_TEST(context.type == "vtk");

--- a/src/logging/config/LogConfiguration.cpp
+++ b/src/logging/config/LogConfiguration.cpp
@@ -52,6 +52,7 @@ LogConfiguration::LogConfiguration
 
 void LogConfiguration::xmlTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE(tag.getFullName());
@@ -69,6 +70,7 @@ void LogConfiguration::xmlTagCallback
 
 void LogConfiguration::xmlEndTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE(tag.getFullName());

--- a/src/logging/config/LogConfiguration.hpp
+++ b/src/logging/config/LogConfiguration.hpp
@@ -12,9 +12,9 @@ class LogConfiguration : public xml::XMLTag::Listener
 public:
   LogConfiguration(xml::XMLTag& parent);
 
-  virtual void xmlTagCallback(xml::XMLTag& tag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag);
 
-  virtual void xmlEndTagCallback(xml::XMLTag& tag);
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag);
 
 private:
   precice::logging::Logger _log{"logging::config::LogConfiguration"};

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -137,7 +137,7 @@ m2n::PtrM2N M2NConfiguration::getM2N(const std::string &from, const std::string 
   throw std::runtime_error{error.str()};
 }
 
-void M2NConfiguration::xmlTagCallback(xml::XMLTag &tag)
+void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &tag)
 {
   if (tag.getNamespace() == TAG) {
     std::string from = tag.getStringAttributeValue("from");

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -43,9 +43,9 @@ public:
     return _m2ns;
   }
 
-  virtual void xmlTagCallback(xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
 
-  virtual void xmlEndTagCallback(xml::XMLTag &callingTag) {}
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag) {}
 
 private:
   logging::Logger _log{"m2n::M2NConfiguration"};

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -204,6 +204,7 @@ MappingConfiguration:: MappingConfiguration
 
 void MappingConfiguration:: xmlTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE(tag.getName());
@@ -271,7 +272,7 @@ void MappingConfiguration:: xmlTagCallback
   }
 }
 
-void MappingConfiguration::xmlEndTagCallback(xml::XMLTag& tag)
+void MappingConfiguration::xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag)
 {
 }
 

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -76,14 +76,18 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlTagCallback(
+          const xml::ConfigurationContext& context,
+          xml::XMLTag& callingTag);
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlEndTagCallback(
+          const xml::ConfigurationContext& context,
+          xml::XMLTag& callingTag);
 
   /// Returns all configured mappings.
   const std::vector<ConfiguredMapping>& mappings();

--- a/src/mapping/tests/MappingConfigurationTest.cpp
+++ b/src/mapping/tests/MappingConfigurationTest.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
   mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
   meshConfig->setDimensions(3);
   mapping::MappingConfiguration mappingConfig(tag, meshConfig);
-  xml::configure(tag, file);
+  xml::configure(tag, xml::ConfigurationContext{}, file);
     
   BOOST_TEST(meshConfig->meshes().size() == 3);
   BOOST_TEST(mappingConfig.mappings().size() == 3);

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -53,6 +53,7 @@ DataConfiguration::ConfiguredData DataConfiguration:: getRecentlyConfiguredData(
 
 void DataConfiguration:: xmlTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   if (tag.getNamespace() == TAG){
@@ -69,6 +70,7 @@ void DataConfiguration:: xmlTagCallback
 
 void DataConfiguration:: xmlEndTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
 }

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -33,9 +33,13 @@ public:
 
   ConfiguredData getRecentlyConfiguredData() const;
 
-  virtual void xmlTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlTagCallback(
+          const xml::ConfigurationContext& context,
+          xml::XMLTag& callingTag);
 
-  virtual void xmlEndTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlEndTagCallback(
+          const xml::ConfigurationContext& context,
+          xml::XMLTag& callingTag);
 
   /**
    * @brief Adds data manually.

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -73,6 +73,7 @@ void MeshConfiguration:: setDimensions
 
 void MeshConfiguration:: xmlTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE(tag.getName());
@@ -110,6 +111,7 @@ void MeshConfiguration:: xmlTagCallback
 
 void MeshConfiguration:: xmlEndTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
 }

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -47,9 +47,11 @@ public:
   /// Returns the configured mesh with given name, or NULL.
   mesh::PtrMesh getMesh ( const std::string& meshName ) const;
 
-  virtual void xmlTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag);
 
-  virtual void xmlEndTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlEndTagCallback(
+          const xml::ConfigurationContext& context,
+          xml::XMLTag& callingTag);
 
   const PtrDataConfiguration& getDataConfiguration() const;
 

--- a/src/mesh/tests/DataConfigurationTest.cpp
+++ b/src/mesh/tests/DataConfigurationTest.cpp
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(DataConfig)
   XMLTag tag = xml::getRootTag();
   mesh::DataConfiguration dataConfig(tag);
   dataConfig.setDimensions(dim);
-  xml::configure(tag, filename);
+  xml::configure(tag, xml::ConfigurationContext{}, filename);
   BOOST_TEST(dataConfig.data().size() == 3);
   BOOST_TEST(dataConfig.data()[0].name == "vector-data");
   BOOST_TEST(dataConfig.data()[0].dimensions == 3);

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -35,7 +35,7 @@ xml::XMLTag& Configuration:: getXMLTag()
   return _tag;
 }
 
-void Configuration::xmlTagCallback(xml::XMLTag& tag)
+void Configuration::xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag)
 {
   PRECICE_TRACE(tag.getName());
   if (tag.getName() == "precice-configuration") {
@@ -45,6 +45,7 @@ void Configuration::xmlTagCallback(xml::XMLTag& tag)
 
 void Configuration:: xmlEndTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE(tag.getName());

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -35,14 +35,14 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback ( xml::XMLTag& tag );
+  virtual void xmlTagCallback (const xml::ConfigurationContext& context, xml::XMLTag& tag );
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback ( xml::XMLTag& tag );
+  virtual void xmlEndTagCallback (const xml::ConfigurationContext& context, xml::XMLTag& tag );
 
   /**
    * @brief Returns solver interface configuration.

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -287,6 +287,7 @@ void ParticipantConfiguration:: setDimensions
 
 void ParticipantConfiguration:: xmlTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE(tag.getName() );
@@ -370,6 +371,7 @@ void ParticipantConfiguration:: xmlTagCallback
 
 void ParticipantConfiguration:: xmlEndTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   if (tag.getName() == TAG){

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -29,14 +29,18 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlTagCallback (
+          const xml::ConfigurationContext& context,
+          xml::XMLTag& callingTag );
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlEndTagCallback (
+          const xml::ConfigurationContext& context,
+          xml::XMLTag& callingTag );
 
   /**
    * @brief For manual configuration.

--- a/src/precice/config/SolverInterfaceConfiguration.cpp
+++ b/src/precice/config/SolverInterfaceConfiguration.cpp
@@ -39,6 +39,7 @@ SolverInterfaceConfiguration:: SolverInterfaceConfiguration(xml::XMLTag& parent 
 
 void SolverInterfaceConfiguration:: xmlTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE();
@@ -55,6 +56,7 @@ void SolverInterfaceConfiguration:: xmlTagCallback
 
 void SolverInterfaceConfiguration:: xmlEndTagCallback
 (
+  const xml::ConfigurationContext& context,
   xml::XMLTag& tag )
 {
   PRECICE_TRACE();

--- a/src/precice/config/SolverInterfaceConfiguration.hpp
+++ b/src/precice/config/SolverInterfaceConfiguration.hpp
@@ -35,12 +35,12 @@ public:
   /**
    * @brief Callback method required when using xml::XMLTag.
    */
-  virtual void xmlTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag );
 
   /**
    * @brief Callback method required when using xml::XMLTag.
    */
-  virtual void xmlEndTagCallback ( xml::XMLTag& callingTag );
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag );
 
   /**
    * @brief Returns number of spatial dimensions configured.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -102,7 +102,12 @@ void SolverInterfaceImpl:: configure
 {
   utils::Parallel::initializeMPI(nullptr, nullptr);
   config::Configuration config;
-  xml::configure(config.getXMLTag(), configurationFileName);
+  xml::ConfigurationContext context{
+      _accessorName,
+      _accessorProcessRank,
+      _accessorCommunicatorSize
+  };
+  xml::configure(config.getXMLTag(), context, configurationFileName);
   if(_accessorProcessRank==0){
     PRECICE_INFO("This is preCICE version " << PRECICE_VERSION);
     PRECICE_INFO("Revision info: " << precice::preciceRevision);

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -496,6 +496,15 @@ public:
   /// Runs the solver interface in server mode.
   void runServer();
 
+  /// Returns the name of the accessor
+  std::string getAccessorName() const { return _accessorName; }
+
+  /// Returns the rank of the accessor
+  int getAccessorProcessRank() const { return _accessorProcessRank; }
+
+  /// Returns the size of the accessors communicator
+  int getAccessorCommunicatorSize() const { return _accessorCommunicatorSize; }
+
 private:
 
   mutable logging::Logger _log{"impl::SolverInterfaceImpl"};

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup, * testing::OnSize(4))
 {
   SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 4 );
   std::string configFilename = _pathToTests + "config1.xml";
-  slimConfig(interface, configFilename);
+  slimConfigure(interface, configFilename);
   BOOST_TEST ( interface.getDimensions() == 3 );
 
   if(utils::Parallel::getProcessRank()==0){
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
   std::string configFilename = _pathToTests + "config1.xml";
   if(utils::Parallel::getProcessRank()<=1){
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 2 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     double xCoord = 0.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
   }
   else {
     SolverInterface interface ( "SolverTwo", utils::Parallel::getProcessRank()-2, 2 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     double xCoord = -2.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
     SolverInterface interface ( "Ateles", utils::Parallel::getProcessRank(), 3 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("Ateles_Mesh");
 
     int vertexIDs[4];
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
     SolverInterface interface ( "FASTEST", 0, 1 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("FASTEST_Mesh");
     int vertexIDs[10];
     double xCoord = -0.0001;
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
     reset();
 
     SolverInterface interface ( solverName, rank, size );
-    slimConfig(interface, configs[k]);
+    slimConfigure(interface, configs[k]);
     int meshID = interface.getMeshID(meshName);
     int writeDataID = interface.getDataID(writeDataName, meshID);
     int readDataID = interface.getDataID(readDataName, meshID);
@@ -429,7 +429,7 @@ BOOST_AUTO_TEST_CASE(testDistributedCommunications, * testing::OnSize(4))
     }
 
     SolverInterface precice(solverName, rank, size);
-    slimConfig(precice, _pathToTests + fileName);
+    slimConfigure(precice, _pathToTests + fileName);
     int meshID = precice.getMeshID(meshName);
     int forcesID = precice.getDataID("Forces", meshID);
     int velocID = precice.getDataID("Velocities", meshID);
@@ -481,7 +481,7 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, * testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
     SolverInterface interface ( "FluidSolver", utils::Parallel::getProcessRank(), 3 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
 
     if(utils::Parallel::getProcessRank()==1) {
 
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, * testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
     SolverInterface interface ( "SolidSolver", 0, 1 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     const int meshID = interface.getMeshID("Nodes");
     const int dimensions = 3;
     BOOST_TEST(interface.getDimensions()==dimensions);
@@ -665,7 +665,7 @@ BOOST_AUTO_TEST_CASE(MasterSockets, * testing::OnSize(4))
     myMeshName = "SerialMesh";
   }
   SolverInterface interface(myName, myRank, mySize);
-  slimConfig(interface, configFilename);
+  slimConfigure(interface, configFilename);
   int meshID = interface.getMeshID(myMeshName);
   double position[2] = {0, 0};
   interface.setMeshVertex(meshID, position);
@@ -688,7 +688,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3, &myComm );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
 
     int vertexIDs[2];
@@ -705,7 +705,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -732,7 +732,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3, &myComm );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
 
     int vertexIDs[2];
@@ -749,7 +749,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    slimConfig(interface, configFilename);
+    slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -23,7 +23,7 @@ void reset ()
   utils::MasterSlave::reset();
 }
 
-struct ParallelTestFixture : testing::WhiteboxAccessor {
+struct ParallelTestFixture : testing::SlimConfigurator {
 
   std::string _pathToTests;
 
@@ -52,10 +52,7 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup, * testing::OnSize(4))
 {
   SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 4 );
   std::string configFilename = _pathToTests + "config1.xml";
-  config::Configuration config;
-  xml::configure(config.getXMLTag(), configFilename);
-  impl(interface).configure(config.getSolverInterfaceConfiguration());
-
+  slimConfig(interface, configFilename);
   BOOST_TEST ( interface.getDimensions() == 3 );
 
   if(utils::Parallel::getProcessRank()==0){
@@ -81,11 +78,9 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup, * testing::OnSize(4))
 BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "config1.xml";
-  config::Configuration config;
-  xml::configure(config.getXMLTag(), configFilename);
   if(utils::Parallel::getProcessRank()<=1){
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 2 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     double xCoord = 0.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
@@ -96,7 +91,7 @@ BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
   }
   else {
     SolverInterface interface ( "SolverTwo", utils::Parallel::getProcessRank()-2, 2 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     double xCoord = -2.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
@@ -110,17 +105,15 @@ BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
 BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "globalRBFPartitioning.xml";
-  config::Configuration config;
 
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "SolverOne" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator()); //needed since this test uses PETSc
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
@@ -140,10 +133,9 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -160,17 +152,15 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
 BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "localRBFPartitioning.xml";
-  config::Configuration config;
 
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "SolverOne" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
@@ -189,10 +179,9 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -212,16 +201,14 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
 BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "line-coupling.xml";
-  config::Configuration config;
 
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "Ateles" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "Ateles", utils::Parallel::getProcessRank(), 3 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("Ateles_Mesh");
 
     int vertexIDs[4];
@@ -242,9 +229,8 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "FASTEST", 0, 1 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("FASTEST_Mesh");
     int vertexIDs[10];
     double xCoord = -0.0001;
@@ -306,13 +292,9 @@ BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
 
   for(int k=0; k<numberOfTests; k++){
     reset();
-    config::Configuration config;
-    std::string configFilename = configs[k];
-
-    xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( solverName, rank, size );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configs[k]);
     int meshID = interface.getMeshID(meshName);
     int writeDataID = interface.getDataID(writeDataName, meshID);
     int readDataID = interface.getDataID(readDataName, meshID);
@@ -447,9 +429,7 @@ BOOST_AUTO_TEST_CASE(testDistributedCommunications, * testing::OnSize(4))
     }
 
     SolverInterface precice(solverName, rank, size);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + fileName);
-    impl(precice).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(precice, _pathToTests + fileName);
     int meshID = precice.getMeshID(meshName);
     int forcesID = precice.getDataID("Forces", meshID);
     int velocID = precice.getDataID("Velocities", meshID);
@@ -494,16 +474,14 @@ BOOST_AUTO_TEST_CASE(testDistributedCommunications, * testing::OnSize(4))
 BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, * testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "np-repartitioning.xml";
-  config::Configuration config;
 
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "FluidSolver" );
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "FluidSolver", utils::Parallel::getProcessRank(), 3 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
 
     if(utils::Parallel::getProcessRank()==1) {
 
@@ -598,9 +576,8 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, * testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "SolidSolver", 0, 1 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     const int meshID = interface.getMeshID("Nodes");
     const int dimensions = 3;
     BOOST_TEST(interface.getDimensions()==dimensions);
@@ -675,8 +652,6 @@ BOOST_AUTO_TEST_CASE(MasterSockets, * testing::OnSize(4))
   std::string configFilename = _pathToTests + "master-sockets.xml";
   std::string myName, myMeshName;
   int myRank, mySize;
-  config::Configuration config;
-  xml::configure(config.getXMLTag(), configFilename);
   if(utils::Parallel::getProcessRank()<=2){
     myName = "ParallelSolver";
     myRank = utils::Parallel::getProcessRank();
@@ -690,7 +665,7 @@ BOOST_AUTO_TEST_CASE(MasterSockets, * testing::OnSize(4))
     myMeshName = "SerialMesh";
   }
   SolverInterface interface(myName, myRank, mySize);
-  impl(interface).configure(config.getSolverInterfaceConfiguration());
+  slimConfig(interface, configFilename);
   int meshID = interface.getMeshID(myMeshName);
   double position[2] = {0, 0};
   interface.setMeshVertex(meshID, position);
@@ -703,7 +678,6 @@ BOOST_AUTO_TEST_CASE(MasterSockets, * testing::OnSize(4))
 BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, * testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "userDefinedMPICommunicator.xml";
-  config::Configuration config;
   
   if(utils::Parallel::getProcessRank()<=2){
     utils::Parallel::splitCommunicator( "SolverOne" );
@@ -713,9 +687,8 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, * testing::OnSize(4))
     BOOST_TEST(myCommSize == 3);
     utils::Parallel::clearGroups();
 
-    xml::configure(config.getXMLTag(), configFilename);
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3, &myComm );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
 
     int vertexIDs[2];
@@ -730,10 +703,9 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, * testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
@@ -760,8 +732,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, * testing::OnSize(4))
     utils::Parallel::clearGroups();
 
     SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3, &myComm );
-    xml::configure(config.getXMLTag(), configFilename);
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
 
     int vertexIDs[2];
@@ -776,10 +747,9 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, * testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    xml::configure(config.getXMLTag(), configFilename);
 
     SolverInterface interface ( "SolverTwo", 0, 1 );
-    impl(interface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(interface, configFilename);
     int meshID = interface.getMeshID("MeshTwo");
     int vertexIDs[6];
     double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -14,7 +14,7 @@
 using namespace precice;
 
 
-struct SerialTestFixture : testing::WhiteboxAccessor {
+struct SerialTestFixture : testing::SlimConfigurator {
 
   std::string _pathToTests;
 
@@ -42,9 +42,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   std::string filename = _pathToTests + "/configuration.xml";
   // Test configuration for accessor "Peano"
   SolverInterface interfacePeano ("Peano", 0, 1);
-  config::Configuration config;
-  xml::configure(config.getXMLTag(), filename);
-  impl(interfacePeano).configure(config.getSolverInterfaceConfiguration());
+  slimConfig(interfacePeano, filename);
 
   BOOST_TEST(impl(interfacePeano)._participants.size() == 2);
   BOOST_TEST(interfacePeano.getDimensions() == 2);
@@ -63,7 +61,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
 
   // Test configuration for accessor "Comsol"
   SolverInterface interfaceComsol ("Comsol", 0, 1);
-  impl(interfaceComsol).configure(config.getSolverInterfaceConfiguration());
+  slimConfig(interfaceComsol, filename);
   BOOST_TEST(impl(interfaceComsol)._participants.size() == 2);
   BOOST_TEST(interfaceComsol.getDimensions() == 2);
 
@@ -111,10 +109,7 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
     }
 
     SolverInterface couplingInterface(solverName, 0, 1);
-
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), configurationFileName);
-    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(couplingInterface, configurationFileName);
 
     //was necessary to replace pre-defined geometries
     if(solverName=="SolverOne" && couplingInterface.hasMesh("MeshOne")){
@@ -152,9 +147,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface precice("SolverOne", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    impl(precice).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(precice, _pathToTests + "explicit-mpi-single.xml");
 
     double maxDt = precice.initialize();
     int timestep = 0;
@@ -170,9 +163,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface precice("SolverTwo", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    impl(precice).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(precice, _pathToTests + "explicit-mpi-single.xml");
     int meshID = precice.getMeshID("Test-Square");
     precice.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
     precice.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
@@ -203,9 +194,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single.xml");
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     /* int squareID = */ cplInterface.getMeshID("Test-Square");
@@ -250,9 +239,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface cplInterface("SolverTwo", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single.xml");
+
     int meshID = cplInterface.getMeshID("Test-Square");
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
@@ -308,9 +296,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-data-init.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-data-init.xml");
+
     int meshOneID = cplInterface.getMeshID("MeshOne");
     cplInterface.setMeshVertex(meshOneID, Vector3d(1.0,2.0,3.0).data());
     double maxDt = cplInterface.initialize();
@@ -331,9 +318,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface cplInterface("SolverTwo", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-data-init.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-data-init.xml");
+
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
     Vector3d pos = Vector3d::Zero();
     cplInterface.setMeshVertex(meshTwoID, pos.data());
@@ -371,9 +357,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single-non-inc.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
+
     int meshOneID = cplInterface.getMeshID("MeshOne");
     double maxDt = cplInterface.initialize();
     int forcesID = cplInterface.getDataID("Forces", meshOneID);
@@ -451,9 +436,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ) {
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-mpi-single-non-inc.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
+
     int squareID = cplInterface.getMeshID("Test-Square");
     int forcesID = cplInterface.getDataID ( "Forces", squareID );
     int pressuresID = cplInterface.getDataID("Pressures", squareID );
@@ -524,9 +508,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
   if ( utils::Parallel::getProcessRank() == 0 ){
 
     SolverInterface couplingInterface("SolverOne", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(couplingInterface, _pathToTests + "explicit-solvergeometry.xml");
 
     //was necessary to replace pre-defined geometries
     int meshID = couplingInterface.getMeshID("MeshOne");
@@ -544,9 +526,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ){
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
+
     BOOST_TEST(cplInterface.getDimensions() == 3);
     int meshID = cplInterface.getMeshID ( "SolverGeometry" );
     int i0 = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
@@ -591,9 +572,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDisplacingGeometry,
   if ( utils::Parallel::getProcessRank() == 0 ) { // SolverOne part
 
     SolverInterface cplInterface ( "SolverOne", 0, 1 );
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
+
     double dt = cplInterface.initialize();
 
     int meshID = cplInterface.getMeshID("SolverGeometry");
@@ -627,9 +607,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDisplacingGeometry,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ){
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-solvergeometry.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
     int meshID = cplInterface.getMeshID("SolverGeometry");
     int i0 = cplInterface.setMeshVertex(meshID, zero.data());
     int i1 = cplInterface.setMeshVertex(meshID, one.data());
@@ -690,9 +668,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
   double dt;
   if ( utils::Parallel::getProcessRank() == 0 ) { // SolverOne part
     SolverInterface cplInterface ( "SolverOne", 0, 1 );
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-datascaling.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-datascaling.xml");
+
     BOOST_TEST ( cplInterface.getDimensions() == 2 );
 
     int meshID = cplInterface.getMeshID("Test-Square");
@@ -718,9 +695,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ){
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "explicit-datascaling.xml");
-    impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(cplInterface, _pathToTests + "explicit-datascaling.xml");
+
     BOOST_TEST ( cplInterface.getDimensions() == 2 );
     dt = cplInterface.initialize();
     int meshID = cplInterface.getMeshID("Test-Square");
@@ -758,9 +734,7 @@ BOOST_AUTO_TEST_CASE(testImplicit,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface couplingInterface("SolverOne", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "implicit.xml");
-    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(couplingInterface, _pathToTests + "implicit.xml");
 
     int meshID = couplingInterface.getMeshID("Square");
     double pos[3];
@@ -798,9 +772,8 @@ BOOST_AUTO_TEST_CASE(testImplicit,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface couplingInterface("SolverTwo", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "implicit.xml");
-    impl(couplingInterface).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(couplingInterface, _pathToTests + "implicit.xml");
+
     double maxDt = couplingInterface.initialize();
     while (couplingInterface.isCouplingOngoing()){
       if (couplingInterface.isActionRequired(actionWriteIterationCheckpoint())){
@@ -853,16 +826,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     SolverInterface interface(solverName, 0, 1);
-    if (dim == 2){
-      config::Configuration config;
-      xml::configure(config.getXMLTag(), config2D);
-      impl(interface).configure(config.getSolverInterfaceConfiguration());
-    }
-    else {
-      config::Configuration config;
-      xml::configure(config.getXMLTag(), config3D);
-      impl(interface).configure(config.getSolverInterfaceConfiguration());
-    }
+    slimConfig(interface, (dim == 2 ? config2D : config3D));
     BOOST_TEST(interface.getDimensions() == dim);
 
     std::vector<Eigen::VectorXd> positions;
@@ -1025,9 +989,8 @@ BOOST_AUTO_TEST_CASE(testBug,
   std::string solverName = rank == 0 ? "Flite" : "Calculix";
   if (solverName == std::string("Flite")){
     SolverInterface precice("Flite", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), configName);
-    impl(precice).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(precice, configName);
+
     int meshID = precice.getMeshID("FliteNodes");
     int forcesID = precice.getDataID("Forces", meshID);
     int displacementsID = precice.getDataID("Displacements", meshID);
@@ -1058,9 +1021,8 @@ BOOST_AUTO_TEST_CASE(testBug,
   else {
     BOOST_TEST(solverName == std::string("Calculix"), solverName);
     SolverInterface precice("Calculix", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), configName);
-    impl(precice).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(precice, configName);
+
     int meshID = precice.getMeshID("CalculixNodes");
     for (Vector3d& coord : coords){
       precice.setMeshVertex(meshID, coord.data());
@@ -1132,9 +1094,8 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
 
     if (solverName == std::string("SolverOne")){
       SolverInterface precice(solverName, 0, 1);
-      config::Configuration config;
-      xml::configure(config.getXMLTag(), configs[k]);
-      impl(precice).configure(config.getSolverInterfaceConfiguration());
+      slimConfig(precice, configs[k]);
+
       int meshAID = precice.getMeshID("MeshA");
       int meshBID = precice.getMeshID("MeshB");
       precice.setMeshVertex(meshAID, Eigen::Vector2d(0, 0).data());
@@ -1161,9 +1122,8 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     }
     else if (solverName == std::string("SolverTwo")){
       SolverInterface precice(solverName, 0, 1);
-      config::Configuration config;
-      xml::configure(config.getXMLTag(), configs[k]);
-      impl(precice).configure(config.getSolverInterfaceConfiguration());
+      slimConfig(precice, configs[k]);
+
       int meshID = precice.getMeshID("MeshC");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
@@ -1189,9 +1149,8 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     else {
       BOOST_TEST(solverName == std::string("SolverThree"), solverName);
       SolverInterface precice(solverName, 0, 1);
-      config::Configuration config;
-      xml::configure(config.getXMLTag(), configs[k]);
-      impl(precice).configure(config.getSolverInterfaceConfiguration());
+      slimConfig(precice, configs[k]);
+
       int meshID = precice.getMeshID("MeshD");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
@@ -1263,9 +1222,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
     }
 
     SolverInterface precice(participant, 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "/multi.xml");
-    impl(precice).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(precice, _pathToTests + "/multi.xml");
     BOOST_TEST(precice.getDimensions() == 2);
 
     if (utils::Parallel::getProcessRank() == 0){
@@ -1324,9 +1281,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
   else {
     BOOST_TEST(utils::Parallel::getProcessRank() == 3);
     SolverInterface precice("NASTIN", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), _pathToTests + "/multi.xml");
-    impl(precice).configure(config.getSolverInterfaceConfiguration());
+    slimConfig(precice, _pathToTests + "/multi.xml");
     BOOST_TEST(precice.getDimensions() == 2);
     int meshID1 = precice.getMeshID("NASTIN_Mesh1");
     int meshID2 = precice.getMeshID("NASTIN_Mesh2");
@@ -1403,10 +1358,8 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), configFile);
     // namespace is required because we are outside the fixture
-    testing::WhiteboxAccessor::impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    testing::SlimConfigurator::slimConfig(cplInterface, configFile);
     const int meshOneID = cplInterface.getMeshID("MeshOne");
 
     // Setup mesh one.
@@ -1449,10 +1402,8 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface cplInterface("SolverTwo", 0, 1);
-    config::Configuration config;
-    xml::configure(config.getXMLTag(), configFile);
     // namespace is required because we are outside the fixture
-    testing::WhiteboxAccessor::impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+    testing::SlimConfigurator::slimConfig(cplInterface, configFile);
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
 
     // Setup receiving mesh.
@@ -1548,9 +1499,7 @@ BOOST_AUTO_TEST_CASE(testSendMeshToMultipleParticipants,
   }
 
   SolverInterface cplInterface(solverName, 0, 1);
-  config::Configuration config;
-  xml::configure(config.getXMLTag(), configFile);
-  impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+  slimConfig(cplInterface, configFile);
 
   const int meshID = cplInterface.getMeshID(meshName);
 
@@ -1594,9 +1543,7 @@ BOOST_AUTO_TEST_CASE(testPreconditionerBug,
   std::string meshName = utils::Parallel::getProcessRank() == 0 ? "MeshOne" : "MeshTwo";
 
   SolverInterface cplInterface(participantName, 0, 1);
-  config::Configuration config;
-  xml::configure(config.getXMLTag(), configFile);
-  impl(cplInterface).configure(config.getSolverInterfaceConfiguration());
+  slimConfig(cplInterface, configFile);
   const int meshID = cplInterface.getMeshID(meshName);
 
   Vector2d vertex{0.0, 0.0};

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   std::string filename = _pathToTests + "/configuration.xml";
   // Test configuration for accessor "Peano"
   SolverInterface interfacePeano ("Peano", 0, 1);
-  slimConfig(interfacePeano, filename);
+  slimConfigure(interfacePeano, filename);
 
   BOOST_TEST(impl(interfacePeano)._participants.size() == 2);
   BOOST_TEST(interfacePeano.getDimensions() == 2);
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
 
   // Test configuration for accessor "Comsol"
   SolverInterface interfaceComsol ("Comsol", 0, 1);
-  slimConfig(interfaceComsol, filename);
+  slimConfigure(interfaceComsol, filename);
   BOOST_TEST(impl(interfaceComsol)._participants.size() == 2);
   BOOST_TEST(interfaceComsol.getDimensions() == 2);
 
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
     }
 
     SolverInterface couplingInterface(solverName, 0, 1);
-    slimConfig(couplingInterface, configurationFileName);
+    slimConfigure(couplingInterface, configurationFileName);
 
     //was necessary to replace pre-defined geometries
     if(solverName=="SolverOne" && couplingInterface.hasMesh("MeshOne")){
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface precice("SolverOne", 0, 1);
-    slimConfig(precice, _pathToTests + "explicit-mpi-single.xml");
+    slimConfigure(precice, _pathToTests + "explicit-mpi-single.xml");
 
     double maxDt = precice.initialize();
     int timestep = 0;
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface precice("SolverTwo", 0, 1);
-    slimConfig(precice, _pathToTests + "explicit-mpi-single.xml");
+    slimConfigure(precice, _pathToTests + "explicit-mpi-single.xml");
     int meshID = precice.getMeshID("Test-Square");
     precice.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
     precice.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
-    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single.xml");
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     /* int squareID = */ cplInterface.getMeshID("Test-Square");
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface cplInterface("SolverTwo", 0, 1);
-    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single.xml");
 
     int meshID = cplInterface.getMeshID("Test-Square");
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
-    slimConfig(cplInterface, _pathToTests + "explicit-data-init.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-data-init.xml");
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     cplInterface.setMeshVertex(meshOneID, Vector3d(1.0,2.0,3.0).data());
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface cplInterface("SolverTwo", 0, 1);
-    slimConfig(cplInterface, _pathToTests + "explicit-data-init.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-data-init.xml");
 
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
     Vector3d pos = Vector3d::Zero();
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
-    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     double maxDt = cplInterface.initialize();
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ) {
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    slimConfig(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
 
     int squareID = cplInterface.getMeshID("Test-Square");
     int forcesID = cplInterface.getDataID ( "Forces", squareID );
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
   if ( utils::Parallel::getProcessRank() == 0 ){
 
     SolverInterface couplingInterface("SolverOne", 0, 1);
-    slimConfig(couplingInterface, _pathToTests + "explicit-solvergeometry.xml");
+    slimConfigure(couplingInterface, _pathToTests + "explicit-solvergeometry.xml");
 
     //was necessary to replace pre-defined geometries
     int meshID = couplingInterface.getMeshID("MeshOne");
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ){
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    slimConfig(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
 
     BOOST_TEST(cplInterface.getDimensions() == 3);
     int meshID = cplInterface.getMeshID ( "SolverGeometry" );
@@ -572,7 +572,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDisplacingGeometry,
   if ( utils::Parallel::getProcessRank() == 0 ) { // SolverOne part
 
     SolverInterface cplInterface ( "SolverOne", 0, 1 );
-    slimConfig(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
 
     double dt = cplInterface.initialize();
 
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDisplacingGeometry,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ){
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    slimConfig(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
     int meshID = cplInterface.getMeshID("SolverGeometry");
     int i0 = cplInterface.setMeshVertex(meshID, zero.data());
     int i1 = cplInterface.setMeshVertex(meshID, one.data());
@@ -668,7 +668,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
   double dt;
   if ( utils::Parallel::getProcessRank() == 0 ) { // SolverOne part
     SolverInterface cplInterface ( "SolverOne", 0, 1 );
-    slimConfig(cplInterface, _pathToTests + "explicit-datascaling.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-datascaling.xml");
 
     BOOST_TEST ( cplInterface.getDimensions() == 2 );
 
@@ -695,7 +695,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
   }
   else if ( utils::Parallel::getProcessRank() == 1 ){
     SolverInterface cplInterface ( "SolverTwo", 0, 1 );
-    slimConfig(cplInterface, _pathToTests + "explicit-datascaling.xml");
+    slimConfigure(cplInterface, _pathToTests + "explicit-datascaling.xml");
 
     BOOST_TEST ( cplInterface.getDimensions() == 2 );
     dt = cplInterface.initialize();
@@ -734,7 +734,7 @@ BOOST_AUTO_TEST_CASE(testImplicit,
 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface couplingInterface("SolverOne", 0, 1);
-    slimConfig(couplingInterface, _pathToTests + "implicit.xml");
+    slimConfigure(couplingInterface, _pathToTests + "implicit.xml");
 
     int meshID = couplingInterface.getMeshID("Square");
     double pos[3];
@@ -772,7 +772,7 @@ BOOST_AUTO_TEST_CASE(testImplicit,
   }
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface couplingInterface("SolverTwo", 0, 1);
-    slimConfig(couplingInterface, _pathToTests + "implicit.xml");
+    slimConfigure(couplingInterface, _pathToTests + "implicit.xml");
 
     double maxDt = couplingInterface.initialize();
     while (couplingInterface.isCouplingOngoing()){
@@ -826,7 +826,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     SolverInterface interface(solverName, 0, 1);
-    slimConfig(interface, (dim == 2 ? config2D : config3D));
+    slimConfigure(interface, (dim == 2 ? config2D : config3D));
     BOOST_TEST(interface.getDimensions() == dim);
 
     std::vector<Eigen::VectorXd> positions;
@@ -989,7 +989,7 @@ BOOST_AUTO_TEST_CASE(testBug,
   std::string solverName = rank == 0 ? "Flite" : "Calculix";
   if (solverName == std::string("Flite")){
     SolverInterface precice("Flite", 0, 1);
-    slimConfig(precice, configName);
+    slimConfigure(precice, configName);
 
     int meshID = precice.getMeshID("FliteNodes");
     int forcesID = precice.getDataID("Forces", meshID);
@@ -1021,7 +1021,7 @@ BOOST_AUTO_TEST_CASE(testBug,
   else {
     BOOST_TEST(solverName == std::string("Calculix"), solverName);
     SolverInterface precice("Calculix", 0, 1);
-    slimConfig(precice, configName);
+    slimConfigure(precice, configName);
 
     int meshID = precice.getMeshID("CalculixNodes");
     for (Vector3d& coord : coords){
@@ -1094,7 +1094,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
 
     if (solverName == std::string("SolverOne")){
       SolverInterface precice(solverName, 0, 1);
-      slimConfig(precice, configs[k]);
+      slimConfigure(precice, configs[k]);
 
       int meshAID = precice.getMeshID("MeshA");
       int meshBID = precice.getMeshID("MeshB");
@@ -1122,7 +1122,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     }
     else if (solverName == std::string("SolverTwo")){
       SolverInterface precice(solverName, 0, 1);
-      slimConfig(precice, configs[k]);
+      slimConfigure(precice, configs[k]);
 
       int meshID = precice.getMeshID("MeshC");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
@@ -1149,7 +1149,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     else {
       BOOST_TEST(solverName == std::string("SolverThree"), solverName);
       SolverInterface precice(solverName, 0, 1);
-      slimConfig(precice, configs[k]);
+      slimConfigure(precice, configs[k]);
 
       int meshID = precice.getMeshID("MeshD");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
@@ -1222,7 +1222,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
     }
 
     SolverInterface precice(participant, 0, 1);
-    slimConfig(precice, _pathToTests + "/multi.xml");
+    slimConfigure(precice, _pathToTests + "/multi.xml");
     BOOST_TEST(precice.getDimensions() == 2);
 
     if (utils::Parallel::getProcessRank() == 0){
@@ -1281,7 +1281,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
   else {
     BOOST_TEST(utils::Parallel::getProcessRank() == 3);
     SolverInterface precice("NASTIN", 0, 1);
-    slimConfig(precice, _pathToTests + "/multi.xml");
+    slimConfigure(precice, _pathToTests + "/multi.xml");
     BOOST_TEST(precice.getDimensions() == 2);
     int meshID1 = precice.getMeshID("NASTIN_Mesh1");
     int meshID2 = precice.getMeshID("NASTIN_Mesh2");
@@ -1359,7 +1359,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
   if (utils::Parallel::getProcessRank() == 0){
     SolverInterface cplInterface("SolverOne", 0, 1);
     // namespace is required because we are outside the fixture
-    testing::SlimConfigurator::slimConfig(cplInterface, configFile);
+    testing::SlimConfigurator::slimConfigure(cplInterface, configFile);
     const int meshOneID = cplInterface.getMeshID("MeshOne");
 
     // Setup mesh one.
@@ -1403,7 +1403,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
   else if (utils::Parallel::getProcessRank() == 1){
     SolverInterface cplInterface("SolverTwo", 0, 1);
     // namespace is required because we are outside the fixture
-    testing::SlimConfigurator::slimConfig(cplInterface, configFile);
+    testing::SlimConfigurator::slimConfigure(cplInterface, configFile);
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
 
     // Setup receiving mesh.
@@ -1499,7 +1499,7 @@ BOOST_AUTO_TEST_CASE(testSendMeshToMultipleParticipants,
   }
 
   SolverInterface cplInterface(solverName, 0, 1);
-  slimConfig(cplInterface, configFile);
+  slimConfigure(cplInterface, configFile);
 
   const int meshID = cplInterface.getMeshID(meshName);
 
@@ -1543,7 +1543,7 @@ BOOST_AUTO_TEST_CASE(testPreconditionerBug,
   std::string meshName = utils::Parallel::getProcessRank() == 0 ? "MeshOne" : "MeshTwo";
 
   SolverInterface cplInterface(participantName, 0, 1);
-  slimConfig(cplInterface, configFile);
+  slimConfigure(cplInterface, configFile);
   const int meshID = cplInterface.getMeshID(meshName);
 
   Vector2d vertex{0.0, 0.0};

--- a/src/precice/tests/ServerTests.cpp
+++ b/src/precice/tests/ServerTests.cpp
@@ -48,8 +48,9 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
   std::string configFile = _pathToTests + "cplmode-1.xml";
   if ( rank == 0 ){
     SolverInterface interface("ParticipantA", 0, 1);
+    xml::ConfigurationContext context{"ParticipantA", 0, 1};
     config::Configuration config;
-    xml::configure(config.getXMLTag(), configFile);
+    xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
@@ -70,8 +71,9 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
   }
   else if ( rank == 1 ){
     SolverInterface interface("ParticipantB", 0, 1);
+    xml::ConfigurationContext context{"ParticipantB", 0, 1};
     config::Configuration config;
-    xml::configure(config.getXMLTag(), configFile);
+    xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
@@ -89,13 +91,14 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     BOOST_TEST (rank == 2, rank);
     bool isServer = true;
     impl::SolverInterfaceImpl server("ParticipantB", 0, 1, isServer);
+    xml::ConfigurationContext context{"ParticipantB", 0, 1};
 
     // Perform manual configuration without overwritting logging config
     mesh::Mesh::resetGeometryIDsGlobally();
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     config::Configuration config;
-    xml::configure ( config.getXMLTag(), configFile );
+    xml::configure ( config.getXMLTag(), context, configFile );
     server.configure ( config.getSolverInterfaceConfiguration() );
 
     server.runServer();
@@ -109,8 +112,9 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
   std::string configFile = _pathToTests + "cplmode-1.xml";
   if (rank == 0){
     SolverInterface interface("ParticipantA", 0, 1);
+    xml::ConfigurationContext context{"ParticipantA", 0, 1};
     config::Configuration config;
-    xml::configure(config.getXMLTag(), configFile);
+    xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
@@ -148,8 +152,9 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
   }
   else if ((rank == 1) || (rank == 2)){
     SolverInterface interface("ParticipantB", rank-1, 2);
+    xml::ConfigurationContext context{"ParticipantB", rank-1, 2};
     config::Configuration config;
-    xml::configure(config.getXMLTag(), configFile);
+    xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
     double time = 0.0;
     int timesteps = 0;
@@ -177,13 +182,14 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     BOOST_TEST(rank == 3, rank);
     bool isServer = true;
     impl::SolverInterfaceImpl server("ParticipantB", 0, 1, isServer);
+    xml::ConfigurationContext context{"ParticipantB", 0, 1};
 
     // Perform manual configuration without overwritting logging config
     mesh::Mesh::resetGeometryIDsGlobally();
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     config::Configuration config;
-    xml::configure(config.getXMLTag(), configFile);
+    xml::configure(config.getXMLTag(), context, configFile);
     server.configure(config.getSolverInterfaceConfiguration());
     server.runServer();
   }

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -220,7 +220,7 @@ struct SlimConfigurator : WhiteboxAccessor {
      * @param[in] configFilename The filename of the configuration file.
      */
     template<typename T>
-    static void slimConfig(T& interface, const std::string& configFilename) {
+    static void slimConfigure(T& interface, const std::string& configFilename) {
         auto & interfaceImpl = impl(interface);
         precice::xml::ConfigurationContext context{
             interfaceImpl.getAccessorName(),

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -3,6 +3,8 @@
 #include "math/math.hpp"
 #include "utils/Parallel.hpp"
 #include <boost/test/unit_test.hpp>
+#include "precice/config/Configuration.hpp"
+#include "xml/XMLTag.hpp"
 
 namespace precice
 {
@@ -206,6 +208,30 @@ struct WhiteboxAccessor {
     }
 };
 
+/// struct extending WhiteboxAccessor by a slim configuration call.
+struct SlimConfigurator : WhiteboxAccessor {
+    /** Configures the interface given a fileName in a slim and quiet manner.
+     *
+     * This first genenrates a ConfigurationContext from the SolverInterface.
+     * It then configures a config::Configuration using the context and the given file.
+     * Finally, it calls SolverInterface::configure with the configuration.
+     * 
+     * @param[in] interface The SolverInterface to configure.
+     * @param[in] configFilename The filename of the configuration file.
+     */
+    template<typename T>
+    static void slimConfig(T& interface, const std::string& configFilename) {
+        auto & interfaceImpl = impl(interface);
+        precice::xml::ConfigurationContext context{
+            interfaceImpl.getAccessorName(),
+            interfaceImpl.getAccessorProcessRank(),
+            interfaceImpl.getAccessorCommunicatorSize()
+        };
+        precice::config::Configuration config;
+        precice::xml::configure(config.getXMLTag(), context, configFilename);
+        interfaceImpl.configure(config.getSolverInterfaceConfiguration());
+    }
+};
 
 /// equals to be used in tests. Prints both operatorans on failure
 template <class DerivedA, class DerivedB>

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -212,7 +212,7 @@ struct WhiteboxAccessor {
 struct SlimConfigurator : WhiteboxAccessor {
     /** Configures the interface given a fileName in a slim and quiet manner.
      *
-     * This first genenrates a ConfigurationContext from the SolverInterface.
+     * This first generates a ConfigurationContext from the SolverInterface.
      * It then configures a config::Configuration using the context and the given file.
      * Finally, it calls SolverInterface::configure with the configuration.
      * 

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -128,7 +128,7 @@ int ConfigParser::readXmlFile(std::string const &filePath)
   return 0;
 }
 
-void ConfigParser::connectTags(std::vector<std::shared_ptr<XMLTag>> &DefTags, CTagPtrVec &SubTags)
+void ConfigParser::connectTags(const ConfigurationContext& context, std::vector<std::shared_ptr<XMLTag>> &DefTags, CTagPtrVec &SubTags)
 {
   std::vector<std::string> usedTags;
 
@@ -151,14 +151,14 @@ void ConfigParser::connectTags(std::vector<std::shared_ptr<XMLTag>> &DefTags, CT
 
         pDefSubTag->_configuredNamespaces[pDefSubTag->_namespace] = true;
         pDefSubTag->readAttributes(subtag->m_aAttributes);
-        pDefSubTag->_listener.xmlTagCallback(*pDefSubTag);
+        pDefSubTag->_listener.xmlTagCallback(context, *pDefSubTag);
         pDefSubTag->_configured = true;
 
-        connectTags(pDefSubTag->_subtags, subtag->m_aSubTags);
+        connectTags(context, pDefSubTag->_subtags, subtag->m_aSubTags);
 
         if (!pDefSubTag->_subtags.empty()) {
           pDefSubTag->areAllSubtagsConfigured();
-          pDefSubTag->_listener.xmlEndTagCallback(*pDefSubTag);
+          pDefSubTag->_listener.xmlEndTagCallback(context, *pDefSubTag);
         }
 
         break;

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -156,10 +156,8 @@ void ConfigParser::connectTags(const ConfigurationContext& context, std::vector<
 
         connectTags(context, pDefSubTag->_subtags, subtag->m_aSubTags);
 
-        if (!pDefSubTag->_subtags.empty()) {
-          pDefSubTag->areAllSubtagsConfigured();
-          pDefSubTag->_listener.xmlEndTagCallback(context, *pDefSubTag);
-        }
+        pDefSubTag->areAllSubtagsConfigured();
+        pDefSubTag->_listener.xmlEndTagCallback(context, *pDefSubTag);
 
         break;
       }

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -59,7 +59,7 @@ void OnCharacters(void *ctx, const xmlChar *ch, int len)
 
 precice::logging::Logger ConfigParser::_log("xml::XMLParser");
 
-ConfigParser::ConfigParser(const std::string &filePath, std::shared_ptr<precice::xml::XMLTag> pXmlTag)
+ConfigParser::ConfigParser(const std::string &filePath, const ConfigurationContext& context, std::shared_ptr<precice::xml::XMLTag> pXmlTag)
 {
   m_pXmlTag = pXmlTag;
   readXmlFile(filePath);
@@ -73,7 +73,7 @@ ConfigParser::ConfigParser(const std::string &filePath, std::shared_ptr<precice:
     SubTags.push_back(m_AllTags[0]);
 
   try {
-    connectTags(DefTags, SubTags);
+    connectTags(context, DefTags, SubTags);
   } catch (const std::string& error) {
     PRECICE_ERROR(error);
   }

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -40,7 +40,7 @@ private:
 
 public:
   /// Parser ctor for Callback init
-  ConfigParser(const std::string &filePath, std::shared_ptr<XMLTag> pXmlTag);
+  ConfigParser(const std::string &filePath, const ConfigurationContext& context, std::shared_ptr<XMLTag> pXmlTag);
 
   /// Parser ctor without Callbacks
   ConfigParser(const std::string &filePath);
@@ -53,7 +53,7 @@ public:
    * @param DefTags predefined tags
    * @param SubTags actual tags from xml file
    */
-  void connectTags(std::vector<std::shared_ptr<precice::xml::XMLTag>> &DefTags, CTagPtrVec &SubTags);
+  void connectTags(const ConfigurationContext& context, std::vector<std::shared_ptr<precice::xml::XMLTag>> &DefTags, CTagPtrVec &SubTags);
 
   /// Callback for Start-Tag
   void OnStartElement(

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -11,6 +11,7 @@ namespace precice
 namespace xml
 {
 class XMLTag; // forward declaration to resolve circular import
+struct ConfigurationContext;
 
 class ConfigParser
 {

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -518,6 +518,7 @@ XMLTag getRootTag()
 
 void configure(
     XMLTag &           tag,
+    const precice::xml::ConfigurationContext& context,
     const std::string &configurationFilename)
 {
   logging::Logger _log("xml");
@@ -526,7 +527,7 @@ void configure(
   NoPListener nopListener;
   XMLTag      root(nopListener, "", XMLTag::OCCUR_ONCE);
 
-  precice::xml::ConfigParser p(configurationFilename, std::make_shared<XMLTag>(tag));
+  precice::xml::ConfigParser p(configurationFilename, context, std::make_shared<XMLTag>(tag));
 
   root.addSubtag(tag);
 }

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -21,19 +21,19 @@ namespace precice
 namespace xml
 {
 
+/// Tightly coupled to the parameters of SolverInterface()
+struct ConfigurationContext {
+    std::string name;
+    int rank;
+    int size;
+};
+
 /// Represents an XML tag to be configured automatically.
 class XMLTag
 {
   friend class precice::xml::ConfigParser;
 
 public:
-  /// Tightly coupled to the parameters of SolverInterface()
-  struct ConfigurationContext {
-      std::string name;
-      int rank;
-      int size;
-  };
-
   /// Callback interface for configuration classes using XMLTag.
   struct Listener {
 
@@ -233,8 +233,8 @@ private:
 
 /// No operation listener for tests.
 struct NoPListener : public XMLTag::Listener {
-  void xmlTagCallback(XMLTag &callingTag) override {}
-  void xmlEndTagCallback(XMLTag &callingTag) override {}
+  void xmlTagCallback(ConfigurationContext const & context, XMLTag &callingTag) override {}
+  void xmlEndTagCallback(ConfigurationContext const & context, XMLTag &callingTag) override {}
 };
 
 /**
@@ -254,6 +254,7 @@ XMLTag getRootTag();
 /// Configures the given configuration from file configurationFilename.
 void configure(
     XMLTag &           tag,
+    const precice::xml::ConfigurationContext& context,
     const std::string &configurationFilename);
 
 }} // namespace precice, xml

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -27,6 +27,13 @@ class XMLTag
   friend class precice::xml::ConfigParser;
 
 public:
+  /// Tightly coupled to the parameters of SolverInterface()
+  struct ConfigurationContext {
+      std::string name;
+      int rank;
+      int size;
+  };
+
   /// Callback interface for configuration classes using XMLTag.
   struct Listener {
 
@@ -39,7 +46,7 @@ public:
      * At this callback, the attributes of the callingTag are already parsed and
      * available, while the subtags are not yet parsed.
      */
-    virtual void xmlTagCallback(XMLTag &callingTag) = 0;
+    virtual void xmlTagCallback(ConfigurationContext const& context, XMLTag &callingTag) = 0;
 
     /**
      * @brief Callback at end of XML tag and at end of subtag.
@@ -48,7 +55,7 @@ public:
      * This callback is first done for the listener, and then for the parent tag
      * listener (if existing).
      */
-    virtual void xmlEndTagCallback(XMLTag &callingTag) = 0;
+    virtual void xmlEndTagCallback(ConfigurationContext const& context, XMLTag &callingTag) = 0;
   };
 
   /// Types of occurrences of an XML tag.

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -16,7 +16,7 @@ struct CallbackHostAttr : public XMLTag::Listener {
   bool            boolValue;
   std::string     stringValue;
 
-  void xmlTagCallback(XMLTag &callingTag)
+  void xmlTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
   {
     if (callingTag.getName() == "test-double") {
       doubleValue = callingTag.getDoubleAttributeValue("attribute");
@@ -39,7 +39,7 @@ struct CallbackHostAttr : public XMLTag::Listener {
     }
   }
 
-  void xmlEndTagCallback(XMLTag &callingTag)
+  void xmlEndTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
   {
     std::ignore = callingTag;
   }
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(AttributeTypeTest)
 
   rootTag.addSubtag(testcaseTag);
 
-  configure(rootTag, filename);
+  configure(rootTag, ConfigurationContext{}, filename);
 
   BOOST_TEST(cb.boolValue == true);
   BOOST_TEST(cb.doubleValue == 3.1);
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(OccurenceTest)
 
   rootTag.addSubtag(testcaseTag);
 
-  configure(rootTag, filename);
+  configure(rootTag, ConfigurationContext{}, filename);
 }
 
 BOOST_AUTO_TEST_CASE(NamespaceTest)
@@ -138,7 +138,37 @@ BOOST_AUTO_TEST_CASE(NamespaceTest)
 
   rootTag.addSubtag(testcaseTag);
 
-  configure(rootTag, filename);
+  configure(rootTag, ConfigurationContext{}, filename);
+}
+
+struct ContextListener: public XMLTag::Listener {
+  ConfigurationContext startContext;
+  ConfigurationContext endContext;
+
+  void xmlTagCallback(const ConfigurationContext& context, XMLTag &callingTag)
+  {
+      startContext = context;
+  }
+
+  void xmlEndTagCallback(const ConfigurationContext& context, XMLTag &callingTag){
+      endContext = context;
+  }
+};
+
+BOOST_AUTO_TEST_CASE(Context)
+{
+  std::string filename(getPathToSources() + "/xml/tests/config_xmltest_context.xml");
+
+  ContextListener cl;
+  XMLTag          rootTag(cl, "configuration", XMLTag::OCCUR_ONCE);
+  ConfigurationContext context{"test", 12, 32};
+  configure(rootTag, context, filename);
+  BOOST_TEST(cl.startContext.name == "test");
+  BOOST_TEST(cl.startContext.rank == 12);
+  BOOST_TEST(cl.startContext.size == 32);
+  BOOST_TEST(cl.endContext.name == "test");
+  BOOST_TEST(cl.endContext.rank == 12);
+  BOOST_TEST(cl.endContext.size == 32);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/xml/tests/XMLTest.cpp
+++ b/src/xml/tests/XMLTest.cpp
@@ -12,14 +12,14 @@ BOOST_AUTO_TEST_SUITE(XML)
 struct CallbackHost : public XMLTag::Listener {
   Eigen::VectorXd eigenVectorXd;
 
-  void xmlTagCallback(XMLTag &callingTag)
+  void xmlTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
   {
     if (callingTag.getName() == "test-eigen-vectorxd-attributes") {
       eigenVectorXd = callingTag.getEigenVectorXdAttributeValue("value", 3);
     }
   }
 
-  void xmlEndTagCallback(XMLTag &callingTag)
+  void xmlEndTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
   {
     std::ignore = callingTag;
   }
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(AttributeConcatenation)
   testcaseTag.addSubtag(testTag);
   rootTag.addSubtag(testcaseTag);
 
-  configure(rootTag, filename);
+  configure(rootTag, ConfigurationContext{}, filename);
 }
 
 BOOST_AUTO_TEST_CASE(VectorAttributes)
@@ -55,10 +55,11 @@ BOOST_AUTO_TEST_CASE(VectorAttributes)
   testTagEigenXd.addAttribute(attrEigenXd);
   rootTag.addSubtag(testTagEigenXd);
 
-  configure(rootTag, filename);
+  configure(rootTag, ConfigurationContext{}, filename);
   BOOST_TEST(cb.eigenVectorXd(0) == 3.0);
   BOOST_TEST(cb.eigenVectorXd(1) == 2.0);
   BOOST_TEST(cb.eigenVectorXd(2) == 1.0);
 }
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/xml/tests/config_xmltest_context.xml
+++ b/src/xml/tests/config_xmltest_context.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+
+<configuration>
+</configuration>


### PR DESCRIPTION
The primary goal of this PR is to add the name, rank and com size as a context to the configuration.

The implementation passes an immutable context to the tag callbacks, which is passed to the entire tag-tree. The function `xml::configure()` now takes the context as an additional parameter.

As a direct consequence, the majority of our integration tests had to change.
For this reason I introduces a new test fixture `testing::SlimConfigurator` which builds a context from a solverinterface, generates the configuration and finally configures the solverinterface.
I also had to extend the interface of SolverInterfaceImpl to access the parameters passed to the constructor.
This reduces the verbosity of our test setup a lot!

I also added the test `XML/Context` which detected an old bug in the `ConfigParser` which lead to `Listener::xmlEndTagCallback()` never being called _if a tag is empty_.

_edit: clarified the bug_