### PR TITLE
Refactor meshids

### DIFF
--- a/src/acceleration/test/AccelerationMasterSlaveTest.cpp
+++ b/src/acceleration/test/AccelerationMasterSlaveTest.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
   std::vector<int> vertexOffsets {4, 8, 8 , 10};
 
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
   std::vector<int> vertexOffsets {4, 8, 8 , 10};
 
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()) );
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
   PtrPreconditioner _preconditioner = PtrPreconditioner (new ResidualSumPreconditioner(-1));
   std::vector<int> vertexOffsets {0, 11, 22, 22};
 
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("dummyMesh", 2, false, testing::meshIDManager()) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("dummyMesh", 2, false, testing::nextMeshID()) );
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,

--- a/src/acceleration/test/AccelerationMasterSlaveTest.cpp
+++ b/src/acceleration/test/AccelerationMasterSlaveTest.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
   std::vector<int> vertexOffsets {4, 8, 8 , 10};
 
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
   std::vector<int> vertexOffsets {4, 8, 8 , 10};
 
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()) );
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
   PtrPreconditioner _preconditioner = PtrPreconditioner (new ResidualSumPreconditioner(-1));
   std::vector<int> vertexOffsets {0, 11, 22, 22};
 
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("dummyMesh", 2, false) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("dummyMesh", 2, false, testing::meshIDManager()) );
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,

--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_SUITE(Python, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(AllMethods)
 {
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
   mesh->createVertex(Eigen::Vector3d::Constant(1.0));
   mesh->createVertex(Eigen::Vector3d::Constant(2.0));
   mesh->createVertex(Eigen::Vector3d::Constant(3.0));
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
     action.performAction(0.0, 0.0, 0.0, 0.0);
   }
   {
-    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false));
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
     mesh->createVertex(Eigen::Vector3d::Zero());
     mesh::PtrData data = mesh->createData("TargetData", 1);
     mesh->allocateDataValues();
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
     action.performAction(0.0, 0.0, 0.0, 0.0);
   }
   {
-    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false));
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
     mesh->createVertex(Eigen::Vector3d::Zero());
     mesh::PtrData data = mesh->createData("SourceData", 1);
     mesh->allocateDataValues();

--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_SUITE(Python, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(AllMethods)
 {
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector3d::Constant(1.0));
   mesh->createVertex(Eigen::Vector3d::Constant(2.0));
   mesh->createVertex(Eigen::Vector3d::Constant(3.0));
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
     action.performAction(0.0, 0.0, 0.0, 0.0);
   }
   {
-    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
     mesh::PtrData data = mesh->createData("TargetData", 1);
     mesh->allocateDataValues();
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
     action.performAction(0.0, 0.0, 0.0, 0.0);
   }
   {
-    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
     mesh::PtrData data = mesh->createData("SourceData", 1);
     mesh->allocateDataValues();

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(Scale, *testing::OnMaster())
 BOOST_AUTO_TEST_CASE(DivideByArea)
 {
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 2, true, testing::meshIDManager()));
+  PtrMesh mesh(new Mesh("Mesh", 2, true, testing::nextMeshID()));
   PtrData data   = mesh->createData("test-data", 1);
   int     dataID = data->getID();
   Vertex &v0     = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(DivideByArea)
 BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepLength)
 {
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::meshIDManager()));
+  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::nextMeshID()));
   PtrData sourceData   = mesh->createData("SourceData", 1);
   PtrData targetData   = mesh->createData("TargetData", 1);
   int     sourceDataID = sourceData->getID();
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepLength)
 BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepPartLength)
 {
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::meshIDManager()));
+  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::nextMeshID()));
   PtrData sourceData   = mesh->createData("SourceData", 1);
   PtrData targetData   = mesh->createData("TargetData", 1);
   int     sourceDataID = sourceData->getID();

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(Scale, *testing::OnMaster())
 BOOST_AUTO_TEST_CASE(DivideByArea)
 {
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 2, true));
+  PtrMesh mesh(new Mesh("Mesh", 2, true, testing::meshIDManager()));
   PtrData data   = mesh->createData("test-data", 1);
   int     dataID = data->getID();
   Vertex &v0     = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(DivideByArea)
 BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepLength)
 {
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 3, true));
+  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::meshIDManager()));
   PtrData sourceData   = mesh->createData("SourceData", 1);
   PtrData targetData   = mesh->createData("TargetData", 1);
   int     sourceDataID = sourceData->getID();
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepLength)
 BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepPartLength)
 {
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 3, true));
+  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::meshIDManager()));
   PtrData sourceData   = mesh->createData("SourceData", 1);
   PtrData targetData   = mesh->createData("TargetData", 1);
   int     sourceDataID = sourceData->getID();

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
   std::string participant1("rank1");
 
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::meshIDManager());
+    mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
     mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
     mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
         comMesh.sendMesh(sendMesh, 0);
       } else if (utils::Parallel::getProcessRank() == 1) {
         // receiveMesh can also deal with delta meshes
-        mesh::Mesh recvMesh("Received Mesh", dim, false, testing::meshIDManager());        
+        mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());        
         recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
         utils::Parallel::splitCommunicator(participant1);
         com->requestConnection(participant0, participant1, 0, 1);
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
   std::string participant1("rank1");
 
   int dim = 3;
-  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::meshIDManager());
+  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
   mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
   mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
   mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
       com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
       comMesh.sendMesh(sendMesh, 0);
     } else if (utils::Parallel::getProcessRank() == 1) {
-      mesh::Mesh recvMesh("Received Mesh", dim, false, testing::meshIDManager());
+      mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
       // receiveMesh can also deal with delta meshes
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       utils::Parallel::splitCommunicator(participant1);
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
   std::string participant1("rank1");
 
   int dim = 3;
-  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::meshIDManager());
+  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
   mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
   mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
   mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
       com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
       comMesh.broadcastSendMesh(sendMesh);
       } else if (utils::Parallel::getProcessRank() == 1) {
-      mesh::Mesh recvMesh("Received Mesh", dim, false, testing::meshIDManager());
+      mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
       // receiveMesh can also deal with delta meshes
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       utils::Parallel::splitCommunicator(participant1);

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
   std::string participant1("rank1");
 
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh sendMesh("Sent Mesh", dim, false);
+    mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::meshIDManager());
     mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
     mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
         comMesh.sendMesh(sendMesh, 0);
       } else if (utils::Parallel::getProcessRank() == 1) {
         // receiveMesh can also deal with delta meshes
-        mesh::Mesh recvMesh("Received Mesh", dim, false);        
+        mesh::Mesh recvMesh("Received Mesh", dim, false, testing::meshIDManager());        
         recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
         utils::Parallel::splitCommunicator(participant1);
         com->requestConnection(participant0, participant1, 0, 1);
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
   std::string participant1("rank1");
 
   int dim = 3;
-  mesh::Mesh sendMesh("Sent Mesh", dim, false);
+  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::meshIDManager());
   mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
   mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
   mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
       com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
       comMesh.sendMesh(sendMesh, 0);
     } else if (utils::Parallel::getProcessRank() == 1) {
-      mesh::Mesh recvMesh("Received Mesh", dim, false);
+      mesh::Mesh recvMesh("Received Mesh", dim, false, testing::meshIDManager());
       // receiveMesh can also deal with delta meshes
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       utils::Parallel::splitCommunicator(participant1);
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
   std::string participant1("rank1");
 
   int dim = 3;
-  mesh::Mesh sendMesh("Sent Mesh", dim, false);
+  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::meshIDManager());
   mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
   mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
   mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
       com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
       comMesh.broadcastSendMesh(sendMesh);
       } else if (utils::Parallel::getProcessRank() == 1) {
-      mesh::Mesh recvMesh("Received Mesh", dim, false);
+      mesh::Mesh recvMesh("Received Mesh", dim, false, testing::meshIDManager());
       // receiveMesh can also deal with delta meshes
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       utils::Parallel::splitCommunicator(participant1);

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -285,7 +285,7 @@ BOOST_FIXTURE_TEST_CASE(testSimpleExplicitCoupling, testing::M2NFixture,
   dataConfig->addData ( "Data0", 1 );
   dataConfig->addData ( "Data1", 3 );
   mesh::MeshConfiguration meshConfig ( root, dataConfig );
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()) );
+  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()) );
   mesh->createData ( "Data0", 1 );
   mesh->createData ( "Data1", 3 );
   mesh->createVertex ( Eigen::Vector3d::Zero() );
@@ -636,7 +636,7 @@ BOOST_FIXTURE_TEST_CASE(testExplicitCouplingWithSubcycling, testing::M2NFixture,
   dataConfig->addData ( "Data1", 3 );
   mesh::MeshConfiguration meshConfig ( root, dataConfig );
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()) );
+  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()) );
   mesh->createData ( "Data0", 1 );
   mesh->createData ( "Data1", 3 );
   mesh->createVertex ( Eigen::Vector3d::Zero() );

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -285,7 +285,7 @@ BOOST_FIXTURE_TEST_CASE(testSimpleExplicitCoupling, testing::M2NFixture,
   dataConfig->addData ( "Data0", 1 );
   dataConfig->addData ( "Data1", 3 );
   mesh::MeshConfiguration meshConfig ( root, dataConfig );
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false) );
+  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()) );
   mesh->createData ( "Data0", 1 );
   mesh->createData ( "Data1", 3 );
   mesh->createVertex ( Eigen::Vector3d::Zero() );
@@ -636,7 +636,7 @@ BOOST_FIXTURE_TEST_CASE(testExplicitCouplingWithSubcycling, testing::M2NFixture,
   dataConfig->addData ( "Data1", 3 );
   mesh::MeshConfiguration meshConfig ( root, dataConfig );
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false) );
+  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()) );
   mesh->createData ( "Data0", 1 );
   mesh->createData ( "Data1", 3 );
   mesh->createVertex ( Eigen::Vector3d::Zero() );

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   std::vector<double> factors;
   factors.resize(2,1.0);
   acceleration::impl::PtrPreconditioner prec(new acceleration::impl::ConstantPreconditioner(factors));
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()) );
 
 
   acceleration::MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   std::map<int, double> scalings;
   scalings.insert(std::make_pair(0,1.0));
   scalings.insert(std::make_pair(1,1.0));
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()) );
 
   acceleration::IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
       timestepsReused, filter, singularityLimit, dataIDs, prec);
@@ -281,7 +281,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
   const auto dataID0 = mesh->createData("Data0", 1)->getID();
   const auto dataID1 = mesh->createData("Data1", 3)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   std::vector<double> factors;
   factors.resize(2,1.0);
   acceleration::impl::PtrPreconditioner prec(new acceleration::impl::ConstantPreconditioner(factors));
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()) );
 
 
   acceleration::MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   std::map<int, double> scalings;
   scalings.insert(std::make_pair(0,1.0));
   scalings.insert(std::make_pair(1,1.0));
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false) );
+  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::meshIDManager()) );
 
   acceleration::IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
       timestepsReused, filter, singularityLimit, dataIDs, prec);
