### PR TITLE
Change the Debug output for first mapped values.

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1454,7 +1454,7 @@ void SolverInterfaceImpl:: mapWrittenData()
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map from dataID " << inDataID << " to dataID: " << outDataID);
       context.mappingContext.mapping->map(inDataID, outDataID);
-      PRECICE_DEBUG("First mapped values = " << utils::previewRange(3, context.toData->values()));
+      PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
     }
   }
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1504,7 +1504,7 @@ void SolverInterfaceImpl:: mapReadData()
       PRECICE_DEBUG("Map read data \"" << context.fromData->getName()
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       context.mappingContext.mapping->map(inDataID, outDataID);
-      PRECICE_DEBUG("First mapped values = " << utils::previewRange(3, context.toData->values()));
+      PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
     }
   }
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -999,7 +999,7 @@ void SolverInterfaceImpl:: mapReadDataTo
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       PRECICE_ASSERT(mappingContext.mapping==context.mappingContext.mapping);
       mappingContext.mapping->map(inDataID, outDataID);
-      PRECICE_DEBUG("First mapped values = " << utils::previewRange(3, context.toData->values()));
+      PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
     }
   }
   mappingContext.hasMappedData = true;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -999,7 +999,7 @@ void SolverInterfaceImpl:: mapReadDataTo
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       PRECICE_ASSERT(mappingContext.mapping==context.mappingContext.mapping);
       mappingContext.mapping->map(inDataID, outDataID);
-      PRECICE_DEBUG("First mapped values = " << utils::firstN(context.toData->values(), 10));
+      PRECICE_DEBUG("First mapped values = " << utils::previewRange(3, context.toData->values()));
     }
   }
   mappingContext.hasMappedData = true;
@@ -1454,7 +1454,7 @@ void SolverInterfaceImpl:: mapWrittenData()
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map from dataID " << inDataID << " to dataID: " << outDataID);
       context.mappingContext.mapping->map(inDataID, outDataID);
-      PRECICE_DEBUG("First mapped values = " << utils::firstN(context.toData->values(), 10));
+      PRECICE_DEBUG("First mapped values = " << utils::previewRange(3, context.toData->values()));
     }
   }
 
@@ -1504,7 +1504,7 @@ void SolverInterfaceImpl:: mapReadData()
       PRECICE_DEBUG("Map read data \"" << context.fromData->getName()
                    << "\" to mesh \"" << context.mesh->getName() << "\"");
       context.mappingContext.mapping->map(inDataID, outDataID);
-      PRECICE_DEBUG("First mapped values = " << utils::firstN(context.toData->values(), 10));
+      PRECICE_DEBUG("First mapped values = " << utils::previewRange(3, context.toData->values()));
     }
   }
 

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -59,10 +59,10 @@ auto firstN(const Eigen::PlainObjectBase<Derived>& val, unsigned n) -> const Eig
     return {val.data(), std::min<Eigen::Index>(n,val.size())};
 }
 
-template<typename Derived, typename Iter = const typename Derived::Scalar*, typename Size = typename std::iterator_traits<Iter>::difference_type>>
-const RangePreview<Iter> previewRange( n, const Eigen::PlainObjectBase<Derived>& eigen) {
-    const auto begin = eigen.data();
-    const auto end = begin;
+template<typename Derived, typename Iter = const typename Derived::Scalar*, typename Size = typename std::iterator_traits<Iter>::difference_type>
+const RangePreview<Iter> previewRange(Size n, const Eigen::PlainObjectBase<Derived>& eigen) {
+    auto begin = eigen.data();
+    auto end = begin;
     std::advance(end, eigen.size());
     return {n, begin, end};
 }

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -59,6 +59,14 @@ auto firstN(const Eigen::PlainObjectBase<Derived>& val, unsigned n) -> const Eig
     return {val.data(), std::min<Eigen::Index>(n,val.size())};
 }
 
+template<typename Derived, typename Iter = const typename Derived::Scalar*, typename Size = typename std::iterator_traits<Iter>::difference_type>>
+const RangePreview<Iter> previewRange( n, const Eigen::PlainObjectBase<Derived>& eigen) {
+    const auto begin = eigen.data();
+    const auto end = begin;
+    std::advance(end, eigen.size());
+    return {n, begin, end};
+}
+
 
 template<typename DerivedLHS, typename DerivedRHS>
 bool componentWiseLess(const Eigen::PlainObjectBase<DerivedLHS>& lhs, const Eigen::PlainObjectBase<DerivedRHS>& rhs)

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -4,6 +4,7 @@
 #include<array>
 #include<functional>
 #include<type_traits>
