### PR TITLE
delete copy and assign operator (C++11 feature)

### DIFF
--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -803,10 +803,10 @@ public:
 
   ///@}
 
-  /// Disable copy construction by making copy constructor private.
+  /// Disable copy construction 
   SolverInterface ( const SolverInterface& copy ) = delete;
 
-  /// Disable assignment construction by making assign. constructor private.
+  /// Disable assignment construction
   SolverInterface& operator= ( const SolverInterface& assign ) = delete;
 
 private:

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -803,16 +803,17 @@ public:
 
   ///@}
 
+  /// Disable copy construction by making copy constructor private.
+  SolverInterface ( const SolverInterface& copy ) = delete;
+
+  /// Disable assignment construction by making assign. constructor private.
+  SolverInterface& operator= ( const SolverInterface& assign ) = delete;
+
 private:
 
   /// Pointer to implementation of SolverInterface.
   std::unique_ptr<impl::SolverInterfaceImpl> _impl;
 
-  /// Disable copy construction by making copy constructor private.
-  SolverInterface ( const SolverInterface& copy );
-
-  /// Disable assignment construction by making assign. constructor private.
-  SolverInterface& operator= ( const SolverInterface& assign );
 
   // @brief To allow white box tests.
   friend struct testing::WhiteboxAccessor;


### PR DESCRIPTION
Hi,

Instead of making the copy and assignment operator private it would be more easy to read/understand and less error-prone to [delete these operators](https://docs.microsoft.com/en-us/cpp/cpp/explicitly-defaulted-and-deleted-functions?view=vs-2019). This is a C++11 feature thus it is easy to integrate as preCICE requires at least C++11.

It can avoid also compile/link errors if somebody still tries to use the operations (see [Stackoverflow](https://stackoverflow.com/questions/7823845/disable-compiler-generated-copy-assignment-operator)).

Best,
Alex