@@ -281,7 +281,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
   const auto dataID0 = mesh->createData("Data0", 1)->getID();
   const auto dataID1 = mesh->createData("Data1", 3)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
 {
   using namespace mesh;
 
-  PtrMesh mesh(new Mesh("MyMesh", 3, false));
+  PtrMesh mesh(new Mesh("MyMesh", 3, false, testing::meshIDManager()));
   PtrData data = mesh->createData("MyData", 1);
   int dataID = data->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -526,7 +526,7 @@ BOOST_FIXTURE_TEST_CASE(testAbsConvergenceMeasureSynchronized, testing::M2NFixtu
 
   MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new Mesh("Mesh", 3, false));
+  mesh::PtrMesh mesh(new Mesh("Mesh", 3, false, testing::meshIDManager()));
   mesh->createData("data0", 1);
   mesh->createData("data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -637,7 +637,7 @@ BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronized, testing::M2NF
 
   mesh::MeshConfiguration meshConfig (root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh (new mesh::Mesh("Mesh", 3, false));
+  mesh::PtrMesh mesh (new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
   mesh->createData ("data0", 1);
   mesh->createData ("data1", 3);
   mesh->createVertex (Eigen::Vector3d::Zero());
@@ -699,7 +699,7 @@ BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling,
 
   mesh::MeshConfiguration meshConfig ( root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false));
+  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
   mesh->createData ( "data0", 1);
   mesh->createData ( "data1", 3);
   mesh->createVertex ( Eigen::Vector3d::Zero());
@@ -764,7 +764,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
   const auto dataID0 = mesh->createData("Data0", 1)->getID();
   const auto dataID1 = mesh->createData("Data1", 3)->getID();;
   mesh->createVertex(Eigen::Vector3d::Zero());

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
 {
   using namespace mesh;
 
-  PtrMesh mesh(new Mesh("MyMesh", 3, false, testing::meshIDManager()));
+  PtrMesh mesh(new Mesh("MyMesh", 3, false, testing::nextMeshID()));
   PtrData data = mesh->createData("MyData", 1);
   int dataID = data->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -526,7 +526,7 @@ BOOST_FIXTURE_TEST_CASE(testAbsConvergenceMeasureSynchronized, testing::M2NFixtu
 
   MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new Mesh("Mesh", 3, false, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new Mesh("Mesh", 3, false, testing::nextMeshID()));
   mesh->createData("data0", 1);
   mesh->createData("data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -637,7 +637,7 @@ BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronized, testing::M2NF
 
   mesh::MeshConfiguration meshConfig (root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh (new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
+  mesh::PtrMesh mesh (new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
   mesh->createData ("data0", 1);
   mesh->createData ("data1", 3);
   mesh->createVertex (Eigen::Vector3d::Zero());
@@ -699,7 +699,7 @@ BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling,
 
   mesh::MeshConfiguration meshConfig ( root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
+  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
   mesh->createData ( "data0", 1);
   mesh->createData ( "data1", 3);
   mesh->createVertex ( Eigen::Vector3d::Zero());
@@ -764,7 +764,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
   const auto dataID0 = mesh->createData("Data0", 1)->getID();
   const auto dataID1 = mesh->createData("Data1", 3)->getID();;
   mesh->createVertex(Eigen::Vector3d::Zero());

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   int             dim           = 2;
   bool            invertNormals = false;
-  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
+  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Constant(dim, 0.0);
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   int             dim           = 3;
   bool            invertNormals = false;
-  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
+  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(ExportQuadMesh)
   using namespace mesh;
   int  dim           = 3;
   bool invertNormals = false;
-  mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::meshIDManager());
+  mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::nextMeshID());
   // z=0 plane
   Vertex &v0 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   Vertex &v1 = mesh.createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   int             dim           = 2;
   bool            invertNormals = false;
-  mesh::Mesh      mesh("MyMesh", dim, invertNormals);
+  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Constant(dim, 0.0);
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   int             dim           = 3;
   bool            invertNormals = false;
-  mesh::Mesh      mesh("MyMesh", dim, invertNormals);
+  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(ExportQuadMesh)
   using namespace mesh;
   int  dim           = 3;
   bool invertNormals = false;
-  Mesh mesh("QuadMesh", dim, invertNormals);
+  mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::meshIDManager());
   // z=0 plane
   Vertex &v0 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   Vertex &v1 = mesh.createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   int        dim           = 2;
   bool       invertNormals = false;
-  mesh::Mesh mesh("MyMesh", dim, invertNormals);
+  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   int        dim           = 3;
   bool       invertNormals = false;
-  mesh::Mesh mesh("MyMesh", dim, invertNormals);
+  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(ExportQuadMesh)
   using namespace mesh;
   int  dim           = 3;
   bool invertNormals = false;
-  Mesh mesh("QuadMesh", dim, invertNormals);
+  mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::meshIDManager());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh.getVertexDistribution()[0] = {};

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   int        dim           = 2;
   bool       invertNormals = false;
-  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
+  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   int        dim           = 3;
   bool       invertNormals = false;
-  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::meshIDManager());
+  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(ExportQuadMesh)
   using namespace mesh;
   int  dim           = 3;
   bool invertNormals = false;
-  mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::meshIDManager());
+  mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh.getVertexDistribution()[0] = {};

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest, *testing::OnSize(4))
   Eigen::VectorXd offset           = Eigen::VectorXd::Zero(dimensions);
 
   if (utils::Parallel::getProcessRank() == 0) { // Part1
-    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
     m2n->createDistributedCommunication(pMesh);
     m2n->acceptSlavesConnection("Part1", "Part2Master");
     Eigen::VectorXd values = Eigen::VectorXd::Zero(numberOfVertices);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest, *testing::OnSize(4))
     BOOST_TEST(values[5] == 12.0);
 
   } else {
-    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
     m2n->createDistributedCommunication(pMesh);
     m2n->requestSlavesConnection("Part1", "Part2Master");
 

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest, *testing::OnSize(4))
   Eigen::VectorXd offset           = Eigen::VectorXd::Zero(dimensions);
 
   if (utils::Parallel::getProcessRank() == 0) { // Part1
-    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals));
+    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
     m2n->createDistributedCommunication(pMesh);
     m2n->acceptSlavesConnection("Part1", "Part2Master");
     Eigen::VectorXd values = Eigen::VectorXd::Zero(numberOfVertices);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest, *testing::OnSize(4))
     BOOST_TEST(values[5] == 12.0);
 
   } else {
-    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals));
+    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
     m2n->createDistributedCommunication(pMesh);
     m2n->requestSlavesConnection("Part1", "Part2Master");
 

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -32,7 +32,7 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
 
   MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
 
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::nextMeshID()));
 
   m2n::PointToPointCommunication c(cf, mesh);
 
@@ -147,7 +147,7 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
 
   MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
 
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::nextMeshID()));
 
   m2n::PointToPointCommunication c(cf, mesh);
 
@@ -259,7 +259,7 @@ void connectionTest(com::PtrCommunicationFactory cf)
   
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));  
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));  
 
   std::vector<std::string> conections = {"same", "cross"};
 
@@ -392,7 +392,7 @@ void emptyConnectionTest(com::PtrCommunicationFactory cf)
   
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
 
   utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
   
@@ -477,7 +477,7 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
   
   switch (utils::Parallel::getProcessRank()) {
   case 0: {
@@ -582,7 +582,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
 
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager())); 
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID())); 
   const auto expectedId = mesh->getID();
   std::map<int, std::vector<int>> localCommunicationMap;
 

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -583,6 +583,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   int dimensions = 2;
   bool flipNormals = false;
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager())); 
+  const auto expectedId = mesh->getID();
   std::map<int, std::vector<int>> localCommunicationMap;
 
   switch (utils::Parallel::getProcessRank()) {
@@ -648,13 +649,13 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   
     c.requestPreConnection("Solid", "Fluid");
     c.broadcastSendLCM(localCommunicationMap);
-    BOOST_TEST(mesh->getID()==0);
+    BOOST_TEST(mesh->getID()==expectedId);
    
   } else
   {
     c.acceptPreConnection("Solid", "Fluid");
     c.broadcastReceiveLCM(localCommunicationMap);
-    BOOST_TEST(mesh->getID()==0);
+    BOOST_TEST(mesh->getID()==expectedId);
   }
 
  if(utils::Parallel::getProcessRank() == 2 )

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -32,7 +32,7 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
 
   MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
 
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::meshIDManager()));
 
   m2n::PointToPointCommunication c(cf, mesh);
 
@@ -147,7 +147,7 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
 
   MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
 
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::meshIDManager()));
 
   m2n::PointToPointCommunication c(cf, mesh);
 
@@ -259,7 +259,7 @@ void connectionTest(com::PtrCommunicationFactory cf)
   
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals));  
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));  
 
   std::vector<std::string> conections = {"same", "cross"};
 
@@ -380,7 +380,6 @@ void connectionTest(com::PtrCommunicationFactory cf)
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());  
   }
@@ -393,7 +392,7 @@ void emptyConnectionTest(com::PtrCommunicationFactory cf)
   
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
 
   utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
   
@@ -467,7 +466,6 @@ void emptyConnectionTest(com::PtrCommunicationFactory cf)
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());   
 }
@@ -479,7 +477,7 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager()));
   
   switch (utils::Parallel::getProcessRank()) {
   case 0: {
@@ -573,7 +571,6 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());  
 }
@@ -585,7 +582,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
 
   int dimensions = 2;
   bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals)); 
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::meshIDManager())); 
   std::map<int, std::vector<int>> localCommunicationMap;
 
   switch (utils::Parallel::getProcessRank()) {
@@ -685,7 +682,6 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());  
 }

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   using testing::equals;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::meshIDManager()));
   PtrData inDataScalar = inMesh->createData("InDataScalar", 1);
   PtrData inDataVector = inMesh->createData("InDataVector", 2);
   int inDataScalarID = inDataScalar->getID();
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   inValuesVector << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   PtrData outDataScalar = outMesh->createData("OutDataScalar", 1);
   PtrData outDataVector = outMesh->createData("OutDataVector", 2);
   int outDataScalarID = outDataScalar->getID();
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::meshIDManager()));
   PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   Vertex& inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   inValues(1) = 2.0;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   Vertex& outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   using testing::equals;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::meshIDManager()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   PtrData inDataScalar = inMesh->createData("InDataScalar", 1);
   PtrData inDataVector = inMesh->createData("InDataVector", 2);
   int inDataScalarID = inDataScalar->getID();
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   inValuesVector << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outDataScalar = outMesh->createData("OutDataScalar", 1);
   PtrData outDataVector = outMesh->createData("OutDataVector", 2);
   int outDataScalarID = outDataScalar->getID();
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::meshIDManager()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   Vertex& inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   inValues(1) = 2.0;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   Vertex& outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   int dimensions = 2;
 
   // Setup geometry to map to
-  PtrMesh outMesh ( new Mesh("OutMesh", dimensions, true, testing::meshIDManager()) );
+  PtrMesh outMesh ( new Mesh("OutMesh", dimensions, true, testing::nextMeshID()) );
   PtrData outData = outMesh->createData ( "Data", 1 );
   int outDataID = outData->getID();
   Vertex& v1 = outMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   {
       // Setup mapping with mapping coordinates and geometry used
       mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-      PtrMesh inMesh ( new Mesh("InMesh0", dimensions, false, testing::meshIDManager()) );
+      PtrMesh inMesh ( new Mesh("InMesh0", dimensions, false, testing::nextMeshID()) );
       PtrData inData = inMesh->createData ( "Data0", 1 );
       int inDataID = inData->getID();
 
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   {
       // Setup mapping with mapping coordinates and geometry used
       mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-      PtrMesh inMesh ( new Mesh("InMesh1", dimensions, false, testing::meshIDManager()) );
+      PtrMesh inMesh ( new Mesh("InMesh1", dimensions, false, testing::nextMeshID()) );
       PtrData inData = inMesh->createData ( "Data1", 1 );
       int inDataID = inData->getID();
 
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   Vertex& v1 = inMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh0", dimensions, false, testing::meshIDManager()) );
+      PtrMesh outMesh ( new Mesh("OutMesh0", dimensions, false, testing::nextMeshID()) );
       PtrData outData = outMesh->createData ( "OutData", 1 );
       int outDataID = outData->getID();
 
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::meshIDManager()) );
+      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()) );
       PtrData outData = outMesh->createData ( "OutData", 1 );
       int outDataID = outData->getID();
 
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   int dimensions = 3;
 
   // Create mesh to map from
-  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   Vertex& v1 = inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
 
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::meshIDManager()) );
+      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()) );
       PtrData outData = outMesh->createData ( "OutData1", 1 );
       int outDataID = outData->getID();
 
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   }
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh2", dimensions, false, testing::meshIDManager()) );
+      PtrMesh outMesh ( new Mesh("OutMesh2", dimensions, false, testing::nextMeshID()) );
       PtrData outData = outMesh->createData ( "OutData2", 1 );
       int outDataID = outData->getID();
 
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
     int dimensions = 3;
 
     // Create mesh to map from
-    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
     PtrData inData = inMesh->createData ( "InData", 1 );
     int inDataID = inData->getID ();
     Vertex& v1 = inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
     values(2) = valueVertex3;
 
     // Create mesh to map to
-    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
     PtrData outData = outMesh->createData ( "OutData", 1 );
     int outDataID = outData->getID();
 
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
     int dimensions = 3;
 
     // Create mesh to map from
-    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
     PtrData inData = inMesh->createData ( "InData", 1 );
     int inDataID = inData->getID ();
     inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
     values(2) = valueVertex3;
 
     // Create mesh to map to
-    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
     PtrData outData = outMesh->createData ( "OutData", 1 );
     int outDataID = outData->getID();
 
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   constexpr int dimensions = 3;
 
   // Create mesh to map from with Triangles ABD and BDC
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::meshIDManager()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   Vertex& inVA = inMesh->createVertex(Eigen::Vector3d{0,0,0});
   Vertex& inVB = inMesh->createVertex(Eigen::Vector3d{0,1,0});
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   inData->values() << 1.0, 1.0, 1.0, 1.0;
 
   // Create mesh to map to with one vertex per defined traingle
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{0.33, 0.33, 0});
   outMesh->createVertex(Eigen::Vector3d{0.66, 0.66, 0});
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::meshIDManager()));
+  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   const double z1 = 0.1;
   const double z2 = -0.1;
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   inMesh->computeState();
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
   outMesh->allocateDataValues();

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   int dimensions = 2;
 
   // Setup geometry to map to
