### PR TITLE
Reduce parallel tests

### DIFF
--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -9,7 +9,7 @@ using namespace precice;
 using namespace precice::action;
 
 BOOST_AUTO_TEST_SUITE(ActionTests)
-BOOST_AUTO_TEST_SUITE(Python)
+BOOST_AUTO_TEST_SUITE(Python, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(AllMethods)
 {

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -12,7 +12,7 @@
 using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(ActionTests)
-BOOST_AUTO_TEST_SUITE(Scale)
+BOOST_AUTO_TEST_SUITE(Scale, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(DivideByArea)
 {

--- a/src/cplscheme/tests/AbsoluteConvergenceMeasureTest.cpp
+++ b/src/cplscheme/tests/AbsoluteConvergenceMeasureTest.cpp
@@ -1,12 +1,12 @@
 #include "../impl/AbsoluteConvergenceMeasure.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(CplSchemeTests)
-
 using namespace precice;
 using namespace cplscheme;
 
-BOOST_AUTO_TEST_CASE(AbsoluteConvergenceMeasureTest)
+BOOST_AUTO_TEST_SUITE(CplSchemeTests)
+
+BOOST_AUTO_TEST_CASE(AbsoluteConvergenceMeasureTest, *testing::OnMaster())
 {
   using Eigen::Vector3d;
   // Create convergence measure for Vector data

--- a/src/mapping/tests/MappingConfigurationTest.cpp
+++ b/src/mapping/tests/MappingConfigurationTest.cpp
@@ -9,7 +9,7 @@ using namespace precice;
 using namespace precice::mapping;
 
 BOOST_AUTO_TEST_SUITE(MappingTests)
-BOOST_AUTO_TEST_SUITE(Configuration)
+BOOST_AUTO_TEST_SUITE(Configuration, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Configuration)
 {

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -10,7 +10,7 @@ using namespace precice;
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MappingTests)
-BOOST_AUTO_TEST_SUITE(NearestNeighborMapping)
+BOOST_AUTO_TEST_SUITE(NearestNeighborMapping, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
 {

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -8,7 +8,7 @@
 using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(MappingTests)
-BOOST_AUTO_TEST_SUITE(NearestProjectionMapping)
+BOOST_AUTO_TEST_SUITE(NearestProjectionMapping, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)                
 {

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -10,7 +10,7 @@ using namespace precice;
 using namespace precice::mapping;
 
 BOOST_AUTO_TEST_SUITE(MappingTests)
-BOOST_AUTO_TEST_SUITE(RadialBasisFunctionMapping)
+BOOST_AUTO_TEST_SUITE(RadialBasisFunctionMapping, *testing::OnMaster())
 
 // Forward declarations, see end of file for definitions
 void perform2DTestConsistentMapping(Mapping& mapping);

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -3,10 +3,11 @@
 #include "math/barycenter.hpp"
 #include "math/math.hpp"
 
+using namespace precice;
 using namespace precice::math::barycenter;
 
 BOOST_AUTO_TEST_SUITE(MathTests)
-BOOST_AUTO_TEST_SUITE(Barycenter)
+BOOST_AUTO_TEST_SUITE(Barycenter, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(BarycenterEdge)
 {

--- a/src/math/tests/DifferencesTest.cpp
+++ b/src/math/tests/DifferencesTest.cpp
@@ -2,10 +2,11 @@
 
 #include "math/math.hpp"
 
+using namespace precice;
 using namespace precice::math;
 
 BOOST_AUTO_TEST_SUITE(MathTests)
-BOOST_AUTO_TEST_SUITE(Differences)
+BOOST_AUTO_TEST_SUITE(Differences, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Scalar)
 {

--- a/src/math/tests/GeometryTest.cpp
+++ b/src/math/tests/GeometryTest.cpp
@@ -1,10 +1,11 @@
 #include "../geometry.hpp"
 #include "testing/Testing.hpp"
 
+using namespace precice;
 using namespace precice::math;
 
 BOOST_AUTO_TEST_SUITE(MathTests)
-BOOST_AUTO_TEST_SUITE(Geometry)
+BOOST_AUTO_TEST_SUITE(Geometry, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Collinear)
 {

--- a/src/mesh/tests/DataConfigurationTest.cpp
+++ b/src/mesh/tests/DataConfigurationTest.cpp
@@ -6,7 +6,7 @@ using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
-BOOST_AUTO_TEST_CASE(DataConfig)
+BOOST_AUTO_TEST_CASE(DataConfig, *testing::OnMaster())
 {
   std::string filename(testing::getPathToSources()  + "/mesh/tests/data-config.xml");
   int dim = 3;

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -3,9 +3,11 @@
 #include "mesh/Edge.hpp"
 #include <Eigen/Core>
 
+using namespace precice;
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(EdgeTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Edges)
 {
@@ -72,4 +74,5 @@ BOOST_AUTO_TEST_CASE(EdgeConnectedTo)
 }
 
 
+BOOST_AUTO_TEST_SUITE_END() // Edge
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/GroupTest.cpp
+++ b/src/mesh/tests/GroupTest.cpp
@@ -5,9 +5,11 @@
 #include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
 
+using namespace precice;
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(GroupTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Groups)
 {
@@ -59,4 +61,5 @@ BOOST_AUTO_TEST_CASE(Groups)
   BOOST_TEST(group.size() == 11);
 }
 
+BOOST_AUTO_TEST_SUITE_END() // Group
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/MergeTest.cpp
+++ b/src/mesh/tests/MergeTest.cpp
@@ -7,9 +7,11 @@
 #include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
 
+using namespace precice;
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(MergeTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(MergeTest)
 {
@@ -68,4 +70,5 @@ BOOST_AUTO_TEST_CASE(MergeTest)
   BOOST_TEST(merge.content().size() == 10);
 }
 
+BOOST_AUTO_TEST_SUITE_END() // Merge
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -17,7 +17,7 @@ using Eigen::Vector3d;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
-BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(MeshTests, *testing::OnMaster())
 
 
 BOOST_AUTO_TEST_CASE(SubIDs)

--- a/src/mesh/tests/PropertyContainerTest.cpp
+++ b/src/mesh/tests/PropertyContainerTest.cpp
@@ -5,7 +5,7 @@ using namespace precice;
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
-BOOST_AUTO_TEST_SUITE(PropertyContainerTest)
+BOOST_AUTO_TEST_SUITE(PropertyContainerTest, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(SinglePropertyContainer)
 {

--- a/src/mesh/tests/QuadTest.cpp
+++ b/src/mesh/tests/QuadTest.cpp
@@ -7,9 +7,11 @@
 
 #include <vector>
 
+using namespace precice;
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(QuadTests, *testing::OnMaster())
 
 
 BOOST_AUTO_TEST_CASE(Quads)
@@ -239,4 +241,6 @@ BOOST_AUTO_TEST_CASE(QuadWKTPrint)
     std::string q1string("POLYGON ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0))");
     BOOST_TEST(q1string == stream.str());
 }
+
+BOOST_AUTO_TEST_SUITE_END() // Quad
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -4,13 +4,14 @@
 #include "mesh/impl/RTreeAdapter.hpp"
 #include "math/geometry.hpp"
 
+using namespace precice;
 using namespace precice::mesh;
 
 namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
-BOOST_AUTO_TEST_SUITE(RTree)
+BOOST_AUTO_TEST_SUITE(RTree, *testing::OnMaster())
 BOOST_AUTO_TEST_SUITE(BGAdapters)
 
 BOOST_AUTO_TEST_CASE(VectorAdapter)
@@ -572,9 +573,9 @@ BOOST_AUTO_TEST_CASE(PrimitveIndexComparison) {
 
 BOOST_FIXTURE_TEST_CASE(IndexSinglePrimitiveType, MeshFixture) {
   PrimitiveRTree rtree;
-  impl::AABBGenerator gen{mesh};
+  mesh::impl::AABBGenerator gen{mesh};
 
-  using impl::indexPrimitive;
+  using mesh::impl::indexPrimitive;
   BOOST_TEST(rtree.empty());
   indexPrimitive(rtree, gen, mesh.vertices());
   BOOST_TEST(rtree.size() == vertex_cnt);

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -7,9 +7,11 @@
 
 #include <iterator>
 
+using namespace precice;
 using namespace precice::mesh;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(TriangleTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Triangles)
 {
@@ -218,4 +220,5 @@ BOOST_AUTO_TEST_CASE(TriangleWKTPrint)
     BOOST_TEST(t1string == stream.str());
 }
 
+BOOST_AUTO_TEST_SUITE_END() // Triangle
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/VertexTest.cpp
+++ b/src/mesh/tests/VertexTest.cpp
@@ -5,6 +5,7 @@
 using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(VertexTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Vertices)
 {
@@ -45,4 +46,6 @@ BOOST_AUTO_TEST_CASE(VertexWKTPrint)
     std::string v2str("POINT (1 2 3)");
     BOOST_TEST(v2str == v2stream.str());
 }
+
+BOOST_AUTO_TEST_SUITE_END() // Vertex
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/query/tests/FindClosestTest.cpp
+++ b/src/query/tests/FindClosestTest.cpp
@@ -12,7 +12,7 @@ using namespace precice;
 using namespace precice::query;
 
 BOOST_AUTO_TEST_SUITE(QueryTests)
-BOOST_AUTO_TEST_SUITE(FindClosestTests)
+BOOST_AUTO_TEST_SUITE(FindClosestTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
 {

--- a/src/query/tests/FindClosestVertexVisitorTest.cpp
+++ b/src/query/tests/FindClosestVertexVisitorTest.cpp
@@ -6,7 +6,7 @@
 using namespace precice;
 using namespace precice::query;
 
-BOOST_AUTO_TEST_SUITE(QueryTests)
+BOOST_AUTO_TEST_SUITE(QueryTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(FindClosestVertexVisitor)
 {

--- a/src/utils/tests/AlgorithmTest.cpp
+++ b/src/utils/tests/AlgorithmTest.cpp
@@ -2,9 +2,11 @@
 #include "utils/algorithm.hpp"
 #include <Eigen/Core>
 
+using namespace precice;
 namespace pu = precice::utils;
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
+BOOST_AUTO_TEST_SUITE(AlgorithmTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(MakeArray)
 {
@@ -110,6 +112,8 @@ BOOST_AUTO_TEST_CASE(EmptyRange)
     BOOST_TEST(str == "<Empty Range>");
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END() // Range
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END() // Alorithm
+
+BOOST_AUTO_TEST_SUITE_END() // Utils

--- a/src/utils/tests/DimensionsTest.cpp
+++ b/src/utils/tests/DimensionsTest.cpp
@@ -3,9 +3,11 @@
 #include "testing/Testing.hpp"
 #include "utils/Dimensions.hpp"
 
+using namespace precice;
 using namespace precice::utils;
 
-BOOST_AUTO_TEST_SUITE(UtilsTests)
+BOOST_AUTO_TEST_SUITE(DimensionTests)
+BOOST_AUTO_TEST_SUITE(UtilsTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(LinearizeDelinearize)
 {
@@ -86,4 +88,5 @@ BOOST_AUTO_TEST_CASE(LinearizeDelinearize)
   }
 }
 
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/EigenHelperFunctionsTest.cpp
+++ b/src/utils/tests/EigenHelperFunctionsTest.cpp
@@ -1,9 +1,11 @@
 #include "testing/Testing.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 
+using namespace precice;
 using namespace precice::utils;
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
+BOOST_AUTO_TEST_SUITE(EigenHelperFunctionsTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(FirstN)
 {
@@ -52,4 +54,5 @@ BOOST_AUTO_TEST_CASE(ComponentWiseLess)
 }
 
 
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/ManageUniqueIDsTest.cpp
+++ b/src/utils/tests/ManageUniqueIDsTest.cpp
@@ -1,9 +1,11 @@
 #include "testing/Testing.hpp"
 #include "utils/ManageUniqueIDs.hpp"
 
+using namespace precice;
 using namespace precice::utils;
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
+BOOST_AUTO_TEST_SUITE(ManageUniqueIDsTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(UniqueIDs)
 {
@@ -18,4 +20,5 @@ BOOST_AUTO_TEST_CASE(UniqueIDs)
   BOOST_TEST(id == 3);
 }
 
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/MultiLockTest.cpp
+++ b/src/utils/tests/MultiLockTest.cpp
@@ -2,9 +2,11 @@
 #include "testing/Testing.hpp"
 #include "utils/MultiLock.hpp"
 
+using namespace precice;
 using namespace precice::utils;
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
+BOOST_AUTO_TEST_SUITE(MultiLockTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(MultiLockTest)
 {
@@ -44,4 +46,5 @@ BOOST_AUTO_TEST_CASE(MultiLockTest)
     BOOST_TEST(mlock.checkAll());
 }
 
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/PointerVectorTest.cpp
+++ b/src/utils/tests/PointerVectorTest.cpp
@@ -5,7 +5,7 @@ using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
 
-BOOST_AUTO_TEST_CASE(PointerVector)
+BOOST_AUTO_TEST_CASE(PointerVector, *testing::OnMaster())
 {
   utils::ptr_vector<double> ptrVector;
 }

--- a/src/utils/tests/StatisticsTest.cpp
+++ b/src/utils/tests/StatisticsTest.cpp
@@ -2,11 +2,12 @@
 #include "utils/Statistics.hpp"
 #include <Eigen/Core>
 
+using namespace precice;
 namespace pu = precice::utils;
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
 
-BOOST_AUTO_TEST_CASE(DistanceAccumulator)
+BOOST_AUTO_TEST_CASE(DistanceAccumulator, *testing::OnMaster())
 {
     pu::statistics::DistanceAccumulator acc;
     acc(0);

--- a/src/utils/tests/StringTest.cpp
+++ b/src/utils/tests/StringTest.cpp
@@ -2,9 +2,11 @@
 #include "testing/Testing.hpp"
 #include "utils/String.hpp"
 
+using namespace precice;
 using namespace precice::utils;
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
+BOOST_AUTO_TEST_SUITE(StringTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(StringWrap)
 {
@@ -64,4 +66,5 @@ BOOST_AUTO_TEST_CASE(ConvertStringToBool)
 }
 
 
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -4,10 +4,11 @@
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
 
+using namespace precice;
 using namespace precice::xml;
 using precice::testing::getPathToSources;
 
-BOOST_AUTO_TEST_SUITE(XML)
+BOOST_AUTO_TEST_SUITE(XML, *testing::OnMaster())
 
 struct CallbackHostAttr : public XMLTag::Listener {
   Eigen::VectorXd eigenValue;

--- a/src/xml/tests/XMLTest.cpp
+++ b/src/xml/tests/XMLTest.cpp
@@ -4,10 +4,11 @@
 #include "xml/XMLTag.hpp"
 
 
+using namespace precice;
 using namespace precice::xml;
 using precice::testing::getPathToSources;
 
-BOOST_AUTO_TEST_SUITE(XML)
+BOOST_AUTO_TEST_SUITE(XML, *testing::OnMaster())
 
 struct CallbackHost : public XMLTag::Listener {
   Eigen::VectorXd eigenVectorXd;


### PR DESCRIPTION
This PR applies the `testing::OnMaster()` decorator to serial tests.
This reduces the amount of running tests in configurations with enabled MPI:

Rank | Old :fire:  | Now :deciduous_tree:
--- | --- | ---
0 | 294 | 294 
1 | 289 | 123
2 | 289 | 123
3 | 289 | 123
**Total** | 1161 | 663