### PR TITLE
Fix XML Parser Messages not being handled

### DIFF
--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -35,9 +35,7 @@ private:
   CTagPtrVec m_CurrentTags;
 
   std::shared_ptr<precice::xml::XMLTag> m_pXmlTag;
-
-  static void GenericErrorFunc(void *ctx, const char *msg, ...);
-
+   
 public:
   /// Parser ctor for Callback init
   ConfigParser(const std::string &filePath, std::shared_ptr<XMLTag> pXmlTag);
@@ -64,8 +62,11 @@ public:
   /// Callback for End-Tag
   void OnEndElement();
 
-  // Callback for text sections in xml file
+  /// Callback for text sections in xml file
   void OnTextSection(std::string ch);
+
+  /// Proxy for error and warning messages from libxml2
+  static void MessageProxy(int level, const std::string& mess);
 };
 }
 }


### PR DESCRIPTION
This PR fixes a bug in the ConfigParser which results in it not handling messages from the libxml2 library.
I also added a filter to ignore all `Namespace` errors, as we abuse that feature.

The ConfigParser now throws an `ERROR` when the XML file is not formatted properly (e.g. forgot to close tags)

**Example** xml with missing closing `solver-interface` tag:
```
(0) 14:23:03 [xml::XMLParser]:105 in MessageProxy: ERROR: Opening and ending tag mismatch: solver-interface line 0 and precice-configuration
```