### PR TITLE
Set post-processing occurrence to OCCUR_ONCE

### DIFF
--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -86,7 +86,7 @@ void AccelerationConfiguration::connectTags(xml::XMLTag &parent)
   // static int recursionCounter = 0;
   // recursionCounter++;
 
-  XMLTag::Occurrence occ = XMLTag::OCCUR_NOT_OR_ONCE;
+  XMLTag::Occurrence occ = XMLTag::OCCUR_ONCE;
   std::list<XMLTag>  tags;
   {
     XMLTag tag(*this, VALUE_CONSTANT, occ, TAG);


### PR DESCRIPTION
Updated occurrence flag for 'post-processing' XML Tag in 
precice/src/acceleration/config/AccelerationConfiguration.cpp to OCCUR_ONCE

Fixes #524