-  PtrMesh outMesh ( new Mesh("OutMesh", dimensions, true) );
+  PtrMesh outMesh ( new Mesh("OutMesh", dimensions, true, testing::meshIDManager()) );
   PtrData outData = outMesh->createData ( "Data", 1 );
   int outDataID = outData->getID();
   Vertex& v1 = outMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   {
       // Setup mapping with mapping coordinates and geometry used
       mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-      PtrMesh inMesh ( new Mesh("InMesh0", dimensions, false) );
+      PtrMesh inMesh ( new Mesh("InMesh0", dimensions, false, testing::meshIDManager()) );
       PtrData inData = inMesh->createData ( "Data0", 1 );
       int inDataID = inData->getID();
 
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   {
       // Setup mapping with mapping coordinates and geometry used
       mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-      PtrMesh inMesh ( new Mesh("InMesh1", dimensions, false) );
+      PtrMesh inMesh ( new Mesh("InMesh1", dimensions, false, testing::meshIDManager()) );
       PtrData inData = inMesh->createData ( "Data1", 1 );
       int inDataID = inData->getID();
 
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false) );
+  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   Vertex& v1 = inMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh0", dimensions, false) );
+      PtrMesh outMesh ( new Mesh("OutMesh0", dimensions, false, testing::meshIDManager()) );
       PtrData outData = outMesh->createData ( "OutData", 1 );
       int outDataID = outData->getID();
 
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false) );
+      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::meshIDManager()) );
       PtrData outData = outMesh->createData ( "OutData", 1 );
       int outDataID = outData->getID();
 
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   int dimensions = 3;
 
   // Create mesh to map from
-  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false) );
+  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   Vertex& v1 = inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
 
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false) );
+      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::meshIDManager()) );
       PtrData outData = outMesh->createData ( "OutData1", 1 );
       int outDataID = outData->getID();
 
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   }
   {
       // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh2", dimensions, false) );
+      PtrMesh outMesh ( new Mesh("OutMesh2", dimensions, false, testing::meshIDManager()) );
       PtrData outData = outMesh->createData ( "OutData2", 1 );
       int outDataID = outData->getID();
 
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
     int dimensions = 3;
 
     // Create mesh to map from
-    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false) );
+    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
     PtrData inData = inMesh->createData ( "InData", 1 );
     int inDataID = inData->getID ();
     Vertex& v1 = inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
     values(2) = valueVertex3;
 
     // Create mesh to map to
-    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false) );
+    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
     PtrData outData = outMesh->createData ( "OutData", 1 );
     int outDataID = outData->getID();
 
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
     int dimensions = 3;
 
     // Create mesh to map from
-    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false) );
+    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
     PtrData inData = inMesh->createData ( "InData", 1 );
     int inDataID = inData->getID ();
     inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
     values(2) = valueVertex3;
 
     // Create mesh to map to
-    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false) );
+    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
     PtrData outData = outMesh->createData ( "OutData", 1 );
     int outDataID = outData->getID();
 
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   constexpr int dimensions = 3;
 
   // Create mesh to map from with Triangles ABD and BDC
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::meshIDManager()));
   PtrData inData = inMesh->createData("InData", 1);
   Vertex& inVA = inMesh->createVertex(Eigen::Vector3d{0,0,0});
   Vertex& inVB = inMesh->createVertex(Eigen::Vector3d{0,1,0});
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   inData->values() << 1.0, 1.0, 1.0, 1.0;
 
   // Create mesh to map to with one vertex per defined traingle
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{0.33, 0.33, 0});
   outMesh->createVertex(Eigen::Vector3d{0.66, 0.66, 0});
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh inMesh(new precice::mesh::Mesh("InMesh", 3, false));
+  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::meshIDManager()));
   PtrData inData = inMesh->createData("InData", 1);
   const double z1 = 0.1;
   const double z2 = -0.1;
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   inMesh->computeState();
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
   outMesh->allocateDataValues();

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -102,13 +102,13 @@ void testDistributed(Mapping& mapping,
   int meshDimension = inMeshSpec[0].position.size();
   int valueDimension = inMeshSpec[0].value.size();
 
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
   int inDataID = inData->getID();
 
   getDistributedMesh(inMeshSpec, inMesh, inData, inGlobalIndexOffset);
 
-  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData( "OutData", valueDimension );
   int outDataID = outData->getID();
 
@@ -642,11 +642,11 @@ void testTagging(MeshSpecification inMeshSpec,
   int meshDimension = inMeshSpec[0].position.size();
   int valueDimension = inMeshSpec[0].value.size();
 
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
   getDistributedMesh(inMeshSpec, inMesh, inData);
 
-  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData( "OutData", valueDimension);
   getDistributedMesh(outMeshSpec, outMesh, outData);
 
@@ -739,7 +739,7 @@ void perform2DTestConsistentMapping(Mapping& mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0.0, 0.0) );
@@ -753,7 +753,7 @@ void perform2DTestConsistentMapping(Mapping& mapping)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Vector2d(0, 0) );
@@ -833,7 +833,7 @@ void perform3DTestConsistentMapping(Mapping& mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -851,7 +851,7 @@ void perform3DTestConsistentMapping(Mapping& mapping)
   values << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex(Eigen::Vector3d::Zero());
@@ -968,7 +968,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   mesh::Vertex& vertex0 = inMesh->createVertex ( Vector2d(0,0) );
@@ -978,7 +978,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID ();
   outMesh->createVertex ( Vector2d(0.0, 0.0) );
@@ -1037,7 +1037,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   mesh::Vertex& vertex0 = inMesh->createVertex(Vector3d(0,0,0));
@@ -1047,7 +1047,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -1224,7 +1224,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0.0, 1.0) );
@@ -1238,7 +1238,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Vector2d(0,0) );
@@ -1271,7 +1271,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector3d(0.0, 3.0, 0.0) );
@@ -1285,7 +1285,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   values << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex ( Vector3d(0.0, 2.9, 0.0) );
@@ -1321,7 +1321,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0.0, 1.0) );  inMesh->createVertex ( Vector2d(1.0, 1.0) );
@@ -1332,7 +1332,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
   inData->values() << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0, 3));
@@ -1369,7 +1369,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(1, 1) );  inMesh->createVertex ( Vector2d(1, 0) );
@@ -1379,7 +1379,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(3, 3)); // Point is outside the inMesh
@@ -1431,7 +1431,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0, 0) );  inMesh->createVertex ( Vector2d(1, 0) );
@@ -1441,7 +1441,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.4, 0));
@@ -1513,13 +1513,13 @@ BOOST_AUTO_TEST_CASE(NoMapping)
 
   {
     // Call only computeMapping
-    mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", 2, false, testing::meshIDManager()) );
+    mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", 2, false, testing::nextMeshID()) );
     mesh::PtrData inData = inMesh->createData ( "InData", 1 );
     inMesh->createVertex ( Eigen::Vector2d(0, 0) );
     inMesh->allocateDataValues();
     addGlobalIndex(inMesh);
 
-    mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", 2, false, testing::meshIDManager()) );
+    mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", 2, false, testing::nextMeshID()) );
     mesh::PtrData outData = outMesh->createData( "OutData", 1 );
     outMesh->createVertex( Eigen::Vector2d(0, 0));
     outMesh->allocateDataValues();
@@ -1543,7 +1543,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(1, 1) ).setGlobalIndex(2);
@@ -1555,7 +1555,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.5, 0.5));

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -102,13 +102,13 @@ void testDistributed(Mapping& mapping,
   int meshDimension = inMeshSpec[0].position.size();
   int valueDimension = inMeshSpec[0].value.size();
 
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
   int inDataID = inData->getID();
 
   getDistributedMesh(inMeshSpec, inMesh, inData, inGlobalIndexOffset);
 
-  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData( "OutData", valueDimension );
   int outDataID = outData->getID();
 
@@ -642,11 +642,11 @@ void testTagging(MeshSpecification inMeshSpec,
   int meshDimension = inMeshSpec[0].position.size();
   int valueDimension = inMeshSpec[0].value.size();
 
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
   getDistributedMesh(inMeshSpec, inMesh, inData);
 
-  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData( "OutData", valueDimension);
   getDistributedMesh(outMeshSpec, outMesh, outData);
 
@@ -739,7 +739,7 @@ void perform2DTestConsistentMapping(Mapping& mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0.0, 0.0) );
@@ -753,7 +753,7 @@ void perform2DTestConsistentMapping(Mapping& mapping)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Vector2d(0, 0) );
@@ -833,7 +833,7 @@ void perform3DTestConsistentMapping(Mapping& mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -851,7 +851,7 @@ void perform3DTestConsistentMapping(Mapping& mapping)
   values << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex(Eigen::Vector3d::Zero());
@@ -968,7 +968,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   mesh::Vertex& vertex0 = inMesh->createVertex ( Vector2d(0,0) );
@@ -978,7 +978,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID ();
   outMesh->createVertex ( Vector2d(0.0, 0.0) );
@@ -1037,7 +1037,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   mesh::Vertex& vertex0 = inMesh->createVertex(Vector3d(0,0,0));
@@ -1047,7 +1047,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -1224,7 +1224,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0.0, 1.0) );
@@ -1238,7 +1238,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Vector2d(0,0) );
@@ -1271,7 +1271,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector3d(0.0, 3.0, 0.0) );
@@ -1285,7 +1285,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   values << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex ( Vector3d(0.0, 2.9, 0.0) );
@@ -1321,7 +1321,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0.0, 1.0) );  inMesh->createVertex ( Vector2d(1.0, 1.0) );
@@ -1332,7 +1332,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
   inData->values() << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0, 3));
@@ -1369,7 +1369,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(1, 1) );  inMesh->createVertex ( Vector2d(1, 0) );
@@ -1379,7 +1379,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(3, 3)); // Point is outside the inMesh
@@ -1431,7 +1431,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(0, 0) );  inMesh->createVertex ( Vector2d(1, 0) );
@@ -1441,7 +1441,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.4, 0));
@@ -1513,13 +1513,13 @@ BOOST_AUTO_TEST_CASE(NoMapping)
 
   {
     // Call only computeMapping
-    mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", 2, false) );
+    mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", 2, false, testing::meshIDManager()) );
     mesh::PtrData inData = inMesh->createData ( "InData", 1 );
     inMesh->createVertex ( Eigen::Vector2d(0, 0) );
     inMesh->allocateDataValues();
     addGlobalIndex(inMesh);
 
-    mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", 2, false) );
+    mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", 2, false, testing::meshIDManager()) );
     mesh::PtrData outData = outMesh->createData( "OutData", 1 );
     outMesh->createVertex( Eigen::Vector2d(0, 0));
     outMesh->allocateDataValues();
@@ -1543,7 +1543,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector2d(1, 1) ).setGlobalIndex(2);
@@ -1555,7 +1555,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.5, 0.5));

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2D)
                                                   xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Eigen::Vector2d(0.0, 1.0) );
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2D)
   inData->values() << 1.0, 2.0, 2.0, 1.0;
   
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Eigen::Vector2d::Zero() );
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector3d(0.0, 3.0, 0.0) );
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   inData->values() << 1.0, 2.0, 3.0, 4.0;
   
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex ( Vector3d(0.0, 2.9, 0.0) );
@@ -248,7 +248,7 @@ void perform2DTestConsistentMapping(Mapping& mapping )
   int dimensions = 2;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -259,7 +259,7 @@ void perform2DTestConsistentMapping(Mapping& mapping )
   inData->values() << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Eigen::Vector2d::Constant(0.0) );
@@ -339,7 +339,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   int dimensions = 2;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   mesh::Vertex& vertex0 = inMesh->createVertex ( Eigen::Vector2d::Zero() );
@@ -348,7 +348,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   inData->values() << 1.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID ();
   outMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -402,7 +402,7 @@ void perform3DTestConsistentMapping(Mapping& mapping )
   int dimensions = 3;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -417,7 +417,7 @@ void perform3DTestConsistentMapping(Mapping& mapping )
   inData->values() << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex(Eigen::Vector3d::Zero());
@@ -531,7 +531,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   int dimensions = 3;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   mesh::Vertex& vertex0 = inMesh->createVertex(Eigen::Vector3d::Zero());
@@ -540,7 +540,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   inData->values() << 1.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2D)
                                                   xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Eigen::Vector2d(0.0, 1.0) );
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2D)
   inData->values() << 1.0, 2.0, 2.0, 1.0;
   
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Eigen::Vector2d::Zero() );
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Vector3d(0.0, 3.0, 0.0) );
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   inData->values() << 1.0, 2.0, 3.0, 4.0;
   
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   outMesh->createVertex ( Vector3d(0.0, 2.9, 0.0) );
@@ -248,7 +248,7 @@ void perform2DTestConsistentMapping(Mapping& mapping )
   int dimensions = 2;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   inMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -259,7 +259,7 @@ void perform2DTestConsistentMapping(Mapping& mapping )
   inData->values() << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex ( Eigen::Vector2d::Constant(0.0) );
@@ -339,7 +339,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   int dimensions = 2;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false) );
+  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData inData = inMesh->createData ( "InData", 1 );
   int inDataID = inData->getID ();
   mesh::Vertex& vertex0 = inMesh->createVertex ( Eigen::Vector2d::Zero() );
