### PR TITLE
Fix assertion in getMeshVertexIDsFromPositions

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -742,7 +742,7 @@ void SolverInterfaceImpl:: getMeshVertexIDsFromPositions (
     mesh::PtrMesh mesh(context.mesh);
     PRECICE_DEBUG("Get IDs");
     const auto &vertices = mesh->vertices();
-    PRECICE_ASSERT(vertices.size() <= size, vertices.size(), size);
+    PRECICE_ASSERT(vertices.size() >= size, vertices.size(), size);
     Eigen::Map<const Eigen::MatrixXd> posMatrix{
         positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
     const auto vsize = vertices.size();

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -742,7 +742,6 @@ void SolverInterfaceImpl:: getMeshVertexIDsFromPositions (
     mesh::PtrMesh mesh(context.mesh);
     PRECICE_DEBUG("Get IDs");
     const auto &vertices = mesh->vertices();
-    PRECICE_ASSERT(vertices.size() >= size, vertices.size(), size);
     Eigen::Map<const Eigen::MatrixXd> posMatrix{
         positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
     const auto vsize = vertices.size();


### PR DESCRIPTION
`size` of the vertices where we request `vertexIDs` has to be `<=` the `size` of `mesh.vertices`. Not `>=`!