### PR TITLE
Add cleanup step prior to running tests

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -4,6 +4,7 @@
 
 set(PRECICE_TEST_DIR "${preCICE_BINARY_DIR}/TestOutput")
 mark_as_advanced(PRECICE_TEST_DIR)
+file(MAKE_DIRECTORY "${PRECICE_TEST_DIR}")
 
 function(add_precice_test)
   cmake_parse_arguments(PARSE_ARGV 0 PAT "MPI;CANFAIL" "NAME;ARGUMENTS;TIMEOUT" "")
@@ -15,7 +16,12 @@ function(add_precice_test)
   message(STATUS "Adding Test ${PAT_FULL_NAME}")
   # Generate working directory
   set(PAT_WDIR "${PRECICE_TEST_DIR}/${PAT_NAME}")
-  file(MAKE_DIRECTORY "${PAT_WDIR}")
+  add_test(NAME ${PAT_FULL_NAME}.setup
+    COMMAND ${CMAKE_COMMAND} -DDIR=${PAT_WDIR} -P ${CMAKE_CURRENT_LIST_DIR}/setuptest.cmake)
+  set_tests_properties(${PAT_FULL_NAME}.setup
+    PROPERTIES
+    FIXTURES_SETUP ${PAT_FULL_NAME}.fixture)
+
   # Assemble the command
   if(PAT_MPI)
     add_test(NAME ${PAT_FULL_NAME}
@@ -31,6 +37,7 @@ function(add_precice_test)
     RUN_SERIAL TRUE # Do not run this test in parallel with others
     WORKING_DIRECTORY "${PAT_WDIR}"
     ENVIRONMENT PRECICE_ROOT=${preCICE_SOURCE_DIR}
+    FIXTURES_REQUIRES "${PAT_FULL_NAME}.fixture"
     )
   if(PAT_TIMEOUT)
     set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PAT_TIMEOUT} )

--- a/cmake/setuptest.cmake
+++ b/cmake/setuptest.cmake
@@ -1,0 +1,17 @@
+#
+# Setup script for the preCICE tests.
+#
+# The script wipes the given test directory.
+#
+# Arguments:
+# DIR - the directory of the test
+#
+cmake_minimum_required(VERSION 3.10)
+
+if(NOT DIR)
+  message(FATAL_ERROR "You have to define a directory using the variable DIR !")
+endif()
+
+get_filename_component(_PATH ${DIR} ABSOLUTE)
+file(REMOVE_RECURSE ${_PATH})
+file(MAKE_DIRECTORY ${_PATH})


### PR DESCRIPTION
This PR adds a cleanup/setup step, which wipes the working directories of tests prior to running them.

This ensures the tests don't clog up due to a stale `precice-run` directory and removes irrelevant files from previous runs.