@@ -348,7 +348,7 @@ void perform2DTestConservativeMapping(Mapping& mapping)
   inData->values() << 1.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false) );
+  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()) );
   mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
   int outDataID = outData->getID ();
   outMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
@@ -402,7 +402,7 @@ void perform3DTestConsistentMapping(Mapping& mapping )
   int dimensions = 3;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -417,7 +417,7 @@ void perform3DTestConsistentMapping(Mapping& mapping )
   inData->values() << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   mesh::Vertex& vertex = outMesh->createVertex(Eigen::Vector3d::Zero());
@@ -531,7 +531,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   int dimensions = 3;
   
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData inData = inMesh->createData("InData", 1);
   int inDataID = inData->getID();
   mesh::Vertex& vertex0 = inMesh->createVertex(Eigen::Vector3d::Zero());
@@ -540,7 +540,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   inData->values() << 1.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::meshIDManager()));
   mesh::PtrData outData = outMesh->createData("OutData", 1);
   int outDataID = outData->getID();
   outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -17,16 +17,14 @@ Mesh::Mesh(
     const std::string &     name,
     int                     dimensions,
     bool                    flipNormals,
-    utils::ManageUniqueIDs &meshIdManager)
+    int                     id)
     : _name(name),
       _dimensions(dimensions),
       _flipNormals(flipNormals),
-      _managePropertyIDs(meshIdManager)
+      _id(id)
 {
   PRECICE_ASSERT((_dimensions == 2) || (_dimensions == 3), _dimensions);
   PRECICE_ASSERT(_name != std::string(""));
-  _nameIDPairs[_name] = _managePropertyIDs.getFreeID ();
-  setProperty(INDEX_GEOMETRY_ID, _nameIDPairs[_name]);
 
   meshChanged.connect([](Mesh & m){rtree::clear(m);});
   meshDestroyed.connect([](Mesh & m){rtree::clear(m);});
@@ -187,24 +185,9 @@ void Mesh:: setFlipNormals
   _flipNormals = flipNormals;
 }
 
-const std::map<std::string,int>& Mesh:: getNameIDPairs()
-{
-  return _nameIDPairs;
-}
-
-int Mesh:: getID
-(
-  const std::string& name ) const
-{
-  PRECICE_ASSERT(_nameIDPairs.count(name) > 0);
-  return _nameIDPairs.find(name)->second;
-}
-
 int Mesh:: getID() const
 {
-  std::map<std::string,int>::const_iterator iter = _nameIDPairs.find(_name);
-  PRECICE_ASSERT(iter != _nameIDPairs.end());
-  return iter->second;
+  return _id;
 }
 
 bool Mesh::isValidVertexID(int vertexID) const

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -13,31 +13,20 @@
 namespace precice {
 namespace mesh {
 
-std::unique_ptr<utils::ManageUniqueIDs> Mesh::_managePropertyIDs;
-
-void Mesh:: resetGeometryIDsGlobally()
+Mesh::Mesh(
+    const std::string &     name,
+    int                     dimensions,
+    bool                    flipNormals,
+    utils::ManageUniqueIDs &meshIdManager)
+    : _name(name),
+      _dimensions(dimensions),
+      _flipNormals(flipNormals),
+      _managePropertyIDs(meshIdManager)
 {
-  if (_managePropertyIDs) {
-    _managePropertyIDs->resetIDs();
-  }
-}
-
-Mesh:: Mesh
-(
-  const std::string& name,
-  int                dimensions,
-  bool               flipNormals )
-:
-  _name(name),
-  _dimensions(dimensions),
-  _flipNormals(flipNormals)
-{
-  if (not _managePropertyIDs) {
-    _managePropertyIDs.reset(new utils::ManageUniqueIDs);
-  }
   PRECICE_ASSERT((_dimensions == 2) || (_dimensions == 3), _dimensions);
   PRECICE_ASSERT(_name != std::string(""));
-  _nameIDPairs[_name] = _managePropertyIDs->getFreeID ();
+  _nameIDPairs[_name] = _managePropertyIDs.getFreeID ();
+  setProperty(INDEX_GEOMETRY_ID, _nameIDPairs[_name]);
 
   meshChanged.connect([](Mesh & m){rtree::clear(m);});
   meshDestroyed.connect([](Mesh & m){rtree::clear(m);});

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -53,18 +53,22 @@ public:
   /// Signal is emitted when the mesh is destroyed
   boost::signals2::signal<void(Mesh &)> meshDestroyed;
 
+  /// Use if the id of the mesh is not necessary
+  static constexpr int MESH_ID_UNDEFINED{-1};
+
   /**
    * @brief Constructor.
    *
    * @param[in] name Unique name of the mesh.
    * @param[in] dimensions Dimensionalty of the mesh.
    * @param[in] flipNormals Inverts the standard direction of normals.
+   * @param[in] id The id of this mesh
    */
   Mesh(
       const std::string &     name,
       int                     dimensions,
       bool                    flipNormals,
-      utils::ManageUniqueIDs &meshIdManager);
+      int                     id);
 
   /// Destructor, deletes created objects.
   ~Mesh();
@@ -164,12 +168,6 @@ public:
 
   void setFlipNormals ( bool flipNormals );
 
-  /// Returns all used geometry IDs paired with their names
-  const std::map<std::string,int>& getNameIDPairs();
-
-  /// Returns the geometry ID corresponding to the given name.
-  int getID ( const std::string& name ) const;
-
   /// Returns the base ID of the mesh.
   int getID() const;
 
@@ -253,12 +251,6 @@ public:
   
   bool operator!=(const Mesh& other) const;
 
-  /// returns the used id Manager
-  utils::ManageUniqueIDs& getIDManager()
-  {
-      return _managePropertyIDs;
-  }
-
 private:
 
   /// Computes the normals for all primitives.
@@ -269,9 +261,6 @@ private:
 
   mutable logging::Logger _log{"mesh::Mesh"};
 
-  /// Provides unique IDs for all geometry objects
-  utils::ManageUniqueIDs& _managePropertyIDs;
-
   /// Name of the mesh.
   std::string _name;
 
@@ -281,8 +270,8 @@ private:
   /// Flag for flipping normals direction.
   bool _flipNormals;
 
-  /// Holds all mesh names and the corresponding IDs belonging to the mesh.
-  std::map<std::string,int> _nameIDPairs;
+  /// The ID of this mesh.
+  int _id;
 
   /// Holds vertices, edges, and triangles.
   VertexContainer _vertices;

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -54,23 +54,17 @@ public:
   boost::signals2::signal<void(Mesh &)> meshDestroyed;
 
   /**
-   * @brief Resets the internal geometry ID counter to start from anew.
-   *
-   * This method is only used for test cases.
-   */
-  static void resetGeometryIDsGlobally();
-
-  /**
    * @brief Constructor.
    *
    * @param[in] name Unique name of the mesh.
    * @param[in] dimensions Dimensionalty of the mesh.
    * @param[in] flipNormals Inverts the standard direction of normals.
    */
-  Mesh (
-    const std::string& name,
-    int                dimensions,
-    bool               flipNormals );
+  Mesh(
+      const std::string &     name,
+      int                     dimensions,
+      bool                    flipNormals,
+      utils::ManageUniqueIDs &meshIdManager);
 
   /// Destructor, deletes created objects.
   ~Mesh();
@@ -259,6 +253,12 @@ public:
   
   bool operator!=(const Mesh& other) const;
 
+  /// returns the used id Manager
+  utils::ManageUniqueIDs& getIDManager()
+  {
+      return _managePropertyIDs;
+  }
+
 private:
 
   /// Computes the normals for all primitives.
@@ -270,7 +270,7 @@ private:
   mutable logging::Logger _log{"mesh::Mesh"};
 
   /// Provides unique IDs for all geometry objects
-  static std::unique_ptr<utils::ManageUniqueIDs> _managePropertyIDs;
+  utils::ManageUniqueIDs& _managePropertyIDs;
 
   /// Name of the mesh.
   std::string _name;

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -21,7 +21,9 @@ MeshConfiguration:: MeshConfiguration
   _dimensions(0),
   _dataConfig(config),
   _meshes(),
-  _neededMeshes()
+  _neededMeshes(),
+  _neededMeshes(),
+  _meshIdManager(new utils::ManageUniqueIDs())
 {
   using namespace xml;
   std::string doc;
@@ -69,7 +71,8 @@ void MeshConfiguration:: xmlTagCallback
     PRECICE_ASSERT(_dimensions != 0);
     std::string name = tag.getStringAttributeValue(ATTR_NAME);
     bool flipNormals = tag.getBooleanAttributeValue(ATTR_FLIP_NORMALS);
-    _meshes.push_back(PtrMesh(new Mesh(name, _dimensions, flipNormals)));
+    PRECICE_ASSERT(_meshIdManager);
+    _meshes.push_back(PtrMesh(new Mesh(name, _dimensions, flipNormals, *_meshIdManager)));
   }
   else if (tag.getName() == TAG_DATA){
     std::string name = tag.getStringAttributeValue(ATTR_NAME);

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -22,7 +22,6 @@ MeshConfiguration:: MeshConfiguration
   _dataConfig(config),
   _meshes(),
   _neededMeshes(),
-  _neededMeshes(),
   _meshIdManager(new utils::ManageUniqueIDs())
 {
   using namespace xml;
@@ -72,7 +71,7 @@ void MeshConfiguration:: xmlTagCallback
     std::string name = tag.getStringAttributeValue(ATTR_NAME);
     bool flipNormals = tag.getBooleanAttributeValue(ATTR_FLIP_NORMALS);
     PRECICE_ASSERT(_meshIdManager);
-    _meshes.push_back(PtrMesh(new Mesh(name, _dimensions, flipNormals, *_meshIdManager)));
+    _meshes.push_back(PtrMesh(new Mesh(name, _dimensions, flipNormals, _meshIdManager->getFreeID())));
   }
   else if (tag.getName() == TAG_DATA){
     std::string name = tag.getStringAttributeValue(ATTR_NAME);

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -3,6 +3,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "xml/XMLTag.hpp"
+#include "utils/ManageUniqueIDs.hpp"
 #include <vector>
 #include <list>
 #include <map>
@@ -57,6 +58,10 @@ public:
     const std::string& participant,
     const std::string& mesh);
 
+  std::unique_ptr<utils::ManageUniqueIDs> extractMeshIdManager() {
+      return std::move(_meshIdManager);
+  }
+
 private:
 
   logging::Logger _log{"mesh::MeshConfiguration"};
@@ -77,6 +82,8 @@ private:
 
   /// to check later if all meshes that any coupling scheme needs are actually used by the participants
   std::map<std::string,std::vector<std::string> > _neededMeshes;
+
+  std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
 };
 
 }} // namespace precice, mesh

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -18,10 +18,9 @@ BOOST_AUTO_TEST_SUITE(MeshTests)
 
 BOOST_AUTO_TEST_SUITE(MeshTests, *testing::OnMaster())
 
