### PR TITLE
Fix missing check for optional occurrence

### DIFF
--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -154,7 +154,7 @@ void ConfigParser::connectTags(const ConfigurationContext& context, std::vector<
         found = true;
         pDefSubTag->resetAttributes();
 
-        if (pDefSubTag->_occurrence == XMLTag::OCCUR_ONCE) {
+        if ((pDefSubTag->_occurrence == XMLTag::OCCUR_ONCE) || (pDefSubTag->_occurrence == XMLTag::OCCUR_NOT_OR_ONCE)) {
           if (std::find(usedTags.begin(), usedTags.end(), pDefSubTag->_fullName) != usedTags.end()) {
             PRECICE_ERROR("Tag <" + pDefSubTag->_fullName + "> is already used");
           }


### PR DESCRIPTION
This PR fixes a bug in the XML parser, which did check for multiple definitions of `OCCUR_ONCE`, but not `OCCUR_NOT_OR_ONCE`.

Special thanks to @huangq1234553 for exposing the bug!

Fixes #524 
Closes #558