### PR TITLE
WIP: Add PETSc test fixture

### DIFF
--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -8,6 +8,7 @@
 #include "mesh/Vertex.hpp"
 #include "math/math.hpp"
 #include "testing/Testing.hpp"
+#include "testing/Fixtures.hpp"
 
 using namespace precice;
 using namespace precice::mesh;
@@ -23,9 +24,8 @@ void addGlobalIndex(mesh::PtrMesh &mesh, int offset = 0)
   }
 }
 
-
-BOOST_AUTO_TEST_SUITE(Parallel,
-                      * testing::MinRanks(4))
+BOOST_FIXTURE_TEST_SUITE(Parallel, testing::PETScTestFixture<4>,
+                         *testing::MinRanks(4))
 
 
 /// Holds rank, owner, position and value of a single vertex
@@ -729,8 +729,7 @@ BOOST_AUTO_TEST_CASE(testTagFirstRound){
 
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
-BOOST_AUTO_TEST_SUITE(Serial,
-                      * boost::unit_test::fixture<testing::SingleRankFixture>())
+BOOST_FIXTURE_TEST_SUITE(Serial, testing::PETScTestFixture<1>, * testing::OnMaster())
 
 
 void perform2DTestConsistentMapping(Mapping& mapping)

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -16,7 +16,7 @@ using Par = precice::utils::Parallel;
 
 /// Fixture to set and reset MPI communicator
 struct MPICommRestrictFixture {
-  explicit MPICommRestrictFixture(std::vector<int> &ranks)
+  explicit MPICommRestrictFixture(const std::vector<int> &ranks)
   {
     // Restriction MUST always be called on all ranks, otherwise we hang
     if (static_cast<int>(ranks.size()) < Par::getCommunicatorSize()) {

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -4,7 +4,6 @@
 #include <boost/test/tree/test_case_counter.hpp> 
 #include <boost/filesystem.hpp>
 #include "utils/Parallel.hpp"
-#include "utils/Petsc.hpp"
 #include "utils/EventUtils.hpp"
 #include "utils/MasterSlave.hpp"
 #include "logging/LogConfiguration.hpp"
@@ -104,7 +103,6 @@ int main(int argc, char* argv[])
   logging::setupLogging(); // first logging initalization, as early as possible
   utils::Parallel::initializeMPI(&argc, &argv);
   logging::setMPIRank(utils::Parallel::getProcessRank());
-  utils::Petsc::initialize(&argc, &argv);
   utils::EventRegistry::instance().initialize("precice-Tests", "", utils::Parallel::getGlobalCommunicator());
     
   if (utils::Parallel::getCommunicatorSize() < 4) {
@@ -124,7 +122,6 @@ int main(int argc, char* argv[])
   }
 
   utils::EventRegistry::instance().finalize();
-  utils::Petsc::finalize();
   utils::Parallel::finalizeMPI();
   utils::MasterSlave::_communication = nullptr;
   return retCode;

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -252,6 +252,11 @@ Parallel::Communicator Parallel::getRestrictedCommunicator(const std::vector<int
   PRECICE_ASSERT(_isInitialized);
   PRECICE_ASSERT(not ranks.empty());
   PRECICE_ASSERT(ranks.size() <= static_cast<size_t>(getCommunicatorSize()));
+
+  // When asked to restrict to a single rank, then we can simply use MPI_COMM_SELF.
+  if (ranks.size() == 1) {
+      return MPI_COMM_SELF;
+  }
   // Create group, containing all processes of communicator
   MPI_Group currentGroup;
   MPI_Comm_group(_globalCommunicator, &currentGroup);
@@ -293,6 +298,7 @@ Parallel::Communicator Parallel::getRestrictedCommunicator(const std::vector<int
 
 void Parallel::restrictGlobalCommunicator(const std::vector<int> &ranks)
 {
+  PRECICE_ASSERT(!ranks.empty());
   auto restrComm = getRestrictedCommunicator(ranks);
   if (std::find(ranks.begin(), ranks.end(), getProcessRank()) != ranks.end())
     setGlobalCommunicator(restrComm);

--- a/src/utils/Parallel.hpp
+++ b/src/utils/Parallel.hpp
@@ -112,6 +112,9 @@ public:
    * @attention Has to be called by every process in the communicator to be
    *            restricted, otherwise, a deadlock is achieved!
    *
+   * @note Requesting a restricted communicator given a single rank will return
+   *       MPI_COMM_SELF.
+   *
    * @param[in] ranks Process ranks to be selected for restricted comm.
    */
   static Communicator getRestrictedCommunicator(const std::vector<int> &ranks);


### PR DESCRIPTION
This PR adds the fixture `PETScTestFixture`, which restricts the communicator to a given amount of ranks and then both initializes and finalizes PETSc.

This has two effects:
1. Every PetRBF test now runs in a fresh environment, which makes debugging saner as the test order does not matter any more.
2. The test `main` does not have to initialize or finalize PETSc any more.

This is a first step of #597