### PR TITLE
Split CTest Tests by Module

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -24,13 +24,21 @@ function(add_precice_test)
   # We always prefix our tests
   set(PAT_FULL_NAME "precice.${PAT_NAME}")
 
+  # Are direct dependencies fullfilled?
+  if( (PAT_MPI AND NOT MPI) OR (PAT_PETSC AND NOT PETSC) )
+    message(STATUS "Test ${PAT_FULL_NAME} - skipped")
+    return()
+  endif()
+
   # Assemble the command
-  if(NOT PAT_NOMPI AND MPI)
+  if(PAT_PETSC OR (NOT PAT_NOMPI AND MPI))
+    # Parallel tests, dispatched by MPI
     message(STATUS "Test ${PAT_FULL_NAME} - parallel")
     add_test(NAME ${PAT_FULL_NAME}
       COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS} ${MPIEXEC_POSTFLAGS}
       )
   elseif(NOT PAT_MPI)
+    # Serial tests, called directly
     message(STATUS "Test ${PAT_FULL_NAME} - serial")
     add_test(NAME ${PAT_FULL_NAME}
       COMMAND $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS}

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -9,26 +9,40 @@ set(PRECICE_TEST_DIR "${preCICE_BINARY_DIR}/TestOutput")
 mark_as_advanced(PRECICE_TEST_DIR)
 
 function(add_precice_test)
-  cmake_parse_arguments(PARSE_ARGV 0 PAT "MPI;CANFAIL" "NAME;ARGUMENTS;TIMEOUT" "")
+  cmake_parse_arguments(PARSE_ARGV 0 PAT "NOMPI;PETSC;MPI;CANFAIL" "NAME;ARGUMENTS;TIMEOUT;LABELS" "")
+  # Check arguments
   if(NOT PAT_NAME)
     message(FATAL_ERROR "Argument NAME not passed")
   endif()
+  if(PAT_MPI AND PAT_NOMPI)
+    message(FATAL_ERROR "You cannot specify MPI and NOMPI simultaneously.")
+  endif()
+  if(PAT_NOMPI AND PAT_PETSC)
+    message(FATAL_ERROR "You cannot specify NOMPI and PETSC simultaneously.")
+  endif()
+
   # We always prefix our tests
   set(PAT_FULL_NAME "precice.${PAT_NAME}")
-  message(STATUS "Adding Test ${PAT_FULL_NAME}")
-  # Generate working directory
-  set(PAT_WDIR "${PRECICE_TEST_DIR}/${PAT_NAME}")
-  file(MAKE_DIRECTORY "${PAT_WDIR}")
+
   # Assemble the command
-  if(PAT_MPI)
+  if(NOT PAT_NOMPI AND MPI)
+    message(STATUS "Test ${PAT_FULL_NAME} - parallel")
     add_test(NAME ${PAT_FULL_NAME}
       COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS} ${MPIEXEC_POSTFLAGS}
       )
-  else()
+  elseif(NOT PAT_MPI)
+    message(STATUS "Test ${PAT_FULL_NAME} - serial")
     add_test(NAME ${PAT_FULL_NAME}
       COMMAND $<TARGET_FILE:testprecice> ${PAT_ARGUMENTS}
       )
+  else()
+    message(STATUS "Test ${PAT_FULL_NAME} - skipped")
+    return()
   endif()
+  # Generate working directory
+  set(PAT_WDIR "${PRECICE_TEST_DIR}/${PAT_NAME}")
+  file(MAKE_DIRECTORY "${PAT_WDIR}")
+  # Setting properties
   set_tests_properties(${PAT_FULL_NAME}
     PROPERTIES
     RUN_SERIAL TRUE # Do not run this test in parallel with others
@@ -38,56 +52,140 @@ function(add_precice_test)
   if(PAT_TIMEOUT)
     set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PAT_TIMEOUT} )
   endif()
+  set(_labels ${PAT_LABELS})
   if(PAT_CANFAIL)
-    set_tests_properties(${PAT_FULL_NAME} PROPERTIES LABELS "canfail")
+    list(APPEND _labels "canfail")
   endif()
+  set_tests_properties(${PAT_FULL_NAME} PROPERTIES LABELS "${_labels}")
 endfunction(add_precice_test)
 
 enable_testing()
 
