### PR TITLE
Add debug log for ConnectionInfoReader

### DIFF
--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -38,10 +38,12 @@ std::string ConnectionInfoReader::read() const
 {
   std::ifstream ifs;
   auto path = getFilename();
+  PRECICE_DEBUG("Waiting for connection file " << path);
   do {
     ifs.open(path, std::ifstream::in);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   } while (not ifs);
+  PRECICE_DEBUG("Found connection file " << path);
   
   std::string addressData;
   ifs >> addressData;

--- a/src/com/ConnectionInfoPublisher.hpp
+++ b/src/com/ConnectionInfoPublisher.hpp
@@ -45,6 +45,8 @@ protected:
    * (acceptorName, requesterName, rank)/rest of hash.
    */
   std::string getFilename() const;
+
+  mutable logging::Logger _log{"com::ConnectionInfoPublisher"};
 };
 
 
@@ -105,10 +107,6 @@ public:
    * set at construction.
    */
   void write(std::string const & info) const;
-
-private:
-
-  mutable logging::Logger _log{"com::ConnectionInfoPublisher"};
 };
 
 


### PR DESCRIPTION
This adds additional debug log to the ConnectionInfoReader:
```
(0) 14:27:44 [com::ConnectionInfoPublisher]:41 in read: Waiting for connection file ./precice-run/3e/7f05eb02d657cca803124e01f0d8a0
(0) 14:27:44 [com::ConnectionInfoPublisher]:46 in read: Found connection file ./precice-run/3e/7f05eb02d657cca803124e01f0d8a0
```

Closes #567 