+#include<iterator>
 
 namespace precice {
 namespace utils {
@@ -44,6 +45,24 @@ bool unique_elements(const Container& c, BinaryPredicate p = {})
 }
 
 
+/** intersperse a the range [first, last[ with a given element.
+ * 
+ * This results in a range [first, elem, first+1, elem, ... , elem, last[
+ * 
+ * \tparam InputIter the type of the input iterators
+ * \tparam ElemT the type of the element to intersperse
+ */
+template<class InputIter, class ElemT>
+void intersperse(InputIter first, InputIter last, const ElemT& elem, std::ostream& out) {
+    if (first == last) return;
+
+    out << *first++;
+    for (;first != last; ++first) {
+        out << elem << *first;
+    }
+}
+
+
 /** std::mismatch
  * @todo{Remove when migrating to c++14}
  */
@@ -55,6 +74,65 @@ std::pair<InputIt1, InputIt2>
         ++first1, ++first2;
     }
     return std::make_pair(first1, first2);
+}
+
+
+/// The RangePreview object used as a lazy proxy struct for proviewing the content of a Range
+template<typename Range>
+struct RangePreview {
+    using Size = typename Range::const_iterator::difference_type;
+    Size n;
+    typename Range::const_iterator begin;
+    typename Range::const_iterator end;
+
+    RangePreview(Size n, const Range & range) : n(n), begin(range.begin()), end(range.end()) {}
+
+    void print(std::ostream& out) const
+    {
+        if (begin == end) {
+            out << "<Empty Range>";
+            return;
+        }
+
+        out << '[';
+
+        if (n == 0) {
+            out << " ... ";
+        } else {
+            auto dist = std::distance(begin, end);
+            const std::string sep{", "};
+            if (dist <= n*2) {
+                intersperse(begin, end, sep, out);
+            } else {
+                auto last1 = begin;
+                std::advance(last1, n);
+                intersperse(begin, last1, sep, out);
+                out << sep << "... " << sep;
+                auto first2 = begin;
+                std::advance(first2, dist-n);
+                intersperse(first2, end, sep, out);
+            }
+        }
+
+        auto mm = std::minmax_element(begin, end);
+        out << "] min:" << *mm.first << " max:" << *mm.second;
+    }
+};
+
+/// Allows streaming of RangePreview objects
+template<typename Range>
+std::ostream& operator<<(std::ostream& out, const RangePreview<Range>& rp) {
+    rp.print(out);
+    return out;
+}
+
+/** returns a display object which previews a range
+ *
+ * The preview contains the first and last n elements and the minmax-elements.
+ */
+template<typename Range, typename Size = typename Range::const_iterator::difference_type>
+const RangePreview<Range> previewRange(Size n, const Range& range) {
+    return {n, range};
 }
 
 

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -80,7 +80,7 @@ std::pair<InputIt1, InputIt2>
 /// The RangePreview object used as a lazy proxy struct for proviewing the content of a Range
 template<typename InputIter>
 struct RangePreview {
-    using Size = typename InputIter::difference_type;
+    using Size = typename std::iterator_traits<InputIter>::difference_type;
     Size n;
     InputIter begin;
     InputIter end;

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -78,14 +78,14 @@ std::pair<InputIt1, InputIt2>
 
 
 /// The RangePreview object used as a lazy proxy struct for proviewing the content of a Range
-template<typename Range>
+template<typename InputIter>
 struct RangePreview {
-    using Size = typename Range::const_iterator::difference_type;
+    using Size = typename InputIter::difference_type;
     Size n;
-    typename Range::const_iterator begin;
-    typename Range::const_iterator end;
+    InputIter begin;
+    InputIter end;
 
-    RangePreview(Size n, const Range & range) : n(n), begin(range.begin()), end(range.end()) {}
+    RangePreview(Size n, InputIter begin, InputIter end) : n(n), begin(begin), end(end) {}
 
     void print(std::ostream& out) const
     {
@@ -120,8 +120,8 @@ struct RangePreview {
 };
 
 /// Allows streaming of RangePreview objects
-template<typename Range>
-std::ostream& operator<<(std::ostream& out, const RangePreview<Range>& rp) {
+template<typename Iter>
+std::ostream& operator<<(std::ostream& out, const RangePreview<Iter>& rp) {
     rp.print(out);
     return out;
 }
@@ -130,11 +130,10 @@ std::ostream& operator<<(std::ostream& out, const RangePreview<Range>& rp) {
  *
  * The preview contains the first and last n elements and the minmax-elements.
  */
-template<typename Range, typename Size = typename Range::const_iterator::difference_type>
-const RangePreview<Range> previewRange(Size n, const Range& range) {
-    return {n, range};
+template<typename Range, typename Iter = typename Range::const_iterator, typename Size = typename std::iterator_traits<Iter>::difference_type>
+const RangePreview<Iter> previewRange(Size n, const Range& range) {
+    return {n, std::begin(range), std::end(range)};
 }
-
 
 } // namespace utils
 } // namespace precice

--- a/src/utils/tests/AlgorithmTest.cpp
+++ b/src/utils/tests/AlgorithmTest.cpp
@@ -85,8 +85,7 @@ BOOST_AUTO_TEST_SUITE(RangePreview)
 
 BOOST_AUTO_TEST_CASE(NormalRangePreview)
 {
-    Eigen::VectorXd a(7);
-    a << 1, 2, 3, 4, 5, 6, 0;
+    std::vector<int> a{1, 2, 3, 4, 5, 6, 0};
     std::ostringstream oss;
     oss << pu::previewRange(2, a);
     std::string str{oss.str()};
@@ -95,8 +94,7 @@ BOOST_AUTO_TEST_CASE(NormalRangePreview)
 
 BOOST_AUTO_TEST_CASE(PrintNoElements)
 {
-    Eigen::VectorXd a(7);
-    a << 1, 2, 3, 4, 5, 6, 0;
+    std::vector<int> a{1, 2, 3, 4, 5, 6, 0};
     std::ostringstream oss;
     oss << pu::previewRange(0, a);
     std::string str{oss.str()};
@@ -105,7 +103,7 @@ BOOST_AUTO_TEST_CASE(PrintNoElements)
 
 BOOST_AUTO_TEST_CASE(EmptyRange)
 {
-    auto a = Eigen::VectorXd::Zero(0);
+    std::vector<int> a;
     std::ostringstream oss;
     oss << pu::previewRange(3, a);
     std::string str{oss.str()};

--- a/src/utils/tests/AlgorithmTest.cpp
+++ b/src/utils/tests/AlgorithmTest.cpp
@@ -81,7 +81,37 @@ BOOST_AUTO_TEST_CASE(Mismatch)
     BOOST_TEST(*ab.second == 0);
 }
 
+BOOST_AUTO_TEST_SUITE(RangePreview)
 
+BOOST_AUTO_TEST_CASE(NormalRangePreview)
+{
+    Eigen::VectorXd a(7);
+    a << 1, 2, 3, 4, 5, 6, 0;
+    std::ostringstream oss;
+    oss << pu::previewRange(2, a);
+    std::string str{oss.str()};
+    BOOST_TEST(str == "[1, 2, ... , 6, 0] min:0 max:6");
+}
 
+BOOST_AUTO_TEST_CASE(PrintNoElements)
+{
+    Eigen::VectorXd a(7);
+    a << 1, 2, 3, 4, 5, 6, 0;
+    std::ostringstream oss;
+    oss << pu::previewRange(0, a);
+    std::string str{oss.str()};
+    BOOST_TEST(str == "[ ... ] min:0 max:6");
+}
+
+BOOST_AUTO_TEST_CASE(EmptyRange)
+{
+    auto a = Eigen::VectorXd::Zero(0);
+    std::ostringstream oss;
+    oss << pu::previewRange(3, a);
+    std::string str{oss.str()};
+    BOOST_TEST(str == "<Empty Range>");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/EigenHelperFunctionsTest.cpp
+++ b/src/utils/tests/EigenHelperFunctionsTest.cpp
@@ -14,6 +14,20 @@ BOOST_AUTO_TEST_CASE(FirstN)
     BOOST_TEST(firstN(a, 3) == b);
 }
 
+BOOST_AUTO_TEST_SUITE(RangePreview)
+
+BOOST_AUTO_TEST_CASE(EigenVector)
+{
+    Eigen::VectorXd a{7};
+    a << 1, 2, 3, 4, 5, 6, 0;
+    std::ostringstream oss;
+    oss << previewRange(2, a);
+    std::string str{oss.str()};
+    BOOST_TEST(str == "[1, 2, ... , 6, 0] min:0 max:6");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_CASE(ComponentWiseLess)
 {
     precice::utils::ComponentWiseLess cwl;


### PR DESCRIPTION
This PR changes the data output to the follow:
```
(0) 17:12:04 [impl::SolverInterfaceImpl]:1457 in mapWrittenData: First mapped values = [-5.0503, -21.4203, -21.4203, -5.0503] min:-21.4203 max:-5.0503
```

Data longer than 6 will be shortened like so:
 ```
[0, 1, 2, ... , 3, 4, 5] min:0 max:5
 ```
Fixes #556 