### PR TITLE
Refactor xml package

### DIFF
--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -203,7 +203,7 @@ void ConfigParser::OnEndElement()
   m_CurrentTags.pop_back();
 }
 
-void ConfigParser::OnTextSection(std::string ch)
+void ConfigParser::OnTextSection(const std::string&)
 {
   // This page intentionally left blank
 }

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -26,14 +26,14 @@ void OnStartElementNs(
   for (int indexAttribute = 0; indexAttribute < nb_attributes; ++indexAttribute, index += 5) {
     std::string attributeName(reinterpret_cast<const char *>(attributes[index]));
 
-    const xmlChar *valueBegin = attributes[index + 3];
-    const xmlChar *valueEnd   = attributes[index + 4];
-    std::string    value((const char *) valueBegin, (const char *) valueEnd);
+    auto valueBegin = reinterpret_cast<const char*>(attributes[index + 3]);
+    auto valueEnd   = reinterpret_cast<const char*>(attributes[index + 4]);
+    std::string value(valueBegin, valueEnd);
 
     attributesMap[attributeName] = value;
   }
 
-  ConfigParser *pParser = static_cast<ConfigParser *>(ctx);
+  auto pParser = static_cast<ConfigParser *>(ctx);
 
   std::string sPrefix(prefix == nullptr ? "" : reinterpret_cast<const char *>(prefix));
 
@@ -73,13 +73,11 @@ void OnStructuredErrorFunc(void * userData, xmlError* error)
 precice::logging::Logger ConfigParser::_log("xml::XMLParser");
 
 ConfigParser::ConfigParser(const std::string &filePath, const ConfigurationContext& context, std::shared_ptr<precice::xml::XMLTag> pXmlTag)
+    :m_pXmlTag(std::move(pXmlTag))
 {
-  m_pXmlTag = pXmlTag;
   readXmlFile(filePath);
 
-  std::vector<std::shared_ptr<XMLTag>> DefTags;
-  DefTags.push_back(m_pXmlTag);
-
+  std::vector<std::shared_ptr<XMLTag>> DefTags{m_pXmlTag};
   CTagPtrVec SubTags;
   // Initialize with the root tag, if any.
   if (not m_AllTags.empty())

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -64,7 +64,7 @@ public:
   void OnEndElement();
 
   /// Callback for text sections in xml file
-  void OnTextSection(std::string ch);
+  void OnTextSection(const std::string& ch);
 
   /// Proxy for error and warning messages from libxml2
   static void MessageProxy(int level, const std::string& mess);

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -534,20 +534,21 @@ void configure(
 
 std::string XMLTag::getOccurrenceString(Occurrence occurrence) const
 {
-  if (occurrence == OCCUR_ARBITRARY) {
-    return std::string("0..*");
-  } else if (occurrence == OCCUR_NOT_OR_ONCE) {
-    return std::string("0..1");
-  } else if (occurrence == OCCUR_ONCE) {
-    return std::string("1");
-  } else if (occurrence == OCCUR_ONCE_OR_MORE) {
-    return std::string("1..*");
+  switch (occurrence) {
+  case OCCUR_ARBITRARY:
+    return "0..*";
+  case OCCUR_NOT_OR_ONCE:
+    return "0..1";
+  case OCCUR_ONCE:
+    return "1";
+  case OCCUR_ONCE_OR_MORE:
+    return "1..*";
+  default:
+    PRECICE_ASSERT(false, "Unknown occurrence type = " << occurrence);
+    return "";
   }
-  PRECICE_ERROR("Unknown occurrence type = " << occurrence);
-  return "";
 }
-}
-} // namespace precice, xml
+}} // namespace precice, xml
 
 //std::ostream& operator<<
 //(

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -8,13 +8,13 @@ namespace xml
 {
 
 XMLTag::XMLTag(
-    Listener &         listener,
-    const std::string &tagName,
-    Occurrence         occurrence,
-    const std::string &xmlNamespace)
+    Listener &  listener,
+    std::string tagName,
+    Occurrence  occurrence,
+    std::string xmlNamespace)
     : _listener(listener),
-      _name(tagName),
-      _namespace(xmlNamespace),
+      _name(std::move(tagName)),
+      _namespace(std::move(xmlNamespace)),
       _occurrence(occurrence)
 {
   if (not _namespace.empty()) {

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -317,7 +317,7 @@ void XMLTag::resetAttributes()
     pair.second.setRead(false);
   }
 
-  for (auto tag : _subtags) {
+  for (auto &tag : _subtags) {
     tag->_configured = false;
     tag->resetAttributes();
   }
@@ -389,7 +389,7 @@ std::string XMLTag::printDTD(const bool start) const
   }
 
   if (not _subtags.empty()) {
-    for (auto const subtag : _subtags) {
+    for (auto const &subtag : _subtags) {
       dtd << subtag->printDTD();
     }
   }
@@ -493,7 +493,7 @@ std::string XMLTag::printDocumentation(int indentation) const
 
   if (not _subtags.empty()) {
     doc << ">\n\n";
-    for (auto const subtag : _subtags) {
+    for (auto const &subtag : _subtags) {
       doc << subtag->printDocumentation(indentation + 3);
     }
     doc << indent << "</" << _fullName << ">\n\n";

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -346,20 +346,17 @@ std::string XMLTag::printDTD(const bool start) const
     dtd << "(";
 
     bool first = true;
-    for (auto const subtag : _subtags) {
-
-      std::string occurrenceChar = "";
-
-      Occurrence occ = subtag->getOccurrence();
-
-      if (occ == OCCUR_ARBITRARY)
-        occurrenceChar = "*";
-      else if (occ == OCCUR_NOT_OR_ONCE)
-        occurrenceChar = "?";
-      else if (occ == OCCUR_ONCE_OR_MORE)
-        occurrenceChar = "+";
-
-      dtd << (first ? "" : ", ") << subtag->getFullName() << occurrenceChar;
+    for (auto const &subtag : _subtags) {
+       dtd << (first ? "" : ", ") << subtag->getFullName();
+       switch(subtag->getOccurrence()) {
+           case OCCUR_ARBITRARY:
+               dtd << '*';
+           case OCCUR_NOT_OR_ONCE:
+               dtd << '?';
+           case OCCUR_ONCE_OR_MORE:
+               dtd << '+';
+            default:;
+       }
       first = false;
     }
 

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -76,10 +76,10 @@ public:
    * @param[in] xmlNamespace Defines a prefix/namespace for the tag. Tags with equal namespace or treated as group.
    */
   XMLTag(
-      Listener &         listener,
-      const std::string &name,
-      Occurrence         occurrence,
-      const std::string &xmlNamespace = "");
+      Listener &  listener,
+      std::string name,
+      Occurrence  occurrence,
+      std::string xmlNamespace = "");
 
   /**
    * @brief Adds a description of the purpose of this XML tag.


### PR DESCRIPTION
This PR refactors the XML package by:
* using more STL algorithms
* using `unordered_set` instead of `std::vector` + `std::find`
* removing complexity by restructuring the control flow
* using pass by val and move for strings