-
 BOOST_AUTO_TEST_CASE(ComputeState_2D)
 {  
-  mesh::Mesh mesh ( "MyMesh", 2, true );
+  mesh::Mesh mesh ( "MyMesh", 2, true , testing::meshIDManager());
   // Create mesh
   Vertex& v1 = mesh.createVertex ( Vector2d(0.0, 0.0) );
   Vertex& v2 = mesh.createVertex ( Vector2d(1.0, 0.0) );
@@ -51,7 +50,7 @@ BOOST_AUTO_TEST_CASE(ComputeState_2D)
 
 BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
 {
-  precice::mesh::Mesh mesh ( "MyMesh", 3, true );
+  precice::mesh::Mesh mesh ( "MyMesh", 3, true , testing::meshIDManager());
   // Create mesh
   Vertex& v1 = mesh.createVertex ( Vector3d(0.0, 0.0, 0.0) );
   Vertex& v2 = mesh.createVertex ( Vector3d(1.0, 0.0, 1.0) );
@@ -111,7 +110,7 @@ BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
 
 BOOST_AUTO_TEST_CASE(ComputeState_3D_Quad)
 {
-  mesh::Mesh mesh("MyMesh", 3, true);
+  mesh::Mesh mesh("MyMesh", 3, true, testing::meshIDManager());
   // Create mesh (Two rectangles with a common edge at z-axis. One extends in
   // x-y-plane (2 long), the other in y-z-plane (1 long))
   Vertex& v0 = mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -185,7 +184,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
   Eigen::Vector2d coords1(-1, 4);
   Eigen::Vector2d coords2(0, 1);
 
-  mesh::Mesh mesh ("2D Testmesh", 2, false );
+  mesh::Mesh mesh ("2D Testmesh", 2, false , testing::meshIDManager());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -220,7 +219,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
   Eigen::Vector3d coords2(0, 1, -2);
   Eigen::Vector3d coords3(3.5, 2, -2);
 
-  mesh::Mesh mesh ("3D Testmesh", 3, false );
+  mesh::Mesh mesh ("3D Testmesh", 3, false , testing::meshIDManager());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -256,7 +255,7 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     // Create mesh object
     std::string meshName ( "MyMesh" );
     bool flipNormals = false; // The normals of triangles, edges, vertices
-    precice::mesh::Mesh mesh ( meshName, dim, flipNormals );
+    precice::mesh::Mesh mesh ( meshName, dim, flipNormals , testing::meshIDManager());
 
     // Validate mesh object state
     BOOST_TEST(mesh.getName() == meshName);
@@ -370,9 +369,9 @@ BOOST_AUTO_TEST_CASE(Demonstration)
 BOOST_AUTO_TEST_CASE(MeshEquality)
 {
     int dim = 3;
-    Mesh mesh1 ( "Mesh1", dim, false );
-    Mesh mesh1flipped ( "Mesh1flipped", dim, true );
-    Mesh mesh2 ( "Mesh2", dim, false );
+    Mesh mesh1 ( "Mesh1", dim, false, testing::meshIDManager());
+    Mesh mesh1flipped ( "Mesh1flipped", dim, true, testing::meshIDManager());
+    Mesh mesh2 ( "Mesh2", dim, false, testing::meshIDManager());
     Mesh *meshes[3] = {&mesh1, &mesh1flipped, &mesh2};
     for (auto ptr : meshes){
         auto& mesh = *ptr;
@@ -403,7 +402,7 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
 
 BOOST_AUTO_TEST_CASE(MeshWKTPrint)
 {
-    Mesh mesh ("WKTMesh", 3, false);
+    Mesh mesh ("WKTMesh", 3, false, testing::meshIDManager());
     Vertex& v0 = mesh.createVertex(Eigen::Vector3d(0., 0., 0.));
     Vertex& v1 = mesh.createVertex(Eigen::Vector3d(1., 0., 0.));
     Vertex& v2 = mesh.createVertex(Eigen::Vector3d(0., 0., 1.));
@@ -432,7 +431,7 @@ BOOST_AUTO_TEST_CASE(MeshWKTPrint)
 BOOST_AUTO_TEST_CASE(CreateUniqueEdge)
 {
     int dim = 3;
-    Mesh mesh1 ( "Mesh1", dim, false );
+    Mesh mesh1 ( "Mesh1", dim, false, testing::meshIDManager() );
     auto& mesh = mesh1;
     Eigen::VectorXd coords0(dim);
     Eigen::VectorXd coords1(dim);

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_SUITE(MeshTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(ComputeState_2D)
 {  
-  mesh::Mesh mesh ( "MyMesh", 2, true , testing::meshIDManager());
+  mesh::Mesh mesh ( "MyMesh", 2, true , testing::nextMeshID());
   // Create mesh
   Vertex& v1 = mesh.createVertex ( Vector2d(0.0, 0.0) );
   Vertex& v2 = mesh.createVertex ( Vector2d(1.0, 0.0) );
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(ComputeState_2D)
 
 BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
 {
-  precice::mesh::Mesh mesh ( "MyMesh", 3, true , testing::meshIDManager());
+  precice::mesh::Mesh mesh ( "MyMesh", 3, true , testing::nextMeshID());
   // Create mesh
   Vertex& v1 = mesh.createVertex ( Vector3d(0.0, 0.0, 0.0) );
   Vertex& v2 = mesh.createVertex ( Vector3d(1.0, 0.0, 1.0) );
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
 
 BOOST_AUTO_TEST_CASE(ComputeState_3D_Quad)
 {
-  mesh::Mesh mesh("MyMesh", 3, true, testing::meshIDManager());
+  mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());
   // Create mesh (Two rectangles with a common edge at z-axis. One extends in
   // x-y-plane (2 long), the other in y-z-plane (1 long))
   Vertex& v0 = mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
   Eigen::Vector2d coords1(-1, 4);
   Eigen::Vector2d coords2(0, 1);
 
-  mesh::Mesh mesh ("2D Testmesh", 2, false , testing::meshIDManager());
+  mesh::Mesh mesh ("2D Testmesh", 2, false , testing::nextMeshID());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
   Eigen::Vector3d coords2(0, 1, -2);
   Eigen::Vector3d coords3(3.5, 2, -2);
 
-  mesh::Mesh mesh ("3D Testmesh", 3, false , testing::meshIDManager());
+  mesh::Mesh mesh ("3D Testmesh", 3, false , testing::nextMeshID());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     // Create mesh object
     std::string meshName ( "MyMesh" );
     bool flipNormals = false; // The normals of triangles, edges, vertices
-    precice::mesh::Mesh mesh ( meshName, dim, flipNormals , testing::meshIDManager());
+    precice::mesh::Mesh mesh ( meshName, dim, flipNormals , testing::nextMeshID());
 
     // Validate mesh object state
     BOOST_TEST(mesh.getName() == meshName);
@@ -369,9 +369,9 @@ BOOST_AUTO_TEST_CASE(Demonstration)
 BOOST_AUTO_TEST_CASE(MeshEquality)
 {
     int dim = 3;
-    Mesh mesh1 ( "Mesh1", dim, false, testing::meshIDManager());
-    Mesh mesh1flipped ( "Mesh1flipped", dim, true, testing::meshIDManager());
-    Mesh mesh2 ( "Mesh2", dim, false, testing::meshIDManager());
+    Mesh mesh1 ( "Mesh1", dim, false, testing::nextMeshID());
+    Mesh mesh1flipped ( "Mesh1flipped", dim, true, testing::nextMeshID());
+    Mesh mesh2 ( "Mesh2", dim, false, testing::nextMeshID());
     Mesh *meshes[3] = {&mesh1, &mesh1flipped, &mesh2};
     for (auto ptr : meshes){
         auto& mesh = *ptr;
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
 
 BOOST_AUTO_TEST_CASE(MeshWKTPrint)
 {
-    Mesh mesh ("WKTMesh", 3, false, testing::meshIDManager());
+    Mesh mesh ("WKTMesh", 3, false, testing::nextMeshID());
     Vertex& v0 = mesh.createVertex(Eigen::Vector3d(0., 0., 0.));
     Vertex& v1 = mesh.createVertex(Eigen::Vector3d(1., 0., 0.));
     Vertex& v2 = mesh.createVertex(Eigen::Vector3d(0., 0., 1.));
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(MeshWKTPrint)
 BOOST_AUTO_TEST_CASE(CreateUniqueEdge)
 {
     int dim = 3;
-    Mesh mesh1 ( "Mesh1", dim, false, testing::meshIDManager() );
+    Mesh mesh1 ( "Mesh1", dim, false, testing::nextMeshID() );
     auto& mesh = mesh1;
     Eigen::VectorXd coords0(dim);
     Eigen::VectorXd coords1(dim);

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(VectorAdapter)
 
 BOOST_AUTO_TEST_CASE(VertexAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::nextMeshID());
   auto & v = mesh.createVertex(Eigen::Vector2d(1, 2));
   BOOST_TEST(bg::get<0>(v) == 1);
   BOOST_TEST(bg::get<1>(v) == 2);
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(VertexAdapter)
 
 BOOST_AUTO_TEST_CASE(EdgeAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::nextMeshID());
   auto & v1 = mesh.createVertex(Eigen::Vector2d(1, 2));
   auto & v2 = mesh.createVertex(Eigen::Vector2d(3, 4));
   auto & e = mesh.createEdge(v1, v2);
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(EdgeAdapter)
 
 BOOST_AUTO_TEST_CASE(TriangleAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false, precice::testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, precice::testing::nextMeshID());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(TriangleAdapter)
 
 BOOST_AUTO_TEST_CASE(QuadAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(QuadAdapter)
 
 BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto & lv1 = mesh.createVertex(Eigen::Vector3d(-1, 1, 0.1));
   auto & lv2 = mesh.createVertex(Eigen::Vector3d( 0,-1, 0));
   auto & lv3 = mesh.createVertex(Eigen::Vector3d(-2, 0,-0.1));
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto & a = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
   auto & b = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
   auto & c = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
 
 BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 {
   using precice::testing::equals;
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
 {
   using precice::testing::equals;
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
 BOOST_AUTO_TEST_SUITE_END() // BG Adapters
 
 struct MeshFixture {
-  MeshFixture() : mesh("MyMesh", 3, false, testing::meshIDManager()) {
+  MeshFixture() : mesh("MyMesh", 3, false, testing::nextMeshID()) {
     auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
     auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
     auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
@@ -288,7 +288,7 @@ struct MeshFixture {
 
 BOOST_AUTO_TEST_CASE(Query_2D)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, testing::meshIDManager()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
   mesh->createVertex(Eigen::Vector2d(0, 1));
   auto& v1 = mesh->createVertex(Eigen::Vector2d(1, 0));
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(Query_2D)
 
 BOOST_AUTO_TEST_CASE(Query_3D)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::meshIDManager()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector3d(0, 0, 0));
   mesh->createVertex(Eigen::Vector3d(0, 0, 1));
   mesh->createVertex(Eigen::Vector3d(0, 1, 0));
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(Query_3D)
 
 BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::meshIDManager()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
   const double z1 = 0.1;
   const double z2 = -0.1;
   auto& v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
 /// Resembles how boost geometry is used inside the PetRBF
 BOOST_AUTO_TEST_CASE(QueryWithBox)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::meshIDManager()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector3d(0, 0, 0));
   mesh->createVertex(Eigen::Vector3d(0, 0, 1));
   mesh->createVertex(Eigen::Vector3d(0, 1, 0));
@@ -536,7 +536,7 @@ BOOST_AUTO_TEST_CASE(QueryWithBox)
 
 BOOST_AUTO_TEST_CASE(CacheClearing)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, precice::testing::meshIDManager()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
 
   

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(VectorAdapter)
 
 BOOST_AUTO_TEST_CASE(VertexAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 2, false);
+  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::meshIDManager());
   auto & v = mesh.createVertex(Eigen::Vector2d(1, 2));
   BOOST_TEST(bg::get<0>(v) == 1);
   BOOST_TEST(bg::get<1>(v) == 2);
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(VertexAdapter)
 
 BOOST_AUTO_TEST_CASE(EdgeAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 2, false);
+  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::meshIDManager());
   auto & v1 = mesh.createVertex(Eigen::Vector2d(1, 2));
   auto & v2 = mesh.createVertex(Eigen::Vector2d(3, 4));
   auto & e = mesh.createEdge(v1, v2);
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(EdgeAdapter)
 
 BOOST_AUTO_TEST_CASE(TriangleAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, precice::testing::meshIDManager());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(TriangleAdapter)
 
 BOOST_AUTO_TEST_CASE(QuadAdapter)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(QuadAdapter)
 
 BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
   auto & lv1 = mesh.createVertex(Eigen::Vector3d(-1, 1, 0.1));
   auto & lv2 = mesh.createVertex(Eigen::Vector3d( 0,-1, 0));
   auto & lv3 = mesh.createVertex(Eigen::Vector3d(-2, 0,-0.1));
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
   auto & a = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
   auto & b = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
   auto & c = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
 
 BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 {
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 {
   using precice::testing::equals;
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
 {
   using precice::testing::equals;
-  precice::mesh::Mesh mesh("MyMesh", 3, false);
+  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::meshIDManager());
   auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
 BOOST_AUTO_TEST_SUITE_END() // BG Adapters
 
 struct MeshFixture {
-  MeshFixture() : mesh("MyMesh", 3, false) {
+  MeshFixture() : mesh("MyMesh", 3, false, testing::meshIDManager()) {
     auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
     auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
     auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
@@ -288,7 +288,7 @@ struct MeshFixture {
 
 BOOST_AUTO_TEST_CASE(Query_2D)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, testing::meshIDManager()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
   mesh->createVertex(Eigen::Vector2d(0, 1));
   auto& v1 = mesh->createVertex(Eigen::Vector2d(1, 0));
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(Query_2D)
 
 BOOST_AUTO_TEST_CASE(Query_3D)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::meshIDManager()));
   mesh->createVertex(Eigen::Vector3d(0, 0, 0));
   mesh->createVertex(Eigen::Vector3d(0, 0, 1));
   mesh->createVertex(Eigen::Vector3d(0, 1, 0));
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(Query_3D)
 
 BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::meshIDManager()));
   const double z1 = 0.1;
   const double z2 = -0.1;
   auto& v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
 /// Resembles how boost geometry is used inside the PetRBF
 BOOST_AUTO_TEST_CASE(QueryWithBox)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::meshIDManager()));
   mesh->createVertex(Eigen::Vector3d(0, 0, 0));
   mesh->createVertex(Eigen::Vector3d(0, 0, 1));
   mesh->createVertex(Eigen::Vector3d(0, 1, 0));
@@ -536,7 +536,7 @@ BOOST_AUTO_TEST_CASE(QueryWithBox)
 
 BOOST_AUTO_TEST_CASE(CacheClearing)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, precice::testing::meshIDManager()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
 
   

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -26,7 +26,7 @@ void ProvidedPartition::communicate()
     Event e1("partition.gatherMesh." + _mesh->getName(), precice::syncMode);
 
     // Temporary globalMesh such that the master also keeps his local mesh
-    mesh::Mesh globalMesh(_mesh->getName(), _mesh->getDimensions(), _mesh->isFlipNormals());
+    mesh::Mesh globalMesh(_mesh->getName(), _mesh->getDimensions(), _mesh->isFlipNormals(), _mesh->getIDManager());
 
     if (not utils::MasterSlave::isSlave()) {
       globalMesh.addMesh(*_mesh); // Add local master mesh to global mesh

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -26,7 +26,7 @@ void ProvidedPartition::communicate()
     Event e1("partition.gatherMesh." + _mesh->getName(), precice::syncMode);
 
     // Temporary globalMesh such that the master also keeps his local mesh
-    mesh::Mesh globalMesh(_mesh->getName(), _mesh->getDimensions(), _mesh->isFlipNormals(), _mesh->getIDManager());
+    mesh::Mesh globalMesh(_mesh->getName(), _mesh->getDimensions(), _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
 
     if (not utils::MasterSlave::isSlave()) {
       globalMesh.addMesh(*_mesh); // Add local master mesh to global mesh

--- a/src/partition/ReceivedBoundingBox.cpp
+++ b/src/partition/ReceivedBoundingBox.cpp
@@ -158,7 +158,7 @@ void ReceivedBoundingBox::compute()
   // (1) Bounding Box Filter
 
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by bounding-box");  
-  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals());
+  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
   
   filterMesh(filteredMesh, true);
     

--- a/src/partition/ReceivedBoundingBox.cpp
+++ b/src/partition/ReceivedBoundingBox.cpp
@@ -158,7 +158,7 @@ void ReceivedBoundingBox::compute()
   // (1) Bounding Box Filter
 
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by bounding-box");  
-  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
+  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
   
   filterMesh(filteredMesh, true);
     

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -107,7 +107,7 @@ void ReceivedPartition::compute()
 
         PRECICE_DEBUG("From slave " << rankSlave << ", bounding mesh: " << _bb[0].first
               << ", " << _bb[0].second << " and " << _bb[1].first << ", " << _bb[1].second);
-        mesh::Mesh slaveMesh("SlaveMesh", _dimensions, _mesh->isFlipNormals());
+        mesh::Mesh slaveMesh("SlaveMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
         filterMesh(slaveMesh, true);
         PRECICE_DEBUG("Send filtered mesh to slave: " << rankSlave);
         com::CommunicateMesh(utils::MasterSlave::_communication).sendMesh(slaveMesh, rankSlave);
@@ -115,7 +115,7 @@ void ReceivedPartition::compute()
 
       // Now also filter the remaining master mesh
       prepareBoundingBox();
-      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals());
+      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
       filterMesh(filteredMesh, true);
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
@@ -151,7 +151,7 @@ void ReceivedPartition::compute()
       Event e2("partition.filterMeshBB." + _mesh->getName(), precice::syncMode);
 
       prepareBoundingBox();
-      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals());
+      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
       filterMesh(filteredMesh, true);
 
       if(areProvidedMeshesEmpty()) {
@@ -195,7 +195,7 @@ void ReceivedPartition::compute()
   // (5) Filter mesh according to tag
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by mappings");
   Event e5("partition.filterMeshMappings" + _mesh->getName(), precice::syncMode);
-  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals());
+  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
   filterMesh(filteredMesh, false);
   PRECICE_DEBUG("Mapping filter, filtered from " << _mesh->vertices().size() << " vertices to " << filteredMesh.vertices().size() << " vertices.");
   _mesh->clear();

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -107,7 +107,7 @@ void ReceivedPartition::compute()
 
         PRECICE_DEBUG("From slave " << rankSlave << ", bounding mesh: " << _bb[0].first
               << ", " << _bb[0].second << " and " << _bb[1].first << ", " << _bb[1].second);
-        mesh::Mesh slaveMesh("SlaveMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
+        mesh::Mesh slaveMesh("SlaveMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
         filterMesh(slaveMesh, true);
         PRECICE_DEBUG("Send filtered mesh to slave: " << rankSlave);
         com::CommunicateMesh(utils::MasterSlave::_communication).sendMesh(slaveMesh, rankSlave);
@@ -115,7 +115,7 @@ void ReceivedPartition::compute()
 
       // Now also filter the remaining master mesh
       prepareBoundingBox();
-      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
+      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
       filterMesh(filteredMesh, true);
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
@@ -151,7 +151,7 @@ void ReceivedPartition::compute()
       Event e2("partition.filterMeshBB." + _mesh->getName(), precice::syncMode);
 
       prepareBoundingBox();
-      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
+      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
       filterMesh(filteredMesh, true);
 
       if(areProvidedMeshesEmpty()) {
@@ -195,7 +195,7 @@ void ReceivedPartition::compute()
   // (5) Filter mesh according to tag
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by mappings");
   Event e5("partition.filterMeshMappings" + _mesh->getName(), precice::syncMode);
-  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), _mesh->getIDManager());
+  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
   filterMesh(filteredMesh, false);
   PRECICE_DEBUG("Mapping filter, filtered from " << _mesh->vertices().size() << " vertices to " << filteredMesh.vertices().size() << " vertices.");
   _mesh->clear();

--- a/src/partition/tests/ProvidedBoundingBoxTest.cpp
+++ b/src/partition/tests/ProvidedBoundingBoxTest.cpp
@@ -107,7 +107,6 @@ void tearDownParallelEnvironment(){
   utils::MasterSlave::reset();
   // utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
@@ -131,7 +130,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox2D, * testing::OnSize(4))
 
   if (utils::Parallel::getProcessRank() != 0) { //NASTIN
   
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     if(utils::Parallel::getProcessRank() == 1){//Master
       Eigen::VectorXd position(dimensions);
@@ -230,7 +229,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox3D, * testing::OnSize(4))
 
   if (utils::Parallel::getProcessRank() != 0) { //NASTIN
   
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     if(utils::Parallel::getProcessRank() == 1){//Master
       Eigen::VectorXd position(dimensions);
@@ -352,7 +351,7 @@ BOOST_AUTO_TEST_CASE(TestComputeBoundingBox, * testing::OnSize(4))
   else
   { //NASTIN
   
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));    
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));    
  
     double safetyFactor = 0.0;
     bool hasToSend = true;    
@@ -393,7 +392,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions, * testing::OnSize(4))
   bool flipNormals = true;
   double safetyFactor = 0.1;
   bool hasToSend=true;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
 
   // create second communicator for m2n mesh and communciation map exchange 
   com::PtrCommunication participantsCom =  com::PtrCommunication(new com::SocketCommunication());
@@ -514,8 +513,8 @@ BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
   bool flipNormals = true;
   double safetyFactor = 0;
   bool hasToSend=true;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals));
-  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
 
   
   switch (utils::Parallel::getProcessRank()) {
@@ -681,8 +680,8 @@ BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
   bool flipNormals = true;
   double safetyFactor = 0.0;
   bool hasToSend=true;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals));
-  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
   
   switch (utils::Parallel::getProcessRank()) {
   case 0: {

--- a/src/partition/tests/ProvidedBoundingBoxTest.cpp
+++ b/src/partition/tests/ProvidedBoundingBoxTest.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox2D, * testing::OnSize(4))
 
   if (utils::Parallel::getProcessRank() != 0) { //NASTIN
   
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     if(utils::Parallel::getProcessRank() == 1){//Master
       Eigen::VectorXd position(dimensions);
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox3D, * testing::OnSize(4))
 
   if (utils::Parallel::getProcessRank() != 0) { //NASTIN
   
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     if(utils::Parallel::getProcessRank() == 1){//Master
       Eigen::VectorXd position(dimensions);
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(TestComputeBoundingBox, * testing::OnSize(4))
   else
   { //NASTIN
   
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));    
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));    
  
     double safetyFactor = 0.0;
     bool hasToSend = true;    
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions, * testing::OnSize(4))
   bool flipNormals = true;
   double safetyFactor = 0.1;
   bool hasToSend=true;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
 
   // create second communicator for m2n mesh and communciation map exchange 
   com::PtrCommunication participantsCom =  com::PtrCommunication(new com::SocketCommunication());
@@ -513,8 +513,8 @@ BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
   bool flipNormals = true;
   double safetyFactor = 0;
   bool hasToSend=true;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
-  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
 
   
   switch (utils::Parallel::getProcessRank()) {
@@ -680,8 +680,8 @@ BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
   bool flipNormals = true;
   double safetyFactor = 0.0;
   bool hasToSend=true;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
-  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
   
   switch (utils::Parallel::getProcessRank()) {
   case 0: {

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -57,7 +57,6 @@ void tearDownParallelEnvironment()
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
@@ -76,7 +75,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //NASTIN
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     double safetyFactor = 0.1;
 
@@ -91,7 +90,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D, *testing::OnSize(4))
       BOOST_TEST(pSolidzMesh->vertices()[i].getGlobalIndex() == i);
     }
   } else { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     if (utils::Parallel::getProcessRank() == 1) { //Master
       Eigen::VectorXd position(dimensions);
@@ -152,7 +151,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //NASTIN
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     double safetyFactor = 0.1;
 
@@ -168,7 +167,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D, *testing::OnSize(4))
       BOOST_TEST(pSolidzMesh->vertices()[i].getGlobalIndex() == i);
     }
   } else { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     if (utils::Parallel::getProcessRank() == 1) { //Master
       Eigen::VectorXd position(dimensions);
@@ -255,7 +254,7 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D,
   std::string   meshName("MyMesh");
   int           dim         = 2;
   bool          flipNormals = false; // The normals of triangles, edges, vertices
-  mesh::PtrMesh pMesh(new mesh::Mesh(meshName, dim, flipNormals));
+  mesh::PtrMesh pMesh(new mesh::Mesh(meshName, dim, flipNormals, testing::meshIDManager()));
 
   if (utils::Parallel::getProcessRank() == 0) { //Master
     Eigen::VectorXd position(dim);

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //NASTIN
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     double safetyFactor = 0.1;
 
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D, *testing::OnSize(4))
       BOOST_TEST(pSolidzMesh->vertices()[i].getGlobalIndex() == i);
     }
   } else { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     if (utils::Parallel::getProcessRank() == 1) { //Master
       Eigen::VectorXd position(dimensions);
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //NASTIN
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     double safetyFactor = 0.1;
 
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D, *testing::OnSize(4))
       BOOST_TEST(pSolidzMesh->vertices()[i].getGlobalIndex() == i);
     }
   } else { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     if (utils::Parallel::getProcessRank() == 1) { //Master
       Eigen::VectorXd position(dimensions);
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D,
   std::string   meshName("MyMesh");
   int           dim         = 2;
   bool          flipNormals = false; // The normals of triangles, edges, vertices
-  mesh::PtrMesh pMesh(new mesh::Mesh(meshName, dim, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pMesh(new mesh::Mesh(meshName, dim, flipNormals, testing::nextMeshID()));
 
   if (utils::Parallel::getProcessRank() == 0) { //Master
     Eigen::VectorXd position(dim);

--- a/src/partition/tests/ReceivedBoundingBoxTest.cpp
+++ b/src/partition/tests/ReceivedBoundingBoxTest.cpp
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap2D, * testing::OnSize(4))
     std::vector<int> connectedRanksList;
     int connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));     
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));     
     m2n->getMasterCommunication()->send(3, 0);     
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0 );
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
@@ -173,8 +173,8 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap2D, * testing::OnSize(4))
   }  
   else
   {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap3D, * testing::OnSize(4))
     std::vector<int> connectedRanksList;
     int connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));     
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));     
     m2n->getMasterCommunication()->send(3, 0);     
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0 );
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
@@ -254,8 +254,8 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap3D, * testing::OnSize(4))
   }  
   else
   {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));

--- a/src/partition/tests/ReceivedBoundingBoxTest.cpp
+++ b/src/partition/tests/ReceivedBoundingBoxTest.cpp
@@ -62,7 +62,6 @@ void tearDownParallelEnvironment(){
   utils::MasterSlave::reset();
   //utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
@@ -151,7 +150,7 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap2D, * testing::OnSize(4))
     std::vector<int> connectedRanksList;
     int connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));     
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));     
     m2n->getMasterCommunication()->send(3, 0);     
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0 );
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
@@ -174,8 +173,8 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap2D, * testing::OnSize(4))
   }  
   else
   {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -232,7 +231,7 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap3D, * testing::OnSize(4))
     std::vector<int> connectedRanksList;
     int connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));     
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));     
     m2n->getMasterCommunication()->send(3, 0);     
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0 );
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
@@ -255,8 +254,8 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap3D, * testing::OnSize(4))
   }  
   else
   {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -211,14 +211,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D, *testing::OnSize(4))
   Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -270,14 +270,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D, *testing::OnSize(4))
   Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
     createSolidzMesh2DSmall(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -327,14 +327,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestProjectionMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -375,8 +375,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D,
 {
   int           dimensions  = 2;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::nextMeshID()));
 
   mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
       new mapping::PetRadialBasisFctMapping<mapping::ThinPlateSplines>(mapping::Mapping::CONSISTENT, dimensions,
@@ -455,8 +455,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1,
 {
   int           dimensions  = 2;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::nextMeshID()));
 
   double supportRadius = 0.25;
 
