### PR TITLE
Add minimum pip version 10.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
         - PY_CMD=python3
         - $PY_CMD -m pip install --user --upgrade pip wheel setuptools
       install:
-        - pip3 install --user cython numpy mpi4py
+        - pip3 install --user cython numpy mpi4py packaging
       script:
         - $TRAVIS_BUILD_DIR/tools/travis-bindings-test.sh
 
@@ -103,7 +103,7 @@ before_install:
 
 install:
   - $TRAVIS_BUILD_DIR/tools/travis-install-dependencies.sh $LOCAL_INSTALL
-  - pip3 install --user cython numpy mpi4py
+  - pip3 install --user cython numpy mpi4py packaging
   - export PATH=${LOCAL_INSTALL}/cmake/bin:${LOCAL_INSTALL}/bin:${PATH}
 
 before_script:

--- a/src/precice/bindings/python/pyproject.toml
+++ b/src/precice/bindings/python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools", "wheel", "Cython>=0.29"]
+requires = ["setuptools", "wheel", "Cython>=0.29", "pip>=10.0.1"]

--- a/src/precice/bindings/python/pyproject.toml
+++ b/src/precice/bindings/python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools", "wheel", "Cython>=0.29", "pip>=10.0.1"]
+requires = ["setuptools", "wheel", "Cython>=0.29", "packaging"]

--- a/src/precice/bindings/python/setup.py
+++ b/src/precice/bindings/python/setup.py
@@ -9,6 +9,10 @@ from Cython.Distutils.build_ext import new_build_ext as build_ext
 from Cython.Build import cythonize
 from distutils.command.install import install
 from distutils.command.build import build
+from packaging import version
+import pip
+
+assert(version.parse(pip.__version__) >= version.parse("10.0.1"))  # minimum version 10.0.1 is required. See https://github.com/precice/precice/wiki/Non%E2%80%93standard-APIs#python-bindings-version-of-pip3-is-too-old
 
 # name of Interfacing API
 APPNAME = "precice"


### PR DESCRIPTION
This PR tries to avoid the problems that we observe in https://github.com/precice/systemtests/pull/97 https://github.com/precice/systemtests/pull/98 and https://github.com/precice/systemtests/pull/129, when the version of pip is too low. If we cannot avoid these problems, we should at least provide more helpful error messages, if the pip version is too low.

We require the minimum pip version `10.0.1` due to failing build with pip version `9.0.1` or older. See [here](https://travis-ci.org/precice/systemtests/jobs/618377756?utm_medium=notification&utm_source=github_status).