-if(MPI AND MPIEXEC_EXECUTABLE)
-  # Configured with MPI
-  # Register the uncritical base-set
-  add_precice_test(
-    NAME Base
-    ARGUMENTS "--run_test=\!@MPI_Ports:\!MappingTests/PetRadialBasisFunctionMapping/Parallel/\*"
-    TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-    MPI
-    )
-  add_precice_test(
-    NAME MPI_Ports
-    ARGUMENTS "--run_test=@MPI_Ports"
-    TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+add_precice_test(
+  NAME acceleration
+  ARGUMENTS "--run_test=AccelerationTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME action
+  ARGUMENTS "--run_test=ActionTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME com
+  ARGUMENTS "--run_test=CommunicationTests:\!CommunicationTests/MPIPorts"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  MPI
+  )
+add_precice_test(
+  NAME com.mpiports
+  ARGUMENTS "--run_test=CommunicationTests/MPIPorts"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  LABELS "mpiports;canfail"
+  MPI
+  )
+add_precice_test(
+  NAME cplscheme
+  ARGUMENTS "--run_test=CplSchemeTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME io
+  ARGUMENTS "--run_test=IOTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME m2n
+  ARGUMENTS "--run_test=M2NTests:\!M2NTests/MPIPortsCommunication"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  MPI
+  )
+add_precice_test(
+  NAME m2n.mpiports
+  ARGUMENTS "--run_test=M2NTests/MPIPortsCommunication"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  LABELS "mpiports;canfail"
+  MPI
+  )
+add_precice_test(
+  NAME mapping
+  ARGUMENTS "--run_test=MappingTests:\!MappingTests/PetRadiaBasisFunctionMapping"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME mapping.petrbf
+  ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  LABELS petsc
+  MPI
+  PETSC
+  )
+add_precice_test(
+  NAME math
+  ARGUMENTS "--run_test=MathTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME mesh
+  ARGUMENTS "--run_test=MeshTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME partition
+  ARGUMENTS "--run_test=PartitionTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  MPI
+  )
+add_precice_test(
+  NAME interface
+  ARGUMENTS "--run_test=PreciceTests:\!PreciceTests/Serial:\!PreciceTests/Parallel"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME serial
+  ARGUMENTS "--run_test=PreciceTests/Serial"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  MPI
+  )
+add_precice_test(
+  NAME parallel
+  ARGUMENTS "--run_test=PreciceTests/Parallel"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  MPI
+  )
+add_precice_test(
+  NAME query
+  ARGUMENTS "--run_test=QueryTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME testing
+  ARGUMENTS "--run_test=TestingTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME utils
+  ARGUMENTS "--run_test=UtilsTests"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
+add_precice_test(
+  NAME xml
+  ARGUMENTS "--run_test=XML"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  )
 
-    MPI
-    CANFAIL
-    )
-  if(PETSC)
-    add_precice_test(
-      NAME PetRBFParallel
-      ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping/Parallel/\*"
-      TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-      MPI
-      CANFAIL
-      )
-  endif()
+if(MPI)
   add_precice_test(
-    NAME NoMPI
+    NAME nompi
     TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-    )
-else()
-  # Configured without MPI
-  add_precice_test(
-    NAME Base
-    TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
+    NOMPI
     )
 endif()
-
 
 # Add a separate target to test only the base
 add_custom_target(
   test_base
-  COMMAND ctest -V -R precice.Base
+  COMMAND ctest -V -LE canfail
   DEPENDS testprecice
   WORKING_DIRECTORY ${preCICE_BINARY_DIR}
   USES_TERMINAL

--- a/tools/travis-build-test.sh
+++ b/tools/travis-build-test.sh
@@ -20,5 +20,8 @@ else
     mkdir $PRECICE_BUILD_DIR && cd $PRECICE_BUILD_DIR
     cmake -DPETSC=$PETSC -DMPI=$MPI -DPYTHON=on -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache $TRAVIS_BUILD_DIR
     cmake --build . -- -j $(nproc)
-    ctest --output-on-failure -O $TRAVIS_BUILD_DIR/tests/boost-test-output
+    # Run tests with moderate console output
+    ctest -LE mpiports --output-on-failure -O $TRAVIS_BUILD_DIR/tests/boost-test-output
+    # Run tests which should be muted
+    ctest -L mpiports
 fi


### PR DESCRIPTION
This PR splits up the tests run by CTest. They are now grouped by module, some of which are only registered when MPI is turned off.
This allows for fine-grained ouput on test failure.

Travis now discards the log of the failing tests of mpi ports as they tend to flood the streams.

`make test_base` now runs all tests except mpiports.

# Example output of `ctest` with MPI and PETSc

```
Test project /tmp/precice
      Start  1: precice.acceleration
 1/21 Test  #1: precice.acceleration .............   Passed    0.14 sec
      Start  2: precice.action
 2/21 Test  #2: precice.action ...................   Passed    0.13 sec
      Start  3: precice.com
 3/21 Test  #3: precice.com ......................   Passed    0.37 sec
      Start  4: precice.com.mpiports
 4/21 Test  #4: precice.com.mpiports .............***Failed    0.07 sec
      Start  5: precice.cplscheme
 5/21 Test  #5: precice.cplscheme ................   Passed    0.90 sec
      Start  6: precice.io
 6/21 Test  #6: precice.io .......................   Passed    0.06 sec
      Start  7: precice.m2n
 7/21 Test  #7: precice.m2n ......................   Passed    0.20 sec
      Start  8: precice.m2n.mpiports
 8/21 Test  #8: precice.m2n.mpiports .............***Timeout  21.01 sec
      Start  9: precice.mapping
 9/21 Test  #9: precice.mapping ..................   Passed    1.72 sec
      Start 10: precice.mapping.petrbf
10/21 Test #10: precice.mapping.petrbf ...........   Passed    1.59 sec
      Start 11: precice.math
11/21 Test #11: precice.math .....................   Passed    0.08 sec
      Start 12: precice.mesh
12/21 Test #12: precice.mesh .....................   Passed    0.07 sec
      Start 13: precice.partition
13/21 Test #13: precice.partition ................   Passed    0.43 sec
      Start 14: precice.interface
14/21 Test #14: precice.interface ................   Passed    0.21 sec
      Start 15: precice.serial
15/21 Test #15: precice.serial ...................   Passed    2.34 sec
      Start 16: precice.parallel
16/21 Test #16: precice.parallel .................   Passed    5.69 sec
      Start 17: precice.query
17/21 Test #17: precice.query ....................   Passed    0.09 sec
      Start 18: precice.testing
18/21 Test #18: precice.testing ..................   Passed    0.07 sec
      Start 19: precice.utils
19/21 Test #19: precice.utils ....................   Passed    0.06 sec
      Start 20: precice.xml
20/21 Test #20: precice.xml ......................   Passed    0.06 sec
      Start 21: precice.nompi
21/21 Test #21: precice.nompi ....................   Passed    1.81 sec

90% tests passed, 2 tests failed out of 21

Label Time Summary:
canfail     =  21.08 sec*proc (2 tests)
mpiports    =  21.08 sec*proc (2 tests)
petsc       =   1.59 sec*proc (1 test)

Total Test time (real) =  37.43 sec

The following tests FAILED:
	  4 - precice.com.mpiports (Failed)
	  8 - precice.m2n.mpiports (Timeout)
Errors while running CTest
```

# Example output of `ctest` without MPI nor PETSc

```
Test project /tmp/precice-nompo
      Start  1: precice.acceleration
 1/12 Test  #1: precice.acceleration .............   Passed    0.02 sec
      Start  2: precice.action
 2/12 Test  #2: precice.action ...................   Passed    0.07 sec
      Start  3: precice.cplscheme
 3/12 Test  #3: precice.cplscheme ................   Passed    0.01 sec
      Start  4: precice.io
 4/12 Test  #4: precice.io .......................   Passed    0.01 sec
      Start  5: precice.mapping
 5/12 Test  #5: precice.mapping ..................   Passed    0.09 sec
      Start  6: precice.math
 6/12 Test  #6: precice.math .....................   Passed    0.01 sec
      Start  7: precice.mesh
 7/12 Test  #7: precice.mesh .....................   Passed    0.01 sec
      Start  8: precice.interface
 8/12 Test  #8: precice.interface ................   Passed    0.01 sec
      Start  9: precice.query
 9/12 Test  #9: precice.query ....................   Passed    0.01 sec
      Start 10: precice.testing
10/12 Test #10: precice.testing ..................   Passed    0.01 sec
      Start 11: precice.utils
11/12 Test #11: precice.utils ....................   Passed    0.01 sec
      Start 12: precice.xml
12/12 Test #12: precice.xml ......................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =   0.26 sec
```