@@ -525,8 +525,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2,
 {
   int           dimensions  = 2;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::nextMeshID()));
 
   double supportRadius = 2.45;
 
@@ -601,8 +601,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D,
 {
   int           dimensions  = 3;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::nextMeshID()));
 
   double supportRadius1 = 1.2;
   double supportRadius2 = 0.2;
@@ -696,14 +696,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNPBroadcastFilter3D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
     createSolidzMesh3D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestProjectionMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -747,8 +747,8 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D,
   // Create mesh object
   int           dimensions  = 2;
   bool          flipNormals = false; // The normals of triangles, edges, vertices
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::nextMeshID()));
 
   mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
       new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -844,7 +844,7 @@ BOOST_FIXTURE_TEST_CASE(ProvideAndReceiveCouplingMode, testing::M2NFixture,
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
@@ -869,9 +869,9 @@ BOOST_FIXTURE_TEST_CASE(ProvideAndReceiveCouplingMode, testing::M2NFixture,
     BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
     BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
   } else {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
-    mesh::PtrMesh       pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh       pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::nextMeshID()));
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
     boundingFromMapping->setMeshes(pSolidzMesh, pOtherMesh);

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -61,7 +61,6 @@ void tearDownParallelEnvironment()
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
@@ -212,14 +211,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D, *testing::OnSize(4))
   Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -271,14 +270,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D, *testing::OnSize(4))
   Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
     createSolidzMesh2DSmall(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -328,14 +327,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestProjectionMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -376,8 +375,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D,
 {
   int           dimensions  = 2;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
 
   mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
       new mapping::PetRadialBasisFctMapping<mapping::ThinPlateSplines>(mapping::Mapping::CONSISTENT, dimensions,
@@ -456,8 +455,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1,
 {
   int           dimensions  = 2;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
 
   double supportRadius = 0.25;
 
@@ -526,8 +525,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2,
 {
   int           dimensions  = 2;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
 
   double supportRadius = 2.45;
 
@@ -602,8 +601,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D,
 {
   int           dimensions  = 3;
   bool          flipNormals = false;
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
 
   double supportRadius1 = 1.2;
   double supportRadius2 = 0.2;
@@ -697,14 +696,14 @@ BOOST_AUTO_TEST_CASE(RePartitionNPBroadcastFilter3D, *testing::OnSize(4))
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
     createSolidzMesh3D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::meshIDManager()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestProjectionMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -748,8 +747,8 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D,
   // Create mesh object
   int           dimensions  = 2;
   bool          flipNormals = false; // The normals of triangles, edges, vertices
-  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals));
-  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals));
+  mesh::PtrMesh pMesh(new mesh::Mesh("MyMesh", dimensions, flipNormals, testing::meshIDManager()));
+  mesh::PtrMesh pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
 
   mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
       new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -845,7 +844,7 @@ BOOST_FIXTURE_TEST_CASE(ProvideAndReceiveCouplingMode, testing::M2NFixture,
   bool flipNormals = false;
 
   if (utils::Parallel::getProcessRank() == 0) {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
@@ -870,9 +869,9 @@ BOOST_FIXTURE_TEST_CASE(ProvideAndReceiveCouplingMode, testing::M2NFixture,
     BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
     BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
   } else {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::meshIDManager()));
 
-    mesh::PtrMesh       pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals));
+    mesh::PtrMesh       pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::meshIDManager()));
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
     boundingFromMapping->setMeshes(pSolidzMesh, pOtherMesh);

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -409,6 +409,7 @@ partition::ReceivedPartition::GeometricFilter ParticipantConfiguration:: getGeoF
   }
 }
 
