### PR TITLE
Speedup mesh operations

### DIFF
--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "mesh/Mesh.hpp"
+#include <boost/container/flat_map.hpp>
+
+namespace precice {
+namespace mesh {
+
+/** filters the source Mesh and adds it to the destination Mesh
+ * @param[inout] destination the destination mesh to append the filtered Mesh to
+ * @param[in] source the source Mesh to filter
+ * @param[in] p the filter as a UnaryPredicate on mesh::Vertex 
+ */
+template <typename UnaryPredicate>
+void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
+{
+  PRECICE_TRACE();
+
+  // Create a flat_map which can contain all vertices of the original mesh.
+  // This prevents resizes during the map build-up.
+  boost::container::flat_map<int, Vertex *> vertexMap;
+  vertexMap.reserve(source.vertices().size());
+
+  for (const Vertex &vertex : source.vertices()) {
+    if (p(vertex)) {
+      Vertex &v = destination.createVertex(vertex.getCoords());
+      v.setGlobalIndex(vertex.getGlobalIndex());
+      if (vertex.isTagged())
+        v.tag();
+      v.setOwner(vertex.isOwner());
+      vertexMap[vertex.getID()] = &v;
+    }
+  }
+
+  // Create a flat_map which can contain all edges of the original mesh.
+  // This prevents resizes during the map build-up.
+  boost::container::flat_map<int, Edge *> edgeMap;
+  edgeMap.reserve(source.edges().size());
+
+  // Add all edges formed by the contributing vertices
+  for (Edge &edge : source.edges()) {
+    int vertexIndex1 = edge.vertex(0).getID();
+    int vertexIndex2 = edge.vertex(1).getID();
+    if (vertexMap.count(vertexIndex1) == 1 &&
+        vertexMap.count(vertexIndex2) == 1) {
+      Edge &e         = destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
+      edgeMap[edge.getID()] = &e;
+    }
+  }
+
+  // Add all triangles formed by the contributing edges
+  if (source.getDimensions() == 3) {
+    for (Triangle &triangle : source.triangles()) {
+      int edgeIndex1 = triangle.edge(0).getID();
+      int edgeIndex2 = triangle.edge(1).getID();
+      int edgeIndex3 = triangle.edge(2).getID();
+      if (edgeMap.count(edgeIndex1) == 1 &&
+          edgeMap.count(edgeIndex2) == 1 &&
+          edgeMap.count(edgeIndex3) == 1) {
+        destination.createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
+      }
+    }
+  }
+}
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -14,8 +14,6 @@ namespace mesh {
 template <typename UnaryPredicate>
 void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
 {
-  PRECICE_TRACE();
-
   // Create a flat_map which can contain all vertices of the original mesh.
   // This prevents resizes during the map build-up.
   boost::container::flat_map<int, Vertex *> vertexMap;
@@ -38,7 +36,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
   edgeMap.reserve(source.edges().size());
 
   // Add all edges formed by the contributing vertices
-  for (Edge &edge : source.edges()) {
+  for (const Edge &edge : source.edges()) {
     int vertexIndex1 = edge.vertex(0).getID();
     int vertexIndex2 = edge.vertex(1).getID();
     if (vertexMap.count(vertexIndex1) == 1 &&
@@ -50,7 +48,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
 
   // Add all triangles formed by the contributing edges
   if (source.getDimensions() == 3) {
-    for (Triangle &triangle : source.triangles()) {
+    for (const Triangle &triangle : source.triangles()) {
       int edgeIndex1 = triangle.edge(0).getID();
       int edgeIndex2 = triangle.edge(1).getID();
       int edgeIndex3 = triangle.edge(2).getID();

--- a/src/partition/ReceivedBoundingBox.cpp
+++ b/src/partition/ReceivedBoundingBox.cpp
@@ -161,6 +161,10 @@ void ReceivedBoundingBox::compute()
 
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by bounding-box");  
   mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return isVertexInBB(v);});
+  PRECICE_DEBUG("Filtered mesh. #vertices: " << filteredMesh.vertices().size()
+          << ", #edges: " << filteredMesh.edges().size()
+          << ", #triangles: " << filteredMesh.triangles().size()
+          << ", rank: " << utils::MasterSlave::getRank());
     
   if ((_fromMapping.use_count() > 0 && _fromMapping->getOutputMesh()->vertices().size() > 0) ||
       (_toMapping.use_count() > 0 && _toMapping->getInputMesh()->vertices().size() > 0))
@@ -174,7 +178,10 @@ void ReceivedBoundingBox::compute()
       "of the decomposition strategy might be necessary.";
     //PRECICE_CHECK(filteredMesh.vertices().size() > 0, msg);
   }
-  PRECICE_DEBUG("Bounding box filter, filtered from " << _mesh->vertices().size() << " vertices to " << filteredMesh.vertices().size() << " vertices.");
+  PRECICE_DEBUG("Bounding box filter, filtered from "
+          << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+          << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+          << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
   _mesh->clear();
   _mesh->addMesh(filteredMesh);
   _mesh->computeState();
@@ -204,7 +211,10 @@ void ReceivedBoundingBox::compute()
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by mappings");
   filteredMesh.clear();
   mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return v.isTagged();});
-  PRECICE_DEBUG("Mapping filter, filtered from " << _mesh->vertices().size() << " vertices to " << filteredMesh.vertices().size() << " vertices.");
+  PRECICE_DEBUG("Mapping filter, filtered from "
+          << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+          << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+          << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
   _mesh->clear();
   _mesh->addMesh(filteredMesh);
   _mesh->computeState();

--- a/src/partition/ReceivedBoundingBox.cpp
+++ b/src/partition/ReceivedBoundingBox.cpp
@@ -9,6 +9,7 @@
 #include "mesh/Vertex.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Triangle.hpp"
+#include "mesh/Filter.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/MasterSlave.hpp"
 
@@ -154,13 +155,12 @@ void ReceivedBoundingBox::compute()
   
   // _mesh->buildBoundingBox();
   prepareBoundingBox();  
+  mesh::Mesh filteredMesh{"FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED};
   
   // (1) Bounding Box Filter
 
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by bounding-box");  
-  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
-  
-  filterMesh(filteredMesh, true);
+  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return isVertexInBB(v);});
     
   if ((_fromMapping.use_count() > 0 && _fromMapping->getOutputMesh()->vertices().size() > 0) ||
       (_toMapping.use_count() > 0 && _toMapping->getInputMesh()->vertices().size() > 0))
@@ -201,9 +201,9 @@ void ReceivedBoundingBox::compute()
   
   
   // (5) Filter mesh according to tag
-  filteredMesh.clear();
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by mappings");
-  filterMesh(filteredMesh, false);
+  filteredMesh.clear();
+  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return v.isTagged();});
   PRECICE_DEBUG("Mapping filter, filtered from " << _mesh->vertices().size() << " vertices to " << filteredMesh.vertices().size() << " vertices.");
   _mesh->clear();
   _mesh->addMesh(filteredMesh);
@@ -343,65 +343,6 @@ void ReceivedBoundingBox::prepareBoundingBox()
     _bb[d].first -= _safetyFactor * maxSideLength;
     PRECICE_DEBUG("Merged BoundingBox, dim: " << d << ", first: " << _bb[d].first << ", second: " << _bb[d].second);
   }
-}
-
-
-void ReceivedBoundingBox:: filterMesh(mesh::Mesh& filteredMesh, const bool filterByBB) {
-  PRECICE_TRACE(filterByBB);
-
-  PRECICE_DEBUG("Bounding mesh. #vertices: " << _mesh->vertices().size()
-               <<", #edges: " << _mesh->edges().size()
-               <<", #triangles: " << _mesh->triangles().size() << ", rank: " << utils::MasterSlave::getRank());
-
-  std::map<int, mesh::Vertex*> vertexMap;
-  std::map<int, mesh::Edge*> edgeMap;
-  int vertexCounter = 0;
-
-  for (const mesh::Vertex& vertex : _mesh->vertices())
-  {
-    if ((filterByBB && isVertexInBB(vertex)) || (not filterByBB && vertex.isTagged()))
-    {
-      mesh::Vertex& v = filteredMesh.createVertex(vertex.getCoords());
-      v.setGlobalIndex(vertex.getGlobalIndex());
-      if(vertex.isTagged()) v.tag();
-      v.setOwner(vertex.isOwner());
-      vertexMap[vertex.getID()] = &v;
-    }
-    vertexCounter++;
-  }
-
-  // Add all edges formed by the contributing vertices
-  for (mesh::Edge& edge : _mesh->edges())
-  {
-    int vertexIndex1 = edge.vertex(0).getID();
-    int vertexIndex2 = edge.vertex(1).getID();
-    if (utils::contained(vertexIndex1, vertexMap) &&
-        utils::contained(vertexIndex2, vertexMap)) {
-      mesh::Edge& e = filteredMesh.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
-      edgeMap[edge.getID()] = &e;
-    }
-  }
-
-  // Add all triangles formed by the contributing edges
-  if (_dimensions==3)
-  {
-    for (mesh::Triangle& triangle : _mesh->triangles() )
-    {
-      int edgeIndex1 = triangle.edge(0).getID();
-      int edgeIndex2 = triangle.edge(1).getID();
-      int edgeIndex3 = triangle.edge(2).getID();
-      if (utils::contained(edgeIndex1, edgeMap) &&
-          utils::contained(edgeIndex2, edgeMap) &&
-          utils::contained(edgeIndex3, edgeMap))
-      {
-        filteredMesh.createTriangle(*edgeMap[edgeIndex1],*edgeMap[edgeIndex2],*edgeMap[edgeIndex3]);
-      }
-    }
-  }
-
-  PRECICE_DEBUG("Filtered mesh. #vertices: " << filteredMesh.vertices().size()
-               <<", #edges: " << filteredMesh.edges().size()
-               <<", #triangles: " << filteredMesh.triangles().size() << ", rank: " << utils::MasterSlave::getRank());
 }
 
 bool ReceivedBoundingBox::isVertexInBB(const mesh::Vertex& vertex) {

--- a/src/partition/ReceivedBoundingBox.hpp
+++ b/src/partition/ReceivedBoundingBox.hpp
@@ -42,14 +42,6 @@ private:
 
   logging::Logger _log{"partition::ReceivedBoundingBox"};
 
-
-  /* Create filteredMesh from the filtered _mesh:
-   * Copies all vertices/edges/triangles that are either contained in the bounding box
-   * or tagged to the filteredMesh. Edges and triangles are copied, when ALL vertices
-   * are part of the filteredMesh i.e. their IDs are contained in vertexMap.
-   */
-  void filterMesh(mesh::Mesh &filteredMesh, const bool filterByBB);
-
   /// compares to bounding box and if they have intersection, returns true, otherwise flase!
   static bool overlapping(mesh::Mesh::BoundingBox const & currentBB, mesh::Mesh::BoundingBox const & receivedBB);
 

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -124,7 +124,10 @@ void ReceivedPartition::compute()
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
       _mesh->computeState();
-      PRECICE_DEBUG("Master mesh after filtering, #vertices " << _mesh->vertices().size());
+      PRECICE_DEBUG("Master mesh, filtered from "
+              << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+              << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+              << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
 
       if(areProvidedMeshesEmpty()) {
         std::string msg = "The re-partitioning completely filtered out the mesh " + _mesh->getName() + " received on this rank at the coupling interface. "
@@ -167,7 +170,11 @@ void ReceivedPartition::compute()
         PRECICE_CHECK(not filteredMesh.vertices().empty(), msg);
       }
 
-      PRECICE_DEBUG("Bounding box filter, filtered from " << _mesh->vertices().size() << " vertices to " << filteredMesh.vertices().size() << " vertices.");
+      PRECICE_DEBUG("Bounding box filter, filtered from "
+              << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+              << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+              << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
+
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
       _mesh->computeState();
@@ -201,7 +208,11 @@ void ReceivedPartition::compute()
   Event e5("partition.filterMeshMappings" + _mesh->getName(), precice::syncMode);
   mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
   mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return v.isTagged();});
-  PRECICE_DEBUG("Mapping filter, filtered from " << _mesh->vertices().size() << " vertices to " << filteredMesh.vertices().size() << " vertices.");
+  PRECICE_DEBUG("Mapping filter, filtered from "
+          << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+          << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+          << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
+
   _mesh->clear();
   _mesh->addMesh(filteredMesh);
   _mesh->computeState();

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -42,14 +42,6 @@ public:
   virtual void compute() override;
 
 private:
-  /// Create filteredMesh from the filtered _mesh.
-  /*
-   * Copies all vertices/edges/triangles that are either contained in the bounding box
-   * or tagged to the filteredMesh. Edges and triangles are copied, when ALL vertices
-   * are part of the filteredMesh i.e. their IDs are contained in vertexMap.
-   */
-  void filterMesh(mesh::Mesh &filteredMesh, const bool filterByBB);
-  
   /// Sets _bb to the union with the mesh from fromMapping resp. toMapping, also enlage by _safetyFactor
   void prepareBoundingBox();
 

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -182,6 +182,7 @@ target_sources(precice
     src/mesh/Data.hpp
     src/mesh/Edge.cpp
     src/mesh/Edge.hpp
+    src/mesh/Filter.hpp
     src/mesh/Mesh.cpp
     src/mesh/Mesh.hpp
     src/mesh/Quad.cpp


### PR DESCRIPTION
This PR speeds-up the operations on meshes by migrating the maps to flat_maps, preventing them to resize and by moving some code around.
I also took the liberty to refactor the `filteredMesh` out of the partition classes and put it into `mesh/Filter.hpp`. This is now templated on the UnaryPredicate used to filter vertices.

This reduces the runtime of these functions for large Meshes ~500000 vertices by 1/3.

Current downside is that we loose the debug output at the beginning and the end of the original `filteredMesh`.

Reviewers: Do we have to keep the debug output?
_update: The output is usefull, so I added it at the call-side_