+/// @todo remove
 mesh::PtrMesh ParticipantConfiguration:: copy
 (
   const mesh::PtrMesh& mesh ) const
@@ -416,7 +417,7 @@ mesh::PtrMesh ParticipantConfiguration:: copy
   int dim = mesh->getDimensions();
   std::string name(mesh->getName());
   bool flipNormals = mesh->isFlipNormals();
-  mesh::Mesh* meshCopy = new mesh::Mesh("Local_" + name, dim, flipNormals, mesh->getIDManager());
+  mesh::Mesh* meshCopy = new mesh::Mesh("Local_" + name, dim, flipNormals, mesh::Mesh::MESH_ID_UNDEFINED);
   for (const mesh::PtrData& data : mesh->data()){
     meshCopy->createData(data->getName(), data->getDimensions());
   }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -416,7 +416,7 @@ mesh::PtrMesh ParticipantConfiguration:: copy
   int dim = mesh->getDimensions();
   std::string name(mesh->getName());
   bool flipNormals = mesh->isFlipNormals();
-  mesh::Mesh* meshCopy = new mesh::Mesh("Local_" + name, dim, flipNormals);
+  mesh::Mesh* meshCopy = new mesh::Mesh("Local_" + name, dim, flipNormals, mesh->getIDManager());
   for (const mesh::PtrData& data : mesh->data()){
     meshCopy->createData(data->getName(), data->getDimensions());
   }

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -11,6 +11,7 @@
 #include "utils/PointerVector.hpp"
 #include "partition/ReceivedPartition.hpp"
 #include "utils/MasterSlave.hpp"
+#include "utils/ManageUniqueIDs.hpp"
 #include <string>
 
 namespace precice {
@@ -144,6 +145,10 @@ public:
 
   void setUseMaster(bool useMaster);
 
+  void setMeshIdManager(std::unique_ptr<utils::ManageUniqueIDs>&& idm) {
+      _meshIdManager = std::move(idm);
+  }
+
   /**
    * @brief Returns true, if the
    */
@@ -191,6 +196,8 @@ private:
   com::PtrCommunication _clientServerCommunication;
 
   bool _useMaster = false;
+
+  std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
 
   template<typename ELEMENT_T>
   bool isDataValid (

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -170,16 +170,14 @@ void SolverInterfaceImpl:: configure
   // Add meshIDs and data IDs
   for (const MeshContext* meshContext : _accessor->usedMeshContexts()) {
     const mesh::PtrMesh& mesh = meshContext->mesh;
-    for (std::pair<std::string,int> nameID : mesh->getNameIDPairs()) {
-      PRECICE_ASSERT(not utils::contained(nameID.first, _meshIDs));
-      _meshIDs[nameID.first] = nameID.second;
-    }
-    PRECICE_ASSERT(_dataIDs.find(mesh->getID())==_dataIDs.end());
-    _dataIDs[mesh->getID()] = std::map<std::string,int>();
-    PRECICE_ASSERT(_dataIDs.find(mesh->getID())!=_dataIDs.end());
+    const auto meshID = mesh->getID();
+    _meshIDs[mesh->getName()] = meshID;
+    PRECICE_ASSERT(_dataIDs.find(meshID)==_dataIDs.end());
+    _dataIDs[meshID] = std::map<std::string,int>();
+    PRECICE_ASSERT(_dataIDs.find(meshID)!=_dataIDs.end());
     for (const mesh::PtrData& data : mesh->data()) {
-      PRECICE_ASSERT(_dataIDs[mesh->getID()].find(data->getName())==_dataIDs[mesh->getID()].end());
-      _dataIDs[mesh->getID()][data->getName()] = data->getID();
+      PRECICE_ASSERT(_dataIDs[meshID].find(data->getName())==_dataIDs[meshID].end());
+      _dataIDs[meshID][data->getName()] = data->getID();
     }
     std::string meshName = mesh->getName();
     mesh::PtrMeshConfiguration meshConfig = config.getMeshConfiguration();

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -123,13 +123,13 @@ void SolverInterfaceImpl:: configure
   Event e("configure"); // no precice::syncMode as this is not yet configured here
   utils::ScopedEventPrefix sep("configure/");
 
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   Participant::resetParticipantCount();
   _meshLock.clear();
 
   _dimensions = config.getDimensions();
   _accessor = determineAccessingParticipant(config);
+  _accessor->setMeshIdManager(config.getMeshConfiguration()->extractMeshIdManager());
 
   PRECICE_CHECK(not (_accessor->useServer() && _accessor->useMaster()), "You cannot use a server and a master.");
   PRECICE_CHECK(_accessorCommunicatorSize==1 || _accessor->useMaster() || _accessor->useServer(),

--- a/src/precice/tests/MeshHandleTest.cpp
+++ b/src/precice/tests/MeshHandleTest.cpp
@@ -8,7 +8,7 @@
 using namespace precice;
 
 struct MeshFixture {
-    MeshFixture() : mesh("MyMesh", 3, false, testing::meshIDManager()), handle(mesh.content()) {
+    MeshFixture() : mesh("MyMesh", 3, false, testing::nextMeshID()), handle(mesh) {
         auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
         auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
         auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));

--- a/src/precice/tests/MeshHandleTest.cpp
+++ b/src/precice/tests/MeshHandleTest.cpp
@@ -8,7 +8,7 @@
 using namespace precice;
 
 struct MeshFixture {
-    MeshFixture() : mesh("MyMesh", 3, false), handle(mesh) {
+    MeshFixture() : mesh("MyMesh", 3, false, testing::meshIDManager()), handle(mesh.content()) {
         auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
         auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
         auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -17,7 +17,6 @@ using namespace precice;
 
 void reset ()
 {
-  mesh::Mesh::resetGeometryIDsGlobally();
   mesh::Data::resetDataCount();
   impl::Participant::resetParticipantCount();
   utils::MasterSlave::reset();

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -19,7 +19,6 @@ struct SerialTestFixture : testing::SlimConfigurator {
   std::string _pathToTests;
 
   void reset(){
-     mesh::Mesh::resetGeometryIDsGlobally();
      mesh::Data::resetDataCount();
      impl::Participant::resetParticipantCount();
      utils::MasterSlave::reset();
@@ -291,7 +290,6 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
-  mesh::Mesh::resetGeometryIDsGlobally();
   using Eigen::Vector3d;
 
   if (utils::Parallel::getProcessRank() == 0){
@@ -499,8 +497,6 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
-
-  mesh::Mesh::resetGeometryIDsGlobally ();
 
   int timesteps = 0;
   double time = 0;
@@ -723,7 +719,6 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
 
   for (int dim: {2, 3}){
     // @todo this should normally happen in finalize and should not be necessary
-    mesh::Mesh::resetGeometryIDsGlobally();
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     SolverInterface interface(solverName, 0, 1);
@@ -1232,7 +1227,6 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
 
 void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string configFile)
 {
-  mesh::Mesh::resetGeometryIDsGlobally();
   using Eigen::Vector3d;
 
   const double z = 0.3;
@@ -1376,8 +1370,6 @@ BOOST_AUTO_TEST_CASE(testSendMeshToMultipleParticipants,
   if (utils::Parallel::getCommunicatorSize() != 3)
     return;
 
-  mesh::Mesh::resetGeometryIDsGlobally();
-
   const std::string configFile = _pathToTests + "send-mesh-to-multiple-participants.xml";
   std::string solverName;
   std::string meshName;
@@ -1434,7 +1426,6 @@ BOOST_AUTO_TEST_CASE(testPreconditionerBug,
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
-  mesh::Mesh::resetGeometryIDsGlobally();
   using Eigen::Vector2d;
   using namespace precice::constants;
 

--- a/src/precice/tests/ServerTests.cpp
+++ b/src/precice/tests/ServerTests.cpp
@@ -18,7 +18,6 @@ struct ServerTestFixture : testing::WhiteboxAccessor {
   std::string _pathToTests;
 
   void reset(){
-     mesh::Mesh::resetGeometryIDsGlobally();
      mesh::Data::resetDataCount();
      impl::Participant::resetParticipantCount();
      utils::MasterSlave::reset();
@@ -94,7 +93,6 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     xml::ConfigurationContext context{"ParticipantB", 0, 1};
 
     // Perform manual configuration without overwritting logging config
-    mesh::Mesh::resetGeometryIDsGlobally();
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     config::Configuration config;
@@ -185,7 +183,6 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     xml::ConfigurationContext context{"ParticipantB", 0, 1};
 
     // Perform manual configuration without overwritting logging config
-    mesh::Mesh::resetGeometryIDsGlobally();
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     config::Configuration config;

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(WatchPoint)
   // Setup geometry
   std::string name("rectangle");
   bool flipNormals = false;
-  PtrMesh mesh(new Mesh(name, dim, flipNormals, testing::meshIDManager()));
+  PtrMesh mesh(new Mesh(name, dim, flipNormals, testing::nextMeshID()));
 
   mesh::Vertex& v1 = mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
   mesh::Vertex& v2 = mesh->createVertex(Eigen::Vector2d(2.0, 1.0));

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(WatchPoint)
   // Setup geometry
   std::string name("rectangle");
   bool flipNormals = false;
-  PtrMesh mesh(new Mesh(name, dim, flipNormals));
+  PtrMesh mesh(new Mesh(name, dim, flipNormals, testing::meshIDManager()));
 
   mesh::Vertex& v1 = mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
   mesh::Vertex& v2 = mesh->createVertex(Eigen::Vector2d(2.0, 1.0));

--- a/src/query/tests/FindClosestTest.cpp
+++ b/src/query/tests/FindClosestTest.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_SUITE(FindClosestTests, *testing::OnMaster())
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
 {
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh mesh("RootMesh", dim, false);
+    mesh::Mesh mesh("RootMesh", dim, false, testing::meshIDManager());
     mesh.createVertex(Eigen::VectorXd::Zero(dim));
     Eigen::VectorXd queryCoords0 = Eigen::VectorXd::Zero(dim);
     queryCoords0[0]              = 1.0;
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
     double                distance = closest.distance;
     BOOST_TEST(distance == 1.0);
     if (dim == 3) {
-      mesh::Mesh mesh3D("Mesh3D", dim, false);
+      mesh::Mesh mesh3D("Mesh3D", dim, false, testing::meshIDManager());
       mesh3D.createVertex(Eigen::Vector3d::Constant(1));
       FindClosest find2(Eigen::Vector3d::Constant(-1));
       find2(mesh3D);
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
 BOOST_AUTO_TEST_CASE(SignOfShortestDistance)
 {
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh      mesh("Mesh", dim, false);
+    mesh::Mesh      mesh("Mesh", dim, false, testing::meshIDManager());
     mesh::Vertex &  vertex = mesh.createVertex(Eigen::VectorXd::Zero(dim));
     Eigen::VectorXd normal = Eigen::VectorXd::Zero(dim);
     normal[0]              = 1.0;
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(SignOfShortestDistance)
 BOOST_AUTO_TEST_CASE(IndependenceOfSignOfShortestDistance)
 {
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh    mesh("Mesh", dim, false);
+    mesh::Mesh    mesh("Mesh", dim, false, testing::meshIDManager());
     mesh::Vertex &vertex = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     vertex.setNormal(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &vertex2 = mesh.createVertex(Eigen::VectorXd::Constant(dim, -2));
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges)
 {
   for (int dim = 2; dim <= 3; dim++) {
     // Create mesh consisting of two vertices and an edge
-    mesh::Mesh      mesh("Mesh", dim, false);
+    mesh::Mesh      mesh("Mesh", dim, false, testing::meshIDManager());
     mesh::Vertex &  v1     = mesh.createVertex(Eigen::VectorXd::Constant(dim, -1));
     mesh::Vertex &  v2     = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Edge &    edge   = mesh.createEdge(v1, v2);
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges3D)
 {
   int dim = 3;
   // Cremeshetry consisting of two vertices and an edge
-  mesh::Mesh      mesh("Mesh", dim, false);
+  mesh::Mesh      mesh("Mesh", dim, false, testing::meshIDManager());
   mesh::Vertex &  v1   = mesh.createVertex(Eigen::Vector3d(-1.0, -1.0, 0.0));
   mesh::Vertex &  v2   = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
   mesh::Edge &    edge = mesh.createEdge(v1, v2);
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges3D)
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToTriangles)
 {
   // Create mesh to query
-  mesh::Mesh    mesh("Mesh", 3, true);
+  mesh::Mesh    mesh("Mesh", 3, true, testing::meshIDManager());
   mesh::Vertex &v0 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToTriangles)
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToTrianglesAndVertices)
 {
   int           dim = 2;
-  mesh::Mesh    mesh("Mesh", dim, false);
+  mesh::Mesh    mesh("Mesh", dim, false, testing::meshIDManager());
   mesh::Vertex &vertex1 = mesh.createVertex(Eigen::Vector2d(0.0, 0.0));
   vertex1.setNormal(Eigen::Vector2d(-0.5, 0.5));
 
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(WeigthsOfVertices)
   int dim = 2;
 
   // Create mesh
-  mesh::Mesh mesh("Mesh", dim, true);
+  mesh::Mesh mesh("Mesh", dim, true, testing::meshIDManager());
   mesh::Vertex &vertex1 = mesh.createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &vertex2 = mesh.createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh.createEdge(vertex1, vertex2);
@@ -326,7 +326,7 @@ struct MeshFixture {
     mesh::Vertex *v1, *v2, *v3, *vinside, *voutside;
     mesh::Edge *e12, *e23, *e31;
     mesh::Triangle* t;
-    MeshFixture() : mesh("Mesh", dimension, true)
+    MeshFixture() : mesh("Mesh", dimension, true, testing::meshIDManager())
     {
         v1 = &mesh.createVertex(Eigen::Vector3d(0.0, 0.0, z));
         v2 = &mesh.createVertex(Eigen::Vector3d(1.0, 0.0, z));

--- a/src/query/tests/FindClosestTest.cpp
+++ b/src/query/tests/FindClosestTest.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_SUITE(FindClosestTests, *testing::OnMaster())
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
 {
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh mesh("RootMesh", dim, false, testing::meshIDManager());
+    mesh::Mesh mesh("RootMesh", dim, false, testing::nextMeshID());
     mesh.createVertex(Eigen::VectorXd::Zero(dim));
     Eigen::VectorXd queryCoords0 = Eigen::VectorXd::Zero(dim);
     queryCoords0[0]              = 1.0;
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
     double                distance = closest.distance;
     BOOST_TEST(distance == 1.0);
     if (dim == 3) {
-      mesh::Mesh mesh3D("Mesh3D", dim, false, testing::meshIDManager());
+      mesh::Mesh mesh3D("Mesh3D", dim, false, testing::nextMeshID());
       mesh3D.createVertex(Eigen::Vector3d::Constant(1));
       FindClosest find2(Eigen::Vector3d::Constant(-1));
       find2(mesh3D);
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
 BOOST_AUTO_TEST_CASE(SignOfShortestDistance)
 {
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh      mesh("Mesh", dim, false, testing::meshIDManager());
+    mesh::Mesh      mesh("Mesh", dim, false, testing::nextMeshID());
     mesh::Vertex &  vertex = mesh.createVertex(Eigen::VectorXd::Zero(dim));
     Eigen::VectorXd normal = Eigen::VectorXd::Zero(dim);
     normal[0]              = 1.0;
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(SignOfShortestDistance)
 BOOST_AUTO_TEST_CASE(IndependenceOfSignOfShortestDistance)
 {
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh    mesh("Mesh", dim, false, testing::meshIDManager());
+    mesh::Mesh    mesh("Mesh", dim, false, testing::nextMeshID());
     mesh::Vertex &vertex = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     vertex.setNormal(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &vertex2 = mesh.createVertex(Eigen::VectorXd::Constant(dim, -2));
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges)
 {
   for (int dim = 2; dim <= 3; dim++) {
     // Create mesh consisting of two vertices and an edge
-    mesh::Mesh      mesh("Mesh", dim, false, testing::meshIDManager());
+    mesh::Mesh      mesh("Mesh", dim, false, testing::nextMeshID());
     mesh::Vertex &  v1     = mesh.createVertex(Eigen::VectorXd::Constant(dim, -1));
     mesh::Vertex &  v2     = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Edge &    edge   = mesh.createEdge(v1, v2);
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges3D)
 {
   int dim = 3;
   // Cremeshetry consisting of two vertices and an edge
-  mesh::Mesh      mesh("Mesh", dim, false, testing::meshIDManager());
+  mesh::Mesh      mesh("Mesh", dim, false, testing::nextMeshID());
   mesh::Vertex &  v1   = mesh.createVertex(Eigen::Vector3d(-1.0, -1.0, 0.0));
   mesh::Vertex &  v2   = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
   mesh::Edge &    edge = mesh.createEdge(v1, v2);
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges3D)
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToTriangles)
 {
   // Create mesh to query
-  mesh::Mesh    mesh("Mesh", 3, true, testing::meshIDManager());
+  mesh::Mesh    mesh("Mesh", 3, true, testing::nextMeshID());
   mesh::Vertex &v0 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToTriangles)
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToTrianglesAndVertices)
 {
   int           dim = 2;
-  mesh::Mesh    mesh("Mesh", dim, false, testing::meshIDManager());
+  mesh::Mesh    mesh("Mesh", dim, false, testing::nextMeshID());
   mesh::Vertex &vertex1 = mesh.createVertex(Eigen::Vector2d(0.0, 0.0));
   vertex1.setNormal(Eigen::Vector2d(-0.5, 0.5));
 
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(WeigthsOfVertices)
   int dim = 2;
 
   // Create mesh
-  mesh::Mesh mesh("Mesh", dim, true, testing::meshIDManager());
+  mesh::Mesh mesh("Mesh", dim, true, testing::nextMeshID());
   mesh::Vertex &vertex1 = mesh.createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &vertex2 = mesh.createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh.createEdge(vertex1, vertex2);
@@ -326,7 +326,7 @@ struct MeshFixture {
     mesh::Vertex *v1, *v2, *v3, *vinside, *voutside;
     mesh::Edge *e12, *e23, *e31;
     mesh::Triangle* t;
-    MeshFixture() : mesh("Mesh", dimension, true, testing::meshIDManager())
+    MeshFixture() : mesh("Mesh", dimension, true, testing::nextMeshID())
     {
         v1 = &mesh.createVertex(Eigen::Vector3d(0.0, 0.0, z));
         v2 = &mesh.createVertex(Eigen::Vector3d(1.0, 0.0, z));

--- a/src/query/tests/FindClosestVertexVisitorTest.cpp
+++ b/src/query/tests/FindClosestVertexVisitorTest.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_SUITE(QueryTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(FindClosestVertexVisitor)
 {
-  mesh::Mesh mesh("Mesh", 2, false, testing::meshIDManager());
+  mesh::Mesh mesh("Mesh", 2, false, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh.createVertex(Eigen::Vector2d(0.0, 5.0));
   FindClosestVertex find(Eigen::Vector2d(1, 0));

--- a/src/query/tests/FindClosestVertexVisitorTest.cpp
+++ b/src/query/tests/FindClosestVertexVisitorTest.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_SUITE(QueryTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(FindClosestVertexVisitor)
 {
-  mesh::Mesh mesh("Mesh", 2, false);
+  mesh::Mesh mesh("Mesh", 2, false, testing::meshIDManager());
   mesh.createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh.createVertex(Eigen::Vector2d(0.0, 5.0));
   FindClosestVertex find(Eigen::Vector2d(1, 0));

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -5,6 +5,7 @@
 #include <boost/test/unit_test.hpp>
 #include "precice/config/Configuration.hpp"
 #include "xml/XMLTag.hpp"
+#include "utils/ManageUniqueIDs.hpp"
 
 namespace precice
 {
@@ -268,6 +269,18 @@ typename std::enable_if<std::is_arithmetic<Scalar>::value, boost::test_tools::pr
 
 /// Returns $PRECICE_ROOT/src, the base path to the sources.
 std::string getPathToSources();
+
+/** Reference to testing mesh id manager
+ *
+ * This is the accessor for the mesh::Mesh ID manager to be used in testing.
+ *
+ * @returns a reference to the Singleton
+ */
+inline utils::ManageUniqueIDs& meshIDManager()
+{
+    static utils::ManageUniqueIDs manager;
+    return manager;
+}
 
 } // namespace testing
 } // namespace precice

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -270,16 +270,14 @@ typename std::enable_if<std::is_arithmetic<Scalar>::value, boost::test_tools::pr
 /// Returns $PRECICE_ROOT/src, the base path to the sources.
 std::string getPathToSources();
 
-/** Reference to testing mesh id manager
+/** Generates a new mesh id for use in tests.
  *
- * This is the accessor for the mesh::Mesh ID manager to be used in testing.
- *
- * @returns a reference to the Singleton
+ * @returns a new unique mesh ID
  */
-inline utils::ManageUniqueIDs& meshIDManager()
+inline int nextMeshID()
 {
     static utils::ManageUniqueIDs manager;
-    return manager;
+    return manager.getFreeID();
 }
 
 } // namespace testing


### PR DESCRIPTION
This PR refactors the static IdManager for Meshes, as well as Mesh-internal Meshes, out of the Mesh.
It is now injected as a dependency via the constructor.
This makes testing easier, as we can use separate IdManagers instead to make assumptions on IDs.
For everything else, we can use a common manager (`testing::meshIDManager()`)

The owner of this IDManager is first the MeshConfiguration and then the actual Participant.
During the configuration creates the Meshes and thus requires this Manager. This is moved to the actual Participant after it was determined.

**However** this manager is only required to set [subIDs](https://xgm.de/precice/docs/develop/classprecice_1_1mesh_1_1Mesh.html#a2e65d1316c0d507ff751bbc3de7a2d05), a function that could theoretically be removed. @uekerman can you comment on that please?

This also reduces the global state of of the program.

Fixes #559