### PR TITLE
Reformat the Code-Base

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,10 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlinesLeft: false
+AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
@@ -17,7 +16,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:   
@@ -29,17 +28,25 @@ BraceWrapping:
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     0
 CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
@@ -47,14 +54,22 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
 IncludeCategories: 
   - Regex:           '^(<|"(gtest|isl|json)/)'
     Priority:        1
   - Regex:           '.*'
     Priority:        2
+  - Regex:           '.*'
+    Priority:        1
 IncludeIsMainRegex: '$'
 IndentCaseLabels: false
+IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
@@ -64,21 +79,30 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 100
 PointerAlignment: Right
 ReflowComments:  true
 SortIncludes:    true
+SortUsingDeclarations: true
 SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
@@ -87,6 +111,10 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11
+StatementMacros: 
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
 TabWidth:        2
 UseTab:          Never
 ...
+

--- a/docs/documents/070_tooling.dox
+++ b/docs/documents/070_tooling.dox
@@ -11,6 +11,8 @@ clang-format
 
 The tool [clang-format](https://clang.llvm.org/docs/ClangFormat.html) applies a configured code style to C and C++ files.
 It checks parent directories for a `.clang-format` file and applies the style to a given source file.
+To keep the code-base consistent, please use `clang-format` version 8.
+Scripts will explicitly use `clang-format-8` to prevent any problems.
 
 To use the tool form the shell, run:
 ```

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -7,22 +7,17 @@
 #include "cplscheme/BaseCouplingScheme.hpp"
 #include "cplscheme/SharedPointer.hpp"
 
-namespace precice
-{
-namespace io
-{
+namespace precice {
+namespace io {
 class TXTWriter;
 class TXTReader;
-}
-}
+} // namespace io
+} // namespace precice
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
-class Acceleration
-{
+class Acceleration {
 public:
   static const int NOFILTER      = 0;
   static const int QR1FILTER     = 1;
@@ -92,5 +87,5 @@ public:
     return false;
   }
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -1,36 +1,34 @@
 #include <Eigen/Core>
 #include <limits>
 
+#include "acceleration/AitkenAcceleration.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "math/math.hpp"
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
-#include "acceleration/AitkenAcceleration.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
-AitkenAcceleration::AitkenAcceleration(double initialRelaxation,
-                                           std::vector<int> dataIDs)
-  :_initialRelaxation(initialRelaxation),
-   _dataIDs(dataIDs),
-   _aitkenFactor(initialRelaxation)
+AitkenAcceleration::AitkenAcceleration(double           initialRelaxation,
+                                       std::vector<int> dataIDs)
+    : _initialRelaxation(initialRelaxation),
+      _dataIDs(dataIDs),
+      _aitkenFactor(initialRelaxation)
 {
   PRECICE_CHECK((_initialRelaxation > 0.0) && (_initialRelaxation <= 1.0),
-        "Initial relaxation factor for aitken acceleration has to "
-        << "be larger than zero and smaller or equal than one!");
+                "Initial relaxation factor for aitken acceleration has to "
+                    << "be larger than zero and smaller or equal than one!");
 }
 
 void AitkenAcceleration::initialize(DataMap &cplData)
 {
   PRECICE_CHECK(utils::contained(*_dataIDs.begin(), cplData),
-        "Data with ID " << *_dataIDs.begin() << " is not contained in data given at initialization!");
+                "Data with ID " << *_dataIDs.begin() << " is not contained in data given at initialization!");
   size_t entries = 0;
   if (_dataIDs.size() == 1) {
     entries = cplData[_dataIDs.at(0)]->values->size();
@@ -147,5 +145,5 @@ void AitkenAcceleration::setDesignSpecification(
   _designSpecification = q;
   PRECICE_ERROR("design specification for Aitken relaxation is not supported yet.");
 }
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -6,14 +6,10 @@
 #include "acceleration/Acceleration.hpp"
 #include "logging/Logger.hpp"
 
+namespace precice {
+namespace acceleration {
 
-namespace precice
-{
-namespace acceleration
-{
-
-class AitkenAcceleration : public Acceleration
-{
+class AitkenAcceleration : public Acceleration {
 public:
   AitkenAcceleration(
       double           initialRelaxationFactor,
@@ -55,5 +51,5 @@ private:
 
   Eigen::VectorXd _designSpecification;
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -1,35 +1,33 @@
+#include "acceleration/BaseQNAcceleration.hpp"
+#include "acceleration/impl/Preconditioner.hpp"
+#include "acceleration/impl/QRFactorization.hpp"
 #include "com/Communication.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
-#include "acceleration/BaseQNAcceleration.hpp"
-#include "acceleration/impl/QRFactorization.hpp"
-#include "acceleration/impl/Preconditioner.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Event.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
+namespace precice {
 extern bool syncMode;
-namespace acceleration
-{
+namespace acceleration {
 
 /* ----------------------------------------------------------------------------
  *     Constructor
  * ----------------------------------------------------------------------------
  */
 BaseQNAcceleration::BaseQNAcceleration(
-    double            initialRelaxation,
-    bool              forceInitialRelaxation,
-    int               maxIterationsUsed,
-    int               timestepsReused,
-    int               filter,
-    double            singularityLimit,
-    std::vector<int>  dataIDs,
+    double                  initialRelaxation,
+    bool                    forceInitialRelaxation,
+    int                     maxIterationsUsed,
+    int                     timestepsReused,
+    int                     filter,
+    double                  singularityLimit,
+    std::vector<int>        dataIDs,
     impl::PtrPreconditioner preconditioner)
-  :   _preconditioner(preconditioner),
+    : _preconditioner(preconditioner),
       _initialRelaxation(initialRelaxation),
       _maxIterationsUsed(maxIterationsUsed),
       _timestepsReused(timestepsReused),
@@ -41,12 +39,12 @@ BaseQNAcceleration::BaseQNAcceleration(
       _infostringstream(std::ostringstream::ate)
 {
   PRECICE_CHECK((_initialRelaxation > 0.0) && (_initialRelaxation <= 1.0),
-        "Initial relaxation factor for QN acceleration has to "
-            << "be larger than zero and smaller or equal than one!");
+                "Initial relaxation factor for QN acceleration has to "
+                    << "be larger than zero and smaller or equal than one!");
   PRECICE_CHECK(_maxIterationsUsed > 0,
-        "Maximal iterations used for QN acceleration has to be larger than zero!");
+                "Maximal iterations used for QN acceleration has to be larger than zero!");
   PRECICE_CHECK(_timestepsReused >= 0,
-        "Number of old timesteps to be reused for QN acceleration has to be >= 0!");
+                "Number of old timesteps to be reused for QN acceleration has to be >= 0!");
 }
 
 /** ---------------------------------------------------------------------------------------------
@@ -84,7 +82,7 @@ void BaseQNAcceleration::initialize(
 
   for (auto &elem : _dataIDs) {
     PRECICE_CHECK(utils::contained(elem, cplData),
-          "Data with ID " << elem << " is not contained in data given at initialization!");
+                  "Data with ID " << elem << " is not contained in data given at initialization!");
     entries += cplData[elem]->values->size();
     subVectorSizes.push_back(cplData[elem]->values->size());
   }
@@ -571,7 +569,8 @@ void BaseQNAcceleration::iterationsConverged(
   // we need to do underrelax in the first iteration of the second timesteps
   // so "_firstTimeStep" is slightly misused, but still the best way to understand
   // the concept
-  if(not _firstIteration) _firstTimeStep = false;
+  if (not _firstIteration)
+    _firstTimeStep = false;
 
   // update preconditioner depending on residuals or values (must be after specialized iterations converged --> IMVJ)
   _preconditioner->update(true, _values, _residuals);
@@ -702,5 +701,5 @@ void BaseQNAcceleration::writeInfo(
   }
   _infostringstream << std::flush;
 }
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -5,10 +5,10 @@
 #include <fstream>
 #include <sstream>
 
-#include "logging/Logger.hpp"
 #include "acceleration/Acceleration.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
+#include "logging/Logger.hpp"
 
 /* ****************************************************************************
  * 
@@ -45,27 +45,23 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 /**
  * @brief Base Class for quasi-Newton acceleration schemes
  * 
  */
-class BaseQNAcceleration : public Acceleration
-{
+class BaseQNAcceleration : public Acceleration {
 public:
-
   BaseQNAcceleration(
-      double            initialRelaxation,
-      bool              forceInitialRelaxation,
-      int               maxIterationsUsed,
-      int               timestepsReused,
-      int               filter,
-      double            singularityLimit,
-      std::vector<int>  dataIDs,
+      double                  initialRelaxation,
+      bool                    forceInitialRelaxation,
+      int                     maxIterationsUsed,
+      int                     timestepsReused,
+      int                     filter,
+      double                  singularityLimit,
+      std::vector<int>        dataIDs,
       impl::PtrPreconditioner preconditioner);
 
   /**
@@ -308,5 +304,5 @@ private:
   /// Additional debugging info, is not important for computation:
   int _nbDelCols = 0;
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/BroydenAcceleration.cpp
+++ b/src/acceleration/BroydenAcceleration.cpp
@@ -1,29 +1,28 @@
 #include <Eigen/Core>
 
+#include "acceleration/BroydenAcceleration.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "cplscheme/SharedPointer.hpp"
-#include "acceleration/BroydenAcceleration.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 using namespace precice::acceleration::impl;
 
 BroydenAcceleration::BroydenAcceleration(
-    double            initialRelaxation,
-    bool              forceInitialRelaxation,
-    int               maxIterationsUsed,
-    int               timestepsReused,
-    int               filter,
-    double            singularityLimit,
-    std::vector<int>  dataIDs,
+    double                  initialRelaxation,
+    bool                    forceInitialRelaxation,
+    int                     maxIterationsUsed,
+    int                     timestepsReused,
+    int                     filter,
+    double                  singularityLimit,
+    std::vector<int>        dataIDs,
     impl::PtrPreconditioner preconditioner)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, timestepsReused,
-                           filter, singularityLimit, dataIDs, preconditioner),
+                         filter, singularityLimit, dataIDs, preconditioner),
       _maxColumns(maxIterationsUsed)
-{}
+{
+}
 
 void BroydenAcceleration::initialize(
     DataMap &cplData)
@@ -42,8 +41,8 @@ void BroydenAcceleration::computeUnderrelaxationSecondaryData(
 {
   // Perform underrelaxation with initial relaxation factor for secondary data
   for (int id : _secondaryDataIDs) {
-    cplscheme::PtrCouplingData  data   = cplData[id];
-    Eigen::VectorXd &values = *(data->values);
+    cplscheme::PtrCouplingData data   = cplData[id];
+    Eigen::VectorXd &          values = *(data->values);
     values *= _initialRelaxation; // new * omg
     Eigen::VectorXd &secResiduals = _secondaryResiduals[id];
     secResiduals                  = data->oldValues.col(0); // old
@@ -56,7 +55,7 @@ void BroydenAcceleration::updateDifferenceMatrices(
     DataMap &cplData)
 {
   if (not _firstIteration) {
-      _currentColumns++;
+    _currentColumns++;
   }
 
   // call the base method for common update of V, W matrices
@@ -116,5 +115,5 @@ void BroydenAcceleration::specializedIterationsConverged(
   // store old Jacobian
   _oldInvJacobian = _invJacobian;
 }
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/BroydenAcceleration.hpp
+++ b/src/acceleration/BroydenAcceleration.hpp
@@ -4,10 +4,8 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 /**
  * @brief Multi vector quasi-Newton update scheme 
@@ -22,20 +20,19 @@ namespace acceleration
  * MVQN-related data. The data is called "secondary" henceforth and additional
  * old value and data matrices are needed for it.
  */
-class BroydenAcceleration : public BaseQNAcceleration
-{
+class BroydenAcceleration : public BaseQNAcceleration {
 public:
   /**
    * @brief Constructor.
    */
   BroydenAcceleration(
-      double            initialRelaxation,
-      bool              forceInitialRelaxation,
-      int               maxIterationsUsed,
-      int               timestepsReused,
-      int               filter,
-      double            singularityLimit,
-      std::vector<int>  dataIDs,
+      double                  initialRelaxation,
+      bool                    forceInitialRelaxation,
+      int                     maxIterationsUsed,
+      int                     timestepsReused,
+      int                     filter,
+      double                  singularityLimit,
+      std::vector<int>        dataIDs,
       impl::PtrPreconditioner preconditioner);
 
   /**
@@ -80,5 +77,5 @@ private:
   virtual void computeUnderrelaxationSecondaryData(DataMap &cplData);
   //void computeNewtonFactorsQRDecomposition(DataMap& cplData, Eigen::VectorXd& update);
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/ConstantRelaxationAcceleration.cpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.cpp
@@ -1,33 +1,31 @@
 #include <Eigen/Core>
 
+#include "acceleration/ConstantRelaxationAcceleration.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
-#include "acceleration/ConstantRelaxationAcceleration.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Helpers.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 ConstantRelaxationAcceleration::ConstantRelaxationAcceleration(
     double           relaxation,
     std::vector<int> dataIDs)
-  : _relaxation(relaxation),
-    _dataIDs(dataIDs)
+    : _relaxation(relaxation),
+      _dataIDs(dataIDs)
 {
   PRECICE_CHECK((relaxation > 0.0) && (relaxation <= 1.0),
-        "Relaxation factor for constant relaxation acceleration "
-        << "has to be larger than zero and smaller or equal than one!");
+                "Relaxation factor for constant relaxation acceleration "
+                    << "has to be larger than zero and smaller or equal than one!");
 }
 
 void ConstantRelaxationAcceleration::initialize(DataMap &cplData)
 {
   PRECICE_CHECK(_dataIDs.empty() || utils::contained(*_dataIDs.begin(), cplData),
-        "Data with ID " << *_dataIDs.begin()
-                        << " is not contained in data given at initialization!");
+                "Data with ID " << *_dataIDs.begin()
+                                << " is not contained in data given at initialization!");
 
   // Append column for old values if not done by coupling scheme yet
   int entries = 0;
@@ -88,5 +86,5 @@ void ConstantRelaxationAcceleration::setDesignSpecification(Eigen::VectorXd &q)
   _designSpecification = q;
   PRECICE_ERROR("Design specification for constant relaxation is not supported yet.");
 }
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -2,16 +2,13 @@
 
 #include <map>
 
-#include "logging/Logger.hpp"
 #include "acceleration/Acceleration.hpp"
+#include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
-class ConstantRelaxationAcceleration : public Acceleration
-{
+class ConstantRelaxationAcceleration : public Acceleration {
 public:
   ConstantRelaxationAcceleration(
       double           relaxation,
@@ -46,5 +43,5 @@ private:
 
   Eigen::VectorXd _designSpecification;
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/IQNILSAcceleration.hpp
+++ b/src/acceleration/IQNILSAcceleration.hpp
@@ -2,10 +2,8 @@
 
 #include "acceleration/BaseQNAcceleration.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 /**
  * @brief Interface quasi-Newton with interface least-squares approximation.
@@ -20,17 +18,16 @@ namespace acceleration
  * IQN-related data. The data is called "secondary" henceforth and additional
  * old value and data matrices are needed for it.
  */
-class IQNILSAcceleration : public BaseQNAcceleration
-{
+class IQNILSAcceleration : public BaseQNAcceleration {
 public:
   IQNILSAcceleration(
-      double            initialRelaxation,
-      bool              forceInitialRelaxation,
-      int               maxIterationsUsed,
-      int               timestepsReused,
-      int               filter,
-      double            singularityLimit,
-      std::vector<int>  dataIDs,
+      double                  initialRelaxation,
+      bool                    forceInitialRelaxation,
+      int                     maxIterationsUsed,
+      int                     timestepsReused,
+      int                     filter,
+      double                  singularityLimit,
+      std::vector<int>        dataIDs,
       impl::PtrPreconditioner preconditioner);
 
   virtual ~IQNILSAcceleration() {}
@@ -68,5 +65,5 @@ private:
   /// Removes one iteration from V,W matrices and adapts _matrixCols.
   virtual void removeMatrixColumn(int columnIndex);
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/MMAcceleration.cpp
+++ b/src/acceleration/MMAcceleration.cpp
@@ -2,34 +2,32 @@
 
 #include <Eigen/Dense>
 
+#include "acceleration/MMAcceleration.hpp"
+#include "acceleration/impl/QRFactorization.hpp"
 #include "com/Communication.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
-#include "acceleration/MMAcceleration.hpp"
-#include "acceleration/impl/QRFactorization.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 /* ----------------------------------------------------------------------------
  *     Constructor
  * ----------------------------------------------------------------------------
  */
 MMAcceleration::MMAcceleration(
-    PtrAcceleration       coarseModelOptimization,
-    int                     maxIterationsUsed,
-    int                     timestepsReused,
-    int                     filter,
-    double                  singularityLimit,
-    bool                    estimateJacobian,
-    std::vector<int>        fineDataIDs,
-    std::vector<int>        coarseDataIDs,
+    PtrAcceleration  coarseModelOptimization,
+    int              maxIterationsUsed,
+    int              timestepsReused,
+    int              filter,
+    double           singularityLimit,
+    bool             estimateJacobian,
+    std::vector<int> fineDataIDs,
+    std::vector<int> coarseDataIDs,
     //std::map<int, double> scalings,
     impl::PtrPreconditioner preconditioner)
     : Acceleration(),
@@ -47,12 +45,12 @@ MMAcceleration::MMAcceleration(
       _filter(filter)
 {
   PRECICE_CHECK(_maxIterationsUsed > 0,
-        "Maximal iterations used for MM acceleration has to be larger than zero!");
+                "Maximal iterations used for MM acceleration has to be larger than zero!");
   PRECICE_CHECK(_maxIterCoarseModelOpt > 0,
-        "Maximal iterations used for coarse model optimization for MM acceleration has to "
-            << "be larger than zero!");
+                "Maximal iterations used for coarse model optimization for MM acceleration has to "
+                    << "be larger than zero!");
   PRECICE_CHECK(_timestepsReused >= 0,
-        "Number of old timesteps to be reused for MM acceleration has to be >= 0!");
+                "Number of old timesteps to be reused for MM acceleration has to be >= 0!");
 }
 
 /** ---------------------------------------------------------------------------------------------
@@ -76,14 +74,14 @@ void MMAcceleration::initialize(DataMap &cplData)
 
   for (auto &elem : _fineDataIDs) {
     PRECICE_CHECK(utils::contained(elem, cplData),
-          "Data with ID " << elem << " is not contained in data given at initialization!");
+                  "Data with ID " << elem << " is not contained in data given at initialization!");
     entries += cplData[elem]->values->size();
     subVectorSizes.push_back(cplData[elem]->values->size());
   }
 
   for (auto &elem : _coarseDataIDs) {
     PRECICE_CHECK(utils::contained(elem, cplData),
-          "Data with ID " << elem << " is not contained in data given at initialization!");
+                  "Data with ID " << elem << " is not contained in data given at initialization!");
     coarseEntries += cplData[elem]->values->size();
   }
 
@@ -491,15 +489,15 @@ void MMAcceleration::performAcceleration(
       //(*_isCoarseModelOptimizationActive)  = false;
       _notConvergedWithinMaxIter = true;
       PRECICE_WARN("The coarse model optimization in coupling iteration " << its
-                                                                  << " exceeds maximal number of optimization cycles (" << _maxIterCoarseModelOpt << " without convergence!");
+                                                                          << " exceeds maximal number of optimization cycles (" << _maxIterCoarseModelOpt << " without convergence!");
     }
   }
 
   if (_notConvergedWithinMaxIter) {
     if (std::isnan(utils::MasterSlave::l2norm(_input_Xstar))) {
       PRECICE_ERROR("The coupling iteration in time step " << tSteps << " failed to converge and NaN values occured throughout the coupling process. "
-                                                   << "This is most likely due to the fact that the coarse model failed to converge within "
-                                                   << "the given maximum number of allowed iterations: " << _maxIterCoarseModelOpt);
+                                                           << "This is most likely due to the fact that the coarse model failed to converge within "
+                                                           << "the given maximum number of allowed iterations: " << _maxIterCoarseModelOpt);
     }
   }
 
@@ -820,5 +818,5 @@ int MMAcceleration::getLSSystemRows()
   return _fineResiduals.size();
   //return _matrixF.rows();
 }
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/MMAcceleration.hpp
+++ b/src/acceleration/MMAcceleration.hpp
@@ -3,23 +3,20 @@
 #include <Eigen/Core>
 #include <deque>
 
-#include "logging/Logger.hpp"
 #include "acceleration/Acceleration.hpp"
 #include "acceleration/SharedPointer.hpp"
 #include "acceleration/impl/Preconditioner.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
+#include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 /// Base Class for quasi-Newton acceleration schemes
-class MMAcceleration : public Acceleration
-{
+class MMAcceleration : public Acceleration {
 public:
   MMAcceleration(
-      PtrAcceleration       coarseModelOptimization,
+      PtrAcceleration         coarseModelOptimization,
       int                     maxIterationsUsed,
       int                     timestepsReused,
       int                     filter,
@@ -27,7 +24,7 @@ public:
       bool                    estimateJacobian,
       std::vector<int>        fineDataIDs,
       std::vector<int>        coarseDataIDs,
-      impl::PtrPreconditioner       preconditioner);
+      impl::PtrPreconditioner preconditioner);
 
   virtual ~MMAcceleration()
   {
@@ -274,5 +271,5 @@ private:
   /// Indicates whether the design specification has been set and is active or not
   bool isSet(Eigen::VectorXd &designSpec);
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/MVQNAcceleration.hpp
+++ b/src/acceleration/MVQNAcceleration.hpp
@@ -11,10 +11,8 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 /**
  * @brief Multi vector quasi-Newton update scheme 
@@ -29,8 +27,7 @@ namespace acceleration
  * MVQN-related data. The data is called "secondary" henceforth and additional
  * old value and data matrices are needed for it.
  */
-class MVQNAcceleration : public BaseQNAcceleration
-{
+class MVQNAcceleration : public BaseQNAcceleration {
 public:
   static const int NO_RESTART = 0;
   static const int RS_ZERO    = 1;
@@ -42,19 +39,19 @@ public:
    * @brief Constructor.
    */
   MVQNAcceleration(
-      double            initialRelaxation,
-      bool              forceInitialRelaxation,
-      int               maxIterationsUsed,
-      int               timestepsReused,
-      int               filter,
-      double            singularityLimit,
-      std::vector<int>  dataIDs,
+      double                  initialRelaxation,
+      bool                    forceInitialRelaxation,
+      int                     maxIterationsUsed,
+      int                     timestepsReused,
+      int                     filter,
+      double                  singularityLimit,
+      std::vector<int>        dataIDs,
       impl::PtrPreconditioner preconditioner,
-      bool              alwaysBuildJacobian,
-      int               imvjRestartType,
-      int               chunkSize,
-      int               RSLSreusedTimesteps,
-      double            RSSVDtruncationEps);
+      bool                    alwaysBuildJacobian,
+      int                     imvjRestartType,
+      int                     chunkSize,
+      int                     RSLSreusedTimesteps,
+      double                  RSSVDtruncationEps);
 
   /**
     * @brief Destructor, empty.
@@ -203,7 +200,7 @@ private:
   /// @brief: Removes one column form the V_RSLS and W_RSLS matrices and adapts _matrixCols_RSLS
   void removeMatrixColumnRSLS(int columnINdex);
 };
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice
 
 #endif /* PRECICE_NO_MPI */

--- a/src/acceleration/SharedPointer.hpp
+++ b/src/acceleration/SharedPointer.hpp
@@ -2,14 +2,12 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 class Acceleration;
 class AccelerationConfiguration;
 
-using PtrAcceleration     = std::shared_ptr<Acceleration>;
+using PtrAcceleration              = std::shared_ptr<Acceleration>;
 using PtrAccelerationConfiguration = std::shared_ptr<AccelerationConfiguration>;
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -1,6 +1,5 @@
-#include "mesh/Data.hpp"
-#include "mesh/Mesh.hpp"
-#include "mesh/config/MeshConfiguration.hpp"
+#include "acceleration/config/AccelerationConfiguration.hpp"
+#include "acceleration/Acceleration.hpp"
 #include "acceleration/AitkenAcceleration.hpp"
 #include "acceleration/BaseQNAcceleration.hpp"
 #include "acceleration/BroydenAcceleration.hpp"
@@ -8,19 +7,18 @@
 #include "acceleration/IQNILSAcceleration.hpp"
 #include "acceleration/MMAcceleration.hpp"
 #include "acceleration/MVQNAcceleration.hpp"
-#include "acceleration/Acceleration.hpp"
-#include "acceleration/config/AccelerationConfiguration.hpp"
 #include "acceleration/impl/ConstantPreconditioner.hpp"
 #include "acceleration/impl/ResidualPreconditioner.hpp"
 #include "acceleration/impl/ResidualSumPreconditioner.hpp"
 #include "acceleration/impl/ValuePreconditioner.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/config/MeshConfiguration.hpp"
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
 using namespace precice::acceleration::impl;
 
@@ -105,9 +103,9 @@ void AccelerationConfiguration::connectTags(xml::XMLTag &parent)
     XMLTag tag(*this, VALUE_MVQN, occ, TAG);
 
     auto alwaybuildJacobian = makeXMLAttribute(ATTR_BUILDJACOBIAN, false)
-        .setDocumentation("If set to true, the IMVJ will set up the Jacobian matrix"
-                " in each coupling iteration, which is inefficient. If set to false (or not set)"
-                " the Jacobian is only build in the last iteration and the updates are computed using (relatively) cheap MATVEC products.");
+                                  .setDocumentation("If set to true, the IMVJ will set up the Jacobian matrix"
+                                                    " in each coupling iteration, which is inefficient. If set to false (or not set)"
+                                                    " the Jacobian is only build in the last iteration and the updates are computed using (relatively) cheap MATVEC products.");
     tag.addAttribute(alwaybuildJacobian);
 
     addTypeSpecificSubtags(tag);
@@ -144,8 +142,8 @@ PtrAccelerationConfiguration AccelerationConfiguration::getCoarseModelOptimizati
 }
 
 void AccelerationConfiguration::xmlTagCallback(
-    const xml::ConfigurationContext& context,
-    xml::XMLTag &callingTag)
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    callingTag)
 {
   PRECICE_TRACE(callingTag.getFullName());
 
@@ -241,8 +239,8 @@ void AccelerationConfiguration::xmlTagCallback(
 }
 
 void AccelerationConfiguration::xmlEndTagCallback(
-    const xml::ConfigurationContext& context,
-    xml::XMLTag &callingTag)
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    callingTag)
 {
   PRECICE_TRACE(callingTag.getName());
   if (callingTag.getNamespace() == TAG) {
@@ -328,7 +326,7 @@ void AccelerationConfiguration::xmlEndTagCallback(
               _config.timestepsReused,
               _config.filter, _config.singularityLimit,
               _config.estimateJacobian,
-              _config.dataIDs,                                                   // fine data IDs
+              _config.dataIDs,                                                 // fine data IDs
               _coarseModelOptimizationConfig->getAcceleration()->getDataIDs(), // coarse data IDs
               _preconditioner));
     } else if (callingTag.getName() == VALUE_BROYDEN) {
@@ -349,7 +347,7 @@ void AccelerationConfiguration::xmlEndTagCallback(
 
 void AccelerationConfiguration::clear()
 {
-  _config         = ConfigurationData();
+  _config       = ConfigurationData();
   _acceleration = PtrAcceleration();
   _neededMeshes.clear();
 }
@@ -397,21 +395,20 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     XMLTag                    tagData(*this, TAG_DATA, XMLTag::OCCUR_ONCE_OR_MORE);
     XMLAttribute<std::string> attrName(ATTR_NAME);
     XMLAttribute<std::string> attrMesh(ATTR_MESH);
-    auto attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
-        .setDocumentation(
-                "To improve the performance of a parallel or a multi coupling schemes, "
-                "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
+    auto                      attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
+                           .setDocumentation(
+                               "To improve the performance of a parallel or a multi coupling schemes, "
+                               "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
     tagData.addAttribute(attrScaling);
     tagData.addAttribute(attrName);
     tagData.addAttribute(attrMesh);
     tag.addSubtag(tagData);
 
-    XMLTag                       tagFilter(*this, TAG_FILTER, XMLTag::OCCUR_NOT_OR_ONCE);
-   auto attrFilterName = XMLAttribute<std::string>(ATTR_TYPE)
-        .setOptions({
-                VALUE_QR1FILTER,
-                VALUE_QR1_ABSFILTER,
-                VALUE_QR2FILTER});
+    XMLTag tagFilter(*this, TAG_FILTER, XMLTag::OCCUR_NOT_OR_ONCE);
+    auto   attrFilterName = XMLAttribute<std::string>(ATTR_TYPE)
+                              .setOptions({VALUE_QR1FILTER,
+                                           VALUE_QR1_ABSFILTER,
+                                           VALUE_QR2FILTER});
     tagFilter.addAttribute(attrFilterName);
     XMLAttribute<double> attrSingularityLimit(ATTR_SINGULARITYLIMIT, 1e-16);
     tagFilter.addAttribute(attrSingularityLimit);
@@ -425,25 +422,24 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                "are filtered out.");
     tag.addSubtag(tagFilter);
 
-    XMLTag                       tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
-   auto attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
-        .setDocumentation(
-                "To improve the performance of a parallel or a multi coupling schemes a preconditioner"
-                " can be applied. A constant preconditioner scales every acceleration data by a constant value, which you can define as"
-                " an attribute of data. "
-                " A value preconditioner scales every acceleration data by the norm of the data in the previous timestep."
-                " A residual preconditioner scales every acceleration data by the current residual."
-                " A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current timestep.")
-        .setOptions({
-                VALUE_CONSTANT_PRECONDITIONER,
-                VALUE_VALUE_PRECONDITIONER,
-                VALUE_RESIDUAL_PRECONDITIONER,
-                VALUE_RESIDUAL_SUM_PRECONDITIONER});
+    XMLTag tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
+    auto   attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
+                                      .setDocumentation(
+                                          "To improve the performance of a parallel or a multi coupling schemes a preconditioner"
+                                          " can be applied. A constant preconditioner scales every acceleration data by a constant value, which you can define as"
+                                          " an attribute of data. "
+                                          " A value preconditioner scales every acceleration data by the norm of the data in the previous timestep."
+                                          " A residual preconditioner scales every acceleration data by the current residual."
+                                          " A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current timestep.")
+                                      .setOptions({VALUE_CONSTANT_PRECONDITIONER,
+                                                   VALUE_VALUE_PRECONDITIONER,
+                                                   VALUE_RESIDUAL_PRECONDITIONER,
+                                                   VALUE_RESIDUAL_SUM_PRECONDITIONER});
     tagPreconditioner.addAttribute(attrPreconditionerType);
     auto nonconstTSteps = makeXMLAttribute(ATTR_PRECOND_NONCONST_TIMESTEPS, -1)
-        .setDocumentation(
-                "After the given number of time steps, the preconditioner weights "
-                "are freezed and the preconditioner acts like a constant preconditioner.");
+                              .setDocumentation(
+                                  "After the given number of time steps, the preconditioner weights "
+                                  "are freezed and the preconditioner acts like a constant preconditioner.");
     tagPreconditioner.addAttribute(nonconstTSteps);
     tag.addSubtag(tagPreconditioner);
 
@@ -455,15 +451,14 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     tagInitRelax.addAttribute(attrEnforce);
     tag.addSubtag(tagInitRelax);
 
-    XMLTag                       tagIMVJRESTART(*this, TAG_IMVJRESTART, XMLTag::OCCUR_NOT_OR_ONCE);
-   auto attrRestartName = XMLAttribute<std::string>(ATTR_TYPE)
-        .setOptions({
-                VALUE_NO_RESTART,
-                VALUE_ZERO_RESTART,
-                VALUE_LS_RESTART,
-                VALUE_SVD_RESTART,
-                VALUE_SLIDE_RESTART})
-        .setDefaultValue(VALUE_SVD_RESTART);
+    XMLTag tagIMVJRESTART(*this, TAG_IMVJRESTART, XMLTag::OCCUR_NOT_OR_ONCE);
+    auto   attrRestartName = XMLAttribute<std::string>(ATTR_TYPE)
+                               .setOptions({VALUE_NO_RESTART,
+                                            VALUE_ZERO_RESTART,
+                                            VALUE_LS_RESTART,
+                                            VALUE_SVD_RESTART,
+                                            VALUE_SLIDE_RESTART})
+                               .setDefaultValue(VALUE_SVD_RESTART);
     tagIMVJRESTART.addAttribute(attrRestartName);
     tagIMVJRESTART.setDocumentation("Type of IMVJ restart mode that is used\n"
                                     "  no-restart: IMVJ runs in normal mode with explicit representation of Jacobian\n"
@@ -472,11 +467,11 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                     "  RS-SVD:     IMVJ runs in restart mode. After M time steps a truncated SVD of the Jacobian is updated.\n"
                                     "  RS-SLIDE:   IMVJ runs in sliding window restart mode.\n");
     auto attrChunkSize = makeXMLAttribute(ATTR_IMVJCHUNKSIZE, 8)
-        .setDocumentation("Specifies the number of time steps M after which the IMVJ restarts, if run in restart-mode. Defaul value is M=8.");
+                             .setDocumentation("Specifies the number of time steps M after which the IMVJ restarts, if run in restart-mode. Defaul value is M=8.");
     auto attrReusedTimeStepsAtRestart = makeXMLAttribute(ATTR_RSLS_REUSEDTSTEPS, 8)
-        .setDocumentation("If IMVJ restart-mode=RS-LS, the number of reused time steps at restart can be specified.");
+                                            .setDocumentation("If IMVJ restart-mode=RS-LS, the number of reused time steps at restart can be specified.");
     auto attrRSSVD_truncationEps = makeXMLAttribute(ATTR_RSSVD_TRUNCATIONEPS, 1e-4)
-        .setDocumentation("If IMVJ restart-mode=RS-SVD, the truncation threshold for the updated SVD can be set.");
+                                       .setDocumentation("If IMVJ restart-mode=RS-SVD, the truncation threshold for the updated SVD can be set.");
     tagIMVJRESTART.addAttribute(attrChunkSize);
     tagIMVJRESTART.addAttribute(attrReusedTimeStepsAtRestart);
     tagIMVJRESTART.addAttribute(attrRSSVD_truncationEps);
@@ -494,10 +489,10 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     XMLTag                    tagData(*this, TAG_DATA, XMLTag::OCCUR_ONCE_OR_MORE);
     XMLAttribute<std::string> attrName(ATTR_NAME);
     XMLAttribute<std::string> attrMesh(ATTR_MESH);
-    auto attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
-        .setDocumentation(
-                "To improve the performance of a parallel or a multi coupling schemes, "
-                "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
+    auto                      attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
+                           .setDocumentation(
+                               "To improve the performance of a parallel or a multi coupling schemes, "
+                               "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
     tagData.addAttribute(attrScaling);
     tagData.addAttribute(attrName);
     tagData.addAttribute(attrMesh);
@@ -506,11 +501,10 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     XMLTag               tagFilter(*this, TAG_FILTER, XMLTag::OCCUR_NOT_OR_ONCE);
     XMLAttribute<double> attrSingularityLimit(ATTR_SINGULARITYLIMIT, 1e-16);
     tagFilter.addAttribute(attrSingularityLimit);
-   auto attrFilterName = XMLAttribute<std::string>(ATTR_TYPE)
-        .setOptions({
-                VALUE_QR1FILTER,
-                VALUE_QR1_ABSFILTER,
-                VALUE_QR2FILTER});
+    auto attrFilterName = XMLAttribute<std::string>(ATTR_TYPE)
+                              .setOptions({VALUE_QR1FILTER,
+                                           VALUE_QR1_ABSFILTER,
+                                           VALUE_QR2FILTER});
     tagFilter.addAttribute(attrFilterName);
     tagFilter.setDocumentation("Type of filtering technique that is used to "
                                "maintain good conditioning in the least-squares system. Possible filters:\n"
@@ -522,23 +516,22 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                "are filtered out.");
     tag.addSubtag(tagFilter);
 
-    XMLTag                       tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
-   auto attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
-        .setOptions({
-                VALUE_CONSTANT_PRECONDITIONER,
-                VALUE_VALUE_PRECONDITIONER,
-                VALUE_RESIDUAL_PRECONDITIONER,
-                VALUE_RESIDUAL_SUM_PRECONDITIONER})
-        .setDocumentation(
-                "To improve the performance of a parallel or a multi coupling schemes a preconditioner"
-                " can be applied. A constant preconditioner scales every acceleration data by a constant value, which you can define as"
-                " an attribute of data. "
-                " A value preconditioner scales every acceleration data by the norm of the data in the previous timestep."
-                " A residual preconditioner scales every acceleration data by the current residual."
-                " A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current timestep.");
+    XMLTag tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
+    auto   attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
+                                      .setOptions({VALUE_CONSTANT_PRECONDITIONER,
+                                                   VALUE_VALUE_PRECONDITIONER,
+                                                   VALUE_RESIDUAL_PRECONDITIONER,
+                                                   VALUE_RESIDUAL_SUM_PRECONDITIONER})
+                                      .setDocumentation(
+                                          "To improve the performance of a parallel or a multi coupling schemes a preconditioner"
+                                          " can be applied. A constant preconditioner scales every acceleration data by a constant value, which you can define as"
+                                          " an attribute of data. "
+                                          " A value preconditioner scales every acceleration data by the norm of the data in the previous timestep."
+                                          " A residual preconditioner scales every acceleration data by the current residual."
+                                          " A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current timestep.");
     tagPreconditioner.addAttribute(attrPreconditionerType);
     auto nonconstTSteps = makeXMLAttribute(ATTR_PRECOND_NONCONST_TIMESTEPS, -1)
-        .setDocumentation("After the given number of time steps, the preconditioner weights are freezed and the preconditioner acts like a constant preconditioner.");
+                              .setDocumentation("After the given number of time steps, the preconditioner weights are freezed and the preconditioner acts like a constant preconditioner.");
     tagPreconditioner.addAttribute(nonconstTSteps);
     tag.addSubtag(tagPreconditioner);
   } else if (tag.getName() == VALUE_ManifoldMapping) {
@@ -553,12 +546,12 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     _coarseModelOptimizationConfig->setIsAddManifoldMappingTagAllowed(false);
     _coarseModelOptimizationConfig->connectTags(tag);
 
-    XMLTag             tagEstimateJacobian(*this, TAG_ESTIMATEJACOBIAN, XMLTag::OCCUR_NOT_OR_ONCE);
-   auto attrBoolValue = XMLAttribute<bool>(ATTR_VALUE)
-        .setDocumentation(
-                "If manifold mapping is used as acceleration one can switch"
-                " between explicit estimation and updating of the Jacobian (multi-vector method)"
-                " and a matrix free computation. The default is matrix free.");
+    XMLTag tagEstimateJacobian(*this, TAG_ESTIMATEJACOBIAN, XMLTag::OCCUR_NOT_OR_ONCE);
+    auto   attrBoolValue = XMLAttribute<bool>(ATTR_VALUE)
+                             .setDocumentation(
+                                 "If manifold mapping is used as acceleration one can switch"
+                                 " between explicit estimation and updating of the Jacobian (multi-vector method)"
+                                 " and a matrix free computation. The default is matrix free.");
     tagEstimateJacobian.addAttribute(attrBoolValue);
     tag.addSubtag(tagEstimateJacobian);
 
@@ -574,21 +567,20 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     XMLTag                    tagData(*this, TAG_DATA, XMLTag::OCCUR_ONCE_OR_MORE);
     XMLAttribute<std::string> attrName(ATTR_NAME);
     XMLAttribute<std::string> attrMesh(ATTR_MESH);
-    auto attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
-        .setDocumentation(
-                "To improve the performance of a parallel or a multi coupling schemes, "
-                "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
+    auto                      attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
+                           .setDocumentation(
+                               "To improve the performance of a parallel or a multi coupling schemes, "
+                               "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
     tagData.addAttribute(attrScaling);
     tagData.addAttribute(attrName);
     tagData.addAttribute(attrMesh);
     tag.addSubtag(tagData);
 
-    XMLTag                       tagFilter(*this, TAG_FILTER, XMLTag::OCCUR_NOT_OR_ONCE);
-   auto attrFilterName = XMLAttribute<std::string>(ATTR_TYPE)
-        .setOptions({
-                VALUE_QR1FILTER,
-                VALUE_QR1_ABSFILTER,
-                VALUE_QR2FILTER});
+    XMLTag tagFilter(*this, TAG_FILTER, XMLTag::OCCUR_NOT_OR_ONCE);
+    auto   attrFilterName = XMLAttribute<std::string>(ATTR_TYPE)
+                              .setOptions({VALUE_QR1FILTER,
+                                           VALUE_QR1_ABSFILTER,
+                                           VALUE_QR2FILTER});
     tagFilter.addAttribute(attrFilterName);
     XMLAttribute<double> attrSingularityLimit(ATTR_SINGULARITYLIMIT, 1e-16);
     tagFilter.addAttribute(attrSingularityLimit);
@@ -602,25 +594,24 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                "are filtered out.");
     tag.addSubtag(tagFilter);
 
-    XMLTag                       tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
-   auto attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
-        .setDocumentation(
-                "To improve the performance of a parallel or a multi coupling schemes a preconditioner"
-                " can be applied. A constant preconditioner scales every acceleration data by a constant value, which you can define as"
-                " an attribute of data. "
-                " A value preconditioner scales every acceleration data by the norm of the data in the previous timestep."
-                " A residual preconditioner scales every acceleration data by the current residual."
-                " A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current timestep.")
-    .setOptions({
-            VALUE_CONSTANT_PRECONDITIONER,
-            VALUE_VALUE_PRECONDITIONER,
-            VALUE_RESIDUAL_PRECONDITIONER,
-            VALUE_RESIDUAL_SUM_PRECONDITIONER});
+    XMLTag tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
+    auto   attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
+                                      .setDocumentation(
+                                          "To improve the performance of a parallel or a multi coupling schemes a preconditioner"
+                                          " can be applied. A constant preconditioner scales every acceleration data by a constant value, which you can define as"
+                                          " an attribute of data. "
+                                          " A value preconditioner scales every acceleration data by the norm of the data in the previous timestep."
+                                          " A residual preconditioner scales every acceleration data by the current residual."
+                                          " A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current timestep.")
+                                      .setOptions({VALUE_CONSTANT_PRECONDITIONER,
+                                                   VALUE_VALUE_PRECONDITIONER,
+                                                   VALUE_RESIDUAL_PRECONDITIONER,
+                                                   VALUE_RESIDUAL_SUM_PRECONDITIONER});
     tagPreconditioner.addAttribute(attrPreconditionerType);
     auto nonconstTSteps = makeXMLAttribute(ATTR_PRECOND_NONCONST_TIMESTEPS, -1)
-        .setDocumentation(
-                "After the given number of time steps, the preconditioner weights are "
-                "freezed and the preconditioner acts like a constant preconditioner.");
+                              .setDocumentation(
+                                  "After the given number of time steps, the preconditioner weights are "
+                                  "freezed and the preconditioner acts like a constant preconditioner.");
     tagPreconditioner.addAttribute(nonconstTSteps);
     tag.addSubtag(tagPreconditioner);
 
@@ -644,18 +635,18 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     XMLTag                    tagData(*this, TAG_DATA, XMLTag::OCCUR_ONCE_OR_MORE);
     XMLAttribute<std::string> attrName(ATTR_NAME);
     XMLAttribute<std::string> attrMesh(ATTR_MESH);
-    auto attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
-        .setDocumentation(
-                "To improve the performance of a parallel or a multi coupling schemes, "
-                "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
+    auto                      attrScaling = makeXMLAttribute(ATTR_SCALING, 1.0)
+                           .setDocumentation(
+                               "To improve the performance of a parallel or a multi coupling schemes, "
+                               "data values can be manually scaled. We recommend, however, to use an automatic scaling via a preconditioner.");
     tagData.addAttribute(attrScaling);
     tagData.addAttribute(attrName);
     tagData.addAttribute(attrMesh);
     tag.addSubtag(tagData);
   } else {
     PRECICE_ERROR("Acceleration of type \""
-          << tag.getName() << "\" is unknown!");
+                  << tag.getName() << "\" is unknown!");
   }
 }
-}
-} // namespace precice, acceleration
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "acceleration/MVQNAcceleration.hpp"
 #include "acceleration/Acceleration.hpp"
+#include "acceleration/MVQNAcceleration.hpp"
 #include "acceleration/SharedPointer.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
 #include "logging/Logger.hpp"
@@ -9,13 +9,10 @@
 #include "precice/config/SharedPointer.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
+namespace precice {
+namespace acceleration {
 
-class AccelerationConfiguration : public xml::XMLTag::Listener
-{
+class AccelerationConfiguration : public xml::XMLTag::Listener {
 public:
   AccelerationConfiguration(const mesh::PtrMeshConfiguration &meshConfig);
 
@@ -28,10 +25,10 @@ public:
   PtrAccelerationConfiguration getCoarseModelOptimizationConfig();
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /// Removes configured acceleration.
   void clear();
@@ -113,19 +110,19 @@ private:
     std::vector<int>      dataIDs;
     std::map<int, double> scalings;
     std::string           type;
-    double                relaxationFactor = 0;
-    bool                  forceInitialRelaxation = false;
-    int                   maxIterationsUsed = 0;
-    int                   timestepsReused = 0;
-    int                   filter = Acceleration::NOFILTER;
-    int                   imvjRestartType = 0;
-    int                   imvjChunkSize = 0;
+    double                relaxationFactor          = 0;
+    bool                  forceInitialRelaxation    = false;
+    int                   maxIterationsUsed         = 0;
+    int                   timestepsReused           = 0;
+    int                   filter                    = Acceleration::NOFILTER;
+    int                   imvjRestartType           = 0;
+    int                   imvjChunkSize             = 0;
     int                   imvjRSLS_reustedTimesteps = 0;
-    int                   precond_nbNonConstTSteps = -1;
-    double                singularityLimit= 0;
-    double                imvjRSSVD_truncationEps = 0;
-    bool                  estimateJacobian = false;
-    bool                  alwaysBuildJacobian = false;
+    int                   precond_nbNonConstTSteps  = -1;
+    double                singularityLimit          = 0;
+    double                imvjRSSVD_truncationEps   = 0;
+    bool                  estimateJacobian          = false;
+    bool                  alwaysBuildJacobian       = false;
     std::string           preconditionerType;
   } _config;
 
@@ -133,5 +130,5 @@ private:
 
   void addTypeSpecificSubtags(xml::XMLTag &tag);
 };
-}
-} // namespace precice, cplscheme
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ConstantPreconditioner.cpp
+++ b/src/acceleration/impl/ConstantPreconditioner.cpp
@@ -1,11 +1,8 @@
 #include "acceleration/impl/ConstantPreconditioner.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 ConstantPreconditioner::ConstantPreconditioner(std::vector<double> factors)
     : Preconditioner(-1),
@@ -13,7 +10,7 @@ ConstantPreconditioner::ConstantPreconditioner(std::vector<double> factors)
 {
 }
 
-void ConstantPreconditioner::initialize(std::vector<size_t> & svs)
+void ConstantPreconditioner::initialize(std::vector<size_t> &svs)
 {
   PRECICE_TRACE();
   Preconditioner::initialize(svs);
@@ -34,7 +31,7 @@ void ConstantPreconditioner::initialize(std::vector<size_t> & svs)
   }
 }
 
-void ConstantPreconditioner::_update_(bool timestepComplete,
+void ConstantPreconditioner::_update_(bool                   timestepComplete,
                                       const Eigen::VectorXd &oldValues,
                                       const Eigen::VectorXd &res)
 {
@@ -42,4 +39,6 @@ void ConstantPreconditioner::_update_(bool timestepComplete,
   //nothing to do here
 }
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ConstantPreconditioner.hpp
+++ b/src/acceleration/impl/ConstantPreconditioner.hpp
@@ -2,16 +2,12 @@
 
 #include "acceleration/impl/Preconditioner.hpp"
 
-namespace precice
-{
-namespace acceleration
-{ 
-namespace impl
-{ 
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 /// Preconditioner that uses the constant user-defined factors to scale the quasi-Newton system.
-class ConstantPreconditioner : public Preconditioner
-{
+class ConstantPreconditioner : public Preconditioner {
 public:
   explicit ConstantPreconditioner(std::vector<double> factors);
 
@@ -20,7 +16,7 @@ public:
    */
   virtual ~ConstantPreconditioner() {}
 
-  virtual void initialize(std::vector<size_t> & svs);
+  virtual void initialize(std::vector<size_t> &svs);
 
 private:
   /**
@@ -36,4 +32,6 @@ private:
   std::vector<double> _factors;
 };
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ParallelMatrixOperations.cpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.cpp
@@ -1,15 +1,12 @@
 #ifndef PRECICE_NO_MPI
 
-#include "com/MPIPortsCommunication.hpp"
 #include "acceleration/impl/ParallelMatrixOperations.hpp"
+#include "com/MPIPortsCommunication.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 void ParallelMatrixOperations::initialize(
     com::PtrCommunication leftComm,
@@ -33,6 +30,8 @@ void ParallelMatrixOperations::initialize(
   }
 }
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice
 
 #endif

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -10,16 +10,11 @@
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
 
+namespace precice {
+namespace acceleration {
+namespace impl {
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
-
-class ParallelMatrixOperations
-{
+class ParallelMatrixOperations {
 public:
   /// Destructor, empty.
   virtual ~ParallelMatrixOperations(){};
@@ -267,7 +262,7 @@ private:
 
     // ensure that both matrices are stored in the same order. Important for reduce function, that adds serialized data.
     PRECICE_ASSERT(static_cast<int>(leftMatrix.IsRowMajor) == static_cast<int>(rightMatrix.IsRowMajor),
-              leftMatrix.IsRowMajor, rightMatrix.IsRowMajor);
+                   leftMatrix.IsRowMajor, rightMatrix.IsRowMajor);
 
     // multiply local block (saxpy-based approach)
     // dimension: (n_global x n_local) * (n_local x m) = (n_global x m)
@@ -316,6 +311,8 @@ private:
   bool _needCycliclComm = true;
 };
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice
 
 #endif

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -6,12 +6,9 @@
 #include "cplscheme/SharedPointer.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 /**
  * @brief Interface for preconditioner variants that can be applied to quasi-Newton acceleration schemes.
@@ -22,21 +19,21 @@ namespace impl
  * revert() reverts the weighting, i.e. transforms from balanced values back to physical values.
  * update() updates the preconditioner, after every FSI iteration (though some variants might only be updated after a complete timestep)
  */
-class Preconditioner
-{
+class Preconditioner {
 public:
   Preconditioner(int maxNonConstTimesteps)
-    : _maxNonConstTimesteps(maxNonConstTimesteps)
-  {}
-      
+      : _maxNonConstTimesteps(maxNonConstTimesteps)
+  {
+  }
+
   /// Destructor, empty.
   virtual ~Preconditioner() {}
-  
+
   /**
    * @brief initialize the preconditioner
    * @param size of the pp system (e.g. rows of V)
    */
-  virtual void initialize(std::vector<size_t> & svs)
+  virtual void initialize(std::vector<size_t> &svs)
   {
     PRECICE_TRACE();
 
@@ -238,4 +235,6 @@ private:
   logging::Logger _log{"acceleration::Preconditioner"};
 };
 
-}}} // namespace precice, acceleration
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -3,17 +3,14 @@
 #include <iostream>
 #include <vector>
 
-#include "com/Communication.hpp"
 #include "acceleration/BaseQNAcceleration.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
+#include "com/Communication.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 QRFactorization::QRFactorization(
     Eigen::MatrixXd Q,
@@ -778,4 +775,6 @@ void QRFactorization::setFilter(int filter)
   _filter = filter;
 }
 
-}}} // namespace precice, acceleration
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -6,12 +6,9 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 /**
  * @brief Class that provides functionality for a dynamic QR-decomposition, that can be updated 
@@ -21,8 +18,7 @@ namespace impl
  * The Interface provides fnctions such as insertColumn, deleteColumn at arbitrary position an push or pull 
  * column at front or back, resp. 
  */
-class QRFactorization
-{
+class QRFactorization {
 public:
   /**
    * @brief Constructor.
@@ -224,4 +220,6 @@ private:
   int _globalRows;
 };
 
-}}} // namespace precice, acceleration
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ResidualPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualPreconditioner.cpp
@@ -1,18 +1,16 @@
 #include "acceleration/impl/ResidualPreconditioner.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 ResidualPreconditioner::ResidualPreconditioner(int maxNonConstTimesteps)
     : Preconditioner(maxNonConstTimesteps)
-{}
+{
+}
 
-void ResidualPreconditioner::_update_(bool timestepComplete,
+void ResidualPreconditioner::_update_(bool                   timestepComplete,
                                       const Eigen::VectorXd &oldValues,
                                       const Eigen::VectorXd &res)
 {
@@ -43,4 +41,6 @@ void ResidualPreconditioner::_update_(bool timestepComplete,
   }
 }
 
-}}} // namespace precice, acceleration
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ResidualPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualPreconditioner.hpp
@@ -4,18 +4,14 @@
 
 #include "acceleration/impl/Preconditioner.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 /**
  * @brief Preconditioner that uses the recent residual to scale the quasi-Newton system.
  */
-class ResidualPreconditioner : public Preconditioner
-{
+class ResidualPreconditioner : public Preconditioner {
 public:
   ResidualPreconditioner(
       int maxNonConstTimesteps);
@@ -31,11 +27,13 @@ private:
     *
     * @param[in] timestepComplete True if this FSI iteration also completed a timestep
     */
-  virtual void _update_(bool timestepComplete,
+  virtual void _update_(bool                   timestepComplete,
                         const Eigen::VectorXd &oldValues,
                         const Eigen::VectorXd &res);
 
   logging::Logger _log{"acceleration::ResidualPreconditioner"};
 };
 
-}}} // namespace precice, acceleration
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -1,12 +1,9 @@
 #include "acceleration/impl/ResidualSumPreconditioner.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 ResidualSumPreconditioner::ResidualSumPreconditioner(
     int maxNonConstTimesteps)
@@ -22,7 +19,7 @@ void ResidualSumPreconditioner::initialize(std::vector<size_t> &svs)
   _residualSum.resize(_subVectorSizes.size(), 0.0);
 }
 
-void ResidualSumPreconditioner::_update_(bool timestepComplete,
+void ResidualSumPreconditioner::_update_(bool                   timestepComplete,
                                          const Eigen::VectorXd &oldValues,
                                          const Eigen::VectorXd &res)
 {
@@ -67,4 +64,6 @@ void ResidualSumPreconditioner::_update_(bool timestepComplete,
   }
 }
 
-}}} // namespace precice, acceleration
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -2,19 +2,15 @@
 
 #include "acceleration/impl/Preconditioner.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 /**
  * @brief Preconditioner that uses the residuals of all iterations of the current timestep summed up to scale the quasi-Newton system.
  * This is somewhat similar to what is done in the Marks and Luke paper.
  */
-class ResidualSumPreconditioner : public Preconditioner
-{
+class ResidualSumPreconditioner : public Preconditioner {
 public:
   ResidualSumPreconditioner(int maxNonConstTimesteps);
   /**
@@ -37,4 +33,6 @@ private:
   std::vector<double> _residualSum;
 };
 
-}}} // namespace precice, acceleration
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/SVDFactorization.cpp
+++ b/src/acceleration/impl/SVDFactorization.cpp
@@ -4,19 +4,17 @@
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 SVDFactorization::SVDFactorization(
     double            eps,
     PtrPreconditioner preconditioner)
     : _preconditioner(preconditioner),
       _truncationEps(eps)
-{}
+{
+}
 
 void SVDFactorization::initialize(
     PtrParMatrixOps parOps,
@@ -299,6 +297,8 @@ int SVDFactorization::rank()
   return _cols;
 }
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice
 
 #endif // PRECICE_NO_MPI

--- a/src/acceleration/impl/SVDFactorization.hpp
+++ b/src/acceleration/impl/SVDFactorization.hpp
@@ -11,27 +11,23 @@
 #include <Eigen/Dense>
 #include <fstream>
 
-#include "logging/Logger.hpp"
 #include "acceleration/impl/ParallelMatrixOperations.hpp"
 #include "acceleration/impl/Preconditioner.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
+#include "logging/Logger.hpp"
 
 // ------- CLASS DEFINITION
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 /**
  * @brief Class that provides functionality to maintain a SVD decomposition of a matrix
  * via succesive rank-1 updates and truncation with respect to the truncation threshold eps.
  */
-class SVDFactorization
-{
+class SVDFactorization {
 public:
   // Eigen
   typedef Eigen::MatrixXd Matrix;
@@ -299,6 +295,8 @@ private:
   bool          _fstream_set = false;
 };
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice
 
 #endif /* PRECICE_NO_MPI */

--- a/src/acceleration/impl/SharedPointer.hpp
+++ b/src/acceleration/impl/SharedPointer.hpp
@@ -2,17 +2,14 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 class ParallelMatrixOperations;
 class Preconditioner;
 
-using PtrParMatrixOps       = std::shared_ptr<ParallelMatrixOperations>;
-using PtrPreconditioner     = std::shared_ptr<Preconditioner>;
-}
-}
-} // namespace precice, acceleration, impl
+using PtrParMatrixOps   = std::shared_ptr<ParallelMatrixOperations>;
+using PtrPreconditioner = std::shared_ptr<Preconditioner>;
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ValuePreconditioner.cpp
+++ b/src/acceleration/impl/ValuePreconditioner.cpp
@@ -1,12 +1,9 @@
 #include "acceleration/impl/ValuePreconditioner.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 ValuePreconditioner::ValuePreconditioner(
     int maxNonConstTimesteps)
@@ -15,7 +12,7 @@ ValuePreconditioner::ValuePreconditioner(
 {
 }
 
-void ValuePreconditioner::_update_(bool timestepComplete,
+void ValuePreconditioner::_update_(bool                   timestepComplete,
                                    const Eigen::VectorXd &oldValues,
                                    const Eigen::VectorXd &res)
 {
@@ -48,4 +45,6 @@ void ValuePreconditioner::_update_(bool timestepComplete,
   }
 }
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/impl/ValuePreconditioner.hpp
+++ b/src/acceleration/impl/ValuePreconditioner.hpp
@@ -2,16 +2,12 @@
 
 #include "acceleration/impl/Preconditioner.hpp"
 
-namespace precice
-{
-namespace acceleration
-{
-namespace impl
-{
+namespace precice {
+namespace acceleration {
+namespace impl {
 
 /// Preconditioner that uses the values from the previous timestep to scale the quasi-Newton system.
-class ValuePreconditioner : public Preconditioner
-{
+class ValuePreconditioner : public Preconditioner {
 public:
   ValuePreconditioner(
       int maxNonConstTimesteps);
@@ -22,7 +18,7 @@ public:
 
 private:
   logging::Logger _log{"acceleration::ValuePreconditioner"};
-  
+
   /**
    * @brief Update the scaling after every FSI iteration.
    *
@@ -33,4 +29,6 @@ private:
   bool _firstTimestep = true;
 };
 
-}}} // namespace precice, acceleration, impl
+} // namespace impl
+} // namespace acceleration
+} // namespace precice

--- a/src/acceleration/test/AccelerationMasterSlaveTest.cpp
+++ b/src/acceleration/test/AccelerationMasterSlaveTest.cpp
@@ -1,3 +1,9 @@
+#include "acceleration/BaseQNAcceleration.hpp"
+#include "acceleration/IQNILSAcceleration.hpp"
+#include "acceleration/MVQNAcceleration.hpp"
+#include "acceleration/impl/ConstantPreconditioner.hpp"
+#include "acceleration/impl/ResidualSumPreconditioner.hpp"
+#include "acceleration/impl/SharedPointer.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "cplscheme/Constants.hpp"
@@ -10,18 +16,12 @@
 #include "m2n/M2N.hpp"
 #include "mapping/SharedPointer.hpp"
 #include "mesh/Mesh.hpp"
-#include "acceleration/BaseQNAcceleration.hpp"
-#include "acceleration/IQNILSAcceleration.hpp"
-#include "acceleration/MVQNAcceleration.hpp"
-#include "acceleration/impl/ConstantPreconditioner.hpp"
-#include "acceleration/impl/ResidualSumPreconditioner.hpp"
-#include "acceleration/impl/SharedPointer.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/Parallel.hpp"
 
-#include "testing/Testing.hpp"
 #include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 
 using namespace precice;
 using namespace precice::cplscheme;
@@ -32,32 +32,32 @@ using namespace precice::acceleration::impl;
 
 BOOST_AUTO_TEST_SUITE(AccelerationTests)
 
-using DataMap = std::map<int,PtrCouplingData>;
+using DataMap = std::map<int, PtrCouplingData>;
 
 BOOST_AUTO_TEST_SUITE(AccelerationMasterSlaveTests)
 
 /// Test that runs on 4 processors.
-BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
+BOOST_AUTO_TEST_CASE(testVIQNILSpp, *testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
 {
-  double initialRelaxation = 0.01;
-  int    maxIterationsUsed = 50;
-  int    timestepsReused = 6;
-  int filter = BaseQNAcceleration::QR1FILTER;
-  double singularityLimit = 1e-10;
-  bool enforceInitialRelaxation = false;
+  double           initialRelaxation        = 0.01;
+  int              maxIterationsUsed        = 50;
+  int              timestepsReused          = 6;
+  int              filter                   = BaseQNAcceleration::QR1FILTER;
+  double           singularityLimit         = 1e-10;
+  bool             enforceInitialRelaxation = false;
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
   std::vector<double> factors;
-  factors.resize(2,1.0);
+  factors.resize(2, 1.0);
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
-  std::vector<int> vertexOffsets {4, 8, 8 , 10};
+  std::vector<int>  vertexOffsets{4, 8, 8, 10};
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-      timestepsReused, filter, singularityLimit, dataIDs, prec);
+                        timestepsReused, filter, singularityLimit, dataIDs, prec);
 
   Eigen::VectorXd dvalues;
   Eigen::VectorXd dcol1;
@@ -74,12 +74,13 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
      */
 
     //init displacements
-    Eigen::VectorXd insert(4); insert << 1.0, 2.0, 3.0, 4.0;
+    Eigen::VectorXd insert(4);
+    insert << 1.0, 2.0, 3.0, 4.0;
     utils::append(dvalues, insert);
     insert << 1.0, 1.0, 1.0, 1.0;
     utils::append(dcol1, insert);
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
     insert << 0.1, 0.1, 0.1, 0.1;
@@ -87,10 +88,10 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(fcol1, insert);
 
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -105,12 +106,13 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
      */
 
     //init displacements
-    Eigen::VectorXd insert(4); insert << 5.0, 6.0, 7.0, 8.0;
+    Eigen::VectorXd insert(4);
+    insert << 5.0, 6.0, 7.0, 8.0;
     utils::append(dvalues, insert);
     insert << 1.0, 1.0, 1.0, 1.0;
     utils::append(dcol1, insert);
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
     insert << 0.1, 0.1, 0.1, 0.1;
@@ -118,10 +120,10 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(fcol1, insert);
 
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -136,13 +138,13 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
      */
 
     //init displacements
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -157,12 +159,13 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
      */
 
     //init displacements
-    Eigen::VectorXd insert(2); insert << 1.0, 2.0;
+    Eigen::VectorXd insert(2);
+    insert << 1.0, 2.0;
     utils::append(dvalues, insert);
     insert << 1.0, 1.0;
     utils::append(dcol1, insert);
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
     insert << 0.1, 0.1;
@@ -170,10 +173,10 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
     insert << 0.2, 0.2;
     utils::append(fcol1, insert);
 
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -195,7 +198,10 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
     BOOST_TEST(testing::equals((*data.at(1)->values)(2), 0.199), (*data.at(1)->values)(2));
     BOOST_TEST(testing::equals((*data.at(1)->values)(3), 0.199), (*data.at(1)->values)(3));
 
-    utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
 
   } else if (utils::Parallel::getProcessRank() == 1) { //Slave1
 
@@ -208,7 +214,10 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
     BOOST_TEST(testing::equals((*data.at(1)->values)(2), 0.199), (*data.at(1)->values)(2));
     BOOST_TEST(testing::equals((*data.at(1)->values)(3), 0.199), (*data.at(1)->values)(3));
 
-    utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
 
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave2
     // empty proc
@@ -219,7 +228,8 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
     BOOST_TEST(testing::equals((*data.at(1)->values)(0), 0.199), (*data.at(1)->values)(0));
     BOOST_TEST(testing::equals((*data.at(1)->values)(1), 0.199), (*data.at(1)->values)(1));
 
-    utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
   }
 
   data.begin()->second->values = &newdvalues;
@@ -255,34 +265,34 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp, * testing::OnSize(4) * boost::unit_test::fix
 }
 
 /// Test that runs on 4 processors.
-BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
+BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, *testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
 {
-  double initialRelaxation = 0.01;
-  int    maxIterationsUsed = 50;
-  int    timestepsReused = 6;
-  int filter = BaseQNAcceleration::QR1FILTER;
-  int restartType = MVQNAcceleration::NO_RESTART;
-  int chunkSize = 0;
-  int reusedTimeStepsAtRestart = 0;
-  double singularityLimit = 1e-10;
-  double svdTruncationEps = 0.0;
-  bool enforceInitialRelaxation = false;
-  bool alwaysBuildJacobian = false;
+  double initialRelaxation        = 0.01;
+  int    maxIterationsUsed        = 50;
+  int    timestepsReused          = 6;
+  int    filter                   = BaseQNAcceleration::QR1FILTER;
+  int    restartType              = MVQNAcceleration::NO_RESTART;
+  int    chunkSize                = 0;
+  int    reusedTimeStepsAtRestart = 0;
+  double singularityLimit         = 1e-10;
+  double svdTruncationEps         = 0.0;
+  bool   enforceInitialRelaxation = false;
+  bool   alwaysBuildJacobian      = false;
 
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
   std::vector<double> factors;
-  factors.resize(2,1.0);
+  factors.resize(2, 1.0);
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
-  std::vector<int> vertexOffsets {4, 8, 8 , 10};
+  std::vector<int>  vertexOffsets{4, 8, 8, 10};
 
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()) );
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-      timestepsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
-      restartType, chunkSize, reusedTimeStepsAtRestart, svdTruncationEps);
+                      timestepsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
+                      restartType, chunkSize, reusedTimeStepsAtRestart, svdTruncationEps);
 
   Eigen::VectorXd dvalues;
   Eigen::VectorXd dcol1;
@@ -299,12 +309,13 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
      */
 
     //init displacements
-    Eigen::VectorXd insert(4); insert << 1.0, 2.0, 3.0, 4.0;
+    Eigen::VectorXd insert(4);
+    insert << 1.0, 2.0, 3.0, 4.0;
     utils::append(dvalues, insert);
     insert << 1.0, 1.0, 1.0, 1.0;
     utils::append(dcol1, insert);
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
     insert << 0.1, 0.1, 0.1, 0.1;
@@ -312,10 +323,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(fcol1, insert);
 
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -330,12 +341,13 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
      */
 
     //init displacements
-    Eigen::VectorXd insert(4); insert << 5.0, 6.0, 7.0, 8.0;
+    Eigen::VectorXd insert(4);
+    insert << 5.0, 6.0, 7.0, 8.0;
     utils::append(dvalues, insert);
     insert << 1.0, 1.0, 1.0, 1.0;
     utils::append(dcol1, insert);
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
     insert << 0.1, 0.1, 0.1, 0.1;
@@ -343,10 +355,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(fcol1, insert);
 
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -361,13 +373,13 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
      */
 
     //init displacements
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -382,12 +394,13 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
      */
 
     //init displacements
-    Eigen::VectorXd insert(2); insert << 1.0, 2.0;
+    Eigen::VectorXd insert(2);
+    insert << 1.0, 2.0;
     utils::append(dvalues, insert);
     insert << 1.0, 1.0;
     utils::append(dcol1, insert);
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
     //init forces
     insert << 0.1, 0.1;
@@ -395,10 +408,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
     insert << 0.2, 0.2;
     utils::append(fcol1, insert);
 
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
-    data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
     pp.initialize(data);
 
@@ -418,7 +431,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
     BOOST_TEST(testing::equals((*data.at(1)->values)(1), 1.99000000000000010214e-01), (*data.at(1)->values)(1));
     BOOST_TEST(testing::equals((*data.at(1)->values)(2), 1.99000000000000010214e-01), (*data.at(1)->values)(2));
     BOOST_TEST(testing::equals((*data.at(1)->values)(3), 1.99000000000000010214e-01), (*data.at(1)->values)(3));
-    utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
   } else if (utils::Parallel::getProcessRank() == 1) { //Slave1
     BOOST_TEST(testing::equals((*data.at(0)->values)(0), 1.04000000000000003553e+00), (*data.at(0)->values)(0));
     BOOST_TEST(testing::equals((*data.at(0)->values)(1), 1.05000000000000004441e+00), (*data.at(0)->values)(1));
@@ -428,7 +444,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
     BOOST_TEST(testing::equals((*data.at(1)->values)(1), 1.99000000000000010214e-01), (*data.at(1)->values)(1));
     BOOST_TEST(testing::equals((*data.at(1)->values)(2), 1.99000000000000010214e-01), (*data.at(1)->values)(2));
     BOOST_TEST(testing::equals((*data.at(1)->values)(3), 1.99000000000000010214e-01), (*data.at(1)->values)(3));
-    utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave2
     // empty proc
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave3
@@ -436,7 +455,8 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
     BOOST_TEST(testing::equals((*data.at(0)->values)(1), 1.01000000000000000888e+00), (*data.at(0)->values)(1));
     BOOST_TEST(testing::equals((*data.at(1)->values)(0), 1.99000000000000010214e-01), (*data.at(1)->values)(0));
     BOOST_TEST(testing::equals((*data.at(1)->values)(1), 1.99000000000000010214e-01), (*data.at(1)->values)(1));
-    utils::append(newdvalues, 10.0); utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
+    utils::append(newdvalues, 10.0);
   }
 
   data.begin()->second->values = &newdvalues;
@@ -471,33 +491,33 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp, * testing::OnSize(4) * boost::unit_test::fi
 }
 
 /// Test that runs on 4 processors.
-BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
+BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, *testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
 {
   // config:
-  double initialRelaxation = 0.1;
-  int    maxIterationsUsed = 30;
-  int    timestepsReused = 0;
-  int filter = BaseQNAcceleration::QR2FILTER;
-  int restartType = MVQNAcceleration::NO_RESTART;
-  int chunkSize = 0;
-  int reusedTimeStepsAtRestart = 0;
-  double singularityLimit = 1e-2;
-  double svdTruncationEps = 0.0;
-  bool enforceInitialRelaxation = false;
-  bool alwaysBuildJacobian = false;
+  double initialRelaxation        = 0.1;
+  int    maxIterationsUsed        = 30;
+  int    timestepsReused          = 0;
+  int    filter                   = BaseQNAcceleration::QR2FILTER;
+  int    restartType              = MVQNAcceleration::NO_RESTART;
+  int    chunkSize                = 0;
+  int    reusedTimeStepsAtRestart = 0;
+  double singularityLimit         = 1e-2;
+  double svdTruncationEps         = 0.0;
+  bool   enforceInitialRelaxation = false;
+  bool   alwaysBuildJacobian      = false;
 
   std::vector<int> dataIDs;
   dataIDs.push_back(4);
   dataIDs.push_back(5);
-  PtrPreconditioner _preconditioner = PtrPreconditioner (new ResidualSumPreconditioner(-1));
-  std::vector<int> vertexOffsets {0, 11, 22, 22};
+  PtrPreconditioner _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(-1));
+  std::vector<int>  vertexOffsets{0, 11, 22, 22};
 
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("dummyMesh", 2, false, testing::nextMeshID()) );
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("dummyMesh", 2, false, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-      timestepsReused, filter, singularityLimit, dataIDs, _preconditioner, alwaysBuildJacobian,
-      restartType, chunkSize, reusedTimeStepsAtRestart, svdTruncationEps);
+                      timestepsReused, filter, singularityLimit, dataIDs, _preconditioner, alwaysBuildJacobian,
+                      restartType, chunkSize, reusedTimeStepsAtRestart, svdTruncationEps);
 
   Eigen::VectorXd dvalues;
   Eigen::VectorXd doldValues;
@@ -506,7 +526,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
 
   Eigen::VectorXd dref;
   Eigen::VectorXd fref;
-  double drefNorm = 0., frefNorm = 0.;
+  double          drefNorm = 0., frefNorm = 0.;
 
   DataMap data;
 
@@ -515,17 +535,19 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
      * processor with no vertices
      */
 
-    dvalues.resize(0); doldValues.resize(0);
-    fvalues.resize(0); foldValues.resize(0);
+    dvalues.resize(0);
+    doldValues.resize(0);
+    fvalues.resize(0);
+    foldValues.resize(0);
 
     //init displacements
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,2));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 2));
 
     //init forces
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,2));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 2));
 
-    data.insert(std::pair<int,PtrCouplingData>(4,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(5,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(4, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(5, fpcd));
 
     pp.initialize(data);
 
@@ -538,24 +560,24 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
      */
 
     //init displacements
-    dvalues.resize(22); doldValues.resize(22);
-    fvalues.resize(22); foldValues.resize(22);
-    dvalues    << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    doldValues << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    fvalues    << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    foldValues << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
+    dvalues.resize(22);
+    doldValues.resize(22);
+    fvalues.resize(22);
+    foldValues.resize(22);
+    dvalues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    doldValues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    fvalues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    foldValues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
 
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 2));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 2));
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,2));
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,2));
-
-    data.insert(std::pair<int,PtrCouplingData>(4,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(5,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(4, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(5, fpcd));
 
     pp.initialize(data);
 
-
-    fvalues    << -0.01765744149520443,  -0.000534499502588083,  0.05397520666020422,  0.0005546984205735067,  0.05213823386543703,  0.0007618478879228568,  -0.01944857239806249,  -0.0009206665792022876,  -0.02459872346309381,  -0.001296931976456198,  0.04688718434761113,  0.001346643628716769,  -0.01063536095060684,  -0.01905148710330257,  0.02514593936525903,  -0.01643393169986981,  -0.02189723835016068,  -0.000912218689367709,  0.04985117008772211,  0.0009615805506705544,  0.05534647415570375,  0.0004068469082890895;
+    fvalues << -0.01765744149520443, -0.000534499502588083, 0.05397520666020422, 0.0005546984205735067, 0.05213823386543703, 0.0007618478879228568, -0.01944857239806249, -0.0009206665792022876, -0.02459872346309381, -0.001296931976456198, 0.04688718434761113, 0.001346643628716769, -0.01063536095060684, -0.01905148710330257, 0.02514593936525903, -0.01643393169986981, -0.02189723835016068, -0.000912218689367709, 0.04985117008772211, 0.0009615805506705544, 0.05534647415570375, 0.0004068469082890895;
 
     dpcd->oldValues.col(0) = doldValues;
     fpcd->oldValues.col(0) = foldValues;
@@ -566,23 +588,24 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
      */
 
     //init displacements
-    dvalues.resize(22); doldValues.resize(22);
-    fvalues.resize(22); foldValues.resize(22);
-    dvalues    << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    doldValues << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    fvalues    << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    foldValues << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
+    dvalues.resize(22);
+    doldValues.resize(22);
+    fvalues.resize(22);
+    foldValues.resize(22);
+    dvalues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    doldValues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    fvalues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    foldValues << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
 
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 2));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 2));
 
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,2));
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,2));
-
-    data.insert(std::pair<int,PtrCouplingData>(4,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(5,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(4, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(5, fpcd));
 
     pp.initialize(data);
 
-    fvalues << -0.01465589151503364,  -0.0002670111835650672,  0.05711438689366102,  0.0002383730129847531,  -0.01536098575916998,  -0.000285287812066552,  0.05638274807579218,  0.000283961973555227,  -0.006856432131857973,  -0.006815594391460808,  0.02901925611525407,  -0.02907380915674757,  0.05800715138289463,  9.667376010126116e-05,  -0.01376443700165205,  -9.547563271960956e-05,  0.05768190311116184,  0.0001311583226994801,  -0.01408147387131287,  -0.0001216961377915992,  -0.0163823504288376,  -0.0003874626690545313;
+    fvalues << -0.01465589151503364, -0.0002670111835650672, 0.05711438689366102, 0.0002383730129847531, -0.01536098575916998, -0.000285287812066552, 0.05638274807579218, 0.000283961973555227, -0.006856432131857973, -0.006815594391460808, 0.02901925611525407, -0.02907380915674757, 0.05800715138289463, 9.667376010126116e-05, -0.01376443700165205, -9.547563271960956e-05, 0.05768190311116184, 0.0001311583226994801, -0.01408147387131287, -0.0001216961377915992, -0.0163823504288376, -0.0003874626690545313;
 
     dpcd->oldValues.col(0) = doldValues;
     fpcd->oldValues.col(0) = foldValues;
@@ -591,17 +614,19 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
      * processor with no vertices
      */
 
-    dvalues.resize(0); doldValues.resize(0);
-    fvalues.resize(0); foldValues.resize(0);
+    dvalues.resize(0);
+    doldValues.resize(0);
+    fvalues.resize(0);
+    foldValues.resize(0);
 
     //init displacements
-    PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,2));
+    PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 2));
 
     //init forces
-    PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,2));
+    PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 2));
 
-    data.insert(std::pair<int,PtrCouplingData>(4,dpcd));
-    data.insert(std::pair<int,PtrCouplingData>(5,fpcd));
+    data.insert(std::pair<int, PtrCouplingData>(4, dpcd));
+    data.insert(std::pair<int, PtrCouplingData>(5, fpcd));
 
     pp.initialize(data);
 
@@ -612,7 +637,6 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
   // underrelaxation, first iteration
   pp.performAcceleration(data);
 
-
   if (utils::Parallel::getProcessRank() == 0) { //Master
 
   } else if (utils::Parallel::getProcessRank() == 1) { //Slave1
@@ -620,16 +644,16 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    fref << -0.001765744149520443,  -5.344995025880831e-05,  0.005397520666020422,  5.546984205735068e-05,  0.005213823386543704,  7.618478879228569e-05,  -0.001944857239806249,  -9.206665792022876e-05,  -0.002459872346309381,  -0.0001296931976456198,  0.004688718434761114,  0.000134664362871677,  -0.001063536095060684,  -0.001905148710330257,  0.002514593936525903,  -0.001643393169986981,  -0.002189723835016068,  -9.12218689367709e-05,  0.004985117008772211,  9.615805506705544e-05,  0.005534647415570375,  4.068469082890896e-05;
+    dref << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    fref << -0.001765744149520443, -5.344995025880831e-05, 0.005397520666020422, 5.546984205735068e-05, 0.005213823386543704, 7.618478879228569e-05, -0.001944857239806249, -9.206665792022876e-05, -0.002459872346309381, -0.0001296931976456198, 0.004688718434761114, 0.000134664362871677, -0.001063536095060684, -0.001905148710330257, 0.002514593936525903, -0.001643393169986981, -0.002189723835016068, -9.12218689367709e-05, 0.004985117008772211, 9.615805506705544e-05, 0.005534647415570375, 4.068469082890896e-05;
     frefNorm = 0.01286041129960619;
     drefNorm = 0.0;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
 
     // validate norm
@@ -637,36 +661,35 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm), data.at(5)->values->norm());
 
     // update cplData
-    dvalues    << 1.790053057185293e-06,  -2.44566429072041e-08,  1.889281703254964e-06,  -1.972492834475447e-07,  1.681634609242917e-06,  -2.373356532433882e-07,  1.585003447958184e-06,  -5.301850772916681e-08,  1.274187257620066e-06,  -2.137488936999111e-07,  1.362955262700412e-06,  -2.762153471191986e-07,  1.249747540920782e-06,  -3.196338173465977e-07,  1.333501893726392e-06,  -3.161541101487353e-07,  1.394538527892028e-06,  -1.166536323805688e-07,  1.488382850875808e-06,  -2.605379508545059e-07,  2.056077021837937e-06,  -1.341692715765341e-07;
-    fvalues    << -0.01765744187144705,  -0.000534499502451157,  0.05397520721069472,  0.0005546984181272257,  0.05213823442800309,  0.000761847881060882,  -0.01944857277019029,  -0.0009206665773591249,  -0.02459872381892192,  -0.001296931982922439,  0.04688718490326162,  0.001346643636856003,  -0.01063536111298416,  -0.01905148734069537,  0.02514593966043068,  -0.01643393192020026,  -0.02189723869781963,  -0.0009122186870252733,  0.04985117065739809,  0.0009615805515004192,  0.05534647470527156,  0.0004068469091761907;
-    foldValues << -0.001765744149520443,  -5.344995025880831e-05,  0.005397520666020422,  5.546984205735068e-05,  0.005213823386543704,  7.618478879228569e-05,  -0.001944857239806249,  -9.206665792022876e-05,  -0.002459872346309381,  -0.0001296931976456198,  0.004688718434761114,  0.000134664362871677,  -0.001063536095060684,  -0.001905148710330257,  0.002514593936525903,  -0.001643393169986981,  -0.002189723835016068,  -9.12218689367709e-05,  0.004985117008772211,  9.615805506705544e-05,  0.005534647415570375,  4.068469082890896e-05;
+    dvalues << 1.790053057185293e-06, -2.44566429072041e-08, 1.889281703254964e-06, -1.972492834475447e-07, 1.681634609242917e-06, -2.373356532433882e-07, 1.585003447958184e-06, -5.301850772916681e-08, 1.274187257620066e-06, -2.137488936999111e-07, 1.362955262700412e-06, -2.762153471191986e-07, 1.249747540920782e-06, -3.196338173465977e-07, 1.333501893726392e-06, -3.161541101487353e-07, 1.394538527892028e-06, -1.166536323805688e-07, 1.488382850875808e-06, -2.605379508545059e-07, 2.056077021837937e-06, -1.341692715765341e-07;
+    fvalues << -0.01765744187144705, -0.000534499502451157, 0.05397520721069472, 0.0005546984181272257, 0.05213823442800309, 0.000761847881060882, -0.01944857277019029, -0.0009206665773591249, -0.02459872381892192, -0.001296931982922439, 0.04688718490326162, 0.001346643636856003, -0.01063536111298416, -0.01905148734069537, 0.02514593966043068, -0.01643393192020026, -0.02189723869781963, -0.0009122186870252733, 0.04985117065739809, 0.0009615805515004192, 0.05534647470527156, 0.0004068469091761907;
+    foldValues << -0.001765744149520443, -5.344995025880831e-05, 0.005397520666020422, 5.546984205735068e-05, 0.005213823386543704, 7.618478879228569e-05, -0.001944857239806249, -9.206665792022876e-05, -0.002459872346309381, -0.0001296931976456198, 0.004688718434761114, 0.000134664362871677, -0.001063536095060684, -0.001905148710330257, 0.002514593936525903, -0.001643393169986981, -0.002189723835016068, -9.12218689367709e-05, 0.004985117008772211, 9.615805506705544e-05, 0.005534647415570375, 4.068469082890896e-05;
 
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave2
 
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0;
-    fref << -0.001465589151503364,  -2.670111835650672e-05,  0.005711438689366103,  2.383730129847531e-05,  -0.001536098575916998,  -2.85287812066552e-05,  0.005638274807579218,  2.83961973555227e-05,  -0.0006856432131857974,  -0.0006815594391460808,  0.002901925611525407,  -0.002907380915674757,  0.005800715138289463,  9.667376010126117e-06,  -0.001376443700165206,  -9.547563271960956e-06,  0.005768190311116184,  1.311583226994801e-05,  -0.001408147387131287,  -1.216961377915992e-05,  -0.00163823504288376,  -3.874626690545313e-05;
+    dref << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    fref << -0.001465589151503364, -2.670111835650672e-05, 0.005711438689366103, 2.383730129847531e-05, -0.001536098575916998, -2.85287812066552e-05, 0.005638274807579218, 2.83961973555227e-05, -0.0006856432131857974, -0.0006815594391460808, 0.002901925611525407, -0.002907380915674757, 0.005800715138289463, 9.667376010126117e-06, -0.001376443700165206, -9.547563271960956e-06, 0.005768190311116184, 1.311583226994801e-05, -0.001408147387131287, -1.216961377915992e-05, -0.00163823504288376, -3.874626690545313e-05;
     frefNorm = 0.01265754337961098;
     drefNorm = 0.0;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
-
 
     // validate norm
     BOOST_TEST(testing::equals(data.at(4)->values->norm(), drefNorm), data.at(4)->values->norm());
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm), data.at(5)->values->norm());
 
     // update cplData
-    dvalues    << 1.848184969639987e-06,  -1.983566187932991e-07,  1.952383060128974e-06,  1.050101286643166e-07,  2.020975712018586e-06,  -9.297459906882382e-08,  2.123910878481957e-06,  -3.349554682884977e-08,  0,  0,  0,  0,  7.715047421278781e-07,  2.958323850532032e-07,  6.5137785527863e-07,  -3.40165313149562e-07,  1.498023570500414e-06,  2.492038233690158e-07,  1.395223018993416e-06,  -3.150663149441921e-07,  1.954718171910318e-06,  -3.415637300374603e-08;
-    fvalues    << -0.0146558918972568,  -0.000267011181975166,  0.05711438744699839,  0.0002383730136872111,  -0.0153609861368436,  -0.0002852878106683293,  0.05638274862725741,  0.0002839619744993407,  -0.00685643232676097,  -0.006815594586569211,  0.02901925639144463,  -0.02907380943293575,  0.05800715193585099,  9.667375963025685e-05,  -0.01376443739049903,  -9.547563172575954e-05,  0.05768190366530584,  0.0001311583223016465,  -0.01408147425699792,  -0.0001216961368213471,  -0.01638235080508845,  -0.0003874626694560972;
-    foldValues << -0.001465589151503364,  -2.670111835650672e-05,  0.005711438689366103,  2.383730129847531e-05,  -0.001536098575916998,  -2.85287812066552e-05,  0.005638274807579218,  2.83961973555227e-05,  -0.0006856432131857974,  -0.0006815594391460808,  0.002901925611525407,  -0.002907380915674757,  0.005800715138289463,  9.667376010126117e-06,  -0.001376443700165206,  -9.547563271960956e-06,  0.005768190311116184,  1.311583226994801e-05,  -0.001408147387131287,  -1.216961377915992e-05,  -0.00163823504288376,  -3.874626690545313e-05;
+    dvalues << 1.848184969639987e-06, -1.983566187932991e-07, 1.952383060128974e-06, 1.050101286643166e-07, 2.020975712018586e-06, -9.297459906882382e-08, 2.123910878481957e-06, -3.349554682884977e-08, 0, 0, 0, 0, 7.715047421278781e-07, 2.958323850532032e-07, 6.5137785527863e-07, -3.40165313149562e-07, 1.498023570500414e-06, 2.492038233690158e-07, 1.395223018993416e-06, -3.150663149441921e-07, 1.954718171910318e-06, -3.415637300374603e-08;
+    fvalues << -0.0146558918972568, -0.000267011181975166, 0.05711438744699839, 0.0002383730136872111, -0.0153609861368436, -0.0002852878106683293, 0.05638274862725741, 0.0002839619744993407, -0.00685643232676097, -0.006815594586569211, 0.02901925639144463, -0.02907380943293575, 0.05800715193585099, 9.667375963025685e-05, -0.01376443739049903, -9.547563172575954e-05, 0.05768190366530584, 0.0001311583223016465, -0.01408147425699792, -0.0001216961368213471, -0.01638235080508845, -0.0003874626694560972;
+    foldValues << -0.001465589151503364, -2.670111835650672e-05, 0.005711438689366103, 2.383730129847531e-05, -0.001536098575916998, -2.85287812066552e-05, 0.005638274807579218, 2.83961973555227e-05, -0.0006856432131857974, -0.0006815594391460808, 0.002901925611525407, -0.002907380915674757, 0.005800715138289463, 9.667376010126117e-06, -0.001376443700165206, -9.547563271960956e-06, 0.005768190311116184, 1.311583226994801e-05, -0.001408147387131287, -1.216961377915992e-05, -0.00163823504288376, -3.874626690545313e-05;
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave3
     // Dummy Slave to be able to reuse the 4 proc Master Slave Fixture
   }
@@ -684,44 +707,43 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 2.182991240484406e-07,  -2.982517027848927e-09,  2.30400176824822e-07,  -2.405478743936717e-08,  2.050773638768581e-07,  -2.89433684663868e-08,  1.932930774951963e-07,  -6.465670807451687e-09,  1.553886691210811e-07,  -2.606693476135542e-08,  1.662140341429634e-07,  -3.368479391313121e-08,  1.524082162646531e-07,  -3.897972859683727e-08,  1.62622160359393e-07,  -3.85553741174048e-08,  1.700656513328811e-07,  -1.422605082208521e-08,  1.815100794307223e-07,  -3.17729165761968e-08,  2.507410666078866e-07,  -1.636210409619326e-08;
-    fref << -0.01765744154108767,  -0.0005344995025713848,  0.0539752067273372,  0.0005546984202751798,  0.05213823393404264,  0.0007618478870860308,  -0.01944857244344392,  -0.0009206665789775117,  -0.02459872350648748,  -0.001296931977244764,  0.04688718441537337,  0.001346643629709359,  -0.01063536097040895,  -0.01905148713225291,  0.02514593940125557,  -0.01643393172673937,  -0.0218972383925581,  -0.0009122186890820461,  0.04985117015719479,  0.0009615805507717574,  0.05534647422272421,  0.0004068469083972726;
+    dref << 2.182991240484406e-07, -2.982517027848927e-09, 2.30400176824822e-07, -2.405478743936717e-08, 2.050773638768581e-07, -2.89433684663868e-08, 1.932930774951963e-07, -6.465670807451687e-09, 1.553886691210811e-07, -2.606693476135542e-08, 1.662140341429634e-07, -3.368479391313121e-08, 1.524082162646531e-07, -3.897972859683727e-08, 1.62622160359393e-07, -3.85553741174048e-08, 1.700656513328811e-07, -1.422605082208521e-08, 1.815100794307223e-07, -3.17729165761968e-08, 2.507410666078866e-07, -1.636210409619326e-08;
+    fref << -0.01765744154108767, -0.0005344995025713848, 0.0539752067273372, 0.0005546984202751798, 0.05213823393404264, 0.0007618478870860308, -0.01944857244344392, -0.0009206665789775117, -0.02459872350648748, -0.001296931977244764, 0.04688718441537337, 0.001346643629709359, -0.01063536097040895, -0.01905148713225291, 0.02514593940125557, -0.01643393172673937, -0.0218972383925581, -0.0009122186890820461, 0.04985117015719479, 0.0009615805507717574, 0.05534647422272421, 0.0004068469083972726;
     drefNorm = 6.435143632392166e-07;
     frefNorm = 0.1286041131776192;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
-
 
     // validate norm
     BOOST_TEST(testing::equals(data.at(4)->values->norm(), drefNorm), data.at(4)->values->norm());
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm), data.at(5)->values->norm());
 
     // update cplData
-    dvalues    << 1.790034504773721e-05,  -2.446591076368466e-07,  1.889267115021718e-05,  -1.972643201602028e-06,  1.681613350812527e-05,  -2.373460013995369e-06,  1.584978895355817e-05,  -5.302446869164338e-07,  1.274157692078479e-05,  -2.137546278211264e-06,  1.362926508984742e-05,  -2.762211725309514e-06,  1.249719424608544e-05,  -3.19640295598053e-06,  1.333474052315949e-05,  -3.16159193819195e-06,  1.394510078525391e-05,  -1.166587691625877e-06,  1.488356439901566e-05,  -2.605456452904905e-06,  2.056070000286195e-05,  -1.341920935569228e-06;
-    doldValues << 2.182991240484406e-07,  -2.982517027848927e-09,  2.30400176824822e-07,  -2.405478743936717e-08,  2.050773638768581e-07,  -2.89433684663868e-08,  1.932930774951963e-07,  -6.465670807451687e-09,  1.553886691210811e-07,  -2.606693476135542e-08,  1.662140341429634e-07,  -3.368479391313121e-08,  1.524082162646531e-07,  -3.897972859683727e-08,  1.62622160359393e-07,  -3.85553741174048e-08,  1.700656513328811e-07,  -1.422605082208521e-08,  1.815100794307223e-07,  -3.17729165761968e-08,  2.507410666078866e-07,  -1.636210409619326e-08;
-    fvalues    << -0.01845221261910751,  -0.000473660279052688,  0.05115217408647257,  0.0004997712466226923,  0.04953299847638116,  0.0006834967349236343,  -0.02003343430934222,  -0.000812620519068711,  -0.02461452082338934,  -0.00115320030035888,  0.04486850176987132,  0.00121794049154945,  -0.01080003301957858,  -0.01839753254507924,  0.02398381340216066,  -0.01606849579606463,  -0.02220297183992202,  -0.0008082032560853196,  0.04750952330271016,  0.0008672013640382038,  0.05236940113731539,  0.0003710183715860552;
-    foldValues << -0.01765744154108767,  -0.0005344995025713848,  0.0539752067273372,  0.0005546984202751798,  0.05213823393404264,  0.0007618478870860308,  -0.01944857244344392,  -0.0009206665789775117,  -0.02459872350648748,  -0.001296931977244764,  0.04688718441537337,  0.001346643629709359,  -0.01063536097040895,  -0.01905148713225291,  0.02514593940125557,  -0.01643393172673937,  -0.0218972383925581,  -0.0009122186890820461,  0.04985117015719479,  0.0009615805507717574,  0.05534647422272421,  0.0004068469083972726;
+    dvalues << 1.790034504773721e-05, -2.446591076368466e-07, 1.889267115021718e-05, -1.972643201602028e-06, 1.681613350812527e-05, -2.373460013995369e-06, 1.584978895355817e-05, -5.302446869164338e-07, 1.274157692078479e-05, -2.137546278211264e-06, 1.362926508984742e-05, -2.762211725309514e-06, 1.249719424608544e-05, -3.19640295598053e-06, 1.333474052315949e-05, -3.16159193819195e-06, 1.394510078525391e-05, -1.166587691625877e-06, 1.488356439901566e-05, -2.605456452904905e-06, 2.056070000286195e-05, -1.341920935569228e-06;
+    doldValues << 2.182991240484406e-07, -2.982517027848927e-09, 2.30400176824822e-07, -2.405478743936717e-08, 2.050773638768581e-07, -2.89433684663868e-08, 1.932930774951963e-07, -6.465670807451687e-09, 1.553886691210811e-07, -2.606693476135542e-08, 1.662140341429634e-07, -3.368479391313121e-08, 1.524082162646531e-07, -3.897972859683727e-08, 1.62622160359393e-07, -3.85553741174048e-08, 1.700656513328811e-07, -1.422605082208521e-08, 1.815100794307223e-07, -3.17729165761968e-08, 2.507410666078866e-07, -1.636210409619326e-08;
+    fvalues << -0.01845221261910751, -0.000473660279052688, 0.05115217408647257, 0.0004997712466226923, 0.04953299847638116, 0.0006834967349236343, -0.02003343430934222, -0.000812620519068711, -0.02461452082338934, -0.00115320030035888, 0.04486850176987132, 0.00121794049154945, -0.01080003301957858, -0.01839753254507924, 0.02398381340216066, -0.01606849579606463, -0.02220297183992202, -0.0008082032560853196, 0.04750952330271016, 0.0008672013640382038, 0.05236940113731539, 0.0003710183715860552;
+    foldValues << -0.01765744154108767, -0.0005344995025713848, 0.0539752067273372, 0.0005546984202751798, 0.05213823393404264, 0.0007618478870860308, -0.01944857244344392, -0.0009206665789775117, -0.02459872350648748, -0.001296931977244764, 0.04688718441537337, 0.001346643629709359, -0.01063536097040895, -0.01905148713225291, 0.02514593940125557, -0.01643393172673937, -0.0218972383925581, -0.0009122186890820461, 0.04985117015719479, 0.0009615805507717574, 0.05534647422272421, 0.0004068469083972726;
 
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave2
 
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 2.253883807144274e-07,  -2.418982831708627e-08,  2.380954632167933e-07,  1.280611153486133e-08,  2.464604196428374e-07,  -1.133836421999323e-08,  2.590134870407767e-07,  -4.084822236363769e-09,  0,  0,  0,  0,  9.408593154806163e-08,  3.607711529166728e-08,  7.943631316463149e-08,  -4.148356921273439e-08,  1.826857767882953e-07,  3.039070609254422e-08,  1.701491258462493e-07,  -3.842271618341636e-08,  2.38380232908047e-07,  -4.165410783473636e-09;
-    fref << -0.01465589156164622,  -0.0002670111833711768,  0.05711438696114118,  0.0002383730130704187,  -0.01536098580522773,  -0.0002852878118960371,  0.05638274814304403,  0.0002839619736703628,  -0.006856432155626628,  -0.006815594415254513,  0.02901925614893584,  -0.02907380919042905,  0.05800715145032832,  9.667376004382162e-05,  -0.01376443704907241,  -9.547563259840837e-05,  0.05768190317874038,  0.0001311583226509638,  -0.01408147391834763,  -0.0001216961376732758,  -0.01638235047472185,  -0.0003874626691035027;
+    dref << 2.253883807144274e-07, -2.418982831708627e-08, 2.380954632167933e-07, 1.280611153486133e-08, 2.464604196428374e-07, -1.133836421999323e-08, 2.590134870407767e-07, -4.084822236363769e-09, 0, 0, 0, 0, 9.408593154806163e-08, 3.607711529166728e-08, 7.943631316463149e-08, -4.148356921273439e-08, 1.826857767882953e-07, 3.039070609254422e-08, 1.701491258462493e-07, -3.842271618341636e-08, 2.38380232908047e-07, -4.165410783473636e-09;
+    fref << -0.01465589156164622, -0.0002670111833711768, 0.05711438696114118, 0.0002383730130704187, -0.01536098580522773, -0.0002852878118960371, 0.05638274814304403, 0.0002839619736703628, -0.006856432155626628, -0.006815594415254513, 0.02901925614893584, -0.02907380919042905, 0.05800715145032832, 9.667376004382162e-05, -0.01376443704907241, -9.547563259840837e-05, 0.05768190317874038, 0.0001311583226509638, -0.01408147391834763, -0.0001216961376732758, -0.01638235047472185, -0.0003874626691035027;
     drefNorm = 6.131610103923933e-07;
     frefNorm = 0.1265754339635572;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
 
     // validate norm
@@ -729,11 +751,11 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm), data.at(5)->values->norm());
 
     // update cplData
-    dvalues    << 1.848182952307335e-05,  -1.983938722952872e-06,  1.952389995095743e-05,  1.049689886611777e-06,  2.020972044646931e-05,  -9.30012125294331e-07,  2.123911759834233e-05,  -3.352823479948144e-07,  0,  0,  0,  0,  7.715124780435689e-06,  2.958056858428718e-06,  6.513639301665504e-06,  -3.401886529062288e-06,  1.498034283416962e-05,  2.491634858078641e-06,  1.39521486945152e-05,  -3.151050708450101e-06,  1.954707223943552e-05,  -3.417246252999375e-07;
-    doldValues << 2.253883807144274e-07,  -2.418982831708627e-08,  2.380954632167933e-07,  1.280611153486133e-08,  2.464604196428374e-07,  -1.133836421999323e-08,  2.590134870407767e-07,  -4.084822236363769e-09,  0,  0,  0,  0,  9.408593154806163e-08,  3.607711529166728e-08,  7.943631316463149e-08,  -4.148356921273439e-08,  1.826857767882953e-07,  3.039070609254422e-08,  1.701491258462493e-07,  -3.842271618341636e-08,  2.38380232908047e-07,  -4.165410783473636e-09;
-    fvalues    << -0.01568208277628194,  -0.0002595395446636614,  0.0540328986967421,  0.0002362571305830931,  -0.01637736854863682,  -0.0002699645831085989,  0.05331751790879287,  0.0002707054191427001,  -0.007277539612331946,  -0.007235194100552225,  0.02757151633202504,  -0.02762772092892902,  0.05505877464319012,  0.0001052840945529276,  -0.01465499974491537,  -0.0001017767294585529,  0.05464614037258596,  0.0001424559420056945,  -0.01506072500921042,  -0.0001315030046882618,  -0.0173164149989076,  -0.0003474184175392483;
-    foldValues << -0.01465589156164622,  -0.0002670111833711768,  0.05711438696114118,  0.0002383730130704187,  -0.01536098580522773,  -0.0002852878118960371,  0.05638274814304403,  0.0002839619736703628,  -0.006856432155626628,  -0.006815594415254513,  0.02901925614893584,  -0.02907380919042905,  0.05800715145032832,  9.667376004382162e-05,  -0.01376443704907241,  -9.547563259840837e-05,  0.05768190317874038,  0.0001311583226509638,  -0.01408147391834763,  -0.0001216961376732758,  -0.01638235047472185,  -0.0003874626691035027;
-  }  else if (utils::Parallel::getProcessRank() == 3) { //Slave3
+    dvalues << 1.848182952307335e-05, -1.983938722952872e-06, 1.952389995095743e-05, 1.049689886611777e-06, 2.020972044646931e-05, -9.30012125294331e-07, 2.123911759834233e-05, -3.352823479948144e-07, 0, 0, 0, 0, 7.715124780435689e-06, 2.958056858428718e-06, 6.513639301665504e-06, -3.401886529062288e-06, 1.498034283416962e-05, 2.491634858078641e-06, 1.39521486945152e-05, -3.151050708450101e-06, 1.954707223943552e-05, -3.417246252999375e-07;
+    doldValues << 2.253883807144274e-07, -2.418982831708627e-08, 2.380954632167933e-07, 1.280611153486133e-08, 2.464604196428374e-07, -1.133836421999323e-08, 2.590134870407767e-07, -4.084822236363769e-09, 0, 0, 0, 0, 9.408593154806163e-08, 3.607711529166728e-08, 7.943631316463149e-08, -4.148356921273439e-08, 1.826857767882953e-07, 3.039070609254422e-08, 1.701491258462493e-07, -3.842271618341636e-08, 2.38380232908047e-07, -4.165410783473636e-09;
+    fvalues << -0.01568208277628194, -0.0002595395446636614, 0.0540328986967421, 0.0002362571305830931, -0.01637736854863682, -0.0002699645831085989, 0.05331751790879287, 0.0002707054191427001, -0.007277539612331946, -0.007235194100552225, 0.02757151633202504, -0.02762772092892902, 0.05505877464319012, 0.0001052840945529276, -0.01465499974491537, -0.0001017767294585529, 0.05464614037258596, 0.0001424559420056945, -0.01506072500921042, -0.0001315030046882618, -0.0173164149989076, -0.0003474184175392483;
+    foldValues << -0.01465589156164622, -0.0002670111833711768, 0.05711438696114118, 0.0002383730130704187, -0.01536098580522773, -0.0002852878118960371, 0.05638274814304403, 0.0002839619736703628, -0.006856432155626628, -0.006815594415254513, 0.02901925614893584, -0.02907380919042905, 0.05800715145032832, 9.667376004382162e-05, -0.01376443704907241, -9.547563259840837e-05, 0.05768190317874038, 0.0001311583226509638, -0.01408147391834763, -0.0001216961376732758, -0.01638235047472185, -0.0003874626691035027;
+  } else if (utils::Parallel::getProcessRank() == 3) { //Slave3
     // Dummy Slave to be able to reuse the 4 proc Master Slave Fixture
   }
 
@@ -750,16 +772,16 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 1.717512702194643e-05,  -2.347247264125579e-07,  1.812723818498285e-05,  -1.892683301884884e-06,  1.613485037277307e-05,  -2.277271314691775e-06,  1.520766651015439e-05,  -5.087470614753933e-07,  1.222540039026145e-05,  -2.050926769187082e-06,  1.30771205492404e-05,  -2.650282676556395e-06,  1.199091589196657e-05,  -3.066880426987482e-06,  1.279452699120483e-05,  -3.033483087437419e-06,  1.338015894263769e-05,  -1.11930952734218e-06,  1.428059443561221e-05,  -2.499874235762116e-06,  1.972766650768916e-05,  -1.287497600071812e-06;
-    fref << -0.01823457911070198,  -0.0004903200524407003,  0.05192521422826112,  0.0005148121016499705,  0.05024639863781041,  0.0007049518329474636,  -0.01987328081455485,  -0.0008422070677716292,  -0.02461019581850909,  -0.001192558759870676,  0.04542128452828625,  0.001253183648371612,  -0.01075494078801318,  -0.01857660729355974,  0.02430204227390975,  -0.01616856463954442,  -0.02211925279965755,  -0.0008366860858679643,  0.04815074428053346,  0.0008930454810143837,  0.05318462260012811,  0.0003808294014608455;
+    dref << 1.717512702194643e-05, -2.347247264125579e-07, 1.812723818498285e-05, -1.892683301884884e-06, 1.613485037277307e-05, -2.277271314691775e-06, 1.520766651015439e-05, -5.087470614753933e-07, 1.222540039026145e-05, -2.050926769187082e-06, 1.30771205492404e-05, -2.650282676556395e-06, 1.199091589196657e-05, -3.066880426987482e-06, 1.279452699120483e-05, -3.033483087437419e-06, 1.338015894263769e-05, -1.11930952734218e-06, 1.428059443561221e-05, -2.499874235762116e-06, 1.972766650768916e-05, -1.287497600071812e-06;
+    fref << -0.01823457911070198, -0.0004903200524407003, 0.05192521422826112, 0.0005148121016499705, 0.05024639863781041, 0.0007049518329474636, -0.01987328081455485, -0.0008422070677716292, -0.02461019581850909, -0.001192558759870676, 0.04542128452828625, 0.001253183648371612, -0.01075494078801318, -0.01857660729355974, 0.02430204227390975, -0.01616856463954442, -0.02211925279965755, -0.0008366860858679643, 0.04815074428053346, 0.0008930454810143837, 0.05318462260012811, 0.0003808294014608455;
     drefNorm = 5.062970166651817e-05;
     frefNorm = 0.1247902554601672;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
 
     // validate norm
@@ -767,42 +789,40 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm), data.at(5)->values->norm());
 
     // update cplData
-    dvalues    << 1.659080663925766e-05,  -2.839283676791931e-07,  1.756292801739508e-05,  -1.881726812992964e-06,  1.564798101471437e-05,  -2.265931706775091e-06,  1.470124517392331e-05,  -5.705378156142171e-07,  1.186047603634431e-05,  -2.115667271562722e-06,  1.273027556448604e-05,  -2.674541973319838e-06,  1.165645170777486e-05,  -3.135385366949176e-06,  1.247728214631633e-05,  -3.082564251671268e-06,  1.295443089215965e-05,  -1.185450561958201e-06,  1.387356342346108e-05,  -2.500933334689963e-06,  1.911143938064833e-05,  -1.289577439500651e-06;
-    doldValues << 1.717512702194643e-05,  -2.347247264125579e-07,  1.812723818498285e-05,  -1.892683301884884e-06,  1.613485037277307e-05,  -2.277271314691775e-06,  1.520766651015439e-05,  -5.087470614753933e-07,  1.222540039026145e-05,  -2.050926769187082e-06,  1.30771205492404e-05,  -2.650282676556395e-06,  1.199091589196657e-05,  -3.066880426987482e-06,  1.279452699120483e-05,  -3.033483087437419e-06,  1.338015894263769e-05,  -1.11930952734218e-06,  1.428059443561221e-05,  -2.499874235762116e-06,  1.972766650768916e-05,  -1.287497600071812e-06;
-    fvalues    << -0.08018882094302014,  0.004252226533647444,  -0.1681454949889014,  -0.00376664315520894,  -0.1528473285523723,  -0.005402482563102148,  -0.06546415562528343,  0.007580544006107058,  -0.02584070375141325,  0.01001310706105286,  -0.1119519940946071,  -0.008779400784032571,  -0.02359260557541131,  0.03241153400001811,  -0.06629773012631451,  0.01232457880930212,  -0.04595115217779744,  0.007271575191182346,  -0.1343966169086029,  -0.006463593204557456,  -0.1788931815052193,  -0.00241194798896828;
-    foldValues << -0.01823457911070198,  -0.0004903200524407003,  0.05192521422826112,  0.0005148121016499705,  0.05024639863781041,  0.0007049518329474636,  -0.01987328081455485,  -0.0008422070677716292,  -0.02461019581850909,  -0.001192558759870676,  0.04542128452828625,  0.001253183648371612,  -0.01075494078801318,  -0.01857660729355974,  0.02430204227390975,  -0.01616856463954442,  -0.02211925279965755,  -0.0008366860858679643,  0.04815074428053346,  0.0008930454810143837,  0.05318462260012811,  0.0003808294014608455;
+    dvalues << 1.659080663925766e-05, -2.839283676791931e-07, 1.756292801739508e-05, -1.881726812992964e-06, 1.564798101471437e-05, -2.265931706775091e-06, 1.470124517392331e-05, -5.705378156142171e-07, 1.186047603634431e-05, -2.115667271562722e-06, 1.273027556448604e-05, -2.674541973319838e-06, 1.165645170777486e-05, -3.135385366949176e-06, 1.247728214631633e-05, -3.082564251671268e-06, 1.295443089215965e-05, -1.185450561958201e-06, 1.387356342346108e-05, -2.500933334689963e-06, 1.911143938064833e-05, -1.289577439500651e-06;
+    doldValues << 1.717512702194643e-05, -2.347247264125579e-07, 1.812723818498285e-05, -1.892683301884884e-06, 1.613485037277307e-05, -2.277271314691775e-06, 1.520766651015439e-05, -5.087470614753933e-07, 1.222540039026145e-05, -2.050926769187082e-06, 1.30771205492404e-05, -2.650282676556395e-06, 1.199091589196657e-05, -3.066880426987482e-06, 1.279452699120483e-05, -3.033483087437419e-06, 1.338015894263769e-05, -1.11930952734218e-06, 1.428059443561221e-05, -2.499874235762116e-06, 1.972766650768916e-05, -1.287497600071812e-06;
+    fvalues << -0.08018882094302014, 0.004252226533647444, -0.1681454949889014, -0.00376664315520894, -0.1528473285523723, -0.005402482563102148, -0.06546415562528343, 0.007580544006107058, -0.02584070375141325, 0.01001310706105286, -0.1119519940946071, -0.008779400784032571, -0.02359260557541131, 0.03241153400001811, -0.06629773012631451, 0.01232457880930212, -0.04595115217779744, 0.007271575191182346, -0.1343966169086029, -0.006463593204557456, -0.1788931815052193, -0.00241194798896828;
+    foldValues << -0.01823457911070198, -0.0004903200524407003, 0.05192521422826112, 0.0005148121016499705, 0.05024639863781041, 0.0007049518329474636, -0.01987328081455485, -0.0008422070677716292, -0.02461019581850909, -0.001192558759870676, 0.04542128452828625, 0.001253183648371612, -0.01075494078801318, -0.01857660729355974, 0.02430204227390975, -0.01616856463954442, -0.02211925279965755, -0.0008366860858679643, 0.04815074428053346, 0.0008930454810143837, 0.05318462260012811, 0.0003808294014608455;
 
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave2
 
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 1.773301313815872e-05,  -1.903469331632798e-06,  1.873284151703964e-05,  1.007255996407046e-06,  1.939089962749955e-05,  -8.922690925673692e-07,  2.037857848281338e-05,  -3.216215773080572e-07,  0,  0,  0,  0,  7.402516024117914e-06,  2.838268713863215e-06,  6.249761203424372e-06,  -3.263999161516882e-06,  1.437336512054573e-05,  2.390776372597577e-06,  1.338687393172981e-05,  -3.023290389839287e-06,  1.875511666670207e-05,  -3.278415622262174e-07;
-    fref << -0.01540107886229656,  -0.0002615855206049247,  0.05487671246695029,  0.0002368365301820234,  -0.0160990505051311,  -0.0002741605822288765,  0.05415687969310452,  0.0002743355004921105,  -0.007162227035058467,  -0.007120294400987128,  0.02796795558583163,  -0.02802370793272083,  0.05586613813214418,  0.0001029263016352541,  -0.0144111353804976,  -0.0001000512803033142,  0.05547743301530601,  0.0001393622825766435,  -0.01479257484776803,  -0.0001288175608001121,  -0.01706063837893593,  -0.0003583838471874983;
+    dref << 1.773301313815872e-05, -1.903469331632798e-06, 1.873284151703964e-05, 1.007255996407046e-06, 1.939089962749955e-05, -8.922690925673692e-07, 2.037857848281338e-05, -3.216215773080572e-07, 0, 0, 0, 0, 7.402516024117914e-06, 2.838268713863215e-06, 6.249761203424372e-06, -3.263999161516882e-06, 1.437336512054573e-05, 2.390776372597577e-06, 1.338687393172981e-05, -3.023290389839287e-06, 1.875511666670207e-05, -3.278415622262174e-07;
+    fref << -0.01540107886229656, -0.0002615855206049247, 0.05487671246695029, 0.0002368365301820234, -0.0160990505051311, -0.0002741605822288765, 0.05415687969310452, 0.0002743355004921105, -0.007162227035058467, -0.007120294400987128, 0.02796795558583163, -0.02802370793272083, 0.05586613813214418, 0.0001029263016352541, -0.0144111353804976, -0.0001000512803033142, 0.05547743301530601, 0.0001393622825766435, -0.01479257484776803, -0.0001288175608001121, -0.01706063837893593, -0.0003583838471874983;
     drefNorm = 4.824205753272403e-05;
     frefNorm = 0.1225851627302816;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
-
 
     // validate norm
     BOOST_TEST(testing::equals(data.at(4)->values->norm(), drefNorm), data.at(4)->values->norm());
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm), data.at(5)->values->norm());
 
     // update cplData
-    dvalues    << 1.716650969972045e-05,  -1.856138836171773e-06,  1.818701485070425e-05,  9.439657883607802e-07,  1.874709534954619e-05,  -8.85448704675396e-07,  1.975527973304359e-05,  -3.501096287428596e-07,  0,  0,  0,  0,  7.228951427433641e-06,  2.745909101918556e-06,  6.052367643912141e-06,  -3.179587143921995e-06,  1.398276918926419e-05,  2.29762824040882e-06,  1.297587398676e-05,  -2.941551341709183e-06,  1.811863361465251e-05,  -3.546317448342288e-07;
-    doldValues << 1.773301313815872e-05,  -1.903469331632798e-06,  1.873284151703964e-05,  1.007255996407046e-06,  1.939089962749955e-05,  -8.922690925673692e-07,  2.037857848281338e-05,  -3.216215773080572e-07,  0,  0,  0,  0,  7.402516024117914e-06,  2.838268713863215e-06,  6.249761203424372e-06,  -3.263999161516882e-06,  1.437336512054573e-05,  2.390776372597577e-06,  1.338687393172981e-05,  -3.023290389839287e-06,  1.875511666670207e-05,  -3.278415622262174e-07;
-    fvalues    << -0.09539527385890252,  0.0003208855941258066,  -0.1853399184726223,  7.203155656644242e-05,  -0.09532865072058605,  0.0009202649288056726,  -0.1847925968312873,  -0.0007589246108979722,  -0.03998875591551594,  -0.03982927597079221,  -0.08489044889406808,  0.08470593806523596,  -0.1739740974580442,  0.0007742373134568178,  -0.08383286811708256,  -0.0005911288917162662,  -0.1811747642897668,  0.001020161732709184,  -0.09112767929864005,  -0.0008931566039992005,  -0.08987332323372975,  0.002763113283891189;
-    foldValues << -0.01540107886229656,  -0.0002615855206049247,  0.05487671246695029,  0.0002368365301820234,  -0.0160990505051311,  -0.0002741605822288765,  0.05415687969310452,  0.0002743355004921105,  -0.007162227035058467,  -0.007120294400987128,  0.02796795558583163,  -0.02802370793272083,  0.05586613813214418,  0.0001029263016352541,  -0.0144111353804976,  -0.0001000512803033142,  0.05547743301530601,  0.0001393622825766435,  -0.01479257484776803,  -0.0001288175608001121,  -0.01706063837893593,  -0.0003583838471874983;
+    dvalues << 1.716650969972045e-05, -1.856138836171773e-06, 1.818701485070425e-05, 9.439657883607802e-07, 1.874709534954619e-05, -8.85448704675396e-07, 1.975527973304359e-05, -3.501096287428596e-07, 0, 0, 0, 0, 7.228951427433641e-06, 2.745909101918556e-06, 6.052367643912141e-06, -3.179587143921995e-06, 1.398276918926419e-05, 2.29762824040882e-06, 1.297587398676e-05, -2.941551341709183e-06, 1.811863361465251e-05, -3.546317448342288e-07;
+    doldValues << 1.773301313815872e-05, -1.903469331632798e-06, 1.873284151703964e-05, 1.007255996407046e-06, 1.939089962749955e-05, -8.922690925673692e-07, 2.037857848281338e-05, -3.216215773080572e-07, 0, 0, 0, 0, 7.402516024117914e-06, 2.838268713863215e-06, 6.249761203424372e-06, -3.263999161516882e-06, 1.437336512054573e-05, 2.390776372597577e-06, 1.338687393172981e-05, -3.023290389839287e-06, 1.875511666670207e-05, -3.278415622262174e-07;
+    fvalues << -0.09539527385890252, 0.0003208855941258066, -0.1853399184726223, 7.203155656644242e-05, -0.09532865072058605, 0.0009202649288056726, -0.1847925968312873, -0.0007589246108979722, -0.03998875591551594, -0.03982927597079221, -0.08489044889406808, 0.08470593806523596, -0.1739740974580442, 0.0007742373134568178, -0.08383286811708256, -0.0005911288917162662, -0.1811747642897668, 0.001020161732709184, -0.09112767929864005, -0.0008931566039992005, -0.08987332323372975, 0.002763113283891189;
+    foldValues << -0.01540107886229656, -0.0002615855206049247, 0.05487671246695029, 0.0002368365301820234, -0.0160990505051311, -0.0002741605822288765, 0.05415687969310452, 0.0002743355004921105, -0.007162227035058467, -0.007120294400987128, 0.02796795558583163, -0.02802370793272083, 0.05586613813214418, 0.0001029263016352541, -0.0144111353804976, -0.0001000512803033142, 0.05547743301530601, 0.0001393622825766435, -0.01479257484776803, -0.0001288175608001121, -0.01706063837893593, -0.0003583838471874983;
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave3
     // Dummy Slave to be able to reuse the 4 proc Master Slave Fixture
   }
-
 
   data.at(4)->oldValues.col(0) = doldValues;
   data.at(5)->oldValues.col(0) = foldValues;
@@ -817,44 +837,43 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 1.633368119919659e-05,  -2.237360618564265e-07,  1.723960679736894e-05,  -1.800451405634617e-06,  1.534489463502018e-05,  -2.166297690952519e-06,  1.446268777631733e-05,  -4.845152271528126e-07,  1.162685558347312e-05,  -1.951619069146136e-06,  1.243725578988821e-05,  -2.521440338918289e-06,  1.140405450734714e-05,  -2.91813193235939e-06,  1.216867994540041e-05,  -2.886191281742917e-06,  1.272486031358505e-05,  -1.065380276784719e-06,  1.35816114080243e-05,  -2.3781612091675e-06,  1.876166803225929e-05,  -1.224865187618123e-06;
-    fref << -0.01890549129941078,  -0.0004389621840029381,  0.04954204963698766,  0.0004684469509178089,  0.04804708246519945,  0.0006388129115723739,  -0.02036699235959898,  -0.0007509963669595499,  -0.02462352250264116,  -0.00107121393884661,  0.04371708893453349,  0.001144538793507394,  -0.01089395922122854,  -0.01802447191842139,  0.02332094230979109,  -0.01586002180275038,  -0.02237733336181922,  -0.0007488803918274927,  0.04617393036901896,  0.00081337820788483,  0.05067142953803216,  0.0003505856246817933;
+    dref << 1.633368119919659e-05, -2.237360618564265e-07, 1.723960679736894e-05, -1.800451405634617e-06, 1.534489463502018e-05, -2.166297690952519e-06, 1.446268777631733e-05, -4.845152271528126e-07, 1.162685558347312e-05, -1.951619069146136e-06, 1.243725578988821e-05, -2.521440338918289e-06, 1.140405450734714e-05, -2.91813193235939e-06, 1.216867994540041e-05, -2.886191281742917e-06, 1.272486031358505e-05, -1.065380276784719e-06, 1.35816114080243e-05, -2.3781612091675e-06, 1.876166803225929e-05, -1.224865187618123e-06;
+    fref << -0.01890549129941078, -0.0004389621840029381, 0.04954204963698766, 0.0004684469509178089, 0.04804708246519945, 0.0006388129115723739, -0.02036699235959898, -0.0007509963669595499, -0.02462352250264116, -0.00107121393884661, 0.04371708893453349, 0.001144538793507394, -0.01089395922122854, -0.01802447191842139, 0.02332094230979109, -0.01586002180275038, -0.02237733336181922, -0.0007488803918274927, 0.04617393036901896, 0.00081337820788483, 0.05067142953803216, 0.0003505856246817933;
     drefNorm = 4.815113092042934e-05;
-    frefNorm = 0.1204042970796453 ;
+    frefNorm = 0.1204042970796453;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
-
 
     // validate norm
     BOOST_TEST(testing::equals(data.at(4)->values->norm(), drefNorm));
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm));
 
     // update cplData
-    dvalues    << 1.506845042291629e-05,  -3.295713481574521e-07,  1.601708402767785e-05,  -1.776032790440438e-06,  1.428998106709373e-05,  -2.140925300298825e-06,  1.336604025915203e-05,  -6.173668108734595e-07,  1.083614857997936e-05,  -2.09020895349816e-06,  1.168515223592441e-05,  -2.572621503366579e-06,  1.067901778881212e-05,  -3.064421860106172e-06,  1.14804152344671e-05,  -2.990689693425248e-06,  1.180274523671064e-05,  -1.207361572630013e-06,  1.26994053163659e-05,  -2.379420351559266e-06,  1.742665917249236e-05,  -1.228726437307901e-06;
-    doldValues << 1.633368119919659e-05,  -2.237360618564265e-07,  1.723960679736894e-05,  -1.800451405634617e-06,  1.534489463502018e-05,  -2.166297690952519e-06,  1.446268777631733e-05,  -4.845152271528126e-07,  1.162685558347312e-05,  -1.951619069146136e-06,  1.243725578988821e-05,  -2.521440338918289e-06,  1.140405450734714e-05,  -2.91813193235939e-06,  1.216867994540041e-05,  -2.886191281742917e-06,  1.272486031358505e-05,  -1.065380276784719e-06,  1.35816114080243e-05,  -2.3781612091675e-06,  1.876166803225929e-05,  -1.224865187618123e-06;
-    fvalues    << -0.07712271523301416,  0.004018032584755363,  -0.1572746631951394,  -0.003554957358717858,  -0.1428154301136939,  -0.005100471254411636,  -0.06320679903752099,  0.00716455247252809,  -0.02577587645775314,  0.009459639059138256,  -0.1041793821597049,  -0.008283348947413409,  -0.02295652849878388,  0.02989440569403293,  -0.06182269085435656,  0.01091909076145766,  -0.04476922496853244,  0.00687112729333933,  -0.1253800696382085,  -0.006099818450316078,  -0.1674291774005812,  -0.002273881806091619;
-    foldValues << -0.01890549129941078,  -0.0004389621840029381,  0.04954204963698766,  0.0004684469509178089,  0.04804708246519945,  0.0006388129115723739,  -0.02036699235959898,  -0.0007509963669595499,  -0.02462352250264116,  -0.00107121393884661,  0.04371708893453349,  0.001144538793507394,  -0.01089395922122854,  -0.01802447191842139,  0.02332094230979109,  -0.01586002180275038,  -0.02237733336181922,  -0.0007488803918274927,  0.04617393036901896,  0.00081337820788483,  0.05067142953803216,  0.0003505856246817933;
+    dvalues << 1.506845042291629e-05, -3.295713481574521e-07, 1.601708402767785e-05, -1.776032790440438e-06, 1.428998106709373e-05, -2.140925300298825e-06, 1.336604025915203e-05, -6.173668108734595e-07, 1.083614857997936e-05, -2.09020895349816e-06, 1.168515223592441e-05, -2.572621503366579e-06, 1.067901778881212e-05, -3.064421860106172e-06, 1.14804152344671e-05, -2.990689693425248e-06, 1.180274523671064e-05, -1.207361572630013e-06, 1.26994053163659e-05, -2.379420351559266e-06, 1.742665917249236e-05, -1.228726437307901e-06;
+    doldValues << 1.633368119919659e-05, -2.237360618564265e-07, 1.723960679736894e-05, -1.800451405634617e-06, 1.534489463502018e-05, -2.166297690952519e-06, 1.446268777631733e-05, -4.845152271528126e-07, 1.162685558347312e-05, -1.951619069146136e-06, 1.243725578988821e-05, -2.521440338918289e-06, 1.140405450734714e-05, -2.91813193235939e-06, 1.216867994540041e-05, -2.886191281742917e-06, 1.272486031358505e-05, -1.065380276784719e-06, 1.35816114080243e-05, -2.3781612091675e-06, 1.876166803225929e-05, -1.224865187618123e-06;
+    fvalues << -0.07712271523301416, 0.004018032584755363, -0.1572746631951394, -0.003554957358717858, -0.1428154301136939, -0.005100471254411636, -0.06320679903752099, 0.00716455247252809, -0.02577587645775314, 0.009459639059138256, -0.1041793821597049, -0.008283348947413409, -0.02295652849878388, 0.02989440569403293, -0.06182269085435656, 0.01091909076145766, -0.04476922496853244, 0.00687112729333933, -0.1253800696382085, -0.006099818450316078, -0.1674291774005812, -0.002273881806091619;
+    foldValues << -0.01890549129941078, -0.0004389621840029381, 0.04954204963698766, 0.0004684469509178089, 0.04804708246519945, 0.0006388129115723739, -0.02036699235959898, -0.0007509963669595499, -0.02462352250264116, -0.00107121393884661, 0.04371708893453349, 0.001144538793507394, -0.01089395922122854, -0.01802447191842139, 0.02332094230979109, -0.01586002180275038, -0.02237733336181922, -0.0007488803918274927, 0.04617393036901896, 0.00081337820788483, 0.05067142953803216, 0.0003505856246817933;
 
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave2
 
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref << 1.686458723791834e-05,  -1.810446627874213e-06,  1.781592254220799e-05,  9.575750096228968e-07,  1.844107125032693e-05,  -8.488149913661512e-07,  1.938083795505493e-05,  -3.062726369792662e-07,  0,  0,  0,  0,  7.040556208586022e-06,  2.699202297106055e-06,  5.943687851414432e-06,  -3.104374082089934e-06,  1.367008353382051e-05,  2.273466384432095e-06,  1.27314174291305e-05,  -2.875442657958392e-06,  1.783629704415144e-05,  -3.12140240279707e-07;
-    fref << -0.01626734826572977,  -0.0002552779342950638,  0.05227538136126555,  0.0002350515292044683,  -0.01695703999572442,  -0.0002612258237118909,  0.05156927126324851,  0.0002631458821373055,  -0.007517710152292339,  -0.007474504607240594,  0.02674580053052369,  -0.02680294718917284,  0.05337717466458169,  0.0001101957844225173,  -0.01516291356738642,  -0.0001053694865272746,  0.05291470170150131,  0.0001489003323108161,  -0.01561921932892748,  -0.0001370950096012615,  -0.01784913805041409,  -0.000324580522802835;
-    drefNorm = 4.587992970636867e-05 ;
+    dref << 1.686458723791834e-05, -1.810446627874213e-06, 1.781592254220799e-05, 9.575750096228968e-07, 1.844107125032693e-05, -8.488149913661512e-07, 1.938083795505493e-05, -3.062726369792662e-07, 0, 0, 0, 0, 7.040556208586022e-06, 2.699202297106055e-06, 5.943687851414432e-06, -3.104374082089934e-06, 1.367008353382051e-05, 2.273466384432095e-06, 1.27314174291305e-05, -2.875442657958392e-06, 1.783629704415144e-05, -3.12140240279707e-07;
+    fref << -0.01626734826572977, -0.0002552779342950638, 0.05227538136126555, 0.0002350515292044683, -0.01695703999572442, -0.0002612258237118909, 0.05156927126324851, 0.0002631458821373055, -0.007517710152292339, -0.007474504607240594, 0.02674580053052369, -0.02680294718917284, 0.05337717466458169, 0.0001101957844225173, -0.01516291356738642, -0.0001053694865272746, 0.05291470170150131, 0.0001489003323108161, -0.01561921932892748, -0.0001370950096012615, -0.01784913805041409, -0.000324580522802835;
+    drefNorm = 4.587992970636867e-05;
     frefNorm = 0.1180354804938519;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
 
     // validate norm
@@ -862,10 +881,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     BOOST_TEST(testing::equals(data.at(5)->values->norm(), frefNorm));
 
     // update cplData
-    dvalues    << 1.563743909676446e-05,  -1.707572586404205e-06,  1.663287551913161e-05,  8.210579991784308e-07,  1.704678071734513e-05,  -8.336427145015805e-07,  1.803030552728031e-05,  -3.673472962716038e-07,  0,  0,  0,  0,  6.663771864888832e-06,  2.499283366425937e-06,  5.516134032932667e-06,  -2.921164340377279e-06,  1.282308279788757e-05,  2.07209067754735e-06,  1.184094543159743e-05,  -2.698009821996337e-06,  1.645805878055576e-05,  -3.696322259193852e-07;
-    doldValues << 1.686458723791834e-05,  -1.810446627874213e-06,  1.781592254220799e-05,  9.575750096228968e-07,  1.844107125032693e-05,  -8.488149913661512e-07,  1.938083795505493e-05,  -3.062726369792662e-07,  0,  0,  0,  0,  7.040556208586022e-06,  2.699202297106055e-06,  5.943687851414432e-06,  -3.104374082089934e-06,  1.367008353382051e-05,  2.273466384432095e-06,  1.27314174291305e-05,  -2.875442657958392e-06,  1.783629704415144e-05,  -3.12140240279707e-07;
-    fvalues    << -0.09143825207871489,  0.0002922798859936043,  -0.1734744585823354,  8.018501629471556e-05,  -0.09140909287296797,  0.0008614262538692869,  -0.1729893406976169,  -0.0007078492982043917,  -0.03836482525057584,  -0.03821118279703851,  -0.07931609050916776,  0.07913795276507131,  -0.1626218046186428,  0.0007411076261039719,  -0.08039872451576649,  -0.0005667402343291361,  -0.1694857588798654,  0.0009766586358261331,  -0.0873517838382746,  -0.0008552683303008771,  -0.08627064033821233,  0.002609015553424872;
-    foldValues << -0.01626734826572977,  -0.0002552779342950638,  0.05227538136126555,  0.0002350515292044683,  -0.01695703999572442,  -0.0002612258237118909,  0.05156927126324851,  0.0002631458821373055,  -0.007517710152292339,  -0.007474504607240594,  0.02674580053052369,  -0.02680294718917284,  0.05337717466458169,  0.0001101957844225173,  -0.01516291356738642,  -0.0001053694865272746,  0.05291470170150131,  0.0001489003323108161,  -0.01561921932892748,  -0.0001370950096012615,  -0.01784913805041409,  -0.000324580522802835;
+    dvalues << 1.563743909676446e-05, -1.707572586404205e-06, 1.663287551913161e-05, 8.210579991784308e-07, 1.704678071734513e-05, -8.336427145015805e-07, 1.803030552728031e-05, -3.673472962716038e-07, 0, 0, 0, 0, 6.663771864888832e-06, 2.499283366425937e-06, 5.516134032932667e-06, -2.921164340377279e-06, 1.282308279788757e-05, 2.07209067754735e-06, 1.184094543159743e-05, -2.698009821996337e-06, 1.645805878055576e-05, -3.696322259193852e-07;
+    doldValues << 1.686458723791834e-05, -1.810446627874213e-06, 1.781592254220799e-05, 9.575750096228968e-07, 1.844107125032693e-05, -8.488149913661512e-07, 1.938083795505493e-05, -3.062726369792662e-07, 0, 0, 0, 0, 7.040556208586022e-06, 2.699202297106055e-06, 5.943687851414432e-06, -3.104374082089934e-06, 1.367008353382051e-05, 2.273466384432095e-06, 1.27314174291305e-05, -2.875442657958392e-06, 1.783629704415144e-05, -3.12140240279707e-07;
+    fvalues << -0.09143825207871489, 0.0002922798859936043, -0.1734744585823354, 8.018501629471556e-05, -0.09140909287296797, 0.0008614262538692869, -0.1729893406976169, -0.0007078492982043917, -0.03836482525057584, -0.03821118279703851, -0.07931609050916776, 0.07913795276507131, -0.1626218046186428, 0.0007411076261039719, -0.08039872451576649, -0.0005667402343291361, -0.1694857588798654, 0.0009766586358261331, -0.0873517838382746, -0.0008552683303008771, -0.08627064033821233, 0.002609015553424872;
+    foldValues << -0.01626734826572977, -0.0002552779342950638, 0.05227538136126555, 0.0002350515292044683, -0.01695703999572442, -0.0002612258237118909, 0.05156927126324851, 0.0002631458821373055, -0.007517710152292339, -0.007474504607240594, 0.02674580053052369, -0.02680294718917284, 0.05337717466458169, 0.0001101957844225173, -0.01516291356738642, -0.0001053694865272746, 0.05291470170150131, 0.0001489003323108161, -0.01561921932892748, -0.0001370950096012615, -0.01784913805041409, -0.000324580522802835;
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave3
     // Dummy Slave to be able to reuse the 4 proc Master Slave Fixture
   }
@@ -883,30 +902,28 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref <<
-        1.275776729912441e-06,  -7.411719120649928e-07,  2.009844043916140e-06,  -8.166362562036991e-07,
-        1.98429549697312266297e-06,  -1.006128466370864e-06, 1.26860076890459333335e-06, -1.038973060940335e-06,
-        1.553926578960109e-06,  -1.85501566670221e-06, 2.21293251735091021427e-06, -1.645357854619679e-06,
-        1.820890655907848e-06,  -2.41565468511731e-06, 2.44472211085250353034e-06, -2.153167028992053e-06,
-        1.367377699262639e-06,  -1.402360838056698e-06, 2.05877363493188315457e-06, -1.275601072931189e-06,
+    dref << 1.275776729912441e-06, -7.411719120649928e-07, 2.009844043916140e-06, -8.166362562036991e-07,
+        1.98429549697312266297e-06, -1.006128466370864e-06, 1.26860076890459333335e-06, -1.038973060940335e-06,
+        1.553926578960109e-06, -1.85501566670221e-06, 2.21293251735091021427e-06, -1.645357854619679e-06,
+        1.820890655907848e-06, -2.41565468511731e-06, 2.44472211085250353034e-06, -2.153167028992053e-06,
+        1.367377699262639e-06, -1.402360838056698e-06, 2.05877363493188315457e-06, -1.275601072931189e-06,
         2.16056223288899190422e-06, -6.758668464219906e-07;
 
-    fref <<
-        -0.02494062387644205, 2.83457783442084623737e-05, 2.78926996928726099456e-02, 4.927873553950413e-05,
-        0.02806450388830189,  4.133693821366594e-05,  -0.02479702682061509,  7.828236584438153e-05,
-        -0.02470268458079963,  3.17420733502629e-05,  0.0282235973672153,  0.0001624809599050109,
-        -0.01213681562464092,  -0.01299265397817983,  0.01440494173854578,  -0.01303642911469127,
-        -0.02467306876921166,  4.955128897708022e-05,  0.02820821342518329,  9.359794339403125e-05,
-        0.02784148826297314,  7.700134509804057e-05;
+    fref << -0.02494062387644205, 2.83457783442084623737e-05, 2.78926996928726099456e-02, 4.927873553950413e-05,
+        0.02806450388830189, 4.133693821366594e-05, -0.02479702682061509, 7.828236584438153e-05,
+        -0.02470268458079963, 3.17420733502629e-05, 0.0282235973672153, 0.0001624809599050109,
+        -0.01213681562464092, -0.01299265397817983, 0.01440494173854578, -0.01303642911469127,
+        -0.02467306876921166, 4.955128897708022e-05, 0.02820821342518329, 9.359794339403125e-05,
+        0.02784148826297314, 7.700134509804057e-05;
 
     drefNorm = 7.910283453653413e-06;
     frefNorm = 0.08415800797163485;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i), 1e-8));
 
     // validate norm
@@ -918,16 +935,14 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     dref = Eigen::VectorXd::Zero(22);
     fref = Eigen::VectorXd::Zero(22);
 
-    dref <<
-        1.782695896956317e-06,  -3.609665456581163e-07,  2.549165865006206e-06, -2.9152246796606e-07,
-        1.641256623136569e-06,  -3.63485032734166e-07,  2.399541139942214e-06, -5.221960935703056e-07,
+    dref << 1.782695896956317e-06, -3.609665456581163e-07, 2.549165865006206e-06, -2.9152246796606e-07,
+        1.641256623136569e-06, -3.63485032734166e-07, 2.399541139942214e-06, -5.221960935703056e-07,
         0, 0, 0, 0,
-        1.540562829986484e-06,  2.646900958343007e-07,  6.572995607065404e-07, -5.789378440843989e-07,
-        2.312916074266845e-06,  2.909615579313369e-08, 1.55690286980020939237e-06, -4.907962897313283e-07,
+        1.540562829986484e-06, 2.646900958343007e-07, 6.572995607065404e-07, -5.789378440843989e-07,
+        2.312916074266845e-06, 2.909615579313369e-08, 1.55690286980020939237e-06, -4.907962897313283e-07,
         1.41306136610511245499e-06, -5.042593080795539e-07;
 
-    fref <<
-        -0.02407925914468757, -0.0001962517462601011, 2.86388026412357221684e-02, 0.0002189694547629064,
+    fref << -0.02407925914468757, -0.0001962517462601011, 2.86388026412357221684e-02, 0.0002189694547629064,
         -0.02469057752137756, -0.0001420431374215673, 0.02806138636325711, 0.0001618659175134536,
         -0.01072215615486178, -0.01066770812537758, 0.01563815124261267, -0.01570783185165062,
         0.03075510899502418, 0.0001765574924817709, -0.02194129299700746, -0.0001523229943385313,
@@ -938,10 +953,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp, * testing::OnSize(4) * boost::unit_t
     frefNorm = 0.08353026170200345;
 
     // validate values
-    for(int i = 0; i < data.at(4)->values->size(); i++)
+    for (int i = 0; i < data.at(4)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(4)->values)(i), dref(i)));
 
-    for(int i = 0; i < data.at(5)->values->size(); i++)
+    for (int i = 0; i < data.at(5)->values->size(); i++)
       BOOST_TEST(testing::equals((*data.at(5)->values)(i), fref(i)));
 
     // validate norm
@@ -956,4 +971,3 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 
 #endif // PRECICE_NO_MPI
-

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -2,11 +2,11 @@
 
 #include <Eigen/Core>
 
+#include "acceleration/impl/ParallelMatrixOperations.hpp"
 #include "com/Communication.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "cplscheme/Constants.hpp"
-#include "acceleration/impl/ParallelMatrixOperations.hpp"
 #include "testing/Fixtures.hpp"
 #include "testing/Testing.hpp"
 #include "utils/MasterSlave.hpp"
@@ -41,7 +41,7 @@ void validate_result_equals_reference(
   }
 }
 
-BOOST_AUTO_TEST_CASE(ParVectorOperations, * boost::unit_test::fixture<testing::MasterComFixture>())
+BOOST_AUTO_TEST_CASE(ParVectorOperations, *boost::unit_test::fixture<testing::MasterComFixture>())
 {
   int              n_global = 10;
   int              n_local;
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations, * boost::unit_test::fixture<testing::M
   BOOST_TEST(testing::equals(dotproduct, 7.069617899295469));
 }
 
-BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp,  * boost::unit_test::fixture<testing::MasterComFixture>())
+BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp, *boost::unit_test::fixture<testing::MasterComFixture>())
 {
   com::PtrCommunication _cyclicCommLeft  = com::PtrCommunication(new com::MPIPortsCommunication("."));
   com::PtrCommunication _cyclicCommRight = com::PtrCommunication(new com::MPIPortsCommunication("."));

--- a/src/acceleration/test/PreconditionerTest.cpp
+++ b/src/acceleration/test/PreconditionerTest.cpp
@@ -1,11 +1,11 @@
-#include "com/MPIDirectCommunication.hpp"
 #include "acceleration/impl/ConstantPreconditioner.hpp"
 #include "acceleration/impl/ResidualPreconditioner.hpp"
 #include "acceleration/impl/ResidualSumPreconditioner.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
 #include "acceleration/impl/ValuePreconditioner.hpp"
-#include "testing/Testing.hpp"
+#include "com/MPIDirectCommunication.hpp"
 #include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 
 BOOST_AUTO_TEST_SUITE(AccelerationTests)
 

--- a/src/action/Action.hpp
+++ b/src/action/Action.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
-#include "mesh/SharedPointer.hpp"
 #include "mapping/Mapping.hpp"
+#include "mesh/SharedPointer.hpp"
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 /**
  * @brief Abstract base class for configurable actions on data and/or meshes.
@@ -15,8 +13,7 @@ namespace action
  * precice::SolverInterface::initializeData(), and precice::SolverInterface::advance(). They can change meshes and in particular
  * data values.
  */
-class Action
-{
+class Action {
 public:
   /// Defines the time and place of application of the action.
   enum Timing {
@@ -28,8 +25,8 @@ public:
   };
 
   Action(
-      Timing               timing,
-      const mesh::PtrMesh &mesh,
+      Timing                            timing,
+      const mesh::PtrMesh &             mesh,
       mapping::Mapping::MeshRequirement requirement)
       : _timing(timing),
         _mesh(mesh),
@@ -39,14 +36,13 @@ public:
 
   Action(
       Timing               timing,
-      const mesh::PtrMesh &mesh
-      )
+      const mesh::PtrMesh &mesh)
       : _timing(timing),
         _mesh(mesh)
   {
   }
 
-  Action& operator=(Action &&) = delete;
+  Action &operator=(Action &&) = delete;
 
   /// Destructor, empty.
   virtual ~Action() {}

--- a/src/action/ComputeCurvatureAction.cpp
+++ b/src/action/ComputeCurvatureAction.cpp
@@ -6,10 +6,8 @@
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 ComputeCurvatureAction::ComputeCurvatureAction(
     Timing               timing,

--- a/src/action/ComputeCurvatureAction.hpp
+++ b/src/action/ComputeCurvatureAction.hpp
@@ -4,14 +4,11 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 /// Computes the curvature of a mesh geometry.
-class ComputeCurvatureAction : public Action
-{
+class ComputeCurvatureAction : public Action {
 public:
   /// Constructor. Curvature values are stored in scalar data with given ID.
   ComputeCurvatureAction(

--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -1,15 +1,13 @@
 #ifndef PRECICE_NO_PYTHON
+#include "PythonAction.hpp"
 #include <Python.h>
 #include <numpy/arrayobject.h>
-#include "PythonAction.hpp"
+#include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
-#include "mesh/Data.hpp"
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 PythonAction::PythonAction(
     Timing               timing,
@@ -81,7 +79,7 @@ void PythonAction::performAction(double time,
     if (PyErr_Occurred()) {
       PyErr_Print();
       PRECICE_ERROR("Error occurred during call of function "
-            << "performAction() python module \"" << _moduleName << "\"!");
+                    << "performAction() python module \"" << _moduleName << "\"!");
     }
   }
 
@@ -108,7 +106,7 @@ void PythonAction::performAction(double time,
       if (PyErr_Occurred()) {
         PyErr_Print();
         PRECICE_ERROR("Error occurred during call of function "
-              << "vertexCallback() python module \"" << _moduleName << "\"!");
+                      << "vertexCallback() python module \"" << _moduleName << "\"!");
       }
     }
     Py_DECREF(vertexArgs);
@@ -120,7 +118,7 @@ void PythonAction::performAction(double time,
     if (PyErr_Occurred()) {
       PyErr_Print();
       PRECICE_ERROR("Error occurred during call of function "
-            << "postAction() in python module \"" << _moduleName << "\"!");
+                    << "postAction() in python module \"" << _moduleName << "\"!");
     }
     Py_DECREF(postActionArgs);
   }

--- a/src/action/PythonAction.hpp
+++ b/src/action/PythonAction.hpp
@@ -1,22 +1,19 @@
 #pragma once
 #ifndef PRECICE_NO_PYTHON
 
-#include "action/Action.hpp"
-#include "mesh/SharedPointer.hpp"
-#include "logging/Logger.hpp"
 #include <string>
+#include "action/Action.hpp"
+#include "logging/Logger.hpp"
+#include "mesh/SharedPointer.hpp"
 
 struct _object;
 using PyObject = _object;
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 /// Action whose implementation is given in a Python file.
-class PythonAction : public Action
-{
+class PythonAction : public Action {
 public:
   PythonAction(
       Timing               timing,
@@ -61,7 +58,7 @@ private:
 
   PyObject *_vertexCallback = nullptr;
 
-  PyObject *_postAction = nullptr; 
+  PyObject *_postAction = nullptr;
 
   void initialize();
 

--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -3,10 +3,8 @@
 #include "mesh/Edge.hpp"
 #include "mesh/Mesh.hpp"
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 ScaleByAreaAction::ScaleByAreaAction(
     Timing               timing,

--- a/src/action/ScaleByAreaAction.hpp
+++ b/src/action/ScaleByAreaAction.hpp
@@ -4,22 +4,17 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 class Edge;
 class Triangle;
 } // namespace mesh
 } // namespace precice
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
-class ScaleByAreaAction : public Action
-{
+class ScaleByAreaAction : public Action {
 public:
   enum Scaling {
     /// Divides the data by the area of neighboring edges/triangles.

--- a/src/action/ScaleByDtAction.cpp
+++ b/src/action/ScaleByDtAction.cpp
@@ -3,10 +3,8 @@
 #include "mesh/Edge.hpp"
 #include "mesh/Mesh.hpp"
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 ScaleByDtAction::ScaleByDtAction(
     Timing               timing,
@@ -20,7 +18,7 @@ ScaleByDtAction::ScaleByDtAction(
       _scaling(scaling)
 {
   PRECICE_ASSERT(_sourceData->getDimensions() == _targetData->getDimensions(),
-            _sourceData->getDimensions(), _targetData->getDimensions());
+                 _sourceData->getDimensions(), _targetData->getDimensions());
 }
 
 void ScaleByDtAction::performAction(
@@ -33,7 +31,7 @@ void ScaleByDtAction::performAction(
   auto &sourceValues = _sourceData->values();
   auto &targetValues = _targetData->values();
   PRECICE_ASSERT(sourceValues.size() == targetValues.size(),
-            sourceValues.size(), targetValues.size());
+                 sourceValues.size(), targetValues.size());
   if (_scaling == SCALING_BY_COMPUTED_DT_RATIO) {
     double scaling = dt / fullDt;
     PRECICE_DEBUG("Scale by computed dt ratio " << scaling);

--- a/src/action/ScaleByDtAction.hpp
+++ b/src/action/ScaleByDtAction.hpp
@@ -4,13 +4,10 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
-class ScaleByDtAction : public Action
-{
+class ScaleByDtAction : public Action {
 public:
   enum Scaling {
     /// Scales data by ratio of last computed timestep to full timestep length.

--- a/src/action/SharedPointer.hpp
+++ b/src/action/SharedPointer.hpp
@@ -2,10 +2,8 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace action
-{
+namespace precice {
+namespace action {
 
 class Action;
 class ActionConfiguration;

--- a/src/action/config/ActionConfiguration.cpp
+++ b/src/action/config/ActionConfiguration.cpp
@@ -1,44 +1,42 @@
 #include "ActionConfiguration.hpp"
-#include "xml/XMLAttribute.hpp"
-#include "action/ScaleByAreaAction.hpp"
-#include "action/ScaleByDtAction.hpp"
 #include "action/ComputeCurvatureAction.hpp"
 #include "action/PythonAction.hpp"
-#include "mesh/config/MeshConfiguration.hpp"
-#include "mesh/Mesh.hpp"
+#include "action/ScaleByAreaAction.hpp"
+#include "action/ScaleByDtAction.hpp"
 #include "mesh/Data.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/config/MeshConfiguration.hpp"
+#include "xml/XMLAttribute.hpp"
 
 namespace precice {
 namespace action {
 
-ActionConfiguration:: ActionConfiguration
-(
-  xml::XMLTag&                    parent,
-  const mesh::PtrMeshConfiguration& meshConfig )
-:
-  NAME_DIVIDE_BY_AREA ( "divide-by-area" ),
-  NAME_MULTIPLY_BY_AREA ( "multiply-by-area" ),
-  NAME_SCALE_BY_COMPUTED_DT_RATIO ( "scale-by-computed-dt-ratio" ),
-  NAME_SCALE_BY_COMPUTED_DT_PART_RATIO ( "scale-by-computed-dt-part-ratio" ),
-  NAME_SCALE_BY_DT ( "scale-by-dt" ),
-  NAME_COMPUTE_CURVATURE ( "compute-curvature" ),
-  NAME_PYTHON ( "python" ),
-  TAG_SOURCE_DATA ( "source-data" ),
-  TAG_TARGET_DATA ( "target-data" ),
-  TAG_CONVERGENCE_TOLERANCE ( "convergence-tolerance" ),
-  TAG_MAX_ITERATIONS ( "max-iterations" ),
-  TAG_MODULE_PATH ( "path" ),
-  TAG_MODULE_NAME ( "module" ),
-  VALUE_REGULAR_PRIOR ( "regular-prior" ),
-  VALUE_REGULAR_POST ( "regular-post" ),
-  VALUE_ON_EXCHANGE_PRIOR ( "on-exchange-prior" ),
-  VALUE_ON_EXCHANGE_POST ( "on-exchange-post" ),
-  VALUE_ON_TIMESTEP_COMPLETE_POST("on-timestep-complete-post"),
-  _meshConfig ( meshConfig )
+ActionConfiguration::ActionConfiguration(
+    xml::XMLTag &                     parent,
+    const mesh::PtrMeshConfiguration &meshConfig)
+    : NAME_DIVIDE_BY_AREA("divide-by-area"),
+      NAME_MULTIPLY_BY_AREA("multiply-by-area"),
+      NAME_SCALE_BY_COMPUTED_DT_RATIO("scale-by-computed-dt-ratio"),
+      NAME_SCALE_BY_COMPUTED_DT_PART_RATIO("scale-by-computed-dt-part-ratio"),
+      NAME_SCALE_BY_DT("scale-by-dt"),
+      NAME_COMPUTE_CURVATURE("compute-curvature"),
+      NAME_PYTHON("python"),
+      TAG_SOURCE_DATA("source-data"),
+      TAG_TARGET_DATA("target-data"),
+      TAG_CONVERGENCE_TOLERANCE("convergence-tolerance"),
+      TAG_MAX_ITERATIONS("max-iterations"),
+      TAG_MODULE_PATH("path"),
+      TAG_MODULE_NAME("module"),
+      VALUE_REGULAR_PRIOR("regular-prior"),
+      VALUE_REGULAR_POST("regular-post"),
+      VALUE_ON_EXCHANGE_PRIOR("on-exchange-prior"),
+      VALUE_ON_EXCHANGE_POST("on-exchange-post"),
+      VALUE_ON_TIMESTEP_COMPLETE_POST("on-timestep-complete-post"),
+      _meshConfig(meshConfig)
 {
   using namespace xml;
   std::string doc;
-  XMLTag tagSourceData(*this, TAG_SOURCE_DATA, XMLTag::OCCUR_ONCE);
+  XMLTag      tagSourceData(*this, TAG_SOURCE_DATA, XMLTag::OCCUR_ONCE);
   tagSourceData.setDocumentation("Data to read from.");
   XMLTag tagTargetData(*this, TAG_TARGET_DATA, XMLTag::OCCUR_ONCE);
   tagSourceData.setDocumentation("Data to read from and write to.");
@@ -47,7 +45,7 @@ ActionConfiguration:: ActionConfiguration
   tagSourceData.addAttribute(attrName);
   tagTargetData.addAttribute(attrName);
 
-  std::list<XMLTag> tags;
+  std::list<XMLTag>  tags;
   XMLTag::Occurrence occ = XMLTag::OCCUR_ARBITRARY;
   {
     XMLTag tag(*this, NAME_MULTIPLY_BY_AREA, occ, TAG);
@@ -129,72 +127,62 @@ ActionConfiguration:: ActionConfiguration
     tags.push_back(tag);
   }
 
- auto attrTiming  = XMLAttribute<std::string>( ATTR_TIMING )
-      .setDocumentation(
-              "Determines when (relative to advancing the coupling scheme) the action is executed.")
-      .setOptions({
-              VALUE_REGULAR_PRIOR, VALUE_REGULAR_POST,
-              VALUE_ON_EXCHANGE_PRIOR, VALUE_ON_EXCHANGE_POST,
-              VALUE_ON_TIMESTEP_COMPLETE_POST});
+  auto attrTiming = XMLAttribute<std::string>(ATTR_TIMING)
+                        .setDocumentation(
+                            "Determines when (relative to advancing the coupling scheme) the action is executed.")
+                        .setOptions({VALUE_REGULAR_PRIOR, VALUE_REGULAR_POST,
+                                     VALUE_ON_EXCHANGE_PRIOR, VALUE_ON_EXCHANGE_POST,
+                                     VALUE_ON_TIMESTEP_COMPLETE_POST});
 
- auto attrMesh = XMLAttribute<std::string>(ATTR_MESH)
-      .setDocumentation("Determines mesh used in action.");
-  for (XMLTag& tag : tags) {
+  auto attrMesh = XMLAttribute<std::string>(ATTR_MESH)
+                      .setDocumentation("Determines mesh used in action.");
+  for (XMLTag &tag : tags) {
     tag.addAttribute(attrTiming);
     tag.addAttribute(attrMesh);
     parent.addSubtag(tag);
   }
 }
 
-void ActionConfiguration:: xmlTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& callingTag )
+void ActionConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    callingTag)
 {
   PRECICE_TRACE(callingTag.getName());
-  if (callingTag.getNamespace() == TAG){
-    _configuredAction = ConfiguredAction();
-    _configuredAction.type = callingTag.getName();
+  if (callingTag.getNamespace() == TAG) {
+    _configuredAction        = ConfiguredAction();
+    _configuredAction.type   = callingTag.getName();
     _configuredAction.timing = callingTag.getStringAttributeValue(ATTR_TIMING);
-    _configuredAction.mesh = callingTag.getStringAttributeValue(ATTR_MESH);
+    _configuredAction.mesh   = callingTag.getStringAttributeValue(ATTR_MESH);
     //addSubtags ( callingTag, _configured.type );
-  }
-  else if (callingTag.getName() == TAG_SOURCE_DATA){
+  } else if (callingTag.getName() == TAG_SOURCE_DATA) {
     _configuredAction.sourceData = callingTag.getStringAttributeValue(ATTR_NAME);
-  }
-  else if (callingTag.getName() == TAG_TARGET_DATA){
+  } else if (callingTag.getName() == TAG_TARGET_DATA) {
     _configuredAction.targetData = callingTag.getStringAttributeValue(ATTR_NAME);
-  }
-  else if (callingTag.getName() == TAG_CONVERGENCE_TOLERANCE){
+  } else if (callingTag.getName() == TAG_CONVERGENCE_TOLERANCE) {
     _configuredAction.convergenceTolerance =
         callingTag.getDoubleAttributeValue(ATTR_VALUE);
-  }
-  else if (callingTag.getName() == TAG_MAX_ITERATIONS){
+  } else if (callingTag.getName() == TAG_MAX_ITERATIONS) {
     _configuredAction.maxIterations = callingTag.getIntAttributeValue(ATTR_VALUE);
-  }
-  else if (callingTag.getName() == TAG_MODULE_PATH){
+  } else if (callingTag.getName() == TAG_MODULE_PATH) {
     _configuredAction.path = callingTag.getStringAttributeValue(ATTR_NAME);
-  }
-  else if (callingTag.getName() == TAG_MODULE_NAME){
+  } else if (callingTag.getName() == TAG_MODULE_NAME) {
     _configuredAction.module = callingTag.getStringAttributeValue(ATTR_NAME);
   }
 }
 
-void ActionConfiguration:: xmlEndTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& callingTag )
+void ActionConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    callingTag)
 {
-  if (callingTag.getNamespace() == TAG){
+  if (callingTag.getNamespace() == TAG) {
     createAction();
   }
 }
 
-
-int ActionConfiguration:: getUsedMeshID() const
+int ActionConfiguration::getUsedMeshID() const
 {
   for (mesh::PtrMesh mesh : _meshConfig->meshes()) {
-    if (mesh->getName() == _configuredAction.mesh){
+    if (mesh->getName() == _configuredAction.mesh) {
       return mesh->getID();
     }
   }
@@ -202,8 +190,7 @@ int ActionConfiguration:: getUsedMeshID() const
   return -1; // To please compiler
 }
 
-
-void ActionConfiguration:: createAction()
+void ActionConfiguration::createAction()
 {
   PRECICE_TRACE();
 
@@ -211,105 +198,96 @@ void ActionConfiguration:: createAction()
   action::Action::Timing timing = getTiming();
 
   // Determine data and mesh
-  int sourceDataID = -1;
-  int targetDataID = -1;
+  int           sourceDataID = -1;
+  int           targetDataID = -1;
   mesh::PtrMesh mesh;
   for (mesh::PtrMesh aMesh : _meshConfig->meshes()) {
-    if (aMesh->getName() == _configuredAction.mesh){
+    if (aMesh->getName() == _configuredAction.mesh) {
       mesh = aMesh;
       for (const mesh::PtrData &data : mesh->data()) {
-        if (data->getName() == _configuredAction.sourceData){
-          sourceDataID = data->getID ();
+        if (data->getName() == _configuredAction.sourceData) {
+          sourceDataID = data->getID();
         }
-        if (data->getName() == _configuredAction.targetData){
+        if (data->getName() == _configuredAction.targetData) {
           targetDataID = data->getID();
         }
       }
     }
   }
-  if (mesh.get() == nullptr){
+  if (mesh.get() == nullptr) {
     std::ostringstream stream;
     stream << "Data action uses mesh \"" << _configuredAction.mesh
            << "\" which is not configured";
     throw std::runtime_error{stream.str()};
   }
-  if ((not _configuredAction.sourceData.empty()) && (sourceDataID == -1)){
+  if ((not _configuredAction.sourceData.empty()) && (sourceDataID == -1)) {
     std::ostringstream stream;
     stream << "Data action uses source data \"" << _configuredAction.sourceData
            << "\" which is not configured";
     throw std::runtime_error{stream.str()};
   }
-  if ((not _configuredAction.targetData.empty()) && (targetDataID == -1)){
+  if ((not _configuredAction.targetData.empty()) && (targetDataID == -1)) {
     std::ostringstream stream;
     stream << "Data action uses target data \"" << _configuredAction.targetData
            << "\" which is not configured";
     throw std::runtime_error{stream.str()};
   }
   action::PtrAction action;
-  if (_configuredAction.type == NAME_MULTIPLY_BY_AREA){
+  if (_configuredAction.type == NAME_MULTIPLY_BY_AREA) {
     action = action::PtrAction(
         new action::ScaleByAreaAction(timing, targetDataID,
-        mesh, action::ScaleByAreaAction::SCALING_MULTIPLY_BY_AREA));
-  }
-  else if (_configuredAction.type == NAME_DIVIDE_BY_AREA){
+                                      mesh, action::ScaleByAreaAction::SCALING_MULTIPLY_BY_AREA));
+  } else if (_configuredAction.type == NAME_DIVIDE_BY_AREA) {
     action = action::PtrAction(
         new action::ScaleByAreaAction(timing, targetDataID,
-        mesh, action::ScaleByAreaAction::SCALING_DIVIDE_BY_AREA));
-  }
-  else if (_configuredAction.type == NAME_SCALE_BY_COMPUTED_DT_RATIO){
+                                      mesh, action::ScaleByAreaAction::SCALING_DIVIDE_BY_AREA));
+  } else if (_configuredAction.type == NAME_SCALE_BY_COMPUTED_DT_RATIO) {
     action = action::PtrAction(
         new action::ScaleByDtAction(timing, sourceDataID, targetDataID,
-        mesh, action::ScaleByDtAction::SCALING_BY_COMPUTED_DT_RATIO));
-  }
-  else if ( _configuredAction.type == NAME_SCALE_BY_COMPUTED_DT_PART_RATIO ){
+                                    mesh, action::ScaleByDtAction::SCALING_BY_COMPUTED_DT_RATIO));
+  } else if (_configuredAction.type == NAME_SCALE_BY_COMPUTED_DT_PART_RATIO) {
     action = action::PtrAction(
         new action::ScaleByDtAction(timing, sourceDataID, targetDataID,
-        mesh, action::ScaleByDtAction::SCALING_BY_COMPUTED_DT_PART_RATIO));
-  }
-  else if ( _configuredAction.type == NAME_SCALE_BY_DT ){
+                                    mesh, action::ScaleByDtAction::SCALING_BY_COMPUTED_DT_PART_RATIO));
+  } else if (_configuredAction.type == NAME_SCALE_BY_DT) {
     action = action::PtrAction(
         new action::ScaleByDtAction(timing, sourceDataID, targetDataID,
-        mesh, action::ScaleByDtAction::SCALING_BY_DT));
-  }
-  else if (_configuredAction.type == NAME_COMPUTE_CURVATURE){
+                                    mesh, action::ScaleByDtAction::SCALING_BY_DT));
+  } else if (_configuredAction.type == NAME_COMPUTE_CURVATURE) {
     action = action::PtrAction(
         new action::ComputeCurvatureAction(timing, targetDataID,
-        mesh));
+                                           mesh));
   }
-  #ifndef PRECICE_NO_PYTHON
-  else if ( _configuredAction.type == NAME_PYTHON ){
-    action = action::PtrAction (
+#ifndef PRECICE_NO_PYTHON
+  else if (_configuredAction.type == NAME_PYTHON) {
+    action = action::PtrAction(
         new action::PythonAction(timing, _configuredAction.path, _configuredAction.module,
-        mesh, targetDataID, sourceDataID) );
+                                 mesh, targetDataID, sourceDataID));
   }
-  #endif
+#endif
   PRECICE_ASSERT(action.get() != nullptr);
   _actions.push_back(action);
 }
 
-action::Action::Timing ActionConfiguration:: getTiming () const
+action::Action::Timing ActionConfiguration::getTiming() const
 {
-  PRECICE_TRACE(_configuredAction.timing );
+  PRECICE_TRACE(_configuredAction.timing);
   action::Action::Timing timing;
-  if ( _configuredAction.timing == VALUE_REGULAR_PRIOR ){
+  if (_configuredAction.timing == VALUE_REGULAR_PRIOR) {
     timing = action::Action::ALWAYS_PRIOR;
-  }
-  else if ( _configuredAction.timing == VALUE_REGULAR_POST ){
+  } else if (_configuredAction.timing == VALUE_REGULAR_POST) {
     timing = action::Action::ALWAYS_POST;
-  }
-  else if ( _configuredAction.timing == VALUE_ON_EXCHANGE_PRIOR ){
+  } else if (_configuredAction.timing == VALUE_ON_EXCHANGE_PRIOR) {
     timing = action::Action::ON_EXCHANGE_PRIOR;
-  }
-  else if ( _configuredAction.timing == VALUE_ON_EXCHANGE_POST ){
+  } else if (_configuredAction.timing == VALUE_ON_EXCHANGE_POST) {
     timing = action::Action::ON_EXCHANGE_POST;
-  }
-  else if (_configuredAction.timing == VALUE_ON_TIMESTEP_COMPLETE_POST){
+  } else if (_configuredAction.timing == VALUE_ON_TIMESTEP_COMPLETE_POST) {
     timing = action::Action::ON_TIMESTEP_COMPLETE_POST;
-  }
-  else {
-    PRECICE_ERROR("Unknown action timing \"" <<  _configuredAction.timing << "\"!" );
+  } else {
+    PRECICE_ERROR("Unknown action timing \"" << _configuredAction.timing << "\"!");
   }
   return timing;
 }
 
-}} // namespace precice, config
+} // namespace action
+} // namespace precice

--- a/src/action/config/ActionConfiguration.hpp
+++ b/src/action/config/ActionConfiguration.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <list>
+#include <string>
 #include "action/Action.hpp"
 #include "action/SharedPointer.hpp"
-#include "xml/XMLTag.hpp"
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
-#include <string>
-#include <list>
+#include "xml/XMLTag.hpp"
 
 namespace precice {
 namespace action {
@@ -14,27 +14,25 @@ namespace action {
 /**
  * @brief Configures an Action subclass object.
  */
-class ActionConfiguration : public xml::XMLTag::Listener
-{
+class ActionConfiguration : public xml::XMLTag::Listener {
 public:
-
-  ActionConfiguration (
-    xml::XMLTag&                    parent,
-    const mesh::PtrMeshConfiguration& meshConfig );
-
-  /**
-   * @brief Callback function required for use of automatic configuration.
-   *
-   * @return True, if successful.
-   */
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag);
+  ActionConfiguration(
+      xml::XMLTag &                     parent,
+      const mesh::PtrMeshConfiguration &meshConfig);
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+
+  /**
+   * @brief Callback function required for use of automatic configuration.
+   *
+   * @return True, if successful.
+   */
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /**
    * @brief Returns the id of the mesh used in the data action.
@@ -44,7 +42,7 @@ public:
   /**
    * @brief Returns the configured action.
    */
-  const std::list<PtrAction>& actions() const
+  const std::list<PtrAction> &actions() const
   {
     return _actions;
   }
@@ -55,19 +53,17 @@ public:
   }
 
 private:
-
   /**
    * @brief Stores configuration information temporarily to create the Action.
    */
-  struct ConfiguredAction
-  {
+  struct ConfiguredAction {
     std::string type;
     std::string timing;
     std::string sourceData;
     std::string targetData;
     std::string mesh;
-    double convergenceTolerance = 0;
-    int maxIterations = 0;
+    double      convergenceTolerance = 0;
+    int         maxIterations        = 0;
     std::string path;
     std::string module;
   };
@@ -91,11 +87,11 @@ private:
   const std::string TAG_MODULE_PATH;
   const std::string TAG_MODULE_NAME;
 
-  const std::string ATTR_TYPE = "type";
+  const std::string ATTR_TYPE   = "type";
   const std::string ATTR_TIMING = "timing";
-  const std::string ATTR_NAME = "name";
-  const std::string ATTR_VALUE = "value";
-  const std::string ATTR_MESH = "mesh";
+  const std::string ATTR_NAME   = "name";
+  const std::string ATTR_VALUE  = "value";
+  const std::string ATTR_MESH   = "mesh";
 
   const std::string VALUE_REGULAR_PRIOR;
   const std::string VALUE_REGULAR_POST;
@@ -109,12 +105,12 @@ private:
 
   std::list<PtrAction> _actions;
 
-//  /**
-//   * @brief Adds all required subtags to the main action tag.
-//   */
-//  void addSubtags (
-//    std::list<xml::XMLTag>& tags,
-//    const std::string&        type );
+  //  /**
+  //   * @brief Adds all required subtags to the main action tag.
+  //   */
+  //  void addSubtags (
+  //    std::list<xml::XMLTag>& tags,
+  //    const std::string&        type );
 
   /**
    * @brief Creates the Action object.
@@ -124,4 +120,5 @@ private:
   Action::Timing getTiming() const;
 };
 
-}} // namespace precice, action
+} // namespace action
+} // namespace precice

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
 {
   {
     std::string                filename = testing::getPathToSources() + "/action/tests/ScaleActionTest-testConfiguration-1.xml";
-    xml::XMLTag              tag      = xml::getRootTag();
+    xml::XMLTag                tag      = xml::getRootTag();
     mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(tag));
     dataConfig->setDimensions(3);
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
   }
   {
     std::string                filename = testing::getPathToSources() + "/action/tests/ScaleActionTest-testConfiguration-2.xml";
-    xml::XMLTag              tag      = xml::getRootTag();
+    xml::XMLTag                tag      = xml::getRootTag();
     mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(tag));
     dataConfig->setDimensions(3);
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
   }
   {
     std::string                filename = testing::getPathToSources() + "/action/tests/ScaleActionTest-testConfiguration-3.xml";
-    xml::XMLTag              tag      = xml::getRootTag();
+    xml::XMLTag                tag      = xml::getRootTag();
     mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(tag));
     dataConfig->setDimensions(3);
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
   }
   {
     std::string                filename = testing::getPathToSources() + "/action/tests/ScaleActionTest-testConfiguration-4.xml";
-    xml::XMLTag              tag      = xml::getRootTag();
+    xml::XMLTag                tag      = xml::getRootTag();
     mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(tag));
     dataConfig->setDimensions(3);
     mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));

--- a/src/com/CommunicateBoundingBox.cpp
+++ b/src/com/CommunicateBoundingBox.cpp
@@ -1,10 +1,8 @@
 #include "CommunicateBoundingBox.hpp"
 #include "Communication.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 CommunicateBoundingBox::CommunicateBoundingBox(
     com::PtrCommunication communication)
     : _communication(communication)
@@ -39,7 +37,7 @@ void CommunicateBoundingBox::sendBoundingBoxMap(
     mesh::Mesh::BoundingBoxMap &bbm,
     int                         rankReceiver)
 {
-  
+
   PRECICE_TRACE(rankReceiver);
   _communication->send((int) bbm.size(), rankReceiver);
 
@@ -55,9 +53,9 @@ void CommunicateBoundingBox::receiveBoundingBoxMap(
   PRECICE_TRACE(rankSender);
   int sizeOfReceivingMap;
   _communication->receive(sizeOfReceivingMap, rankSender);
-  
+
   PRECICE_ASSERT(sizeOfReceivingMap == (int) bbm.size());
-  
+
   for (auto &bb : bbm) {
     receiveBoundingBox(bb.second, rankSender);
   }
@@ -65,7 +63,7 @@ void CommunicateBoundingBox::receiveBoundingBoxMap(
 
 void CommunicateBoundingBox::sendConnectionMap(
     std::map<int, std::vector<int>> const &fbm,
-    int                              rankReceiver)
+    int                                    rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
   _communication->send((int) fbm.size(), rankReceiver);
@@ -87,9 +85,9 @@ void CommunicateBoundingBox::receiveConnectionMap(
   PRECICE_ASSERT(sizeOfReceivingMap == (int) fbm.size());
 
   std::vector<int> connected_ranks;
-  
+
   for (size_t i = 0; i < fbm.size(); ++i) {
-    int              rank;  
+    int rank;
     _communication->receive(rank, rankSender);
     _communication->receive(connected_ranks, rankSender);
     fbm[rank] = connected_ranks;

--- a/src/com/CommunicateBoundingBox.hpp
+++ b/src/com/CommunicateBoundingBox.hpp
@@ -3,14 +3,11 @@
 #include "logging/Logger.hpp"
 #include "mesh/Mesh.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 
 /// Copies either a bounding box around a mesh partition or complete maps of bounding boxes from a sender to a receiver.
-class CommunicateBoundingBox
-{
+class CommunicateBoundingBox {
 public:
   /// Constructor, takes communication to be used in transfer.
   explicit CommunicateBoundingBox(
@@ -34,7 +31,7 @@ public:
 
   void sendConnectionMap(
       std::map<int, std::vector<int>> const &fbm,
-      int                              rankReceiver);
+      int                                    rankReceiver);
 
   void receiveConnectionMap(
       std::map<int, std::vector<int>> &fbm,

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -1,4 +1,6 @@
 #include "CommunicateMesh.hpp"
+#include <boost/container/flat_map.hpp>
+#include <future>
 #include <map>
 #include <vector>
 #include "Communication.hpp"
@@ -7,13 +9,9 @@
 #include "mesh/Mesh.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
-#include <boost/container/flat_map.hpp>
-#include <future>
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 CommunicateMesh::CommunicateMesh(
     com::PtrCommunication communication)
     : _communication(communication)
@@ -31,7 +29,7 @@ void CommunicateMesh::sendMesh(
   _communication->send(numberOfVertices, rankReceiver);
   if (not mesh.vertices().empty()) {
     std::vector<double> coords(static_cast<size_t>(numberOfVertices) * dim);
-    std::vector<int> globalIDs(numberOfVertices);
+    std::vector<int>    globalIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
       for (int d = 0; d < dim; d++) {
         coords[i * dim + d] = mesh.vertices()[i].getCoords()[d];
@@ -99,7 +97,7 @@ void CommunicateMesh::receiveMesh(
   vertices.reserve(numberOfVertices);
   if (numberOfVertices > 0) {
     std::vector<double> vertexCoords;
-    std::vector<int> globalIDs;
+    std::vector<int>    globalIDs;
     _communication->receive(vertexCoords, rankSender);
     _communication->receive(globalIDs, rankSender);
     for (int i = 0; i < numberOfVertices; i++) {
@@ -179,7 +177,7 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
   _communication->broadcast(numberOfVertices);
   if (numberOfVertices > 0) {
     std::vector<double> coords(static_cast<size_t>(numberOfVertices) * dim);
-    std::vector<int> globalIDs(numberOfVertices);
+    std::vector<int>    globalIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
       for (int d = 0; d < dim; d++) {
         coords[i * dim + d] = mesh.vertices()[i].getCoords()[d];
@@ -246,7 +244,7 @@ void CommunicateMesh::broadcastReceiveMesh(
 
   if (numberOfVertices > 0) {
     std::vector<double> vertexCoords;
-    std::vector<int> globalIDs;
+    std::vector<int>    globalIDs;
     _communication->broadcast(vertexCoords, rankBroadcaster);
     _communication->broadcast(globalIDs, rankBroadcaster);
     for (int i = 0; i < numberOfVertices; i++) {

--- a/src/com/CommunicateMesh.hpp
+++ b/src/com/CommunicateMesh.hpp
@@ -4,14 +4,11 @@
 #include "logging/Logger.hpp"
 #include "mesh/Mesh.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 
 /// Copies a Mesh object from a sender to a receiver.
-class CommunicateMesh
-{
+class CommunicateMesh {
 public:
   /// Constructor, takes communication to be used in transfer.
   explicit CommunicateMesh(
@@ -43,7 +40,7 @@ public:
 
 private:
   logging::Logger _log{"com::CommunicateMesh"};
-  
+
   /// Communication means used for the transfer of the geometry.
   com::PtrCommunication _communication;
 };

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -1,10 +1,8 @@
 #include "Communication.hpp"
 #include "Request.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 /**
  * @attention This method modifies the input buffer.
  */
@@ -13,7 +11,7 @@ void Communication::reduceSum(double *itemsToSend, double *itemsToReceive, int s
   PRECICE_TRACE(size);
 
   std::copy(itemsToSend, itemsToSend + size, itemsToReceive);
-  
+
   // receive local results from slaves
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request = aReceive(itemsToSend, size, rank + _rankOffset);
@@ -62,7 +60,7 @@ void Communication::allreduceSum(double *itemsToSend, double *itemsToReceive, in
   PRECICE_TRACE(size);
 
   std::copy(itemsToSend, itemsToSend + size, itemsToReceive);
-  
+
   // receive local results from slaves
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request = aReceive(itemsToSend, size, rank + _rankOffset);
@@ -75,7 +73,7 @@ void Communication::allreduceSum(double *itemsToSend, double *itemsToReceive, in
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aSend(itemsToReceive, size, rank + _rankOffset);
+    auto request   = aSend(itemsToReceive, size, rank + _rankOffset);
     requests[rank] = request;
   }
   Request::wait(requests);
@@ -110,7 +108,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aSend(&itemToReceive, 1, rank + _rankOffset);
+    auto request   = aSend(&itemToReceive, 1, rank + _rankOffset);
     requests[rank] = request;
   }
   Request::wait(requests);
@@ -142,7 +140,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aSend(&itemToReceive, 1, rank + _rankOffset);
+    auto request   = aSend(&itemToReceive, 1, rank + _rankOffset);
     requests[rank] = request;
   }
   Request::wait(requests);
@@ -165,7 +163,7 @@ void Communication::broadcast(const int *itemsToSend, int size)
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aSend(itemsToSend, size, rank + _rankOffset);
+    auto request   = aSend(itemsToSend, size, rank + _rankOffset);
     requests[rank] = request;
   }
 
@@ -186,7 +184,7 @@ void Communication::broadcast(int itemToSend)
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aSend(itemToSend, rank + _rankOffset);
+    auto request   = aSend(itemToSend, rank + _rankOffset);
     requests[rank] = request;
   }
 
@@ -206,7 +204,7 @@ void Communication::broadcast(const double *itemsToSend, int size)
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aSend(itemsToSend, size, rank + _rankOffset);
+    auto request   = aSend(itemsToSend, size, rank + _rankOffset);
     requests[rank] = request;
   }
 
@@ -228,7 +226,7 @@ void Communication::broadcast(double itemToSend)
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aSend(itemToSend, rank + _rankOffset);
+    auto request   = aSend(itemToSend, rank + _rankOffset);
     requests[rank] = request;
   }
 
@@ -259,7 +257,7 @@ void Communication::broadcast(bool &itemToReceive, int rankBroadcaster)
 void Communication::broadcast(std::vector<int> const &v)
 {
   broadcast(static_cast<int>(v.size()));
-  broadcast(const_cast<int*>(v.data()), v.size()); // make it send vector
+  broadcast(const_cast<int *>(v.data()), v.size()); // make it send vector
 }
 
 void Communication::broadcast(std::vector<int> &v, int rankBroadcaster)

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -3,10 +3,8 @@
 #include "Request.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 /**
  * @brief Interface for all interprocess communication classes.
  *
@@ -41,12 +39,10 @@ namespace com
  * sized appropriatly. Asynchronous receive methods also expect the vector
  * be sized correctly.
  */
-class Communication
-{
+class Communication {
 
 public:
-
-  Communication& operator=(Communication &&) = delete;
+  Communication &operator=(Communication &&) = delete;
 
   /// Destructor, empty.
   virtual ~Communication()
@@ -101,11 +97,11 @@ public:
    * @param[in] acceptorRank Rank of accepting server, usually the rank of the current process.
    * @param[in] requesterCommunicatorSize Size of the requester (N)
    */
-   virtual void acceptConnectionAsServer(std::string const &acceptorName,
-                                         std::string const &requesterName,
-                                         int                acceptorRank,
-                                         int                requesterCommunicatorSize) = 0;
-  
+  virtual void acceptConnectionAsServer(std::string const &acceptorName,
+                                        std::string const &requesterName,
+                                        int                acceptorRank,
+                                        int                requesterCommunicatorSize) = 0;
+
   /**
    * @brief Connects to another communicator, which has to call acceptConnection().
    *
@@ -138,11 +134,11 @@ public:
    * @param[in] acceptorRanks Set of ranks that accept a connection
    * @param[in] requesterRank Rank that requests the connection, usually the caller's rank
    */
-   virtual void requestConnectionAsClient(std::string   const &acceptorName,
-                                          std::string   const &requesterName,
-                                          std::set<int> const &acceptorRanks,
-                                          int                  requesterRank) = 0;
-  
+  virtual void requestConnectionAsClient(std::string const &  acceptorName,
+                                         std::string const &  requesterName,
+                                         std::set<int> const &acceptorRanks,
+                                         int                  requesterRank) = 0;
+
   /**
    * @brief Disconnects from communication space, i.e. participant.
    *
@@ -161,7 +157,7 @@ public:
   virtual void cleanupEstablishment() {}
 
   /// @}
-  
+
   /// @name Reduction
   /// @{
 
@@ -183,7 +179,7 @@ public:
   virtual void allreduceSum(int itemToSend, int &itemToReceive);
 
   /// @}
-  
+
   /// @name Broadcast
   /// @{
 
@@ -203,16 +199,16 @@ public:
   virtual void broadcast(bool &itemToReceive, int rankBroadcaster);
 
   virtual void broadcast(std::vector<int> const &v);
-  virtual void broadcast(std::vector<int>& v, int rankBroadcaster);
+  virtual void broadcast(std::vector<int> &v, int rankBroadcaster);
 
   virtual void broadcast(std::vector<double> const &v);
-  virtual void broadcast(std::vector<double>& v, int rankBroadcaster);
+  virtual void broadcast(std::vector<double> &v, int rankBroadcaster);
 
   /// @}
-  
+
   /// @name Send
   /// @{
-  
+
   /// Sends a std::string to process with given rank.
   virtual void send(std::string const &itemToSend, int rankReceiver) = 0;
 
@@ -231,31 +227,31 @@ public:
   virtual PtrRequest aSend(const double *itemsToSend, int size, int rankReceiver) = 0;
 
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(std::vector<double> const & itemsToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, int rankReceiver) = 0;
 
   /// Sends a double to process with given rank.
   virtual void send(double itemToSend, int rankReceiver) = 0;
 
   /// Asynchronously sends a double to process with given rank.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const double & itemToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const double &itemToSend, int rankReceiver) = 0;
 
   /// Sends an int to process with given rank.
   virtual void send(int itemToSend, int rankReceiver) = 0;
 
   /// Asynchronously sends an int to process with given rank.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const int & itemToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const int &itemToSend, int rankReceiver) = 0;
 
   /// Sends a bool to process with given rank.
   virtual void send(bool itemToSend, int rankReceiver) = 0;
 
   /// Asynchronously sends a bool to process with given rank.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend( const bool & itemToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const bool &itemToSend, int rankReceiver) = 0;
 
   /// @}
-  
+
   /// @name Receive
   /// @{
 
@@ -277,7 +273,7 @@ public:
   /*
    * @attention All asynchronous receives methods require the vector to be appropriately sized
    */
-  virtual PtrRequest aReceive(std::vector<double> & itemsToReceive, int rankSender) = 0;
+  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, int rankSender) = 0;
 
   /// Receives a double from process with given rank.
   virtual void receive(double &itemToReceive, int rankSender) = 0;
@@ -297,7 +293,6 @@ public:
   /// Asynchronously receives a bool from process with given rank.
   virtual PtrRequest aReceive(bool &itemToReceive, int rankSender) = 0;
 
-  
   virtual void send(std::vector<int> const &v, int rankReceiver) = 0;
   /// Receives an std::vector of ints. The vector will be resized accordingly.
   virtual void receive(std::vector<int> &v, int rankSender) = 0;
@@ -322,7 +317,6 @@ protected:
 
 private:
   logging::Logger _log{"com::Communication"};
-  
 };
 } // namespace com
 } // namespace precice

--- a/src/com/CommunicationFactory.hpp
+++ b/src/com/CommunicationFactory.hpp
@@ -4,12 +4,9 @@
 #include <string>
 #include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace com
-{
-class CommunicationFactory
-{
+namespace precice {
+namespace com {
+class CommunicationFactory {
 
 public:
   virtual ~CommunicationFactory(){};

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -1,55 +1,47 @@
 #include "ConnectionInfoPublisher.hpp"
-#include <chrono>
-#include <thread>
+#include <boost/filesystem.hpp>
 #include <boost/uuid/name_generator.hpp>
 #include <boost/uuid/string_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/filesystem.hpp>
+#include <chrono>
+#include <thread>
 
-
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 
 std::string ConnectionInfoPublisher::getFilename() const
 {
   using namespace boost::filesystem;
-  
-  constexpr int firstLevelLen = 2;
+
+  constexpr int                  firstLevelLen = 2;
   boost::uuids::string_generator ns_gen;
-  auto ns = ns_gen("af7ce8f2-a9ee-46cb-38ee-71c318aa3580"); // md5 hash of precice.org as namespace
-  
+  auto                           ns = ns_gen("af7ce8f2-a9ee-46cb-38ee-71c318aa3580"); // md5 hash of precice.org as namespace
+
   boost::uuids::name_generator gen{ns};
-  std::string const s = acceptorName + requesterName + std::to_string(rank);
-  std::string hash = boost::uuids::to_string(gen(s));
+  std::string const            s    = acceptorName + requesterName + std::to_string(rank);
+  std::string                  hash = boost::uuids::to_string(gen(s));
   hash.erase(std::remove(hash.begin(), hash.end(), '-'), hash.end());
-  
-  path p = path(addressDirectory)
-    / path("precice-run")
-    / path(hash.substr(0, firstLevelLen))
-    / hash.substr(firstLevelLen);
-  
+
+  path p = path(addressDirectory) / path("precice-run") / path(hash.substr(0, firstLevelLen)) / hash.substr(firstLevelLen);
+
   return p.string();
 }
-
 
 std::string ConnectionInfoReader::read() const
 {
   std::ifstream ifs;
-  auto path = getFilename();
+  auto          path = getFilename();
   PRECICE_DEBUG("Waiting for connection file " << path);
   do {
     ifs.open(path, std::ifstream::in);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   } while (not ifs);
   PRECICE_DEBUG("Found connection file " << path);
-  
+
   std::string addressData;
   ifs >> addressData;
   return addressData;
 }
-
 
 ConnectionInfoWriter::~ConnectionInfoWriter()
 {
@@ -59,11 +51,11 @@ ConnectionInfoWriter::~ConnectionInfoWriter()
   fs::remove(p);
 }
 
-void ConnectionInfoWriter::write(std::string const & info) const
+void ConnectionInfoWriter::write(std::string const &info) const
 {
   namespace fs = boost::filesystem;
-  auto path = getFilename();
-  auto tmp = fs::path(path + "~");
+  auto path    = getFilename();
+  auto tmp     = fs::path(path + "~");
   PRECICE_DEBUG("Writing connection file " << path);
   fs::create_directories(tmp.parent_path());
   {
@@ -74,5 +66,5 @@ void ConnectionInfoWriter::write(std::string const & info) const
   fs::rename(tmp, path);
 }
 
-}
-}
+} // namespace com
+} // namespace precice

--- a/src/com/ConnectionInfoPublisher.hpp
+++ b/src/com/ConnectionInfoPublisher.hpp
@@ -5,38 +5,32 @@
 namespace precice {
 namespace com {
 
-
-class ConnectionInfoPublisher
-{
+class ConnectionInfoPublisher {
 public:
-  
   ConnectionInfoPublisher(std::string acceptorName,
                           std::string requesterName,
-                          int rank,
+                          int         rank,
                           std::string addressDirectory) noexcept
-    :
-    acceptorName(std::move(acceptorName)),
-    requesterName(std::move(requesterName)),
-    rank(rank),
-    addressDirectory(std::move(addressDirectory))
-  {}
-
+      : acceptorName(std::move(acceptorName)),
+        requesterName(std::move(requesterName)),
+        rank(rank),
+        addressDirectory(std::move(addressDirectory))
+  {
+  }
 
   ConnectionInfoPublisher(std::string acceptorName,
                           std::string requesterName,
                           std::string addressDirectory) noexcept
-    :
-    acceptorName(std::move(acceptorName)),
-    requesterName(std::move(requesterName)),
-    addressDirectory(std::move(addressDirectory))
-  {}
-
+      : acceptorName(std::move(acceptorName)),
+        requesterName(std::move(requesterName)),
+        addressDirectory(std::move(addressDirectory))
+  {
+  }
 
 protected:
-
   std::string const acceptorName;
   std::string const requesterName;
-  int const rank = -1;
+  int const         rank = -1;
   std::string const addressDirectory;
 
   /// Returns the file name for the connection information.
@@ -49,54 +43,48 @@ protected:
   mutable logging::Logger _log{"com::ConnectionInfoPublisher"};
 };
 
-
 /// Reads the connection info for the given participant/rank information
-class ConnectionInfoReader : public ConnectionInfoPublisher
-{
+class ConnectionInfoReader : public ConnectionInfoPublisher {
 public:
-  
   ConnectionInfoReader(std::string acceptorName,
                        std::string requesterName,
-                       int rank,
+                       int         rank,
                        std::string addressDirectory) noexcept
-    : ConnectionInfoPublisher(acceptorName, requesterName, rank, addressDirectory)
-  {}
-
+      : ConnectionInfoPublisher(acceptorName, requesterName, rank, addressDirectory)
+  {
+  }
 
   ConnectionInfoReader(std::string acceptorName,
                        std::string requesterName,
                        std::string addressDirectory) noexcept
-    : ConnectionInfoPublisher(acceptorName, requesterName, addressDirectory)
-  {}
-
+      : ConnectionInfoPublisher(acceptorName, requesterName, addressDirectory)
+  {
+  }
 
   /// Reads the info from the connection info file. Will block, if the the file is not present.
   std::string read() const;
 };
 
-
 /// Writes the connection info for the given participant/rank information.
 /**
  * The file is removed, when the object is destroyed.
  */
-class ConnectionInfoWriter : public ConnectionInfoPublisher
-{
+class ConnectionInfoWriter : public ConnectionInfoPublisher {
 public:
-  
   ConnectionInfoWriter(std::string acceptorName,
                        std::string requesterName,
-                       int rank,
+                       int         rank,
                        std::string addressDirectory) noexcept
-    : ConnectionInfoPublisher(acceptorName, requesterName, rank, addressDirectory)
-  {}
-  
-  
-  ConnectionInfoWriter(std::string acceptorName,
-                       std::string requesterName,
-                       std::string addressDirectory) noexcept
-    : ConnectionInfoPublisher(acceptorName, requesterName, addressDirectory)
-  {}
+      : ConnectionInfoPublisher(acceptorName, requesterName, rank, addressDirectory)
+  {
+  }
 
+  ConnectionInfoWriter(std::string acceptorName,
+                       std::string requesterName,
+                       std::string addressDirectory) noexcept
+      : ConnectionInfoPublisher(acceptorName, requesterName, addressDirectory)
+  {
+  }
 
   /// Removes the connection info file and the directories ./precice-run/[hash], is empty.
   ~ConnectionInfoWriter();
@@ -106,9 +94,8 @@ public:
    * which is determined by acceptorName, requesterName, rank, addressDirectory
    * set at construction.
    */
-  void write(std::string const & info) const;
+  void write(std::string const &info) const;
 };
 
-
-}
-}
+} // namespace com
+} // namespace precice

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -32,10 +32,8 @@ MPI_Datatype MPI_Select_unsigned_integer_datatype<8>::datatype = MPI_UNSIGNED_LO
 
 #define MPI_BOOL MPI_Select_unsigned_integer_datatype<sizeof(bool)>::datatype
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 MPICommunication::MPICommunication()
 {
 }
@@ -57,7 +55,7 @@ void MPICommunication::send(const int *itemsToSend, int size, int rankReceiver)
 {
   PRECICE_TRACE(size);
   rankReceiver = rankReceiver - _rankOffset;
-  MPI_Send(const_cast<int*>(itemsToSend),
+  MPI_Send(const_cast<int *>(itemsToSend),
            size,
            MPI_INT,
            rank(rankReceiver),
@@ -71,7 +69,7 @@ PtrRequest MPICommunication::aSend(const int *itemsToSend, int size, int rankRec
   rankReceiver = rankReceiver - _rankOffset;
 
   MPI_Request request;
-  MPI_Isend(const_cast<int*>(itemsToSend),
+  MPI_Isend(const_cast<int *>(itemsToSend),
             size,
             MPI_INT,
             rank(rankReceiver),
@@ -86,7 +84,7 @@ void MPICommunication::send(const double *itemsToSend, int size, int rankReceive
 {
   PRECICE_TRACE(size);
   rankReceiver = rankReceiver - _rankOffset;
-  MPI_Send(const_cast<double*>(itemsToSend),
+  MPI_Send(const_cast<double *>(itemsToSend),
            size,
            MPI_DOUBLE,
            rank(rankReceiver),
@@ -100,7 +98,7 @@ PtrRequest MPICommunication::aSend(const double *itemsToSend, int size, int rank
   rankReceiver = rankReceiver - _rankOffset;
 
   MPI_Request request;
-  MPI_Isend(const_cast<double*>(itemsToSend),
+  MPI_Isend(const_cast<double *>(itemsToSend),
             size,
             MPI_DOUBLE,
             rank(rankReceiver),
@@ -111,13 +109,13 @@ PtrRequest MPICommunication::aSend(const double *itemsToSend, int size, int rank
   return PtrRequest(new MPIRequest(request));
 }
 
-PtrRequest MPICommunication::aSend(std::vector<double> const & itemsToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(std::vector<double> const &itemsToSend, int rankReceiver)
 {
   PRECICE_TRACE(rankReceiver, itemsToSend.size(), itemsToSend);
   rankReceiver = rankReceiver - _rankOffset;
 
   MPI_Request request;
-  MPI_Isend(const_cast<double*>(itemsToSend.data()),
+  MPI_Isend(const_cast<double *>(itemsToSend.data()),
             itemsToSend.size(),
             MPI_DOUBLE,
             rank(rankReceiver),
@@ -140,7 +138,7 @@ void MPICommunication::send(double itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const double& itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const double &itemToSend, int rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
@@ -157,7 +155,7 @@ void MPICommunication::send(int itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const int& itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const int &itemToSend, int rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
@@ -174,13 +172,13 @@ void MPICommunication::send(bool itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const bool& itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const bool &itemToSend, int rankReceiver)
 {
   PRECICE_TRACE();
   rankReceiver = rankReceiver - _rankOffset;
 
   MPI_Request request;
-  MPI_Isend(const_cast<bool*>(&itemToSend),
+  MPI_Isend(const_cast<bool *>(&itemToSend),
             1,
             MPI_BOOL,
             rank(rankReceiver),
@@ -215,7 +213,7 @@ void MPICommunication::receive(int *itemsToReceive, int size, int rankSender)
 {
   PRECICE_TRACE(size);
   rankSender = rankSender - _rankOffset;
-  
+
   MPI_Status status;
   MPI_Recv(itemsToReceive,
            size,
@@ -230,7 +228,7 @@ void MPICommunication::receive(double *itemsToReceive, int size, int rankSender)
 {
   PRECICE_TRACE(size);
   rankSender = rankSender - _rankOffset;
-  
+
   MPI_Status status;
   MPI_Recv(itemsToReceive,
            size,
@@ -258,7 +256,7 @@ PtrRequest MPICommunication::aReceive(double *itemsToReceive, int size, int rank
   return PtrRequest(new MPIRequest(request));
 }
 
-PtrRequest MPICommunication::aReceive(std::vector<double> & itemsToReceive, int rankSender)
+PtrRequest MPICommunication::aReceive(std::vector<double> &itemsToReceive, int rankSender)
 {
   PRECICE_TRACE(itemsToReceive.size());
   rankSender = rankSender - _rankOffset;
@@ -279,7 +277,7 @@ void MPICommunication::receive(double &itemToReceive, int rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender = rankSender - _rankOffset;
-  
+
   MPI_Status status;
   MPI_Recv(&itemToReceive,
            1,
@@ -366,14 +364,14 @@ void MPICommunication::send(std::vector<int> const &v, int rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
   rankReceiver = rankReceiver - _rankOffset;
-  MPI_Send(const_cast<int*>(v.data()), v.size(), MPI_INT,
+  MPI_Send(const_cast<int *>(v.data()), v.size(), MPI_INT,
            rank(rankReceiver), 0, communicator(rankReceiver));
 }
 
 void MPICommunication::receive(std::vector<int> &v, int rankSender)
 {
   PRECICE_TRACE(rankSender);
-  rankSender = rankSender - _rankOffset;
+  rankSender        = rankSender - _rankOffset;
   int        length = -1;
   MPI_Status status;
   MPI_Probe(rank(rankSender), 0, communicator(rankSender), &status);
@@ -387,14 +385,14 @@ void MPICommunication::send(std::vector<double> const &v, int rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
   rankReceiver = rankReceiver - _rankOffset;
-  MPI_Send(const_cast<double*>(v.data()), v.size(), MPI_DOUBLE,
+  MPI_Send(const_cast<double *>(v.data()), v.size(), MPI_DOUBLE,
            rank(rankReceiver), 0, communicator(rankReceiver));
 }
 
 void MPICommunication::receive(std::vector<double> &v, int rankSender)
 {
   PRECICE_TRACE(rankSender);
-  rankSender = rankSender - _rankOffset;
+  rankSender        = rankSender - _rankOffset;
   int        length = -1;
   MPI_Status status;
   MPI_Probe(rank(rankSender), 0, communicator(rankSender), &status);
@@ -403,7 +401,6 @@ void MPICommunication::receive(std::vector<double> &v, int rankSender)
   MPI_Recv(v.data(), length, MPI_DOUBLE, rank(rankSender),
            0, communicator(rankSender), MPI_STATUS_IGNORE);
 }
-
 
 } // namespace com
 } // namespace precice

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -3,28 +3,26 @@
 #pragma once
 
 #include <mpi.h>
+#include <vector>
 #include "com/Communication.hpp"
 #include "logging/Logger.hpp"
-#include <vector>
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 /**
  * @brief Provides implementation for basic MPI point-to-point communication.
  *
  * The methods for establishing a connection between two coupling participants
  * are not implemented and left to subclasses.
  */
-class MPICommunication : public Communication
-{
+class MPICommunication : public Communication {
 public:
   MPICommunication();
 
   /// Destructor, empty.
   virtual ~MPICommunication()
-  {}
+  {
+  }
 
   /**
    * @brief Sends a std::string to process with given rank.
@@ -45,8 +43,8 @@ public:
   /// Asynchronously sends an array of double values.
   virtual PtrRequest aSend(const double *itemsToSend, int size, int rankReceiver) override;
 
-  virtual PtrRequest aSend(std::vector<double> const & itemsToSend, int rankReceiver) override;
-  
+  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, int rankReceiver) override;
+
   /**
    * @brief Sends a double to process with given rank.
    *
@@ -55,7 +53,7 @@ public:
   virtual void send(double itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(const double& itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const double &itemToSend, int rankReceiver) override;
 
   /**
    * @brief Sends an int to process with given rank.
@@ -65,7 +63,7 @@ public:
   virtual void send(int itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(const int& itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const int &itemToSend, int rankReceiver) override;
 
   /**
    * @brief Sends a bool to process with given rank.
@@ -75,7 +73,7 @@ public:
   virtual void send(bool itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(const bool& itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const bool &itemToSend, int rankReceiver) override;
 
   /**
    * @brief Receives a std::string from process with given rank.
@@ -95,8 +93,8 @@ public:
                               int     size,
                               int     rankSender) override;
 
-  virtual PtrRequest aReceive(std::vector<double> & itemsToReceive, int rankSender) override;
-  
+  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, int rankSender) override;
+
   /**
    * @brief Receives a double from process with given rank.
    *
@@ -132,7 +130,6 @@ public:
 
   void send(std::vector<double> const &v, int rankReceiver) override;
   void receive(std::vector<double> &v, int rankSender) override;
-
 
 protected:
   /// Returns the communicator.

--- a/src/com/MPIDirectCommunication.cpp
+++ b/src/com/MPIDirectCommunication.cpp
@@ -4,10 +4,8 @@
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 MPIDirectCommunication::MPIDirectCommunication()
     : _communicator(utils::Parallel::getGlobalCommunicator()),
       _globalCommunicator(utils::Parallel::getGlobalCommunicator()),
@@ -40,7 +38,7 @@ void MPIDirectCommunication::acceptConnection(std::string const &acceptorName,
   utils::Parallel::splitCommunicator(acceptorName);
 
   PRECICE_CHECK(utils::Parallel::getCommunicatorSize() > 1,
-        "MPI communication direct (i.e. single) can be only used with more than one process in base communicator!");
+                "MPI communication direct (i.e. single) can be only used with more than one process in base communicator!");
 
   _globalCommunicator = utils::Parallel::getGlobalCommunicator();
   _localCommunicator  = utils::Parallel::getLocalCommunicator();
@@ -76,7 +74,7 @@ void MPIDirectCommunication::requestConnection(std::string const &acceptorName,
   utils::Parallel::splitCommunicator(requesterName);
 
   PRECICE_CHECK(utils::Parallel::getCommunicatorSize() > 1,
-        "MPI communication direct (i.e. single) can be only used with more than one process in base communicator!");
+                "MPI communication direct (i.e. single) can be only used with more than one process in base communicator!");
 
   _globalCommunicator = utils::Parallel::getGlobalCommunicator();
   _localCommunicator  = utils::Parallel::getLocalCommunicator();
@@ -93,7 +91,7 @@ void MPIDirectCommunication::requestConnection(std::string const &acceptorName,
 int MPIDirectCommunication::getGroupID(std::string const &accessorName)
 {
   PRECICE_TRACE(accessorName);
-  using Par = utils::Parallel;
+  using Par                                      = utils::Parallel;
   const std::vector<Par::AccessorGroup> &_groups = Par::getAccessorGroups();
   for (const Par::AccessorGroup &group : _groups) {
     if (group.name == accessorName) {
@@ -107,7 +105,7 @@ int MPIDirectCommunication::getGroupID(std::string const &accessorName)
 int MPIDirectCommunication::getLeaderRank(std::string const &accessorName)
 {
   PRECICE_TRACE(accessorName);
-  using Par = utils::Parallel;
+  using Par                                      = utils::Parallel;
   const std::vector<Par::AccessorGroup> &_groups = Par::getAccessorGroups();
   for (const Par::AccessorGroup &group : _groups) {
     if (group.name == accessorName) {
@@ -195,7 +193,7 @@ void MPIDirectCommunication::allreduceSum(int itemToSend, int &itemToReceive, in
 void MPIDirectCommunication::broadcast(const int *itemsToSend, int size)
 {
   PRECICE_TRACE(size);
-  MPI_Bcast(const_cast<int*>(itemsToSend), size, MPI_INT, MPI_ROOT, _communicator);
+  MPI_Bcast(const_cast<int *>(itemsToSend), size, MPI_INT, MPI_ROOT, _communicator);
 }
 
 void MPIDirectCommunication::broadcast(int *itemsToReceive,
@@ -221,7 +219,7 @@ void MPIDirectCommunication::broadcast(int &itemToReceive, int rankBroadcaster)
 void MPIDirectCommunication::broadcast(const double *itemsToSend, int size)
 {
   PRECICE_TRACE(size);
-  MPI_Bcast(const_cast<double*>(itemsToSend), size, MPI_DOUBLE, MPI_ROOT, _communicator);
+  MPI_Bcast(const_cast<double *>(itemsToSend), size, MPI_DOUBLE, MPI_ROOT, _communicator);
 }
 
 void MPIDirectCommunication::broadcast(double *itemsToReceive,

--- a/src/com/MPIDirectCommunication.hpp
+++ b/src/com/MPIDirectCommunication.hpp
@@ -4,13 +4,11 @@
 
 #include <string>
 #include "MPICommunication.hpp"
-#include "utils/assertion.hpp"
 #include "logging/Logger.hpp"
+#include "utils/assertion.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 /**
  * @brief Provides connection methods for processes located in one communicator.
  *
@@ -22,8 +20,7 @@ namespace com
  * participate in the communication. If one of the processes does not call
  * either acceptConnection(), or closeConnection(), a deadlock is achieved.
  */
-class MPIDirectCommunication : public MPICommunication
-{
+class MPIDirectCommunication : public MPICommunication {
 public:
   MPIDirectCommunication();
 
@@ -55,8 +52,8 @@ public:
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
-  virtual void requestConnectionAsClient(std::string   const &acceptorName,
-                                         std::string   const &requesterName,
+  virtual void requestConnectionAsClient(std::string const &  acceptorName,
+                                         std::string const &  requesterName,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) override
   {

--- a/src/com/MPIPortsCommunication.hpp
+++ b/src/com/MPIPortsCommunication.hpp
@@ -5,18 +5,15 @@
 #include "MPICommunication.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 /**
  * @brief Provides connection methods based on MPI ports (part of MPI 2.0).
  *
  * The two participants to be connected can be run in two process groups started
  * up individually, i.e. not within the same process group.
  */
-class MPIPortsCommunication : public MPICommunication
-{
+class MPIPortsCommunication : public MPICommunication {
 public:
   explicit MPIPortsCommunication(std::string const &addressDirectory = ".");
 
@@ -32,16 +29,16 @@ public:
                                         std::string const &requesterName,
                                         int                acceptorRank,
                                         int                requesterCommunicatorSize) override;
-  
+
   virtual void requestConnection(std::string const &acceptorName,
                                  std::string const &requesterName,
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
-  virtual void requestConnectionAsClient(std::string      const &acceptorName,
-                                         std::string      const &requesterName,
-                                         std::set<int>    const &acceptorRanks,
-                                         int                     requesterRank) override;
+  virtual void requestConnectionAsClient(std::string const &  acceptorName,
+                                         std::string const &  requesterName,
+                                         std::set<int> const &acceptorRanks,
+                                         int                  requesterRank) override;
 
   virtual void closeConnection() override;
 
@@ -61,7 +58,6 @@ private:
   std::string _portName = std::string(MPI_MAX_PORT_NAME, '\0');
 
   bool _isAcceptor = false;
-
 };
 } // namespace com
 } // namespace precice

--- a/src/com/MPIPortsCommunicationFactory.cpp
+++ b/src/com/MPIPortsCommunicationFactory.cpp
@@ -5,10 +5,8 @@
 #include "MPIPortsCommunication.hpp"
 #include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 MPIPortsCommunicationFactory::MPIPortsCommunicationFactory(std::string const &addressDirectory)
     : _addressDirectory(addressDirectory)
 {

--- a/src/com/MPIPortsCommunicationFactory.hpp
+++ b/src/com/MPIPortsCommunicationFactory.hpp
@@ -7,12 +7,9 @@
 
 #include <string>
 
-namespace precice
-{
-namespace com
-{
-class MPIPortsCommunicationFactory : public CommunicationFactory
-{
+namespace precice {
+namespace com {
+class MPIPortsCommunicationFactory : public CommunicationFactory {
 public:
   explicit MPIPortsCommunicationFactory(std::string const &addressDirectory = ".");
 

--- a/src/com/MPIRequest.cpp
+++ b/src/com/MPIRequest.cpp
@@ -2,10 +2,8 @@
 
 #include "MPIRequest.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 MPIRequest::MPIRequest(MPI_Request request)
     : _request(request)
 {

--- a/src/com/MPIRequest.hpp
+++ b/src/com/MPIRequest.hpp
@@ -1,15 +1,12 @@
 #pragma once
 #ifndef PRECICE_NO_MPI
 
-#include "Request.hpp"
 #include <mpi.h>
+#include "Request.hpp"
 
-namespace precice
-{
-namespace com
-{
-class MPIRequest : public Request
-{
+namespace precice {
+namespace com {
+class MPIRequest : public Request {
 public:
   explicit MPIRequest(MPI_Request request);
 

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -2,14 +2,12 @@
 
 #include "MPISinglePortsCommunication.hpp"
 #include "ConnectionInfoPublisher.hpp"
-#include "utils/assertion.hpp"
-#include "utils/Parallel.hpp"
 #include "utils/MasterSlave.hpp"
+#include "utils/Parallel.hpp"
+#include "utils/assertion.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 MPISinglePortsCommunication::MPISinglePortsCommunication(std::string const &addressDirectory)
     : _addressDirectory(addressDirectory)
 {
@@ -46,9 +44,9 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
 
   ConnectionInfoWriter conPub(acceptorName, requesterName, _addressDirectory);
   conPub.write(_portName);
-    
-  size_t peerCurrent = 0; // current peer to connect to
-  size_t peerCount   = 0; // The total count of peers (initialized in the first iteration)
+
+  size_t peerCurrent               = 0; // current peer to connect to
+  size_t peerCount                 = 0; // The total count of peers (initialized in the first iteration)
   size_t requesterCommunicatorSize = 0;
 
   do {
@@ -59,22 +57,22 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
 
     int requesterRank = -1;
     // Exchange information to which rank I am connected and which communicator size on the other side
-    MPI_Recv(&requesterRank,             1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
+    MPI_Recv(&requesterRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
     MPI_Recv(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
-    MPI_Send(&acceptorRank,              1, MPI_INT, 0, 42, communicator);
-    
+    MPI_Send(&acceptorRank, 1, MPI_INT, 0, 42, communicator);
+
     // Initialize the count of peers to connect to
     if (peerCurrent == 0) {
       peerCount = requesterCommunicatorSize;
     }
-    
+
     PRECICE_CHECK(requesterCommunicatorSize > 0,
-          "Requester communicator size has to be > 0!");
+                  "Requester communicator size has to be > 0!");
     PRECICE_CHECK(requesterCommunicatorSize == peerCount,
-          "Requester communicator sizes are inconsistent!");
+                  "Requester communicator sizes are inconsistent!");
     PRECICE_CHECK(_communicators.count(requesterRank) == 0,
-          "Duplicate request to connect by same rank (" << requesterRank << ")!");
-    
+                  "Duplicate request to connect by same rank (" << requesterRank << ")!");
+
     _communicators[requesterRank] = communicator;
 
   } while (++peerCurrent < requesterCommunicatorSize);
@@ -93,7 +91,7 @@ void MPISinglePortsCommunication::acceptConnectionAsServer(
   PRECICE_ASSERT(not isConnected());
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, _addressDirectory);
-  
+
   _isAcceptor = true;
 
   if (utils::MasterSlave::getRank() == 0) { // only master opens a port
@@ -101,13 +99,13 @@ void MPISinglePortsCommunication::acceptConnectionAsServer(
     conInfo.write(_portName);
     PRECICE_DEBUG("Accept connection at " << _portName);
   }
-  
+
   MPI_Comm communicator;
   MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0,
                   utils::Parallel::getGlobalCommunicator(), &communicator);
   PRECICE_DEBUG("Accepted connection at " << _portName);
   _communicators[0] = communicator; // all comms are the same
-  
+
   _isConnected = true;
 }
 
@@ -131,21 +129,21 @@ void MPISinglePortsCommunication::requestConnection(std::string const &acceptorN
   _isConnected = true;
 
   int acceptorRank;
-  MPI_Send(&requesterRank,             1, MPI_INT, 0, 42, communicator);
+  MPI_Send(&requesterRank, 1, MPI_INT, 0, 42, communicator);
   MPI_Send(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator);
-  MPI_Recv(&acceptorRank,              1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
+  MPI_Recv(&acceptorRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
   _communicators[0] = communicator; // should be acceptorRank
 }
 
-void MPISinglePortsCommunication::requestConnectionAsClient(std::string      const &acceptorName,
-                                                            std::string      const &requesterName,
-                                                            std::set<int>    const &acceptorRanks,
-                                                            int                     requesterRank)
-                                                      
+void MPISinglePortsCommunication::requestConnectionAsClient(std::string const &  acceptorName,
+                                                            std::string const &  requesterName,
+                                                            std::set<int> const &acceptorRanks,
+                                                            int                  requesterRank)
+
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected());
-  
+
   _isAcceptor = false;
 
   ConnectionInfoReader conInfo(acceptorName, requesterName, _addressDirectory);
@@ -157,7 +155,7 @@ void MPISinglePortsCommunication::requestConnectionAsClient(std::string      con
                    utils::Parallel::getGlobalCommunicator(), &communicator);
   PRECICE_DEBUG("Requested connection to " << _portName);
   _communicators[0] = communicator; // all comms are the same
-  _isConnected = true;
+  _isConnected      = true;
 }
 
 void MPISinglePortsCommunication::closeConnection()
@@ -167,7 +165,7 @@ void MPISinglePortsCommunication::closeConnection()
   if (not isConnected())
     return;
 
-  for (auto & communicator : _communicators) {
+  for (auto &communicator : _communicators) {
     MPI_Comm_disconnect(&communicator.second);
   }
 

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -5,10 +5,8 @@
 #include "MPICommunication.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 /**
  * @brief Provides connection methods based on MPI ports (part of MPI 2.0).
  *
@@ -29,8 +27,7 @@ namespace com
  *
  * If we agree, that acceptConnection / requestConnection just does 1:1 connection, we can rewrite and simplifiy the code.
 **/
-class MPISinglePortsCommunication : public MPICommunication
-{
+class MPISinglePortsCommunication : public MPICommunication {
 public:
   explicit MPISinglePortsCommunication(std::string const &addressDirectory = ".");
 
@@ -52,10 +49,10 @@ public:
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
-  virtual void requestConnectionAsClient(std::string      const &acceptorName,
-                                         std::string      const &requesterName,
-                                         std::set<int>    const &acceptorRanks,
-                                         int                     requesterRank) override;
+  virtual void requestConnectionAsClient(std::string const &  acceptorName,
+                                         std::string const &  requesterName,
+                                         std::set<int> const &acceptorRanks,
+                                         int                  requesterRank) override;
 
   virtual void closeConnection() override;
 
@@ -75,7 +72,6 @@ private:
   std::string _portName = std::string(MPI_MAX_PORT_NAME, '\0');
 
   bool _isAcceptor = false;
-
 };
 } // namespace com
 } // namespace precice

--- a/src/com/MPISinglePortsCommunicationFactory.cpp
+++ b/src/com/MPISinglePortsCommunicationFactory.cpp
@@ -5,10 +5,8 @@
 #include "MPISinglePortsCommunication.hpp"
 #include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 MPISinglePortsCommunicationFactory::MPISinglePortsCommunicationFactory(std::string const &addressDirectory)
     : _addressDirectory(addressDirectory)
 {

--- a/src/com/MPISinglePortsCommunicationFactory.hpp
+++ b/src/com/MPISinglePortsCommunicationFactory.hpp
@@ -7,12 +7,9 @@
 
 #include <string>
 
-namespace precice
-{
-namespace com
-{
-class MPISinglePortsCommunicationFactory : public CommunicationFactory
-{
+namespace precice {
+namespace com {
+class MPISinglePortsCommunicationFactory : public CommunicationFactory {
 public:
   explicit MPISinglePortsCommunicationFactory(std::string const &addressDirectory = ".");
 

--- a/src/com/Request.cpp
+++ b/src/com/Request.cpp
@@ -1,9 +1,7 @@
 #include "Request.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 
 void Request::wait(std::vector<PtrRequest> &requests)
 {

--- a/src/com/Request.hpp
+++ b/src/com/Request.hpp
@@ -3,12 +3,9 @@
 #include <vector>
 #include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace com
-{
-class Request
-{
+namespace precice {
+namespace com {
+class Request {
 
 public:
   static void wait(std::vector<PtrRequest> &requests);

--- a/src/com/SharedPointer.hpp
+++ b/src/com/SharedPointer.hpp
@@ -2,10 +2,8 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 
 class Communication;
 class CommunicationFactory;

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -1,20 +1,17 @@
 #pragma once
 
-#include "com/Communication.hpp"
 #include <boost/asio.hpp>
-#include "logging/Logger.hpp"
+#include <map>
 #include <thread>
 #include <vector>
-#include <map>
+#include "com/Communication.hpp"
 #include "com/SocketSendQueue.hpp"
+#include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 /// Implements Communication by using sockets.
-class SocketCommunication : public Communication
-{
+class SocketCommunication : public Communication {
 public:
   SocketCommunication(unsigned short     portNumber       = 0,
                       bool               reuseAddress     = false,
@@ -41,11 +38,10 @@ public:
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
-  virtual void requestConnectionAsClient(std::string   const &acceptorName,
-                                         std::string   const &requesterName,
+  virtual void requestConnectionAsClient(std::string const &  acceptorName,
+                                         std::string const &  requesterName,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) override;
-
 
   virtual void closeConnection() override;
 
@@ -64,25 +60,25 @@ public:
   /// Asynchronously sends an array of double values.
   virtual PtrRequest aSend(const double *itemsToSend, int size, int rankReceiver) override;
 
-  virtual PtrRequest aSend(std::vector<double> const & itemsToSend, int rankReceiver) override;
-  
+  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, int rankReceiver) override;
+
   /// Sends a double to process with given rank.
   virtual void send(double itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(const double & itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const double &itemToSend, int rankReceiver) override;
 
   /// Sends an int to process with given rank.
   virtual void send(int itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(const int & itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const int &itemToSend, int rankReceiver) override;
 
   /// Sends a bool to process with given rank.
   virtual void send(bool itemToSend, int rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(const bool & itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const bool &itemToSend, int rankReceiver) override;
 
   /// Receives a std::string from process with given rank.
   virtual void receive(std::string &itemToReceive, int rankSender) override;
@@ -98,8 +94,8 @@ public:
                               int     size,
                               int     rankSender) override;
 
-  virtual PtrRequest aReceive(std::vector<double> & itemsToReceive, int rankSender) override;
-  
+  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, int rankSender) override;
+
   /// Receives a double from process with given rank.
   virtual void receive(double &itemToReceive, int rankSender) override;
 
@@ -123,7 +119,7 @@ public:
 
   void send(std::vector<double> const &v, int rankReceiver) override;
   void receive(std::vector<double> &v, int rankSender) override;
-  
+
 private:
   logging::Logger _log{"com::SocketCommunication"};
 
@@ -138,14 +134,14 @@ private:
   /// Directory where IP address is exchanged by file.
   std::string _addressDirectory;
 
-  using IOService     = boost::asio::io_service;
-  using Socket        = boost::asio::ip::tcp::socket;
-  using Work          = boost::asio::io_service::work;
-  
+  using IOService = boost::asio::io_service;
+  using Socket    = boost::asio::ip::tcp::socket;
+  using Work      = boost::asio::io_service::work;
+
   std::shared_ptr<IOService> _ioService;
-  std::shared_ptr<Work> _work;
-  std::thread _thread;
-  
+  std::shared_ptr<Work>      _work;
+  std::thread                _thread;
+
   /// Remote rank -> socket map
   std::map<int, std::shared_ptr<Socket>> _sockets;
 
@@ -158,4 +154,3 @@ private:
 };
 } // namespace com
 } // namespace precice
-

--- a/src/com/SocketCommunicationFactory.cpp
+++ b/src/com/SocketCommunicationFactory.cpp
@@ -3,10 +3,8 @@
 #include "SocketCommunicationFactory.hpp"
 #include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 SocketCommunicationFactory::SocketCommunicationFactory(
     unsigned short     portNumber,
     bool               reuseAddress,

--- a/src/com/SocketCommunicationFactory.hpp
+++ b/src/com/SocketCommunicationFactory.hpp
@@ -5,12 +5,9 @@
 
 #include <string>
 
-namespace precice
-{
-namespace com
-{
-class SocketCommunicationFactory : public CommunicationFactory
-{
+namespace precice {
+namespace com {
+class SocketCommunicationFactory : public CommunicationFactory {
 public:
   SocketCommunicationFactory(unsigned short     portNumber       = 0,
                              bool               reuseAddress     = false,
@@ -31,4 +28,3 @@ private:
 };
 } // namespace com
 } // namespace precice
-

--- a/src/com/SocketRequest.cpp
+++ b/src/com/SocketRequest.cpp
@@ -1,9 +1,7 @@
 #include "SocketRequest.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 SocketRequest::SocketRequest()
     : _complete(false)
 {

--- a/src/com/SocketRequest.hpp
+++ b/src/com/SocketRequest.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
-#include "Request.hpp"
 #include <condition_variable>
 #include <mutex>
+#include "Request.hpp"
 
-namespace precice
-{
-namespace com
-{
-class SocketRequest : public Request
-{
+namespace precice {
+namespace com {
+class SocketRequest : public Request {
 public:
   SocketRequest();
 

--- a/src/com/SocketSendQueue.cpp
+++ b/src/com/SocketSendQueue.cpp
@@ -1,9 +1,7 @@
 #include "SocketSendQueue.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 namespace asio = boost::asio;
 
 /// If items are left in the queue upon destruction, something went really wrong.
@@ -11,12 +9,12 @@ SocketSendQueue::~SocketSendQueue()
 {
   if (not _itemQueue.empty())
     PRECICE_ERROR("The SocketSendQueue is not empty upon destruction.\n"
-          "Make sure it always outlives all the requests pushed onto it");
+                  "Make sure it always outlives all the requests pushed onto it");
 }
 
-void SocketSendQueue::dispatch(std::shared_ptr<Socket> sock,
+void SocketSendQueue::dispatch(std::shared_ptr<Socket>      sock,
                                boost::asio::const_buffers_1 data,
-                               std::function<void()> callback)
+                               std::function<void()>        callback)
 {
   _itemQueue.push_back({std::move(sock), std::move(data), callback});
   process(); // if queue was previously empty, start it now.
@@ -39,5 +37,5 @@ void SocketSendQueue::process()
                     });
 }
 
-
-}}
+} // namespace com
+} // namespace precice

--- a/src/com/SocketSendQueue.hpp
+++ b/src/com/SocketSendQueue.hpp
@@ -1,29 +1,25 @@
 #pragma once
 
-#include <deque>
 #include <boost/asio.hpp>
+#include <deque>
 #include <functional>
 #include <mutex>
 #include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 
 /// This Queue is intended for SocketCommunication to push requests which should be sent onto it.
 /// It ensures that the invocations of asio::aSend are done serially.
-class SocketSendQueue
-{
+class SocketSendQueue {
 public:
-
   using Socket = boost::asio::ip::tcp::socket;
 
   SocketSendQueue() = default;
   ~SocketSendQueue();
 
-  SocketSendQueue(SocketSendQueue const &) =delete;
-  SocketSendQueue& operator=(SocketSendQueue const &) =delete;
+  SocketSendQueue(SocketSendQueue const &) = delete;
+  SocketSendQueue &operator=(SocketSendQueue const &) = delete;
 
   /// Put data in the queue, start processing the queue.
   void dispatch(std::shared_ptr<Socket> sock, boost::asio::const_buffers_1 data, std::function<void()> callback);
@@ -34,16 +30,16 @@ private:
   /// This method can be called arbitrarily many times, but enough times to ensure the queue makes progress.
   void process();
 
-  struct SendItem
-  {
-    std::shared_ptr<Socket> sock;
+  struct SendItem {
+    std::shared_ptr<Socket>      sock;
     boost::asio::const_buffers_1 data;
-    std::function<void()> callback;
+    std::function<void()>        callback;
   };
 
   std::deque<SendItem> _itemQueue;
-  std::mutex _sendMutex;
-  bool _ready = true;
+  std::mutex           _sendMutex;
+  bool                 _ready = true;
 };
 
-}}
+} // namespace com
+} // namespace precice

--- a/src/com/config/CommunicationConfiguration.cpp
+++ b/src/com/config/CommunicationConfiguration.cpp
@@ -4,10 +4,8 @@
 #include "com/SocketCommunication.hpp"
 #include "utils/Helpers.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 PtrCommunication CommunicationConfiguration::createCommunication(
     const xml::XMLTag &tag) const
 {
@@ -17,12 +15,11 @@ PtrCommunication CommunicationConfiguration::createCommunication(
     int         port    = tag.getIntAttributeValue("port");
 
     PRECICE_CHECK(not utils::isTruncated<unsigned short>(port),
-          "The value given for the \"port\" attribute is not a 16-bit unsigned integer: " << port);
+                  "The value given for the \"port\" attribute is not a 16-bit unsigned integer: " << port);
 
     std::string dir = tag.getStringAttributeValue("exchange-directory");
     com             = std::make_shared<com::SocketCommunication>(port, false, network, dir);
-  }
-  else if (tag.getName() == "mpi") {
+  } else if (tag.getName() == "mpi") {
     std::string dir = tag.getStringAttributeValue("exchange-directory");
 #ifdef PRECICE_NO_MPI
     std::ostringstream error;
@@ -32,8 +29,7 @@ PtrCommunication CommunicationConfiguration::createCommunication(
 #else
     com = std::make_shared<com::MPIPortsCommunication>(dir);
 #endif
-  }
-  else if (tag.getName() == "mpi-single") {
+  } else if (tag.getName() == "mpi-single") {
 #ifdef PRECICE_NO_MPI
     std::ostringstream error;
     error << "Communication type \"mpi-single\" can only be used "

--- a/src/com/config/CommunicationConfiguration.hpp
+++ b/src/com/config/CommunicationConfiguration.hpp
@@ -1,20 +1,17 @@
 #pragma once
 
+#include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "xml/XMLTag.hpp"
-#include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace com
-{
+namespace precice {
+namespace com {
 
 /**
  * @brief Configuration for communication channels between server and clients or master and slaves.
  * The communication between two solvers is configured in m2n::M2NConfiguration
  */
-class CommunicationConfiguration
-{
+class CommunicationConfiguration {
 public:
   virtual ~CommunicationConfiguration() {}
 

--- a/src/com/tests/CommunicateBoundingBoxTest.cpp
+++ b/src/com/tests/CommunicateBoundingBoxTest.cpp
@@ -13,8 +13,7 @@ BOOST_AUTO_TEST_SUITE(CommunicationTests)
 BOOST_AUTO_TEST_SUITE(CommunicateBoundingBoxTests)
 
 BOOST_FIXTURE_TEST_CASE(SendAndReceiveBoundingBox, testing::M2NFixture,
-                        *testing::MinRanks(2)
-                        * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
@@ -45,8 +44,7 @@ BOOST_FIXTURE_TEST_CASE(SendAndReceiveBoundingBox, testing::M2NFixture,
 }
 
 BOOST_FIXTURE_TEST_CASE(SendAndReceiveBoundingBoxMap, testing::M2NFixture,
-                        *testing::MinRanks(2)
-                        * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
@@ -95,8 +93,7 @@ BOOST_FIXTURE_TEST_CASE(SendAndReceiveBoundingBoxMap, testing::M2NFixture,
 }
 
 BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveBoundingBoxMap,
-                     *testing::OnSize(4)
-                     * boost::unit_test::fixture<testing::MasterComFixture>())
+                     *testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
 {
 
   // Build BB/BBMap to communicate
@@ -139,8 +136,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveBoundingBoxMap,
 }
 
 BOOST_FIXTURE_TEST_CASE(SendAndReceiveConnectionMap, testing::M2NFixture,
-                        *testing::MinRanks(2)
-                        * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -3,8 +3,8 @@
 #include "com/CommunicateMesh.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
 #include "utils/Parallel.hpp"
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(CommunicationTests)
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
 BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
-                     * testing::MinRanks(2))
+                     *testing::MinRanks(2))
 {
   utils::Parallel::synchronizeProcesses();
   BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
@@ -26,18 +26,18 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
   std::string participant1("rank1");
 
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
+    mesh::Mesh    sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
     mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
     mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
-    mesh::Edge &e0 = sendMesh.createEdge(v0, v1);
-    mesh::Edge &e1 = sendMesh.createEdge(v1, v2);
-    mesh::Edge &e2 = sendMesh.createEdge(v2, v0);
+    mesh::Edge &  e0 = sendMesh.createEdge(v0, v1);
+    mesh::Edge &  e1 = sendMesh.createEdge(v1, v2);
+    mesh::Edge &  e2 = sendMesh.createEdge(v2, v0);
 
     // Create mesh communicator
     std::vector<int> involvedRanks = {0, 1};
     MPI_Comm         comm          = utils::Parallel::getRestrictedCommunicator(involvedRanks);
-    
+
     if (utils::Parallel::getProcessRank() < 2) {
       utils::Parallel::setGlobalCommunicator(comm);
       com::PtrCommunication com(new com::MPIDirectCommunication());
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
         comMesh.sendMesh(sendMesh, 0);
       } else if (utils::Parallel::getProcessRank() == 1) {
         // receiveMesh can also deal with delta meshes
-        mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());        
+        mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
         recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
         utils::Parallel::splitCommunicator(participant1);
         com->requestConnection(participant0, participant1, 0, 1);
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
         BOOST_TEST(recvMesh.edges()[2] == e2);
       }
       com->closeConnection();
-      
+
       utils::Parallel::clearGroups();
       utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
     }
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
 }
 
 BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
-                     * testing::MinRanks(2))
+                     *testing::MinRanks(2))
 {
   utils::Parallel::synchronizeProcesses();
   BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
@@ -80,20 +80,20 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
   std::string participant0("rank0");
   std::string participant1("rank1");
 
-  int dim = 3;
-  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
-  mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
-  mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
-  mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
-  mesh::Edge &e0 = sendMesh.createEdge(v0, v1);
-  mesh::Edge &e1 = sendMesh.createEdge(v1, v2);
-  mesh::Edge &e2 = sendMesh.createEdge(v2, v0);
+  int             dim = 3;
+  mesh::Mesh      sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
+  mesh::Vertex &  v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
+  mesh::Vertex &  v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
+  mesh::Vertex &  v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
+  mesh::Edge &    e0 = sendMesh.createEdge(v0, v1);
+  mesh::Edge &    e1 = sendMesh.createEdge(v1, v2);
+  mesh::Edge &    e2 = sendMesh.createEdge(v2, v0);
   mesh::Triangle &t0 = sendMesh.createTriangle(e0, e1, e2);
 
   // Create mesh communicator
   std::vector<int> involvedRanks = {0, 1};
   MPI_Comm         comm          = utils::Parallel::getRestrictedCommunicator(involvedRanks);
-    
+
   if (utils::Parallel::getProcessRank() < 2) {
     utils::Parallel::setGlobalCommunicator(comm);
     com::PtrCommunication com(new com::MPIDirectCommunication());
@@ -118,18 +118,18 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
       BOOST_TEST(recvMesh.edges()[0] == e0);
       BOOST_TEST(recvMesh.edges()[1] == e1);
       BOOST_TEST(recvMesh.edges()[2] == e2);
-      
+
       BOOST_TEST(recvMesh.triangles()[0] == t0);
     }
     com->closeConnection();
-    
+
     utils::Parallel::clearGroups();
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
   }
 }
 
 BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
-                     * testing::MinRanks(2))
+                     *testing::MinRanks(2))
 {
   utils::Parallel::synchronizeProcesses();
   BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
@@ -137,20 +137,20 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
   std::string participant0("rank0");
   std::string participant1("rank1");
 
-  int dim = 3;
-  mesh::Mesh sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
-  mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
-  mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
-  mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
-  mesh::Edge &e0 = sendMesh.createEdge(v0, v1);
-  mesh::Edge &e1 = sendMesh.createEdge(v1, v2);
-  mesh::Edge &e2 = sendMesh.createEdge(v2, v0);
+  int             dim = 3;
+  mesh::Mesh      sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
+  mesh::Vertex &  v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
+  mesh::Vertex &  v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
+  mesh::Vertex &  v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
+  mesh::Edge &    e0 = sendMesh.createEdge(v0, v1);
+  mesh::Edge &    e1 = sendMesh.createEdge(v1, v2);
+  mesh::Edge &    e2 = sendMesh.createEdge(v2, v0);
   mesh::Triangle &t0 = sendMesh.createTriangle(e0, e1, e2);
-  
+
   // Create mesh communicator
   std::vector<int> involvedRanks = {0, 1};
   MPI_Comm         comm          = utils::Parallel::getRestrictedCommunicator(involvedRanks);
-    
+
   if (utils::Parallel::getProcessRank() < 2) {
     utils::Parallel::setGlobalCommunicator(comm);
     com::PtrCommunication com(new com::MPIDirectCommunication());
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
       utils::Parallel::splitCommunicator(participant0);
       com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
       comMesh.broadcastSendMesh(sendMesh);
-      } else if (utils::Parallel::getProcessRank() == 1) {
+    } else if (utils::Parallel::getProcessRank() == 1) {
       mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
       // receiveMesh can also deal with delta meshes
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
@@ -177,13 +177,12 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
       BOOST_TEST(recvMesh.edges()[2] == e2);
       BOOST_TEST(recvMesh.triangles()[0] == t0);
     }
-    com->closeConnection();      
+    com->closeConnection();
 
     utils::Parallel::clearGroups();
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
   }
 }
-
 
 BOOST_AUTO_TEST_SUITE_END() // Mesh
 BOOST_AUTO_TEST_SUITE_END() // Communication

--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -1,18 +1,24 @@
 #pragma once
 
+#include <Eigen/Core>
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <vector>
+#include "testing/Testing.hpp"
+#include "utils/Parallel.hpp"
+
 using namespace precice;
 
 /// Generic test function that is called from the tests for MPIPortsCommunication,
 /// MPIDirectCommunication and SocketCommunication
 
-
 /// This tests still uses the old rank enumeration
-template<typename T>
+template <typename T>
 void TestSendAndReceivePrimitiveTypes()
 {
-  T com;
+  T         com;
   const int rank = utils::Parallel::getProcessRank();
-  
+
   if (rank == 0) {
     com.acceptConnection("process0", "process1", rank);
     {
@@ -75,15 +81,15 @@ void TestSendAndReceivePrimitiveTypes()
 }
 
 /// This tests still uses the old rank enumeration
-template<typename T>
+template <typename T>
 void TestSendAndReceiveVectors()
 {
-  T com;
+  T         com;
   const int rank = utils::Parallel::getProcessRank();
-  
+
   if (rank == 0) {
     com.acceptConnection("process0", "process1", rank);
-     {
+    {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
       com.receive(msg.data(), msg.size(), 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector3d::Constant(1)));
@@ -141,15 +147,14 @@ void TestSendAndReceiveVectors()
   }
 }
 
-
 /// Tests connecting four processes using acceptConnection and requestConnection
-template<typename T>
+template <typename T>
 void TestSendReceiveFourProcesses()
 {
-  T communication;
-  const int rank = utils::Parallel::getProcessRank();
-  int message = -1;
-  
+  T         communication;
+  const int rank    = utils::Parallel::getProcessRank();
+  int       message = -1;
+
   switch (rank) {
   case 0: {
     communication.acceptConnection("A", "B", rank);
@@ -171,30 +176,30 @@ void TestSendReceiveFourProcesses()
   }
   case 2: {
     communication.requestConnection("A", "B", rank, 2);
-    
+
     communication.receive(message, 0);
     BOOST_TEST(message == 10);
     message *= 2;
     communication.send(message, 0);
-    
+
     communication.closeConnection();
     break;
   }
   case 3: {
     communication.requestConnection("A", "B", rank, 2);
-    
+
     communication.receive(message, 0);
     BOOST_TEST(message == 20);
     message *= 2;
     communication.send(message, 0);
-    
+
     communication.closeConnection();
     break;
   }
   }
 }
 
-template<typename T>
+template <typename T>
 void TestSendAndReceive()
 {
   TestSendAndReceivePrimitiveTypes<T>();
@@ -202,13 +207,13 @@ void TestSendAndReceive()
 }
 
 /// Tests connecting two processes using acceptConnectionAsServer and requestConnectionAsClient
-template<typename T>
+template <typename T>
 void TestSendReceiveTwoProcessesServerClient()
 {
-  T communication;
-  const int rank = utils::Parallel::getProcessRank();
-  int message = 1;
-  
+  T         communication;
+  const int rank    = utils::Parallel::getProcessRank();
+  int       message = 1;
+
   switch (rank) {
   case 0: {
     communication.acceptConnectionAsServer("A", "B", rank, 1);
@@ -230,13 +235,13 @@ void TestSendReceiveTwoProcessesServerClient()
   }
 }
 
-template<typename T>
+template <typename T>
 void TestSendReceiveFourProcessesServerClient()
 {
-  T communication;
-  const int rank = utils::Parallel::getProcessRank();
-  int message = -1;
-  
+  T         communication;
+  const int rank    = utils::Parallel::getProcessRank();
+  int       message = -1;
+
   switch (rank) {
   case 0: {
     communication.acceptConnectionAsServer("A", "B", rank, 2);
@@ -258,34 +263,34 @@ void TestSendReceiveFourProcessesServerClient()
   }
   case 2: {
     communication.requestConnectionAsClient("A", "B", {0}, rank);
-    
+
     communication.receive(message, 0);
     BOOST_TEST(message == 10);
     message *= 2;
     communication.send(message, 0);
-    
+
     communication.closeConnection();
     break;
   }
   case 3: {
     communication.requestConnectionAsClient("A", "B", {0}, rank);
-    
+
     communication.receive(message, 0);
     BOOST_TEST(message == 20);
     message *= 2;
     communication.send(message, 0);
-    
+
     communication.closeConnection();
     break;
   }
   }
 }
 
-template<typename T>
+template <typename T>
 void TestSendReceiveFourProcessesServerClientV2()
 {
-  T communication;
-  int rank = utils::Parallel::getProcessRank();
+  T   communication;
+  int rank    = utils::Parallel::getProcessRank();
   int message = -1;
 
   switch (rank) {
@@ -318,8 +323,8 @@ void TestSendReceiveFourProcessesServerClientV2()
     break;
   }
   case 2: {
-    communication.requestConnectionAsClient("A", "B", {0,1}, rank);
-    
+    communication.requestConnectionAsClient("A", "B", {0, 1}, rank);
+
     communication.receive(message, 0);
     BOOST_TEST(message == 10);
     communication.send(20, 0);
@@ -327,12 +332,12 @@ void TestSendReceiveFourProcessesServerClientV2()
     communication.receive(message, 1);
     BOOST_TEST(message == 20);
     communication.send(40, 1);
-    
+
     communication.closeConnection();
     break;
   }
   case 3: {
-    communication.requestConnectionAsClient("A", "B", {0,1}, rank);
+    communication.requestConnectionAsClient("A", "B", {0, 1}, rank);
 
     communication.receive(message, 0);
     BOOST_TEST(message == 100);

--- a/src/com/tests/MPIDirectCommunicationTest.cpp
+++ b/src/com/tests/MPIDirectCommunicationTest.cpp
@@ -1,8 +1,8 @@
 #ifndef PRECICE_NO_MPI
 
+#include "GenericTestFunctions.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "testing/Testing.hpp"
-#include "GenericTestFunctions.hpp"
 
 using namespace precice;
 using namespace precice::com;
@@ -12,9 +12,7 @@ BOOST_AUTO_TEST_SUITE(CommunicationTests)
 BOOST_AUTO_TEST_SUITE(MPIDirect)
 
 BOOST_AUTO_TEST_CASE(SendAndReceive,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>()
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::SyncProcessesFixture>() * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   TestSendAndReceive<MPIDirectCommunication>();
 }

--- a/src/com/tests/MPIPortsCommunicationTest.cpp
+++ b/src/com/tests/MPIPortsCommunicationTest.cpp
@@ -1,9 +1,9 @@
 #ifndef PRECICE_NO_MPI
 
+#include "GenericTestFunctions.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "testing/Testing.hpp"
 #include "utils/Parallel.hpp"
-#include "GenericTestFunctions.hpp"
 
 using namespace precice;
 using namespace precice::com;
@@ -11,44 +11,36 @@ using namespace precice::com;
 BOOST_AUTO_TEST_SUITE(CommunicationTests)
 
 BOOST_AUTO_TEST_SUITE(MPIPorts,
-                      * boost::unit_test::label("MPI_Ports"))
-
+                      *boost::unit_test::label("MPI_Ports"))
 
 BOOST_AUTO_TEST_CASE(SendAndReceive,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>()
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::SyncProcessesFixture>() * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   TestSendAndReceive<MPIPortsCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcesses,
-                     * testing::MinRanks(4)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>())
+                     *testing::MinRanks(4) * boost::unit_test::fixture<testing::SyncProcessesFixture>())
 {
   TestSendReceiveFourProcesses<MPIPortsCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>()
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
-       
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::SyncProcessesFixture>() * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+
 {
   TestSendReceiveTwoProcessesServerClient<MPIPortsCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient,
-                     * testing::MinRanks(4)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>())
-       
+                     *testing::MinRanks(4) * boost::unit_test::fixture<testing::SyncProcessesFixture>())
+
 {
   TestSendReceiveFourProcessesServerClient<MPIPortsCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2,
-                     * testing::MinRanks(4)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>())
+                     *testing::MinRanks(4) * boost::unit_test::fixture<testing::SyncProcessesFixture>())
 {
   TestSendReceiveFourProcessesServerClientV2<MPIPortsCommunication>();
 }

--- a/src/com/tests/SocketCommunicationTest.cpp
+++ b/src/com/tests/SocketCommunicationTest.cpp
@@ -1,10 +1,9 @@
+#include "GenericTestFunctions.hpp"
 #include "com/SocketCommunication.hpp"
 #include "testing/Testing.hpp"
-#include "GenericTestFunctions.hpp"
 
 using namespace precice;
 using namespace precice::com;
-
 
 BOOST_TEST_SPECIALIZED_COLLECTION_COMPARE(std::vector<int>)
 
@@ -12,41 +11,35 @@ BOOST_AUTO_TEST_SUITE(CommunicationTests)
 
 BOOST_AUTO_TEST_SUITE(Socket)
 
-
 BOOST_AUTO_TEST_CASE(SendAndReceive,
-                     * testing::MinRanks(2))
+                     *testing::MinRanks(2))
 {
   TestSendAndReceive<SocketCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcesses,
-                     * testing::MinRanks(4)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>())
+                     *testing::MinRanks(4) * boost::unit_test::fixture<testing::SyncProcessesFixture>())
 {
   TestSendReceiveFourProcesses<SocketCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>())
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::SyncProcessesFixture>())
 {
   TestSendReceiveTwoProcessesServerClient<SocketCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient,
-                     * testing::MinRanks(4)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>())
+                     *testing::MinRanks(4) * boost::unit_test::fixture<testing::SyncProcessesFixture>())
 {
   TestSendReceiveFourProcessesServerClient<SocketCommunication>();
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2,
-                     * testing::MinRanks(4)
-                     * boost::unit_test::fixture<testing::SyncProcessesFixture>())
+                     *testing::MinRanks(4) * boost::unit_test::fixture<testing::SyncProcessesFixture>())
 {
   TestSendReceiveFourProcessesServerClientV2<SocketCommunication>();
 }
-
 
 BOOST_AUTO_TEST_SUITE_END() // Socket
 BOOST_AUTO_TEST_SUITE_END() // Communication

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -2,10 +2,10 @@
 #include <Eigen/Core>
 #include <limits>
 #include <sstream>
+#include "acceleration/Acceleration.hpp"
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "impl/ConvergenceMeasure.hpp"
-#include "acceleration/Acceleration.hpp"
 #include "io/TXTReader.hpp"
 #include "io/TXTWriter.hpp"
 #include "m2n/M2N.hpp"
@@ -16,10 +16,8 @@
 #include "utils/Helpers.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
+namespace precice {
+namespace cplscheme {
 
 BaseCouplingScheme::BaseCouplingScheme(
     double maxTime,
@@ -43,13 +41,13 @@ BaseCouplingScheme::BaseCouplingScheme(
       _validDigits(validDigits)
 {
   PRECICE_CHECK(not((maxTime != UNDEFINED_TIME) && (maxTime < 0.0)),
-        "Maximum time has to be larger than zero!");
+                "Maximum time has to be larger than zero!");
   PRECICE_CHECK(not((maxTimesteps != UNDEFINED_TIMESTEPS) && (maxTimesteps < 0)),
-        "Maximum timestep number has to be larger than zero!");
+                "Maximum timestep number has to be larger than zero!");
   PRECICE_CHECK(not((timestepLength != UNDEFINED_TIMESTEP_LENGTH) && (timestepLength < 0.0)),
-        "Timestep length has to be larger than zero!");
+                "Timestep length has to be larger than zero!");
   PRECICE_CHECK((_validDigits >= 1) && (_validDigits < 17),
-        "Valid digits of timestep length has to be between 1 and 16!");
+                "Valid digits of timestep length has to be between 1 and 16!");
 }
 
 BaseCouplingScheme::BaseCouplingScheme(
@@ -63,7 +61,7 @@ BaseCouplingScheme::BaseCouplingScheme(
     m2n::PtrM2N                   m2n,
     int                           maxIterations,
     constants::TimesteppingMethod dtMethod)
-  :   _firstParticipant(firstParticipant),
+    : _firstParticipant(firstParticipant),
       _secondParticipant(secondParticipant),
       _localParticipant(localParticipant),
       _eps(std::pow(10.0, -1 * validDigits)),
@@ -80,19 +78,19 @@ BaseCouplingScheme::BaseCouplingScheme(
       _validDigits(validDigits)
 {
   PRECICE_CHECK(not((maxTime != UNDEFINED_TIME) && (maxTime < 0.0)),
-        "Maximum time has to be larger than zero!");
+                "Maximum time has to be larger than zero!");
   PRECICE_CHECK(not((maxTimesteps != UNDEFINED_TIMESTEPS) && (maxTimesteps < 0)),
-        "Maximum timestep number has to be larger than zero!");
+                "Maximum timestep number has to be larger than zero!");
   PRECICE_CHECK(not((timestepLength != UNDEFINED_TIMESTEP_LENGTH) && (timestepLength < 0.0)),
-        "Timestep length has to be larger than zero!");
+                "Timestep length has to be larger than zero!");
   PRECICE_CHECK((_validDigits >= 1) && (_validDigits < 17),
-        "Valid digits of timestep length has to be between 1 and 16!");
+                "Valid digits of timestep length has to be between 1 and 16!");
   PRECICE_CHECK(_firstParticipant != _secondParticipant,
-        "First participant and second participant must have different names! Called from BaseCoupling.");
+                "First participant and second participant must have different names! Called from BaseCoupling.");
   if (dtMethod == constants::FIXED_DT) {
     PRECICE_CHECK(hasTimestepLength(),
-          "Timestep length value has to be given when the fixed timestep length method "
-          << "is chosen for an implicit coupling scheme!");
+                  "Timestep length value has to be given when the fixed timestep length method "
+                      << "is chosen for an implicit coupling scheme!");
   }
   if (localParticipant == _firstParticipant) {
     _doesFirstStep = true;
@@ -106,11 +104,11 @@ BaseCouplingScheme::BaseCouplingScheme(
     }
   } else {
     PRECICE_ERROR("Name of local participant \""
-          << localParticipant << "\" does not match any "
-          << "participant specified for the coupling scheme!");
+                  << localParticipant << "\" does not match any "
+                  << "participant specified for the coupling scheme!");
   }
   PRECICE_CHECK((maxIterations > 0) || (maxIterations == -1),
-        "Maximal iteration limit has to be larger than zero!");
+                "Maximal iteration limit has to be larger than zero!");
 }
 
 void BaseCouplingScheme::receiveAndSetDt()
@@ -308,7 +306,7 @@ void BaseCouplingScheme::setExtrapolationOrder(
     int order)
 {
   PRECICE_CHECK((order == 0) || (order == 1) || (order == 2),
-        "Extrapolation order has to be  0, 1, or 2!");
+                "Extrapolation order has to be  0, 1, or 2!");
   _extrapolationOrder = order;
 }
 
@@ -370,9 +368,9 @@ void BaseCouplingScheme::addComputedTime(
   // Check validness
   bool valid = math::greaterEquals(getThisTimestepRemainder(), 0.0, _eps);
   PRECICE_CHECK(valid, "The computed timestep length of "
-                   << timeToAdd << " exceeds the maximum timestep limit of "
-                   << _timestepLength - _computedTimestepPart + timeToAdd
-                   << " for this time step!");
+                           << timeToAdd << " exceeds the maximum timestep limit of "
+                           << _timestepLength - _computedTimestepPart + timeToAdd
+                           << " for this time step!");
 }
 
 bool BaseCouplingScheme::willDataBeExchanged(
@@ -590,8 +588,8 @@ void BaseCouplingScheme::setupConvergenceMeasures()
   PRECICE_TRACE();
   PRECICE_ASSERT(not doesFirstStep());
   PRECICE_CHECK(not _convergenceMeasures.empty(),
-        "At least one convergence measure has to be defined for "
-            << "an implicit coupling scheme!");
+                "At least one convergence measure has to be defined for "
+                    << "an implicit coupling scheme!");
   for (ConvergenceMeasure &convMeasure : _convergenceMeasures) {
     int dataID = convMeasure.data->getID();
     if ((getSendData(dataID) != nullptr)) {
@@ -619,11 +617,11 @@ void BaseCouplingScheme::addConvergenceMeasure(
     impl::PtrConvergenceMeasure measure)
 {
   ConvergenceMeasure convMeasure;
-  convMeasure.data     = std::move(data);
+  convMeasure.data         = std::move(data);
   convMeasure.couplingData = nullptr;
-  convMeasure.suffices = suffices;
-  convMeasure.level    = level;
-  convMeasure.measure  = std::move(measure);
+  convMeasure.suffices     = suffices;
+  convMeasure.level        = level;
+  convMeasure.measure      = std::move(measure);
   _convergenceMeasures.push_back(convMeasure);
   _firstResiduumNorm.push_back(0);
 }
@@ -869,5 +867,5 @@ bool BaseCouplingScheme::maxIterationsReached()
     return _iterationsCoarseOptimization == _maxIterations;
   }
 }
-}
-} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -6,16 +6,14 @@
 #include "CouplingData.hpp"
 #include "CouplingScheme.hpp"
 #include "SharedPointer.hpp"
-#include "impl/SharedPointer.hpp"
 #include "acceleration/SharedPointer.hpp"
+#include "impl/SharedPointer.hpp"
 #include "io/TXTTableWriter.hpp"
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
+namespace precice {
+namespace cplscheme {
 
 /**
  * @brief Abstract base class for standard coupling schemes.
@@ -45,8 +43,7 @@ namespace cplscheme
  * -# when the method isCouplingOngoing() returns false, call finalize() to
  *    stop the coupling scheme
  */
-class BaseCouplingScheme : public CouplingScheme
-{
+class BaseCouplingScheme : public CouplingScheme {
 public:
   BaseCouplingScheme(
       double maxTime,
@@ -581,5 +578,5 @@ private:
 
   int getVertexOffset(std::map<int, int> &vertexDistribution, int rank, int dim);
 };
-}
-} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -1,23 +1,21 @@
 #include "CompositionalCouplingScheme.hpp"
-#include "Constants.hpp"
 #include <limits>
+#include "Constants.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
 namespace cplscheme {
 
-void CompositionalCouplingScheme:: addCouplingScheme
-(
-  PtrCouplingScheme couplingScheme )
+void CompositionalCouplingScheme::addCouplingScheme(
+    PtrCouplingScheme couplingScheme)
 {
   PRECICE_TRACE();
   _couplingSchemes.emplace_back(couplingScheme);
 }
 
-void CompositionalCouplingScheme:: initialize
-(
-  double startTime,
-  int    startTimestep )
+void CompositionalCouplingScheme::initialize(
+    double startTime,
+    int    startTimestep)
 {
   PRECICE_TRACE(startTime, startTimestep);
   for (Scheme scheme : _couplingSchemes) {
@@ -26,7 +24,7 @@ void CompositionalCouplingScheme:: initialize
   determineActiveCouplingSchemes();
 }
 
-bool CompositionalCouplingScheme:: isInitialized() const
+bool CompositionalCouplingScheme::isInitialized() const
 {
   PRECICE_TRACE();
   bool isInitialized = true;
@@ -37,7 +35,7 @@ bool CompositionalCouplingScheme:: isInitialized() const
   return isInitialized;
 }
 
-void CompositionalCouplingScheme:: initializeData()
+void CompositionalCouplingScheme::initializeData()
 {
   PRECICE_TRACE();
   for (Scheme scheme : _couplingSchemes) {
@@ -45,10 +43,10 @@ void CompositionalCouplingScheme:: initializeData()
   }
 }
 
-void CompositionalCouplingScheme:: addComputedTime(double timeToAdd)
+void CompositionalCouplingScheme::addComputedTime(double timeToAdd)
 {
   PRECICE_TRACE(timeToAdd);
-  for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
+  for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
     if (not it->onHold) {
       it->scheme->addComputedTime(timeToAdd);
     }
@@ -56,12 +54,12 @@ void CompositionalCouplingScheme:: addComputedTime(double timeToAdd)
   _lastAddedTime += timeToAdd;
 }
 
-void CompositionalCouplingScheme:: advance()
+void CompositionalCouplingScheme::advance()
 {
   PRECICE_TRACE();
   bool moreSchemesToHandle = false;
   do {
-    for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
+    for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
       if (not it->onHold) {
         it->scheme->advance();
       }
@@ -77,7 +75,7 @@ void CompositionalCouplingScheme:: advance()
   _lastAddedTime = 0.0;
 }
 
-void CompositionalCouplingScheme:: finalize()
+void CompositionalCouplingScheme::finalize()
 {
   PRECICE_TRACE();
   for (Scheme scheme : _couplingSchemes) {
@@ -107,7 +105,7 @@ void CompositionalCouplingScheme:: finalize()
 //  return isUsed;
 //}
 
-std::vector<std::string> CompositionalCouplingScheme:: getCouplingPartners() const
+std::vector<std::string> CompositionalCouplingScheme::getCouplingPartners() const
 {
   PRECICE_TRACE();
   std::vector<std::string> partners;
@@ -123,7 +121,7 @@ bool CompositionalCouplingScheme::willDataBeExchanged(double lastSolverTimestepL
 {
   PRECICE_TRACE(lastSolverTimestepLength);
   bool willBeExchanged = false;
-  for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
+  for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
     if (not it->onHold) {
       willBeExchanged |= it->scheme->willDataBeExchanged(lastSolverTimestepLength);
     }
@@ -132,12 +130,12 @@ bool CompositionalCouplingScheme::willDataBeExchanged(double lastSolverTimestepL
   return willBeExchanged;
 }
 
-bool CompositionalCouplingScheme:: hasDataBeenExchanged() const
+bool CompositionalCouplingScheme::hasDataBeenExchanged() const
 {
   PRECICE_TRACE();
   bool hasBeenExchanged = false;
   // Question: Does it suffice to only check the active ones?
-  for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
+  for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
     if (not it->onHold) {
       hasBeenExchanged |= it->scheme->hasDataBeenExchanged();
     }
@@ -146,7 +144,7 @@ bool CompositionalCouplingScheme:: hasDataBeenExchanged() const
   return hasBeenExchanged;
 }
 
-double CompositionalCouplingScheme:: getTime() const
+double CompositionalCouplingScheme::getTime() const
 {
   PRECICE_TRACE();
   double time = std::numeric_limits<double>::max();
@@ -159,7 +157,7 @@ double CompositionalCouplingScheme:: getTime() const
   return time;
 }
 
-int CompositionalCouplingScheme:: getTimesteps() const
+int CompositionalCouplingScheme::getTimesteps() const
 {
   PRECICE_TRACE();
   int timesteps = std::numeric_limits<int>::max();
@@ -172,7 +170,7 @@ int CompositionalCouplingScheme:: getTimesteps() const
   return timesteps;
 }
 
-double CompositionalCouplingScheme:: getMaxTime() const
+double CompositionalCouplingScheme::getMaxTime() const
 {
   PRECICE_TRACE();
   double maxTime = 0.0;
@@ -183,7 +181,7 @@ double CompositionalCouplingScheme:: getMaxTime() const
   return maxTime;
 }
 
-int CompositionalCouplingScheme:: getMaxTimesteps() const
+int CompositionalCouplingScheme::getMaxTimesteps() const
 {
   PRECICE_TRACE();
   int maxTimesteps = 0;
@@ -204,7 +202,7 @@ int CompositionalCouplingScheme:: getMaxTimesteps() const
 //  return isSubiterating;
 //}
 
-bool CompositionalCouplingScheme:: hasTimestepLength() const
+bool CompositionalCouplingScheme::hasTimestepLength() const
 {
   PRECICE_TRACE();
   bool hasIt = false;
@@ -215,12 +213,12 @@ bool CompositionalCouplingScheme:: hasTimestepLength() const
   return hasIt;
 }
 
-double CompositionalCouplingScheme:: getTimestepLength() const
+double CompositionalCouplingScheme::getTimestepLength() const
 {
   PRECICE_TRACE();
   double timestepLength = std::numeric_limits<double>::max();
   for (Scheme scheme : _couplingSchemes) {
-    if (scheme.scheme->getTimestepLength() < timestepLength){
+    if (scheme.scheme->getTimestepLength() < timestepLength) {
       timestepLength = scheme.scheme->getTimestepLength();
     }
   }
@@ -228,13 +226,13 @@ double CompositionalCouplingScheme:: getTimestepLength() const
   return timestepLength;
 }
 
-double CompositionalCouplingScheme:: getThisTimestepRemainder() const
+double CompositionalCouplingScheme::getThisTimestepRemainder() const
 {
   PRECICE_TRACE();
   double maxRemainder = 0.0;
   for (Scheme scheme : _couplingSchemes) {
-    if (not scheme.onHold){
-      if (scheme.scheme->getThisTimestepRemainder() > maxRemainder){
+    if (not scheme.onHold) {
+      if (scheme.scheme->getThisTimestepRemainder() > maxRemainder) {
         maxRemainder = scheme.scheme->getThisTimestepRemainder();
       }
     }
@@ -243,7 +241,7 @@ double CompositionalCouplingScheme:: getThisTimestepRemainder() const
   return maxRemainder;
 }
 
-double CompositionalCouplingScheme:: getComputedTimestepPart() const
+double CompositionalCouplingScheme::getComputedTimestepPart() const
 {
   PRECICE_TRACE();
   double timestepPart = std::numeric_limits<double>::max();
@@ -256,7 +254,7 @@ double CompositionalCouplingScheme:: getComputedTimestepPart() const
   return timestepPart;
 }
 
-double CompositionalCouplingScheme:: getNextTimestepMaxLength() const
+double CompositionalCouplingScheme::getNextTimestepMaxLength() const
 {
   PRECICE_TRACE();
   double maxLength = std::numeric_limits<double>::max();
@@ -269,7 +267,7 @@ double CompositionalCouplingScheme:: getNextTimestepMaxLength() const
   return maxLength;
 }
 
-bool CompositionalCouplingScheme:: isCouplingOngoing() const
+bool CompositionalCouplingScheme::isCouplingOngoing() const
 {
   PRECICE_TRACE();
   bool isOngoing = false;
@@ -280,7 +278,7 @@ bool CompositionalCouplingScheme:: isCouplingOngoing() const
   return isOngoing;
 }
 
-bool CompositionalCouplingScheme:: isCouplingTimestepComplete() const
+bool CompositionalCouplingScheme::isCouplingTimestepComplete() const
 {
   PRECICE_TRACE();
   bool isComplete = true;
@@ -291,9 +289,8 @@ bool CompositionalCouplingScheme:: isCouplingTimestepComplete() const
   return isComplete;
 }
 
-bool CompositionalCouplingScheme:: isActionRequired
-(
-  const std::string& actionName) const
+bool CompositionalCouplingScheme::isActionRequired(
+    const std::string &actionName) const
 {
   PRECICE_TRACE(actionName);
   bool isRequired = false;
@@ -306,9 +303,8 @@ bool CompositionalCouplingScheme:: isActionRequired
   return isRequired;
 }
 
-void CompositionalCouplingScheme:: performedAction
-(
-  const std::string& actionName)
+void CompositionalCouplingScheme::performedAction(
+    const std::string &actionName)
 {
   PRECICE_TRACE(actionName);
   for (Scheme scheme : _couplingSchemes) {
@@ -318,10 +314,8 @@ void CompositionalCouplingScheme:: performedAction
   }
 }
 
-
-void CompositionalCouplingScheme:: requireAction
-(
-  const std::string& actionName )
+void CompositionalCouplingScheme::requireAction(
+    const std::string &actionName)
 {
   PRECICE_TRACE(actionName);
   for (Scheme scheme : _couplingSchemes) {
@@ -329,12 +323,12 @@ void CompositionalCouplingScheme:: requireAction
   }
 }
 
-std::string CompositionalCouplingScheme:: printCouplingState() const
+std::string CompositionalCouplingScheme::printCouplingState() const
 {
-  std::string state;
+  std::string              state;
   std::vector<std::string> partners;
   for (Scheme scheme : _couplingSchemes) {
-    if (not state.empty()){
+    if (not state.empty()) {
       state += "\n";
     }
     partners = scheme.scheme->getCouplingPartners();
@@ -345,10 +339,9 @@ std::string CompositionalCouplingScheme:: printCouplingState() const
   return state;
 }
 
-void CompositionalCouplingScheme:: sendState
-(
-  com::PtrCommunication communication,
-  int                   rankReceiver )
+void CompositionalCouplingScheme::sendState(
+    com::PtrCommunication communication,
+    int                   rankReceiver)
 {
   PRECICE_TRACE();
   for (Scheme scheme : _couplingSchemes) {
@@ -356,10 +349,9 @@ void CompositionalCouplingScheme:: sendState
   }
 }
 
-void CompositionalCouplingScheme:: receiveState
-(
-  com::PtrCommunication communication,
-  int                   rankSender )
+void CompositionalCouplingScheme::receiveState(
+    com::PtrCommunication communication,
+    int                   rankSender)
 {
   PRECICE_TRACE();
   for (Scheme scheme : _couplingSchemes) {
@@ -367,23 +359,22 @@ void CompositionalCouplingScheme:: receiveState
   }
 }
 
-bool CompositionalCouplingScheme:: determineActiveCouplingSchemes()
+bool CompositionalCouplingScheme::determineActiveCouplingSchemes()
 {
   PRECICE_TRACE();
-  bool newActiveSchemes = false;
-  std::string writeCheckpoint = constants::actionWriteIterationCheckpoint();
-  std::string readCheckpoint = constants::actionReadIterationCheckpoint();
-  if (_activeSchemesBegin == _activeSchemesEnd){
+  bool        newActiveSchemes = false;
+  std::string writeCheckpoint  = constants::actionWriteIterationCheckpoint();
+  std::string readCheckpoint   = constants::actionReadIterationCheckpoint();
+  if (_activeSchemesBegin == _activeSchemesEnd) {
     PRECICE_DEBUG("Case After Init");
     // First call after initialization of all coupling schemes. All coupling
     // schemes are set active up to (but not including) the first explicit
     // scheme after an implicit scheme.
     _activeSchemesBegin = _couplingSchemes.begin();
-    _activeSchemesEnd = _couplingSchemes.begin();
+    _activeSchemesEnd   = _couplingSchemes.begin();
     advanceActiveCouplingSchemes();
     newActiveSchemes = true;
-  }
-  else {
+  } else {
     PRECICE_DEBUG("Normal Case");
     // Redetermine active schemes. First, all preceding explicit schemes are
     // removed. Then, all remaining implicit schemes are checked for the
@@ -392,52 +383,47 @@ bool CompositionalCouplingScheme:: determineActiveCouplingSchemes()
     // is determined.
 
     // Remove preceding explicit schemes
-    while (_activeSchemesBegin != _activeSchemesEnd){
+    while (_activeSchemesBegin != _activeSchemesEnd) {
       bool explicitScheme = true;
       explicitScheme &= not _activeSchemesBegin->scheme->isActionRequired(writeCheckpoint);
       explicitScheme &= not _activeSchemesBegin->scheme->isActionRequired(readCheckpoint);
       if (explicitScheme) {
         _activeSchemesBegin++;
         PRECICE_DEBUG("Remove preceding explicit scheme");
-      }
-      else {
+      } else {
         break;
       }
     }
 
     // Check implicit schemes for convergence and remove if converged
     bool converged = true;
-    for (SchemesIt it=_activeSchemesBegin; it != _activeSchemesEnd; it++){
-      if (it->scheme->isActionRequired(readCheckpoint)){
+    for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
+      if (it->scheme->isActionRequired(readCheckpoint)) {
         converged = false;
         PRECICE_DEBUG("Non converged implicit scheme");
-      }
-      else if (it->scheme->isActionRequired(writeCheckpoint)
-               || not it->scheme->isCouplingOngoing())
-      {
+      } else if (it->scheme->isActionRequired(writeCheckpoint) || not it->scheme->isCouplingOngoing()) {
         it->onHold = true;
         PRECICE_DEBUG("Put converged/finished implicit scheme on hold");
       }
     }
     if (converged) {
       PRECICE_DEBUG("Active implicit schemes converged");
-      for (SchemesIt it=_activeSchemesBegin; it != _activeSchemesEnd; it++){
+      for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
         it->onHold = false;
       }
       _activeSchemesBegin = _activeSchemesEnd;
     }
 
     // Determine next set of active schemes if current is empty
-    if (_activeSchemesBegin == _activeSchemesEnd){
-      if (_activeSchemesBegin == _couplingSchemes.end()){
+    if (_activeSchemesBegin == _activeSchemesEnd) {
+      if (_activeSchemesBegin == _couplingSchemes.end()) {
         PRECICE_DEBUG("Through with all coupling schemes");
         // All coupling schemes are through
         _activeSchemesBegin = _couplingSchemes.begin();
-        _activeSchemesEnd = _couplingSchemes.begin();
+        _activeSchemesEnd   = _couplingSchemes.begin();
         advanceActiveCouplingSchemes();
         // newActiveSchemes stays false, since the current it/dt is complete
-      }
-      else {
+      } else {
         PRECICE_DEBUG("Coupling schemes remaining");
         advanceActiveCouplingSchemes();
         newActiveSchemes = true;
@@ -448,17 +434,17 @@ bool CompositionalCouplingScheme:: determineActiveCouplingSchemes()
   return newActiveSchemes;
 }
 
-void CompositionalCouplingScheme:: advanceActiveCouplingSchemes()
+void CompositionalCouplingScheme::advanceActiveCouplingSchemes()
 {
   PRECICE_TRACE();
   std::string writeCheckpoint = constants::actionWriteIterationCheckpoint();
-  bool iterating = false;
-  while (_activeSchemesEnd != _couplingSchemes.end()){
-    if (_activeSchemesEnd->scheme->isActionRequired(writeCheckpoint)){
+  bool        iterating       = false;
+  while (_activeSchemesEnd != _couplingSchemes.end()) {
+    if (_activeSchemesEnd->scheme->isActionRequired(writeCheckpoint)) {
       PRECICE_DEBUG("Found implicit scheme");
       iterating = true;
     }
-    if (iterating && (not _activeSchemesEnd->scheme->isActionRequired(writeCheckpoint))){
+    if (iterating && (not _activeSchemesEnd->scheme->isActionRequired(writeCheckpoint))) {
       PRECICE_DEBUG("Found explicit scheme after implicit scheme");
       break;
     }
@@ -468,7 +454,8 @@ void CompositionalCouplingScheme:: advanceActiveCouplingSchemes()
   PRECICE_ASSERT(_activeSchemesBegin != _activeSchemesEnd);
 }
 
-}} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice
 
 //#include "CompositionalCouplingScheme.hpp"
 //#include "Constants.hpp"
@@ -1002,4 +989,3 @@ void CompositionalCouplingScheme:: advanceActiveCouplingSchemes()
 //}
 //
 //}} // namespace precice, cplscheme
-

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "CouplingScheme.hpp"
 #include "Constants.hpp"
+#include "CouplingScheme.hpp"
 #include "SharedPointer.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 
-#include <vector>
 #include <list>
+#include <vector>
 
 namespace precice {
 namespace cplscheme {
@@ -54,10 +54,8 @@ namespace cplscheme {
  * on how the participants are configured to be first and second in the schemes.
  * If not configured properly, a deadlock might be created.
  */
-class CompositionalCouplingScheme : public CouplingScheme
-{
+class CompositionalCouplingScheme : public CouplingScheme {
 public:
-
   /// Destructor, empty.
   virtual ~CompositionalCouplingScheme() {}
 
@@ -77,9 +75,9 @@ public:
    * @brief Initializes the coupling scheme and establishes a communiation
    *        connection to the coupling partner.
    */
-  virtual void initialize (
-    double startTime,
-    int    startTimesteps );
+  virtual void initialize(
+      double startTime,
+      int    startTimesteps);
 
   /// Returns true, if initialize has been called.
   virtual bool isInitialized() const;
@@ -213,13 +211,13 @@ public:
    *
    * True, if any of the composed coupling schemes requires the action.
    */
-  virtual bool isActionRequired(const std::string& actionName) const;
+  virtual bool isActionRequired(const std::string &actionName) const;
 
   /// Tells the coupling scheme that the accessor has performed the given action.
-  virtual void performedAction(const std::string& actionName);
+  virtual void performedAction(const std::string &actionName);
 
   /// Sets an action required to be performed by the accessor.
-  virtual void requireAction(const std::string& actionName);
+  virtual void requireAction(const std::string &actionName);
 
   /// Returns a string representation of the current coupling state.
   virtual std::string printCouplingState() const;
@@ -232,9 +230,9 @@ public:
    * is transferred between the solver coupling scheme and the server coupling
    * scheme via sendState and receiveState.
    */
-  virtual void sendState (
-   com::PtrCommunication communication,
-   int                   rankReceiver );
+  virtual void sendState(
+      com::PtrCommunication communication,
+      int                   rankReceiver);
 
   /**
    * @brief Receive the state of the coupling scheme from another remote scheme.
@@ -244,16 +242,16 @@ public:
    * is transferred between the solver coupling scheme and the server coupling
    * scheme via sendState and receiveState.
    */
-  virtual void receiveState (
-   com::PtrCommunication communication,
-   int                   rankSender );
+  virtual void receiveState(
+      com::PtrCommunication communication,
+      int                   rankSender);
 
 private:
   mutable logging::Logger _log{"cplscheme::CompositionalCouplingScheme"};
 
   /// Groups a coupling scheme with additional associated variables.
   struct Scheme {
-    
+
     /// The actual coupling scheme
     PtrCouplingScheme scheme;
 
@@ -268,10 +266,10 @@ private:
     bool onHold;
 
     Scheme(PtrCouplingScheme scheme)
-    : scheme(scheme), onHold(false) {}
+        : scheme(scheme), onHold(false) {}
   };
 
-  typedef std::list<Scheme> Schemes;
+  typedef std::list<Scheme>           Schemes;
   typedef std::list<Scheme>::iterator SchemesIt;
   //typedef std::list<PtrCouplingScheme>::const_iterator ConstSchemesIt;
 
@@ -284,7 +282,7 @@ private:
   SchemesIt _activeSchemesBegin = _couplingSchemes.end();
 
   /// Iterator to behind the end of coupling schemes currently active.
-  SchemesIt _activeSchemesEnd  = _couplingSchemes.end();
+  SchemesIt _activeSchemesEnd = _couplingSchemes.end();
 
   /// Stores time added since last call of advance.
   double _lastAddedTime = 0;
@@ -307,4 +305,5 @@ private:
   void advanceActiveCouplingSchemes();
 };
 
-}} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/Constants.cpp
+++ b/src/cplscheme/Constants.cpp
@@ -4,22 +4,24 @@ namespace precice {
 namespace cplscheme {
 namespace constants {
 
-const std::string& actionWriteIterationCheckpoint ()
+const std::string &actionWriteIterationCheckpoint()
 {
-  static std::string actionWriteIterationCheckpoint ( "write-iteration-checkpoint" );
+  static std::string actionWriteIterationCheckpoint("write-iteration-checkpoint");
   return actionWriteIterationCheckpoint;
 }
 
-const std::string& actionReadIterationCheckpoint ()
+const std::string &actionReadIterationCheckpoint()
 {
-  static std::string actionReadIterationCheckpoint ( "read-iteration-checkpoint" );
+  static std::string actionReadIterationCheckpoint("read-iteration-checkpoint");
   return actionReadIterationCheckpoint;
 }
 
-const std::string& actionWriteInitialData ()
+const std::string &actionWriteInitialData()
 {
-  static std::string actionWriteInitialData ( "write-initial-data" );
+  static std::string actionWriteInitialData("write-initial-data");
   return actionWriteInitialData;
 }
 
-}}} // namespace precice, cplscheme, constants
+} // namespace constants
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/Constants.hpp
+++ b/src/cplscheme/Constants.hpp
@@ -6,17 +6,17 @@ namespace precice {
 namespace cplscheme {
 namespace constants {
 
-const std::string& actionWriteIterationCheckpoint();
+const std::string &actionWriteIterationCheckpoint();
 
-const std::string& actionReadIterationCheckpoint();
+const std::string &actionReadIterationCheckpoint();
 
-const std::string& actionWriteInitialData();
+const std::string &actionWriteInitialData();
 
-enum TimesteppingMethod
-{
+enum TimesteppingMethod {
   FIXED_DT,
   FIRST_PARTICIPANT_SETS_DT
 };
 
-
-}}} // namespace precice, cplscheme, constants
+} // namespace constants
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
+#include <Eigen/Core>
+#include "mesh/Data.hpp"
 #include "mesh/SharedPointer.hpp"
 #include "utils/assertion.hpp"
-#include "mesh/Data.hpp"
-#include <Eigen/Core>
 
 namespace precice {
 namespace cplscheme {
 
-struct CouplingData
-{
+struct CouplingData {
   using DataMatrix = Eigen::MatrixXd;
 
   /// Data values of current iteration.
-  Eigen::VectorXd* values;
+  Eigen::VectorXd *values;
 
   /// Data values of previous iteration (1st col) and previous timesteps.
   DataMatrix oldValues;
@@ -31,25 +30,25 @@ struct CouplingData
    *
    * Necessary when compiler creates template code for std::map::operator[].
    */
-  CouplingData ()
-    {
-      PRECICE_ASSERT( false );
-    }
+  CouplingData()
+  {
+    PRECICE_ASSERT(false);
+  }
 
-  CouplingData (
-    Eigen::VectorXd*  values,
-    mesh::PtrMesh     mesh,
-    bool              initialize,
-    int               dimension)
-    :
-    values ( values ),
-    mesh(mesh),
-    initialize ( initialize ),
-    dimension(dimension)
-    {
-      PRECICE_ASSERT( values != NULL );
-      PRECICE_ASSERT( mesh.use_count()>0);
-    }
+  CouplingData(
+      Eigen::VectorXd *values,
+      mesh::PtrMesh    mesh,
+      bool             initialize,
+      int              dimension)
+      : values(values),
+        mesh(mesh),
+        initialize(initialize),
+        dimension(dimension)
+  {
+    PRECICE_ASSERT(values != NULL);
+    PRECICE_ASSERT(mesh.use_count() > 0);
+  }
 };
 
-}} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/CouplingScheme.cpp
+++ b/src/cplscheme/CouplingScheme.cpp
@@ -3,10 +3,11 @@
 namespace precice {
 namespace cplscheme {
 
-const double CouplingScheme:: UNDEFINED_TIME = -1.0;
+const double CouplingScheme::UNDEFINED_TIME = -1.0;
 
-const int CouplingScheme:: UNDEFINED_TIMESTEPS = -1;
+const int CouplingScheme::UNDEFINED_TIMESTEPS = -1;
 
-const double CouplingScheme:: UNDEFINED_TIMESTEP_LENGTH = -1.0;
+const double CouplingScheme::UNDEFINED_TIMESTEP_LENGTH = -1.0;
 
-}} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "com/SharedPointer.hpp"
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
+#include "com/SharedPointer.hpp"
 
 namespace precice {
 namespace cplscheme {
@@ -36,10 +36,8 @@ namespace cplscheme {
  * -# when the method isCouplingOngoing() returns false, call finalize() to
  *    stop the coupling scheme
  */
-class CouplingScheme
-{
+class CouplingScheme {
 public:
-
   /// Does not define a time limit for the coupled simulation.
   static const double UNDEFINED_TIME;
 
@@ -49,7 +47,7 @@ public:
   /// To be used, when the coupling timestep length is determined dynamically during the coupling.
   static const double UNDEFINED_TIMESTEP_LENGTH;
 
-  CouplingScheme& operator=(CouplingScheme &&) = delete;
+  CouplingScheme &operator=(CouplingScheme &&) = delete;
 
   virtual ~CouplingScheme() {}
 
@@ -57,12 +55,12 @@ public:
    * @brief Initializes the coupling scheme and establishes a communiation
    *        connection to the coupling partner.
    */
-  virtual void initialize (
-    double startTime,
-    int    startTimesteps ) =0;
+  virtual void initialize(
+      double startTime,
+      int    startTimesteps) = 0;
 
   /// Returns true, if initialize has been called.
-  virtual bool isInitialized() const =0;
+  virtual bool isInitialized() const = 0;
 
   /**
    * @brief Initializes the data for first implicit coupling scheme iteration.
@@ -77,10 +75,10 @@ public:
    * advance(). The second participant has to write the initial data values
    * to preCICE after initialize() and before initializeData().
    */
-  virtual void initializeData() =0;
+  virtual void initializeData() = 0;
 
   /// @brief Adds newly computed time. Has to be called before every advance.
-  virtual void addComputedTime(double timeToAdd) =0;
+  virtual void addComputedTime(double timeToAdd) = 0;
 
   /**
    * @brief Exchanges data and updates the state of the coupling scheme.
@@ -89,13 +87,13 @@ public:
    *
    * Does not necessarily advances in time.
    */
-  virtual void advance() =0;
+  virtual void advance() = 0;
 
   /// Finalizes the coupling and disconnects communication.
-  virtual void finalize() =0;
+  virtual void finalize() = 0;
 
   /// Returns list of all coupling partners.
-  virtual std::vector<std::string> getCouplingPartners() const =0;
+  virtual std::vector<std::string> getCouplingPartners() const = 0;
 
   /*
    * @brief Returns true, if data will be exchanged when calling advance().
@@ -106,23 +104,23 @@ public:
    * @param lastSolverTimestepLength [IN] The length of the last timestep
    *        computed by the solver calling willDataBeExchanged().
    */
-  virtual bool willDataBeExchanged(double lastSolverTimestepLength) const =0;
+  virtual bool willDataBeExchanged(double lastSolverTimestepLength) const = 0;
 
   /// @brief Returns true, if data has been exchanged in last call of advance().
   /// actually, this only means that data has been received, data is always sent
-  virtual bool hasDataBeenExchanged() const =0;
+  virtual bool hasDataBeenExchanged() const = 0;
 
   /// Returns the currently computed time of the coupling scheme.
-  virtual double getTime() const =0;
+  virtual double getTime() const = 0;
 
   /// Returns the currently computed timesteps of the coupling scheme.
-  virtual int getTimesteps() const =0;
+  virtual int getTimesteps() const = 0;
 
   /// Returns the maximal time to be computed.
-  virtual double getMaxTime() const =0;
+  virtual double getMaxTime() const = 0;
 
   /// Returns the maximal timesteps to be computed.
-  virtual int getMaxTimesteps() const =0;
+  virtual int getMaxTimesteps() const = 0;
 
   //
   // @brief Returns current subiteration number in timestep.
@@ -130,7 +128,7 @@ public:
   //virtual int getSubIteration() const =0;
 
   /// Returns true, if timestep length is prescribed by the cpl scheme.
-  virtual bool hasTimestepLength() const =0;
+  virtual bool hasTimestepLength() const = 0;
 
   /**
    * @brief Returns the timestep length, if one is given by the coupling scheme.
@@ -138,8 +136,7 @@ public:
    * An assertion is thrown, if no valid timestep is given. Check with
    * hasTimestepLength().
    */
-  virtual double getTimestepLength() const =0;
-
+  virtual double getTimestepLength() const = 0;
 
   /// Defaults to false, i.e., no multilevel PP
   virtual bool isCoarseModelOptimizationActive()
@@ -156,10 +153,10 @@ public:
    * If no timestep length is precribed by the coupling scheme, always 0.0 is
    * returned.
    */
-  virtual double getThisTimestepRemainder() const =0;
+  virtual double getThisTimestepRemainder() const = 0;
 
   /// Returns part of the current timestep that has been computed already.
-  virtual double getComputedTimestepPart() const =0;
+  virtual double getComputedTimestepPart() const = 0;
 
   /**
    * @brief Returns the maximal length of the next timestep to be computed.
@@ -167,7 +164,7 @@ public:
    * If no timestep length is prescribed by the coupling scheme, always the
    * maximal double accuracy floating point number value is returned.
    */
-  virtual double getNextTimestepMaxLength() const =0;
+  virtual double getNextTimestepMaxLength() const = 0;
 
   //
   // @brief Returns the number of valid digits when compare times.
@@ -175,22 +172,22 @@ public:
   //virtual int getValidDigits() const =0;
 
   /// Returns true, when the coupled simulation is still ongoing.
-  virtual bool isCouplingOngoing() const =0;
+  virtual bool isCouplingOngoing() const = 0;
 
   /// Returns true, when the accessor can advance to the next timestep.
-  virtual bool isCouplingTimestepComplete() const =0;
+  virtual bool isCouplingTimestepComplete() const = 0;
 
   /// Returns true, if the given action has to be performed by the accessor.
-  virtual bool isActionRequired(const std::string& actionName) const =0;
+  virtual bool isActionRequired(const std::string &actionName) const = 0;
 
   /// Tells the coupling scheme that the accessor has performed the given action.
-  virtual void performedAction(const std::string& actionName) =0;
+  virtual void performedAction(const std::string &actionName) = 0;
 
   /// Sets an action required to be performed by the accessor.
-  virtual void requireAction(const std::string& actionName) =0;
+  virtual void requireAction(const std::string &actionName) = 0;
 
   /// Returns a string representation of the current coupling state.
-  virtual std::string printCouplingState() const =0;
+  virtual std::string printCouplingState() const = 0;
 
   /**
    * @brief Send the state of the coupling scheme to another remote scheme.
@@ -200,9 +197,9 @@ public:
    * is transferred between the solver coupling scheme and the server coupling
    * scheme via sendState and receiveState.
    */
-  virtual void sendState (
-    com::PtrCommunication communication,
-    int                   rankReceiver ) =0;
+  virtual void sendState(
+      com::PtrCommunication communication,
+      int                   rankReceiver) = 0;
 
   /**
    * @brief Receive the state of the coupling scheme from another remote scheme.
@@ -212,11 +209,10 @@ public:
    * is transferred between the solver coupling scheme and the server coupling
    * scheme via sendState and receiveState.
    */
-  virtual void receiveState (
-    com::PtrCommunication communication,
-    int                   rankSender ) =0;
-
+  virtual void receiveState(
+      com::PtrCommunication communication,
+      int                   rankSender) = 0;
 };
 
-}} // namespace precice, cplscheme
-
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -1,32 +1,30 @@
 #include "MultiCouplingScheme.hpp"
 #include "acceleration/Acceleration.hpp"
+#include "m2n/M2N.hpp"
+#include "m2n/SharedPointer.hpp"
+#include "math/math.hpp"
 #include "mesh/Mesh.hpp"
 #include "utils/EigenHelperFunctions.hpp"
-#include "utils/MasterSlave.hpp"
-#include "m2n/SharedPointer.hpp"
-#include "m2n/M2N.hpp"
-#include "math/math.hpp"
 #include "utils/Helpers.hpp"
+#include "utils/MasterSlave.hpp"
 
 namespace precice {
 namespace cplscheme {
 
-MultiCouplingScheme::MultiCouplingScheme
-(
-  double                maxTime,
-  int                   maxTimesteps,
-  double                timestepLength,
-  int                   validDigits,
-  const std::string&    localParticipant,
-  std::vector<m2n::PtrM2N> communications,
-  constants::TimesteppingMethod dtMethod,
-  int                   maxIterations)
-  :
-  BaseCouplingScheme(maxTime,maxTimesteps,timestepLength,validDigits,"neverFirstParticipant",
-      localParticipant,localParticipant,m2n::PtrM2N(),maxIterations,dtMethod),
-  _communications(communications)
+MultiCouplingScheme::MultiCouplingScheme(
+    double                        maxTime,
+    int                           maxTimesteps,
+    double                        timestepLength,
+    int                           validDigits,
+    const std::string &           localParticipant,
+    std::vector<m2n::PtrM2N>      communications,
+    constants::TimesteppingMethod dtMethod,
+    int                           maxIterations)
+    : BaseCouplingScheme(maxTime, maxTimesteps, timestepLength, validDigits, "neverFirstParticipant",
+                         localParticipant, localParticipant, m2n::PtrM2N(), maxIterations, dtMethod),
+      _communications(communications)
 {
-  for(size_t i = 0; i < _communications.size(); ++i) {
+  for (size_t i = 0; i < _communications.size(); ++i) {
     DataMap receiveMap;
     DataMap sendMap;
     _receiveDataVector.push_back(receiveMap);
@@ -34,10 +32,9 @@ MultiCouplingScheme::MultiCouplingScheme
   }
 }
 
-void MultiCouplingScheme::initialize
-(
-  double startTime,
-  int    startTimestep )
+void MultiCouplingScheme::initialize(
+    double startTime,
+    int    startTimestep)
 {
   PRECICE_TRACE(startTime, startTimestep);
   PRECICE_ASSERT(not isInitialized());
@@ -46,32 +43,29 @@ void MultiCouplingScheme::initialize
   setTime(startTime);
   setTimesteps(startTimestep);
 
-
-  mergeData(); // merge send and receive data for all pp calls
-  setupConvergenceMeasures(); // needs _couplingData configured
+  mergeData();                 // merge send and receive data for all pp calls
+  setupConvergenceMeasures();  // needs _couplingData configured
   setupDataMatrices(_allData); // Reserve memory and initialize data with zero
   if (getAcceleration().get() != nullptr) {
-    PRECICE_CHECK(getAcceleration()->getDataIDs().size()>=3,
-          "For parallel coupling, the number of coupling data vectors has to be at least 3, not: "
-          << getAcceleration()->getDataIDs().size());
+    PRECICE_CHECK(getAcceleration()->getDataIDs().size() >= 3,
+                  "For parallel coupling, the number of coupling data vectors has to be at least 3, not: "
+                      << getAcceleration()->getDataIDs().size());
     getAcceleration()->initialize(_allData); // Reserve memory, initialize
   }
-
 
   requireAction(constants::actionWriteIterationCheckpoint());
   initializeTXTWriters();
 
-
-  for (DataMap& dataMap : _sendDataVector) {
-    for (DataMap::value_type & pair : dataMap) {
+  for (DataMap &dataMap : _sendDataVector) {
+    for (DataMap::value_type &pair : dataMap) {
       if (pair.second->initialize) {
         setHasToSendInitData(true);
         break;
       }
     }
   }
-  for (DataMap& dataMap : _receiveDataVector) {
-    for (DataMap::value_type & pair : dataMap) {
+  for (DataMap &dataMap : _receiveDataVector) {
+    for (DataMap::value_type &pair : dataMap) {
       if (pair.second->initialize) {
         setHasToReceiveInitData(true);
         break;
@@ -96,20 +90,19 @@ void MultiCouplingScheme::initializeData()
     return;
   }
 
-  PRECICE_CHECK(not (hasToSendInitData() && isActionRequired(constants::actionWriteInitialData())),
-        "InitialData has to be written to preCICE before calling initializeData()");
+  PRECICE_CHECK(not(hasToSendInitData() && isActionRequired(constants::actionWriteInitialData())),
+                "InitialData has to be written to preCICE before calling initializeData()");
 
   setHasDataBeenExchanged(false);
-
 
   if (hasToReceiveInitData()) {
     receiveData();
     setHasDataBeenExchanged(true);
 
     // second participant has to save values for extrapolation
-    if (getExtrapolationOrder() > 0){
-      for (DataMap& dataMap : _receiveDataVector) {
-        for (DataMap::value_type & pair : dataMap){
+    if (getExtrapolationOrder() > 0) {
+      for (DataMap &dataMap : _receiveDataVector) {
+        for (DataMap::value_type &pair : dataMap) {
           pair.second->oldValues.col(0) = *pair.second->values;
           // For extrapolation, treat the initial value as old timestep value
           utils::shiftSetFirst(pair.second->oldValues, *pair.second->values);
@@ -119,8 +112,8 @@ void MultiCouplingScheme::initializeData()
   }
   if (hasToSendInitData()) {
     if (getExtrapolationOrder() > 0) {
-      for (DataMap& dataMap : _sendDataVector) {
-        for (DataMap::value_type & pair : dataMap) {
+      for (DataMap &dataMap : _sendDataVector) {
+        for (DataMap::value_type &pair : dataMap) {
           pair.second->oldValues.col(0) = *pair.second->values;
           // For extrapolation, treat the initial value as old timestep value
           utils::shiftSetFirst(pair.second->oldValues, *pair.second->values);
@@ -129,7 +122,6 @@ void MultiCouplingScheme::initializeData()
     }
     sendData();
   }
-
 
   // in order to check in advance if initializeData has been called (if necessary)
   setHasToSendInitData(false);
@@ -142,7 +134,7 @@ void MultiCouplingScheme::advance()
   checkCompletenessRequiredActions();
 
   PRECICE_CHECK(!hasToReceiveInitData() && !hasToSendInitData(),
-        "initializeData() needs to be called before advance if data has to be initialized!");
+                "initializeData() needs to be called before advance if data has to be initialized!");
 
   setHasDataBeenExchanged(false);
   setIsCouplingTimestepComplete(false);
@@ -153,7 +145,7 @@ void MultiCouplingScheme::advance()
     receiveData();
 
     auto designSpecifications = getAcceleration()->getDesignSpecification(_allData);
-    convergence = measureConvergence(designSpecifications);
+    convergence               = measureConvergence(designSpecifications);
 
     // Stop, when maximal iteration count (given in config) is reached
     if (maxIterationsReached()) {
@@ -165,8 +157,7 @@ void MultiCouplingScheme::advance()
       }
       newConvergenceMeasurements();
       timestepCompleted();
-    }
-    else if (getAcceleration().get() != nullptr) {
+    } else if (getAcceleration().get() != nullptr) {
       getAcceleration()->performAcceleration(_allData);
     }
 
@@ -176,12 +167,11 @@ void MultiCouplingScheme::advance()
       m2n->send(_isCoarseModelOptimizationActive); //need to do this to match with ParallelCplScheme
     }
 
-    if (convergence && (getExtrapolationOrder() > 0)){
+    if (convergence && (getExtrapolationOrder() > 0)) {
       extrapolateData(_allData); // Also stores data
-    }
-    else { // Store data for conv. measurement, acceleration, or extrapolation
-      for (DataMap::value_type& pair : _allData) {
-        if (pair.second->oldValues.size() > 0){
+    } else {                     // Store data for conv. measurement, acceleration, or extrapolation
+      for (DataMap::value_type &pair : _allData) {
+        if (pair.second->oldValues.size() > 0) {
           pair.second->oldValues.col(0) = *pair.second->values;
         }
       }
@@ -191,8 +181,7 @@ void MultiCouplingScheme::advance()
     if (not convergence) {
       PRECICE_DEBUG("No convergence achieved");
       requireAction(constants::actionReadIterationCheckpoint());
-    }
-    else {
+    } else {
       PRECICE_DEBUG("Convergence achieved");
       advanceTXTWriters();
     }
@@ -202,69 +191,62 @@ void MultiCouplingScheme::advance()
   } // subcycling complete
 }
 
-
-
-
 void MultiCouplingScheme::mergeData()
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(_allData.empty(), "This function should only be called once.");
-  PRECICE_ASSERT(_sendDataVector.size()==_receiveDataVector.size());
-  for(size_t i=0;i<_sendDataVector.size();i++){
+  PRECICE_ASSERT(_sendDataVector.size() == _receiveDataVector.size());
+  for (size_t i = 0; i < _sendDataVector.size(); i++) {
     _allData.insert(_sendDataVector[i].begin(), _sendDataVector[i].end());
     _allData.insert(_receiveDataVector[i].begin(), _receiveDataVector[i].end());
   }
 }
 
-void MultiCouplingScheme:: addDataToSend
-(
-  mesh::PtrData data,
-  mesh::PtrMesh mesh,
-  bool          initialize,
-  int           index)
+void MultiCouplingScheme::addDataToSend(
+    mesh::PtrData data,
+    mesh::PtrMesh mesh,
+    bool          initialize,
+    int           index)
 {
   int id = data->getID();
-  if(! utils::contained(id, _sendDataVector[index])) {
-    PtrCouplingData ptrCplData (new CouplingData(& (data->values()), mesh, initialize, data->getDimensions()));
-    DataMap::value_type pair = std::make_pair (id, ptrCplData);
+  if (!utils::contained(id, _sendDataVector[index])) {
+    PtrCouplingData     ptrCplData(new CouplingData(&(data->values()), mesh, initialize, data->getDimensions()));
+    DataMap::value_type pair = std::make_pair(id, ptrCplData);
     _sendDataVector[index].insert(pair);
-  }
-  else {
+  } else {
     PRECICE_ERROR("Data \"" << data->getName()
-          << "\" of mesh \"" << mesh->getName() << "\" cannot be "
-          << "added twice for sending!");
+                            << "\" of mesh \"" << mesh->getName() << "\" cannot be "
+                            << "added twice for sending!");
   }
 }
 
-void MultiCouplingScheme:: addDataToReceive
-(
-  mesh::PtrData data,
-  mesh::PtrMesh mesh,
-  bool          initialize,
-  int           index)
+void MultiCouplingScheme::addDataToReceive(
+    mesh::PtrData data,
+    mesh::PtrMesh mesh,
+    bool          initialize,
+    int           index)
 {
   int id = data->getID();
-  if(! utils::contained(id, _receiveDataVector[index])) {
-    PtrCouplingData ptrCplData (new CouplingData(& (data->values()), mesh, initialize, data->getDimensions()));
-    DataMap::value_type pair = std::make_pair (id, ptrCplData);
+  if (!utils::contained(id, _receiveDataVector[index])) {
+    PtrCouplingData     ptrCplData(new CouplingData(&(data->values()), mesh, initialize, data->getDimensions()));
+    DataMap::value_type pair = std::make_pair(id, ptrCplData);
     _receiveDataVector[index].insert(pair);
-  }
-  else {
+  } else {
     PRECICE_ERROR("Data \"" << data->getName()
-          << "\" of mesh \"" << mesh->getName() << "\" cannot be "
-          << "added twice for receiving!");
+                            << "\" of mesh \"" << mesh->getName() << "\" cannot be "
+                            << "added twice for receiving!");
   }
 }
 
-void MultiCouplingScheme:: sendData()
+void MultiCouplingScheme::sendData()
 {
   PRECICE_TRACE();
 
-  for(size_t i=0;i<_communications.size();i++){
+  for (size_t i = 0; i < _communications.size(); i++) {
     PRECICE_ASSERT(_communications[i].get() != nullptr);
     PRECICE_ASSERT(_communications[i]->isConnected());
 
-    for (DataMap::value_type& pair : _sendDataVector[i]) {
+    for (DataMap::value_type &pair : _sendDataVector[i]) {
       int size = pair.second->values->size();
       if (size > 0) {
         _communications[i]->send(pair.second->values->data(), size, pair.second->mesh->getID(), pair.second->dimension);
@@ -273,15 +255,15 @@ void MultiCouplingScheme:: sendData()
   }
 }
 
-void MultiCouplingScheme:: receiveData()
+void MultiCouplingScheme::receiveData()
 {
   PRECICE_TRACE();
 
-  for(size_t i=0;i<_communications.size();i++){
+  for (size_t i = 0; i < _communications.size(); i++) {
     PRECICE_ASSERT(_communications[i].get() != nullptr);
     PRECICE_ASSERT(_communications[i]->isConnected());
 
-    for (DataMap::value_type& pair : _receiveDataVector[i]) {
+    for (DataMap::value_type &pair : _receiveDataVector[i]) {
       int size = pair.second->values->size();
       if (size > 0) {
         _communications[i]->receive(pair.second->values->data(), size, pair.second->mesh->getID(), pair.second->dimension);
@@ -290,30 +272,29 @@ void MultiCouplingScheme:: receiveData()
   }
 }
 
-
 void MultiCouplingScheme::setupConvergenceMeasures()
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(not doesFirstStep());
   PRECICE_CHECK(not _convergenceMeasures.empty(),
-        "At least one convergence measure has to be defined for an implicit coupling scheme!");
-  for (ConvergenceMeasure& convMeasure : _convergenceMeasures) {
-    int dataID = convMeasure.data->getID();
+                "At least one convergence measure has to be defined for an implicit coupling scheme!");
+  for (ConvergenceMeasure &convMeasure : _convergenceMeasures) {
+    int dataID               = convMeasure.data->getID();
     convMeasure.couplingData = getData(dataID);
     PRECICE_ASSERT(convMeasure.couplingData != nullptr);
   }
 }
 
-CouplingData* MultiCouplingScheme:: getData
-(
-  int dataID)
+CouplingData *MultiCouplingScheme::getData(
+    int dataID)
 {
   PRECICE_TRACE(dataID);
   DataMap::iterator iter = _allData.find(dataID);
   if (iter != _allData.end()) {
-    return  &(*(iter->second));
+    return &(*(iter->second));
   }
   return nullptr;
 }
 
-}}
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -6,19 +6,17 @@
 namespace precice {
 namespace cplscheme {
 
-class MultiCouplingScheme : public BaseCouplingScheme
-{
+class MultiCouplingScheme : public BaseCouplingScheme {
 public:
-  MultiCouplingScheme (
-    double                maxTime,
-    int                   maxTimesteps,
-    double                timestepLength,
-    int                   validDigits,
-    const std::string&    localParticipant,
-    std::vector<m2n::PtrM2N> communications,
-    constants::TimesteppingMethod dtMethod,
-    int                   maxIterations = 1)
-    ;
+  MultiCouplingScheme(
+      double                        maxTime,
+      int                           maxTimesteps,
+      double                        timestepLength,
+      int                           validDigits,
+      const std::string &           localParticipant,
+      std::vector<m2n::PtrM2N>      communications,
+      constants::TimesteppingMethod dtMethod,
+      int                           maxIterations = 1);
 
   logging::Logger _log{"cplscheme::MultiCouplingScheme"};
 
@@ -29,28 +27,28 @@ public:
   virtual void advance();
 
   /// Adds data to be sent on data exchange and possibly be modified during coupling iterations.
-  void addDataToSend (
-    mesh::PtrData data,
-    mesh::PtrMesh mesh,
-    bool          initialize,
-    int           index);
+  void addDataToSend(
+      mesh::PtrData data,
+      mesh::PtrMesh mesh,
+      bool          initialize,
+      int           index);
 
   /// Adds data to be received on data exchange.
-  void addDataToReceive (
-    mesh::PtrData data,
-    mesh::PtrMesh mesh,
-    bool          initialize,
-    int           index);
+  void addDataToReceive(
+      mesh::PtrData data,
+      mesh::PtrMesh mesh,
+      bool          initialize,
+      int           index);
 
 protected:
   /// merges send and receive data into one map (for parallel acceleration)
   virtual void mergeData();
 
 private:
-  void sendData();
-  void receiveData();
-  void setupConvergenceMeasures();
-  CouplingData* getData ( int dataID );
+  void          sendData();
+  void          receiveData();
+  void          setupConvergenceMeasures();
+  CouplingData *getData(int dataID);
 
   /// Communication device to the other coupling participant.
   std::vector<m2n::PtrM2N> _communications;
@@ -60,8 +58,7 @@ private:
 
   std::vector<DataMap> _receiveDataVector;
   std::vector<DataMap> _sendDataVector;
-
-
 };
 
-}}
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -1,29 +1,27 @@
 #include "ParallelCouplingScheme.hpp"
 #include "acceleration/Acceleration.hpp"
 #include "m2n/M2N.hpp"
+#include "math/math.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/MasterSlave.hpp"
-#include "math/math.hpp"
 
 namespace precice {
 namespace cplscheme {
 
-ParallelCouplingScheme::ParallelCouplingScheme
-(
-  double                maxTime,
-  int                   maxTimesteps,
-  double                timestepLength,
-  int                   validDigits,
-  const std::string&    firstParticipant,
-  const std::string&    secondParticipant,
-  const std::string&    localParticipant,
-  m2n::PtrM2N           m2n,
-  constants::TimesteppingMethod dtMethod,
-  CouplingMode          cplMode,
-  int                   maxIterations)
-  :
-  BaseCouplingScheme(maxTime,maxTimesteps,timestepLength,validDigits,firstParticipant,
-                     secondParticipant,localParticipant,m2n,maxIterations,dtMethod)
+ParallelCouplingScheme::ParallelCouplingScheme(
+    double                        maxTime,
+    int                           maxTimesteps,
+    double                        timestepLength,
+    int                           validDigits,
+    const std::string &           firstParticipant,
+    const std::string &           secondParticipant,
+    const std::string &           localParticipant,
+    m2n::PtrM2N                   m2n,
+    constants::TimesteppingMethod dtMethod,
+    CouplingMode                  cplMode,
+    int                           maxIterations)
+    : BaseCouplingScheme(maxTime, maxTimesteps, timestepLength, validDigits, firstParticipant,
+                         secondParticipant, localParticipant, m2n, maxIterations, dtMethod)
 {
   _couplingMode = cplMode;
   // Coupling mode must be either Explicit or Implicit when using SerialCouplingScheme.
@@ -33,10 +31,9 @@ ParallelCouplingScheme::ParallelCouplingScheme
   }
 }
 
-void ParallelCouplingScheme::initialize
-(
-  double startTime,
-  int    startTimestep )
+void ParallelCouplingScheme::initialize(
+    double startTime,
+    int    startTimestep)
 {
   PRECICE_TRACE(startTime, startTimestep);
   PRECICE_ASSERT(not isInitialized());
@@ -46,9 +43,9 @@ void ParallelCouplingScheme::initialize
   setTimesteps(startTimestep);
   if (_couplingMode == Implicit) {
     PRECICE_CHECK(not getSendData().empty(), "No send data configured! Use explicit scheme for one-way coupling.");
-    if (not doesFirstStep()) { // second participant
-      setupConvergenceMeasures(); // needs _couplingData configured
-      mergeData(); // merge send and receive data for all pp calls
+    if (not doesFirstStep()) {         // second participant
+      setupConvergenceMeasures();      // needs _couplingData configured
+      mergeData();                     // merge send and receive data for all pp calls
       setupDataMatrices(getAllData()); // Reserve memory and initialize data with zero
       if (getAcceleration().get() != nullptr) {
         getAcceleration()->initialize(getAllData()); // Reserve memory, initialize
@@ -59,13 +56,13 @@ void ParallelCouplingScheme::initialize
     initializeTXTWriters();
   }
 
-  for (DataMap::value_type & pair : getSendData()) {
+  for (DataMap::value_type &pair : getSendData()) {
     if (pair.second->initialize) {
       setHasToSendInitData(true);
       break;
     }
   }
-  for (DataMap::value_type & pair : getReceiveData()) {
+  for (DataMap::value_type &pair : getReceiveData()) {
     if (pair.second->initialize) {
       setHasToReceiveInitData(true);
       break;
@@ -89,8 +86,8 @@ void ParallelCouplingScheme::initializeData()
     return;
   }
 
-  PRECICE_CHECK(not (hasToSendInitData() && isActionRequired(constants::actionWriteInitialData())),
-        "InitialData has to be written to preCICE before calling initializeData()");
+  PRECICE_CHECK(not(hasToSendInitData() && isActionRequired(constants::actionWriteInitialData())),
+                "InitialData has to be written to preCICE before calling initializeData()");
 
   setHasDataBeenExchanged(false);
 
@@ -111,10 +108,10 @@ void ParallelCouplingScheme::initializeData()
       setHasDataBeenExchanged(true);
 
       // second participant has to save values for extrapolation
-      if (_couplingMode == Implicit){
-        for (DataMap::value_type & pair : getReceiveData()) {
+      if (_couplingMode == Implicit) {
+        for (DataMap::value_type &pair : getReceiveData()) {
           if (pair.second->oldValues.cols() == 0)
-                    break;
+            break;
           pair.second->oldValues.col(0) = *pair.second->values;
           // For extrapolation, treat the initial value as old timestep value
           utils::shiftSetFirst(pair.second->oldValues, *pair.second->values);
@@ -123,9 +120,9 @@ void ParallelCouplingScheme::initializeData()
     }
     if (hasToSendInitData()) {
       if (_couplingMode == Implicit) {
-        for (DataMap::value_type & pair : getSendData()) {
+        for (DataMap::value_type &pair : getSendData()) {
           if (pair.second->oldValues.cols() == 0)
-                    break;
+            break;
           pair.second->oldValues.col(0) = *pair.second->values;
           // For extrapolation, treat the initial value as old timestep value
           utils::shiftSetFirst(pair.second->oldValues, *pair.second->values);
@@ -144,8 +141,7 @@ void ParallelCouplingScheme::advance()
 {
   if (_couplingMode == Explicit) {
     explicitAdvance();
-  }
-  else if (_couplingMode == Implicit) {
+  } else if (_couplingMode == Implicit) {
     implicitAdvance();
   }
 }
@@ -155,7 +151,7 @@ void ParallelCouplingScheme::explicitAdvance()
   PRECICE_TRACE();
   checkCompletenessRequiredActions();
   PRECICE_CHECK(!hasToReceiveInitData() && !hasToSendInitData(),
-        "initializeData() needs to be called before advance if data has to be initialized!");
+                "initializeData() needs to be called before advance if data has to be initialized!");
   setHasDataBeenExchanged(false);
   setIsCouplingTimestepComplete(false);
 
@@ -172,8 +168,7 @@ void ParallelCouplingScheme::explicitAdvance()
       receiveAndSetDt();
       receiveData(getM2N());
       setHasDataBeenExchanged(true);
-    }
-    else { //second participant
+    } else { //second participant
       PRECICE_DEBUG("Receiving data...");
       receiveAndSetDt();
       receiveData(getM2N());
@@ -195,13 +190,13 @@ void ParallelCouplingScheme::implicitAdvance()
   checkCompletenessRequiredActions();
 
   PRECICE_CHECK(!hasToReceiveInitData() && !hasToSendInitData(),
-        "initializeData() needs to be called before advance if data has to be initialized!");
+                "initializeData() needs to be called before advance if data has to be initialized!");
 
   setHasDataBeenExchanged(false);
   setIsCouplingTimestepComplete(false);
-  bool convergence = false;
+  bool convergence                   = false;
   bool convergenceCoarseOptimization = true;
-  bool doOnlySolverEvaluation = false;
+  bool doOnlySolverEvaluation        = false;
   if (math::equals(getThisTimestepRemainder(), 0.0, _eps)) {
     PRECICE_DEBUG("Computed full length of iteration");
     if (doesFirstStep()) { //First participant
@@ -212,8 +207,7 @@ void ParallelCouplingScheme::implicitAdvance()
         timestepCompleted();
       }
       receiveData(getM2N());
-    }
-    else { // second participant
+    } else { // second participant
       receiveData(getM2N());
 
       // get the current design specifications from the acceleration (for convergence measure)
@@ -223,7 +217,7 @@ void ParallelCouplingScheme::implicitAdvance()
       }
 
       // measure convergence for coarse model optimization
-      if(_isCoarseModelOptimizationActive){
+      if (_isCoarseModelOptimizationActive) {
         PRECICE_DEBUG("measure convergence of coarse model optimization.");
         // in case of multilevel acceleration only: measure the convergence of the coarse model optimization
         convergenceCoarseOptimization = measureConvergenceCoarseModelOptimization(designSpecifications);
@@ -234,22 +228,23 @@ void ParallelCouplingScheme::implicitAdvance()
         convergence = false;
         // in case of multilevel PP only: if coarse model optimization converged
         // steering the requests for evaluation of coarse and fine model, respectively
-        if(convergenceCoarseOptimization){
+        if (convergenceCoarseOptimization) {
           _isCoarseModelOptimizationActive = false;
-          doOnlySolverEvaluation = true;
-        }else{
+          doOnlySolverEvaluation           = true;
+        } else {
           _isCoarseModelOptimizationActive = true;
         }
       }
       // measure convergence of coupling iteration
-      else{
+      else {
         PRECICE_DEBUG("measure convergence.");
         doOnlySolverEvaluation = false;
 
         // measure convergence of the coupling iteration,
         convergence = measureConvergence(designSpecifications);
         // Stop, when maximal iteration count (given in config) is reached
-        if (maxIterationsReached())   convergence = true;
+        if (maxIterationsReached())
+          convergence = true;
       }
 
       // passed by reference, modified in MM acceleration. No-op for all other accelerations
@@ -257,11 +252,9 @@ void ParallelCouplingScheme::implicitAdvance()
         getAcceleration()->setCoarseModelOptimizationActive(&_isCoarseModelOptimizationActive);
       }
 
-
       // for multi-level case, i.e., manifold mapping: after convergence of coarse problem
       // we only want to evaluate the fine model for the new input, no acceleration etc..
-      if (not doOnlySolverEvaluation)
-      {
+      if (not doOnlySolverEvaluation) {
         if (convergence) {
           if (getAcceleration().get() != nullptr) {
             _deletedColumnsPPFiltering = getAcceleration()->getDeletedColumns();
@@ -269,42 +262,40 @@ void ParallelCouplingScheme::implicitAdvance()
           }
           newConvergenceMeasurements();
           timestepCompleted();
-        }
-        else if (getAcceleration().get() != nullptr) {
+        } else if (getAcceleration().get() != nullptr) {
           getAcceleration()->performAcceleration(getAllData());
         }
 
         // extrapolate new input data for the solver evaluation in time.
         if (convergence && (getExtrapolationOrder() > 0)) {
           extrapolateData(getAllData()); // Also stores data
-        }
-        else { // Store data for conv. measurement, acceleration, or extrapolation
-          for (DataMap::value_type& pair : getSendData()) {
+        } else {                         // Store data for conv. measurement, acceleration, or extrapolation
+          for (DataMap::value_type &pair : getSendData()) {
             if (pair.second->oldValues.size() > 0) {
               pair.second->oldValues.col(0) = *pair.second->values;
             }
           }
-          for (DataMap::value_type& pair : getReceiveData()) {
+          for (DataMap::value_type &pair : getReceiveData()) {
             if (pair.second->oldValues.size() > 0) {
               pair.second->oldValues.col(0) = *pair.second->values;
             }
           }
         }
-      }else {
+      } else {
 
-       // if the coarse model problem converged within the first iteration, i.e., no acceleration at all
-       // we need to register the coarse initialized data again on the fine input data,
-       // otherwise the fine input data would be zero in this case, neither anything has been computed so far for the fine
-       // model nor the acceleration did any data registration
-       // ATTENTION: assumes that coarse data is defined after fine data in same ordering.
-       if (_iterationsCoarseOptimization == 1   && getAcceleration().get() != nullptr) {
-         auto fineIDs = getAcceleration()->getDataIDs();
-         auto& allData = getAllData();
-         for(auto& fineID : fineIDs) {
-           *allData.at( fineID )->values = allData.at( fineID+fineIDs.size() )->oldValues.col(0);
-         }
-       }
-     }
+        // if the coarse model problem converged within the first iteration, i.e., no acceleration at all
+        // we need to register the coarse initialized data again on the fine input data,
+        // otherwise the fine input data would be zero in this case, neither anything has been computed so far for the fine
+        // model nor the acceleration did any data registration
+        // ATTENTION: assumes that coarse data is defined after fine data in same ordering.
+        if (_iterationsCoarseOptimization == 1 && getAcceleration().get() != nullptr) {
+          auto  fineIDs = getAcceleration()->getDataIDs();
+          auto &allData = getAllData();
+          for (auto &fineID : fineIDs) {
+            *allData.at(fineID)->values = allData.at(fineID + fineIDs.size())->oldValues.col(0);
+          }
+        }
+      }
 
       getM2N()->send(convergence);
       getM2N()->send(_isCoarseModelOptimizationActive);
@@ -316,8 +307,7 @@ void ParallelCouplingScheme::implicitAdvance()
     if (not convergence) {
       PRECICE_DEBUG("No convergence achieved");
       requireAction(constants::actionReadIterationCheckpoint());
-    }
-    else {
+    } else {
       PRECICE_DEBUG("Convergence achieved");
       advanceTXTWriters();
     }
@@ -327,15 +317,14 @@ void ParallelCouplingScheme::implicitAdvance()
   } // subcycling complete
 }
 
-
-
 void ParallelCouplingScheme::mergeData()
 {
   PRECICE_TRACE();
-  PRECICE_ASSERT(!doesFirstStep(), "Only the second participant should do the acceleration." );
+  PRECICE_ASSERT(!doesFirstStep(), "Only the second participant should do the acceleration.");
   PRECICE_ASSERT(_allData.empty(), "This function should only be called once.");
   _allData.insert(getSendData().begin(), getSendData().end());
   _allData.insert(getReceiveData().begin(), getReceiveData().end());
 }
 
-}}
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -11,22 +11,21 @@ namespace cplscheme {
  *
  * For more information, look into Benjamin's thesis, Section 3.5. 
  * https://mediatum.ub.tum.de/doc/1320661/document.pdf
- */ 	
-class ParallelCouplingScheme : public BaseCouplingScheme
-{
+ */
+class ParallelCouplingScheme : public BaseCouplingScheme {
 public:
-  ParallelCouplingScheme (
-    double                maxTime,
-    int                   maxTimesteps,
-    double                timestepLength,
-    int                   validDigits,
-    const std::string&    firstParticipant,
-    const std::string&    secondParticipant,
-    const std::string&    localParticipant,
-    m2n::PtrM2N           m2n,
-    constants::TimesteppingMethod dtMethod,
-    CouplingMode          cplMode,
-    int                   maxIterations = 1);
+  ParallelCouplingScheme(
+      double                        maxTime,
+      int                           maxTimesteps,
+      double                        timestepLength,
+      int                           validDigits,
+      const std::string &           firstParticipant,
+      const std::string &           secondParticipant,
+      const std::string &           localParticipant,
+      m2n::PtrM2N                   m2n,
+      constants::TimesteppingMethod dtMethod,
+      CouplingMode                  cplMode,
+      int                           maxIterations = 1);
 
   virtual void initialize(double startTime, int startTimestep);
 
@@ -34,22 +33,20 @@ public:
 
   virtual void advance();
 
-
 protected:
   /// merges send and receive data into one map (for parallel acceleration)
   virtual void mergeData();
 
   /// Returns all data (receive and send)
-  DataMap& getAllData()
+  DataMap &getAllData()
   {
-    PRECICE_ASSERT(!doesFirstStep(), "Only the second participant should do the acceleration." );
+    PRECICE_ASSERT(!doesFirstStep(), "Only the second participant should do the acceleration.");
     return _allData;
   }
 
-
 private:
   logging::Logger _log{"cplscheme::ParallelCouplingScheme"};
-  
+
   /// Map from data ID -> all data (receive and send) with that ID
   DataMap _allData;
 
@@ -58,4 +55,5 @@ private:
   virtual void implicitAdvance();
 };
 
-}}
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -5,10 +5,10 @@
 
 // Forward declaration to friend the boost test struct
 namespace CplSchemeTests {
-namespace SerialImplicitCouplingSchemeTests{
+namespace SerialImplicitCouplingSchemeTests {
 struct testExtrapolateData;
-}}
-
+}
+} // namespace CplSchemeTests
 
 namespace precice {
 namespace cplscheme {
@@ -19,11 +19,9 @@ namespace cplscheme {
  * For more information, look into Benjamin's thesis, Section 3.5. 
  * https://mediatum.ub.tum.de/doc/1320661/document.pdf
  */
-class SerialCouplingScheme : public BaseCouplingScheme
-{
+class SerialCouplingScheme : public BaseCouplingScheme {
 public:
-
-/**
+  /**
  * @brief Constructor.
  *
  * @param[in] maxTime Simulation time limit, or UNDEFINED_TIME.
@@ -35,19 +33,18 @@ public:
  * @param[in] communication Communication object for com. between participants.
  * @param[in] monitorIterations If true, a txt file monitoring iterations is written.
  */
-  SerialCouplingScheme (
-    double                      maxTime,
-    int                         maxTimesteps,
-    double                      timestepLength,
-    int                         validDigits,
-    const std::string&          firstParticipant,
-    const std::string&          secondParticipant,
-    const std::string&          localParticipant,
-    m2n::PtrM2N                 m2n,
-    constants::TimesteppingMethod dtMethod,
-    CouplingMode                cplMode,
-    int                         maxIterations = 1
-    );
+  SerialCouplingScheme(
+      double                        maxTime,
+      int                           maxTimesteps,
+      double                        timestepLength,
+      int                           validDigits,
+      const std::string &           firstParticipant,
+      const std::string &           secondParticipant,
+      const std::string &           localParticipant,
+      m2n::PtrM2N                   m2n,
+      constants::TimesteppingMethod dtMethod,
+      CouplingMode                  cplMode,
+      int                           maxIterations = 1);
 
   virtual void initialize(double startTime, int startTimestep);
 
@@ -57,8 +54,8 @@ public:
 
   logging::Logger _log{"cplschemes::SerialCouplingSchemes"};
 
-  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testExtrapolateData;  // For whitebox tests
-
+  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testExtrapolateData; // For whitebox tests
 };
 
-}}
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/SharedPointer.hpp
+++ b/src/cplscheme/SharedPointer.hpp
@@ -13,4 +13,5 @@ using PtrCouplingScheme              = std::shared_ptr<CouplingScheme>;
 using PtrCouplingSchemeConfiguration = std::shared_ptr<CouplingSchemeConfiguration>;
 using PtrCouplingData                = std::shared_ptr<CouplingData>;
 
-}} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -1,14 +1,14 @@
 #include "CouplingSchemeConfiguration.hpp"
+#include "acceleration/Acceleration.hpp"
+#include "acceleration/config/AccelerationConfiguration.hpp"
 #include "cplscheme/CompositionalCouplingScheme.hpp"
 #include "cplscheme/MultiCouplingScheme.hpp"
 #include "cplscheme/ParallelCouplingScheme.hpp"
 #include "cplscheme/SerialCouplingScheme.hpp"
 #include "cplscheme/SharedPointer.hpp"
-#include "acceleration/config/AccelerationConfiguration.hpp"
 #include "cplscheme/impl/AbsoluteConvergenceMeasure.hpp"
 #include "cplscheme/impl/ConvergenceMeasure.hpp"
 #include "cplscheme/impl/MinIterationConvergenceMeasure.hpp"
-#include "acceleration/Acceleration.hpp"
 #include "cplscheme/impl/RelativeConvergenceMeasure.hpp"
 #include "cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp"
 #include "m2n/M2N.hpp"
@@ -21,10 +21,8 @@
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
+namespace precice {
+namespace cplscheme {
 
 using precice::impl::PtrParticipant;
 
@@ -139,14 +137,14 @@ const PtrCouplingScheme &CouplingSchemeConfiguration::getCouplingScheme(
     const std::string &participantName) const
 {
   PRECICE_CHECK(utils::contained(participantName, _couplingSchemes),
-        "No coupling scheme defined for "
-            << "participant \"" << participantName << "\"!");
+                "No coupling scheme defined for "
+                    << "participant \"" << participantName << "\"!");
   return _couplingSchemes.find(participantName)->second;
 }
 
 void CouplingSchemeConfiguration::xmlTagCallback(
-    const xml::ConfigurationContext& context,
-    xml::XMLTag &tag)
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getFullName());
   if (tag.getNamespace() == TAG) {
@@ -160,7 +158,7 @@ void CouplingSchemeConfiguration::xmlTagCallback(
     bool control = tag.getBooleanAttributeValue(ATTR_CONTROL);
     if (control) {
       PRECICE_CHECK(not _config.setController,
-            "Only one controller per MultiCoupling can be defined");
+                    "Only one controller per MultiCoupling can be defined");
       _config.controller    = tag.getStringAttributeValue(ATTR_NAME);
       _config.setController = true;
     } else {
@@ -250,8 +248,8 @@ void CouplingSchemeConfiguration::xmlTagCallback(
 }
 
 void CouplingSchemeConfiguration::xmlEndTagCallback(
-    const xml::ConfigurationContext& context,
-    xml::XMLTag &tag)
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getFullName());
   if (tag.getNamespace() == TAG) {
@@ -295,7 +293,7 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
       _config = Config();
     } else if (_config.type == VALUE_MULTI) {
       PRECICE_CHECK(_config.setController,
-            "One controller per MultiCoupling need to be defined");
+                    "One controller per MultiCoupling need to be defined");
       for (std::string &accessor : _config.participants) {
         PtrCouplingScheme scheme = createMultiCouplingScheme(accessor);
         addCouplingScheme(scheme, accessor);
@@ -403,13 +401,13 @@ void CouplingSchemeConfiguration::addTransientLimitTags(
   tagMaxTimesteps.addAttribute(attrValueMaxTimesteps);
   tag.addSubtag(tagMaxTimesteps);
 
-  XMLTag               tagTimestepLength(*this, TAG_TIMESTEP_LENGTH, XMLTag::OCCUR_ONCE);
-  auto attrValueTimestepLength = makeXMLAttribute(ATTR_VALUE, CouplingScheme::UNDEFINED_TIMESTEP_LENGTH);
+  XMLTag tagTimestepLength(*this, TAG_TIMESTEP_LENGTH, XMLTag::OCCUR_ONCE);
+  auto   attrValueTimestepLength = makeXMLAttribute(ATTR_VALUE, CouplingScheme::UNDEFINED_TIMESTEP_LENGTH);
   tagTimestepLength.addAttribute(attrValueTimestepLength);
   XMLAttribute<int> attrValidDigits(ATTR_VALID_DIGITS, 10);
   tagTimestepLength.addAttribute(attrValidDigits);
   auto attrMethod = makeXMLAttribute(ATTR_METHOD, VALUE_FIXED)
-      .setOptions({ VALUE_FIXED, VALUE_FIRST_PARTICIPANT});
+                        .setOptions({VALUE_FIXED, VALUE_FIRST_PARTICIPANT});
   tagTimestepLength.addAttribute(attrMethod);
   tag.addSubtag(tagTimestepLength);
 }
@@ -506,16 +504,16 @@ void CouplingSchemeConfiguration::addBaseAttributesTagConvergenceMeasure(
 {
   using namespace xml;
   auto attrData = XMLAttribute<std::string>(ATTR_DATA)
-      .setDocumentation("Data to be measured.");
+                      .setDocumentation("Data to be measured.");
   tag.addAttribute(attrData);
   auto attrMesh = XMLAttribute<std::string>(ATTR_MESH)
-      .setDocumentation("Mesh holding the data.");
+                      .setDocumentation("Mesh holding the data.");
   tag.addAttribute(attrMesh);
   auto attrSuffices = makeXMLAttribute(ATTR_SUFFICES, false)
-      .setDocumentation("If true, suffices to lead to convergence.");
+                          .setDocumentation("If true, suffices to lead to convergence.");
   tag.addAttribute(attrSuffices);
   auto attrLevel = makeXMLAttribute(ATTR_LEVEL, 0)
-      .setDocumentation("For multi-level based coupling schemes: Indicates the coarseness level of the associated coupling data for this convergence measure.");
+                       .setDocumentation("For multi-level based coupling schemes: Indicates the coarseness level of the associated coupling data for this convergence measure.");
   tag.addAttribute(attrLevel);
 }
 
@@ -617,7 +615,7 @@ mesh::PtrData CouplingSchemeConfiguration::getData(
     }
   }
   PRECICE_ERROR("Data \"" << dataName << "\" used by mesh \""
-                  << meshName << "\" is not configured!");
+                          << meshName << "\" is not configured!");
 }
 
 PtrCouplingScheme CouplingSchemeConfiguration::createSerialExplicitCouplingScheme(
@@ -811,7 +809,7 @@ CouplingSchemeConfiguration::getTimesteppingMethod(
   //    return constants::SECOND_PARTICIPANT_SETS_DT;
   //  }
   PRECICE_ERROR("Unknown timestepping method \""
-        << method << "\"!");
+                << method << "\"!");
 }
 
 void CouplingSchemeConfiguration::addDataToBeExchanged(
@@ -905,8 +903,8 @@ void CouplingSchemeConfiguration::checkIfDataIsExchanged(
     }
   }
   PRECICE_CHECK(hasFound,
-        "You need to exchange every data that you use for convergence measures"
-            << " and/or the iteration acceleration");
+                "You need to exchange every data that you use for convergence measures"
+                    << " and/or the iteration acceleration");
 }
 
 bool CouplingSchemeConfiguration::checkIfDataIsCoarse(
@@ -954,5 +952,5 @@ bool CouplingSchemeConfiguration::checkIfDataIsCoarse(
     PRECICE_ERROR("Data ID " << id << " is not contained in the exchange data for the fine model and no coarse model optimization method is defined.");
   return true;
 }
-}
-} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -3,12 +3,12 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include "acceleration/SharedPointer.hpp"
 #include "cplscheme/Constants.hpp"
 #include "cplscheme/CouplingScheme.hpp"
 #include "cplscheme/MultiCouplingScheme.hpp"
 #include "cplscheme/SharedPointer.hpp"
 #include "cplscheme/impl/SharedPointer.hpp"
-#include "acceleration/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "m2n/config/M2NConfiguration.hpp"
 #include "mesh/SharedPointer.hpp"
@@ -16,36 +16,28 @@
 #include "precice/impl/MeshContext.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
+namespace precice {
+namespace cplscheme {
 class CompositionalCouplingScheme;
 class BaseCouplingScheme;
-}
-}
+} // namespace cplscheme
+} // namespace precice
 
 // Forward declaration to friend the boost test struct
-namespace CplSchemeTests
-{
-namespace ParallelImplicitCouplingSchemeTests
-{
+namespace CplSchemeTests {
+namespace ParallelImplicitCouplingSchemeTests {
 struct testParseConfigurationWithRelaxation;
 }
-namespace SerialImplicitCouplingSchemeTests
-{
+namespace SerialImplicitCouplingSchemeTests {
 struct testParseConfigurationWithRelaxation;
 }
-}
+} // namespace CplSchemeTests
 
 // ----------------------------------------------------------- CLASS DEFINITION
-namespace precice
-{
-namespace cplscheme
-{
+namespace precice {
+namespace cplscheme {
 /// Configuration for coupling schemes.
-class CouplingSchemeConfiguration : public xml::XMLTag::Listener
-{
+class CouplingSchemeConfiguration : public xml::XMLTag::Listener {
 public:
   /**
    * @brief Constructor.
@@ -72,16 +64,15 @@ public:
   const std::string &getDataToExchange(int index) const;
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /// Adds a manually configured coupling scheme for a participant.
   void addCouplingScheme(PtrCouplingScheme cplScheme, const std::string &participantName);
 
 private:
-
   mutable logging::Logger _log{"cplscheme::CouplingSchemeConfiguration"};
 
   const std::string TAG;
@@ -131,19 +122,19 @@ private:
     std::string                   name;
     std::vector<std::string>      participants;
     std::string                   controller;
-    bool                          setController = false;
-    double                        maxTime = CouplingScheme::UNDEFINED_TIME;
-    int                           maxTimesteps = CouplingScheme::UNDEFINED_TIMESTEPS;
+    bool                          setController  = false;
+    double                        maxTime        = CouplingScheme::UNDEFINED_TIME;
+    int                           maxTimesteps   = CouplingScheme::UNDEFINED_TIMESTEPS;
     double                        timestepLength = CouplingScheme::UNDEFINED_TIMESTEP_LENGTH;
-    int                           validDigits = 16;
-    constants::TimesteppingMethod dtMethod = constants::FIXED_DT;
+    int                           validDigits    = 16;
+    constants::TimesteppingMethod dtMethod       = constants::FIXED_DT;
     /// Tuples of exchange data, mesh, and participant name.
     typedef std::tuple<mesh::PtrData, mesh::PtrMesh, std::string, std::string, bool> Exchange;
     std::vector<Exchange>                                                            exchanges;
     /// Tuples of data ID, mesh ID, and convergence measure.
     std::vector<std::tuple<mesh::PtrData, bool, std::string, int, impl::PtrConvergenceMeasure>> convMeasures;
-    int                                                                               maxIterations = -1;
-    int                                                                               extrapolationOrder = 0;
+    int                                                                                         maxIterations      = -1;
+    int                                                                                         extrapolationOrder = 0;
 
   } _config;
 
@@ -257,9 +248,8 @@ private:
 
   bool checkIfDataIsCoarse(int id) const;
 
-  friend struct CplSchemeTests::ParallelImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation;  // For whitebox tests
-  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation;  // For whitebox tests
-
+  friend struct CplSchemeTests::ParallelImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation; // For whitebox tests
+  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation;   // For whitebox tests
 };
-}
-} // namespace precice, cplscheme
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.cpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.cpp
@@ -1,18 +1,17 @@
 #include "AbsoluteConvergenceMeasure.hpp"
 #include "math/math.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 AbsoluteConvergenceMeasure::AbsoluteConvergenceMeasure(double convergenceLimit)
-  : _convergenceLimit(convergenceLimit)
+    : _convergenceLimit(convergenceLimit)
 {
   PRECICE_CHECK(not math::greaterEquals(0.0, _convergenceLimit),
-        "Absolute convergence limit has to be greater than zero!");
+                "Absolute convergence limit has to be greater than zero!");
 }
 
-}}} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
@@ -4,23 +4,17 @@
 #include "logging/Logger.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace tests
-{
+namespace precice {
+namespace cplscheme {
+namespace tests {
 class AbsoluteConvergenceMeasureTest;
 }
-}
-}
+} // namespace cplscheme
+} // namespace precice
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 /**
  * @brief Measures the convergence from an old data set to a new one.
@@ -32,8 +26,7 @@ namespace impl
  * For a description of how to perform the measurement, see class
  * ConvergenceMeasure.
  */
-class AbsoluteConvergenceMeasure : public ConvergenceMeasure
-{
+class AbsoluteConvergenceMeasure : public ConvergenceMeasure {
 public:
   explicit AbsoluteConvergenceMeasure(double convergenceLimit);
 
@@ -91,6 +84,6 @@ private:
 
   bool _isConvergence = false;
 };
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/ConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ConvergenceMeasure.hpp
@@ -2,12 +2,9 @@
 
 #include <Eigen/Core>
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 /**
  * @brief Interface for measures checking the convergence of a series of datasets.
@@ -22,8 +19,7 @@ namespace impl
  * -# call measure() for convergence measurement
  * -# retrieve the convergence status via isConvergence()
  */
-class ConvergenceMeasure
-{
+class ConvergenceMeasure {
 public:
   /// Destructor, empty.
   virtual ~ConvergenceMeasure() {}
@@ -54,6 +50,6 @@ public:
     return 0;
   }
 };
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/MinIterationConvergenceMeasure.cpp
+++ b/src/cplscheme/impl/MinIterationConvergenceMeasure.cpp
@@ -1,11 +1,8 @@
 #include "MinIterationConvergenceMeasure.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 MinIterationConvergenceMeasure::MinIterationConvergenceMeasure(
     int minimumIterationCount)
@@ -19,6 +16,6 @@ void MinIterationConvergenceMeasure::newMeasurementSeries()
   _currentIteration = 0;
   _isConvergence    = false;
 }
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/MinIterationConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/MinIterationConvergenceMeasure.hpp
@@ -4,15 +4,11 @@
 #include "cplscheme/CouplingData.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
-class MinIterationConvergenceMeasure : public ConvergenceMeasure
-{
+class MinIterationConvergenceMeasure : public ConvergenceMeasure {
 public:
   explicit MinIterationConvergenceMeasure(int minimumIterationCount);
 
@@ -58,6 +54,6 @@ private:
 
   bool _isConvergence = false;
 };
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.cpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.cpp
@@ -1,18 +1,15 @@
 #include "RelativeConvergenceMeasure.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 RelativeConvergenceMeasure::RelativeConvergenceMeasure(double convergenceLimitPercent)
-  : _convergenceLimitPercent(convergenceLimitPercent)
+    : _convergenceLimitPercent(convergenceLimitPercent)
 {
   PRECICE_CHECK(math::greater(_convergenceLimitPercent, 0.0) && math::greaterEquals(1.0, _convergenceLimitPercent),
-        "Relative convergence limit has to be in ]0;1] !");
+                "Relative convergence limit has to be in ]0;1] !");
 }
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -6,25 +6,19 @@
 #include "math/math.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace tests
-{
+namespace precice {
+namespace cplscheme {
+namespace tests {
 class RelativeConvergenceMeasureTest;
 }
-}
-}
+} // namespace cplscheme
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 /**
  * @brief Measures the convergence from an old data set to a new one.
@@ -37,8 +31,7 @@ namespace impl
  * For a description of how to perform the measurement, see class
  * ConvergenceMeasure.
  */
-class RelativeConvergenceMeasure : public ConvergenceMeasure
-{
+class RelativeConvergenceMeasure : public ConvergenceMeasure {
 public:
   /**
     * @brief Constructor.
@@ -120,6 +113,6 @@ private:
 
   bool _isConvergence = false;
 };
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.cpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.cpp
@@ -1,20 +1,16 @@
 #include "ResidualRelativeConvergenceMeasure.hpp"
 #include "math/math.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
-
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 ResidualRelativeConvergenceMeasure::ResidualRelativeConvergenceMeasure(double convergenceLimitPercent)
-  : _convergenceLimitPercent(convergenceLimitPercent)
+    : _convergenceLimitPercent(convergenceLimitPercent)
 {
   PRECICE_CHECK(math::greater(_convergenceLimitPercent, 0.0) && math::greaterEquals(1.0, _convergenceLimitPercent),
-        "Relative convergence limit has to be in ]0;1] !");
+                "Relative convergence limit has to be in ]0;1] !");
 }
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
@@ -6,12 +6,9 @@
 #include "logging/Logger.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 /**
  * @brief Measures the convergence from an old data set to a new one.
@@ -24,8 +21,7 @@ namespace impl
  * For a description of how to perform the measurement, see class
  * ConvergenceMeasure.
  */
-class ResidualRelativeConvergenceMeasure : public ConvergenceMeasure
-{
+class ResidualRelativeConvergenceMeasure : public ConvergenceMeasure {
 public:
   /**
     * @brief Constructor.
@@ -96,6 +92,6 @@ private:
 
   bool _isConvergence = false;
 };
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/impl/SharedPointer.hpp
+++ b/src/cplscheme/impl/SharedPointer.hpp
@@ -2,17 +2,14 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace cplscheme
-{
-namespace impl
-{
+namespace precice {
+namespace cplscheme {
+namespace impl {
 
 class ConvergenceMeasure;
 class ParallelMatrixOperations;
 
 using PtrConvergenceMeasure = std::shared_ptr<ConvergenceMeasure>;
-}
-}
-} // namespace precice, cplscheme, impl
+} // namespace impl
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/tests/AbsoluteConvergenceMeasureTest.cpp
+++ b/src/cplscheme/tests/AbsoluteConvergenceMeasureTest.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(AbsoluteConvergenceMeasureTest, *testing::OnMaster())
 {
   using Eigen::Vector3d;
   // Create convergence measure for Vector data
-  double                           convergenceLimit = 9.0;
+  double                                      convergenceLimit = 9.0;
   cplscheme::impl::AbsoluteConvergenceMeasure measure(convergenceLimit);
 
   // Create data sets for old state of data and new state of data

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -1,18 +1,18 @@
-#include "DummyCouplingScheme.hpp"
-#include "../SharedPointer.hpp"
+#include <vector>
 #include "../CompositionalCouplingScheme.hpp"
 #include "../Constants.hpp"
+#include "../SharedPointer.hpp"
 #include "../config/CouplingSchemeConfiguration.hpp"
-#include "mesh/SharedPointer.hpp"
+#include "DummyCouplingScheme.hpp"
+#include "com/MPIDirectCommunication.hpp"
+#include "m2n/M2N.hpp"
+#include "m2n/config/M2NConfiguration.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
 #include "mesh/Vertex.hpp"
 #include "mesh/config/DataConfiguration.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
-#include "com/MPIDirectCommunication.hpp"
-#include "m2n/config/M2NConfiguration.hpp"
-#include "m2n/M2N.hpp"
 #include "xml/XMLTag.hpp"
-#include <vector>
 
 #include "testing/Testing.hpp"
 
@@ -23,15 +23,15 @@ using namespace precice::cplscheme;
 
 BOOST_AUTO_TEST_SUITE(CplSchemeTests)
 
-struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor
-{
+struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
   std::string _pathToTests;
 
-  CompositionalCouplingSchemeFixture(){
+  CompositionalCouplingSchemeFixture()
+  {
     _pathToTests = testing::getPathToSources() + "/cplscheme/tests/";
   }
 
-  void setupAndRunThreeSolverCoupling(const std::string& configFilename)
+  void setupAndRunThreeSolverCoupling(const std::string &configFilename)
   {
     using namespace mesh;
     utils::Parallel::synchronizeProcesses();
@@ -43,23 +43,21 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor
     std::string nameParticipant2("Participant2");
     std::string localParticipant("");
 
-    xml::XMLTag root = xml::getRootTag();
+    xml::XMLTag          root = xml::getRootTag();
     PtrDataConfiguration dataConfig(new DataConfiguration(root));
     dataConfig->setDimensions(3);
     PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
     meshConfig->setDimensions(3);
     m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
-    CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig );
+    CouplingSchemeConfiguration          cplSchemeConfig(root, meshConfig, m2nConfig);
 
-    if (utils::Parallel::getProcessRank() == 0){
+    if (utils::Parallel::getProcessRank() == 0) {
       localParticipant = nameParticipant0;
-    }
-    else if (utils::Parallel::getProcessRank() == 1){
+    } else if (utils::Parallel::getProcessRank() == 1) {
       localParticipant = nameParticipant1;
-    }
-    else {
+    } else {
       BOOST_TEST(utils::Parallel::getProcessRank() == 2,
-          utils::Parallel::getProcessRank());
+                 utils::Parallel::getProcessRank());
       localParticipant = nameParticipant2;
     }
 
@@ -75,26 +73,24 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor
     meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
     meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
 
-    if (utils::Parallel::getProcessRank() == 0){
+    if (utils::Parallel::getProcessRank() == 0) {
       connect(nameParticipant0, nameParticipant1, localParticipant, m2n0);
-    }
-    else if (utils::Parallel::getProcessRank() == 1){
+    } else if (utils::Parallel::getProcessRank() == 1) {
       connect(nameParticipant0, nameParticipant1, localParticipant, m2n0);
       connect(nameParticipant1, nameParticipant2, localParticipant, m2n1);
-    }
-    else {
+    } else {
       connect(nameParticipant1, nameParticipant2, localParticipant, m2n1);
     }
 
     runThreeSolverCoupling(cplSchemeConfig.getCouplingScheme(localParticipant),
-        localParticipant, meshConfig);
+                           localParticipant, meshConfig);
     utils::Parallel::clearGroups();
   }
 
   void runThreeSolverCoupling(
       PtrCouplingScheme          cplScheme,
-      const std::string&         participantName,
-      mesh::PtrMeshConfiguration meshConfig )
+      const std::string &        participantName,
+      mesh::PtrMeshConfiguration meshConfig)
   {
     BOOST_TEST(meshConfig->meshes().size() == 1);
     mesh::PtrMesh mesh = meshConfig->meshes()[0];
@@ -104,31 +100,30 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor
     std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
     std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
 
-    double computedTime = 0.0;
-    int computedTimesteps = 0;
+    double computedTime      = 0.0;
+    int    computedTimesteps = 0;
 
-    if (participantName == std::string("Participant0")){
+    if (participantName == std::string("Participant0")) {
       cplScheme->initialize(0.0, 1);
       BOOST_TEST(not cplScheme->hasDataBeenExchanged());
       BOOST_TEST(not cplScheme->isCouplingTimestepComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());
-      while (cplScheme->isCouplingOngoing()){
+      while (cplScheme->isCouplingOngoing()) {
         BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
-        if (cplScheme->isActionRequired(writeIterationCheckpoint)){
+        if (cplScheme->isActionRequired(writeIterationCheckpoint)) {
           cplScheme->performedAction(writeIterationCheckpoint);
         }
         cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
         cplScheme->advance();
-        if (cplScheme->isActionRequired(readIterationCheckpoint)){
+        if (cplScheme->isActionRequired(readIterationCheckpoint)) {
           cplScheme->performedAction(readIterationCheckpoint);
-        }
-        else {
+        } else {
           BOOST_TEST(cplScheme->isCouplingTimestepComplete());
           computedTime += cplScheme->getNextTimestepMaxLength();
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
-        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps()-1);
+        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps() - 1);
         BOOST_TEST(cplScheme->hasDataBeenExchanged());
       }
       cplScheme->finalize();
@@ -136,29 +131,27 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor
       BOOST_TEST(cplScheme->isCouplingTimestepComplete());
       BOOST_TEST(not cplScheme->isCouplingOngoing());
       BOOST_TEST(cplScheme->getNextTimestepMaxLength() > 0.0); // ??
-    }
-    else if (participantName == std::string("Participant1")){
+    } else if (participantName == std::string("Participant1")) {
       cplScheme->initialize(0.0, 1);
       BOOST_TEST(cplScheme->hasDataBeenExchanged());
       BOOST_TEST(not cplScheme->isCouplingTimestepComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());
-      while (cplScheme->isCouplingOngoing()){
+      while (cplScheme->isCouplingOngoing()) {
         BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
-        if (cplScheme->isActionRequired(writeIterationCheckpoint)){
+        if (cplScheme->isActionRequired(writeIterationCheckpoint)) {
           cplScheme->performedAction(writeIterationCheckpoint);
         }
         cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
         cplScheme->advance();
-        if (cplScheme->isActionRequired(readIterationCheckpoint)){
+        if (cplScheme->isActionRequired(readIterationCheckpoint)) {
           cplScheme->performedAction(readIterationCheckpoint);
-        }
-        else {
+        } else {
           BOOST_TEST(cplScheme->isCouplingTimestepComplete());
           computedTime += cplScheme->getNextTimestepMaxLength();
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
-        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps()-1);
+        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps() - 1);
         BOOST_TEST(cplScheme->hasDataBeenExchanged());
       }
       cplScheme->finalize();
@@ -166,31 +159,29 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor
       BOOST_TEST(cplScheme->isCouplingTimestepComplete());
       BOOST_TEST(not cplScheme->isCouplingOngoing());
       BOOST_TEST(cplScheme->getNextTimestepMaxLength() > 0.0); // ??
-    }
-    else {
+    } else {
       BOOST_TEST(participantName == std::string("Participant2"), participantName);
       cplScheme->initialize(0.0, 1);
       BOOST_TEST(cplScheme->hasDataBeenExchanged());
       BOOST_TEST(not cplScheme->isCouplingTimestepComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());
-      while (cplScheme->isCouplingOngoing()){
+      while (cplScheme->isCouplingOngoing()) {
         BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
-        if (cplScheme->isActionRequired(writeIterationCheckpoint)){
+        if (cplScheme->isActionRequired(writeIterationCheckpoint)) {
           cplScheme->performedAction(writeIterationCheckpoint);
         }
         cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
         cplScheme->advance();
-        if (cplScheme->isActionRequired(readIterationCheckpoint)){
+        if (cplScheme->isActionRequired(readIterationCheckpoint)) {
           cplScheme->performedAction(readIterationCheckpoint);
-        }
-        else {
+        } else {
           BOOST_TEST(cplScheme->isCouplingTimestepComplete());
           computedTime += cplScheme->getNextTimestepMaxLength();
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
-        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps()-1);
-        if(cplScheme->isCouplingOngoing())
+        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps() - 1);
+        if (cplScheme->isCouplingOngoing())
           BOOST_TEST(cplScheme->hasDataBeenExchanged());
       }
       cplScheme->finalize();
@@ -201,21 +192,20 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor
     }
   }
 
-  void connect(const std::string&     participant0,
-               const std::string&     participant1,
-               const std::string&     localParticipant,
-               m2n::PtrM2N communication ) const
+  void connect(const std::string &participant0,
+               const std::string &participant1,
+               const std::string &localParticipant,
+               m2n::PtrM2N        communication) const
   {
-    BOOST_TEST ( communication );
-    BOOST_TEST ( not communication->isConnected() );
-    utils::Parallel::splitCommunicator( localParticipant );
+    BOOST_TEST(communication);
+    BOOST_TEST(not communication->isConnected());
+    utils::Parallel::splitCommunicator(localParticipant);
     useOnlyMasterCom(communication) = true;
-    if ( participant0 == localParticipant ) {
-      communication->requestMasterConnection ( participant1, participant0 );
-    }
-    else {
-      BOOST_TEST ( participant1 == localParticipant );
-      communication->acceptMasterConnection ( participant1, participant0 );
+    if (participant0 == localParticipant) {
+      communication->requestMasterConnection(participant1, participant0);
+    } else {
+      BOOST_TEST(participant1 == localParticipant);
+      communication->acceptMasterConnection(participant1, participant0);
     }
   }
 };
@@ -228,41 +218,41 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 1;
-  int maxTimesteps = 10;
-  PtrCouplingScheme scheme(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  int                         numberIterations = 1;
+  int                         maxTimesteps     = 10;
+  PtrCouplingScheme           scheme(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
   }
   composition.finalize();
   BOOST_TEST(advances == 10);
-  BOOST_TEST(scheme->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme->getTimesteps() - 1 == 10);
 }
 
 // Test one implicit dummy coupling scheme
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit1)
 {
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-  int numberIterations = 2;
-  int maxTimesteps = 10;
-  PtrCouplingScheme scheme(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  std::string                 writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
+  std::string                 readIterationCheckpoint(constants::actionReadIterationCheckpoint());
+  int                         numberIterations = 2;
+  int                         maxTimesteps     = 10;
+  PtrCouplingScheme           scheme(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme->getTimesteps() - 1 == 10);
 }
 
 // Test two explicit dummy coupling schemes
@@ -271,8 +261,8 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 1;
-  int maxTimesteps = 10;
+  int               numberIterations = 1;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(
       new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   PtrCouplingScheme scheme2(
@@ -282,14 +272,14 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
   composition.addCouplingScheme(scheme2);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
   }
   composition.finalize();
   BOOST_TEST(advances == 10);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
 }
 
 // Test three explicit dummy coupling schemes
@@ -298,8 +288,8 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 1;
-  int maxTimesteps = 10;
+  int               numberIterations = 1;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(
       new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   PtrCouplingScheme scheme2(
@@ -312,15 +302,15 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
   }
   composition.finalize();
   BOOST_TEST(advances == 10);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 // Test two implicit dummy coupling schemes
@@ -329,8 +319,8 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 2;
-  int maxTimesteps = 10;
+  int               numberIterations = 2;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(
       new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   PtrCouplingScheme scheme2(
@@ -340,22 +330,21 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2)
   composition.addCouplingScheme(scheme2);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%2 == 1){
+    if (advances % 2 == 1) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-    }
-    else if (advances%2 == 0){
+    } else if (advances % 2 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
 }
 
 // Test two implicit dummy coupling schemes with different iteration number
@@ -364,36 +353,34 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2DiffIteration)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 2;
-  int maxTimesteps = 10;
+  int               numberIterations = 2;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 3;
-  PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%3 == 2){
+    if (advances % 3 == 2) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-    }
-    else if (advances%3 == 1){
+    } else if (advances % 3 == 1) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-    }
-    else if (advances%3 == 0){
+    } else if (advances % 3 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
 }
 
 // Test three implicit dummy coupling schemes
@@ -402,26 +389,25 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 2;
-  int maxTimesteps = 10;
-  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
-  PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
-  PtrCouplingScheme scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  int                         numberIterations = 2;
+  int                         maxTimesteps     = 10;
+  PtrCouplingScheme           scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%2 == 0){
+    if (advances % 2 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
-    }
-    else {
+    } else {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
@@ -429,9 +415,9 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3)
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 // Test three implicit dummy coupling schemes with different iteration number
@@ -440,38 +426,35 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3DiffIteration)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 3;
-  int maxTimesteps = 10;
+  int               numberIterations = 3;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 4;
   PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 2;
-  PtrCouplingScheme scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%4 == 0){
+    if (advances % 4 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
-    }
-    else if (advances%4 == 1){
+    } else if (advances % 4 == 1) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
-    }
-    else if (advances%4 == 2){
+    } else if (advances % 4 == 2) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
-    }
-    else if (advances%4 == 3){
+    } else if (advances % 4 == 3) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
@@ -479,9 +462,9 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3DiffIteration)
   }
   composition.finalize();
   BOOST_TEST(advances == 40);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 // Test E, I(2)
@@ -490,32 +473,31 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 1;
-  int maxTimesteps = 10;
+  int               numberIterations = 1;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 2;
-  PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%2 == 0){
+    if (advances % 2 == 0) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/2);
-    }
-    else {
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
+    } else {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances+1)/2);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
 }
 
 // Test I(2), E
@@ -524,32 +506,31 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 2;
-  int maxTimesteps = 10;
+  int               numberIterations = 2;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 1;
-  PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%2 == 0){
+    if (advances % 2 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/2);
-    }
-    else {
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
+    } else {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances-1)/2);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
 }
 
 // Test E, I(3)
@@ -558,8 +539,8 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 1;
-  int maxTimesteps = 10;
+  int               numberIterations = 1;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(
       new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 3;
@@ -570,22 +551,21 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
   composition.addCouplingScheme(scheme2);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%3 == 0){
+    if (advances % 3 == 0) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/3);
-    }
-    else {
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
+    } else {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances+(3-advances%3))/3);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + (3 - advances % 3)) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
 }
 
 // Test I(3), E
@@ -594,32 +574,31 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3Explicit1)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 3;
-  int maxTimesteps = 10;
+  int               numberIterations = 3;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 1;
-  PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%3 == 0){
+    if (advances % 3 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/3);
-    }
-    else {
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
+    } else {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances-(advances%3))/3);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - (advances % 3)) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
 }
 
 // Test E, I(2), I(2)
@@ -628,37 +607,36 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2Implicit2)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 1;
-  int maxTimesteps = 10;
+  int               numberIterations = 1;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 2;
-  PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
-  PtrCouplingScheme scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%2 == 0){
+    if (advances % 2 == 0) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/2);
-    }
-    else {
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
+    } else {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances+1)/2);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 // Test E, I(2), I(3)
@@ -667,43 +645,41 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2Implicit3)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 1;
-  int maxTimesteps = 10;
+  int               numberIterations = 1;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 2;
   PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 3;
-  PtrCouplingScheme scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%3 == 0){
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/3);
+    if (advances % 3 == 0) {
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
-    }
-    else if (advances%3 == 1){
+    } else if (advances % 3 == 1) {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances+2)/3);
-    }
-    else if (advances%3 == 2){
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 2) / 3);
+    } else if (advances % 3 == 2) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances+1)/3);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 1) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 // Test I(2), I(2), E
@@ -712,41 +688,40 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Implicit2Explicit1)
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 2;
-  int maxTimesteps = 10;
+  int               numberIterations = 2;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 1;
-  PtrCouplingScheme scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%2 == 0){
+    if (advances % 2 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/2);
-      BOOST_TEST(scheme2->getTimesteps()-1 == advances/2);
-      BOOST_TEST(scheme3->getTimesteps()-1 == advances/2);
-    }
-    else {
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
+      BOOST_TEST(scheme2->getTimesteps() - 1 == advances / 2);
+      BOOST_TEST(scheme3->getTimesteps() - 1 == advances / 2);
+    } else {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances-1)/2);
-      BOOST_TEST(scheme2->getTimesteps()-1 == (advances-1)/2);
-      BOOST_TEST(scheme3->getTimesteps()-1 == (advances-1)/2);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 1) / 2);
+      BOOST_TEST(scheme2->getTimesteps() - 1 == (advances - 1) / 2);
+      BOOST_TEST(scheme3->getTimesteps() - 1 == (advances - 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 // Test I(2), I(2), E
@@ -755,49 +730,47 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Implicit2Explicit1DiffIt
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 3;
-  int maxTimesteps = 10;
+  int               numberIterations = 3;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 2;
   PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 1;
-  PtrCouplingScheme scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances%3 == 0){
+    if (advances % 3 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == advances/3);
-      BOOST_TEST(scheme2->getTimesteps()-1 == advances/3);
-      BOOST_TEST(scheme3->getTimesteps()-1 == advances/3);
-    }
-    else if (advances%3 == 1){
+      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
+      BOOST_TEST(scheme2->getTimesteps() - 1 == advances / 3);
+      BOOST_TEST(scheme3->getTimesteps() - 1 == advances / 3);
+    } else if (advances % 3 == 1) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances-1)/3);
-      BOOST_TEST(scheme2->getTimesteps()-1 == (advances-1)/3);
-      BOOST_TEST(scheme3->getTimesteps()-1 == (advances-1)/3);
-    }
-    else if (advances%3 == 2){
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 1) / 3);
+      BOOST_TEST(scheme2->getTimesteps() - 1 == (advances - 1) / 3);
+      BOOST_TEST(scheme3->getTimesteps() - 1 == (advances - 1) / 3);
+    } else if (advances % 3 == 2) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances-2)/3);
-      BOOST_TEST(scheme2->getTimesteps()-1 == (advances+1)/3);
-      BOOST_TEST(scheme3->getTimesteps()-1 == (advances-2)/3);
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 2) / 3);
+      BOOST_TEST(scheme2->getTimesteps() - 1 == (advances + 1) / 3);
+      BOOST_TEST(scheme3->getTimesteps() - 1 == (advances - 2) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionUntitled) /// @todo give a better name, what is this test doing?
@@ -805,37 +778,36 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionUntitled) /// @todo give a better
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int numberIterations = 3;
-  int maxTimesteps = 10;
+  int               numberIterations = 3;
+  int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 1;
   PtrCouplingScheme scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   numberIterations = 2;
-  PtrCouplingScheme scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme3(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
   composition.initialize(0.0, 1);
   int advances = 0;
-  while (composition.isCouplingOngoing()){
+  while (composition.isCouplingOngoing()) {
     composition.advance();
     advances++;
-    if (advances % 4 >= 3){
+    if (advances % 4 >= 3) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps()-1 == (advances-(advances%4)+4)/4);
-    }
-    else if (advances % 4 != 0){
+      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - (advances % 4) + 4) / 4);
+    } else if (advances % 4 != 0) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
     }
-    BOOST_TEST(scheme2->getTimesteps()-1 == (advances+1)/4);
-    BOOST_TEST(scheme2->getTimesteps()-1 == (advances+1)/4);
+    BOOST_TEST(scheme2->getTimesteps() - 1 == (advances + 1) / 4);
+    BOOST_TEST(scheme2->getTimesteps() - 1 == (advances + 1) / 4);
   }
   composition.finalize();
   BOOST_TEST(advances == 40);
-  BOOST_TEST(scheme1->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme2->getTimesteps()-1 == 10);
-  BOOST_TEST(scheme3->getTimesteps()-1 == 10);
+  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -844,8 +816,7 @@ BOOST_FIXTURE_TEST_SUITE(CompositionalCouplingSchemeTests, CompositionalCoupling
 
 /// Test that runs on 3 processors.
 BOOST_AUTO_TEST_CASE(testExplicitSchemeComposition1,
-                     * testing::MinRanks(3)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
+                     *testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
 {
   if (utils::Parallel::getCommunicatorSize() != 3) // only run test on ranks {0,1,2}, for other ranks return
     return;
@@ -856,8 +827,7 @@ BOOST_AUTO_TEST_CASE(testExplicitSchemeComposition1,
 
 /// Test that runs on 3 processors.
 BOOST_AUTO_TEST_CASE(testImplicitSchemeComposition,
-                     * testing::MinRanks(3)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
+                     *testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
 {
   if (utils::Parallel::getCommunicatorSize() != 3) // only run test on ranks {0,1,2}, for other ranks return
     return;
@@ -867,7 +837,7 @@ BOOST_AUTO_TEST_CASE(testImplicitSchemeComposition,
 }
 
 /// Test that runs on 3 processors.
-BOOST_AUTO_TEST_CASE(testImplicitExplicitSchemeComposition, * testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
+BOOST_AUTO_TEST_CASE(testImplicitExplicitSchemeComposition, *testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
 {
   if (utils::Parallel::getCommunicatorSize() != 3) // only run test on ranks {0,1,2}, for other ranks return
     return;
@@ -877,7 +847,7 @@ BOOST_AUTO_TEST_CASE(testImplicitExplicitSchemeComposition, * testing::MinRanks(
 }
 
 /// Test that runs on 3 processors.
-BOOST_AUTO_TEST_CASE(testExplicitImplicitSchemeComposition, * testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
+BOOST_AUTO_TEST_CASE(testExplicitImplicitSchemeComposition, *testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
 {
   if (utils::Parallel::getCommunicatorSize() != 3) // only run test on ranks {0,1,2}, for other ranks return
     return;

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -1,38 +1,35 @@
 #include "DummyCouplingScheme.hpp"
 #include "../Constants.hpp"
 
-
 namespace precice {
 namespace cplscheme {
 namespace tests {
 
-DummyCouplingScheme:: DummyCouplingScheme
-(
-  int numberIterations,
-  int maxTimesteps )
-:
-  _numberIterations(numberIterations),
-  _maxTimesteps(maxTimesteps)
-{}
+DummyCouplingScheme::DummyCouplingScheme(
+    int numberIterations,
+    int maxTimesteps)
+    : _numberIterations(numberIterations),
+      _maxTimesteps(maxTimesteps)
+{
+}
 
-void DummyCouplingScheme:: initialize
-(
-  double startTime,
-  int    startTimesteps )
+void DummyCouplingScheme::initialize(
+    double startTime,
+    int    startTimesteps)
 {
   PRECICE_ASSERT(not _isInitialized);
   _isInitialized = true;
-  _isOngoing = true;
-  _timesteps = startTimesteps;
-  _iterations=1;
+  _isOngoing     = true;
+  _timesteps     = startTimesteps;
+  _iterations    = 1;
 }
 
-void DummyCouplingScheme:: advance()
+void DummyCouplingScheme::advance()
 {
   PRECICE_ASSERT(_isInitialized);
   PRECICE_ASSERT(_isOngoing);
-  if (_iterations == _numberIterations){
-    if (_timesteps == _maxTimesteps){
+  if (_iterations == _numberIterations) {
+    if (_timesteps == _maxTimesteps) {
       _isOngoing = false;
     }
     _timesteps++;
@@ -41,30 +38,29 @@ void DummyCouplingScheme:: advance()
   _iterations++;
 }
 
-void DummyCouplingScheme:: finalize()
+void DummyCouplingScheme::finalize()
 {
   PRECICE_ASSERT(_isInitialized);
   PRECICE_ASSERT(not _isOngoing);
 }
 
-bool DummyCouplingScheme:: isCouplingOngoing() const
+bool DummyCouplingScheme::isCouplingOngoing() const
 {
-  if (_timesteps <= _maxTimesteps) return true;
+  if (_timesteps <= _maxTimesteps)
+    return true;
   return false;
 }
 
-bool DummyCouplingScheme:: isActionRequired
-(
-  const std::string& actionName ) const
+bool DummyCouplingScheme::isActionRequired(
+    const std::string &actionName) const
 {
-  if (_numberIterations > 1){
-    if (actionName == constants::actionWriteIterationCheckpoint()){
+  if (_numberIterations > 1) {
+    if (actionName == constants::actionWriteIterationCheckpoint()) {
       if (_iterations == 1) {
         PRECICE_DEBUG("return true");
         return true;
       }
-    }
-    else if (actionName == constants::actionReadIterationCheckpoint()){
+    } else if (actionName == constants::actionReadIterationCheckpoint()) {
       if (_iterations != 1) {
         PRECICE_DEBUG("return true");
         return true;
@@ -75,4 +71,6 @@ bool DummyCouplingScheme:: isActionRequired
   return false;
 }
 
-}}} // namespace precice, cplscheme, tests
+} // namespace tests
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -11,10 +11,8 @@ namespace tests {
 /**
  * @brief Used to test CompositionalCouplingScheme.
  */
-class DummyCouplingScheme : public CouplingScheme
-{
+class DummyCouplingScheme : public CouplingScheme {
 public:
-
   /**
    * @brief Constructor.
    *
@@ -22,8 +20,8 @@ public:
    *        otherwise and implicit one.
    */
   DummyCouplingScheme(
-    int numberIterations,
-    int maxTimesteps );
+      int numberIterations,
+      int maxTimesteps);
 
   /**
    * @brief Destructor, empty.
@@ -33,24 +31,33 @@ public:
   /**
    * @brief
    */
-  virtual void initialize (
-     double startTime,
-     int    startTimesteps );
+  virtual void initialize(
+      double startTime,
+      int    startTimesteps);
 
   /**
    * @brief Not implemented.
    */
-  virtual bool isInitialized() const { PRECICE_ASSERT(false); return false; }
+  virtual bool isInitialized() const
+  {
+    PRECICE_ASSERT(false);
+    return false;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual void initializeData() { PRECICE_ASSERT(false); }
+  virtual void initializeData()
+  {
+    PRECICE_ASSERT(false);
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual void addComputedTime(double timeToAdd) { /* Do nothing */ }
+  virtual void addComputedTime(double timeToAdd)
+  { /* Do nothing */
+  }
 
   /**
    * @brief
@@ -65,62 +72,110 @@ public:
   /*
    * @brief Not implemented.
    */
-  virtual std::vector<std::string> getCouplingPartners() const { PRECICE_ASSERT(false); return std::vector<std::string>(); }
+  virtual std::vector<std::string> getCouplingPartners() const
+  {
+    PRECICE_ASSERT(false);
+    return std::vector<std::string>();
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual bool willDataBeExchanged(double lastSolverTimestepLength) const { PRECICE_ASSERT(false); return false; }
+  virtual bool willDataBeExchanged(double lastSolverTimestepLength) const
+  {
+    PRECICE_ASSERT(false);
+    return false;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual bool hasDataBeenExchanged() const { PRECICE_ASSERT(false); return false; }
+  virtual bool hasDataBeenExchanged() const
+  {
+    PRECICE_ASSERT(false);
+    return false;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual double getTime() const { PRECICE_ASSERT(false); return 0; }
+  virtual double getTime() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual int getTimesteps() const { return _timesteps; return 0; }
+  virtual int getTimesteps() const
+  {
+    return _timesteps;
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual double getMaxTime() const { PRECICE_ASSERT(false); return 0; }
+  virtual double getMaxTime() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual int getMaxTimesteps() const { PRECICE_ASSERT(false); return 0; }
+  virtual int getMaxTimesteps() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual bool hasTimestepLength() const { PRECICE_ASSERT(false); return false; }
+  virtual bool hasTimestepLength() const
+  {
+    PRECICE_ASSERT(false);
+    return false;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual double getTimestepLength() const { PRECICE_ASSERT(false); return 0; }
+  virtual double getTimestepLength() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual double getThisTimestepRemainder() const { PRECICE_ASSERT(false); return 0; }
+  virtual double getThisTimestepRemainder() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual double getComputedTimestepPart() const { PRECICE_ASSERT(false); return 0; }
+  virtual double getComputedTimestepPart() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual double getNextTimestepMaxLength() const { PRECICE_ASSERT(false); return 0; }
+  virtual double getNextTimestepMaxLength() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
@@ -130,59 +185,75 @@ public:
   /**
    * @brief Not implemented.
    */
-  virtual bool isCouplingTimestepComplete() const { PRECICE_ASSERT(false); return false; }
+  virtual bool isCouplingTimestepComplete() const
+  {
+    PRECICE_ASSERT(false);
+    return false;
+  }
 
   /**
    * @brief
    */
-  virtual bool isActionRequired(const std::string& actionName) const;
+  virtual bool isActionRequired(const std::string &actionName) const;
 
   /**
    * @brief Not implemented.
    */
-  virtual void performedAction(const std::string& actionName) { PRECICE_ASSERT(false); }
+  virtual void performedAction(const std::string &actionName)
+  {
+    PRECICE_ASSERT(false);
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual int getCheckpointTimestepInterval() const { PRECICE_ASSERT(false); return 0; }
+  virtual int getCheckpointTimestepInterval() const
+  {
+    PRECICE_ASSERT(false);
+    return 0;
+  }
 
   /**
    * @brief Not implemented.
    */
-  virtual void requireAction(const std::string& actionName) { PRECICE_ASSERT(false); }
+  virtual void requireAction(const std::string &actionName)
+  {
+    PRECICE_ASSERT(false);
+  }
 
   /**
    * @brief Empty.
    */
-  virtual std::string printCouplingState() const { return std::string(); }
+  virtual std::string printCouplingState() const
+  {
+    return std::string();
+  }
 
   /**
    * @brief Empty.
    */
-  virtual void exportState(const std::string& filenamePrefix) const {}
+  virtual void exportState(const std::string &filenamePrefix) const {}
 
   /**
    * @brief Empty.
    */
-  virtual void importState(const std::string& filenamePrefix) {}
+  virtual void importState(const std::string &filenamePrefix) {}
 
   /**
    * @brief Empty.
    */
-  virtual void sendState (
-    com::PtrCommunication communication,
-    int                   rankReceiver ) {}
+  virtual void sendState(
+      com::PtrCommunication communication,
+      int                   rankReceiver) {}
 
   /**
    * @brief Empty.
    */
-  virtual void receiveState (
-    com::PtrCommunication communication,
-    int                   rankSender ) {}
+  virtual void receiveState(
+      com::PtrCommunication communication,
+      int                   rankSender) {}
 
 private:
-
   mutable logging::Logger _log{"cplscheme::tests::DummyCouplingScheme"};
 
   // @brief Number of iterations performed per timestep. 1 --> explicit.
@@ -204,4 +275,6 @@ private:
   bool _isOngoing = false;
 };
 
-}}} // namespace precice, cplscheme, tests
+} // namespace tests
+} // namespace cplscheme
+} // namespace precice

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -1,22 +1,22 @@
+#include <Eigen/Core>
+#include "com/Communication.hpp"
+#include "com/MPIDirectCommunication.hpp"
+#include "cplscheme/Constants.hpp"
 #include "cplscheme/SerialCouplingScheme.hpp"
 #include "cplscheme/config/CouplingSchemeConfiguration.hpp"
-#include "cplscheme/Constants.hpp"
-#include "mesh/SharedPointer.hpp"
+#include "m2n/GatherScatterCommunication.hpp"
+#include "m2n/M2N.hpp"
+#include "m2n/config/M2NConfiguration.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
 #include "mesh/Vertex.hpp"
 #include "mesh/config/DataConfiguration.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
-#include "com/Communication.hpp"
-#include "com/MPIDirectCommunication.hpp"
-#include "m2n/M2N.hpp"
-#include "m2n/GatherScatterCommunication.hpp"
-#include "m2n/config/M2NConfiguration.hpp"
 #include "utils/Parallel.hpp"
 #include "xml/XMLTag.hpp"
-#include <Eigen/Core>
 
-#include "testing/Testing.hpp"
 #include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 
 using namespace precice;
 using namespace precice::cplscheme;
@@ -26,43 +26,43 @@ using namespace precice::cplscheme;
 BOOST_AUTO_TEST_SUITE(CplSchemeTests)
 
 void runSimpleExplicitCoupling(
-      CouplingScheme&                cplScheme,
-      const std::string&             participantName,
-      const mesh::MeshConfiguration& meshConfig )
+    CouplingScheme &               cplScheme,
+    const std::string &            participantName,
+    const mesh::MeshConfiguration &meshConfig)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig.meshes()[0];
   BOOST_TEST(mesh->data().size() == 2);
-  auto& dataValues0 = mesh->data()[0]->values();
-  auto& dataValues1 = mesh->data()[1]->values();
+  auto &dataValues0 = mesh->data()[0]->values();
+  auto &dataValues1 = mesh->data()[1]->values();
   BOOST_TEST(mesh->vertices().size() > 0);
-  mesh::Vertex& vertex = mesh->vertices()[0];
-  double valueData0 = 1.0;
-  Eigen::VectorXd valueData1 = Eigen::VectorXd::Constant(3, 1.0 );
+  mesh::Vertex &  vertex     = mesh->vertices()[0];
+  double          valueData0 = 1.0;
+  Eigen::VectorXd valueData1 = Eigen::VectorXd::Constant(3, 1.0);
 
-  double computedTime = 0.0;
-  int computedTimesteps = 0;
+  double computedTime      = 0.0;
+  int    computedTimesteps = 0;
 
-  if ( participantName == std::string("Participant0") ) {
-    cplScheme.initialize ( 0.0, 1 );
+  if (participantName == std::string("Participant0")) {
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.hasDataBeenExchanged());
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
-    while ( cplScheme.isCouplingOngoing() ) {
+    while (cplScheme.isCouplingOngoing()) {
       dataValues0(vertex.getID()) = valueData0;
       computedTime += cplScheme.getNextTimestepMaxLength();
-      computedTimesteps ++;
-      cplScheme.addComputedTime ( cplScheme.getNextTimestepMaxLength() );
+      computedTimesteps++;
+      cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
       cplScheme.advance();
       BOOST_TEST(cplScheme.isCouplingTimestepComplete());
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps()-1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
       BOOST_TEST(not cplScheme.isActionRequired("WriteIterationCheckpoint"));
       BOOST_TEST(not cplScheme.isActionRequired("ReadIterationCheckpoint"));
       BOOST_TEST(cplScheme.isCouplingTimestepComplete());
-      if ( cplScheme.isCouplingOngoing() ) {
+      if (cplScheme.isCouplingOngoing()) {
         // No receive takes place for the participant that has started the
         // coupled simulation, in the last advance call
         Eigen::VectorXd value = dataValues1.segment(vertex.getID() * 3, 3);
@@ -72,7 +72,7 @@ void runSimpleExplicitCoupling(
       // Increment data values, to test if send/receive operations are also
       // correct in following timesteps.
       valueData0 += 1.0;
-      valueData1 += Eigen::VectorXd::Constant(3, 1.0 );
+      valueData1 += Eigen::VectorXd::Constant(3, 1.0);
     }
     cplScheme.finalize();
     // Validate results
@@ -83,9 +83,8 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
-  }
-  else if ( participantName == std::string("Participant1") ) {
-    cplScheme.initialize ( 0.0, 1 );
+  } else if (participantName == std::string("Participant1")) {
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenExchanged());
     double value = dataValues0(vertex.getID());
     BOOST_TEST(testing::equals(value, valueData0));
@@ -94,18 +93,18 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
-    while ( cplScheme.isCouplingOngoing() ) {
-      dataValues1.segment(vertex.getID()*3, 3) = valueData1;
+    while (cplScheme.isCouplingOngoing()) {
+      dataValues1.segment(vertex.getID() * 3, 3) = valueData1;
       computedTime += cplScheme.getNextTimestepMaxLength();
-      computedTimesteps ++;
-      cplScheme.addComputedTime ( cplScheme.getNextTimestepMaxLength() );
+      computedTimesteps++;
+      cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
       cplScheme.advance();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps()-1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
       BOOST_TEST(cplScheme.isCouplingTimestepComplete());
-      if ( cplScheme.isCouplingOngoing() ) {
+      if (cplScheme.isCouplingOngoing()) {
         // The participant not starting the coupled simulation does neither
         // receive nor send data in the last call to advance
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
@@ -113,9 +112,9 @@ void runSimpleExplicitCoupling(
         BOOST_TEST(testing::equals(value, valueData0));
       }
       valueData0 += 1.0;
-      valueData1 += Eigen::VectorXd::Constant(3, 1.0 );
+      valueData1 += Eigen::VectorXd::Constant(3, 1.0);
     }
-    cplScheme.finalize ();
+    cplScheme.finalize();
     // Validate results
     BOOST_TEST(testing::equals(computedTime, 1.0));
     BOOST_TEST(computedTimesteps == 10);
@@ -128,56 +127,56 @@ void runSimpleExplicitCoupling(
 }
 
 void runExplicitCouplingWithSubcycling(
-      CouplingScheme&                cplScheme,
-      const std::string&             participantName,
-      const mesh::MeshConfiguration& meshConfig )
+    CouplingScheme &               cplScheme,
+    const std::string &            participantName,
+    const mesh::MeshConfiguration &meshConfig)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig.meshes()[0];
   BOOST_TEST(mesh->data().size() == 2);
   BOOST_TEST(mesh->vertices().size() > 0);
-  mesh::Vertex& vertex = mesh->vertices()[0];
-  double valueData0 = 1.0;
-  Eigen::VectorXd valueData1 = Eigen::VectorXd::Constant(3, 1.0);
-  auto& dataValues0 = mesh->data()[0]->values();
-  auto& dataValues1 = mesh->data()[1]->values();
+  mesh::Vertex &  vertex      = mesh->vertices()[0];
+  double          valueData0  = 1.0;
+  Eigen::VectorXd valueData1  = Eigen::VectorXd::Constant(3, 1.0);
+  auto &          dataValues0 = mesh->data()[0]->values();
+  auto &          dataValues1 = mesh->data()[1]->values();
 
-  double computedTime = 0.0;
-  int computedTimesteps = 0;
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  BOOST_TEST ( ((participantName == nameParticipant0) || (participantName == nameParticipant1)) );
-  if ( participantName == nameParticipant0 ) {
-    cplScheme.initialize ( 0.0, 1 );
+  double      computedTime      = 0.0;
+  int         computedTimesteps = 0;
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  BOOST_TEST(((participantName == nameParticipant0) || (participantName == nameParticipant1)));
+  if (participantName == nameParticipant0) {
+    cplScheme.initialize(0.0, 1);
     double dtDesired = cplScheme.getNextTimestepMaxLength() / 2.0;
-    double dtUsed = dtDesired;
+    double dtUsed    = dtDesired;
     BOOST_TEST(not cplScheme.hasDataBeenExchanged());
     BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
     BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
-    while ( cplScheme.isCouplingOngoing() ) {
+    while (cplScheme.isCouplingOngoing()) {
       dataValues0(vertex.getID()) = valueData0;
       computedTime += dtUsed;
-      computedTimesteps ++;
+      computedTimesteps++;
       cplScheme.addComputedTime(dtUsed);
       cplScheme.advance();
       // If the dt from preCICE is larger than the desired one, do subcycling,
       // else, use the dt from preCICE
       dtUsed = cplScheme.getNextTimestepMaxLength() > dtDesired
-              ? dtDesired
-              : cplScheme.getNextTimestepMaxLength();
+                   ? dtDesired
+                   : cplScheme.getNextTimestepMaxLength();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
-      if ( computedTimesteps % 2 == 0 ) {
+      if (computedTimesteps % 2 == 0) {
         // Data exchange takes only place at every second local timestep,
         // since a subcycling of 2 is used.
         BOOST_TEST(cplScheme.isCouplingTimestepComplete());
-        if ( cplScheme.isCouplingOngoing() ) {
+        if (cplScheme.isCouplingOngoing()) {
           // No receive takes place for the participant that has started the
           // coupled simulation, in the last advance call.
-          Eigen::VectorXd value = dataValues1.segment(vertex.getID()*3, 3);
+          Eigen::VectorXd value = dataValues1.segment(vertex.getID() * 3, 3);
           BOOST_TEST(testing::equals(value, valueData1));
         }
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
@@ -185,12 +184,11 @@ void runExplicitCouplingWithSubcycling(
         // correct in following timesteps.
         valueData0 += 1.0;
         valueData1 += Eigen::VectorXd::Constant(3, 1.0);
-      }
-      else {
+      } else {
         BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
       }
     }
-    cplScheme.finalize ();
+    cplScheme.finalize();
     BOOST_TEST(testing::equals(computedTime, 1.0));
     BOOST_TEST(computedTimesteps == 20);
     BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
@@ -198,10 +196,9 @@ void runExplicitCouplingWithSubcycling(
     BOOST_TEST(cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
-  }
-  else if(participantName == nameParticipant1) {
+  } else if (participantName == nameParticipant1) {
     // Start coupling
-    cplScheme.initialize ( 0.0, 1 );
+    cplScheme.initialize(0.0, 1);
     // Validate current coupling status
     BOOST_TEST(cplScheme.hasDataBeenExchanged());
     BOOST_TEST(testing::equals(dataValues0(vertex.getID()), valueData0));
@@ -210,18 +207,18 @@ void runExplicitCouplingWithSubcycling(
     BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
-    while ( cplScheme.isCouplingOngoing() ) {
-      dataValues1.segment(vertex.getID()*3, 3) = valueData1;
-      computedTime += cplScheme.getNextTimestepMaxLength ();
-      computedTimesteps ++;
-      cplScheme.addComputedTime ( cplScheme.getNextTimestepMaxLength() );
+    while (cplScheme.isCouplingOngoing()) {
+      dataValues1.segment(vertex.getID() * 3, 3) = valueData1;
+      computedTime += cplScheme.getNextTimestepMaxLength();
+      computedTimesteps++;
+      cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
       cplScheme.advance();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps()-1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
       BOOST_TEST(cplScheme.isCouplingTimestepComplete());
-      if ( cplScheme.isCouplingOngoing() ) {
+      if (cplScheme.isCouplingOngoing()) {
         // The participant not starting the coupled simulation does neither
         // receive nor send data in the last call to advance
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
@@ -231,7 +228,7 @@ void runExplicitCouplingWithSubcycling(
       valueData0 += 1.0;
       valueData1 += Eigen::VectorXd::Constant(3, 1.0);
     }
-    cplScheme.finalize ();
+    cplScheme.finalize();
     BOOST_TEST(testing::equals(computedTime, 1.0));
     BOOST_TEST(computedTimesteps == 10);
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
@@ -242,30 +239,29 @@ void runExplicitCouplingWithSubcycling(
   }
 }
 
-struct ExplicitCouplingSchemeFixture : m2n::WhiteboxAccessor
-{
+struct ExplicitCouplingSchemeFixture : m2n::WhiteboxAccessor {
   std::string _pathToTests;
 
-  ExplicitCouplingSchemeFixture(){
+  ExplicitCouplingSchemeFixture()
+  {
     _pathToTests = testing::getPathToSources() + "/cplscheme/tests/";
   }
 
   void connect(
-      const std::string&      participant0,
-      const std::string&      participant1,
-      const std::string&      localParticipant,
-      m2n::PtrM2N& communication )
+      const std::string &participant0,
+      const std::string &participant1,
+      const std::string &localParticipant,
+      m2n::PtrM2N &      communication)
   {
     BOOST_TEST(communication);
     BOOST_TEST(not communication->isConnected());
-    utils::Parallel::splitCommunicator( localParticipant );
+    utils::Parallel::splitCommunicator(localParticipant);
     useOnlyMasterCom(communication) = true;
-    if ( participant0 == localParticipant ) {
-      communication->requestMasterConnection ( participant1, participant0);
-    }
-    else {
-      BOOST_TEST ( participant1 == localParticipant );
-      communication->acceptMasterConnection ( participant1, participant0);
+    if (participant0 == localParticipant) {
+      communication->requestMasterConnection(participant1, participant0);
+    } else {
+      BOOST_TEST(participant1 == localParticipant);
+      communication->acceptMasterConnection(participant1, participant0);
     }
   }
 };
@@ -275,127 +271,79 @@ BOOST_FIXTURE_TEST_SUITE(ExplicitCouplingSchemeTests, ExplicitCouplingSchemeFixt
 /// Test that runs on 2 processors.
 
 BOOST_FIXTURE_TEST_CASE(testSimpleExplicitCoupling, testing::M2NFixture,
-                      * testing::MinRanks(2)
-                      * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
 
-  xml::XMLTag root = xml::getRootTag();
-  mesh::PtrDataConfiguration dataConfig ( new mesh::DataConfiguration(root) );
-  dataConfig->addData ( "Data0", 1 );
-  dataConfig->addData ( "Data1", 3 );
-  mesh::MeshConfiguration meshConfig ( root, dataConfig );
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()) );
-  mesh->createData ( "Data0", 1 );
-  mesh->createData ( "Data1", 3 );
-  mesh->createVertex ( Eigen::Vector3d::Zero() );
-  mesh->allocateDataValues ();
-  meshConfig.addMesh ( mesh );
+  xml::XMLTag                root = xml::getRootTag();
+  mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(root));
+  dataConfig->addData("Data0", 1);
+  dataConfig->addData("Data1", 3);
+  mesh::MeshConfiguration meshConfig(root, dataConfig);
+  mesh::PtrMesh           mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh->createData("Data0", 1);
+  mesh->createData("Data1", 3);
+  mesh->createVertex(Eigen::Vector3d::Zero());
+  mesh->allocateDataValues();
+  meshConfig.addMesh(mesh);
 
-  double maxTime = 1.0;
-  int maxTimesteps = 10;
-  double timestepLength = 0.1;
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  std::string nameLocalParticipant ( "" );
-  int sendDataIndex = -1;
-  int receiveDataIndex = -1;
-  if ( utils::Parallel::getProcessRank() == 0 ) {
+  double      maxTime        = 1.0;
+  int         maxTimesteps   = 10;
+  double      timestepLength = 0.1;
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
+  int         sendDataIndex    = -1;
+  int         receiveDataIndex = -1;
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-    sendDataIndex = 0;
-    receiveDataIndex = 1;
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ) {
+    sendDataIndex        = 0;
+    receiveDataIndex     = 1;
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
-    sendDataIndex = 1;
-    receiveDataIndex = 0;
+    sendDataIndex        = 1;
+    receiveDataIndex     = 0;
   }
   cplscheme::SerialCouplingScheme cplScheme(
       maxTime, maxTimesteps, timestepLength, 12, nameParticipant0,
       nameParticipant1, nameLocalParticipant, m2n, constants::FIXED_DT,
-      BaseCouplingScheme::Explicit );
-  cplScheme.addDataToSend ( mesh->data()[sendDataIndex], mesh , false );
-  cplScheme.addDataToReceive( mesh->data()[receiveDataIndex], mesh , false );
-  runSimpleExplicitCoupling( cplScheme, nameLocalParticipant, meshConfig );
+      BaseCouplingScheme::Explicit);
+  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
+  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
+  runSimpleExplicitCoupling(cplScheme, nameLocalParticipant, meshConfig);
 }
 
 /// Test that runs on 2 processors.
 BOOST_AUTO_TEST_CASE(testConfiguredSimpleExplicitCoupling,
-                   * testing::MinRanks(2)
-                   * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
 
   using namespace mesh;
-  BOOST_TEST ( utils::Parallel::getCommunicatorSize() > 1 );
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() > 1);
 
-  std::string configurationPath ( _pathToTests + "explicit-coupling-scheme-1.xml" );
+  std::string configurationPath(_pathToTests + "explicit-coupling-scheme-1.xml");
 
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  std::string nameLocalParticipant ( "" );
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
 
-  if ( utils::Parallel::getProcessRank() == 0 ) {
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ) {
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
   }
   xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
 
-  xml::XMLTag root = xml::getRootTag();
+  xml::XMLTag          root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(3);
   PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
   meshConfig->setDimensions(3);
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
-  CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
-
-  xml::configure(root, context, configurationPath);
-  m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
-
-  // some dummy mesh
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->allocateDataValues();
-
-  connect ( nameParticipant0, nameParticipant1, nameLocalParticipant, m2n );
-  runSimpleExplicitCoupling ( *cplSchemeConfig.getCouplingScheme(nameLocalParticipant),
-                               nameLocalParticipant, *meshConfig );
-}
-
-/// Test that runs on 2 processors.
-BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
-                   * testing::MinRanks(2)
-                   * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
-{
-  if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
-    return;
-
-  using namespace mesh;
-  std::string configurationPath ( _pathToTests + "explicit-coupling-scheme-2.xml" );
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  std::string nameLocalParticipant ( "" );
-  if ( utils::Parallel::getProcessRank() == 0 ){
-    nameLocalParticipant = nameParticipant0;
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ){
-    nameLocalParticipant = nameParticipant1;
-  }
-  xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
-
-  xml::XMLTag root = xml::getRootTag();
-  PtrDataConfiguration dataConfig(new DataConfiguration(root));
-  dataConfig->setDimensions(3);
-  PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
-  meshConfig->setDimensions(3);
-  m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
-  CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
+  CouplingSchemeConfiguration          cplSchemeConfig(root, meshConfig, m2nConfig);
 
   xml::configure(root, context, configurationPath);
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
@@ -408,24 +356,66 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
   meshConfig->meshes()[0]->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, nameLocalParticipant, m2n);
-  CouplingScheme& cplScheme = *cplSchemeConfig.getCouplingScheme(nameLocalParticipant);
+  runSimpleExplicitCoupling(*cplSchemeConfig.getCouplingScheme(nameLocalParticipant),
+                            nameLocalParticipant, *meshConfig);
+}
 
-  double computedTime = 0.0;
-  int computedTimesteps = 0;
-  if ( nameLocalParticipant == std::string(nameParticipant0) ){
+/// Test that runs on 2 processors.
+BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+{
+  if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
+    return;
+
+  using namespace mesh;
+  std::string configurationPath(_pathToTests + "explicit-coupling-scheme-2.xml");
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
+  if (utils::Parallel::getProcessRank() == 0) {
+    nameLocalParticipant = nameParticipant0;
+  } else if (utils::Parallel::getProcessRank() == 1) {
+    nameLocalParticipant = nameParticipant1;
+  }
+  xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
+
+  xml::XMLTag          root = xml::getRootTag();
+  PtrDataConfiguration dataConfig(new DataConfiguration(root));
+  dataConfig->setDimensions(3);
+  PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
+  meshConfig->setDimensions(3);
+  m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
+  CouplingSchemeConfiguration          cplSchemeConfig(root, meshConfig, m2nConfig);
+
+  xml::configure(root, context, configurationPath);
+  m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
+
+  // some dummy mesh
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
+  meshConfig->meshes()[0]->allocateDataValues();
+
+  connect(nameParticipant0, nameParticipant1, nameLocalParticipant, m2n);
+  CouplingScheme &cplScheme = *cplSchemeConfig.getCouplingScheme(nameLocalParticipant);
+
+  double computedTime      = 0.0;
+  int    computedTimesteps = 0;
+  if (nameLocalParticipant == std::string(nameParticipant0)) {
     double dt = 0.3;
-    cplScheme.initialize ( 0.0, 1 );
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
-    while ( cplScheme.isCouplingOngoing() ){
+    while (cplScheme.isCouplingOngoing()) {
       computedTime += dt;
       computedTimesteps++;
       cplScheme.addComputedTime(dt);
       cplScheme.advance();
       BOOST_TEST(cplScheme.isCouplingTimestepComplete());
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps()-1);
-      if ( cplScheme.isCouplingOngoing() ){
+      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
+      if (cplScheme.isCouplingOngoing()) {
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
       }
     }
@@ -434,21 +424,20 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
     BOOST_TEST(computedTimesteps == 4);
     BOOST_TEST(cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
-  }
-  else {
-    BOOST_TEST ( nameLocalParticipant == std::string(nameParticipant1), nameLocalParticipant );
-    cplScheme.initialize ( 0.0, 1 );
+  } else {
+    BOOST_TEST(nameLocalParticipant == std::string(nameParticipant1), nameLocalParticipant);
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
-    while ( cplScheme.isCouplingOngoing() ){
+    while (cplScheme.isCouplingOngoing()) {
       computedTime += cplScheme.getTimestepLength();
       computedTimesteps++;
       cplScheme.addComputedTime(cplScheme.getTimestepLength());
       cplScheme.advance();
       BOOST_TEST(cplScheme.isCouplingTimestepComplete());
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps()-1);
-      if ( cplScheme.isCouplingOngoing() ){
+      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
+      if (cplScheme.isCouplingOngoing()) {
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
       }
     }
@@ -462,8 +451,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
 
 /// Test that runs on 2 processors.
 BOOST_AUTO_TEST_CASE(testSerialDataInitialization,
-                   * testing::MinRanks(2)
-                   * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
@@ -471,46 +459,45 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization,
   using namespace mesh;
 
   std::string configurationPath(_pathToTests + "serial-explicit-coupling-datainit.xml");
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  std::string nameLocalParticipant ( "" );
-  if (utils::Parallel::getProcessRank() == 0){
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
   }
   xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
 
-  xml::XMLTag root = xml::getRootTag();
+  xml::XMLTag          root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(2);
   PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
   meshConfig->setDimensions(2);
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
-  CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
+  CouplingSchemeConfiguration          cplSchemeConfig(root, meshConfig, m2nConfig);
 
   xml::configure(root, context, configurationPath);
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
   // some dummy mesh
   meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(2.0,-1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(2.0, -1.0));
   meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(3.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(4.0,-1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(4.0, -1.0));
   meshConfig->meshes()[0]->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, nameLocalParticipant, m2n);
-  CouplingScheme& cplScheme = *cplSchemeConfig.getCouplingScheme(nameLocalParticipant);
+  CouplingScheme &cplScheme = *cplSchemeConfig.getCouplingScheme(nameLocalParticipant);
 
   BOOST_TEST(meshConfig->meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig->meshes()[0];
   BOOST_TEST(mesh->data().size() == 3);
-  auto& dataValues0 = mesh->data()[0]->values();
-  auto& dataValues1 = mesh->data()[1]->values();
-  auto& dataValues2 = mesh->data()[2]->values();
+  auto &dataValues0 = mesh->data()[0]->values();
+  auto &dataValues1 = mesh->data()[1]->values();
+  auto &dataValues2 = mesh->data()[2]->values();
 
-  if (nameLocalParticipant == std::string(nameParticipant0)){
+  if (nameLocalParticipant == std::string(nameParticipant0)) {
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteInitialData()));
     cplScheme.initializeData();
@@ -522,8 +509,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization,
     cplScheme.advance();
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     cplScheme.finalize();
-  }
-  else if (nameLocalParticipant == std::string(nameParticipant1)){
+  } else if (nameLocalParticipant == std::string(nameParticipant1)) {
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.hasDataBeenExchanged());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
@@ -540,8 +526,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization,
 
 /// Test that runs on 2 processors.
 BOOST_AUTO_TEST_CASE(testParallelDataInitialization,
-                   * testing::MinRanks(2)
-                   * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
@@ -549,46 +534,45 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization,
   using namespace mesh;
 
   std::string configurationPath(_pathToTests + "parallel-explicit-coupling-datainit.xml");
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  std::string nameLocalParticipant ( "" );
-  if (utils::Parallel::getProcessRank() == 0){
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
   }
   xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
 
-  xml::XMLTag root = xml::getRootTag();
+  xml::XMLTag          root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(2);
   PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
   meshConfig->setDimensions(2);
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
-  CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
+  CouplingSchemeConfiguration          cplSchemeConfig(root, meshConfig, m2nConfig);
 
   xml::configure(root, context, configurationPath);
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
   // some dummy mesh
   meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(2.0,-1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(2.0, -1.0));
   meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(3.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(4.0,-1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(4.0, -1.0));
   meshConfig->meshes()[0]->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, nameLocalParticipant, m2n);
-  CouplingScheme& cplScheme = *cplSchemeConfig.getCouplingScheme(nameLocalParticipant);
+  CouplingScheme &cplScheme = *cplSchemeConfig.getCouplingScheme(nameLocalParticipant);
 
   BOOST_TEST(meshConfig->meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig->meshes()[0];
   BOOST_TEST(mesh->data().size() == 3);
-  auto& dataValues0 = mesh->data()[0]->values();
-  auto& dataValues1 = mesh->data()[1]->values();
-  auto& dataValues2 = mesh->data()[2]->values();
+  auto &dataValues0 = mesh->data()[0]->values();
+  auto &dataValues1 = mesh->data()[1]->values();
+  auto &dataValues2 = mesh->data()[2]->values();
 
-  if (nameLocalParticipant == std::string(nameParticipant0)){
+  if (nameLocalParticipant == std::string(nameParticipant0)) {
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
     dataValues2(0) = 3.0;
@@ -603,8 +587,7 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization,
     BOOST_TEST(testing::equals(dataValues0(0), 4.0));
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     cplScheme.finalize();
-  }
-  else if (nameLocalParticipant == std::string(nameParticipant1)){
+  } else if (nameLocalParticipant == std::string(nameParticipant1)) {
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.hasDataBeenExchanged());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
@@ -624,99 +607,95 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization,
 
 /// Test that runs on 2 processors.
 BOOST_FIXTURE_TEST_CASE(testExplicitCouplingWithSubcycling, testing::M2NFixture,
-                      * testing::MinRanks(2)
-                      * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
 
-  xml::XMLTag root = xml::getRootTag();
-  mesh::PtrDataConfiguration dataConfig ( new mesh::DataConfiguration(root) );
+  xml::XMLTag                root = xml::getRootTag();
+  mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(root));
   dataConfig->setDimensions(3);
-  dataConfig->addData ( "Data0", 1 );
-  dataConfig->addData ( "Data1", 3 );
-  mesh::MeshConfiguration meshConfig ( root, dataConfig );
+  dataConfig->addData("Data0", 1);
+  dataConfig->addData("Data1", 3);
+  mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()) );
-  mesh->createData ( "Data0", 1 );
-  mesh->createData ( "Data1", 3 );
-  mesh->createVertex ( Eigen::Vector3d::Zero() );
-  mesh->allocateDataValues ();
-  meshConfig.addMesh ( mesh );
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh->createData("Data0", 1);
+  mesh->createData("Data1", 3);
+  mesh->createVertex(Eigen::Vector3d::Zero());
+  mesh->allocateDataValues();
+  meshConfig.addMesh(mesh);
 
-  double maxTime = 1.0;
-  int maxTimesteps = 10;
-  double timestepLength = 0.1;
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  std::string nameLocalParticipant ( "" );
-  int sendDataIndex = -1;
-  int receiveDataIndex = -1;
-  if ( utils::Parallel::getProcessRank() == 0 ) {
+  double      maxTime        = 1.0;
+  int         maxTimesteps   = 10;
+  double      timestepLength = 0.1;
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
+  int         sendDataIndex    = -1;
+  int         receiveDataIndex = -1;
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-    sendDataIndex = 0;
-    receiveDataIndex = 1;
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ) {
+    sendDataIndex        = 0;
+    receiveDataIndex     = 1;
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
-    sendDataIndex = 1;
-    receiveDataIndex = 0;
+    sendDataIndex        = 1;
+    receiveDataIndex     = 0;
   }
-  cplscheme::SerialCouplingScheme cplScheme (
+  cplscheme::SerialCouplingScheme cplScheme(
       maxTime, maxTimesteps, timestepLength, 12, nameParticipant0,
       nameParticipant1, nameLocalParticipant, m2n, constants::FIXED_DT,
-      BaseCouplingScheme::Explicit );
-  cplScheme.addDataToSend ( mesh->data()[sendDataIndex], mesh , false);
-  cplScheme.addDataToReceive ( mesh->data()[receiveDataIndex], mesh , false);
-  runExplicitCouplingWithSubcycling ( cplScheme, nameLocalParticipant, meshConfig );
+      BaseCouplingScheme::Explicit);
+  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
+  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
+  runExplicitCouplingWithSubcycling(cplScheme, nameLocalParticipant, meshConfig);
 }
 
 /// Test that runs on 2 processors.
 BOOST_AUTO_TEST_CASE(testConfiguredExplicitCouplingWithSubcycling,
-                   * testing::MinRanks(2)
-                   * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
 
   using namespace mesh;
 
-  std::string configurationPath ( _pathToTests + "explicit-coupling-scheme-1.xml" );
-  std::string nameParticipant0 ( "Participant0" );
-  std::string nameParticipant1 ( "Participant1" );
-  std::string nameLocalParticipant ( "" );
-  if ( utils::Parallel::getProcessRank() == 0 ) {
+  std::string configurationPath(_pathToTests + "explicit-coupling-scheme-1.xml");
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ) {
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
   }
   xml::ConfigurationContext context{nameLocalParticipant, 0, 1};
 
-  xml::XMLTag root = xml::getRootTag();
+  xml::XMLTag          root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(3);
   PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
   meshConfig->setDimensions(3);
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
-  CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
+  CouplingSchemeConfiguration          cplSchemeConfig(root, meshConfig, m2nConfig);
 
   xml::configure(root, context, configurationPath);
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
   // some dummy mesh
   meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0,-1.0, 1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, -1.0, 1.0));
   meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0,-1.0, 1.0));
+  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, -1.0, 1.0));
   meshConfig->meshes()[0]->allocateDataValues();
 
-  connect ( nameParticipant0, nameParticipant1, nameLocalParticipant, m2n );
-  runExplicitCouplingWithSubcycling (
+  connect(nameParticipant0, nameParticipant1, nameLocalParticipant, m2n);
+  runExplicitCouplingWithSubcycling(
       *cplSchemeConfig.getCouplingScheme(nameLocalParticipant), nameLocalParticipant,
-      *meshConfig );
+      *meshConfig);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 
-# endif // not PRECICE_NO_MPI
+#endif // not PRECICE_NO_MPI

--- a/src/cplscheme/tests/MinIterationConvergenceMeasureTest.cpp
+++ b/src/cplscheme/tests/MinIterationConvergenceMeasureTest.cpp
@@ -9,7 +9,7 @@ using namespace cplscheme;
 BOOST_AUTO_TEST_CASE(MinIterationConvergenceMeasureTest)
 {
   cplscheme::impl::MinIterationConvergenceMeasure measure(5);
-  Eigen::VectorXd                      emptyValues; // No values needed for min-iter
+  Eigen::VectorXd                                 emptyValues; // No values needed for min-iter
 
   for (int iSeries = 0; iSeries < 3; iSeries++) {
     measure.newMeasurementSeries();

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -1,6 +1,12 @@
 #include <Eigen/Core>
 #include <string>
 
+#include "acceleration/BaseQNAcceleration.hpp"
+#include "acceleration/IQNILSAcceleration.hpp"
+#include "acceleration/MVQNAcceleration.hpp"
+#include "acceleration/config/AccelerationConfiguration.hpp"
+#include "acceleration/impl/ConstantPreconditioner.hpp"
+#include "acceleration/impl/SharedPointer.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "cplscheme/Constants.hpp"
 #include "cplscheme/ParallelCouplingScheme.hpp"
@@ -18,30 +24,24 @@
 #include "mesh/Vertex.hpp"
 #include "mesh/config/DataConfiguration.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
-#include "acceleration/BaseQNAcceleration.hpp"
-#include "acceleration/impl/ConstantPreconditioner.hpp"
-#include "acceleration/impl/SharedPointer.hpp"
-#include "acceleration/IQNILSAcceleration.hpp"
-#include "acceleration/MVQNAcceleration.hpp"
-#include "acceleration/config/AccelerationConfiguration.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "xml/XMLTag.hpp"
 
-#include "testing/Testing.hpp"
 #include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 
 using namespace precice;
 using namespace precice::cplscheme;
 
 BOOST_AUTO_TEST_SUITE(CplSchemeTests)
 
-struct ParallelImplicitCouplingSchemeFixture
-{
-  using DataMap = std::map<int,PtrCouplingData>;
+struct ParallelImplicitCouplingSchemeFixture {
+  using DataMap = std::map<int, PtrCouplingData>;
 
   std::string _pathToTests;
 
-  ParallelImplicitCouplingSchemeFixture(){
+  ParallelImplicitCouplingSchemeFixture()
+  {
     _pathToTests = testing::getPathToSources() + "/cplscheme/tests/";
   }
 };
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(testParseConfigurationWithRelaxation)
 
   std::string path(_pathToTests + "parallel-implicit-cplscheme-relax-const-config.xml");
 
-  xml::XMLTag root = xml::getRootTag();
+  xml::XMLTag          root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(3);
   PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
@@ -72,29 +72,28 @@ BOOST_AUTO_TEST_CASE(testParseConfigurationWithRelaxation)
 BOOST_AUTO_TEST_CASE(testMVQNPP)
 {
   //use two vectors and see if underrelaxation works
-  double initialRelaxation = 0.01;
-  int    maxIterationsUsed = 50;
-  int    timestepsReused = 6;
-  int    reusedTimestepsAtRestart = 0;
-  int    chunkSize = 0;
-  int filter = acceleration::Acceleration::QR1FILTER;
-  int restartType = acceleration::MVQNAcceleration::NO_RESTART;
-  double singularityLimit = 1e-10;
-  double svdTruncationEps = 0.0;
-  bool enforceInitialRelaxation = false;
-  bool alwaysBuildJacobian = false;
+  double           initialRelaxation        = 0.01;
+  int              maxIterationsUsed        = 50;
+  int              timestepsReused          = 6;
+  int              reusedTimestepsAtRestart = 0;
+  int              chunkSize                = 0;
+  int              filter                   = acceleration::Acceleration::QR1FILTER;
+  int              restartType              = acceleration::MVQNAcceleration::NO_RESTART;
+  double           singularityLimit         = 1e-10;
+  double           svdTruncationEps         = 0.0;
+  bool             enforceInitialRelaxation = false;
+  bool             alwaysBuildJacobian      = false;
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
   std::vector<double> factors;
-  factors.resize(2,1.0);
+  factors.resize(2, 1.0);
   acceleration::impl::PtrPreconditioner prec(new acceleration::impl::ConstantPreconditioner(factors));
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()) );
-
+  mesh::PtrMesh                         dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
 
   acceleration::MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-      timestepsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
-      restartType, chunkSize, reusedTimestepsAtRestart, svdTruncationEps);
+                                    timestepsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
+                                    restartType, chunkSize, reusedTimestepsAtRestart, svdTruncationEps);
 
   Eigen::VectorXd dvalues;
   Eigen::VectorXd dcol1;
@@ -112,7 +111,7 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   utils::append(dcol1, 1.0);
   utils::append(dcol1, 1.0);
 
-  PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+  PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
   //init forces
   utils::append(fvalues, 0.1);
@@ -125,11 +124,11 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   utils::append(fcol1, 0.2);
   utils::append(fcol1, 0.2);
 
-  PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+  PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
   DataMap data;
-  data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-  data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+  data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+  data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
   pp.initialize(data);
 
@@ -171,27 +170,26 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
 {
   //use two vectors and see if underrelaxation works
 
-  double initialRelaxation = 0.01;
-  int    maxIterationsUsed = 50;
-  int    timestepsReused = 6;
-  int filter = acceleration::BaseQNAcceleration::QR1FILTER;
-  double singularityLimit = 1e-10;
-  bool enforceInitialRelaxation = false;
+  double           initialRelaxation        = 0.01;
+  int              maxIterationsUsed        = 50;
+  int              timestepsReused          = 6;
+  int              filter                   = acceleration::BaseQNAcceleration::QR1FILTER;
+  double           singularityLimit         = 1e-10;
+  bool             enforceInitialRelaxation = false;
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
   std::vector<double> factors;
-  factors.resize(2,1.0);
+  factors.resize(2, 1.0);
   acceleration::impl::PtrPreconditioner prec(new acceleration::impl::ConstantPreconditioner(factors));
 
   std::map<int, double> scalings;
-  scalings.insert(std::make_pair(0,1.0));
-  scalings.insert(std::make_pair(1,1.0));
-  mesh::PtrMesh dummyMesh ( new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()) );
+  scalings.insert(std::make_pair(0, 1.0));
+  scalings.insert(std::make_pair(1, 1.0));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
 
   acceleration::IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-      timestepsReused, filter, singularityLimit, dataIDs, prec);
-
+                                      timestepsReused, filter, singularityLimit, dataIDs, prec);
 
   Eigen::VectorXd dvalues;
   Eigen::VectorXd dcol1;
@@ -209,7 +207,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   utils::append(dcol1, 1.0);
   utils::append(dcol1, 1.0);
 
-  PtrCouplingData dpcd(new CouplingData(&dvalues,dummyMesh,false,1));
+  PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
 
   //init forces
   utils::append(fvalues, 0.1);
@@ -222,11 +220,11 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   utils::append(fcol1, 0.2);
   utils::append(fcol1, 0.2);
 
-  PtrCouplingData fpcd(new CouplingData(&fvalues,dummyMesh,false,1));
+  PtrCouplingData fpcd(new CouplingData(&fvalues, dummyMesh, false, 1));
 
   DataMap data;
-  data.insert(std::pair<int,PtrCouplingData>(0,dpcd));
-  data.insert(std::pair<int,PtrCouplingData>(1,fpcd));
+  data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+  data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
   pp.initialize(data);
 
@@ -265,8 +263,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
 
 /// Test that runs on 2 processors.
 BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
-		              * testing::MinRanks(2)
-                      * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
@@ -282,33 +279,32 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
-  const auto dataID0 = mesh->createData("Data0", 1)->getID();
-  const auto dataID1 = mesh->createData("Data1", 3)->getID();
+  const auto    dataID0 = mesh->createData("Data0", 1)->getID();
+  const auto    dataID1 = mesh->createData("Data1", 3)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create a ParallelImplicitCouplingScheme object
-  double maxTime = 1.0;
-  int maxTimesteps = 3;
-  double timestepLength = 0.1;
+  double      maxTime        = 1.0;
+  int         maxTimesteps   = 3;
+  double      timestepLength = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   std::string nameLocalParticipant("");
-  int sendDataIndex = -1;
-  int receiveDataIndex = -1;
-  bool initData = false;
-  if (utils::Parallel::getProcessRank() == 0){
+  int         sendDataIndex    = -1;
+  int         receiveDataIndex = -1;
+  bool        initData         = false;
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-    sendDataIndex = 0;
-    receiveDataIndex = 1;
-    initData = true;
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+    sendDataIndex        = 0;
+    receiveDataIndex     = 1;
+    initData             = true;
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
-    sendDataIndex = 1;
-    receiveDataIndex = 0;
-    initData = true;
+    sendDataIndex        = 1;
+    receiveDataIndex     = 0;
+    initData             = true;
   }
 
   // Create the coupling scheme object
@@ -319,44 +315,44 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
   cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, initData);
 
   // Add convergence measures
-  int minIterations = 3;
-  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1 (
-      new cplscheme::impl::MinIterationConvergenceMeasure(minIterations) );
-  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure2 (
-      new cplscheme::impl::MinIterationConvergenceMeasure(minIterations) );
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1 );
-  cplScheme.addConvergenceMeasure(mesh->data()[0], false, false, minIterationConvMeasure2 );
+  int                                    minIterations = 3;
+  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
+      new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
+  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure2(
+      new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[0], false, false, minIterationConvMeasure2);
 
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
   cplScheme.initialize(0.0, 0);
 
-  if (nameLocalParticipant == nameParticipant0){
+  if (nameLocalParticipant == nameParticipant0) {
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
     mesh->data(dataID0)->values() = Eigen::VectorXd::Constant(1, 4.0);
     cplScheme.performedAction(constants::actionWriteInitialData());
     cplScheme.initializeData();
     BOOST_TEST(cplScheme.hasDataBeenExchanged());
-    auto& values = mesh->data(dataID1)->values();
+    auto &values = mesh->data(dataID1)->values();
     BOOST_TEST(testing::equals(values, Eigen::Vector3d(1.0, 2.0, 3.0)), values);
 
-    while (cplScheme.isCouplingOngoing()){
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)){
+    while (cplScheme.isCouplingOngoing()) {
+      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
         cplScheme.performedAction(writeIterationCheckpoint);
       }
-      if (cplScheme.isActionRequired(readIterationCheckpoint)){
+      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
         cplScheme.performedAction(readIterationCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.advance();
     }
-  }
-  else {
+  } else {
     BOOST_TEST(nameLocalParticipant == nameParticipant1);
-    auto& values = mesh->data(dataID0)->values();
+    auto &values = mesh->data(dataID0)->values();
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
-    Eigen::VectorXd v(3); v << 1.0, 2.0, 3.0;
+    Eigen::VectorXd v(3);
+    v << 1.0, 2.0, 3.0;
     mesh->data(dataID1)->values() = v;
     cplScheme.performedAction(constants::actionWriteInitialData());
     BOOST_TEST(testing::equals(values(0), 0.0), values);
@@ -364,13 +360,13 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
     BOOST_TEST(cplScheme.hasDataBeenExchanged());
     BOOST_TEST(testing::equals(values(0), 4.0), values);
 
-    while (cplScheme.isCouplingOngoing()){
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)){
+    while (cplScheme.isCouplingOngoing()) {
+      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
         cplScheme.performedAction(writeIterationCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.advance();
-      if (cplScheme.isActionRequired(readIterationCheckpoint)){
+      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
         cplScheme.performedAction(readIterationCheckpoint);
       }
     }
@@ -378,7 +374,7 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
   cplScheme.finalize();
   utils::Parallel::clearGroups();
 }
-# endif // not PRECICE_NO_MPI
+#endif // not PRECICE_NO_MPI
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -1,23 +1,23 @@
-#include "cplscheme/SerialCouplingScheme.hpp"
-#include "cplscheme/config/CouplingSchemeConfiguration.hpp"
+#include <Eigen/Core>
 #include "acceleration/config/AccelerationConfiguration.hpp"
-#include "cplscheme/impl/ConvergenceMeasure.hpp"
-#include "cplscheme/impl/AbsoluteConvergenceMeasure.hpp"
-#include "cplscheme/impl/MinIterationConvergenceMeasure.hpp"
-#include "cplscheme/SharedPointer.hpp"
+#include "com/MPIDirectCommunication.hpp"
 #include "cplscheme/Constants.hpp"
+#include "cplscheme/SerialCouplingScheme.hpp"
+#include "cplscheme/SharedPointer.hpp"
+#include "cplscheme/config/CouplingSchemeConfiguration.hpp"
+#include "cplscheme/impl/AbsoluteConvergenceMeasure.hpp"
+#include "cplscheme/impl/ConvergenceMeasure.hpp"
+#include "cplscheme/impl/MinIterationConvergenceMeasure.hpp"
+#include "m2n/M2N.hpp"
+#include "m2n/config/M2NConfiguration.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
 #include "mesh/config/DataConfiguration.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
-#include "com/MPIDirectCommunication.hpp"
-#include "m2n/M2N.hpp"
-#include "m2n/config/M2NConfiguration.hpp"
 #include "xml/XMLTag.hpp"
-#include <Eigen/Core>
 
-#include "testing/Testing.hpp"
 #include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 
 using namespace precice;
 using namespace precice::cplscheme;
@@ -27,33 +27,33 @@ using namespace precice::cplscheme;
 BOOST_AUTO_TEST_SUITE(CplSchemeTests)
 
 void runCoupling(
-      CouplingScheme&                cplScheme,
-      const std::string&             nameParticipant,
-      const mesh::MeshConfiguration& meshConfig,
-      const std::vector<int>&        validIterations )
+    CouplingScheme &               cplScheme,
+    const std::string &            nameParticipant,
+    const mesh::MeshConfiguration &meshConfig,
+    const std::vector<int> &       validIterations)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig.meshes()[0];
   BOOST_TEST(mesh->data().size() == 2);
   BOOST_TEST(mesh->vertices().size() > 0);
-  mesh::Vertex& vertex = mesh->vertices()[0];
-  int index = vertex.getID();
-  auto& dataValues0 = mesh->data()[0]->values();
-  auto& dataValues1 = mesh->data()[1]->values();
-  double initialStepsizeData0 = 5.0;
-  double stepsizeData0 = 5.0;
+  mesh::Vertex &  vertex               = mesh->vertices()[0];
+  int             index                = vertex.getID();
+  auto &          dataValues0          = mesh->data()[0]->values();
+  auto &          dataValues1          = mesh->data()[1]->values();
+  double          initialStepsizeData0 = 5.0;
+  double          stepsizeData0        = 5.0;
   Eigen::VectorXd initialStepsizeData1 = Eigen::VectorXd::Constant(3, 5.0);
-  Eigen::VectorXd stepsizeData1 = Eigen::VectorXd::Constant(3, 5.0);
-  double computedTime = 0.0;
-  int computedTimesteps = 0;
-  std::string nameParticipant0("Participant0");
-  std::string nameParticipant1("Participant1");
-  BOOST_TEST (((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1)));
-  int iterationCount = 0;
+  Eigen::VectorXd stepsizeData1        = Eigen::VectorXd::Constant(3, 5.0);
+  double          computedTime         = 0.0;
+  int             computedTimesteps    = 0;
+  std::string     nameParticipant0("Participant0");
+  std::string     nameParticipant1("Participant1");
+  BOOST_TEST(((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1)));
+  int                              iterationCount      = 0;
   std::vector<int>::const_iterator iterValidIterations = validIterations.begin();
 
-  if( nameParticipant == nameParticipant0 ){
-    cplScheme.initialize ( 0.0, 1);
+  if (nameParticipant == nameParticipant0) {
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -64,48 +64,46 @@ void runCoupling(
     cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
 
-    while ( cplScheme.isCouplingOngoing() ) {
+    while (cplScheme.isCouplingOngoing()) {
       dataValues0[index] += stepsizeData0;
       // The max timestep length is required to be obeyed.
       double maxLengthTimestep = cplScheme.getNextTimestepMaxLength();
-      cplScheme.addComputedTime ( maxLengthTimestep);
+      cplScheme.addComputedTime(maxLengthTimestep);
       cplScheme.advance();
       iterationCount++;
       // A coupling timestep is complete, when the coupling iterations are
       // globally converged and if subcycling steps have filled one global
       // timestep.
-      if ( cplScheme.isCouplingTimestepComplete() ) {
+      if (cplScheme.isCouplingTimestepComplete()) {
         // Advance participant time and timestep
         computedTime += maxLengthTimestep;
-        computedTimesteps ++;
-        BOOST_TEST(testing::equals(computedTime, cplScheme.getTime() ));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps()-1 ));
+        computedTimesteps++;
+        BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
-        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations ));
-        if ( cplScheme.isCouplingOngoing() ) {
+        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
+        if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-        }
-        else {
+        } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint() ));
+          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         }
         iterationCount = 0;
         iterValidIterations++;
-        if ( iterValidIterations == validIterations.end() ) {
+        if (iterValidIterations == validIterations.end()) {
           BOOST_TEST(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
         // interface values in next timestep.
         stepsizeData0 = initialStepsizeData0;
-      }
-      else { // coupling timestep is not yet complete
+      } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
         BOOST_TEST(iterationCount < *iterValidIterations);
         BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
-        cplScheme.performedAction ( constants::actionReadIterationCheckpoint());
+        cplScheme.performedAction(constants::actionReadIterationCheckpoint());
         BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         // The written data value is decreased in a regular manner, in order
         // to achieve a predictable convergence.
@@ -115,12 +113,11 @@ void runCoupling(
       //if(cplScheme.isCouplingOngoing())
       BOOST_TEST(cplScheme.hasDataBeenExchanged());
     }
-    cplScheme.finalize (); // Ends the coupling scheme
-    BOOST_TEST(testing::equals(computedTime, 0.3 ));
-    BOOST_TEST(testing::equals(computedTimesteps, 3 ));
-  }
-  else if (nameParticipant == nameParticipant1) {
-    cplScheme.initialize ( 0.0, 1);
+    cplScheme.finalize(); // Ends the coupling scheme
+    BOOST_TEST(testing::equals(computedTime, 0.3));
+    BOOST_TEST(testing::equals(computedTimesteps, 3));
+  } else if (nameParticipant == nameParticipant1) {
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -128,56 +125,54 @@ void runCoupling(
 
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
-    cplScheme.performedAction ( constants::actionWriteIterationCheckpoint());
+    cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
 
-    while ( cplScheme.isCouplingOngoing() ) {
+    while (cplScheme.isCouplingOngoing()) {
       Eigen::VectorXd currentData(3);
       currentData = dataValues1.segment(index * 3, 3);
       currentData += stepsizeData1;
       dataValues1.segment(index * 3, 3) = currentData;
       // The max timestep length is required to be obeyed.
       double maxLengthTimestep = cplScheme.getNextTimestepMaxLength();
-      cplScheme.addComputedTime ( maxLengthTimestep);
+      cplScheme.addComputedTime(maxLengthTimestep);
       cplScheme.advance();
       iterationCount++;
       // A coupling timestep is complete, when the coupling iterations are
       // globally converged and if subcycling steps have filled one global
       // timestep.
-      if ( cplScheme.isCouplingTimestepComplete() ) {
+      if (cplScheme.isCouplingTimestepComplete()) {
         // Advance participant time and timestep
         computedTime += maxLengthTimestep;
-        computedTimesteps ++;
-        BOOST_TEST(testing::equals(computedTime, cplScheme.getTime() ));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps()-1 ));
+        computedTimesteps++;
+        BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
         // The iterations are enforced by the controlled decrease of the
         // change of data written
-        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations ));
-        if ( cplScheme.isCouplingOngoing() ) {
+        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
+        if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.performedAction ( constants::actionWriteIterationCheckpoint());
+          cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-        }
-        else {
+        } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint() ));
+          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         }
         iterationCount = 0;
         iterValidIterations++;
-        if ( iterValidIterations == validIterations.end() ) {
+        if (iterValidIterations == validIterations.end()) {
           BOOST_TEST(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
         // interface values in next timestep.
         stepsizeData1 = initialStepsizeData1;
-      }
-      else { // coupling timestep is not yet complete
+      } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
         BOOST_TEST(iterationCount < *iterValidIterations);
         BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         // The load checkpoint action requires to fallback to the cplScheme of the
         // first implicit iteration of the current timestep/time.
-        cplScheme.performedAction ( constants::actionReadIterationCheckpoint());
+        cplScheme.performedAction(constants::actionReadIterationCheckpoint());
         BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         // The written data value is decreased in a regular manner, in order
         // to achieve a predictable convergence.
@@ -185,42 +180,41 @@ void runCoupling(
         stepsizeData1 -= Eigen::Vector3d::Constant(1.0);
       }
       // only check if data is received
-      if(cplScheme.isCouplingOngoing())
+      if (cplScheme.isCouplingOngoing())
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
     }
-    cplScheme.finalize (); // Ends the coupling scheme
-    BOOST_TEST(testing::equals(computedTime, 0.3 ));
-    BOOST_TEST(testing::equals(computedTimesteps, 3 ));
+    cplScheme.finalize(); // Ends the coupling scheme
+    BOOST_TEST(testing::equals(computedTime, 0.3));
+    BOOST_TEST(testing::equals(computedTimesteps, 3));
   }
 }
 
-void runCouplingWithSubcycling
-(
-    CouplingScheme&                cplScheme,
-    const std::string&             nameParticipant,
-    const mesh::MeshConfiguration& meshConfig,
-    const std::vector<int>&        validIterations )
+void runCouplingWithSubcycling(
+    CouplingScheme &               cplScheme,
+    const std::string &            nameParticipant,
+    const mesh::MeshConfiguration &meshConfig,
+    const std::vector<int> &       validIterations)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig.meshes()[0];
   BOOST_TEST(mesh->data().size() == 2);
   BOOST_TEST(mesh->vertices().size() > 0);
-  double initialStepsizeData0 = 5.0;
-  double stepsizeData0 = 5.0;
-  Eigen::Vector3d initialStepsizeData1 = Eigen::Vector3d::Constant ( 5.0);
-  Eigen::Vector3d stepsizeData1 = Eigen::Vector3d::Constant( 5.0);
-  double computedTime = 0.0;
-  int computedTimesteps = 0;
-  std::string nameParticipant0 ( "Participant0");
-  std::string nameParticipant1 ( "Participant1");
+  double          initialStepsizeData0 = 5.0;
+  double          stepsizeData0        = 5.0;
+  Eigen::Vector3d initialStepsizeData1 = Eigen::Vector3d::Constant(5.0);
+  Eigen::Vector3d stepsizeData1        = Eigen::Vector3d::Constant(5.0);
+  double          computedTime         = 0.0;
+  int             computedTimesteps    = 0;
+  std::string     nameParticipant0("Participant0");
+  std::string     nameParticipant1("Participant1");
   BOOST_TEST(((nameParticipant == nameParticipant0) || (nameParticipant == nameParticipant1)));
-  int iterationCount = 0;
+  int                              iterationCount = 0;
   std::vector<int>::const_iterator iterValidIterations =
       validIterations.begin();
 
-  if ( nameParticipant == nameParticipant0 ) {
+  if (nameParticipant == nameParticipant0) {
     iterationCount++; // different handling due to subcycling
-    cplScheme.initialize ( 0.0, 1);
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -228,37 +222,36 @@ void runCouplingWithSubcycling
 
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
-    cplScheme.performedAction ( constants::actionWriteIterationCheckpoint());
+    cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
 
-    double maxTimestepLength = cplScheme.getNextTimestepMaxLength();
+    double maxTimestepLength      = cplScheme.getNextTimestepMaxLength();
     double computedTimestepLength = maxTimestepLength / 2.0;
-    int subcyclingStep = 0;
+    int    subcyclingStep         = 0;
 
     // Main coupling loop
-    while ( cplScheme.isCouplingOngoing() ){
-      cplScheme.addComputedTime ( computedTimestepLength);
+    while (cplScheme.isCouplingOngoing()) {
+      cplScheme.addComputedTime(computedTimestepLength);
       cplScheme.advance();
       // A coupling timestep is complete, when the coupling iterations are
       // globally converged and if subcycling steps have filled one global
       // timestep.
-      if ( cplScheme.isCouplingTimestepComplete() ){
+      if (cplScheme.isCouplingTimestepComplete()) {
         // Advance participant time and timestep
         computedTime += maxTimestepLength;
-        computedTimesteps ++;
+        computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps()-1));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
-        if ( cplScheme.isCouplingOngoing() ) {
+        if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-        }
-        else {
+        } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint() ));
+          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         }
         iterationCount = 1;
         iterValidIterations++;
@@ -270,23 +263,21 @@ void runCouplingWithSubcycling
         stepsizeData0 = initialStepsizeData0;
         BOOST_TEST(testing::equals(subcyclingStep, 1));
         subcyclingStep = 0;
-      }
-      else { // coupling timestep is not yet complete
+      } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
         // If length of global timestep is reached
-        if ( cplScheme.hasDataBeenExchanged() ) {
+        if (cplScheme.hasDataBeenExchanged()) {
           BOOST_TEST(iterationCount <= *iterValidIterations);
           BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.performedAction ( constants::actionReadIterationCheckpoint());
+          cplScheme.performedAction(constants::actionReadIterationCheckpoint());
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           // The written data value is decreased in a regular manner, in order
           // to achieve a predictable convergence.
           stepsizeData0 -= 1.0;
           subcyclingStep = 0; // Subcycling steps
-          iterationCount++; // Implicit coupling iterations
-        }
-        else { // If subcycling
+          iterationCount++;   // Implicit coupling iterations
+        } else {              // If subcycling
           BOOST_TEST(iterationCount <= *iterValidIterations);
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
@@ -295,14 +286,14 @@ void runCouplingWithSubcycling
         }
       }
     }
-    cplScheme.finalize (); // Ends the coupling scheme
+    cplScheme.finalize(); // Ends the coupling scheme
     BOOST_TEST(testing::equals(computedTime, 0.3));
     BOOST_TEST(testing::equals(computedTimesteps, 3));
   }
 
-  else if ( nameParticipant == nameParticipant1 ) {
+  else if (nameParticipant == nameParticipant1) {
     iterationCount++; // different handling due to subcycling
-    cplScheme.initialize ( 0.0, 1);
+    cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.isCouplingTimestepComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -310,46 +301,45 @@ void runCouplingWithSubcycling
 
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
-    cplScheme.performedAction ( constants::actionWriteIterationCheckpoint());
+    cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
 
-    double maxTimestepLength = cplScheme.getNextTimestepMaxLength ();
+    double maxTimestepLength       = cplScheme.getNextTimestepMaxLength();
     double preferredTimestepLength = maxTimestepLength / 2.5;
-    double computedTimestepLength = preferredTimestepLength;
-    int subcyclingStep = 0;
+    double computedTimestepLength  = preferredTimestepLength;
+    int    subcyclingStep          = 0;
 
     // Main coupling loop
-    while ( cplScheme.isCouplingOngoing() ){
-      cplScheme.addComputedTime ( computedTimestepLength);
+    while (cplScheme.isCouplingOngoing()) {
+      cplScheme.addComputedTime(computedTimestepLength);
       cplScheme.advance();
       computedTimestepLength =
           cplScheme.getNextTimestepMaxLength() < preferredTimestepLength
-          ? cplScheme.getNextTimestepMaxLength()
+              ? cplScheme.getNextTimestepMaxLength()
               : preferredTimestepLength;
       // A coupling timestep is complete, when the coupling iterations are
       // globally converged and if subcycling steps have filled one global
       // timestep.
-      if ( cplScheme.isCouplingTimestepComplete() ){
+      if (cplScheme.isCouplingTimestepComplete()) {
         // Advance participant time and timestep
         computedTime += maxTimestepLength;
-        computedTimesteps ++;
+        computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps()-1));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
-        if ( cplScheme.isCouplingOngoing() ) {
+        if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.performedAction(constants::actionWriteIterationCheckpoint());
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-        }
-        else {
+        } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint() ));
+          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         }
         iterationCount = 1;
         iterValidIterations++;
-        if ( iterValidIterations == validIterations.end() ) {
+        if (iterValidIterations == validIterations.end()) {
           BOOST_TEST(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
@@ -357,23 +347,21 @@ void runCouplingWithSubcycling
         stepsizeData1 = initialStepsizeData1;
         BOOST_TEST(testing::equals(subcyclingStep, 2));
         subcyclingStep = 0;
-      }
-      else { // coupling timestep is not yet complete
+      } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
         // If length of global timestep is reached
-        if ( cplScheme.hasDataBeenExchanged() ) {
+        if (cplScheme.hasDataBeenExchanged()) {
           BOOST_TEST(iterationCount <= *iterValidIterations);
           BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.performedAction ( constants::actionReadIterationCheckpoint());
+          cplScheme.performedAction(constants::actionReadIterationCheckpoint());
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           // The written data value is decreased in a regular manner, in order
           // to achieve a predictable convergence.
           stepsizeData1.array() -= 1.0;
           subcyclingStep = 0; // Subcycling steps
-          iterationCount++; // Implicit coupling iterations
-        }
-        else { // If subcycling
+          iterationCount++;   // Implicit coupling iterations
+        } else {              // If subcycling
           BOOST_TEST(iterationCount <= *iterValidIterations);
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
@@ -382,17 +370,17 @@ void runCouplingWithSubcycling
         }
       }
     }
-    cplScheme.finalize (); // Ends the coupling scheme
+    cplScheme.finalize(); // Ends the coupling scheme
     BOOST_TEST(testing::equals(computedTime, 0.3));
     BOOST_TEST(testing::equals(computedTimesteps, 3));
   }
 }
 
-struct SerialImplicitCouplingSchemeFixture : m2n::WhiteboxAccessor
-{
+struct SerialImplicitCouplingSchemeFixture : m2n::WhiteboxAccessor {
   std::string _pathToTests;
 
-  SerialImplicitCouplingSchemeFixture(){
+  SerialImplicitCouplingSchemeFixture()
+  {
     _pathToTests = testing::getPathToSources() + "/cplscheme/tests/";
   }
 };
@@ -405,7 +393,7 @@ BOOST_AUTO_TEST_CASE(testParseConfigurationWithRelaxation)
 
   std::string path(_pathToTests + "serial-implicit-cplscheme-relax-const-config.xml");
 
-  xml::XMLTag root = xml::getRootTag();
+  xml::XMLTag          root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(3);
   PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
@@ -423,55 +411,55 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   using namespace mesh;
 
   PtrMesh mesh(new Mesh("MyMesh", 3, false, testing::nextMeshID()));
-  PtrData data = mesh->createData("MyData", 1);
-  int dataID = data->getID();
+  PtrData data   = mesh->createData("MyData", 1);
+  int     dataID = data->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   BOOST_TEST(data->values().size() == 1);
 
-  double maxTime = CouplingScheme::UNDEFINED_TIME;
-  int maxTimesteps = 1;
-  double dt = 1.0;
-  std::string first = "First";
-  std::string second = "Second";
-  std::string accessor = second;
+  double                maxTime      = CouplingScheme::UNDEFINED_TIME;
+  int                   maxTimesteps = 1;
+  double                dt           = 1.0;
+  std::string           first        = "First";
+  std::string           second       = "Second";
+  std::string           accessor     = second;
   com::PtrCommunication com(new com::MPIDirectCommunication());
-  m2n::PtrM2N globalCom(new m2n::M2N(com, m2n::DistributedComFactory::SharedPointer()));
-  int maxIterations = 1;
+  m2n::PtrM2N           globalCom(new m2n::M2N(com, m2n::DistributedComFactory::SharedPointer()));
+  int                   maxIterations = 1;
 
   // Test first order extrapolation
   SerialCouplingScheme scheme(maxTime, maxTimesteps, dt, 16, first, second,
-      accessor, globalCom, constants::FIXED_DT,
-      BaseCouplingScheme::Implicit, maxIterations);
+                              accessor, globalCom, constants::FIXED_DT,
+                              BaseCouplingScheme::Implicit, maxIterations);
 
   scheme.addDataToSend(data, mesh, true);
   scheme.setExtrapolationOrder(1);
   scheme.setupDataMatrices(scheme.getSendData());
-  CouplingData* cplData = scheme.getSendData(dataID);
+  CouplingData *cplData = scheme.getSendData(dataID);
   BOOST_CHECK(cplData); // no nullptr
   BOOST_TEST(cplData->values->size() == 1);
   BOOST_TEST(cplData->oldValues.cols() == 2);
   BOOST_TEST(cplData->oldValues.rows() == 1);
   BOOST_TEST(testing::equals((*cplData->values)[0], 0.0));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,0), 0.0));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,1), 0.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 0.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 0.0));
 
   (*cplData->values)[0] = 1.0;
   scheme.setTimesteps(scheme.getTimesteps() + 1);
   scheme.extrapolateData(scheme.getSendData());
   BOOST_TEST(testing::equals((*cplData->values)[0], 2.0));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,0), 2.0));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,1), 1.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 2.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 1.0));
 
   (*cplData->values)[0] = 4.0;
   scheme.setTimesteps(scheme.getTimesteps() + 1);
   scheme.extrapolateData(scheme.getSendData());
   BOOST_TEST(testing::equals((*cplData->values)[0], 7.0));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,0), 7.0));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,1), 4.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 7.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 4.0));
 
   // Test second order extrapolation
-  *cplData->values = Eigen::VectorXd::Zero(cplData->values->size());
+  *cplData->values   = Eigen::VectorXd::Zero(cplData->values->size());
   cplData->oldValues = Eigen::MatrixXd::Zero(cplData->oldValues.rows(), cplData->oldValues.cols());
   //assign(*cplData->values) = 0.0;
   //assign(cplData->oldValues) = 0.0;
@@ -485,32 +473,31 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(cplData->values->size() == 1);
   BOOST_TEST(cplData->oldValues.cols() == 3);
   BOOST_TEST(cplData->oldValues.rows() == 1);
-  BOOST_TEST(testing::equals((*cplData->values)[0], 0.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,0), 0.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,1), 0.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,2), 0.0 ));
+  BOOST_TEST(testing::equals((*cplData->values)[0], 0.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 0.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 0.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 0.0));
 
   (*cplData->values)[0] = 1.0;
   scheme2.setTimesteps(scheme2.getTimesteps() + 1);
   scheme2.extrapolateData(scheme2.getSendData());
-  BOOST_TEST(testing::equals((*cplData->values)[0], 2.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,0), 2.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,1), 1.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,2), 0.0 ));
+  BOOST_TEST(testing::equals((*cplData->values)[0], 2.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 2.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 1.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 0.0));
 
   (*cplData->values)[0] = 4.0;
   scheme2.setTimesteps(scheme2.getTimesteps() + 1);
   scheme2.extrapolateData(scheme2.getSendData());
-  BOOST_TEST(testing::equals((*cplData->values)[0], 8.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,0), 8.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,1), 4.0 ));
-  BOOST_TEST(testing::equals(cplData->oldValues(0,2), 1.0 ));
+  BOOST_TEST(testing::equals((*cplData->values)[0], 8.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 8.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 4.0));
+  BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 1.0));
 }
 
 /// Test that runs on 2 processors.
 BOOST_FIXTURE_TEST_CASE(testAbsConvergenceMeasureSynchronized, testing::M2NFixture,
-                      * testing::MinRanks(2)
-                      * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
@@ -530,70 +517,67 @@ BOOST_FIXTURE_TEST_CASE(testAbsConvergenceMeasureSynchronized, testing::M2NFixtu
   mesh->createData("data0", 1);
   mesh->createData("data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());
-  mesh->allocateDataValues ();
+  mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double maxTime = 1.0;
-  int maxTimesteps = 3;
-  double timestepLength = 0.1;
+  double      maxTime        = 1.0;
+  int         maxTimesteps   = 3;
+  double      timestepLength = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   std::string nameLocalParticipant("");
-  int sendDataIndex = -1;
-  int receiveDataIndex = -1;
+  int         sendDataIndex    = -1;
+  int         receiveDataIndex = -1;
   if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-    sendDataIndex = 0;
-    receiveDataIndex = 1;
-  }
-  else if (utils::Parallel::getProcessRank() == 1 ) {
+    sendDataIndex        = 0;
+    receiveDataIndex     = 1;
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
-    sendDataIndex = 1;
-    receiveDataIndex = 0;
+    sendDataIndex        = 1;
+    receiveDataIndex     = 0;
   }
 
   // Create the coupling scheme object
-  cplscheme::SerialCouplingScheme cplScheme (
+  cplscheme::SerialCouplingScheme cplScheme(
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0,
       nameParticipant1, nameLocalParticipant, m2n, constants::FIXED_DT,
-      BaseCouplingScheme::Implicit, 100
-  );
-  cplScheme.addDataToSend (mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive (mesh->data()[receiveDataIndex], mesh, false);
+      BaseCouplingScheme::Implicit, 100);
+  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
+  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
 
-  double convergenceLimit1 = sqrt(3.0); // when diff_vector = (1.0, 1.0, 1.0)
-  cplscheme::impl::PtrConvergenceMeasure absoluteConvMeasure1 (
+  double                                 convergenceLimit1 = sqrt(3.0); // when diff_vector = (1.0, 1.0, 1.0)
+  cplscheme::impl::PtrConvergenceMeasure absoluteConvMeasure1(
       new cplscheme::impl::AbsoluteConvergenceMeasure(convergenceLimit1));
   cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, absoluteConvMeasure1);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {5, 5, 5};
-  runCoupling (cplScheme, nameLocalParticipant, meshConfig, validIterations);
+  runCoupling(cplScheme, nameLocalParticipant, meshConfig, validIterations);
 }
 
 BOOST_AUTO_TEST_CASE(testConfiguredAbsConvergenceMeasureSynchronized,
-                   * testing::MinRanks(2)
-                   * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
 
   using namespace mesh;
 
-  std::string configurationPath (
+  std::string configurationPath(
       _pathToTests + "serial-implicit-cplscheme-absolute-config.xml");
 
-  xml::XMLTag root = xml::getRootTag();
+  xml::XMLTag          root = xml::getRootTag();
   PtrDataConfiguration dataConfig(new DataConfiguration(root));
   dataConfig->setDimensions(3);
   PtrMeshConfiguration meshConfig(new MeshConfiguration(root, dataConfig));
   meshConfig->setDimensions(3);
   m2n::M2NConfiguration::SharedPointer m2nConfig(new m2n::M2NConfiguration(root));
-  CouplingSchemeConfiguration cplSchemeConfig(root, meshConfig, m2nConfig);
+  CouplingSchemeConfiguration          cplSchemeConfig(root, meshConfig, m2nConfig);
 
   xml::configure(root, xml::ConfigurationContext{}, configurationPath);
-  m2n::PtrM2N m2n = m2nConfig->getM2N("Participant0", "Participant1");
+  m2n::PtrM2N m2n       = m2nConfig->getM2N("Participant0", "Participant1");
   useOnlyMasterCom(m2n) = true;
 
   // some dummy mesh
@@ -605,151 +589,145 @@ BOOST_AUTO_TEST_CASE(testConfiguredAbsConvergenceMeasureSynchronized,
 
   std::vector<int> validIterations = {5, 5, 5};
 
-  std::string nameLocalParticipant ("");
-  if (utils::Parallel::getProcessRank() == 0 ) {
+  std::string nameLocalParticipant("");
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = "Participant0";
     utils::Parallel::splitCommunicator(nameLocalParticipant);
-    m2n->requestMasterConnection ("Participant1", "Participant0");
-  }
-  else if (utils::Parallel::getProcessRank() == 1 ) {
+    m2n->requestMasterConnection("Participant1", "Participant0");
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = "Participant1";
     utils::Parallel::splitCommunicator(nameLocalParticipant);
-    m2n->acceptMasterConnection ("Participant1", "Participant0");
+    m2n->acceptMasterConnection("Participant1", "Participant0");
   }
 
-  runCoupling (*cplSchemeConfig.getCouplingScheme(nameLocalParticipant),
-      nameLocalParticipant, *meshConfig, validIterations);
+  runCoupling(*cplSchemeConfig.getCouplingScheme(nameLocalParticipant),
+              nameLocalParticipant, *meshConfig, validIterations);
   utils::Parallel::clearGroups();
 }
 
 BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronized, testing::M2NFixture,
-                      * testing::MinRanks(2)
-                      * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
 
   xml::XMLTag root = xml::getRootTag();
   // Create a data configuration, to simplify configuration of data
-  mesh::PtrDataConfiguration dataConfig (new mesh::DataConfiguration(root));
+  mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(root));
   dataConfig->setDimensions(3);
-  dataConfig->addData ("data0", 1);
-  dataConfig->addData ("data1", 3);
+  dataConfig->addData("data0", 1);
+  dataConfig->addData("data1", 3);
 
-  mesh::MeshConfiguration meshConfig (root, dataConfig);
+  mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh (new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
-  mesh->createData ("data0", 1);
-  mesh->createData ("data1", 3);
-  mesh->createVertex (Eigen::Vector3d::Zero());
-  mesh->allocateDataValues ();
-  meshConfig.addMesh (mesh);
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh->createData("data0", 1);
+  mesh->createData("data1", 3);
+  mesh->createVertex(Eigen::Vector3d::Zero());
+  mesh->allocateDataValues();
+  meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double maxTime = 1.0;
-  int maxTimesteps = 3;
-  double timestepLength = 0.1;
-  std::string nameParticipant0 ("Participant0");
-  std::string nameParticipant1 ("Participant1");
-  std::string nameLocalParticipant ("");
-  int sendDataIndex = -1;
-  int receiveDataIndex = -1;
-  if (utils::Parallel::getProcessRank() == 0 ) {
+  double      maxTime        = 1.0;
+  int         maxTimesteps   = 3;
+  double      timestepLength = 0.1;
+  std::string nameParticipant0("Participant0");
+  std::string nameParticipant1("Participant1");
+  std::string nameLocalParticipant("");
+  int         sendDataIndex    = -1;
+  int         receiveDataIndex = -1;
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-    sendDataIndex = 0;
-    receiveDataIndex = 1;
-  }
-  else if (utils::Parallel::getProcessRank() == 1 ) {
+    sendDataIndex        = 0;
+    receiveDataIndex     = 1;
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
-    sendDataIndex = 1;
-    receiveDataIndex = 0;
+    sendDataIndex        = 1;
+    receiveDataIndex     = 0;
   }
 
   // Create the coupling scheme object
-  cplscheme::SerialCouplingScheme cplScheme (
+  cplscheme::SerialCouplingScheme cplScheme(
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
       nameLocalParticipant, m2n, constants::FIXED_DT,
       BaseCouplingScheme::Implicit, 100);
-  cplScheme.addDataToSend (mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive (mesh->data()[receiveDataIndex], mesh, false);
+  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
+  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
 
   // Add convergence measures
-  int minIterations = 3;
-  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1 (
+  int                                    minIterations = 3;
+  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {3, 3, 3};
-  runCoupling (cplScheme, nameLocalParticipant, meshConfig, validIterations);
+  runCoupling(cplScheme, nameLocalParticipant, meshConfig, validIterations);
 }
 
 BOOST_FIXTURE_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling, testing::M2NFixture,
-                      * testing::MinRanks(2)
-                      * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
 
   xml::XMLTag root = xml::getRootTag();
   // Create a data configuration, to simplify configuration of data
-  mesh::PtrDataConfiguration dataConfig ( new mesh::DataConfiguration(root));
+  mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(root));
   dataConfig->setDimensions(3);
-  dataConfig->addData ( "data0", 1);
-  dataConfig->addData ( "data1", 3);
+  dataConfig->addData("data0", 1);
+  dataConfig->addData("data1", 3);
 
-  mesh::MeshConfiguration meshConfig ( root, dataConfig);
+  mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh ( new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
-  mesh->createData ( "data0", 1);
-  mesh->createData ( "data1", 3);
-  mesh->createVertex ( Eigen::Vector3d::Zero());
-  mesh->allocateDataValues ();
-  meshConfig.addMesh ( mesh);
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh->createData("data0", 1);
+  mesh->createData("data1", 3);
+  mesh->createVertex(Eigen::Vector3d::Zero());
+  mesh->allocateDataValues();
+  meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double maxTime = 1.0;
-  int maxTimesteps = 3;
-  double timestepLength = 0.1;
-  std::string nameParticipant0 ( "Participant0");
-  std::string nameParticipant1 ( "Participant1");
-  std::string nameLocalParticipant ( "");
-  int sendDataIndex = -1;
-  int receiveDataIndex = -1;
+  double           maxTime        = 1.0;
+  int              maxTimesteps   = 3;
+  double           timestepLength = 0.1;
+  std::string      nameParticipant0("Participant0");
+  std::string      nameParticipant1("Participant1");
+  std::string      nameLocalParticipant("");
+  int              sendDataIndex    = -1;
+  int              receiveDataIndex = -1;
   std::vector<int> validIterations;
-  if ( utils::Parallel::getProcessRank() == 0 ) {
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-    sendDataIndex = 0;
-    receiveDataIndex = 1;
-    validIterations = {3, 3, 3};
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ) {
+    sendDataIndex        = 0;
+    receiveDataIndex     = 1;
+    validIterations      = {3, 3, 3};
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
-    sendDataIndex = 1;
-    receiveDataIndex = 0;
-    validIterations = {3, 3, 3};
+    sendDataIndex        = 1;
+    receiveDataIndex     = 0;
+    validIterations      = {3, 3, 3};
   }
 
   // Create the coupling scheme object
-  cplscheme::SerialCouplingScheme cplScheme (
+  cplscheme::SerialCouplingScheme cplScheme(
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
       nameLocalParticipant, m2n, constants::FIXED_DT,
       BaseCouplingScheme::Implicit, 100);
-  cplScheme.addDataToSend ( mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive ( mesh->data()[receiveDataIndex], mesh, false);
+  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
+  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
 
   // Add convergence measures
-  int minIterations = 3;
-  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1 (
+  int                                    minIterations = 3;
+  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1);
-  runCouplingWithSubcycling (
+  runCouplingWithSubcycling(
       cplScheme, nameLocalParticipant, meshConfig, validIterations);
 }
 
 BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
-                   * testing::MinRanks(2)
-                   * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2) // only run test on ranks {0,1}, for other ranks return
     return;
@@ -766,32 +744,32 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
-  const auto dataID0 = mesh->createData("Data0", 1)->getID();
-  const auto dataID1 = mesh->createData("Data1", 3)->getID();;
+  const auto    dataID0 = mesh->createData("Data0", 1)->getID();
+  const auto    dataID1 = mesh->createData("Data1", 3)->getID();
+  ;
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double maxTime = 1.0;
-  int maxTimesteps = 3;
-  double timestepLength = 0.1;
+  double      maxTime        = 1.0;
+  int         maxTimesteps   = 3;
+  double      timestepLength = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   std::string nameLocalParticipant("");
-  int sendDataIndex = -1;
-  int receiveDataIndex = -1;
-  bool initData = false;
-  if (utils::Parallel::getProcessRank() == 0){
+  int         sendDataIndex    = -1;
+  int         receiveDataIndex = -1;
+  bool        initData         = false;
+  if (utils::Parallel::getProcessRank() == 0) {
     nameLocalParticipant = nameParticipant0;
-    sendDataIndex = 0;
-    receiveDataIndex = 1;
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+    sendDataIndex        = 0;
+    receiveDataIndex     = 1;
+  } else if (utils::Parallel::getProcessRank() == 1) {
     nameLocalParticipant = nameParticipant1;
-    sendDataIndex = 1;
-    receiveDataIndex = 0;
-    initData = true;
+    sendDataIndex        = 1;
+    receiveDataIndex     = 0;
+    initData             = true;
   }
 
   // Create the coupling scheme object
@@ -803,8 +781,8 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
   cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, not initData);
 
   // Add convergence measures
-  int minIterations = 3;
-  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1 (
+  int                                    minIterations = 3;
+  cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1);
 
@@ -813,41 +791,41 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
 
   cplScheme.initialize(0.0, 1);
 
-  if (nameLocalParticipant == nameParticipant0){
+  if (nameLocalParticipant == nameParticipant0) {
     cplScheme.initializeData();
     BOOST_TEST(cplScheme.hasDataBeenExchanged());
-    auto& values = mesh->data(dataID1)->values();
+    auto &values = mesh->data(dataID1)->values();
     BOOST_TEST(testing::equals(values, Eigen::Vector3d(1.0, 2.0, 3.0)));
     mesh->data(dataID0)->values() = Eigen::VectorXd::Constant(mesh->data(dataID0)->values().size(), 4.0);
-    while (cplScheme.isCouplingOngoing()){
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)){
+    while (cplScheme.isCouplingOngoing()) {
+      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
         cplScheme.performedAction(writeIterationCheckpoint);
       }
-      if (cplScheme.isActionRequired(readIterationCheckpoint)){
+      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
         cplScheme.performedAction(readIterationCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.advance();
     }
-  }
-  else {
+  } else {
     BOOST_TEST(nameLocalParticipant == nameParticipant1);
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
     cplScheme.performedAction(constants::actionWriteInitialData());
-    auto& values = mesh->data(dataID0)->values();
+    auto &values = mesh->data(dataID0)->values();
     BOOST_TEST(testing::equals(values(0), 0.0));
-    Eigen::VectorXd v(3); v << 1.0, 2.0, 3.0;
+    Eigen::VectorXd v(3);
+    v << 1.0, 2.0, 3.0;
     mesh->data(dataID1)->values() = v;
     cplScheme.initializeData();
     BOOST_TEST(cplScheme.hasDataBeenExchanged());
     BOOST_TEST(testing::equals(values(0), 4.0));
-    while (cplScheme.isCouplingOngoing()){
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)){
+    while (cplScheme.isCouplingOngoing()) {
+      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
         cplScheme.performedAction(writeIterationCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.advance();
-      if (cplScheme.isActionRequired(readIterationCheckpoint)){
+      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
         cplScheme.performedAction(readIterationCheckpoint);
       }
     }
@@ -858,4 +836,4 @@ BOOST_FIXTURE_TEST_CASE(testInitializeData, testing::M2NFixture,
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 
-# endif // not PRECICE_NO_MPI
+#endif // not PRECICE_NO_MPI

--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -1,9 +1,9 @@
-#include "utils/Parallel.hpp"
-#include "utils/Petsc.hpp"
-#include "precice/impl/SolverInterfaceImpl.hpp"
-#include "precice/config/Configuration.hpp"
 #include <iostream>
 #include "logging/Logger.hpp"
+#include "precice/config/Configuration.hpp"
+#include "precice/impl/SolverInterfaceImpl.hpp"
+#include "utils/Parallel.hpp"
+#include "utils/Petsc.hpp"
 #include "xml/Printer.hpp"
 
 void printUsage()
@@ -15,34 +15,34 @@ void printUsage()
   std::cout << "Print Markdown reference :  binprecice md" << std::endl;
 }
 
-int main ( int argc, char** argv )
+int main(int argc, char **argv)
 {
-  bool runServer = false;
-  bool runHelp = false;
-  bool runDtd = false;
-  bool runMD = false;
+  bool runServer      = false;
+  bool runHelp        = false;
+  bool runDtd         = false;
+  bool runMD          = false;
   bool hasLogConfFile = false;
 
   bool wrongParameters = true;
 
   if (argc >= 2) {
     std::string action(argv[1]);
-    if ( action == "dtd" ) {
+    if (action == "dtd") {
       wrongParameters = false;
-      runDtd = true;
+      runDtd          = true;
     }
-    if ( action == "md" ) {
+    if (action == "md") {
       wrongParameters = false;
-      runMD = true;
+      runMD           = true;
     }
-    if ( action == "xml" ) {
+    if (action == "xml") {
       wrongParameters = false;
-      runHelp = true;
+      runHelp         = true;
     }
-    if ( action == "server" and argc >= 4 ) {
+    if (action == "server" and argc >= 4) {
       wrongParameters = false;
-      runServer = true;
-      if (argc >= 5){
+      runServer       = true;
+      if (argc >= 5) {
         hasLogConfFile = true;
       }
     }
@@ -53,7 +53,7 @@ int main ( int argc, char** argv )
     return 1;
   }
 
-  if (hasLogConfFile){
+  if (hasLogConfFile) {
     precice::logging::setupLogging(argv[3]);
   } else {
     precice::logging::setupLogging();
@@ -64,39 +64,35 @@ int main ( int argc, char** argv )
 
   precice::utils::Petsc::initialize(&argc, &argv);
 
-  if ( runServer ){
+  if (runServer) {
     PRECICE_ASSERT(not runHelp);
     std::cout << "PreCICE running server...\n";
-    std::string participantName ( argv[2] );
-    std::string configFile ( argv[3] );
+    std::string participantName(argv[2]);
+    std::string configFile(argv[3]);
     std::cout << "  Participant = " << participantName << '\n';
     std::cout << "  Configuration = " << configFile << '\n';
     int size = precice::utils::Parallel::getCommunicatorSize();
-    if ( size != 1 ){
+    if (size != 1) {
       std::cerr << "Server can be run with only one process!\n";
     }
-    precice::impl::SolverInterfaceImpl server ( participantName, 0, 1, true );
+    precice::impl::SolverInterfaceImpl server(participantName, 0, 1, true);
     server.configure(configFile);
     server.runServer();
     std::cout << "\n\n...finished running server\n";
-  }
-  else if (runHelp){
+  } else if (runHelp) {
     PRECICE_ASSERT(not runServer);
     precice::config::Configuration config;
     precice::xml::toDocumentation(std::cout, config.getXMLTag());
-  }
-  else if (runDtd) {
-	PRECICE_ASSERT(not runServer);
+  } else if (runDtd) {
+    PRECICE_ASSERT(not runServer);
     precice::config::Configuration config;
     precice::xml::toDTD(std::cout, config.getXMLTag());
-  }
-  else if (runMD) {
-	PRECICE_ASSERT(not runServer);
+  } else if (runMD) {
+    PRECICE_ASSERT(not runServer);
     precice::config::Configuration config;
     precice::xml::toMarkdown(std::cout, config.getXMLTag());
-  }
-  else {
-    PRECICE_ASSERT( false );
+  } else {
+    PRECICE_ASSERT(false);
   }
   precice::utils::Petsc::finalize();
   //precice::utils::Parallel::synchronizeProcesses();

--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -14,7 +14,7 @@ namespace io {
 /// Abstract base class of all classes exporting container data structures.
 class Export {
 public:
-  Export& operator=(Export &&) = delete;
+  Export &operator=(Export &&) = delete;
 
   virtual ~Export() {}
 

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -322,7 +322,7 @@ void ExportVTKXML::writeVertex(
 
 void ExportVTKXML::writeTriangle(
     const mesh::Triangle &triangle,
-    std::ofstream & outFile)
+    std::ofstream &       outFile)
 {
   outFile << triangle.vertex(0).getID() << "  ";
   outFile << triangle.vertex(1).getID() << "  ";
@@ -330,8 +330,8 @@ void ExportVTKXML::writeTriangle(
 }
 
 void ExportVTKXML::writeQuadrangle(
-    const mesh::Quad &   quad,
-    std::ofstream &outFile)
+    const mesh::Quad &quad,
+    std::ofstream &   outFile)
 {
   outFile << quad.vertex(0).getID() << "  ";
   outFile << quad.vertex(1).getID() << "  ";
@@ -340,8 +340,8 @@ void ExportVTKXML::writeQuadrangle(
 }
 
 void ExportVTKXML::writeLine(
-    const mesh::Edge &   edge,
-    std::ofstream &outFile)
+    const mesh::Edge &edge,
+    std::ofstream &   outFile)
 {
   outFile << edge.vertex(0).getID() << "  ";
   outFile << edge.vertex(1).getID() << "  ";

--- a/src/io/ExportVTKXML.hpp
+++ b/src/io/ExportVTKXML.hpp
@@ -47,16 +47,16 @@ public:
       std::ofstream &        outFile);
 
   static void writeLine(
-      const mesh::Edge &   edge,
-      std::ofstream &outFile);
+      const mesh::Edge &edge,
+      std::ofstream &   outFile);
 
   static void writeTriangle(
       const mesh::Triangle &triangle,
-      std::ofstream & outFile);
+      std::ofstream &       outFile);
 
   static void writeQuadrangle(
-      const mesh::Quad &   quad,
-      std::ofstream &outFile);
+      const mesh::Quad &quad,
+      std::ofstream &   outFile);
 
 private:
   logging::Logger _log{"io::ExportVTKXML"};

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -15,7 +15,7 @@ TXTTableWriter::TXTTableWriter(
   _outputStream.open(filename.c_str());
   if (not _outputStream) {
     PRECICE_ERROR("Could not open file \"" << filename
-                                   << "\" for writing txt table data!");
+                                           << "\" for writing txt table data!");
   }
   _outputStream.setf(std::ios::showpoint);
   _outputStream.setf(std::ios::fixed);

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -46,8 +46,8 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
 }
 
 void ExportConfiguration::xmlTagCallback(
-    const xml::ConfigurationContext& context,
-    xml::XMLTag &tag)
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   if (tag.getNamespace() == TAG) {
     ExportContext context;

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -24,10 +24,10 @@ public:
     return _contexts;
   }
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /// Callback from automatic configuration. Not utilitzed here.
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag) {}
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) {}
 
   void resetExports()
   {

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -62,8 +62,8 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 BOOST_AUTO_TEST_CASE(ExportQuadMesh)
 {
   using namespace mesh;
-  int  dim           = 3;
-  bool invertNormals = false;
+  int        dim           = 3;
+  bool       invertNormals = false;
   mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::nextMeshID());
   // z=0 plane
   Vertex &v0 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -168,8 +168,8 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 BOOST_AUTO_TEST_CASE(ExportQuadMesh)
 {
   using namespace mesh;
-  int  dim           = 3;
-  bool invertNormals = false;
+  int        dim           = 3;
+  bool       invertNormals = false;
   mesh::Mesh mesh("QuadMesh", dim, invertNormals, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -7,88 +7,70 @@
 
 #include <boost/core/null_deleter.hpp>
 
-#include <boost/log/core.hpp>
-#include <boost/log/trivial.hpp>
-#include <boost/log/expressions.hpp>
 #include <boost/log/attributes/mutable_constant.hpp>
-#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
 #include <boost/log/support/date_time.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/log/utility/setup/console.hpp>
 
 #include "precice/impl/versions.hpp"
-#include "utils/assertion.hpp"
 #include "utils/String.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace logging {
 
 /// A custom formatter that handles the TimeStamp format string
-class timestamp_formatter_factory :
-    public boost::log::basic_formatter_factory<char, boost::posix_time::ptime>
-{
+class timestamp_formatter_factory : public boost::log::basic_formatter_factory<char, boost::posix_time::ptime> {
 public:
-  formatter_type create_formatter(boost::log::attribute_name const& name, args_map const& args)
+  formatter_type create_formatter(boost::log::attribute_name const &name, args_map const &args)
   {
-    namespace expr = boost::log::expressions;
+    namespace expr              = boost::log::expressions;
     args_map::const_iterator it = args.find("format");
     if (it != args.end())
-      return expr::stream <<
-        expr::format_date_time<boost::posix_time::ptime>(expr::attr<boost::posix_time::ptime>(name), it->second);
+      return expr::stream << expr::format_date_time<boost::posix_time::ptime>(expr::attr<boost::posix_time::ptime>(name), it->second);
     else
-      return expr::stream <<
-        expr::attr<boost::posix_time::ptime>(name);
+      return expr::stream << expr::attr<boost::posix_time::ptime>(name);
   }
 };
 
 /// A custom formatter that handles the colorized Severity formatting
-class colorized_severity_formatter_factory :
-    public boost::log::formatter_factory<char>
-{
+class colorized_severity_formatter_factory : public boost::log::formatter_factory<char> {
 public:
-  formatter_type create_formatter(boost::log::attribute_name const& name, args_map const& args)
+  formatter_type create_formatter(boost::log::attribute_name const &name, args_map const &args)
   {
     namespace expr = boost::log::expressions;
-    auto severity = expr::attr<boost::log::trivial::severity_level>("Severity");
-    
+    auto severity  = expr::attr<boost::log::trivial::severity_level>("Severity");
+
     return expr::stream
-      << expr::if_(severity == boost::log::trivial::severity_level::error)
-      [
-        expr::stream << "\033[31m"  //red
-        << "ERROR: "
-        ]
-      << expr::if_(severity == boost::log::trivial::severity_level::warning)
-       [
-        expr::stream << "\033[36m"  //cyan
-        << "WARNING: "
-         ]
-      << "\033[0m";
+           << expr::if_(severity == boost::log::trivial::severity_level::error)
+                  [expr::stream << "\033[31m" //red
+                                << "ERROR: "]
+           << expr::if_(severity == boost::log::trivial::severity_level::warning)
+                  [expr::stream << "\033[36m" //cyan
+                                << "WARNING: "]
+           << "\033[0m";
   }
 };
 
 /// A custom formatter that handles non-colorized Severity formatting
-class severity_formatter_factory :
-    public boost::log::formatter_factory<char>
-{
+class severity_formatter_factory : public boost::log::formatter_factory<char> {
 public:
-  formatter_type create_formatter(boost::log::attribute_name const& name, args_map const& args)
+  formatter_type create_formatter(boost::log::attribute_name const &name, args_map const &args)
   {
     namespace expr = boost::log::expressions;
-    auto severity = expr::attr<boost::log::trivial::severity_level>("Severity");
+    auto severity  = expr::attr<boost::log::trivial::severity_level>("Severity");
 
     return expr::stream
-      << expr::if_(severity == boost::log::trivial::severity_level::error)
-      [
-        expr::stream
-        << "ERROR: "
-        ]
-      << expr::if_(severity == boost::log::trivial::severity_level::warning)
-       [
-        expr::stream
-        << "WARNING: "
-         ];
+           << expr::if_(severity == boost::log::trivial::severity_level::error)
+                  [expr::stream
+                   << "ERROR: "]
+           << expr::if_(severity == boost::log::trivial::severity_level::warning)
+                  [expr::stream
+                   << "WARNING: "];
   }
 };
-
-
 
 /// A simple backends that outputs the message to a stream
 /**
@@ -96,29 +78,28 @@ public:
  * between the printing of the message and the endline. This leads to high probability that a process switch 
  * occures and the message is severed from the endline.
  */
-class StreamBackend :
-    public boost::log::sinks::text_ostream_backend
-{
+class StreamBackend : public boost::log::sinks::text_ostream_backend {
 private:
   boost::shared_ptr<std::ostream> _ostream;
-  
+
 public:
-  explicit StreamBackend(boost::shared_ptr<std::ostream> ostream) : _ostream(ostream) {}
-  
-  void consume(boost::log::record_view const& rec, string_type const& formatted_record)
+  explicit StreamBackend(boost::shared_ptr<std::ostream> ostream)
+      : _ostream(ostream) {}
+
+  void consume(boost::log::record_view const &rec, string_type const &formatted_record)
   {
-    *_ostream << formatted_record << '\n' << std::flush;
+    *_ostream << formatted_record << '\n'
+              << std::flush;
   }
 };
 
-
 /// Reads a log file, returns a logging configuration.
-LoggingConfiguration readLogConfFile(std::string const & filename)
+LoggingConfiguration readLogConfFile(std::string const &filename)
 {
   namespace po = boost::program_options;
   po::options_description desc;
-  std::ifstream ifs(filename);
-    
+  std::ifstream           ifs(filename);
+
   po::variables_map vm;
 
   std::map<std::string, BackendConfiguration> configs;
@@ -126,20 +107,19 @@ LoggingConfiguration readLogConfFile(std::string const & filename)
     po::parsed_options parsed = parse_config_file(ifs, desc, true);
     po::store(parsed, vm);
     po::notify(vm);
-    for (auto const & opt : parsed.options) {
+    for (auto const &opt : parsed.options) {
       std::string section = opt.string_key.substr(0, opt.string_key.find('.'));
-      std::string key = opt.string_key.substr(opt.string_key.find('.')+1);
-      configs[section].setOption(key, opt.value[0]);        
+      std::string key     = opt.string_key.substr(opt.string_key.find('.') + 1);
+      configs[section].setOption(key, opt.value[0]);
     }
-  }
-  catch (po::error& e) {
+  } catch (po::error &e) {
     std::cout << "ERROR reading logging configuration: " << e.what() << "\n\n";
     std::exit(-1);
   }
 
   LoggingConfiguration retVal;
-    
-  for (auto const & c : configs)
+
+  for (auto const &c : configs)
     if (c.second.enabled)
       retVal.push_back(c.second);
 
@@ -147,10 +127,10 @@ LoggingConfiguration readLogConfFile(std::string const & filename)
 }
 
 // Default values for filter and format. They are also used from config/LogConfiguration.cpp
-const std::string BackendConfiguration::default_filter = "(%Severity% > debug) and not ((%Severity% = info) and (%Rank% != 0))";
+const std::string BackendConfiguration::default_filter    = "(%Severity% > debug) and not ((%Severity% = info) and (%Rank% != 0))";
 const std::string BackendConfiguration::default_formatter = "(%Rank%) %TimeStamp(format=\"%H:%M:%S\")% [%Module%]:%Line% in %Function%: %ColorizedSeverity%%Message%";
-const std::string BackendConfiguration::default_type = "stream";
-const std::string BackendConfiguration::default_output = "stdout";
+const std::string BackendConfiguration::default_type      = "stream";
+const std::string BackendConfiguration::default_output    = "stdout";
 
 void BackendConfiguration::setOption(std::string key, std::string value)
 {
@@ -170,10 +150,10 @@ void BackendConfiguration::setOption(std::string key, std::string value)
   }
 }
 
-
 void setupLogging(LoggingConfiguration configs, bool enabled)
 {
-  if (_precice_logging_config_lock) return;
+  if (_precice_logging_config_lock)
+    return;
 
   namespace bl = boost::log;
   bl::register_formatter_factory("TimeStamp", boost::make_shared<timestamp_formatter_factory>());
@@ -183,26 +163,26 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
 
   // Possible, longer output format. Currently unused.
   auto fmtStream =
-    bl::expressions::stream
-    << "(" << bl::expressions::attr<int>("Rank") << ") "
-    << bl::expressions::format_date_time<boost::posix_time::ptime>("TimeStamp", "%H:%M:%S") << " "
-    << bl::expressions::attr<std::string>("File") << ":"
-    << bl::expressions::attr<int>("Line")
-    << " [" << bl::expressions::attr<std::string>("Module") << "] in "
-    << bl::expressions::attr<std::string>("Function") << ": "
-    << bl::expressions::message;
+      bl::expressions::stream
+      << "(" << bl::expressions::attr<int>("Rank") << ") "
+      << bl::expressions::format_date_time<boost::posix_time::ptime>("TimeStamp", "%H:%M:%S") << " "
+      << bl::expressions::attr<std::string>("File") << ":"
+      << bl::expressions::attr<int>("Line")
+      << " [" << bl::expressions::attr<std::string>("Module") << "] in "
+      << bl::expressions::attr<std::string>("Function") << ": "
+      << bl::expressions::message;
 
   // Reset
   bl::core::get()->remove_all_sinks();
   bl::core::get()->reset_filter();
 
   bl::core::get()->set_logging_enabled(enabled);
-  
+
   // Add the default config
   if (configs.empty())
     configs.emplace_back();
-  
-  for (const auto& config : configs) {
+
+  for (const auto &config : configs) {
     boost::shared_ptr<StreamBackend> backend;
     if (config.type == "file")
       backend = boost::make_shared<StreamBackend>(boost::shared_ptr<std::ostream>(new std::ofstream(config.output)));
@@ -214,7 +194,7 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
     }
     PRECICE_ASSERT(backend != nullptr, "The logging backend was not initialized properly. Check your log config.");
     backend->auto_flush(true);
-    using sink_t =  boost::log::sinks::synchronous_sink<StreamBackend>;          
+    using sink_t = boost::log::sinks::synchronous_sink<StreamBackend>;
     boost::shared_ptr<sink_t> sink(new sink_t(backend));
     sink->set_formatter(boost::log::parse_formatter(config.format));
     sink->set_filter(boost::log::parse_filter(config.filter));
@@ -222,26 +202,27 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
   }
 }
 
-
-void setupLogging(std::string const & logConfigFile)
+void setupLogging(std::string const &logConfigFile)
 {
   setupLogging(readLogConfFile(logConfigFile));
 }
 
-
-void setMPIRank(int const rank) {
+void setMPIRank(int const rank)
+{
   boost::log::attribute_cast<boost::log::attributes::mutable_constant<int>>(boost::log::core::get()->get_global_attributes()["Rank"]).set(rank);
 }
 
-void setParticipant(std::string const & participant)
+void setParticipant(std::string const &participant)
 {
   boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["Participant"]).set(participant);
 }
 
 bool _precice_logging_config_lock{false};
 
-void lockConf() {
-    _precice_logging_config_lock = true;
+void lockConf()
+{
+  _precice_logging_config_lock = true;
 }
 
-}} // namespace precice, logging
+} // namespace logging
+} // namespace precice

--- a/src/logging/LogConfiguration.hpp
+++ b/src/logging/LogConfiguration.hpp
@@ -7,18 +7,17 @@ namespace precice {
 namespace logging {
 
 /// Holds the configuration for one logging backend (sink) and takes care of default values.
-struct BackendConfiguration
-{
+struct BackendConfiguration {
   static const std::string default_type;
   static const std::string default_output;
   static const std::string default_filter;
   static const std::string default_formatter;
-    
-  std::string type = default_type;
-  std::string output = default_output;
-  std::string filter = default_filter;
-  std::string format = default_formatter;
-  bool enabled = true;
+
+  std::string type    = default_type;
+  std::string output  = default_output;
+  std::string filter  = default_filter;
+  std::string format  = default_formatter;
+  bool        enabled = true;
 
   /// Sets on option, overwrites default values.
   void setOption(std::string key, std::string value);
@@ -28,10 +27,10 @@ struct BackendConfiguration
 using LoggingConfiguration = std::vector<BackendConfiguration>;
 
 /// Reads a log configuration file, returns vector of BackEndConfiguration
-LoggingConfiguration readLogConfFile(std::string const & filename);
+LoggingConfiguration readLogConfFile(std::string const &filename);
 
 /// Configures the logging from a log file
-void setupLogging(std::string const & logConfigFile = "log.conf");
+void setupLogging(std::string const &logConfigFile = "log.conf");
 
 /// Configures the logging from a LoggingConfiguration
 void setupLogging(LoggingConfiguration configs, bool enabled = true);
@@ -40,7 +39,7 @@ void setupLogging(LoggingConfiguration configs, bool enabled = true);
 void setMPIRank(int const rank);
 
 /// Sets the name of the current participant as a logging attribute
-void setParticipant(std::string const & name);
+void setParticipant(std::string const &name);
 
 /// Locks the configuration, ignoring any future calls to setupLogging()
 void lockConf();
@@ -50,4 +49,5 @@ void lockConf();
  */
 extern bool _precice_logging_config_lock;
 
-}} // namespace precice, logging
+} // namespace logging
+} // namespace precice

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <boost/preprocessor/variadic/to_seq.hpp>
+#include <boost/preprocessor/facilities/empty.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/stringize.hpp>
-#include <boost/preprocessor/facilities/empty.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
 
 #include <boost/vmd/is_empty.hpp>
 
 #include <string>
-#include "utils/String.hpp"
 #include "prettyprint/prettyprint.hpp" // so that we can put std::vector et. al. on ostream
+#include "utils/String.hpp"
 
 #include "Tracer.hpp"
 
@@ -17,48 +17,46 @@
 
 #define PRECICE_INFO(message) _log.info(PRECICE_LOG_LOCATION, PRECICE_AS_STRING(message))
 
-#define PRECICE_ERROR(message) do {                                             \
-    _log.error(PRECICE_LOG_LOCATION, PRECICE_AS_STRING(message));               \
-    std::exit(-1);                                                              \
-} while (false)
+#define PRECICE_ERROR(message)                                    \
+  do {                                                            \
+    _log.error(PRECICE_LOG_LOCATION, PRECICE_AS_STRING(message)); \
+    std::exit(-1);                                                \
+  } while (false)
 
-#define PRECICE_CHECK(check, message)                                           \
-  if ( !(check) ) {                                                             \
-    PRECICE_ERROR(message);                                                     \
+#define PRECICE_CHECK(check, message) \
+  if (!(check)) {                     \
+    PRECICE_ERROR(message);           \
   }
 
-#ifdef NDEBUG 
+#ifdef NDEBUG
 
-#define PRECICE_DEBUG(...) {}
-#define PRECICE_TRACE(...) {}
+#define PRECICE_DEBUG(...) \
+  {                        \
+  }
+#define PRECICE_TRACE(...) \
+  {                        \
+  }
 
 #else // NDEBUG
 
 #define PRECICE_DEBUG(message) _log.debug(PRECICE_LOG_LOCATION, PRECICE_AS_STRING(message))
 
 /// Helper macro, used by TRACE
-#define PRECICE_LOG_ARGUMENT(r, data, i, elem)                                  \
-  << '\n' << "  Argument " << i << ": " << BOOST_PP_STRINGIZE(elem) << " == " << elem
+#define PRECICE_LOG_ARGUMENT(r, data, i, elem) \
+  << '\n'                                      \
+  << "  Argument " << i << ": " << BOOST_PP_STRINGIZE(elem) << " == " << elem
 
 // Do not put do {...} while (false) here, it will destroy the _tracer_ right after creation
-#define PRECICE_TRACE(...)                                                      \
-  precice::logging::Tracer _tracer_(_log, PRECICE_LOG_LOCATION);                \
-  _log.trace(PRECICE_LOG_LOCATION, PRECICE_AS_STRING("Entering " << __func__    \
-  BOOST_PP_IF(BOOST_VMD_IS_EMPTY(__VA_ARGS__),                                  \
-              BOOST_PP_EMPTY(),                                                 \
-              BOOST_PP_SEQ_FOR_EACH_I(PRECICE_LOG_ARGUMENT,, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)))));
-
+#define PRECICE_TRACE(...)                                                                                                \
+  precice::logging::Tracer _tracer_(_log, PRECICE_LOG_LOCATION);                                                          \
+  _log.trace(PRECICE_LOG_LOCATION, PRECICE_AS_STRING("Entering " << __func__ BOOST_PP_IF(BOOST_VMD_IS_EMPTY(__VA_ARGS__), \
+                                                                                         BOOST_PP_EMPTY(),                \
+                                                                                         BOOST_PP_SEQ_FOR_EACH_I(PRECICE_LOG_ARGUMENT, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)))));
 
 #endif // ! NDEBUG
 
-
-#define PRECICE_LOG_LOCATION precice::logging::LogLocation{__FILE__,  __LINE__, __func__}
-
-  
-
-
-
-
-
-
-
+#define PRECICE_LOG_LOCATION     \
+  precice::logging::LogLocation  \
+  {                              \
+    __FILE__, __LINE__, __func__ \
+  }

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -1,13 +1,13 @@
 #include "Logger.hpp"
 
+#include <boost/log/attributes/constant.hpp>
 #include <boost/log/attributes/mutable_constant.hpp>
 #include <boost/log/attributes/named_scope.hpp>
-#include <boost/log/attributes/constant.hpp>
-#include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/trivial.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
 
-#include <boost/log/expressions.hpp>
 #include <boost/log/attributes/mutable_constant.hpp>
+#include <boost/log/expressions.hpp>
 
 namespace precice {
 namespace logging {
@@ -16,8 +16,7 @@ namespace logging {
  *
  * @note The point of using a pimpl for the logger is to remove boost::log from logger.hpp
  */
-class Logger::LoggerImpl : public boost::log::sources::severity_logger<boost::log::trivial::severity_level>
-{
+class Logger::LoggerImpl : public boost::log::sources::severity_logger<boost::log::trivial::severity_level> {
 public:
   /** Creates a Boost logger for the said module.
    * @param[in] module the name of the module.
@@ -28,9 +27,9 @@ public:
 Logger::LoggerImpl::LoggerImpl(std::string module)
 {
   add_attribute("Module", boost::log::attributes::constant<std::string>(module));
-  
-  namespace attrs = boost::log::attributes; 
-  namespace log = boost::log;
+
+  namespace attrs = boost::log::attributes;
+  namespace log   = boost::log;
   log::add_common_attributes();
   log::core::get()->add_global_attribute("Scope", attrs::named_scope());
   log::core::get()->add_global_attribute("Participant", attrs::mutable_constant<std::string>(""));
@@ -40,69 +39,70 @@ Logger::LoggerImpl::LoggerImpl(std::string module)
   log::core::get()->add_global_attribute("Function", attrs::mutable_constant<std::string>(""));
 }
 
-Logger::Logger(std::string module) : _impl(new LoggerImpl{std::move(module)}) {}
+Logger::Logger(std::string module)
+    : _impl(new LoggerImpl{std::move(module)}) {}
 
 // This is required for the std::unique_ptr.
 Logger::~Logger() = default;
 
 // Extracts the name saved in the attribute "Module"
-Logger::Logger(const Logger& other)
+Logger::Logger(const Logger &other)
     : Logger{other._impl->get_attributes().find("Module")->second.get_value().extract_or_throw<std::string>()}
 {
 }
 
-Logger::Logger(Logger&& other) = default;
+Logger::Logger(Logger &&other) = default;
 
-Logger& Logger::operator=(Logger other)
+Logger &Logger::operator=(Logger other)
 {
-    swap(other);
-    return *this;
+  swap(other);
+  return *this;
 }
 
-void Logger::swap(Logger& other) noexcept
-{ 
-    _impl.swap(other._impl);
+void Logger::swap(Logger &other) noexcept
+{
+  _impl.swap(other._impl);
 }
-
 
 namespace {
-    /// Sets the log location in the boost core
-    void setLogLocation(LogLocation loc) {
-        boost::log::attribute_cast<boost::log::attributes::mutable_constant<int>>(boost::log::core::get()->get_global_attributes()["Line"]).set(loc.line);
-        boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["File"]).set(loc.file);
-        boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["Function"]).set(loc.func);
-    }
-}
-
-void Logger::error(LogLocation loc, const std::string& mess)
+/// Sets the log location in the boost core
+void setLogLocation(LogLocation loc)
 {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::error) << mess;
+  boost::log::attribute_cast<boost::log::attributes::mutable_constant<int>>(boost::log::core::get()->get_global_attributes()["Line"]).set(loc.line);
+  boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["File"]).set(loc.file);
+  boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["Function"]).set(loc.func);
 }
+} // namespace
 
-void Logger::warning(LogLocation loc, const std::string& mess)
+void Logger::error(LogLocation loc, const std::string &mess)
 {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::warning) << mess;
+  setLogLocation(loc);
+  BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::error) << mess;
 }
 
-void Logger::info(LogLocation loc, const std::string& mess)
+void Logger::warning(LogLocation loc, const std::string &mess)
 {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::info) << mess;
+  setLogLocation(loc);
+  BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::warning) << mess;
 }
 
-void Logger::debug(LogLocation loc, const std::string& mess)
+void Logger::info(LogLocation loc, const std::string &mess)
 {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::debug) << mess;
+  setLogLocation(loc);
+  BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::info) << mess;
 }
 
-void Logger::trace(LogLocation loc, const std::string& mess)
+void Logger::debug(LogLocation loc, const std::string &mess)
 {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::trace) << mess;
+  setLogLocation(loc);
+  BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::debug) << mess;
 }
 
-}}
+void Logger::trace(LogLocation loc, const std::string &mess)
+{
+  setLogLocation(loc);
+  BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::trace) << mess;
+}
 
+} // namespace logging
+} // namespace precice

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <string>
 #include <memory>
+#include <string>
 
 namespace precice {
 namespace logging {
 
 /// Struct used to capture the original location of a log request
 struct LogLocation {
-    const char * file;
-    int line;
-    const char * func;
+  const char *file;
+  int         line;
+  const char *func;
 };
 
 /// This class provides a leightweight logger.
@@ -21,22 +21,22 @@ public:
    */
   explicit Logger(std::string module);
 
-  Logger(const Logger& other);
-  Logger(Logger&& other);
-  Logger& operator=(Logger other);
+  Logger(const Logger &other);
+  Logger(Logger &&other);
+  Logger &operator=(Logger other);
   ~Logger();
 
-  void swap(Logger& other) noexcept;
+  void swap(Logger &other) noexcept;
 
   ///@name Logging operations
   ///@{
-  void error(LogLocation loc, const std::string& mess);
-  void warning(LogLocation loc, const std::string& mess);
-  void info(LogLocation loc, const std::string& mess);
-  void debug(LogLocation loc, const std::string& mess);
-  void trace(LogLocation loc, const std::string& mess);
+  void error(LogLocation loc, const std::string &mess);
+  void warning(LogLocation loc, const std::string &mess);
+  void info(LogLocation loc, const std::string &mess);
+  void debug(LogLocation loc, const std::string &mess);
+  void trace(LogLocation loc, const std::string &mess);
   ///@}
-  
+
 private:
   /// Forward declaration of the implementation of the logger
   class LoggerImpl;
@@ -44,8 +44,8 @@ private:
   std::unique_ptr<LoggerImpl> _impl;
 };
 
-}} // namespace precice, logging
+} // namespace logging
+} // namespace precice
 
 // Include LogMacros here, because using it works only together with a Logger
-#include "LogMacros.hpp" 
-
+#include "LogMacros.hpp"

--- a/src/logging/Tracer.cpp
+++ b/src/logging/Tracer.cpp
@@ -4,19 +4,18 @@
 namespace precice {
 namespace logging {
 
-Tracer::Tracer
-(
-  Logger &log,
-  LogLocation loc
-  )
-  :
-  _log(log),
-  _loc(std::move(loc))
-{}
+Tracer::Tracer(
+    Logger &    log,
+    LogLocation loc)
+    : _log(log),
+      _loc(std::move(loc))
+{
+}
 
 Tracer::~Tracer()
 {
   _log.trace(_loc, std::string{"Leaving "}.append(_loc.func));
 }
 
-}} // namespace precice,logging
+} // namespace logging
+} // namespace precice

--- a/src/logging/Tracer.hpp
+++ b/src/logging/Tracer.hpp
@@ -4,18 +4,16 @@
 namespace precice {
 namespace logging {
 
-class Tracer
-{
-public:  
-  
-  Tracer (Logger &log, LogLocation loc);
+class Tracer {
+public:
+  Tracer(Logger &log, LogLocation loc);
   ~Tracer();
 
 private:
-
   Logger _log;
 
   LogLocation _loc;
 };
 
-}} // namespace precice, logging
+} // namespace logging
+} // namespace precice

--- a/src/logging/config/LogConfiguration.cpp
+++ b/src/logging/config/LogConfiguration.cpp
@@ -3,60 +3,57 @@
 namespace precice {
 namespace config {
 
-
-LogConfiguration::LogConfiguration
-(
-  xml::XMLTag& parent)
+LogConfiguration::LogConfiguration(
+    xml::XMLTag &parent)
 {
   // We do default initialization here, so logging will be initialized
   // as soon as possible and also if there is no <log> tag.
   precice::logging::setupLogging();
-  
+
   using namespace xml;
   XMLTag tagLog(*this, "log", XMLTag::OCCUR_NOT_OR_ONCE);
   tagLog.setDocumentation("Configures logging");
 
   auto attrLogEnabled = makeXMLAttribute("enabled", true)
-    .setDocumentation("Enables logging");
+                            .setDocumentation("Enables logging");
   tagLog.addAttribute(attrLogEnabled);
-  
+
   XMLTag tagSink(*this, "sink", XMLTag::OCCUR_ARBITRARY);
-  auto attrType = XMLAttribute<std::string>("type")
-    .setDocumentation("Type of sink")
-    .setOptions({"stream", "file"})
-    .setDefaultValue(precice::logging::BackendConfiguration::default_type);
+  auto   attrType = XMLAttribute<std::string>("type")
+                      .setDocumentation("Type of sink")
+                      .setOptions({"stream", "file"})
+                      .setDefaultValue(precice::logging::BackendConfiguration::default_type);
   tagSink.addAttribute(attrType);
 
   auto attrOutput = XMLAttribute<std::string>("output")
-    .setDocumentation("Output. If type=stream it can be stdout or stderr. Otherwise it is a filename")
-    .setDefaultValue(precice::logging::BackendConfiguration::default_output);
+                        .setDocumentation("Output. If type=stream it can be stdout or stderr. Otherwise it is a filename")
+                        .setDefaultValue(precice::logging::BackendConfiguration::default_output);
   tagSink.addAttribute(attrOutput);
 
   auto attrFormat = XMLAttribute<std::string>("format")
-    .setDocumentation("Boost Log Format String")
-    .setDefaultValue(precice::logging::BackendConfiguration::default_formatter);
+                        .setDocumentation("Boost Log Format String")
+                        .setDefaultValue(precice::logging::BackendConfiguration::default_formatter);
   tagSink.addAttribute(attrFormat);
 
   auto attrFilter = XMLAttribute<std::string>("filter")
-    .setDocumentation("Boost Log Filter String")
-    .setDefaultValue(precice::logging::BackendConfiguration::default_filter);
+                        .setDocumentation("Boost Log Filter String")
+                        .setDefaultValue(precice::logging::BackendConfiguration::default_filter);
   tagSink.addAttribute(attrFilter);
-  
+
   auto attrEnabled = makeXMLAttribute("enabled", true)
-    .setDocumentation("Enables the sink");
+                         .setDocumentation("Enables the sink");
   tagSink.addAttribute(attrEnabled);
-  
+
   tagLog.addSubtag(tagSink);
   parent.addSubtag(tagLog);
 }
 
-void LogConfiguration::xmlTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void LogConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getFullName());
-  
+
   if (tag.getName() == "sink" and tag.getBooleanAttributeValue("enabled")) {
     precice::logging::BackendConfiguration config;
     config.setOption("type", tag.getStringAttributeValue("type"));
@@ -68,14 +65,14 @@ void LogConfiguration::xmlTagCallback
   }
 }
 
-void LogConfiguration::xmlEndTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void LogConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getFullName());
   if (tag.getName() == "log")
     precice::logging::setupLogging(_logconfig, tag.getBooleanAttributeValue("enabled"));
 }
 
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/logging/config/LogConfiguration.hpp
+++ b/src/logging/config/LogConfiguration.hpp
@@ -7,14 +7,13 @@ namespace precice {
 namespace config {
 
 /// Configures the log config file to use
-class LogConfiguration : public xml::XMLTag::Listener
-{
+class LogConfiguration : public xml::XMLTag::Listener {
 public:
-  LogConfiguration(xml::XMLTag& parent);
+  LogConfiguration(xml::XMLTag &parent);
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
 
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag);
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
 
 private:
   precice::logging::Logger _log{"logging::config::LogConfiguration"};
@@ -22,4 +21,5 @@ private:
   precice::logging::LoggingConfiguration _logconfig;
 };
 
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -1,41 +1,40 @@
 #include "m2n/BoundM2N.hpp"
-#include "m2n/M2N.hpp"
 #include "com/Communication.hpp"
+#include "m2n/M2N.hpp"
 
 namespace precice {
 namespace m2n {
 
 void BoundM2N::prepareEstablishment()
 {
-    m2n->prepareEstablishment();
+  m2n->prepareEstablishment();
 }
 
 void BoundM2N::connectMasters()
 {
-    std::string fullLocalName = localName;
-    if (localServer) fullLocalName += "Server";
+  std::string fullLocalName = localName;
+  if (localServer)
+    fullLocalName += "Server";
 
-    if (isRequesting){
-        m2n->requestMasterConnection(remoteName, fullLocalName);
-    }
-    else {
-        m2n->acceptMasterConnection(fullLocalName, remoteName);
-    }
+  if (isRequesting) {
+    m2n->requestMasterConnection(remoteName, fullLocalName);
+  } else {
+    m2n->acceptMasterConnection(fullLocalName, remoteName);
+  }
 }
 
 void BoundM2N::connectSlaves()
 {
-    if (isRequesting){
-        m2n->requestSlavesConnection(remoteName, localName);
-    }
-    else {
-        m2n->acceptSlavesConnection(localName, remoteName);
-    }
+  if (isRequesting) {
+    m2n->requestSlavesConnection(remoteName, localName);
+  } else {
+    m2n->acceptSlavesConnection(localName, remoteName);
+  }
 }
 
 void BoundM2N::cleanupEstablishment()
 {
-    m2n->cleanupEstablishment();
+  m2n->cleanupEstablishment();
 }
 
 } // namespace m2n

--- a/src/m2n/BoundM2N.hpp
+++ b/src/m2n/BoundM2N.hpp
@@ -1,30 +1,30 @@
 #pragma once
 
-#include "m2n/SharedPointer.hpp"
 #include <string>
+#include "m2n/SharedPointer.hpp"
 
 namespace precice {
 namespace m2n {
-    
+
 /// An M2N between participants with a configured direction
 struct BoundM2N {
-    /// Prepare to establish the connection
-    void prepareEstablishment();
+  /// Prepare to establish the connection
+  void prepareEstablishment();
 
-    /// Connect the Masters of the M2N
-    void connectMasters();
+  /// Connect the Masters of the M2N
+  void connectMasters();
 
-    /// Connect the Slaves of the M2N
-    void connectSlaves();
+  /// Connect the Slaves of the M2N
+  void connectSlaves();
 
-    /// Cleanup after having established the connection
-    void cleanupEstablishment();
+  /// Cleanup after having established the connection
+  void cleanupEstablishment();
 
-    PtrM2N m2n;
-    std::string localName;
-    std::string remoteName;
-    bool isRequesting;
-    bool localServer;
+  PtrM2N      m2n;
+  std::string localName;
+  std::string remoteName;
+  bool        isRequesting;
+  bool        localServer;
 };
 
 } // namespace m2n

--- a/src/m2n/DistributedComFactory.hpp
+++ b/src/m2n/DistributedComFactory.hpp
@@ -4,12 +4,9 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace m2n
-{
-class DistributedComFactory
-{
+namespace precice {
+namespace m2n {
+class DistributedComFactory {
 
 public:
   using SharedPointer = std::shared_ptr<DistributedComFactory>;

--- a/src/m2n/DistributedCommunication.hpp
+++ b/src/m2n/DistributedCommunication.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
-#include "mesh/SharedPointer.hpp"
-#include "mesh/Mesh.hpp"
 #include <map>
 #include <vector>
+#include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 
 /**
  * @brief Interface for all distributed solver to solver communication classes.
@@ -31,14 +29,14 @@ namespace m2n
  * are broadcasted.
  *
  */
-class DistributedCommunication
-{
+class DistributedCommunication {
 public:
   using SharedPointer = std::shared_ptr<DistributedCommunication>;
 
   explicit DistributedCommunication(mesh::PtrMesh mesh)
       : _mesh(mesh)
-  {}
+  {
+  }
 
   /// Destructor, empty.
   virtual ~DistributedCommunication() {}
@@ -75,9 +73,8 @@ public:
    * @param[in] requesterName Name of remote participant to connect to.
    */
   virtual void acceptPreConnection(
-    std::string const &acceptorName,
-    std::string const &requesterName) = 0;
-  
+      std::string const &acceptorName,
+      std::string const &requesterName) = 0;
 
   /**
    * @brief Connects to another participant, which has to call acceptPreConnection().
@@ -88,14 +85,14 @@ public:
    * @param[in] requesterName Name of calling participant.
    */
   virtual void requestPreConnection(
-    std::string const &acceptorName,
-    std::string const &requesterName) = 0;
+      std::string const &acceptorName,
+      std::string const &requesterName) = 0;
 
   /*
    * @brief This function must be called by both acceptor and requester to update the vertex list in _mappings
    */
   virtual void updateVertexList() = 0;
-  
+
   /**
    * @brief Disconnects from communication space, i.e. participant.
    *
@@ -106,8 +103,8 @@ public:
   /// Sends an array of double values from all slaves (different for each slave).
   virtual void send(
       double const *itemsToSend,
-      size_t  size,
-      int     valueDimension) = 0;
+      size_t        size,
+      int           valueDimension) = 0;
 
   /// All slaves receive an array of doubles (different for each slave).
   virtual void receive(
@@ -130,7 +127,7 @@ public:
    * @brief All ranks send their mesh partition to remote local  connected ranks.
    */
   virtual void broadcastSendMesh() = 0;
-  
+
   /**
    * @brief All ranks receive mesh partition from remote local ranks.
    */
@@ -145,14 +142,14 @@ public:
    *  All ranks Send their local communication maps to connected ranks
    */
   virtual void broadcastSendLCM(
-    CommunicationMap &localCommunicationMap)=0;
+      CommunicationMap &localCommunicationMap) = 0;
 
   /*
    *  Each rank revives local communication maps from connected ranks
    */
   virtual void broadcastReceiveLCM(
-    CommunicationMap &localCommunicationMap)=0 ;
-  
+      CommunicationMap &localCommunicationMap) = 0;
+
 protected:
   /**
    * @brief mesh that dictates the distribution of this mapping

--- a/src/m2n/GatherScatterComFactory.cpp
+++ b/src/m2n/GatherScatterComFactory.cpp
@@ -2,10 +2,8 @@
 
 #include "GatherScatterComFactory.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 GatherScatterComFactory::GatherScatterComFactory(
     com::PtrCommunication masterCom)
     : _masterCom(masterCom)

--- a/src/m2n/GatherScatterComFactory.hpp
+++ b/src/m2n/GatherScatterComFactory.hpp
@@ -2,12 +2,9 @@
 
 #include "DistributedComFactory.hpp"
 
-namespace precice
-{
-namespace m2n
-{
-class GatherScatterComFactory : public DistributedComFactory
-{
+namespace precice {
+namespace m2n {
+class GatherScatterComFactory : public DistributedComFactory {
 public:
   GatherScatterComFactory(com::PtrCommunication masterCom);
 

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -3,10 +3,8 @@
 #include "mesh/Mesh.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 GatherScatterCommunication::GatherScatterCommunication(
     com::PtrCommunication com,
     mesh::PtrMesh         mesh)
@@ -55,8 +53,8 @@ void GatherScatterCommunication::closeConnection()
 
 void GatherScatterCommunication::send(
     double const *itemsToSend,
-    size_t  size,
-    int     valueDimension)
+    size_t        size,
+    int           valueDimension)
 {
   PRECICE_TRACE(size);
 
@@ -67,8 +65,8 @@ void GatherScatterCommunication::send(
     }
   } else { // Master or coupling mode
     PRECICE_ASSERT(utils::MasterSlave::getRank() == 0);
-    mesh::Mesh::VertexDistribution  &vertexDistribution = _mesh->getVertexDistribution();
-    int                              globalSize         = _mesh->getGlobalNumberOfVertices() * valueDimension;
+    mesh::Mesh::VertexDistribution &vertexDistribution = _mesh->getVertexDistribution();
+    int                             globalSize         = _mesh->getGlobalNumberOfVertices() * valueDimension;
     PRECICE_DEBUG("Global Size = " << globalSize);
     std::vector<double> globalItemsToSend(globalSize);
 
@@ -159,15 +157,15 @@ void GatherScatterCommunication::receive(
 }
 
 void GatherScatterCommunication::acceptPreConnection(
-  std::string const &acceptorName,
-  std::string const &requesterName)
+    std::string const &acceptorName,
+    std::string const &requesterName)
 {
   PRECICE_ASSERT(false, "This method can only be used with the point to point communication scheme");
 }
 
 void GatherScatterCommunication::requestPreConnection(
-  std::string const &acceptorName,
-  std::string const &requesterName)
+    std::string const &acceptorName,
+    std::string const &requesterName)
 {
   PRECICE_ASSERT(false, "This method can only be used with the point to point communication scheme");
 }

--- a/src/m2n/GatherScatterCommunication.hpp
+++ b/src/m2n/GatherScatterCommunication.hpp
@@ -4,10 +4,8 @@
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 
 /**
  * @brief Implements DistributedCommunication by using a gathering/scattering methodology.
@@ -15,8 +13,7 @@ namespace m2n
  * between slaves is used.
  * For more details see m2n/DistributedCommunication.hpp
  */
-class GatherScatterCommunication : public DistributedCommunication
-{
+class GatherScatterCommunication : public DistributedCommunication {
 public:
   GatherScatterCommunication(
       com::PtrCommunication com,
@@ -59,16 +56,16 @@ public:
    *  @todo: Ideally this should not be here
    */
   virtual void acceptPreConnection(
-    std::string const &acceptorName,
-    std::string const &requesterName);
+      std::string const &acceptorName,
+      std::string const &requesterName);
 
   /** 
    *  This method has not been implemented yet.    
    *  @todo: Ideally this should not be here
    */
   virtual void requestPreConnection(
-    std::string const &acceptorName,
-    std::string const &requesterName);
+      std::string const &acceptorName,
+      std::string const &requesterName);
 
   /*
    * @brief This function must be called by both acceptor and requester to update 
@@ -77,7 +74,7 @@ public:
    * @todo: Ideally this should not be here
    */
   virtual void updateVertexList() override;
-  
+
   /**
    * @brief Disconnects from communication space, i.e. participant.
    *
@@ -88,8 +85,8 @@ public:
   /// Sends an array of double values from all slaves (different for each slave).
   void send(
       double const *itemsToSend,
-      size_t  size,
-      int     valueDimension) override;
+      size_t        size,
+      int           valueDimension) override;
 
   /// All slaves receive an array of doubles (different for each slave).
   void receive(
@@ -97,7 +94,7 @@ public:
       size_t  size,
       int     valueDimension) override;
 
-   /**
+  /**
    * @brief Broadcasts an int to connected ranks
    *
    * @todo: Ideally this should not be here
@@ -118,7 +115,7 @@ public:
    * @todo: Ideally this should not be here
    */
   void broadcastSendMesh() override;
-  
+
   /**
    * @brief All ranks receive mesh partitions from remote local ranks.
    *
@@ -130,13 +127,13 @@ public:
    *  All ranks Send their local communication map to connected ranks
    */
   void broadcastSendLCM(
-    CommunicationMap &localCommunicationMap) override;
+      CommunicationMap &localCommunicationMap) override;
 
   /*
    *  Each rank revives local communication maps from connected ranks
    */
   void broadcastReceiveLCM(
-    CommunicationMap &localCommunicationMap) override;
+      CommunicationMap &localCommunicationMap) override;
 
 private:
   logging::Logger _log{"m2n::GatherScatterCommunication"};

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -8,12 +8,10 @@
 
 using precice::utils::Event;
 
-namespace precice
-{
+namespace precice {
 extern bool syncMode;
 
-namespace m2n
-{
+namespace m2n {
 
 M2N::M2N(com::PtrCommunication masterCom, DistributedComFactory::SharedPointer distrFactory, bool useOnlyMasterCom)
     : _masterCom(masterCom),
@@ -126,13 +124,13 @@ void M2N::acceptSlavesPreConnection(
   for (const auto &pair : _distComs) {
     pair.second->acceptPreConnection(acceptorName, requesterName);
     _areSlavesConnected = _areSlavesConnected && pair.second->isConnected();
-    }
+  }
   PRECICE_ASSERT(_areSlavesConnected);
 }
 
 void M2N::requestSlavesPreConnection(
-  const std::string &acceptorName,
-  const std::string &requesterName)
+    const std::string &acceptorName,
+    const std::string &requesterName)
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not _useOnlyMasterCom);
@@ -140,7 +138,7 @@ void M2N::requestSlavesPreConnection(
   for (const auto &pair : _distComs) {
     pair.second->requestPreConnection(acceptorName, requesterName);
     _areSlavesConnected = _areSlavesConnected && pair.second->isConnected();
-    }
+  }
   PRECICE_ASSERT(_areSlavesConnected);
 }
 
@@ -162,7 +160,7 @@ void M2N::closeConnection()
 
   utils::MasterSlave::broadcast(_isMasterConnected);
 
-  if(not _useOnlyMasterCom){
+  if (not _useOnlyMasterCom) {
     _areSlavesConnected = false;
     for (const auto &pair : _distComs) {
       pair.second->closeConnection();
@@ -188,11 +186,11 @@ void M2N::createDistributedCommunication(mesh::PtrMesh mesh)
 
 void M2N::send(
     double const *itemsToSend,
-    int     size,
-    int     meshID,
-    int     valueDimension)
+    int           size,
+    int           meshID,
+    int           valueDimension)
 {
-  if(not _useOnlyMasterCom){
+  if (not _useOnlyMasterCom) {
     PRECICE_ASSERT(_areSlavesConnected);
     PRECICE_ASSERT(_distComs.find(meshID) != _distComs.end());
     PRECICE_ASSERT(_distComs[meshID].get() != nullptr);
@@ -243,7 +241,7 @@ void M2N::broadcastSendLocalMesh(mesh::Mesh &mesh)
 }
 
 void M2N::broadcastSendLCM(std::map<int, std::vector<int>> &localCommunicationMap,
-                        mesh::Mesh &mesh)
+                           mesh::Mesh &                     mesh)
 {
   if (utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster()) {
     int meshID = mesh.getID();
@@ -286,7 +284,7 @@ void M2N::receive(double *itemsToReceive,
     }
     Event e("m2n.receiveData", precice::syncMode);
     _distComs[meshID]->receive(itemsToReceive, size, valueDimension);
-  } else { 
+  } else {
     PRECICE_ASSERT(_isMasterConnected);
     _masterCom->receive(itemsToReceive, size, 0);
   }

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -1,17 +1,14 @@
 #pragma once
 
+#include <map>
 #include "DistributedComFactory.hpp"
+#include "SharedPointer.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
-#include "SharedPointer.hpp"
-#include <map>
 
-
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 
 // Forward declaration to friend unit tests which only use the master com
 struct WhiteboxAccessor;
@@ -22,8 +19,7 @@ struct WhiteboxAccessor;
  * each possibly with a different decomposition. In principle, this class is only a map from meshes to DistributedCommunications
  *
  */
-class M2N
-{
+class M2N {
 public:
   M2N(com::PtrCommunication masterCom, DistributedComFactory::SharedPointer distrFactory, bool useOnlyMasterCom = false);
 
@@ -69,7 +65,7 @@ public:
   void requestSlavesConnection(const std::string &acceptorName,
                                const std::string &requesterName);
 
-    /**
+  /**
    * Same as acceptSlavesConnection except this only creates the channels,
    * no vertex list needed!
    */
@@ -128,9 +124,9 @@ public:
 
   /// Sends an array of double values from all slaves (different for each slave).
   void send(double const *itemsToSend,
-            int     size,
-            int     meshID,
-            int     valueDimension);
+            int           size,
+            int           meshID,
+            int           valueDimension);
 
   /**
    * @brief The master sends a bool to the other master, for performance reasons, we
@@ -205,9 +201,10 @@ private:
 
 /// struct giving access _useOnlyMasterCom
 struct WhiteboxAccessor {
-    static auto useOnlyMasterCom(PtrM2N m2n) -> typename std::add_lvalue_reference<decltype(m2n->_useOnlyMasterCom)>::type {
-        return m2n->_useOnlyMasterCom;
-    }
+  static auto useOnlyMasterCom(PtrM2N m2n) -> typename std::add_lvalue_reference<decltype(m2n->_useOnlyMasterCom)>::type
+  {
+    return m2n->_useOnlyMasterCom;
+  }
 };
 
 } // namespace m2n

--- a/src/m2n/PointToPointComFactory.cpp
+++ b/src/m2n/PointToPointComFactory.cpp
@@ -3,10 +3,8 @@
 
 #include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 
 PointToPointComFactory::PointToPointComFactory(com::PtrCommunicationFactory comFactory)
     : _comFactory(comFactory) {}

--- a/src/m2n/PointToPointComFactory.hpp
+++ b/src/m2n/PointToPointComFactory.hpp
@@ -3,13 +3,10 @@
 #include "DistributedComFactory.hpp"
 #include "com/SharedPointer.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 
-class PointToPointComFactory : public DistributedComFactory
-{
+class PointToPointComFactory : public DistributedComFactory {
 
 public:
   explicit PointToPointComFactory(com::PtrCommunicationFactory comFactory);

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -1,27 +1,25 @@
 #include "PointToPointCommunication.hpp"
+#include <boost/container/flat_map.hpp>
 #include <iomanip>
-#include <vector>
 #include <thread>
+#include <vector>
+#include "com/CommunicateMesh.hpp"
 #include "com/Communication.hpp"
 #include "com/CommunicationFactory.hpp"
-#include "com/CommunicateMesh.hpp"
-#include "utils/EventUtils.hpp"
 #include "mesh/Mesh.hpp"
 #include "utils/Event.hpp"
+#include "utils/EventUtils.hpp"
 #include "utils/MasterSlave.hpp"
-#include <boost/container/flat_map.hpp>
 
 using precice::utils::Event;
 
-namespace precice
-{
+namespace precice {
 bool extern syncMode;
-namespace m2n
-{
+namespace m2n {
 
 void send(mesh::Mesh::VertexDistribution const &m,
-          int                                    rankReceiver,
-          com::PtrCommunication                  communication)
+          int                                   rankReceiver,
+          com::PtrCommunication                 communication)
 {
   communication->send(static_cast<int>(m.size()), rankReceiver);
 
@@ -34,8 +32,8 @@ void send(mesh::Mesh::VertexDistribution const &m,
 }
 
 void receive(mesh::Mesh::VertexDistribution &m,
-             int                              rankSender,
-             com::PtrCommunication            communication)
+             int                             rankSender,
+             com::PtrCommunication           communication)
 {
   m.clear();
   int size = 0;
@@ -49,7 +47,7 @@ void receive(mesh::Mesh::VertexDistribution &m,
 }
 
 void broadcastSend(mesh::Mesh::VertexDistribution const &m,
-                   com::PtrCommunication                  communication = utils::MasterSlave::_communication)
+                   com::PtrCommunication                 communication = utils::MasterSlave::_communication)
 {
   communication->broadcast(static_cast<int>(m.size()));
 
@@ -62,8 +60,8 @@ void broadcastSend(mesh::Mesh::VertexDistribution const &m,
 }
 
 void broadcastReceive(mesh::Mesh::VertexDistribution &m,
-                      int                              rankBroadcaster,
-                      com::PtrCommunication            communication = utils::MasterSlave::_communication)
+                      int                             rankBroadcaster,
+                      com::PtrCommunication           communication = utils::MasterSlave::_communication)
 {
   m.clear();
   int size = 0;
@@ -81,7 +79,7 @@ void broadcast(mesh::Mesh::VertexDistribution &m)
   if (utils::MasterSlave::isMaster()) {
     // Broadcast (send) vertex distributions.
     m2n::broadcastSend(m);
-  } else if(utils::MasterSlave::isSlave()) {
+  } else if (utils::MasterSlave::isSlave()) {
     // Broadcast (receive) vertex distributions.
     m2n::broadcastReceive(m, 0);
   }
@@ -101,8 +99,7 @@ void print(std::map<int, std::vector<int>> const &m)
 
   if (utils::MasterSlave::isSlave()) {
     utils::MasterSlave::_communication->send(oss.str(), 0);
-  }
-  else{
+  } else {
 
     std::string s;
 
@@ -240,7 +237,7 @@ std::map<int, std::vector<int>> buildCommunicationMap(
     mesh::Mesh::VertexDistribution const &thisVertexDistribution,
     // `otherVertexDistribution' is input vertex distribution from other participant.
     mesh::Mesh::VertexDistribution const &otherVertexDistribution,
-    int                                    thisRank = utils::MasterSlave::getRank())
+    int                                   thisRank = utils::MasterSlave::getRank())
 {
   auto iterator = thisVertexDistribution.find(thisRank);
   if (iterator == thisVertexDistribution.end())
@@ -248,23 +245,23 @@ std::map<int, std::vector<int>> buildCommunicationMap(
 
   // Build lookup table from otherIndex -> rank for the otherVertexDistribution
   const auto lookupIndexRank = [&otherVertexDistribution] {
-      boost::container::flat_multimap<int, int> lookupIndexRank;
-      for (const auto &other : otherVertexDistribution) {
-          for (const auto &otherIndex : other.second) {
-              lookupIndexRank.emplace(otherIndex, other.first);
-          }
+    boost::container::flat_multimap<int, int> lookupIndexRank;
+    for (const auto &other : otherVertexDistribution) {
+      for (const auto &otherIndex : other.second) {
+        lookupIndexRank.emplace(otherIndex, other.first);
       }
-      return lookupIndexRank;
+    }
+    return lookupIndexRank;
   }();
 
   auto const &indices = iterator->second;
 
   std::map<int, std::vector<int>> communicationMap;
   for (size_t index = 0lu; index < indices.size(); ++index) {
-      auto range = lookupIndexRank.equal_range(indices[index]);
-      for(auto iter = range.first; iter != range.second; ++iter){
-              communicationMap[iter->second].push_back(index);
-      }
+    auto range = lookupIndexRank.equal_range(indices[index]);
+    for (auto iter = range.first; iter != range.second; ++iter) {
+      communicationMap[iter->second].push_back(index);
+    }
   }
   return communicationMap;
 }
@@ -333,9 +330,9 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
   //   the remote process with rank 1;
   // - has to communicate (send/receive) data with local indices 0 and 2 with
   //   the remote process with rank 4.
-  Event e2("m2n.buildCommunicationMap", precice::syncMode);
+  Event                           e2("m2n.buildCommunicationMap", precice::syncMode);
   std::map<int, std::vector<int>> communicationMap = m2n::buildCommunicationMap(
-    vertexDistribution, requesterVertexDistribution);
+      vertexDistribution, requesterVertexDistribution);
   e2.stop();
 
 // Print `communicationMap'.
@@ -370,9 +367,9 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
                                            communicationMap.size());
 
   PRECICE_DEBUG("Store communication map");
-  for (auto const & comMap : communicationMap) {
-    int globalRequesterRank = comMap.first;
-    auto indices = std::move(communicationMap[globalRequesterRank]);
+  for (auto const &comMap : communicationMap) {
+    int  globalRequesterRank = comMap.first;
+    auto indices             = std::move(communicationMap[globalRequesterRank]);
 
     _mappings.push_back({globalRequesterRank, std::move(indices), com::PtrRequest(), {}});
   }
@@ -381,15 +378,15 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
 }
 
 void PointToPointCommunication::acceptPreConnection(std::string const &acceptorName,
-                                                 std::string const &requesterName)
+                                                    std::string const &requesterName)
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected(), "Already connected!");
   PRECICE_CHECK(utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave(),
-        "You can only use a point-to-point communication between two participants which both use a master. "
-            << "Please use distribution-type gather-scatter instead.");
+                "You can only use a point-to-point communication between two participants which both use a master. "
+                    << "Please use distribution-type gather-scatter instead.");
 
-  const std::vector<int> & localConnectedRanks = _mesh->getConnectedRanks();
+  const std::vector<int> &localConnectedRanks = _mesh->getConnectedRanks();
 
   if (localConnectedRanks.empty()) {
     _isConnected = true;
@@ -457,11 +454,10 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
   //   the remote process with rank 1;
   // - has to communicate (send/receive) data with local indices 0 and 2 with
   //   the remote process with rank 4.
-  Event e2("m2n.buildCommunicationMap", precice::syncMode);
+  Event                           e2("m2n.buildCommunicationMap", precice::syncMode);
   std::map<int, std::vector<int>> communicationMap = m2n::buildCommunicationMap(
-    vertexDistribution, acceptorVertexDistribution);
+      vertexDistribution, acceptorVertexDistribution);
   e2.stop();
-
 
 // Print `communicationMap'.
 #ifdef P2P_LCM_PRINT
@@ -516,8 +512,8 @@ void PointToPointCommunication::requestPreConnection(std::string const &acceptor
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_CHECK(not isConnected(), "Already connected!");
   PRECICE_CHECK(utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave(),
-        "You can only use a point-to-point communication between two participants which both use a master. "
-        << "Please use distribution-type gather-scatter instead.");
+                "You can only use a point-to-point communication between two participants which both use a master. "
+                    << "Please use distribution-type gather-scatter instead.");
 
   std::vector<int> localConnectedRanks = _mesh->getConnectedRanks();
 
@@ -536,7 +532,7 @@ void PointToPointCommunication::requestPreConnection(std::string const &acceptor
   c->requestConnectionAsClient(acceptorName, requesterName,
                                acceptingRanks, utils::MasterSlave::getRank());
 
-  for (auto & connectedRank : localConnectedRanks) {
+  for (auto &connectedRank : localConnectedRanks) {
     _connectionDataVector.push_back({connectedRank, c, com::PtrRequest()});
   }
   _isConnected = true;
@@ -546,8 +542,7 @@ void PointToPointCommunication::updateVertexList()
 {
   mesh::Mesh::CommunicationMap localCommunicationMap = _mesh->getCommunicationMap();
 
-  for(auto &i : _connectionDataVector)
-  {
+  for (auto &i : _connectionDataVector) {
     _mappings.push_back({i.remoteRank, std::move(localCommunicationMap[i.remoteRank]), i.request, {}});
   }
 }
@@ -566,9 +561,9 @@ void PointToPointCommunication::closeConnection()
   _isConnected = false;
 }
 
-void PointToPointCommunication::send(double const  *itemsToSend,
-                                     size_t         size,
-                                     int            valueDimension)
+void PointToPointCommunication::send(double const *itemsToSend,
+                                     size_t        size,
+                                     int           valueDimension)
 {
 
   if (_mappings.empty()) {
@@ -650,7 +645,7 @@ void PointToPointCommunication::broadcastReceiveMesh()
 
 void PointToPointCommunication::broadcastSendLCM(CommunicationMap &localCommunicationMap)
 {
- for (auto &connectionData : _connectionDataVector) {
+  for (auto &connectionData : _connectionDataVector) {
     connectionData.communication->send(localCommunicationMap[connectionData.remoteRank], connectionData.remoteRank);
   }
 }

--- a/src/m2n/PointToPointCommunication.hpp
+++ b/src/m2n/PointToPointCommunication.hpp
@@ -1,19 +1,17 @@
 #pragma once
 
 #include <list>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "DistributedCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
-#include "mesh/SharedPointer.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 /**
  * @brief Point-to-point communication implementation of DistributedCommunication.
  *
@@ -25,8 +23,7 @@ namespace m2n
  *
  * For the detailed implementation documentation refer to PointToPointCommunication.cpp.
  */
-class PointToPointCommunication : public DistributedCommunication
-{
+class PointToPointCommunication : public DistributedCommunication {
 public:
   PointToPointCommunication(com::PtrCommunicationFactory communicationFactory,
                             mesh::PtrMesh                mesh);
@@ -65,7 +62,7 @@ public:
    */
   virtual void acceptPreConnection(std::string const &acceptorName,
                                    std::string const &requesterName);
-  
+
   /**
    * @brief Requests connection from participant, which has to call acceptConnection().
    *        Only initial connection is created. 
@@ -118,7 +115,7 @@ public:
    * @brief All ranks send their mesh partition to remote local  connected ranks.
    */
   void broadcastSendMesh() override;
-  
+
   /**
    * @brief All ranks receive mesh partitions from remote local ranks.
    */
@@ -128,13 +125,13 @@ public:
    *  @brief All ranks send their local communication map to connected ranks
    */
   void broadcastSendLCM(
-    CommunicationMap &localCommunicationMap) override;
+      CommunicationMap &localCommunicationMap) override;
 
   /**
    *  @brief Each rank revives local communication maps from connected ranks
    */
   void broadcastReceiveLCM(
-    CommunicationMap &localCommunicationMap) override;
+      CommunicationMap &localCommunicationMap) override;
 
 private:
   logging::Logger _log{"m2n::PointToPointCommunication"};
@@ -142,9 +139,9 @@ private:
   /// Checks all stored requests for completion and removes associated buffers
   /**
    * @param[in] blocking False means that the function returns, even when there are requests left.
-   */  
+   */
   void checkBufferedRequests(bool blocking);
-  
+
   com::PtrCommunicationFactory _communicationFactory;
 
   /// Communication class used for this PointToPointCommunication
@@ -152,7 +149,7 @@ private:
    * A Communication object represents all connections to all ranks made by this P2P instance.
    **/
   com::PtrCommunication _communication;
-  
+
   /**
    * @brief Defines mapping between:
    *        1. global remote process rank;
@@ -175,7 +172,7 @@ private:
    */
   std::vector<Mapping> _mappings;
 
-   /**
+  /**
    * @brief this data structure is used to store m2n communication information for the 1 step of 
    *        bounding box initialization. It stores:
    *        1. global remote process rank;
@@ -197,8 +194,8 @@ private:
   bool _isConnected = false;
 
   std::list<std::pair<std::shared_ptr<com::Request>,
-                      std::shared_ptr<std::vector<double>>>> bufferedRequests;
-
+                      std::shared_ptr<std::vector<double>>>>
+      bufferedRequests;
 };
 } // namespace m2n
 } // namespace precice

--- a/src/m2n/SharedPointer.hpp
+++ b/src/m2n/SharedPointer.hpp
@@ -2,10 +2,8 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 
 class M2N;
 

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -8,13 +8,11 @@
 #include "m2n/GatherScatterComFactory.hpp"
 #include "m2n/M2N.hpp"
 #include "m2n/PointToPointComFactory.hpp"
-#include "xml/XMLAttribute.hpp"
 #include "utils/Helpers.hpp"
+#include "xml/XMLAttribute.hpp"
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
 {
   using namespace xml;
@@ -27,27 +25,27 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     tag.setDocumentation(doc);
 
     auto attrPort = makeXMLAttribute("port", 0)
-        .setDocumentation(
-                "Port number (16-bit unsigned integer) to be used for socket "
-                "communication. The default is \"0\", what means that the OS will "
-                "dynamically search for a free port (if at least one exists) and "
-                "bind it automatically.");
+                        .setDocumentation(
+                            "Port number (16-bit unsigned integer) to be used for socket "
+                            "communication. The default is \"0\", what means that the OS will "
+                            "dynamically search for a free port (if at least one exists) and "
+                            "bind it automatically.");
     tag.addAttribute(attrPort);
 
     auto attrNetwork = makeXMLAttribute("network", "lo")
-        .setDocumentation(
-                "Interface name to be used for socket communiation. "
-                "Default is \"lo\", i.e., the local host loopback. "
-                "Might be different on supercomputing systems, e.g. \"ib0\" "
-                "for the InfiniBand on SuperMUC. "
-                "For macOS use \"lo0\". ");
+                           .setDocumentation(
+                               "Interface name to be used for socket communiation. "
+                               "Default is \"lo\", i.e., the local host loopback. "
+                               "Might be different on supercomputing systems, e.g. \"ib0\" "
+                               "for the InfiniBand on SuperMUC. "
+                               "For macOS use \"lo0\". ");
     tag.addAttribute(attrNetwork);
 
-   auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-        .setDocumentation(
-                "Directory where connection information is exchanged. By default, the "
-                "directory of startup is chosen, and both solvers have to be started "
-                "in the same directory.");
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen, and both solvers have to be started "
+                                         "in the same directory.");
     tag.addAttribute(attrExchangeDirectory);
     tags.push_back(tag);
   }
@@ -57,10 +55,10 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     tag.setDocumentation(doc);
 
     auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-        .setDocumentation(
-                "Directory where connection information is exchanged. By default, the "
-                "directory of startup is chosen, and both solvers have to be started "
-                "in the same directory.");
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen, and both solvers have to be started "
+                                         "in the same directory.");
     tag.addAttribute(attrExchangeDirectory);
     tags.push_back(tag);
   }
@@ -69,11 +67,11 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     doc = "Communication via MPI with startup in separated communication spaces, using a single communicator";
     tag.setDocumentation(doc);
 
-   auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-        .setDocumentation(
-                "Directory where connection information is exchanged. By default, the "
-                "directory of startup is chosen, and both solvers have to be started "
-                "in the same directory.");
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen, and both solvers have to be started "
+                                         "in the same directory.");
     tag.addAttribute(attrExchangeDirectory);
     tags.push_back(tag);
   }
@@ -87,14 +85,14 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
 
   XMLAttribute<bool> attrEnforce(ATTR_ENFORCE_GATHER_SCATTER, false);
   attrEnforce.setDocumentation("Enforce the distributed communication to a gather-scatter scheme. "
-                             "Only recommended for trouble shooting.");
+                               "Only recommended for trouble shooting.");
 
   auto attrFrom = XMLAttribute<std::string>("from")
-      .setDocumentation(
-              "First participant name involved in communication. For performance reasons, we recommend to use "
-              "the participant with less ranks at the coupling interface as \"from\" in the m2n communication.");
+                      .setDocumentation(
+                          "First participant name involved in communication. For performance reasons, we recommend to use "
+                          "the participant with less ranks at the coupling interface as \"from\" in the m2n communication.");
   auto attrTo = XMLAttribute<std::string>("to")
-      .setDocumentation("Second participant name involved in communication.");
+                    .setDocumentation("Second participant name involved in communication.");
 
   for (XMLTag &tag : tags) {
     tag.addAttribute(attrFrom);
@@ -119,7 +117,7 @@ m2n::PtrM2N M2NConfiguration::getM2N(const std::string &from, const std::string 
   throw std::runtime_error{error.str()};
 }
 
-void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &tag)
+void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag)
 {
   if (tag.getNamespace() == TAG) {
     std::string from = tag.getStringAttributeValue("from");
@@ -134,7 +132,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext& context, 
       int         port    = tag.getIntAttributeValue("port");
 
       PRECICE_CHECK(not utils::isTruncated<unsigned short>(port),
-            "The value given for the \"port\" attribute is not a 16-bit unsigned integer: " << port);
+                    "The value given for the \"port\" attribute is not a 16-bit unsigned integer: " << port);
 
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
       comFactory      = std::make_shared<com::SocketCommunicationFactory>(port, false, network, dir);
@@ -164,7 +162,9 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext& context, 
     } else if (tag.getName() == "mpi-single") {
 #ifdef PRECICE_NO_MPI
       std::ostringstream error;
-      error << "Communication type \"" << "mpi-single" << "\" can only be used "
+      error << "Communication type \""
+            << "mpi-single"
+            << "\" can only be used "
             << "when preCICE is compiled with argument \"mpi=on\"";
       throw std::runtime_error{error.str()};
 #else

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -10,14 +10,11 @@
 #include <string>
 #include <vector>
 
-namespace precice
-{
-namespace m2n
-{
+namespace precice {
+namespace m2n {
 
 /// Configuration for communication channels between solvers.
-class M2NConfiguration : public xml::XMLTag::Listener
-{
+class M2NConfiguration : public xml::XMLTag::Listener {
 public:
   using SharedPointer = std::shared_ptr<M2NConfiguration>;
   using M2NTuple      = std::tuple<m2n::PtrM2N, std::string, std::string>;
@@ -43,17 +40,16 @@ public:
     return _m2ns;
   }
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag &callingTag) {}
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) {}
 
 private:
   logging::Logger _log{"m2n::M2NConfiguration"};
 
-  const std::string TAG                     = "m2n";
-  const std::string ATTR_EXCHANGE_DIRECTORY = "exchange-directory";
-  const std::string ATTR_ENFORCE_GATHER_SCATTER ="enforce-gather-scatter";
-
+  const std::string TAG                         = "m2n";
+  const std::string ATTR_EXCHANGE_DIRECTORY     = "exchange-directory";
+  const std::string ATTR_ENFORCE_GATHER_SCATTER = "enforce-gather-scatter";
 
   std::vector<M2NTuple> _m2ns;
 

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -21,13 +21,13 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest, *testing::OnSize(4))
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   utils::MasterSlave::reset();
 
-  com::PtrCommunication participantCom = com::PtrCommunication(new com::MPIDirectCommunication());
+  com::PtrCommunication                     participantCom = com::PtrCommunication(new com::MPIDirectCommunication());
   m2n::DistributedComFactory::SharedPointer distrFactory =
       m2n::DistributedComFactory::SharedPointer(
           new m2n::GatherScatterComFactory(participantCom));
-  m2n::PtrM2N           m2n = m2n::PtrM2N(new m2n::M2N(participantCom, distrFactory));
+  m2n::PtrM2N           m2n            = m2n::PtrM2N(new m2n::M2N(participantCom, distrFactory));
   com::PtrCommunication masterSlaveCom = com::PtrCommunication(new com::MPIDirectCommunication());
-  utils::MasterSlave::_communication = masterSlaveCom;
+  utils::MasterSlave::_communication   = masterSlaveCom;
 
   utils::Parallel::synchronizeProcesses();
 

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -51,15 +51,15 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
     mesh->setGlobalNumberOfVertices(10);
 
     mesh->getVertexDistribution()[0].push_back(0);
-    mesh->getVertexDistribution()[0].push_back(1); 
+    mesh->getVertexDistribution()[0].push_back(1);
     mesh->getVertexDistribution()[0].push_back(3);
-    mesh->getVertexDistribution()[0].push_back(5); 
+    mesh->getVertexDistribution()[0].push_back(5);
     mesh->getVertexDistribution()[0].push_back(7);
 
-    mesh->getVertexDistribution()[1].push_back(1); 
+    mesh->getVertexDistribution()[1].push_back(1);
     mesh->getVertexDistribution()[1].push_back(2);
     mesh->getVertexDistribution()[1].push_back(4);
-    mesh->getVertexDistribution()[1].push_back(5); 
+    mesh->getVertexDistribution()[1].push_back(5);
     mesh->getVertexDistribution()[1].push_back(6);
 
     data         = {10, 20, 40, 60, 80};
@@ -87,16 +87,16 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
 
     mesh->setGlobalNumberOfVertices(10);
 
-    mesh->getVertexDistribution()[0].push_back(1); 
+    mesh->getVertexDistribution()[0].push_back(1);
     mesh->getVertexDistribution()[0].push_back(2);
-    mesh->getVertexDistribution()[0].push_back(5); 
+    mesh->getVertexDistribution()[0].push_back(5);
     mesh->getVertexDistribution()[0].push_back(6);
 
     mesh->getVertexDistribution()[1].push_back(0);
-    mesh->getVertexDistribution()[1].push_back(1); 
+    mesh->getVertexDistribution()[1].push_back(1);
     mesh->getVertexDistribution()[1].push_back(3);
     mesh->getVertexDistribution()[1].push_back(4);
-    mesh->getVertexDistribution()[1].push_back(5); 
+    mesh->getVertexDistribution()[1].push_back(5);
     mesh->getVertexDistribution()[1].push_back(7);
 
     data.assign(4, -1);
@@ -165,15 +165,15 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
     mesh->setGlobalNumberOfVertices(10);
 
     mesh->getVertexDistribution()[0].push_back(0);
-    mesh->getVertexDistribution()[0].push_back(1); 
+    mesh->getVertexDistribution()[0].push_back(1);
     mesh->getVertexDistribution()[0].push_back(3);
-    mesh->getVertexDistribution()[0].push_back(5); 
+    mesh->getVertexDistribution()[0].push_back(5);
     mesh->getVertexDistribution()[0].push_back(7);
 
-    mesh->getVertexDistribution()[1].push_back(1); 
+    mesh->getVertexDistribution()[1].push_back(1);
     mesh->getVertexDistribution()[1].push_back(2);
     mesh->getVertexDistribution()[1].push_back(4);
-    mesh->getVertexDistribution()[1].push_back(5); 
+    mesh->getVertexDistribution()[1].push_back(5);
     mesh->getVertexDistribution()[1].push_back(6);
 
     data         = {10, 20, 40, 60, 80};
@@ -201,16 +201,16 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
 
     mesh->setGlobalNumberOfVertices(10);
 
-    mesh->getVertexDistribution()[0].push_back(1); 
+    mesh->getVertexDistribution()[0].push_back(1);
     mesh->getVertexDistribution()[0].push_back(3);
-    mesh->getVertexDistribution()[0].push_back(5); 
+    mesh->getVertexDistribution()[0].push_back(5);
     mesh->getVertexDistribution()[0].push_back(6);
 
     mesh->getVertexDistribution()[1].push_back(0);
-    mesh->getVertexDistribution()[1].push_back(1); 
+    mesh->getVertexDistribution()[1].push_back(1);
     mesh->getVertexDistribution()[1].push_back(3);
     mesh->getVertexDistribution()[1].push_back(4);
-    mesh->getVertexDistribution()[1].push_back(5); 
+    mesh->getVertexDistribution()[1].push_back(5);
     mesh->getVertexDistribution()[1].push_back(7);
 
     data.assign(4, -1);
@@ -255,230 +255,126 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
 void connectionTest(com::PtrCommunicationFactory cf)
 {
 
-  PRECICE_ASSERT(utils::Parallel::getCommunicatorSize() == 4);    
-  
-  int dimensions = 2;
-  bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));  
+  PRECICE_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+
+  int           dimensions  = 2;
+  bool          flipNormals = false;
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
 
   std::vector<std::string> conections = {"same", "cross"};
 
-  for (auto & connectionType : conections)
-  {
+  for (auto &connectionType : conections) {
     utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
-    
-    switch (utils::Parallel::getProcessRank())
-    {
+
+    switch (utils::Parallel::getProcessRank()) {
     case 0: {
       utils::Parallel::splitCommunicator("Fluid.Master");
       utils::MasterSlave::configure(0, 2);
       utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
       utils::MasterSlave::_communication->setRankOffset(1);
 
-      if (connectionType == "same")
-      {
+      if (connectionType == "same") {
         mesh->getConnectedRanks().push_back(0);
-      } else
-      {
+      } else {
         mesh->getConnectedRanks().push_back(1);
       }
       break;
-
     }
     case 1: {
       utils::Parallel::splitCommunicator("Fluid.Slave");
       utils::MasterSlave::configure(1, 2);
       utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
 
-      if (connectionType == "same")
-      {
+      if (connectionType == "same") {
         mesh->getConnectedRanks().push_back(1);
-      } else
-      {
+      } else {
         mesh->getConnectedRanks().push_back(0);
       }
-        break;
-        
+      break;
     }
-    case 2:
-    {
+    case 2: {
       utils::Parallel::splitCommunicator("Solid.Master");
       utils::MasterSlave::configure(0, 2);
       utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
       utils::MasterSlave::_communication->setRankOffset(1);
 
-      if (connectionType == "same")
-      {        
+      if (connectionType == "same") {
         mesh->getConnectedRanks().push_back(0);
-      } else
-      {
+      } else {
         mesh->getConnectedRanks().push_back(1);
       }
       break;
     }
-    case 3:
-    {
+    case 3: {
       utils::Parallel::splitCommunicator("Solid.Slave");
       utils::MasterSlave::configure(1, 2);
-      utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);   
+      utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
 
-      if (connectionType == "same")
-      {
+      if (connectionType == "same") {
         mesh->getConnectedRanks().push_back(1);
-      } else
-      {
+      } else {
         mesh->getConnectedRanks().push_back(0);
-      }   
+      }
       break;
     }
-    }     
+    }
 
-  m2n::PointToPointCommunication c(cf, mesh);
+    m2n::PointToPointCommunication c(cf, mesh);
 
-  std::vector<int> receiveData;
+    std::vector<int> receiveData;
 
-  if (utils::Parallel::getProcessRank() == 0) {
-  
-    c.requestPreConnection("Solid", "Fluid");
-    int sendData = 5;
-    c.broadcastSend(sendData);    
-   
-  } else if (utils::Parallel::getProcessRank() == 1) {
-  
-    c.requestPreConnection("Solid", "Fluid");
-    int sendData = 10;
-    c.broadcastSend(sendData);    
-   
-  } else
-  {    
-    c.acceptPreConnection("Solid", "Fluid");
-    c.broadcastReceiveAll(receiveData);    
-  }
+    if (utils::Parallel::getProcessRank() == 0) {
 
-  if(utils::Parallel::getProcessRank() == 2 )
-  {
-    if (connectionType == "same")
-      {
+      c.requestPreConnection("Solid", "Fluid");
+      int sendData = 5;
+      c.broadcastSend(sendData);
+
+    } else if (utils::Parallel::getProcessRank() == 1) {
+
+      c.requestPreConnection("Solid", "Fluid");
+      int sendData = 10;
+      c.broadcastSend(sendData);
+
+    } else {
+      c.acceptPreConnection("Solid", "Fluid");
+      c.broadcastReceiveAll(receiveData);
+    }
+
+    if (utils::Parallel::getProcessRank() == 2) {
+      if (connectionType == "same") {
         BOOST_TEST(receiveData[0] == 5);
-      } else
-      {        
+      } else {
         BOOST_TEST(receiveData[1] == 10);
-      }  
-    
-  } else if(utils::Parallel::getProcessRank() == 3 )
-  {
-    if (connectionType == "same")
-      {        
+      }
+
+    } else if (utils::Parallel::getProcessRank() == 3) {
+      if (connectionType == "same") {
         BOOST_TEST(receiveData[0] == 10);
-      } else
-      {        
+      } else {
         BOOST_TEST(receiveData[1] == 5);
-      }  
-  }
-  
-  utils::MasterSlave::_communication = nullptr;
-  utils::MasterSlave::reset();
-  utils::Parallel::synchronizeProcesses();
-  utils::Parallel::clearGroups();
-  mesh::Data::resetDataCount();
-  utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());  
+      }
+    }
+
+    utils::MasterSlave::_communication = nullptr;
+    utils::MasterSlave::reset();
+    utils::Parallel::synchronizeProcesses();
+    utils::Parallel::clearGroups();
+    mesh::Data::resetDataCount();
+    utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
   }
 }
 
 void emptyConnectionTest(com::PtrCommunicationFactory cf)
 {
 
-  PRECICE_ASSERT(utils::Parallel::getCommunicatorSize() == 4);    
-  
-  int dimensions = 2;
-  bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
-
-  utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
-  
-  switch (utils::Parallel::getProcessRank())
-  {
-    case 0: {
-      utils::Parallel::splitCommunicator("Fluid.Master");
-      utils::MasterSlave::configure(0, 2);
-      utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
-      utils::MasterSlave::_communication->setRankOffset(1);
-
-      mesh->getConnectedRanks().push_back(0);
-
-      
-      break;
-    }
-    case 1: {
-      utils::Parallel::splitCommunicator("Fluid.Slave");
-      utils::MasterSlave::configure(1, 2);
-      utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
- 
-      break;       
-    }
-    case 2:
-    {
-      utils::Parallel::splitCommunicator("Solid.Master");
-      utils::MasterSlave::configure(0, 2);
-      utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
-      utils::MasterSlave::_communication->setRankOffset(1);
-
-      mesh->getConnectedRanks().push_back(0);
-      
-      break;
-    }
-    case 3:
-    {
-      utils::Parallel::splitCommunicator("Solid.Slave");
-      utils::MasterSlave::configure(1, 2);
-      utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);   
-
-      break;
-    }
-  }
-
-  m2n::PointToPointCommunication c(cf, mesh);
-
-  std::vector<int> receiveData;
-
-  if (utils::Parallel::getProcessRank() < 2) {
-  
-    c.requestPreConnection("Solid", "Fluid");
-    int sendData = 5;
-    c.broadcastSend(sendData);      
-   
-  } else if (utils::Parallel::getProcessRank() > 1) 
-  {    
-    c.acceptPreConnection("Solid", "Fluid");
-    c.broadcastReceiveAll(receiveData);    
-  }
-
-  if(utils::Parallel::getProcessRank() == 2 )
-  {
-    BOOST_TEST(receiveData[0] == 5);
-    
-  } else if(utils::Parallel::getProcessRank() == 3 )
-  {
-    BOOST_TEST(receiveData.size() == 0);
-  }
-  
-  utils::MasterSlave::_communication = nullptr;
-  utils::MasterSlave::reset();
-  utils::Parallel::synchronizeProcesses();
-  utils::Parallel::clearGroups();
-  mesh::Data::resetDataCount();
-  utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());   
-}
-
-void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
-{
   PRECICE_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
-  utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
-  
-  int dimensions = 2;
-  bool flipNormals = false;
+
+  int           dimensions  = 2;
+  bool          flipNormals = false;
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
-  
+
+  utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
+
   switch (utils::Parallel::getProcessRank()) {
   case 0: {
     utils::Parallel::splitCommunicator("Fluid.Master");
@@ -486,15 +382,8 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
     utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
 
-    Eigen::VectorXd position(dimensions);
-    position <<5.5, 0.0;
-    mesh::Vertex& v1 = mesh->createVertex(position);
-    position << 1.0, 2.0;
-    mesh::Vertex& v2 = mesh->createVertex(position);
-    mesh->createEdge(v1, v2);
-
     mesh->getConnectedRanks().push_back(0);
-    
+
     break;
   }
   case 1: {
@@ -502,15 +391,6 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
     utils::MasterSlave::configure(1, 2);
     utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
 
-    Eigen::VectorXd position(dimensions);
-    position <<1.5, 0.0;
-    mesh::Vertex& v1 = mesh->createVertex(position);
-    position << 1.5, 2.0;
-    mesh::Vertex& v2 = mesh->createVertex(position);
-    mesh->createEdge(v1, v2);
-
-    mesh->getConnectedRanks().push_back(1);
-    
     break;
   }
   case 2: {
@@ -527,7 +407,99 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
     utils::Parallel::splitCommunicator("Solid.Slave");
     utils::MasterSlave::configure(1, 2);
     utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
-    
+
+    break;
+  }
+  }
+
+  m2n::PointToPointCommunication c(cf, mesh);
+
+  std::vector<int> receiveData;
+
+  if (utils::Parallel::getProcessRank() < 2) {
+
+    c.requestPreConnection("Solid", "Fluid");
+    int sendData = 5;
+    c.broadcastSend(sendData);
+
+  } else if (utils::Parallel::getProcessRank() > 1) {
+    c.acceptPreConnection("Solid", "Fluid");
+    c.broadcastReceiveAll(receiveData);
+  }
+
+  if (utils::Parallel::getProcessRank() == 2) {
+    BOOST_TEST(receiveData[0] == 5);
+
+  } else if (utils::Parallel::getProcessRank() == 3) {
+    BOOST_TEST(receiveData.size() == 0);
+  }
+
+  utils::MasterSlave::_communication = nullptr;
+  utils::MasterSlave::reset();
+  utils::Parallel::synchronizeProcesses();
+  utils::Parallel::clearGroups();
+  mesh::Data::resetDataCount();
+  utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
+}
+
+void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
+{
+  PRECICE_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
+  utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
+
+  int           dimensions  = 2;
+  bool          flipNormals = false;
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+
+  switch (utils::Parallel::getProcessRank()) {
+  case 0: {
+    utils::Parallel::splitCommunicator("Fluid.Master");
+    utils::MasterSlave::configure(0, 2);
+    utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->setRankOffset(1);
+
+    Eigen::VectorXd position(dimensions);
+    position << 5.5, 0.0;
+    mesh::Vertex &v1 = mesh->createVertex(position);
+    position << 1.0, 2.0;
+    mesh::Vertex &v2 = mesh->createVertex(position);
+    mesh->createEdge(v1, v2);
+
+    mesh->getConnectedRanks().push_back(0);
+
+    break;
+  }
+  case 1: {
+    utils::Parallel::splitCommunicator("Fluid.Slave");
+    utils::MasterSlave::configure(1, 2);
+    utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
+
+    Eigen::VectorXd position(dimensions);
+    position << 1.5, 0.0;
+    mesh::Vertex &v1 = mesh->createVertex(position);
+    position << 1.5, 2.0;
+    mesh::Vertex &v2 = mesh->createVertex(position);
+    mesh->createEdge(v1, v2);
+
+    mesh->getConnectedRanks().push_back(1);
+
+    break;
+  }
+  case 2: {
+    utils::Parallel::splitCommunicator("Solid.Master");
+    utils::MasterSlave::configure(0, 2);
+    utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->setRankOffset(1);
+
+    mesh->getConnectedRanks().push_back(0);
+
+    break;
+  }
+  case 3: {
+    utils::Parallel::splitCommunicator("Solid.Slave");
+    utils::MasterSlave::configure(1, 2);
+    utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
+
     mesh->getConnectedRanks().push_back(1);
 
     break;
@@ -537,53 +509,50 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   m2n::PointToPointCommunication c(cf, mesh);
 
   if (utils::Parallel::getProcessRank() < 2) {
-  
+
     c.requestPreConnection("Solid", "Fluid");
     c.broadcastSendMesh();
   } else {
 
-    c.acceptPreConnection("Solid", "Fluid");    
+    c.acceptPreConnection("Solid", "Fluid");
     c.broadcastReceiveMesh();
 
-      if(utils::Parallel::getProcessRank() ==2 )
-      {
-        // This rank should receive the mesh from rank 0 (fluid master)
-        BOOST_TEST(mesh->vertices().size()==2);
-        BOOST_TEST(mesh->vertices()[0].getCoords()[0]==5.50);
-        BOOST_TEST(mesh->vertices()[0].getCoords()[1]==0.0);
-        BOOST_TEST(mesh->vertices()[1].getCoords()[0]==1.0);
-        BOOST_TEST(mesh->vertices()[1].getCoords()[1]==2.0);        
-      }
+    if (utils::Parallel::getProcessRank() == 2) {
+      // This rank should receive the mesh from rank 0 (fluid master)
+      BOOST_TEST(mesh->vertices().size() == 2);
+      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 5.50);
+      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 1.0);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 2.0);
+    }
 
-      if(utils::Parallel::getProcessRank() ==3 )
-      {
-        // This rank should receive the mesh from rank 1 (fluid slave)
-        BOOST_TEST(mesh->vertices().size()==2);
-        BOOST_TEST(mesh->vertices()[0].getCoords()[0]==1.50);
-        BOOST_TEST(mesh->vertices()[0].getCoords()[1]==0.0);
-        BOOST_TEST(mesh->vertices()[1].getCoords()[0]==1.50);
-        BOOST_TEST(mesh->vertices()[1].getCoords()[1]==2.0);
-      }
-    
+    if (utils::Parallel::getProcessRank() == 3) {
+      // This rank should receive the mesh from rank 1 (fluid slave)
+      BOOST_TEST(mesh->vertices().size() == 2);
+      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 1.50);
+      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 1.50);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 2.0);
+    }
   }
-  
+
   utils::MasterSlave::_communication = nullptr;
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
   mesh::Data::resetDataCount();
-  utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());  
+  utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
 
 void P2PComLCMTest(com::PtrCommunicationFactory cf)
-{  
+{
   PRECICE_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
   utils::MasterSlave::_communication = std::make_shared<com::MPIDirectCommunication>();
 
-  int dimensions = 2;
-  bool flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID())); 
-  const auto expectedId = mesh->getID();
+  int                             dimensions  = 2;
+  bool                            flipNormals = false;
+  mesh::PtrMesh                   mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+  const auto                      expectedId = mesh->getID();
   std::map<int, std::vector<int>> localCommunicationMap;
 
   switch (utils::Parallel::getProcessRank()) {
@@ -594,15 +563,15 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
     utils::MasterSlave::_communication->setRankOffset(1);
 
     // The numbers are chosen in this way to make it easy to test weather
-    // correct values are communicated or not! 
-    mesh->getConnectedRanks().push_back(0);    
+    // correct values are communicated or not!
+    mesh->getConnectedRanks().push_back(0);
     localCommunicationMap[0].push_back(102);
     localCommunicationMap[0].push_back(1022);
     localCommunicationMap[0].push_back(10222);
     localCommunicationMap[1].push_back(103);
     localCommunicationMap[1].push_back(1033);
     localCommunicationMap[1].push_back(10333);
-   
+
     break;
   }
   case 1: {
@@ -611,8 +580,8 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
     utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
 
     // The numbers are chosen in this way to make it easy to test weather
-    // correct values are communicated or not! 
-    mesh->getConnectedRanks().push_back(1);    
+    // correct values are communicated or not!
+    mesh->getConnectedRanks().push_back(1);
     localCommunicationMap[0].push_back(112);
     localCommunicationMap[0].push_back(1122);
     localCommunicationMap[0].push_back(11222);
@@ -627,9 +596,9 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
     utils::MasterSlave::configure(0, 2);
     utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
-    
+
     mesh->getConnectedRanks().push_back(0);
-    
+
     break;
   }
   case 3: {
@@ -638,7 +607,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
     utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
 
     mesh->getConnectedRanks().push_back(1);
-    
+
     break;
   }
   }
@@ -646,50 +615,46 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   m2n::PointToPointCommunication c(cf, mesh);
 
   if (utils::Parallel::getProcessRank() < 2) {
-  
+
     c.requestPreConnection("Solid", "Fluid");
     c.broadcastSendLCM(localCommunicationMap);
-    BOOST_TEST(mesh->getID()==expectedId);
-   
-  } else
-  {
+    BOOST_TEST(mesh->getID() == expectedId);
+
+  } else {
     c.acceptPreConnection("Solid", "Fluid");
     c.broadcastReceiveLCM(localCommunicationMap);
-    BOOST_TEST(mesh->getID()==expectedId);
+    BOOST_TEST(mesh->getID() == expectedId);
   }
 
- if(utils::Parallel::getProcessRank() == 2 )
-  {
+  if (utils::Parallel::getProcessRank() == 2) {
     // The numbers are chosen in this way to make it easy to test weather
-    // correct values are communicated or not! 
+    // correct values are communicated or not!
     BOOST_TEST(localCommunicationMap.size() == 1);
-    BOOST_TEST(localCommunicationMap[0].size() ==3);
-    BOOST_TEST(localCommunicationMap[0][0] ==102);
-    BOOST_TEST(localCommunicationMap[0][1] ==1022);
-    BOOST_TEST(localCommunicationMap[0][2] ==10222);
-    
-  } else if(utils::Parallel::getProcessRank() == 3 )
-  {
+    BOOST_TEST(localCommunicationMap[0].size() == 3);
+    BOOST_TEST(localCommunicationMap[0][0] == 102);
+    BOOST_TEST(localCommunicationMap[0][1] == 1022);
+    BOOST_TEST(localCommunicationMap[0][2] == 10222);
+
+  } else if (utils::Parallel::getProcessRank() == 3) {
     // The numbers are chosen in this way to make it easy to test weather
-    // correct values are communicated or not! 
-    BOOST_TEST(localCommunicationMap.size() == 1);    
-    BOOST_TEST(localCommunicationMap[1].size() ==3);
-    BOOST_TEST(localCommunicationMap[1][0] ==113);
-    BOOST_TEST(localCommunicationMap[1][1] ==1133);
-    BOOST_TEST(localCommunicationMap[1][2] ==11333);   
+    // correct values are communicated or not!
+    BOOST_TEST(localCommunicationMap.size() == 1);
+    BOOST_TEST(localCommunicationMap[1].size() == 3);
+    BOOST_TEST(localCommunicationMap[1][0] == 113);
+    BOOST_TEST(localCommunicationMap[1][1] == 1133);
+    BOOST_TEST(localCommunicationMap[1][2] == 11333);
   }
-  
+
   utils::MasterSlave::_communication = nullptr;
   utils::MasterSlave::reset();
   utils::Parallel::synchronizeProcesses();
   utils::Parallel::clearGroups();
   mesh::Data::resetDataCount();
-  utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());  
+  utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
 
-
 BOOST_AUTO_TEST_CASE(SocketCommunication,
-                     * testing::OnSize(4))
+                     *testing::OnSize(4))
 {
   com::PtrCommunicationFactory cf(new com::SocketCommunicationFactory);
   if (utils::Parallel::getProcessRank() < 4) {
@@ -698,13 +663,12 @@ BOOST_AUTO_TEST_CASE(SocketCommunication,
     connectionTest(cf);
     emptyConnectionTest(cf);
     P2PMeshBroadcastTest(cf);
-    P2PComLCMTest(cf);    
+    P2PComLCMTest(cf);
   }
 }
 
 BOOST_AUTO_TEST_CASE(MPIPortsCommunication,
-                     * testing::OnSize(4)
-                     * boost::unit_test::label("MPI_Ports"))
+                     *testing::OnSize(4) * boost::unit_test::label("MPI_Ports"))
 {
   com::PtrCommunicationFactory cf(new com::MPIPortsCommunicationFactory);
   if (utils::Parallel::getProcessRank() < 4) {

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -1,112 +1,112 @@
 #include "Mapping.hpp"
-#include "utils/assertion.hpp"
 #include <boost/config.hpp>
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace mapping {
 
-Mapping:: Mapping
-(
-  Constraint      constraint,
-  int             dimensions)
-:
-  _constraint(constraint),
-  _inputRequirement(MeshRequirement::UNDEFINED),
-  _outputRequirement(MeshRequirement::UNDEFINED),
-  _input(),
-  _output(),
-  _dimensions(dimensions)
-{}
-
-void Mapping:: setMeshes
-(
-  const mesh::PtrMesh& input,
-  const mesh::PtrMesh& output )
+Mapping::Mapping(
+    Constraint constraint,
+    int        dimensions)
+    : _constraint(constraint),
+      _inputRequirement(MeshRequirement::UNDEFINED),
+      _outputRequirement(MeshRequirement::UNDEFINED),
+      _input(),
+      _output(),
+      _dimensions(dimensions)
 {
-  _input = input;
+}
+
+void Mapping::setMeshes(
+    const mesh::PtrMesh &input,
+    const mesh::PtrMesh &output)
+{
+  _input  = input;
   _output = output;
 }
 
-const mesh::PtrMesh& Mapping:: getInputMesh() const {
+const mesh::PtrMesh &Mapping::getInputMesh() const
+{
   return _input;
 }
 
-const mesh::PtrMesh& Mapping:: getOutputMesh() const {
+const mesh::PtrMesh &Mapping::getOutputMesh() const
+{
   return _output;
 }
 
-Mapping::Constraint Mapping:: getConstraint() const
+Mapping::Constraint Mapping::getConstraint() const
 {
   return _constraint;
 }
 
-Mapping::MeshRequirement Mapping:: getInputRequirement() const
+Mapping::MeshRequirement Mapping::getInputRequirement() const
 {
   return _inputRequirement;
 }
 
-Mapping::MeshRequirement Mapping:: getOutputRequirement() const
+Mapping::MeshRequirement Mapping::getOutputRequirement() const
 {
   return _outputRequirement;
 }
 
-mesh::PtrMesh Mapping:: input() const
+mesh::PtrMesh Mapping::input() const
 {
   return _input;
 }
 
-mesh::PtrMesh Mapping:: output() const
+mesh::PtrMesh Mapping::output() const
 {
   return _output;
 }
 
-void Mapping:: setInputRequirement
-(
-  MeshRequirement requirement )
+void Mapping::setInputRequirement(
+    MeshRequirement requirement)
 {
   _inputRequirement = requirement;
 }
 
-void Mapping:: setOutputRequirement
-(
-  MeshRequirement requirement )
+void Mapping::setOutputRequirement(
+    MeshRequirement requirement)
 {
   _outputRequirement = requirement;
 }
 
-int Mapping:: getDimensions() const
+int Mapping::getDimensions() const
 {
   return _dimensions;
 }
 
-bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs) {
-    switch(lhs) {
-        case(Mapping::MeshRequirement::UNDEFINED):
-            return rhs != Mapping::MeshRequirement::UNDEFINED;
-        case(Mapping::MeshRequirement::VERTEX):
-            return rhs == Mapping::MeshRequirement::FULL;
-        case(Mapping::MeshRequirement::FULL):
-                return false;
-    };
-    BOOST_UNREACHABLE_RETURN(false);
+bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs)
+{
+  switch (lhs) {
+  case (Mapping::MeshRequirement::UNDEFINED):
+    return rhs != Mapping::MeshRequirement::UNDEFINED;
+  case (Mapping::MeshRequirement::VERTEX):
+    return rhs == Mapping::MeshRequirement::FULL;
+  case (Mapping::MeshRequirement::FULL):
+    return false;
+  };
+  BOOST_UNREACHABLE_RETURN(false);
 }
 
-std::ostream &operator<<(std::ostream &out, Mapping::MeshRequirement val) {
-    switch (val) {
-        case (Mapping::MeshRequirement::UNDEFINED):
-            out << "UNDEFINED";
-            break;
-        case (Mapping::MeshRequirement::VERTEX):
-            out << "VERTEX";
-            break;
-        case (Mapping::MeshRequirement::FULL):
-            out << "FULL";
-            break;
-        default:
-            PRECICE_ASSERT(false, "Implementation does not cover all cases");
-    };
-    return out;
+std::ostream &operator<<(std::ostream &out, Mapping::MeshRequirement val)
+{
+  switch (val) {
+  case (Mapping::MeshRequirement::UNDEFINED):
+    out << "UNDEFINED";
+    break;
+  case (Mapping::MeshRequirement::VERTEX):
+    out << "VERTEX";
+    break;
+  case (Mapping::MeshRequirement::FULL):
+    out << "FULL";
+    break;
+  default:
+    PRECICE_ASSERT(false, "Implementation does not cover all cases");
+  };
+  return out;
 }
 
-}} // namespace precice, mapping
-
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -8,10 +8,8 @@ namespace mapping {
 /**
  * @brief Abstract base class for mapping of data from one mesh to another.
  */
-class Mapping
-{
+class Mapping {
 public:
-
   /**
    * @brief Specifies additional constraints for a mapping.
    *
@@ -44,9 +42,9 @@ public:
   };
 
   /// Constructor, takes mapping constraint.
-  Mapping ( Constraint constraint, int dimensions );
+  Mapping(Constraint constraint, int dimensions);
 
-  Mapping& operator=(Mapping &&) = delete;
+  Mapping &operator=(Mapping &&) = delete;
 
   /// Destructor, empty.
   virtual ~Mapping() {}
@@ -57,13 +55,13 @@ public:
    * @param[in] input Mesh with known data values to be mapped.
    * @param[in] output Mesh with unknwon data values to be computed from input.
    */
-  void setMeshes (
-    const mesh::PtrMesh& input,
-    const mesh::PtrMesh& output );
+  void setMeshes(
+      const mesh::PtrMesh &input,
+      const mesh::PtrMesh &output);
 
-  const mesh::PtrMesh& getInputMesh() const;
+  const mesh::PtrMesh &getInputMesh() const;
 
-  const mesh::PtrMesh& getOutputMesh() const;
+  const mesh::PtrMesh &getOutputMesh() const;
 
   /// Returns the constraint (consistent/conservative) of the mapping.
   Constraint getConstraint() const;
@@ -75,14 +73,14 @@ public:
   MeshRequirement getOutputRequirement() const;
 
   /// Computes the mapping coefficients from the in- and output mesh.
-  virtual void computeMapping() =0;
+  virtual void computeMapping() = 0;
 
   /**
    * @brief Returns true, if the mapping has been computed.
    *
    * After a call to clear(), a computed mapping is removed and false returned.
    */
-  virtual bool hasComputedMapping() const =0;
+  virtual bool hasComputedMapping() const = 0;
 
   /// Removes a computed mapping.
   virtual void clear() = 0;
@@ -96,9 +94,9 @@ public:
    * Post-conditions:
    * - output values are computed from input values
    */
-  virtual void map (
-    int inputDataID,
-    int outputDataID ) =0;
+  virtual void map(
+      int inputDataID,
+      int outputDataID) = 0;
 
   /// Method used by partition. Tags vertices that could be owned by this rank.
   virtual void tagMeshFirstRound() = 0;
@@ -106,9 +104,7 @@ public:
   /// Method used by partition. Tags vertices that can be filtered out.
   virtual void tagMeshSecondRound() = 0;
 
-
 protected:
-
   /// Returns pointer to input mesh.
   mesh::PtrMesh input() const;
 
@@ -116,15 +112,14 @@ protected:
   mesh::PtrMesh output() const;
 
   /// Sets the mesh requirement for the input mesh.
-  void setInputRequirement ( MeshRequirement requirement );
+  void setInputRequirement(MeshRequirement requirement);
 
   /// Sets the mesh requirement for the output mesh.
-  void setOutputRequirement ( MeshRequirement requirement );
+  void setOutputRequirement(MeshRequirement requirement);
 
   int getDimensions() const;
 
 private:
-
   /// Determines wether mapping is consistent or conservative.
   Constraint _constraint;
 
@@ -143,7 +138,6 @@ private:
   int _dimensions;
 };
 
-
 /** Defines an ordering for MeshRequirement in terms of specificality
 * @param[in] lhs the left-hand side of the binary operator
 * @param[in] rhs the right-hand side of the binary operator
@@ -154,6 +148,7 @@ bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs);
 * @param[in,out] out stream to output to.
 * @param[in] val the value to output.
 */
-std::ostream& operator<<(std::ostream& out, Mapping::MeshRequirement val);
+std::ostream &operator<<(std::ostream &out, Mapping::MeshRequirement val);
 
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -1,140 +1,135 @@
 #include "NearestNeighborMapping.hpp"
+#include <Eigen/Core>
+#include <boost/container/flat_set.hpp>
+#include <boost/function_output_iterator.hpp>
+#include "mesh/RTree.hpp"
 #include "query/FindClosestVertex.hpp"
+#include "utils/Event.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/Statistics.hpp"
-#include "mesh/RTree.hpp"
-#include <Eigen/Core>
-#include <boost/function_output_iterator.hpp>
-#include <boost/container/flat_set.hpp>
-#include "utils/Event.hpp"
 
 namespace precice {
 extern bool syncMode;
 
 namespace mapping {
 
-NearestNeighborMapping:: NearestNeighborMapping
-(
-  Constraint constraint,
-  int        dimensions)
-:
-  Mapping(constraint, dimensions)
+NearestNeighborMapping::NearestNeighborMapping(
+    Constraint constraint,
+    int        dimensions)
+    : Mapping(constraint, dimensions)
 {
   setInputRequirement(Mapping::MeshRequirement::VERTEX);
   setOutputRequirement(Mapping::MeshRequirement::VERTEX);
 }
 
-void NearestNeighborMapping:: computeMapping()
+void NearestNeighborMapping::computeMapping()
 {
   PRECICE_TRACE(input()->vertices().size());
 
   PRECICE_ASSERT(input().get() != nullptr);
   PRECICE_ASSERT(output().get() != nullptr);
 
-  const std::string baseEvent = "map.nn.computeMapping.From" + input()->getName() + "To" + output()->getName();
+  const std::string     baseEvent = "map.nn.computeMapping.From" + input()->getName() + "To" + output()->getName();
   precice::utils::Event e(baseEvent, precice::syncMode);
-  
-  if (getConstraint() == CONSISTENT){
+
+  if (getConstraint() == CONSISTENT) {
     PRECICE_DEBUG("Compute consistent mapping");
-    precice::utils::Event e2(baseEvent+".getIndexOnVertices", precice::syncMode);
-    auto rtree = mesh::rtree::getVertexRTree(input());
+    precice::utils::Event e2(baseEvent + ".getIndexOnVertices", precice::syncMode);
+    auto                  rtree = mesh::rtree::getVertexRTree(input());
     e2.stop();
     size_t verticesSize = output()->vertices().size();
     _vertexIndices.resize(verticesSize);
     utils::statistics::DistanceAccumulator distanceStatistics;
-    const mesh::Mesh::VertexContainer& outputVertices = output()->vertices();
-    for ( size_t i=0; i < verticesSize; i++ ) {
-        const Eigen::VectorXd& coords = outputVertices[i].getCoords();
-        // Search for the output vertex inside the input mesh and add index to _vertexIndices
-        rtree->query(boost::geometry::index::nearest(coords, 1),
-                     boost::make_function_output_iterator([&](size_t const& val) {
-                         const auto& match = input()->vertices()[val];
-                         _vertexIndices[i] =  match.getID();
-                         distanceStatistics(bg::distance(match, coords));
-                       }));
+    const mesh::Mesh::VertexContainer &    outputVertices = output()->vertices();
+    for (size_t i = 0; i < verticesSize; i++) {
+      const Eigen::VectorXd &coords = outputVertices[i].getCoords();
+      // Search for the output vertex inside the input mesh and add index to _vertexIndices
+      rtree->query(boost::geometry::index::nearest(coords, 1),
+                   boost::make_function_output_iterator([&](size_t const &val) {
+                     const auto &match = input()->vertices()[val];
+                     _vertexIndices[i] = match.getID();
+                     distanceStatistics(bg::distance(match, coords));
+                   }));
     }
     PRECICE_INFO("Mapping distance " << distanceStatistics);
-  }
-  else {
+  } else {
     PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
     PRECICE_DEBUG("Compute conservative mapping");
-    precice::utils::Event e2(baseEvent+".getIndexOnVertices", precice::syncMode);
-    auto rtree = mesh::rtree::getVertexRTree(output());
+    precice::utils::Event e2(baseEvent + ".getIndexOnVertices", precice::syncMode);
+    auto                  rtree = mesh::rtree::getVertexRTree(output());
     e2.stop();
     size_t verticesSize = input()->vertices().size();
     _vertexIndices.resize(verticesSize);
     utils::statistics::DistanceAccumulator distanceStatistics;
-    const mesh::Mesh::VertexContainer& inputVertices = input()->vertices();
-    for ( size_t i=0; i < verticesSize; i++ ){
-      const Eigen::VectorXd& coords = inputVertices[i].getCoords();
+    const mesh::Mesh::VertexContainer &    inputVertices = input()->vertices();
+    for (size_t i = 0; i < verticesSize; i++) {
+      const Eigen::VectorXd &coords = inputVertices[i].getCoords();
       // Search for the input vertex inside the output mesh and add index to _vertexIndices
       rtree->query(boost::geometry::index::nearest(coords, 1),
-                   boost::make_function_output_iterator([&](size_t const& val) {
-                       const auto& match = output()->vertices()[val];
-                       _vertexIndices[i] =  match.getID();
-                       distanceStatistics(bg::distance(match, coords));
-                     }));
+                   boost::make_function_output_iterator([&](size_t const &val) {
+                     const auto &match = output()->vertices()[val];
+                     _vertexIndices[i] = match.getID();
+                     distanceStatistics(bg::distance(match, coords));
+                   }));
     }
     PRECICE_INFO("Mapping distance " << distanceStatistics);
   }
   _hasComputedMapping = true;
 }
 
-bool NearestNeighborMapping:: hasComputedMapping() const
+bool NearestNeighborMapping::hasComputedMapping() const
 {
   PRECICE_TRACE(_hasComputedMapping);
   return _hasComputedMapping;
 }
 
-void NearestNeighborMapping:: clear()
+void NearestNeighborMapping::clear()
 {
   PRECICE_TRACE();
   _vertexIndices.clear();
   _hasComputedMapping = false;
-  if (getConstraint() == CONSISTENT){
-    mesh::rtree::clear(*input()); 
+  if (getConstraint() == CONSISTENT) {
+    mesh::rtree::clear(*input());
   } else {
-    mesh::rtree::clear(*output()); 
+    mesh::rtree::clear(*output());
   }
 }
 
-void NearestNeighborMapping:: map
-(
-  int inputDataID,
-  int outputDataID )
+void NearestNeighborMapping::map(
+    int inputDataID,
+    int outputDataID)
 {
   PRECICE_TRACE(inputDataID, outputDataID);
 
   precice::utils::Event e("map.nn.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
-  const Eigen::VectorXd& inputValues = input()->data(inputDataID)->values();
-  Eigen::VectorXd& outputValues = output()->data(outputDataID)->values();
+  const Eigen::VectorXd &inputValues  = input()->data(inputDataID)->values();
+  Eigen::VectorXd &      outputValues = output()->data(outputDataID)->values();
   //assign(outputValues) = 0.0;
   int valueDimensions = input()->data(inputDataID)->getDimensions();
-  PRECICE_ASSERT( valueDimensions == output()->data(outputDataID)->getDimensions(),
-              valueDimensions, output()->data(outputDataID)->getDimensions() );
-  PRECICE_ASSERT( inputValues.size() / valueDimensions == (int)input()->vertices().size(),
-               inputValues.size(), valueDimensions, input()->vertices().size() );
-  PRECICE_ASSERT( outputValues.size() / valueDimensions == (int)output()->vertices().size(),
-               outputValues.size(), valueDimensions, output()->vertices().size() );
-  if (getConstraint() == CONSISTENT){
+  PRECICE_ASSERT(valueDimensions == output()->data(outputDataID)->getDimensions(),
+                 valueDimensions, output()->data(outputDataID)->getDimensions());
+  PRECICE_ASSERT(inputValues.size() / valueDimensions == (int) input()->vertices().size(),
+                 inputValues.size(), valueDimensions, input()->vertices().size());
+  PRECICE_ASSERT(outputValues.size() / valueDimensions == (int) output()->vertices().size(),
+                 outputValues.size(), valueDimensions, output()->vertices().size());
+  if (getConstraint() == CONSISTENT) {
     PRECICE_DEBUG("Map consistent");
     size_t const outSize = output()->vertices().size();
-    for ( size_t i=0; i < outSize; i++ ){
+    for (size_t i = 0; i < outSize; i++) {
       int inputIndex = _vertexIndices[i] * valueDimensions;
-      for ( int dim=0; dim < valueDimensions; dim++ ){
-        outputValues((i*valueDimensions)+dim) = inputValues(inputIndex+dim);
+      for (int dim = 0; dim < valueDimensions; dim++) {
+        outputValues((i * valueDimensions) + dim) = inputValues(inputIndex + dim);
       }
     }
-  }
-  else {
+  } else {
     PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
     PRECICE_DEBUG("Map conservative");
     size_t const inSize = input()->vertices().size();
-    for ( size_t i=0; i < inSize; i++ ){
+    for (size_t i = 0; i < inSize; i++) {
       int const outputIndex = _vertexIndices[i] * valueDimensions;
-      for ( int dim=0; dim < valueDimensions; dim++ ){
-        outputValues(outputIndex+dim) += inputValues((i*valueDimensions)+dim);
+      for (int dim = 0; dim < valueDimensions; dim++) {
+        outputValues(outputIndex + dim) += inputValues((i * valueDimensions) + dim);
       }
     }
   }
@@ -150,15 +145,14 @@ void NearestNeighborMapping::tagMeshFirstRound()
   // Lookup table of all indices used in the mapping
   const boost::container::flat_set<int> indexSet(_vertexIndices.begin(), _vertexIndices.end());
 
-  if (getConstraint() == CONSISTENT){
-    for(mesh::Vertex& v : input()->vertices()){
+  if (getConstraint() == CONSISTENT) {
+    for (mesh::Vertex &v : input()->vertices()) {
       if (indexSet.count(v.getID()) != 0)
         v.tag();
     }
-  }
-  else {
+  } else {
     PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
-    for(mesh::Vertex& v : output()->vertices()){
+    for (mesh::Vertex &v : output()->vertices()) {
       if (indexSet.count(v.getID()) != 0)
         v.tag();
     }
@@ -173,4 +167,5 @@ void NearestNeighborMapping::tagMeshSecondRound()
   // for NN mapping no operation needed here
 }
 
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/NearestNeighborMapping.hpp
+++ b/src/mapping/NearestNeighborMapping.hpp
@@ -1,24 +1,22 @@
 #pragma once
 
-#include "mapping/Mapping.hpp"
-#include "logging/Logger.hpp"
 #include <vector>
+#include "logging/Logger.hpp"
+#include "mapping/Mapping.hpp"
 
 namespace precice {
 namespace mapping {
 
 /// Mapping using nearest neighboring vertices.
-class NearestNeighborMapping : public Mapping
-{
+class NearestNeighborMapping : public Mapping {
 public:
-
   /**
    * @brief Constructor.
    *
    * @param[in] constraint Specifies mapping to be consistent or conservative.
    * @param[in] dimensions Dimensionality of the meshes
    */
-  NearestNeighborMapping ( Constraint constraint, int dimensions );
+  NearestNeighborMapping(Constraint constraint, int dimensions);
 
   /// Destructor, empty.
   virtual ~NearestNeighborMapping() {}
@@ -33,9 +31,9 @@ public:
   virtual void clear() override;
 
   /// Maps input data to output data from input mesh to output mesh.
-  virtual void map (
-    int inputDataID,
-    int outputDataID ) override;
+  virtual void map(
+      int inputDataID,
+      int outputDataID) override;
 
   virtual void tagMeshFirstRound() override;
   virtual void tagMeshSecondRound() override;
@@ -50,4 +48,5 @@ private:
   std::vector<int> _vertexIndices;
 };
 
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -1,10 +1,9 @@
-#include <Eigen/Core>
 #include "NearestProjectionMapping.hpp"
+#include <Eigen/Core>
 #include "mesh/RTree.hpp"
 #include "query/FindClosest.hpp"
 #include "utils/Event.hpp"
 #include "utils/Statistics.hpp"
-
 
 namespace bg  = boost::geometry;
 namespace bgi = boost::geometry::index;
@@ -47,18 +46,18 @@ struct MatchType {
 void NearestProjectionMapping::computeMapping()
 {
   PRECICE_TRACE(input()->vertices().size(), output()->vertices().size());
-  const std::string baseEvent = "map.np.computeMapping.From" + input()->getName() + "To" + output()->getName();
+  const std::string     baseEvent = "map.np.computeMapping.From" + input()->getName() + "To" + output()->getName();
   precice::utils::Event e(baseEvent, precice::syncMode);
 
   // Setup Direction of Mapping
   mesh::PtrMesh origins, search_space;
   if (getConstraint() == CONSISTENT) {
     PRECICE_DEBUG("Compute consistent mapping");
-    origins = output();
+    origins      = output();
     search_space = input();
   } else {
     PRECICE_DEBUG("Compute conservative mapping");
-    origins = input();
+    origins      = input();
     search_space = output();
   }
 
@@ -75,12 +74,12 @@ void NearestProjectionMapping::computeMapping()
   constexpr int nnearest = 4;
 
   if (getDimensions() == 2) {
-    if(!fVertices.empty() && tEdges.empty()) {
-        PRECICE_WARN("2D Mesh \"" << search_space->getName() << "\" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.");
+    if (!fVertices.empty() && tEdges.empty()) {
+      PRECICE_WARN("2D Mesh \"" << search_space->getName() << "\" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.");
     }
 
-    precice::utils::Event e2(baseEvent+".getIndexOnEdges", precice::syncMode);
-    auto indexEdges    = mesh::rtree::getEdgeRTree(search_space);
+    precice::utils::Event e2(baseEvent + ".getIndexOnEdges", precice::syncMode);
+    auto                  indexEdges = mesh::rtree::getEdgeRTree(search_space);
     e2.stop();
 
     // Lazy evaluation of the vertex index.
@@ -106,15 +105,15 @@ void NearestProjectionMapping::computeMapping()
         if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const &elem) { return elem.weight >= 0.0; })) {
           _weights[i] = std::move(weights);
           distanceStatistics(match.distance);
-          found       = true;
+          found = true;
           break;
         }
       }
 
       if (not found) {
-        if(!indexVertices) {
-            precice::utils::Event e3(baseEvent+".getIndexOnVertices", precice::syncMode);
-            indexVertices = mesh::rtree::getVertexRTree(search_space);
+        if (!indexVertices) {
+          precice::utils::Event e3(baseEvent + ".getIndexOnVertices", precice::syncMode);
+          indexVertices = mesh::rtree::getVertexRTree(search_space);
         }
         // Search for the origin inside the destination meshes vertices
         indexVertices->query(bg::index::nearest(coords, 1),
@@ -127,17 +126,17 @@ void NearestProjectionMapping::computeMapping()
     PRECICE_INFO("Mapping distance " << distanceStatistics);
   } else {
     const auto &tTriangles = search_space->triangles();
-    if(!fVertices.empty() && tTriangles.empty()) {
-         PRECICE_WARN("3D Mesh \"" << search_space->getName() << "\" does not contain triangles. Nearest projection mapping will map to primitives of lower dimension.");
+    if (!fVertices.empty() && tTriangles.empty()) {
+      PRECICE_WARN("3D Mesh \"" << search_space->getName() << "\" does not contain triangles. Nearest projection mapping will map to primitives of lower dimension.");
     }
 
-    precice::utils::Event e2(baseEvent+".getIndexOnTriangles", precice::syncMode);
-    auto indexTriangles = mesh::rtree::getTriangleRTree(search_space);
+    precice::utils::Event e2(baseEvent + ".getIndexOnTriangles", precice::syncMode);
+    auto                  indexTriangles = mesh::rtree::getTriangleRTree(search_space);
     e2.stop();
 
     // Lazy evaluation of indices for edges and vertices.
     // These are not necessary in the case of matching meshes.
-    mesh::rtree::edge_traits::Ptr indexEdges;
+    mesh::rtree::edge_traits::Ptr   indexEdges;
     mesh::rtree::vertex_traits::Ptr indexVertices;
 
     utils::statistics::DistanceAccumulator distanceStatistics;
@@ -167,8 +166,8 @@ void NearestProjectionMapping::computeMapping()
 
       if (not found) {
         if (!indexEdges) {
-            precice::utils::Event e3(baseEvent+".getIndexOnEdges", precice::syncMode);
-            indexEdges = mesh::rtree::getEdgeRTree(search_space);
+          precice::utils::Event e3(baseEvent + ".getIndexOnEdges", precice::syncMode);
+          indexEdges = mesh::rtree::getEdgeRTree(search_space);
         }
         // Search for the vertex inside the destination meshes edges
         matches.clear();
@@ -189,10 +188,10 @@ void NearestProjectionMapping::computeMapping()
       }
 
       if (not found) {
-          if(!indexVertices) {
-            precice::utils::Event e4(baseEvent+".getIndexOnVertices", precice::syncMode);
-            indexVertices = mesh::rtree::getVertexRTree(search_space);
-          }
+        if (!indexVertices) {
+          precice::utils::Event e4(baseEvent + ".getIndexOnVertices", precice::syncMode);
+          indexVertices = mesh::rtree::getVertexRTree(search_space);
+        }
         // Search for the vertex inside the destination meshes vertices
         indexVertices->query(bg::index::nearest(coords, 1),
                              boost::make_function_output_iterator([&](int match) {
@@ -237,7 +236,7 @@ void NearestProjectionMapping::map(
   if (getConstraint() == CONSISTENT) {
     PRECICE_DEBUG("Map consistent");
     PRECICE_ASSERT(_weights.size() == output()->vertices().size(),
-              _weights.size(), output()->vertices().size());
+                   _weights.size(), output()->vertices().size());
     for (size_t i = 0; i < output()->vertices().size(); i++) {
       InterpolationElements &elems     = _weights[i];
       size_t                 outOffset = i * dimensions;
@@ -254,7 +253,7 @@ void NearestProjectionMapping::map(
     PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
     PRECICE_DEBUG("Map conservative");
     PRECICE_ASSERT(_weights.size() == input()->vertices().size(),
-              _weights.size(), input()->vertices().size());
+                   _weights.size(), input()->vertices().size());
     for (size_t i = 0; i < input()->vertices().size(); i++) {
       size_t                 inOffset = i * dimensions;
       InterpolationElements &elems    = _weights[i];
@@ -291,7 +290,7 @@ void NearestProjectionMapping::tagMeshFirstRound()
   // Gather all vertices to be tagged in a first phase.
   // max_count is used to shortcut if all vertices have been tagged.
   std::unordered_set<mesh::Vertex const *> tagged;
-  const std::size_t max_count = origins->vertices().size();
+  const std::size_t                        max_count = origins->vertices().size();
 
   for (const InterpolationElements &elems : _weights) {
     for (const query::InterpolationElement &elem : elems) {
@@ -306,10 +305,10 @@ void NearestProjectionMapping::tagMeshFirstRound()
   }
 
   // Now tag all vertices to be tagged in the second phase.
-  for (auto& v : origins->vertices()) {
-      if(tagged.count(&v) == 1) {
-          v.tag();
-      }
+  for (auto &v : origins->vertices()) {
+    if (tagged.count(&v) == 1) {
+      v.tag();
+    }
   }
   PRECICE_DEBUG("First Round Tagged " << tagged.size() << "/" << max_count << " Vertices");
 

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Mapping.hpp"
 #include <list>
 #include <vector>
+#include "Mapping.hpp"
 #include "logging/Logger.hpp"
 #include "query/FindClosest.hpp"
 
@@ -13,12 +13,10 @@ namespace mapping {
  * @brief Mapping using orthogonal projection to nearest triangle/edge/vertex and
  *        linear interpolation from projected point.
  */
-class NearestProjectionMapping : public Mapping
-{
+class NearestProjectionMapping : public Mapping {
 public:
-
   /// Constructor, taking mapping constraint.
-  NearestProjectionMapping ( Constraint constraint, int dimensions );
+  NearestProjectionMapping(Constraint constraint, int dimensions);
 
   /// Destructor, empty.
   virtual ~NearestProjectionMapping() {}
@@ -40,13 +38,12 @@ public:
    * @param[in] inputDataID Data ID of input data values to be mapped from.
    * @param[in] outputDataID Data ID of output data values to be mapped to.
    */
-  virtual void map (
-    int inputDataID,
-    int outputDataID ) override;
+  virtual void map(
+      int inputDataID,
+      int outputDataID) override;
 
   virtual void tagMeshFirstRound() override;
   virtual void tagMeshSecondRound() override;
-
 
 private:
   logging::Logger _log{"mapping::NearestProjectionMapping"};
@@ -57,4 +54,5 @@ private:
   bool _hasComputedMapping = false;
 };
 
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -2,8 +2,8 @@
 
 #include "Mapping.hpp"
 #include "impl/BasisFunctions.hpp"
-#include "utils/MasterSlave.hpp"
 #include "utils/Event.hpp"
+#include "utils/MasterSlave.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/QR>
@@ -24,11 +24,9 @@ namespace mapping {
  * The radial basis function type has to be given as template parameter, and has
  * to be one of the defined types in this file.
  */
-template<typename RADIAL_BASIS_FUNCTION_T>
-class RadialBasisFctMapping : public Mapping
-{
+template <typename RADIAL_BASIS_FUNCTION_T>
+class RadialBasisFctMapping : public Mapping {
 public:
-
   /**
    * @brief Constructor.
    *
@@ -37,14 +35,13 @@ public:
    * @param[in] function Radial basis function used for mapping.
    * @param[in] xDead, yDead, zDead Deactivates mapping along an axis
    */
-  RadialBasisFctMapping (
-    Constraint              constraint,
-    int                     dimensions,
-    RADIAL_BASIS_FUNCTION_T function,
-    bool                    xDead,
-    bool                    yDead,
-    bool                    zDead);
-
+  RadialBasisFctMapping(
+      Constraint              constraint,
+      int                     dimensions,
+      RADIAL_BASIS_FUNCTION_T function,
+      bool                    xDead,
+      bool                    yDead,
+      bool                    zDead);
 
   /// Computes the mapping coefficients from the in- and output mesh.
   virtual void computeMapping() override;
@@ -56,14 +53,13 @@ public:
   virtual void clear() override;
 
   /// Maps input data to output data from input mesh to output mesh.
-  virtual void map(int inputDataID, int outputDataID ) override;
+  virtual void map(int inputDataID, int outputDataID) override;
 
   virtual void tagMeshFirstRound() override;
 
   virtual void tagMeshSecondRound() override;
 
 private:
-
   precice::logging::Logger _log{"mapping::RadialBasisFctMapping"};
 
   bool _hasComputedMapping = false;
@@ -74,130 +70,125 @@ private:
   Eigen::MatrixXd _matrixA;
 
   Eigen::ColPivHouseholderQR<Eigen::MatrixXd> _qr;
-  
+
   /// true if the mapping along some axis should be ignored
   std::vector<bool> _deadAxis;
 
   /// Deletes all dead directions from fullVector and returns a vector of reduced dimensionality.
-  Eigen::VectorXd reduceVector(const Eigen::VectorXd& fullVector);
-  
+  Eigen::VectorXd reduceVector(const Eigen::VectorXd &fullVector);
+
   void setDeadAxis(bool xDead, bool yDead, bool zDead)
   {
     _deadAxis.resize(getDimensions());
     if (getDimensions() == 2) {
       _deadAxis[0] = xDead;
       _deadAxis[1] = yDead;
-      PRECICE_CHECK(not (xDead && yDead), "You cannot choose all axis to be dead for a RBF mapping");
+      PRECICE_CHECK(not(xDead && yDead), "You cannot choose all axis to be dead for a RBF mapping");
       if (zDead)
         PRECICE_WARN("Setting the z-axis to dead on a 2 dimensional problem has not effect and will be ignored.");
-    }
-    else if (getDimensions() == 3) {
+    } else if (getDimensions() == 3) {
       _deadAxis[0] = xDead;
       _deadAxis[1] = yDead;
       _deadAxis[2] = zDead;
-      PRECICE_CHECK(not (xDead && yDead && zDead), "You cannot choose all axis to be dead for a RBF mapping");
-    }
-    else {
+      PRECICE_CHECK(not(xDead && yDead && zDead), "You cannot choose all axis to be dead for a RBF mapping");
+    } else {
       PRECICE_ASSERT(false);
     }
   }
-
 };
 
 // --------------------------------------------------- HEADER IMPLEMENTATIONS
 
-template<typename RADIAL_BASIS_FUNCTION_T>
-RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: RadialBasisFctMapping
-(
-  Constraint              constraint,
-  int                     dimensions,
-  RADIAL_BASIS_FUNCTION_T function,
-  bool                    xDead,
-  bool                    yDead,
-  bool                    zDead)
-  :
-  Mapping ( constraint, dimensions ),
-  _basisFunction ( function )
+template <typename RADIAL_BASIS_FUNCTION_T>
+RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctMapping(
+    Constraint              constraint,
+    int                     dimensions,
+    RADIAL_BASIS_FUNCTION_T function,
+    bool                    xDead,
+    bool                    yDead,
+    bool                    zDead)
+    : Mapping(constraint, dimensions),
+      _basisFunction(function)
 {
   setInputRequirement(Mapping::MeshRequirement::VERTEX);
   setOutputRequirement(Mapping::MeshRequirement::VERTEX);
   setDeadAxis(xDead, yDead, zDead);
 }
 
-template<typename RADIAL_BASIS_FUNCTION_T>
-void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: computeMapping()
+template <typename RADIAL_BASIS_FUNCTION_T>
+void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
 {
   PRECICE_TRACE();
 
   precice::utils::Event e("map.rbf.computeMapping.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
   PRECICE_CHECK(not utils::MasterSlave::isSlave() && not utils::MasterSlave::isMaster(),
-        "RBF mapping is not supported for a participant in master mode, use petrbf instead");
+                "RBF mapping is not supported for a participant in master mode, use petrbf instead");
 
   PRECICE_ASSERT(input()->getDimensions() == output()->getDimensions(),
-             input()->getDimensions(), output()->getDimensions());
+                 input()->getDimensions(), output()->getDimensions());
   PRECICE_ASSERT(getDimensions() == output()->getDimensions(),
-             getDimensions(), output()->getDimensions());
-  int dimensions = getDimensions();
+                 getDimensions(), output()->getDimensions());
+  int           dimensions = getDimensions();
   mesh::PtrMesh inMesh;
   mesh::PtrMesh outMesh;
-  if (getConstraint() == CONSERVATIVE){
-    inMesh = output();
+  if (getConstraint() == CONSERVATIVE) {
+    inMesh  = output();
     outMesh = input();
-  }
-  else {
-    inMesh = input();
+  } else {
+    inMesh  = input();
     outMesh = output();
   }
-  int inputSize = (int)inMesh->vertices().size();
-  int outputSize = (int)outMesh->vertices().size();
+  int inputSize      = (int) inMesh->vertices().size();
+  int outputSize     = (int) outMesh->vertices().size();
   int deadDimensions = 0;
   for (int d = 0; d < dimensions; d++) {
-    if (_deadAxis[d]) deadDimensions +=1;
+    if (_deadAxis[d])
+      deadDimensions += 1;
   }
   int polyparams = 1 + dimensions - deadDimensions;
   PRECICE_ASSERT(inputSize >= 1 + polyparams, inputSize);
-  int n = inputSize + polyparams; // Add linear polynom degrees
+  int             n = inputSize + polyparams; // Add linear polynom degrees
   Eigen::MatrixXd matrixCLU(n, n);
   matrixCLU.setZero();
   _matrixA = Eigen::MatrixXd(outputSize, n);
   _matrixA.setZero();
 
   // Fill upper right part (due to symmetry) of _matrixCLU with values
-  int i = 0;
+  int             i = 0;
   Eigen::VectorXd difference(dimensions);
-  for (const mesh::Vertex& iVertex : inMesh->vertices()) {
+  for (const mesh::Vertex &iVertex : inMesh->vertices()) {
     for (int j = iVertex.getID(); j < inputSize; j++) {
       difference = iVertex.getCoords();
       difference -= inMesh->vertices()[j].getCoords();
-      matrixCLU(i,j) = _basisFunction.evaluate(reduceVector(difference).norm());
+      matrixCLU(i, j) = _basisFunction.evaluate(reduceVector(difference).norm());
     }
-    matrixCLU(i,inputSize) = 1.0;
-    for (int dim=0; dim < dimensions-deadDimensions; dim++) {
-      matrixCLU(i,inputSize+1+dim) = reduceVector(iVertex.getCoords())[dim];
+    matrixCLU(i, inputSize) = 1.0;
+    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
+      matrixCLU(i, inputSize + 1 + dim) = reduceVector(iVertex.getCoords())[dim];
     }
     i++;
   }
   // Copy values of upper right part of C to lower left part
   for (int i = 0; i < n; i++) {
-    for (int j = i+1; j < n; j++) {
-      matrixCLU(j,i) = matrixCLU(i,j);
+    for (int j = i + 1; j < n; j++) {
+      matrixCLU(j, i) = matrixCLU(i, j);
     }
   }
 
   // Fill _matrixA with values
   i = 0;
-  for (const mesh::Vertex& iVertex : outMesh->vertices()) {
+  for (const mesh::Vertex &iVertex : outMesh->vertices()) {
     int j = 0;
-    for (const mesh::Vertex& jVertex : inMesh->vertices()) {
+    for (const mesh::Vertex &jVertex : inMesh->vertices()) {
       difference = iVertex.getCoords();
       difference -= jVertex.getCoords();
-      _matrixA(i,j) = _basisFunction.evaluate(reduceVector(difference).norm());
+      _matrixA(i, j) = _basisFunction.evaluate(reduceVector(difference).norm());
       j++;
     }
-    _matrixA(i,inputSize) = 1.0;
-    for (int dim=0; dim < dimensions-deadDimensions; dim++) {
-      _matrixA(i,inputSize+1+dim) = reduceVector(iVertex.getCoords())[dim];
+    _matrixA(i, inputSize) = 1.0;
+    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
+      _matrixA(i, inputSize + 1 + dim) = reduceVector(iVertex.getCoords())[dim];
     }
     i++;
   }
@@ -205,30 +196,29 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: computeMapping()
   _qr = matrixCLU.colPivHouseholderQr();
   if (not _qr.isInvertible())
     PRECICE_ERROR("Interpolation matrix C is not invertible.");
-  
+
   _hasComputedMapping = true;
 }
 
-template<typename RADIAL_BASIS_FUNCTION_T>
-bool RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: hasComputedMapping() const
+template <typename RADIAL_BASIS_FUNCTION_T>
+bool RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::hasComputedMapping() const
 {
   return _hasComputedMapping;
 }
 
-template<typename RADIAL_BASIS_FUNCTION_T>
-void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: clear()
+template <typename RADIAL_BASIS_FUNCTION_T>
+void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::clear()
 {
   PRECICE_TRACE();
-  _matrixA = Eigen::MatrixXd();
-  _qr = Eigen::ColPivHouseholderQR<Eigen::MatrixXd>();
+  _matrixA            = Eigen::MatrixXd();
+  _qr                 = Eigen::ColPivHouseholderQR<Eigen::MatrixXd>();
   _hasComputedMapping = false;
 }
 
-template<typename RADIAL_BASIS_FUNCTION_T>
-void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: map
-(
-  int inputDataID,
-  int outputDataID )
+template <typename RADIAL_BASIS_FUNCTION_T>
+void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(
+    int inputDataID,
+    int outputDataID)
 {
   PRECICE_TRACE(inputDataID, outputDataID);
 
@@ -236,24 +226,25 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: map
 
   PRECICE_ASSERT(_hasComputedMapping);
   PRECICE_ASSERT(input()->getDimensions() == output()->getDimensions(),
-             input()->getDimensions(), output()->getDimensions());
+                 input()->getDimensions(), output()->getDimensions());
   PRECICE_ASSERT(getDimensions() == output()->getDimensions(),
-             getDimensions(), output()->getDimensions());
+                 getDimensions(), output()->getDimensions());
 
-  Eigen::VectorXd& inValues = input()->data(inputDataID)->values();
-  Eigen::VectorXd& outValues = output()->data(outputDataID)->values();
-  int valueDim = input()->data(inputDataID)->getDimensions();
+  Eigen::VectorXd &inValues  = input()->data(inputDataID)->values();
+  Eigen::VectorXd &outValues = output()->data(outputDataID)->values();
+  int              valueDim  = input()->data(inputDataID)->getDimensions();
   PRECICE_ASSERT(valueDim == output()->data(outputDataID)->getDimensions(),
-             valueDim, output()->data(outputDataID)->getDimensions());
+                 valueDim, output()->data(outputDataID)->getDimensions());
   int deadDimensions = 0;
   for (int d = 0; d < getDimensions(); d++) {
-    if (_deadAxis[d]) deadDimensions +=1;
+    if (_deadAxis[d])
+      deadDimensions += 1;
   }
   int polyparams = 1 + getDimensions() - deadDimensions;
 
-  if (getConstraint() == CONSERVATIVE){
+  if (getConstraint() == CONSERVATIVE) {
     PRECICE_DEBUG("Map conservative");
-    static int mappingIndex = 0;
+    static int      mappingIndex = 0;
     Eigen::VectorXd Au(_matrixA.cols());  // rows == n
     Eigen::VectorXd in(_matrixA.rows());  // rows == outputSize
     Eigen::VectorXd out(_matrixA.cols()); // rows == n
@@ -264,58 +255,55 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>:: map
 
     for (int dim = 0; dim < valueDim; dim++) {
       for (int i = 0; i < in.size(); i++) { // Fill input data values
-        in[i] = inValues(i*valueDim + dim);
+        in[i] = inValues(i * valueDim + dim);
       }
 
-      Au = _matrixA.transpose() * in;
+      Au  = _matrixA.transpose() * in;
       out = _qr.solve(Au);
 
       // Copy mapped data to output data values
-      for (int i = 0; i < out.size()-polyparams; i++) {
-        outValues(i*valueDim + dim) = out[i];
+      for (int i = 0; i < out.size() - polyparams; i++) {
+        outValues(i * valueDim + dim) = out[i];
       }
     }
     mappingIndex++;
-  }
-  else { // Map consistent
+  } else { // Map consistent
     PRECICE_DEBUG("Map consistent");
-    Eigen::VectorXd p(_matrixA.cols());    // rows == n
-    Eigen::VectorXd in(_matrixA.cols());   // rows == n
-    Eigen::VectorXd out(_matrixA.rows());  // rows == outputSize
+    Eigen::VectorXd p(_matrixA.cols());   // rows == n
+    Eigen::VectorXd in(_matrixA.cols());  // rows == n
+    Eigen::VectorXd out(_matrixA.rows()); // rows == outputSize
     in.setZero();
 
     // For every data dimension, perform mapping
     for (int dim = 0; dim < valueDim; dim++) {
       // Fill input from input data values (last polyparams entries remain zero)
       for (int i = 0; i < in.size() - polyparams; i++) {
-        in[i] = inValues(i*valueDim + dim);
+        in[i] = inValues(i * valueDim + dim);
       }
 
-      p = _qr.solve(in);
+      p   = _qr.solve(in);
       out = _matrixA * p;
 
       // Copy mapped data to ouptut data values
       for (int i = 0; i < out.size(); i++) {
-        outValues(i*valueDim + dim) = out[i];
+        outValues(i * valueDim + dim) = out[i];
       }
     }
   }
 }
 
-
-template<typename RADIAL_BASIS_FUNCTION_T>
-Eigen::VectorXd RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::reduceVector
-(
-  const Eigen::VectorXd& fullVector)
+template <typename RADIAL_BASIS_FUNCTION_T>
+Eigen::VectorXd RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::reduceVector(
+    const Eigen::VectorXd &fullVector)
 {
   int deadDimensions = 0;
   for (int d = 0; d < getDimensions(); d++) {
     if (_deadAxis[d])
-      deadDimensions +=1;
+      deadDimensions += 1;
   }
-  PRECICE_ASSERT(getDimensions()>deadDimensions, getDimensions(), deadDimensions);
-  Eigen::VectorXd reducedVector(getDimensions()-deadDimensions);
-  int k = 0;
+  PRECICE_ASSERT(getDimensions() > deadDimensions, getDimensions(), deadDimensions);
+  Eigen::VectorXd reducedVector(getDimensions() - deadDimensions);
+  int             k = 0;
   for (int d = 0; d < getDimensions(); d++) {
     if (not _deadAxis[d]) {
       reducedVector[k] = fullVector[d];
@@ -325,19 +313,19 @@ Eigen::VectorXd RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::reduceVector
   return reducedVector;
 }
 
-template<typename RADIAL_BASIS_FUNCTION_T>
+template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
 {
   PRECICE_CHECK(not utils::MasterSlave::isSlave() && not utils::MasterSlave::isMaster(),
-        "RBF mapping is not supported for a participant in master mode, use petrbf instead");
+                "RBF mapping is not supported for a participant in master mode, use petrbf instead");
 }
 
-template<typename RADIAL_BASIS_FUNCTION_T>
+template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshSecondRound()
 {
   PRECICE_CHECK(not utils::MasterSlave::isSlave() && not utils::MasterSlave::isMaster(),
-        "RBF mapping is not supported for a participant in master mode, use petrbf instead");
+                "RBF mapping is not supported for a participant in master mode, use petrbf instead");
 }
 
-
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/SharedPointer.hpp
+++ b/src/mapping/SharedPointer.hpp
@@ -11,4 +11,5 @@ class MappingConfiguration;
 using PtrMapping              = std::shared_ptr<Mapping>;
 using PtrMappingConfiguration = std::shared_ptr<MappingConfiguration>;
 
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -1,49 +1,47 @@
 #include "MappingConfiguration.hpp"
 #include "mapping/NearestNeighborMapping.hpp"
 #include "mapping/NearestProjectionMapping.hpp"
-#include "mapping/RadialBasisFctMapping.hpp"
 #include "mapping/PetRadialBasisFctMapping.hpp"
+#include "mapping/RadialBasisFctMapping.hpp"
 #include "mapping/impl/BasisFunctions.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
-#include "xml/XMLTag.hpp"
 #include "xml/XMLAttribute.hpp"
+#include "xml/XMLTag.hpp"
 
 namespace precice {
 namespace mapping {
 
-MappingConfiguration:: MappingConfiguration
-(
-  xml::XMLTag &                   parent,
-  const mesh::PtrMeshConfiguration& meshConfiguration )
-:
-  _meshConfig(meshConfiguration)
+MappingConfiguration::MappingConfiguration(
+    xml::XMLTag &                     parent,
+    const mesh::PtrMeshConfiguration &meshConfiguration)
+    : _meshConfig(meshConfiguration)
 {
   PRECICE_ASSERT(_meshConfig);
   using namespace xml;
 
- auto attrShapeParam  = XMLAttribute<double>( ATTR_SHAPE_PARAM )
-      .setDocumentation("Specific shape parameter for RBF basis function.");
- auto attrSupportRadius  = XMLAttribute<double>( ATTR_SUPPORT_RADIUS )
-      .setDocumentation("Support radius of each RBF basis function (global choice).");
-  auto attrSolverRtol  = makeXMLAttribute( ATTR_SOLVER_RTOL, 1e-9)
-      .setDocumentation("Solver relative tolerance for convergence");
+  auto attrShapeParam = XMLAttribute<double>(ATTR_SHAPE_PARAM)
+                            .setDocumentation("Specific shape parameter for RBF basis function.");
+  auto attrSupportRadius = XMLAttribute<double>(ATTR_SUPPORT_RADIUS)
+                               .setDocumentation("Support radius of each RBF basis function (global choice).");
+  auto attrSolverRtol = makeXMLAttribute(ATTR_SOLVER_RTOL, 1e-9)
+                            .setDocumentation("Solver relative tolerance for convergence");
   auto attrXDead = makeXMLAttribute(ATTR_X_DEAD, false)
-      .setDocumentation("If set to true, the x axis will be ignored for the mapping");
+                       .setDocumentation("If set to true, the x axis will be ignored for the mapping");
   auto attrYDead = makeXMLAttribute(ATTR_Y_DEAD, false)
-      .setDocumentation("If set to true, the y axis will be ignored for the mapping");
+                       .setDocumentation("If set to true, the y axis will be ignored for the mapping");
   auto attrZDead = makeXMLAttribute(ATTR_Z_DEAD, false)
-      .setDocumentation("If set to true, the z axis will be ignored for the mapping");
+                       .setDocumentation("If set to true, the z axis will be ignored for the mapping");
   auto attrPolynomial = makeXMLAttribute("polynomial", "separate")
-      .setDocumentation("Toggles use of the global polynomial")
-      .setOptions({"on", "off", "separate"});
+                            .setDocumentation("Toggles use of the global polynomial")
+                            .setOptions({"on", "off", "separate"});
   auto attrPreallocation = makeXMLAttribute("preallocation", "tree")
-      .setDocumentation("Sets kind of preallocation for PETSc RBF implementation")
-      .setOptions({"estimate", "compute", "off", "save", "tree"});
+                               .setDocumentation("Sets kind of preallocation for PETSc RBF implementation")
+                               .setOptions({"estimate", "compute", "off", "save", "tree"});
   auto attrUseLU = makeXMLAttribute(ATTR_USE_LU, false)
-      .setDocumentation("If set to true, LU decomposition is used to solve the RBF system (only supported in serial)");
+                       .setDocumentation("If set to true, LU decomposition is used to solve the RBF system (only supported in serial)");
 
   XMLTag::Occurrence occ = XMLTag::OCCUR_ARBITRARY;
-  std::list<XMLTag> tags;
+  std::list<XMLTag>  tags;
   {
     XMLTag tag(*this, VALUE_RBF_TPS, occ, TAG);
     tags.push_back(tag);
@@ -83,7 +81,7 @@ MappingConfiguration:: MappingConfiguration
     tags.push_back(tag);
   }
   // Add tags that only, but all RBF mappings use
-  for (XMLTag& tag : tags) {
+  for (XMLTag &tag : tags) {
     tag.addAttribute(attrSolverRtol);
     tag.addAttribute(attrPolynomial);
     tag.addAttribute(attrPreallocation);
@@ -101,20 +99,20 @@ MappingConfiguration:: MappingConfiguration
     tags.push_back(tag);
   }
 
-  auto attrDirection = XMLAttribute<std::string>( ATTR_DIRECTION)
-      .setOptions({ VALUE_WRITE, VALUE_READ });
+  auto attrDirection = XMLAttribute<std::string>(ATTR_DIRECTION)
+                           .setOptions({VALUE_WRITE, VALUE_READ});
 
   XMLAttribute<std::string> attrFromMesh(ATTR_FROM);
   XMLAttribute<std::string> attrToMesh(ATTR_TO);
 
   auto attrConstraint = XMLAttribute<std::string>(ATTR_CONSTRAINT)
-      .setOptions({VALUE_CONSERVATIVE, VALUE_CONSISTENT});
+                            .setOptions({VALUE_CONSERVATIVE, VALUE_CONSISTENT});
 
   auto attrTiming = makeXMLAttribute(ATTR_TIMING, VALUE_TIMING_INITIAL)
-      .setOptions({VALUE_TIMING_INITIAL, VALUE_TIMING_ON_ADVANCE, VALUE_TIMING_ON_DEMAND});
+                        .setOptions({VALUE_TIMING_INITIAL, VALUE_TIMING_ON_ADVANCE, VALUE_TIMING_ON_DEMAND});
 
   // Add tags that all mappings use and add to parent tag
-  for (XMLTag & tag : tags) {
+  for (XMLTag &tag : tags) {
     tag.addAttribute(attrDirection);
     tag.addAttribute(attrFromMesh);
     tag.addAttribute(attrToMesh);
@@ -124,46 +122,45 @@ MappingConfiguration:: MappingConfiguration
   }
 }
 
-void MappingConfiguration:: xmlTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void MappingConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getName());
-  if (tag.getNamespace() == TAG){
-    std::string dir = tag.getStringAttributeValue(ATTR_DIRECTION);
-    std::string fromMesh = tag.getStringAttributeValue(ATTR_FROM);
-    std::string toMesh = tag.getStringAttributeValue(ATTR_TO);
-    std::string type = tag.getName();
-    std::string constraint = tag.getStringAttributeValue(ATTR_CONSTRAINT);
-    Timing timing = getTiming(tag.getStringAttributeValue(ATTR_TIMING));
-    double shapeParameter = 0.0;
-    double supportRadius = 0.0;
-    double solverRtol = 1e-9;
-    bool xDead = false, yDead = false, zDead = false;
-    bool useLU = false;
-    Polynomial polynomial = Polynomial::ON;
+  if (tag.getNamespace() == TAG) {
+    std::string   dir            = tag.getStringAttributeValue(ATTR_DIRECTION);
+    std::string   fromMesh       = tag.getStringAttributeValue(ATTR_FROM);
+    std::string   toMesh         = tag.getStringAttributeValue(ATTR_TO);
+    std::string   type           = tag.getName();
+    std::string   constraint     = tag.getStringAttributeValue(ATTR_CONSTRAINT);
+    Timing        timing         = getTiming(tag.getStringAttributeValue(ATTR_TIMING));
+    double        shapeParameter = 0.0;
+    double        supportRadius  = 0.0;
+    double        solverRtol     = 1e-9;
+    bool          xDead = false, yDead = false, zDead = false;
+    bool          useLU         = false;
+    Polynomial    polynomial    = Polynomial::ON;
     Preallocation preallocation = Preallocation::TREE;
 
-    if (tag.hasAttribute(ATTR_SHAPE_PARAM)){
+    if (tag.hasAttribute(ATTR_SHAPE_PARAM)) {
       shapeParameter = tag.getDoubleAttributeValue(ATTR_SHAPE_PARAM);
     }
-    if (tag.hasAttribute(ATTR_SUPPORT_RADIUS)){
+    if (tag.hasAttribute(ATTR_SUPPORT_RADIUS)) {
       supportRadius = tag.getDoubleAttributeValue(ATTR_SUPPORT_RADIUS);
     }
-    if (tag.hasAttribute(ATTR_SOLVER_RTOL)){
+    if (tag.hasAttribute(ATTR_SOLVER_RTOL)) {
       solverRtol = tag.getDoubleAttributeValue(ATTR_SOLVER_RTOL);
     }
-    if (tag.hasAttribute(ATTR_X_DEAD)){
+    if (tag.hasAttribute(ATTR_X_DEAD)) {
       xDead = tag.getBooleanAttributeValue(ATTR_X_DEAD);
     }
-    if (tag.hasAttribute(ATTR_Y_DEAD)){
+    if (tag.hasAttribute(ATTR_Y_DEAD)) {
       yDead = tag.getBooleanAttributeValue(ATTR_Y_DEAD);
     }
-    if (tag.hasAttribute(ATTR_Z_DEAD)){
+    if (tag.hasAttribute(ATTR_Z_DEAD)) {
       zDead = tag.getBooleanAttributeValue(ATTR_Z_DEAD);
     }
-    if (tag.hasAttribute(ATTR_USE_LU)){
+    if (tag.hasAttribute(ATTR_USE_LU)) {
       useLU = tag.getBooleanAttributeValue(ATTR_USE_LU);
     }
     if (tag.hasAttribute("polynomial")) {
@@ -175,7 +172,7 @@ void MappingConfiguration:: xmlTagCallback
       else if (strPolynomial == "off")
         polynomial = Polynomial::OFF;
     }
-    if (tag.hasAttribute("preallocation")){
+    if (tag.hasAttribute("preallocation")) {
       std::string strPrealloc = tag.getStringAttributeValue("preallocation");
       if (strPrealloc == "estimate")
         preallocation = Preallocation::ESTIMATE;
@@ -196,82 +193,76 @@ void MappingConfiguration:: xmlTagCallback
                                                         xDead, yDead, zDead,
                                                         useLU,
                                                         polynomial, preallocation);
-    checkDuplicates ( configuredMapping );
-    _mappings.push_back ( configuredMapping );
+    checkDuplicates(configuredMapping);
+    _mappings.push_back(configuredMapping);
   }
 }
 
-void MappingConfiguration::xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag)
+void MappingConfiguration::xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag)
 {
 }
 
-const std::vector<MappingConfiguration::ConfiguredMapping>&
-MappingConfiguration:: mappings()
+const std::vector<MappingConfiguration::ConfiguredMapping> &
+MappingConfiguration::mappings()
 {
   return _mappings;
 }
 
-MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping
-(
-  const xml::ConfigurationContext& context,
-  const std::string& direction,
-  const std::string& type,
-  const std::string& constraint,
-  const std::string& fromMeshName,
-  const std::string& toMeshName,
-  Timing             timing,
-  double             shapeParameter,
-  double             supportRadius,
-  double             solverRtol,
-  bool               xDead,
-  bool               yDead,
-  bool               zDead,
-  bool               useLU,
-  Polynomial         polynomial,
-  Preallocation      preallocation) const
+MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
+    const xml::ConfigurationContext &context,
+    const std::string &              direction,
+    const std::string &              type,
+    const std::string &              constraint,
+    const std::string &              fromMeshName,
+    const std::string &              toMeshName,
+    Timing                           timing,
+    double                           shapeParameter,
+    double                           supportRadius,
+    double                           solverRtol,
+    bool                             xDead,
+    bool                             yDead,
+    bool                             zDead,
+    bool                             useLU,
+    Polynomial                       polynomial,
+    Preallocation                    preallocation) const
 {
   PRECICE_TRACE(direction, type, timing, shapeParameter, supportRadius);
   using namespace mapping;
   ConfiguredMapping configuredMapping;
-  mesh::PtrMesh fromMesh(_meshConfig->getMesh(fromMeshName));
-  mesh::PtrMesh toMesh(_meshConfig->getMesh(toMeshName));
+  mesh::PtrMesh     fromMesh(_meshConfig->getMesh(fromMeshName));
+  mesh::PtrMesh     toMesh(_meshConfig->getMesh(toMeshName));
   PRECICE_CHECK(fromMesh.get() != nullptr, "Mesh \"" << fromMeshName << "\" not defined at creation of mapping!");
   PRECICE_CHECK(toMesh.get() != nullptr, "Mesh \"" << toMeshName << "\" not defined at creation of mapping!");
   configuredMapping.fromMesh = fromMesh;
-  configuredMapping.toMesh = toMesh;
-  configuredMapping.timing = timing;
-  int dimensions = fromMesh->getDimensions();
+  configuredMapping.toMesh   = toMesh;
+  configuredMapping.timing   = timing;
+  int dimensions             = fromMesh->getDimensions();
 
-  if (direction == VALUE_WRITE){
-    configuredMapping.direction =  WRITE;
-  }
-  else if (direction == VALUE_READ){
+  if (direction == VALUE_WRITE) {
+    configuredMapping.direction = WRITE;
+  } else if (direction == VALUE_READ) {
     configuredMapping.direction = READ;
-  }
-  else {
+  } else {
     PRECICE_ERROR("Unknown direction type \"" << direction << "\"!");
   }
 
   Mapping::Constraint constraintValue;
-  if (constraint == VALUE_CONSERVATIVE){
+  if (constraint == VALUE_CONSERVATIVE) {
     constraintValue = Mapping::CONSERVATIVE;
-  }
-  else if (constraint == VALUE_CONSISTENT){
+  } else if (constraint == VALUE_CONSISTENT) {
     constraintValue = Mapping::CONSISTENT;
-  }
-  else {
+  } else {
     PRECICE_ERROR("Unknown mapping constraint \"" << constraint << "\"!");
   }
 
-  if (type == VALUE_NEAREST_NEIGHBOR){
-    configuredMapping.mapping = PtrMapping (
-        new NearestNeighborMapping(constraintValue, dimensions) );
+  if (type == VALUE_NEAREST_NEIGHBOR) {
+    configuredMapping.mapping = PtrMapping(
+        new NearestNeighborMapping(constraintValue, dimensions));
     configuredMapping.isRBF = false;
     return configuredMapping;
-  }
-  else if (type == VALUE_NEAREST_PROJECTION){
-    configuredMapping.mapping = PtrMapping (
-      new NearestProjectionMapping(constraintValue, dimensions) );
+  } else if (type == VALUE_NEAREST_PROJECTION) {
+    configuredMapping.mapping = PtrMapping(
+        new NearestProjectionMapping(constraintValue, dimensions));
     configuredMapping.isRBF = false;
     return configuredMapping;
   }
@@ -279,158 +270,138 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping
   // the mapping is a RBF mapping
 
   configuredMapping.isRBF = true;
-  bool isSerial = context.size == 1;
-  bool usePETSc = false;
+  bool isSerial           = context.size == 1;
+  bool usePETSc           = false;
 
-  # ifndef PRECICE_NO_PETSC
-    // for petsc initialization
-    int argc = 1;
-    char* arg = new char[8];
-    strcpy(arg, "precice");
-    char** argv = &arg;
-    utils::Petsc::initialize(&argc, &argv);
-    delete[] arg;
-    usePETSc = true;
-  #endif
-
+#ifndef PRECICE_NO_PETSC
+  // for petsc initialization
+  int   argc = 1;
+  char *arg  = new char[8];
+  strcpy(arg, "precice");
+  char **argv = &arg;
+  utils::Petsc::initialize(&argc, &argv);
+  delete[] arg;
+  usePETSc = true;
+#endif
 
   bool createPetRBF = false;
-  if(usePETSc){
-    if(isSerial){
+  if (usePETSc) {
+    if (isSerial) {
       createPetRBF = not useLU;
-    }
-    else{
-      if(useLU) PRECICE_WARN("LU decomposition is not supported for parallel RBF data mappings. Switching to GMRES (PETSc)");
+    } else {
+      if (useLU)
+        PRECICE_WARN("LU decomposition is not supported for parallel RBF data mappings. Switching to GMRES (PETSc)");
       createPetRBF = true;
     }
-  }
-  else{
+  } else {
     PRECICE_CHECK(isSerial, "Using RBF data mappings in parallel requires building with PETSc.");
   }
 
-  if(not createPetRBF){
-    if (type == VALUE_RBF_TPS){
-      configuredMapping.mapping = PtrMapping (
-        new RadialBasisFctMapping<ThinPlateSplines>(constraintValue, dimensions, ThinPlateSplines(), xDead, yDead, zDead));
-    }
-    else if (type == VALUE_RBF_MULTIQUADRICS){
-      configuredMapping.mapping = PtrMapping (
-        new RadialBasisFctMapping<Multiquadrics>(
-          constraintValue, dimensions, Multiquadrics(shapeParameter), xDead, yDead, zDead ));
-    }
-    else if (type == VALUE_RBF_INV_MULTIQUADRICS){
-      configuredMapping.mapping = PtrMapping (
-        new RadialBasisFctMapping<InverseMultiquadrics>(
-          constraintValue, dimensions, InverseMultiquadrics(shapeParameter), xDead, yDead, zDead ));
-    }
-    else if (type == VALUE_RBF_VOLUME_SPLINES){
-      configuredMapping.mapping = PtrMapping (
-        new RadialBasisFctMapping<VolumeSplines>(constraintValue, dimensions, VolumeSplines(), xDead, yDead, zDead ));
-    }
-    else if (type == VALUE_RBF_GAUSSIAN){
+  if (not createPetRBF) {
+    if (type == VALUE_RBF_TPS) {
+      configuredMapping.mapping = PtrMapping(
+          new RadialBasisFctMapping<ThinPlateSplines>(constraintValue, dimensions, ThinPlateSplines(), xDead, yDead, zDead));
+    } else if (type == VALUE_RBF_MULTIQUADRICS) {
+      configuredMapping.mapping = PtrMapping(
+          new RadialBasisFctMapping<Multiquadrics>(
+              constraintValue, dimensions, Multiquadrics(shapeParameter), xDead, yDead, zDead));
+    } else if (type == VALUE_RBF_INV_MULTIQUADRICS) {
+      configuredMapping.mapping = PtrMapping(
+          new RadialBasisFctMapping<InverseMultiquadrics>(
+              constraintValue, dimensions, InverseMultiquadrics(shapeParameter), xDead, yDead, zDead));
+    } else if (type == VALUE_RBF_VOLUME_SPLINES) {
+      configuredMapping.mapping = PtrMapping(
+          new RadialBasisFctMapping<VolumeSplines>(constraintValue, dimensions, VolumeSplines(), xDead, yDead, zDead));
+    } else if (type == VALUE_RBF_GAUSSIAN) {
       configuredMapping.mapping = PtrMapping(
           new RadialBasisFctMapping<Gaussian>(
-            constraintValue, dimensions, Gaussian(shapeParameter), xDead, yDead, zDead));
-    }
-    else if (type == VALUE_RBF_CTPS_C2){
-      configuredMapping.mapping = PtrMapping (
-        new RadialBasisFctMapping<CompactThinPlateSplinesC2>(
-          constraintValue, dimensions, CompactThinPlateSplinesC2(supportRadius), xDead, yDead, zDead ));
-    }
-    else if (type == VALUE_RBF_CPOLYNOMIAL_C0){
-      configuredMapping.mapping = PtrMapping (
-        new RadialBasisFctMapping<CompactPolynomialC0>(
-          constraintValue, dimensions, CompactPolynomialC0(supportRadius), xDead, yDead, zDead ));
-    }
-    else if (type == VALUE_RBF_CPOLYNOMIAL_C6){
-      configuredMapping.mapping = PtrMapping (
-        new RadialBasisFctMapping<CompactPolynomialC6>(
-          constraintValue, dimensions, CompactPolynomialC6(supportRadius), xDead, yDead, zDead ));
-    }
-    else {
-      PRECICE_ERROR("Unknown mapping type!");
-    }
-  }
-
-  # ifndef PRECICE_NO_PETSC
-
-  if(createPetRBF) {
-    if (type == VALUE_RBF_TPS){
-      configuredMapping.mapping = PtrMapping (
-        new PetRadialBasisFctMapping<ThinPlateSplines>(constraintValue, dimensions, ThinPlateSplines(),
-                                                       xDead, yDead, zDead, solverRtol, polynomial, preallocation) );
-    }
-    else if (type == VALUE_RBF_MULTIQUADRICS){
-      configuredMapping.mapping = PtrMapping (
-        new PetRadialBasisFctMapping<Multiquadrics>(constraintValue, dimensions, Multiquadrics(shapeParameter),
-                                                    xDead, yDead, zDead, solverRtol, polynomial, preallocation) );
-    }
-    else if (type == VALUE_RBF_INV_MULTIQUADRICS){
-      configuredMapping.mapping = PtrMapping (
-        new PetRadialBasisFctMapping<InverseMultiquadrics>(constraintValue, dimensions, InverseMultiquadrics(shapeParameter),
-                                                           xDead, yDead, zDead, solverRtol, polynomial, preallocation) );
-    }
-    else if (type == VALUE_RBF_VOLUME_SPLINES){
-      configuredMapping.mapping = PtrMapping (
-        new PetRadialBasisFctMapping<VolumeSplines>(constraintValue, dimensions, VolumeSplines(),
-                                                    xDead, yDead, zDead, solverRtol, polynomial, preallocation) );
-    }
-    else if (type == VALUE_RBF_GAUSSIAN){
+              constraintValue, dimensions, Gaussian(shapeParameter), xDead, yDead, zDead));
+    } else if (type == VALUE_RBF_CTPS_C2) {
       configuredMapping.mapping = PtrMapping(
-        new PetRadialBasisFctMapping<Gaussian>(constraintValue, dimensions, Gaussian(shapeParameter),
-                                               xDead, yDead, zDead, solverRtol, polynomial, preallocation));
-    }
-    else if (type == VALUE_RBF_CTPS_C2){
-      configuredMapping.mapping = PtrMapping (
-        new PetRadialBasisFctMapping<CompactThinPlateSplinesC2>(constraintValue, dimensions, CompactThinPlateSplinesC2(supportRadius),
-                                                                xDead, yDead, zDead, solverRtol, polynomial, preallocation) );
-    }
-    else if (type == VALUE_RBF_CPOLYNOMIAL_C0){
-      configuredMapping.mapping = PtrMapping (
-        new PetRadialBasisFctMapping<CompactPolynomialC0>(constraintValue, dimensions, CompactPolynomialC0(supportRadius),
-                                                          xDead, yDead, zDead, solverRtol, polynomial, preallocation) );
-    }
-    else if (type == VALUE_RBF_CPOLYNOMIAL_C6){
-      configuredMapping.mapping = PtrMapping (
-        new PetRadialBasisFctMapping<CompactPolynomialC6>(constraintValue, dimensions, CompactPolynomialC6(supportRadius),
-                                                          xDead, yDead, zDead, solverRtol, polynomial, preallocation) );
-    }
-    else {
+          new RadialBasisFctMapping<CompactThinPlateSplinesC2>(
+              constraintValue, dimensions, CompactThinPlateSplinesC2(supportRadius), xDead, yDead, zDead));
+    } else if (type == VALUE_RBF_CPOLYNOMIAL_C0) {
+      configuredMapping.mapping = PtrMapping(
+          new RadialBasisFctMapping<CompactPolynomialC0>(
+              constraintValue, dimensions, CompactPolynomialC0(supportRadius), xDead, yDead, zDead));
+    } else if (type == VALUE_RBF_CPOLYNOMIAL_C6) {
+      configuredMapping.mapping = PtrMapping(
+          new RadialBasisFctMapping<CompactPolynomialC6>(
+              constraintValue, dimensions, CompactPolynomialC6(supportRadius), xDead, yDead, zDead));
+    } else {
       PRECICE_ERROR("Unknown mapping type!");
     }
   }
 
-  #endif
+#ifndef PRECICE_NO_PETSC
+
+  if (createPetRBF) {
+    if (type == VALUE_RBF_TPS) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<ThinPlateSplines>(constraintValue, dimensions, ThinPlateSplines(),
+                                                         xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else if (type == VALUE_RBF_MULTIQUADRICS) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<Multiquadrics>(constraintValue, dimensions, Multiquadrics(shapeParameter),
+                                                      xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else if (type == VALUE_RBF_INV_MULTIQUADRICS) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<InverseMultiquadrics>(constraintValue, dimensions, InverseMultiquadrics(shapeParameter),
+                                                             xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else if (type == VALUE_RBF_VOLUME_SPLINES) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<VolumeSplines>(constraintValue, dimensions, VolumeSplines(),
+                                                      xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else if (type == VALUE_RBF_GAUSSIAN) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<Gaussian>(constraintValue, dimensions, Gaussian(shapeParameter),
+                                                 xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else if (type == VALUE_RBF_CTPS_C2) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<CompactThinPlateSplinesC2>(constraintValue, dimensions, CompactThinPlateSplinesC2(supportRadius),
+                                                                  xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else if (type == VALUE_RBF_CPOLYNOMIAL_C0) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<CompactPolynomialC0>(constraintValue, dimensions, CompactPolynomialC0(supportRadius),
+                                                            xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else if (type == VALUE_RBF_CPOLYNOMIAL_C6) {
+      configuredMapping.mapping = PtrMapping(
+          new PetRadialBasisFctMapping<CompactPolynomialC6>(constraintValue, dimensions, CompactPolynomialC6(supportRadius),
+                                                            xDead, yDead, zDead, solverRtol, polynomial, preallocation));
+    } else {
+      PRECICE_ERROR("Unknown mapping type!");
+    }
+  }
+
+#endif
 
   PRECICE_ASSERT(configuredMapping.mapping);
   return configuredMapping;
 }
 
-void MappingConfiguration:: checkDuplicates(const ConfiguredMapping & mapping)
+void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
 {
-  for ( const ConfiguredMapping & configuredMapping : _mappings ) {
+  for (const ConfiguredMapping &configuredMapping : _mappings) {
     bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
-    bool sameToMesh = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
-    PRECICE_CHECK( !sameFromMesh, "There cannot be two mappings from mesh \""
-           << mapping.fromMesh->getName() << "\"" );
-    PRECICE_CHECK( !sameToMesh, "There cannot be two mappings to mesh \""
-           << mapping.toMesh->getName() << "\"" );
+    bool sameToMesh   = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
+    PRECICE_CHECK(!sameFromMesh, "There cannot be two mappings from mesh \""
+                                     << mapping.fromMesh->getName() << "\"");
+    PRECICE_CHECK(!sameToMesh, "There cannot be two mappings to mesh \""
+                                   << mapping.toMesh->getName() << "\"");
   }
 }
 
-MappingConfiguration::Timing MappingConfiguration:: getTiming(const std::string& timing ) const
+MappingConfiguration::Timing MappingConfiguration::getTiming(const std::string &timing) const
 {
-  if (timing == VALUE_TIMING_INITIAL){
+  if (timing == VALUE_TIMING_INITIAL) {
     return INITIAL;
-  }
-  else if (timing == VALUE_TIMING_ON_ADVANCE){
+  } else if (timing == VALUE_TIMING_ON_ADVANCE) {
     return ON_ADVANCE;
-  }
-  else if (timing == VALUE_TIMING_ON_DEMAND){
+  } else if (timing == VALUE_TIMING_ON_DEMAND) {
     return ON_DEMAND;
   }
   PRECICE_ERROR("Unknown timing value \"" << timing << "\"!");
 }
 
-
-}} // namespace precice, mapping
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "mapping/SharedPointer.hpp"
-#include "mesh/SharedPointer.hpp"
-#include "logging/Logger.hpp"
-#include "xml/XMLTag.hpp"
 #include <string>
 #include <vector>
+#include "logging/Logger.hpp"
+#include "mapping/SharedPointer.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "xml/XMLTag.hpp"
 
 namespace precice {
 namespace mapping {
@@ -30,29 +30,23 @@ enum class Preallocation {
   TREE
 };
 
-
 /// Performs XML configuration and holds configured mappings.
-class MappingConfiguration : public xml::XMLTag::Listener
-{
+class MappingConfiguration : public xml::XMLTag::Listener {
 public:
-
   /// Constants defining the direction of a mapping.
-  enum Direction
-  {
+  enum Direction {
     WRITE,
     READ
   };
 
-  enum Timing
-  {
+  enum Timing {
     INITIAL,
     ON_ADVANCE,
     ON_DEMAND
   };
 
   /// Configuration data for one mapping.
-  struct ConfiguredMapping
-  {
+  struct ConfiguredMapping {
     /// Mapping object.
     PtrMapping mapping;
     /// Remote mesh to map from
@@ -67,9 +61,9 @@ public:
     bool isRBF;
   };
 
-  MappingConfiguration (
-    xml::XMLTag&                    parent,
-    const mesh::PtrMeshConfiguration& meshConfiguration );
+  MappingConfiguration(
+      xml::XMLTag &                     parent,
+      const mesh::PtrMeshConfiguration &meshConfiguration);
 
   /**
    * @brief Callback function required for use of automatic configuration.
@@ -77,8 +71,8 @@ public:
    * @return True, if successful.
    */
   virtual void xmlTagCallback(
-          const xml::ConfigurationContext& context,
-          xml::XMLTag& callingTag);
+      const xml::ConfigurationContext &context,
+      xml::XMLTag &                    callingTag);
 
   /**
    * @brief Callback function required for use of automatic configuration.
@@ -86,79 +80,82 @@ public:
    * @return True, if successful.
    */
   virtual void xmlEndTagCallback(
-          const xml::ConfigurationContext& context,
-          xml::XMLTag& callingTag);
+      const xml::ConfigurationContext &context,
+      xml::XMLTag &                    callingTag);
 
   /// Returns all configured mappings.
-  const std::vector<ConfiguredMapping>& mappings();
+  const std::vector<ConfiguredMapping> &mappings();
 
-  void resetMappings() { _mappings.clear(); }
+  void resetMappings()
+  {
+    _mappings.clear();
+  }
 
 private:
-
   mutable logging::Logger _log{"config:MappingConfiguration"};
 
   const std::string TAG = "mapping";
 
-  const std::string ATTR_DIRECTION = "direction";
-  const std::string ATTR_FROM = "from";
-  const std::string ATTR_TO = "to";
-  const std::string ATTR_TIMING = "timing";
-  const std::string ATTR_TYPE = "type";
-  const std::string ATTR_CONSTRAINT = "constraint";
-  const std::string ATTR_SHAPE_PARAM = "shape-parameter";
+  const std::string ATTR_DIRECTION      = "direction";
+  const std::string ATTR_FROM           = "from";
+  const std::string ATTR_TO             = "to";
+  const std::string ATTR_TIMING         = "timing";
+  const std::string ATTR_TYPE           = "type";
+  const std::string ATTR_CONSTRAINT     = "constraint";
+  const std::string ATTR_SHAPE_PARAM    = "shape-parameter";
   const std::string ATTR_SUPPORT_RADIUS = "support-radius";
-  const std::string ATTR_SOLVER_RTOL = "solver-rtol";
-  const std::string ATTR_X_DEAD = "x-dead";
-  const std::string ATTR_Y_DEAD = "y-dead";
-  const std::string ATTR_Z_DEAD = "z-dead";
-  const std::string ATTR_USE_LU = "use-lu-decomposition";
+  const std::string ATTR_SOLVER_RTOL    = "solver-rtol";
+  const std::string ATTR_X_DEAD         = "x-dead";
+  const std::string ATTR_Y_DEAD         = "y-dead";
+  const std::string ATTR_Z_DEAD         = "z-dead";
+  const std::string ATTR_USE_LU         = "use-lu-decomposition";
 
-  const std::string VALUE_WRITE = "write";
-  const std::string VALUE_READ = "read";
-  const std::string VALUE_CONSISTENT = "consistent";
+  const std::string VALUE_WRITE        = "write";
+  const std::string VALUE_READ         = "read";
+  const std::string VALUE_CONSISTENT   = "consistent";
   const std::string VALUE_CONSERVATIVE = "conservative";
 
-  const std::string VALUE_NEAREST_NEIGHBOR = "nearest-neighbor";
-  const std::string VALUE_NEAREST_PROJECTION = "nearest-projection";
-  const std::string VALUE_RBF_TPS = "rbf-thin-plate-splines";
-  const std::string VALUE_RBF_MULTIQUADRICS = "rbf-multiquadrics";
+  const std::string VALUE_NEAREST_NEIGHBOR      = "nearest-neighbor";
+  const std::string VALUE_NEAREST_PROJECTION    = "nearest-projection";
+  const std::string VALUE_RBF_TPS               = "rbf-thin-plate-splines";
+  const std::string VALUE_RBF_MULTIQUADRICS     = "rbf-multiquadrics";
   const std::string VALUE_RBF_INV_MULTIQUADRICS = "rbf-inverse-multiquadrics";
-  const std::string VALUE_RBF_VOLUME_SPLINES = "rbf-volume-splines";
-  const std::string VALUE_RBF_GAUSSIAN = "rbf-gaussian";
-  const std::string VALUE_RBF_CTPS_C2 = "rbf-compact-tps-c2";
-  const std::string VALUE_RBF_CPOLYNOMIAL_C0 = "rbf-compact-polynomial-c0";
-  const std::string VALUE_RBF_CPOLYNOMIAL_C6 = "rbf-compact-polynomial-c6";
+  const std::string VALUE_RBF_VOLUME_SPLINES    = "rbf-volume-splines";
+  const std::string VALUE_RBF_GAUSSIAN          = "rbf-gaussian";
+  const std::string VALUE_RBF_CTPS_C2           = "rbf-compact-tps-c2";
+  const std::string VALUE_RBF_CPOLYNOMIAL_C0    = "rbf-compact-polynomial-c0";
+  const std::string VALUE_RBF_CPOLYNOMIAL_C6    = "rbf-compact-polynomial-c6";
 
-  const std::string VALUE_TIMING_INITIAL = "initial";
+  const std::string VALUE_TIMING_INITIAL    = "initial";
   const std::string VALUE_TIMING_ON_ADVANCE = "onadvance";
-  const std::string VALUE_TIMING_ON_DEMAND = "ondemand";
+  const std::string VALUE_TIMING_ON_DEMAND  = "ondemand";
 
   mesh::PtrMeshConfiguration _meshConfig;
 
   std::vector<ConfiguredMapping> _mappings;
 
-  ConfiguredMapping createMapping (
-    const xml::ConfigurationContext& context,
-    const std::string& direction,
-    const std::string& type,
-    const std::string& constraint,
-    const std::string& fromMeshName,
-    const std::string& toMeshName,
-    Timing             timing,
-    double             shapeParameter,
-    double             supportRadius,
-    double             solverRtol,
-    bool               xDead,
-    bool               yDead,
-    bool               zDead,
-    bool               useLU,
-    Polynomial         polynomial,
-    Preallocation      preallocation) const;
+  ConfiguredMapping createMapping(
+      const xml::ConfigurationContext &context,
+      const std::string &              direction,
+      const std::string &              type,
+      const std::string &              constraint,
+      const std::string &              fromMeshName,
+      const std::string &              toMeshName,
+      Timing                           timing,
+      double                           shapeParameter,
+      double                           supportRadius,
+      double                           solverRtol,
+      bool                             xDead,
+      bool                             yDead,
+      bool                             zDead,
+      bool                             useLU,
+      Polynomial                       polynomial,
+      Preallocation                    preallocation) const;
 
-  void checkDuplicates ( const ConfiguredMapping& mapping );
+  void checkDuplicates(const ConfiguredMapping &mapping);
 
-  Timing getTiming(const std::string& timing) const;
+  Timing getTiming(const std::string &timing) const;
 };
 
-}} // namespace mapping, config
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -3,10 +3,8 @@
 #include "logging/Logger.hpp"
 #include "math/math.hpp"
 
-namespace precice
-{
-namespace mapping
-{
+namespace precice {
+namespace mapping {
 
 /**
  * @brief Radial basis function with global support.
@@ -15,8 +13,7 @@ namespace mapping
  *
  * Evaluates to: radius^2 * log(radius).
  */
-class ThinPlateSplines
-{
+class ThinPlateSplines {
 public:
   bool hasCompactSupport() const
   {
@@ -45,8 +42,7 @@ public:
  *
  * Evaluates to: sqrt(shape^2 + radius^2).
  */
-class Multiquadrics
-{
+class Multiquadrics {
 public:
   explicit Multiquadrics(double c)
       : _cPow2(std::pow(c, 2)) {}
@@ -78,14 +74,13 @@ private:
  *
  * Evaluates to: 1 / (shape^2 + radius^2).
  */
-class InverseMultiquadrics
-{
+class InverseMultiquadrics {
 public:
   explicit InverseMultiquadrics(double c)
       : _cPow2(std::pow(c, 2))
   {
     PRECICE_CHECK(math::greater(c, 0.0),
-          "Shape parameter for radial-basis-function inverse multiquadric has to be larger than zero!");
+                  "Shape parameter for radial-basis-function inverse multiquadric has to be larger than zero!");
   }
 
   bool hasCompactSupport() const
@@ -116,8 +111,7 @@ private:
  *
  * Evaluates to: radius.
  */
-class VolumeSplines
-{
+class VolumeSplines {
 public:
   bool hasCompactSupport() const
   {
@@ -143,18 +137,17 @@ public:
  *
  * Evaluates to: exp(-1 * (shape * radius)^2).
  */
-class Gaussian
-{
+class Gaussian {
 public:
   Gaussian(const double shape, const double supportRadius = std::numeric_limits<double>::infinity())
       : _shape(shape),
         _supportRadius(supportRadius)
   {
     PRECICE_CHECK(math::greater(_shape, 0.0),
-          "Shape parameter for radial-basis-function gaussian has to be larger than zero!");
+                  "Shape parameter for radial-basis-function gaussian has to be larger than zero!");
     PRECICE_CHECK(math::greater(_supportRadius, 0.0),
-          "Support radius for radial-basis-function gaussian has to be larger than zero!");
-    
+                  "Support radius for radial-basis-function gaussian has to be larger than zero!");
+
     _deltaY          = hasCompactSupport() ? evaluate(supportRadius) : 0;
     double threshold = std::sqrt(-std::log(cutoffThreshold)) / shape;
     _supportRadius   = std::min(supportRadius, threshold);
@@ -204,14 +197,13 @@ private:
  * where rn is the radius r normalized over the support radius sr: rn = r/sr.
  * To work around the issue of log(0), the equation is formulated differently in the last term.
  */
-class CompactThinPlateSplinesC2
-{
+class CompactThinPlateSplinesC2 {
 public:
   explicit CompactThinPlateSplinesC2(double supportRadius)
       : _r(supportRadius)
   {
     PRECICE_CHECK(math::greater(_r, 0.0),
-          "Support radius for radial-basis-function compact thin-plate-splines c2 has to be larger than zero!");
+                  "Support radius for radial-basis-function compact thin-plate-splines c2 has to be larger than zero!");
   }
 
   bool hasCompactSupport() const
@@ -250,14 +242,13 @@ private:
  * Evaluates to: (1 - rn)^2,
  * where rn is the radius r normalized over the support radius sr: rn = r/sr.
  */
-class CompactPolynomialC0
-{
+class CompactPolynomialC0 {
 public:
   explicit CompactPolynomialC0(double supportRadius)
       : _r(supportRadius)
   {
     PRECICE_CHECK(math::greater(_r, 0.0),
-          "Support radius for radial-basis-function compact polynomial c0 has to be larger than zero!");
+                  "Support radius for radial-basis-function compact polynomial c0 has to be larger than zero!");
   }
 
   bool hasCompactSupport() const
@@ -293,14 +284,13 @@ private:
  * Evaluates to: (1 - rn)^8 * (32*rn^3 + 25*rn^2 + 8*rn + 1),
  * where rn is the radius r normalized over the support radius sr: rn = r/sr.
  */
-class CompactPolynomialC6
-{
+class CompactPolynomialC6 {
 public:
   explicit CompactPolynomialC6(double supportRadius)
       : _r(supportRadius)
   {
     PRECICE_CHECK(math::greater(_r, 0.0),
-          "Support radius for radial-basis-function compact polynomial c6 has to be larger than zero!");
+                  "Support radius for radial-basis-function compact polynomial c6 has to be larger than zero!");
   }
 
   bool hasCompactSupport() const

--- a/src/mapping/tests/MappingConfigurationTest.cpp
+++ b/src/mapping/tests/MappingConfigurationTest.cpp
@@ -1,8 +1,8 @@
-#include "testing/Testing.hpp"
+#include "mapping/Mapping.hpp"
+#include "mapping/config/MappingConfiguration.hpp"
 #include "mesh/config/DataConfiguration.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
-#include "mapping/config/MappingConfiguration.hpp"
-#include "mapping/Mapping.hpp"
+#include "testing/Testing.hpp"
 #include "xml/XMLTag.hpp"
 
 using namespace precice;
@@ -13,18 +13,18 @@ BOOST_AUTO_TEST_SUITE(Configuration, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Configuration)
 {
-  
+
   std::string pathToTests = testing::getPathToSources() + "/mapping/tests/";
   std::string file(pathToTests + "mapping-config.xml");
   using xml::XMLTag;
-  XMLTag tag = xml::getRootTag();
-  mesh::PtrDataConfiguration dataConfig( new mesh::DataConfiguration(tag) );
+  XMLTag                     tag = xml::getRootTag();
+  mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(tag));
   dataConfig->setDimensions(3);
   mesh::PtrMeshConfiguration meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
   meshConfig->setDimensions(3);
   mapping::MappingConfiguration mappingConfig(tag, meshConfig);
   xml::configure(tag, xml::ConfigurationContext{}, file);
-    
+
   BOOST_TEST(meshConfig->meshes().size() == 3);
   BOOST_TEST(mappingConfig.mappings().size() == 3);
   BOOST_TEST(mappingConfig.mappings()[0].timing == MappingConfiguration::ON_DEMAND);

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -1,10 +1,10 @@
 #include "testing/Testing.hpp"
 
 #include "mapping/NearestNeighborMapping.hpp"
+#include "math/math.hpp"
+#include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
-#include "mesh/Data.hpp"
-#include "math/math.hpp"
 
 using namespace precice;
 using namespace precice::mesh;
@@ -19,26 +19,26 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
-  PtrData inDataScalar = inMesh->createData("InDataScalar", 1);
-  PtrData inDataVector = inMesh->createData("InDataVector", 2);
-  int inDataScalarID = inDataScalar->getID();
-  int inDataVectorID = inDataVector->getID();
-  Vertex& inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
-  Vertex& inVertex1 = inMesh->createVertex(Eigen::Vector2d::Constant(1.0));
+  PtrData inDataScalar   = inMesh->createData("InDataScalar", 1);
+  PtrData inDataVector   = inMesh->createData("InDataVector", 2);
+  int     inDataScalarID = inDataScalar->getID();
+  int     inDataVectorID = inDataVector->getID();
+  Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
+  Vertex &inVertex1      = inMesh->createVertex(Eigen::Vector2d::Constant(1.0));
   inMesh->allocateDataValues();
-  Eigen::VectorXd& inValuesScalar = inDataScalar->values();
-  Eigen::VectorXd& inValuesVector = inDataVector->values();
+  Eigen::VectorXd &inValuesScalar = inDataScalar->values();
+  Eigen::VectorXd &inValuesVector = inDataVector->values();
   inValuesScalar << 1.0, 2.0;
   inValuesVector << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
-  PtrData outDataScalar = outMesh->createData("OutDataScalar", 1);
-  PtrData outDataVector = outMesh->createData("OutDataVector", 2);
-  int outDataScalarID = outDataScalar->getID();
-  int outDataVectorID = outDataVector->getID();
-  Vertex& outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
-  Vertex& outVertex1 = outMesh->createVertex(Eigen::Vector2d::Constant(1.0));
+  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1);
+  PtrData outDataVector   = outMesh->createData("OutDataVector", 2);
+  int     outDataScalarID = outDataScalar->getID();
+  int     outDataVectorID = outDataVector->getID();
+  Vertex &outVertex0      = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
+  Vertex &outVertex1      = outMesh->createVertex(Eigen::Vector2d::Constant(1.0));
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used
@@ -49,14 +49,14 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   // Map data with coinciding vertices, has to result in equal values.
   mapping.computeMapping();
   mapping.map(inDataScalarID, outDataScalarID);
-  const Eigen::VectorXd& outValuesScalar = outDataScalar->values();
+  const Eigen::VectorXd &outValuesScalar = outDataScalar->values();
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(outValuesScalar(0) == inValuesScalar(0));
   BOOST_TEST(outValuesScalar(1) == inValuesScalar(1));
   mapping.map(inDataVectorID, outDataVectorID);
-  const Eigen::VectorXd& outValuesVector = outDataVector->values();
+  const Eigen::VectorXd &outValuesVector = outDataVector->values();
   BOOST_CHECK(equals(inValuesVector, outValuesVector));
-              
+
   // Map data with almost coinciding vertices, has to result in equal values.
   inVertex0.setCoords(outVertex0.getCoords() + Eigen::Vector2d::Constant(0.1));
   inVertex1.setCoords(outVertex1.getCoords() + Eigen::Vector2d::Constant(0.1));
@@ -98,21 +98,21 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
-  PtrData inData = inMesh->createData("InData", 1);
-  int inDataID = inData->getID();
-  Vertex& inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
-  Vertex& inVertex1 = inMesh->createVertex(Eigen::Vector2d::Constant(1.0));
+  PtrData inData    = inMesh->createData("InData", 1);
+  int     inDataID  = inData->getID();
+  Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
+  Vertex &inVertex1 = inMesh->createVertex(Eigen::Vector2d::Constant(1.0));
   inMesh->allocateDataValues();
-  Eigen::VectorXd& inValues = inData->values();
-  inValues(0) = 1.0;
-  inValues(1) = 2.0;
+  Eigen::VectorXd &inValues = inData->values();
+  inValues(0)               = 1.0;
+  inValues(1)               = 2.0;
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
-  int outDataID = outData->getID();
-  Vertex& outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
-  Vertex& outVertex1 = outMesh->createVertex(Eigen::Vector2d::Constant(1.0));
+  PtrData outData    = outMesh->createData("OutData", 1);
+  int     outDataID  = outData->getID();
+  Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
+  Vertex &outVertex1 = outMesh->createVertex(Eigen::Vector2d::Constant(1.0));
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   // Map data with coinciding vertices, has to result in equal values.
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  Eigen::VectorXd& outValues = outData->values();
+  Eigen::VectorXd &outValues = outData->values();
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(outValues(0) == inValues(0));
   BOOST_TEST(outValues(1) == inValues(1));

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -1,27 +1,27 @@
 #include "testing/Testing.hpp"
 
 #include "mapping/NearestProjectionMapping.hpp"
+#include "mesh/Edge.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
-#include "mesh/Edge.hpp"
 
 using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(MappingTests)
 BOOST_AUTO_TEST_SUITE(NearestProjectionMapping, *testing::OnMaster())
 
-BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)                
+BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
 {
   using namespace mesh;
   int dimensions = 2;
 
   // Setup geometry to map to
-  PtrMesh outMesh ( new Mesh("OutMesh", dimensions, true, testing::nextMeshID()) );
-  PtrData outData = outMesh->createData ( "Data", 1 );
-  int outDataID = outData->getID();
-  Vertex& v1 = outMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
-  Vertex& v2 = outMesh->createVertex ( Eigen::Vector2d(1.0, 1.0) );
-  outMesh->createEdge ( v1, v2 );
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, true, testing::nextMeshID()));
+  PtrData outData   = outMesh->createData("Data", 1);
+  int     outDataID = outData->getID();
+  Vertex &v1        = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &v2        = outMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  outMesh->createEdge(v1, v2);
   outMesh->computeState();
   outMesh->allocateDataValues();
 
@@ -29,76 +29,79 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   double value = 1.0;
 
   {
-      // Setup mapping with mapping coordinates and geometry used
-      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-      PtrMesh inMesh ( new Mesh("InMesh0", dimensions, false, testing::nextMeshID()) );
-      PtrData inData = inMesh->createData ( "Data0", 1 );
-      int inDataID = inData->getID();
+    // Setup mapping with mapping coordinates and geometry used
+    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
+    PtrMesh                           inMesh(new Mesh("InMesh0", dimensions, false, testing::nextMeshID()));
+    PtrData                           inData   = inMesh->createData("Data0", 1);
+    int                               inDataID = inData->getID();
 
-      // Map value 1.0 from middle of edge to geometry. Expect half of the
-      // value to be added to vertex1 and half of it to vertex2.
-      inMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
-      // Map value 1.0 from below edge to geometry. Expect vertex1 to get the
-      // full data value, i.e. 1.0 and in addition the value from before. In total
-      // v1 should have 1.5 * dataValue then.
-      inMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
-      // Do the same thing from above, expect vertex2 to get the full value now.
-      inMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
+    // Map value 1.0 from middle of edge to geometry. Expect half of the
+    // value to be added to vertex1 and half of it to vertex2.
+    inMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
+    // Map value 1.0 from below edge to geometry. Expect vertex1 to get the
+    // full data value, i.e. 1.0 and in addition the value from before. In total
+    // v1 should have 1.5 * dataValue then.
+    inMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
+    // Do the same thing from above, expect vertex2 to get the full value now.
+    inMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
 
-      inMesh->allocateDataValues();
-      inMesh->computeState();
+    inMesh->allocateDataValues();
+    inMesh->computeState();
 
-      //assign(inData->values()) = value;
-      inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
-      //assign(values) = 0.0;
-      Eigen::VectorXd& values = outData->values();
-      values = Eigen::VectorXd::Constant(values.size(), 0.0);
+    //assign(inData->values()) = value;
+    inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
+    //assign(values) = 0.0;
+    Eigen::VectorXd &values = outData->values();
+    values                  = Eigen::VectorXd::Constant(values.size(), 0.0);
 
-      mapping.setMeshes(inMesh, outMesh);
-      mapping.computeMapping();
-      mapping.map(inDataID, outDataID);
-      BOOST_TEST_CONTEXT(*inMesh) {
-          BOOST_TEST(values(0) == value * 1.5);
-          BOOST_TEST(values(1) == value * 1.5);
-      }
+    mapping.setMeshes(inMesh, outMesh);
+    mapping.computeMapping();
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST_CONTEXT(*inMesh)
+    {
+      BOOST_TEST(values(0) == value * 1.5);
+      BOOST_TEST(values(1) == value * 1.5);
+    }
   }
   {
-      // Setup mapping with mapping coordinates and geometry used
-      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-      PtrMesh inMesh ( new Mesh("InMesh1", dimensions, false, testing::nextMeshID()) );
-      PtrData inData = inMesh->createData ( "Data1", 1 );
-      int inDataID = inData->getID();
+    // Setup mapping with mapping coordinates and geometry used
+    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
+    PtrMesh                           inMesh(new Mesh("InMesh1", dimensions, false, testing::nextMeshID()));
+    PtrData                           inData   = inMesh->createData("Data1", 1);
+    int                               inDataID = inData->getID();
 
-      inMesh->createVertex(Eigen::Vector2d(-1.0, -1.0));
-      inMesh->createVertex(Eigen::Vector2d(-1.0, -1.0));
-      inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+    inMesh->createVertex(Eigen::Vector2d(-1.0, -1.0));
+    inMesh->createVertex(Eigen::Vector2d(-1.0, -1.0));
+    inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
-      inMesh->allocateDataValues();
-      inMesh->computeState();
+    inMesh->allocateDataValues();
+    inMesh->computeState();
 
-      //assign(inData->values()) = value;
-      inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
-      //assign(values) = 0.0;
-      Eigen::VectorXd& values = outData->values();
-      values = Eigen::VectorXd::Constant(values.size(), 0.0);
+    //assign(inData->values()) = value;
+    inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
+    //assign(values) = 0.0;
+    Eigen::VectorXd &values = outData->values();
+    values                  = Eigen::VectorXd::Constant(values.size(), 0.0);
 
-      mapping.setMeshes(inMesh, outMesh);
-      mapping.computeMapping();
-      mapping.map(inDataID, outDataID);
-      BOOST_TEST_CONTEXT(*inMesh) {
-          BOOST_TEST(values(0) == value * 2.0);
-          BOOST_TEST(values(1) == value * 1.0);
-      }
+    mapping.setMeshes(inMesh, outMesh);
+    mapping.computeMapping();
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST_CONTEXT(*inMesh)
+    {
+      BOOST_TEST(values(0) == value * 2.0);
+      BOOST_TEST(values(1) == value * 1.0);
+    }
 
-      // reset output value and remap
-      //assign(values) = 0.0;
-      values = Eigen::VectorXd::Constant(values.size(), 0.0);
+    // reset output value and remap
+    //assign(values) = 0.0;
+    values = Eigen::VectorXd::Constant(values.size(), 0.0);
 
-      mapping.map(inDataID, outDataID);
-      BOOST_TEST_CONTEXT(*inMesh) {
-          BOOST_TEST(values(0) == value * 2.0);
-          BOOST_TEST(values(1) == value * 1.0);
-      }
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST_CONTEXT(*inMesh)
+    {
+      BOOST_TEST(values(0) == value * 2.0);
+      BOOST_TEST(values(1) == value * 1.0);
+    }
   }
 }
 
@@ -108,89 +111,89 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  Vertex& v1 = inMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
-  Vertex& v2 = inMesh->createVertex ( Eigen::Vector2d(1.0, 1.0) );
-  inMesh->createEdge ( v1, v2 );
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrData inData   = inMesh->createData("InData", 1);
+  int     inDataID = inData->getID();
+  Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  inMesh->createEdge(v1, v2);
   inMesh->computeState();
   inMesh->allocateDataValues();
-  double valueVertex1 = 1.0;
-  double valueVertex2 = 2.0;
-  Eigen::VectorXd& values = inData->values();
-  values(0) = valueVertex1;
-  values(1) = valueVertex2;
+  double           valueVertex1 = 1.0;
+  double           valueVertex2 = 2.0;
+  Eigen::VectorXd &values       = inData->values();
+  values(0)                     = valueVertex1;
+  values(1)                     = valueVertex2;
 
   {
-      // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh0", dimensions, false, testing::nextMeshID()) );
-      PtrData outData = outMesh->createData ( "OutData", 1 );
-      int outDataID = outData->getID();
+    // Create mesh to map to
+    PtrMesh outMesh(new Mesh("OutMesh0", dimensions, false, testing::nextMeshID()));
+    PtrData outData   = outMesh->createData("OutData", 1);
+    int     outDataID = outData->getID();
 
-      // Setup mapping with mapping coordinates and geometry used
-      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-      mapping.setMeshes ( inMesh, outMesh );
-      BOOST_TEST ( mapping.hasComputedMapping() == false );
+    // Setup mapping with mapping coordinates and geometry used
+    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+    mapping.setMeshes(inMesh, outMesh);
+    BOOST_TEST(mapping.hasComputedMapping() == false);
 
-      outMesh->createVertex ( Eigen::Vector2d(0.5, 0.5) );
-      outMesh->createVertex ( Eigen::Vector2d(-0.5, -0.5) );
-      outMesh->createVertex ( Eigen::Vector2d(1.5, 1.5) );
-      outMesh->allocateDataValues();
+    outMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
+    outMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
+    outMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
+    outMesh->allocateDataValues();
 
-      // Compute and perform mapping
-      mapping.computeMapping();
-      mapping.map ( inDataID, outDataID );
+    // Compute and perform mapping
+    mapping.computeMapping();
+    mapping.map(inDataID, outDataID);
 
-      // Validate results
-      BOOST_TEST ( mapping.hasComputedMapping() == true );
-      BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-      BOOST_TEST ( outData->values()[1] == valueVertex1);
-      BOOST_TEST ( outData->values()[2] == valueVertex2);
+    // Validate results
+    BOOST_TEST(mapping.hasComputedMapping() == true);
+    BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()[1] == valueVertex1);
+    BOOST_TEST(outData->values()[2] == valueVertex2);
 
-      // Redo mapping, results should be
-      //assign(outData->values()) = 0.0;
-      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+    // Redo mapping, results should be
+    //assign(outData->values()) = 0.0;
+    outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-      mapping.map ( inDataID, outDataID );
-      BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-      BOOST_TEST ( outData->values()[1] == valueVertex1);
-      BOOST_TEST ( outData->values()[2] == valueVertex2);
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()[1] == valueVertex1);
+    BOOST_TEST(outData->values()[2] == valueVertex2);
   }
 
   {
-      // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()) );
-      PtrData outData = outMesh->createData ( "OutData", 1 );
-      int outDataID = outData->getID();
+    // Create mesh to map to
+    PtrMesh outMesh(new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()));
+    PtrData outData   = outMesh->createData("OutData", 1);
+    int     outDataID = outData->getID();
 
-      // Setup mapping with mapping coordinates and geometry used
-      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-      mapping.setMeshes ( inMesh, outMesh );
-      BOOST_TEST ( mapping.hasComputedMapping() == false );
+    // Setup mapping with mapping coordinates and geometry used
+    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+    mapping.setMeshes(inMesh, outMesh);
+    BOOST_TEST(mapping.hasComputedMapping() == false);
 
-      outMesh->createVertex ( Eigen::Vector2d(-0.5, -0.5) );
-      outMesh->createVertex ( Eigen::Vector2d(1.5, 1.5) );
-      outMesh->createVertex ( Eigen::Vector2d(0.5, 0.5) );
-      outMesh->allocateDataValues();
+    outMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
+    outMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
+    outMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
+    outMesh->allocateDataValues();
 
-      //assign(outData->values()) = 0.0;
-      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+    //assign(outData->values()) = 0.0;
+    outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-      mapping.computeMapping();
-      mapping.map ( inDataID, outDataID );
-      BOOST_TEST ( outData->values()[0] == valueVertex1);
-      BOOST_TEST ( outData->values()[1] == valueVertex2);
-      BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+    mapping.computeMapping();
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST(outData->values()[0] == valueVertex1);
+    BOOST_TEST(outData->values()[1] == valueVertex2);
+    BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
 
-      // Reset output data to zero and redo the mapping
-      //assign(outData->values()) = 0.0;
-      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+    // Reset output data to zero and redo the mapping
+    //assign(outData->values()) = 0.0;
+    outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-      mapping.map ( inDataID, outDataID );
-      BOOST_TEST ( outData->values()[0] == valueVertex1);
-      BOOST_TEST ( outData->values()[1] == valueVertex2);
-      BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST(outData->values()[0] == valueVertex1);
+    BOOST_TEST(outData->values()[1] == valueVertex2);
+    BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
   }
 }
 
@@ -200,210 +203,216 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   int dimensions = 3;
 
   // Create mesh to map from
-  PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  Vertex& v1 = inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
-  Vertex& v2 = inMesh->createVertex ( Eigen::Vector3d(1.0, 1.0, 0.0) );
-  Vertex& v3 = inMesh->createVertex ( Eigen::Vector3d(2.0, 2.0, 0.0) );
-  Edge & e12 = inMesh->createEdge ( v1, v2 );
-  Edge & e23 = inMesh->createEdge ( v2, v3 );
-  Edge & e31 = inMesh->createEdge ( v3, v1 );
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrData inData   = inMesh->createData("InData", 1);
+  int     inDataID = inData->getID();
+  Vertex &v1       = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  Vertex &v2       = inMesh->createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+  Vertex &v3       = inMesh->createVertex(Eigen::Vector3d(2.0, 2.0, 0.0));
+  Edge &  e12      = inMesh->createEdge(v1, v2);
+  Edge &  e23      = inMesh->createEdge(v2, v3);
+  Edge &  e31      = inMesh->createEdge(v3, v1);
   inMesh->createTriangle(e12, e23, e31);
 
   inMesh->computeState();
   inMesh->allocateDataValues();
-  double valueVertex1 = 1.0;
-  double valueVertex2 = 2.0;
-  double valueVertex3 = 3.0;
-  Eigen::VectorXd& values = inData->values();
-  values(0) = valueVertex1;
-  values(1) = valueVertex2;
-  values(2) = valueVertex3;
+  double           valueVertex1 = 1.0;
+  double           valueVertex2 = 2.0;
+  double           valueVertex3 = 3.0;
+  Eigen::VectorXd &values       = inData->values();
+  values(0)                     = valueVertex1;
+  values(1)                     = valueVertex2;
+  values(2)                     = valueVertex3;
 
   {
-      // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()) );
-      PtrData outData = outMesh->createData ( "OutData1", 1 );
-      int outDataID = outData->getID();
+    // Create mesh to map to
+    PtrMesh outMesh(new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()));
+    PtrData outData   = outMesh->createData("OutData1", 1);
+    int     outDataID = outData->getID();
 
-      // Setup mapping with mapping coordinates and geometry used
-      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-      mapping.setMeshes ( inMesh, outMesh );
-      BOOST_TEST ( mapping.hasComputedMapping() == false );
+    // Setup mapping with mapping coordinates and geometry used
+    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+    mapping.setMeshes(inMesh, outMesh);
+    BOOST_TEST(mapping.hasComputedMapping() == false);
 
-      outMesh->createVertex ( Eigen::Vector3d(0.5, 0.5, 0.0) );
-      outMesh->createVertex ( Eigen::Vector3d(-0.5, -0.5, 0.0) );
-      outMesh->createVertex ( Eigen::Vector3d(1.5, 1.5, 0.0) );
-      outMesh->allocateDataValues();
+    outMesh->createVertex(Eigen::Vector3d(0.5, 0.5, 0.0));
+    outMesh->createVertex(Eigen::Vector3d(-0.5, -0.5, 0.0));
+    outMesh->createVertex(Eigen::Vector3d(1.5, 1.5, 0.0));
+    outMesh->allocateDataValues();
 
-      // Compute and perform mapping
-      mapping.computeMapping();
-      mapping.map ( inDataID, outDataID );
+    // Compute and perform mapping
+    mapping.computeMapping();
+    mapping.map(inDataID, outDataID);
 
-      // Validate results
-      BOOST_TEST ( mapping.hasComputedMapping() == true );
-      BOOST_TEST_CONTEXT(*inMesh) {
-          BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-          BOOST_TEST ( outData->values()[1] ==  valueVertex1 );
-          BOOST_TEST ( outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5 );
-      }
+    // Validate results
+    BOOST_TEST(mapping.hasComputedMapping() == true);
+    BOOST_TEST_CONTEXT(*inMesh)
+    {
+      BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
+      BOOST_TEST(outData->values()[1] == valueVertex1);
+      BOOST_TEST(outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5);
+    }
 
-      // Redo mapping, results should be
-      //assign(outData->values()) = 0.0;
-      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+    // Redo mapping, results should be
+    //assign(outData->values()) = 0.0;
+    outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-      mapping.map ( inDataID, outDataID );
-      BOOST_TEST_CONTEXT(*inMesh) {
-          BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-          BOOST_TEST ( outData->values()[1] ==  valueVertex1 );
-          BOOST_TEST ( outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5 );
-      }
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST_CONTEXT(*inMesh)
+    {
+      BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
+      BOOST_TEST(outData->values()[1] == valueVertex1);
+      BOOST_TEST(outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5);
+    }
   }
   {
-      // Create mesh to map to
-      PtrMesh outMesh ( new Mesh("OutMesh2", dimensions, false, testing::nextMeshID()) );
-      PtrData outData = outMesh->createData ( "OutData2", 1 );
-      int outDataID = outData->getID();
+    // Create mesh to map to
+    PtrMesh outMesh(new Mesh("OutMesh2", dimensions, false, testing::nextMeshID()));
+    PtrData outData   = outMesh->createData("OutData2", 1);
+    int     outDataID = outData->getID();
 
-      // Setup mapping with mapping coordinates and geometry used
-      mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-      mapping.setMeshes ( inMesh, outMesh );
-      BOOST_TEST ( mapping.hasComputedMapping() == false );
+    // Setup mapping with mapping coordinates and geometry used
+    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+    mapping.setMeshes(inMesh, outMesh);
+    BOOST_TEST(mapping.hasComputedMapping() == false);
 
-      outMesh->createVertex ( Eigen::Vector3d(-0.5, -0.5, 0.0) );
-      outMesh->createVertex ( Eigen::Vector3d(1.5, 1.5, 0.0) );
-      outMesh->createVertex ( Eigen::Vector3d(0.5, 0.5, 0.0) );
-      outMesh->allocateDataValues();
+    outMesh->createVertex(Eigen::Vector3d(-0.5, -0.5, 0.0));
+    outMesh->createVertex(Eigen::Vector3d(1.5, 1.5, 0.0));
+    outMesh->createVertex(Eigen::Vector3d(0.5, 0.5, 0.0));
+    outMesh->allocateDataValues();
 
-      //assign(outData->values()) = 0.0;
-      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+    //assign(outData->values()) = 0.0;
+    outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-      mapping.clear();
-      mapping.computeMapping();
-      mapping.map ( inDataID, outDataID );
-      BOOST_TEST_CONTEXT(*inMesh) {
-          BOOST_TEST ( outData->values()[0] == valueVertex1 );
-          BOOST_TEST ( outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5 );
-          BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
-      }
+    mapping.clear();
+    mapping.computeMapping();
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST_CONTEXT(*inMesh)
+    {
+      BOOST_TEST(outData->values()[0] == valueVertex1);
+      BOOST_TEST(outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5);
+      BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
+    }
 
-      // Reset output data to zero and redo the mapping
-      //assign(outData->values()) = 0.0;
-      outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+    // Reset output data to zero and redo the mapping
+    //assign(outData->values()) = 0.0;
+    outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
-      mapping.map ( inDataID, outDataID );
-      BOOST_TEST_CONTEXT(*inMesh) {
-          BOOST_TEST ( outData->values()[0] == valueVertex1 );
-          BOOST_TEST ( outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5 );
-          BOOST_TEST ( outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5 );
-      }
+    mapping.map(inDataID, outDataID);
+    BOOST_TEST_CONTEXT(*inMesh)
+    {
+      BOOST_TEST(outData->values()[0] == valueVertex1);
+      BOOST_TEST(outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5);
+      BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
+    }
   }
 }
 
 BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
 {
-    using namespace mesh;
-    int dimensions = 3;
+  using namespace mesh;
+  int dimensions = 3;
 
-    // Create mesh to map from
-    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-    PtrData inData = inMesh->createData ( "InData", 1 );
-    int inDataID = inData->getID ();
-    Vertex& v1 = inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
-    Vertex& v2 = inMesh->createVertex ( Eigen::Vector3d(0.0, 1.0, 0.0) );
-    Vertex& v3 = inMesh->createVertex ( Eigen::Vector3d(1.0, 0.0, 0.0) );
-    inMesh->createEdge ( v1, v2 );
-    inMesh->createEdge ( v2, v3 );
-    inMesh->createEdge ( v3, v1 );
+  // Create mesh to map from
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrData inData   = inMesh->createData("InData", 1);
+  int     inDataID = inData->getID();
+  Vertex &v1       = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  Vertex &v2       = inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  Vertex &v3       = inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  inMesh->createEdge(v1, v2);
+  inMesh->createEdge(v2, v3);
+  inMesh->createEdge(v3, v1);
 
-    inMesh->computeState();
-    inMesh->allocateDataValues();
-    double valueVertex1 = 1.0;
-    double valueVertex2 = 2.0;
-    double valueVertex3 = 3.0;
-    Eigen::VectorXd& values = inData->values();
-    values(0) = valueVertex1;
-    values(1) = valueVertex2;
-    values(2) = valueVertex3;
+  inMesh->computeState();
+  inMesh->allocateDataValues();
+  double           valueVertex1 = 1.0;
+  double           valueVertex2 = 2.0;
+  double           valueVertex3 = 3.0;
+  Eigen::VectorXd &values       = inData->values();
+  values(0)                     = valueVertex1;
+  values(1)                     = valueVertex2;
+  values(2)                     = valueVertex3;
 
-    // Create mesh to map to
-    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-    PtrData outData = outMesh->createData ( "OutData", 1 );
-    int outDataID = outData->getID();
+  // Create mesh to map to
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrData outData   = outMesh->createData("OutData", 1);
+  int     outDataID = outData->getID();
 
-    // Setup mapping with mapping coordinates and geometry used
-    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-    mapping.setMeshes ( inMesh, outMesh );
-    BOOST_TEST ( mapping.hasComputedMapping() == false );
+  // Setup mapping with mapping coordinates and geometry used
+  mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-    outMesh->createVertex ( Eigen::Vector3d(0.0, 0.5, 0.0) );
-    outMesh->createVertex ( Eigen::Vector3d(0.5, 0.0, 0.0) );
-    outMesh->createVertex ( Eigen::Vector3d(0.5, 0.5, 0.0) );
-    outMesh->allocateDataValues();
+  outMesh->createVertex(Eigen::Vector3d(0.0, 0.5, 0.0));
+  outMesh->createVertex(Eigen::Vector3d(0.5, 0.0, 0.0));
+  outMesh->createVertex(Eigen::Vector3d(0.5, 0.5, 0.0));
+  outMesh->allocateDataValues();
 
-    // Compute and perform mapping
-    mapping.computeMapping();
-    mapping.map ( inDataID, outDataID );
+  // Compute and perform mapping
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
 
-    // Validate results
-    BOOST_TEST ( mapping.hasComputedMapping() == true );
-    BOOST_TEST_CONTEXT(*inMesh) {
-        BOOST_TEST ( outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5 );
-        BOOST_TEST ( outData->values()[1] == (valueVertex1 + valueVertex3) * 0.5 );
-        BOOST_TEST ( outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5 );
-    }
+  // Validate results
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST_CONTEXT(*inMesh)
+  {
+    BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()[1] == (valueVertex1 + valueVertex3) * 0.5);
+    BOOST_TEST(outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
 {
-    using namespace mesh;
-    int dimensions = 3;
+  using namespace mesh;
+  int dimensions = 3;
 
-    // Create mesh to map from
-    PtrMesh inMesh ( new Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-    PtrData inData = inMesh->createData ( "InData", 1 );
-    int inDataID = inData->getID ();
-    inMesh->createVertex ( Eigen::Vector3d(0.0, 0.0, 0.0) );
-    inMesh->createVertex ( Eigen::Vector3d(0.0, 1.0, 0.0) );
-    inMesh->createVertex ( Eigen::Vector3d(1.0, 0.0, 0.0) );
+  // Create mesh to map from
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrData inData   = inMesh->createData("InData", 1);
+  int     inDataID = inData->getID();
+  inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
 
-    inMesh->computeState();
-    inMesh->allocateDataValues();
-    double valueVertex1 = 1.0;
-    double valueVertex2 = 2.0;
-    double valueVertex3 = 3.0;
-    Eigen::VectorXd& values = inData->values();
-    values(0) = valueVertex1;
-    values(1) = valueVertex2;
-    values(2) = valueVertex3;
+  inMesh->computeState();
+  inMesh->allocateDataValues();
+  double           valueVertex1 = 1.0;
+  double           valueVertex2 = 2.0;
+  double           valueVertex3 = 3.0;
+  Eigen::VectorXd &values       = inData->values();
+  values(0)                     = valueVertex1;
+  values(1)                     = valueVertex2;
+  values(2)                     = valueVertex3;
 
-    // Create mesh to map to
-    PtrMesh outMesh ( new Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-    PtrData outData = outMesh->createData ( "OutData", 1 );
-    int outDataID = outData->getID();
+  // Create mesh to map to
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrData outData   = outMesh->createData("OutData", 1);
+  int     outDataID = outData->getID();
 
-    // Setup mapping with mapping coordinates and geometry used
-    mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
-    mapping.setMeshes ( inMesh, outMesh );
-    BOOST_TEST ( mapping.hasComputedMapping() == false );
+  // Setup mapping with mapping coordinates and geometry used
+  mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-    outMesh->createVertex ( Eigen::Vector3d(0.1, 0.1, 0.0) );
-    outMesh->createVertex ( Eigen::Vector3d(0.1, 1.1, 0.0) );
-    outMesh->createVertex ( Eigen::Vector3d(0.9, 0.1, 0.0) );
-    outMesh->allocateDataValues();
+  outMesh->createVertex(Eigen::Vector3d(0.1, 0.1, 0.0));
+  outMesh->createVertex(Eigen::Vector3d(0.1, 1.1, 0.0));
+  outMesh->createVertex(Eigen::Vector3d(0.9, 0.1, 0.0));
+  outMesh->allocateDataValues();
 
-    // Compute and perform mapping
-    mapping.computeMapping();
-    mapping.map ( inDataID, outDataID );
+  // Compute and perform mapping
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
 
-    // Validate results
-    BOOST_TEST ( mapping.hasComputedMapping() == true );
-    BOOST_TEST_CONTEXT(*inMesh) {
-        BOOST_TEST ( outData->values()[0] == valueVertex1 );
-        BOOST_TEST ( outData->values()[1] == valueVertex2 );
-        BOOST_TEST ( outData->values()[2] == valueVertex3 );
-    }
+  // Validate results
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST_CONTEXT(*inMesh)
+  {
+    BOOST_TEST(outData->values()[0] == valueVertex1);
+    BOOST_TEST(outData->values()[1] == valueVertex2);
+    BOOST_TEST(outData->values()[2] == valueVertex3);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
@@ -414,16 +423,16 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   // Create mesh to map from with Triangles ABD and BDC
   PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
-  Vertex& inVA = inMesh->createVertex(Eigen::Vector3d{0,0,0});
-  Vertex& inVB = inMesh->createVertex(Eigen::Vector3d{0,1,0});
-  Vertex& inVC = inMesh->createVertex(Eigen::Vector3d{1,1,0});
-  Vertex& inVD = inMesh->createVertex(Eigen::Vector3d{1,0,0});
+  Vertex &inVA   = inMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+  Vertex &inVB   = inMesh->createVertex(Eigen::Vector3d{0, 1, 0});
+  Vertex &inVC   = inMesh->createVertex(Eigen::Vector3d{1, 1, 0});
+  Vertex &inVD   = inMesh->createVertex(Eigen::Vector3d{1, 0, 0});
 
-  Edge& inEDA = inMesh->createEdge(inVD, inVA);
-  Edge& inEAB = inMesh->createEdge(inVA, inVB);
-  Edge& inEBD = inMesh->createEdge(inVB, inVD);
-  Edge& inEDC = inMesh->createEdge(inVD, inVC);
-  Edge& inECB = inMesh->createEdge(inVC, inVB);
+  Edge &inEDA = inMesh->createEdge(inVD, inVA);
+  Edge &inEAB = inMesh->createEdge(inVA, inVB);
+  Edge &inEBD = inMesh->createEdge(inVB, inVD);
+  Edge &inEDC = inMesh->createEdge(inVD, inVC);
+  Edge &inECB = inMesh->createEdge(inVC, inVB);
 
   inMesh->createTriangle(inEAB, inEBD, inEDA);
   inMesh->createTriangle(inEBD, inEDC, inECB);
@@ -459,26 +468,26 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
-  PtrData inData = inMesh->createData("InData", 1);
-  const double z1 = 0.1;
-  const double z2 = -0.1;
-  auto& v00 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
-  auto& v01 = inMesh->createVertex(Eigen::Vector3d(0, 1, 0));
-  auto& v10 = inMesh->createVertex(Eigen::Vector3d(1, 0, z1));
-  auto& v11 = inMesh->createVertex(Eigen::Vector3d(1, 1, z1));
-  auto& v20 = inMesh->createVertex(Eigen::Vector3d(2, 0, z2));
-  auto& v21 = inMesh->createVertex(Eigen::Vector3d(2, 1, z2));
-  auto& ell = inMesh->createEdge(v00, v01);
-  auto& elt = inMesh->createEdge(v01, v11);
-  auto& elr = inMesh->createEdge(v11, v10);
-  auto& elb = inMesh->createEdge(v10, v00);
-  auto& eld = inMesh->createEdge(v00, v11);
-  auto& erl = elr;
-  auto& ert = inMesh->createEdge(v11, v21);
-  auto& err = inMesh->createEdge(v21, v20);
-  auto& erb = inMesh->createEdge(v20, v10);
-  auto& erd = inMesh->createEdge(v10, v21);
+  PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrData      inData = inMesh->createData("InData", 1);
+  const double z1     = 0.1;
+  const double z2     = -0.1;
+  auto &       v00    = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
+  auto &       v01    = inMesh->createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &       v10    = inMesh->createVertex(Eigen::Vector3d(1, 0, z1));
+  auto &       v11    = inMesh->createVertex(Eigen::Vector3d(1, 1, z1));
+  auto &       v20    = inMesh->createVertex(Eigen::Vector3d(2, 0, z2));
+  auto &       v21    = inMesh->createVertex(Eigen::Vector3d(2, 1, z2));
+  auto &       ell    = inMesh->createEdge(v00, v01);
+  auto &       elt    = inMesh->createEdge(v01, v11);
+  auto &       elr    = inMesh->createEdge(v11, v10);
+  auto &       elb    = inMesh->createEdge(v10, v00);
+  auto &       eld    = inMesh->createEdge(v00, v11);
+  auto &       erl    = elr;
+  auto &       ert    = inMesh->createEdge(v11, v21);
+  auto &       err    = inMesh->createEdge(v21, v20);
+  auto &       erb    = inMesh->createEdge(v20, v10);
+  auto &       erd    = inMesh->createEdge(v10, v21);
   inMesh->createTriangle(ell, elt, eld);
   inMesh->createTriangle(eld, elb, elr);
   inMesh->createTriangle(erl, ert, erd);
@@ -509,7 +518,6 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   BOOST_TEST_INFO("Out Data after Mapping:" << outData->values());
   BOOST_TEST(outData->values()[0] == 1.0);
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -1,12 +1,12 @@
 #ifndef PRECICE_NO_PETSC
 
 #include <Eigen/Core>
-#include "precice/impl/versions.hpp"
 #include "mapping/PetRadialBasisFctMapping.hpp"
-#include "mesh/Mesh.hpp"
-#include "mesh/Data.hpp"
-#include "mesh/Vertex.hpp"
 #include "math/math.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/Vertex.hpp"
+#include "precice/impl/versions.hpp"
 #include "testing/Testing.hpp"
 
 using namespace precice;
@@ -18,21 +18,18 @@ BOOST_AUTO_TEST_SUITE(PetRadialBasisFunctionMapping)
 
 void addGlobalIndex(mesh::PtrMesh &mesh, int offset = 0)
 {
-  for (mesh::Vertex& v : mesh->vertices()) {
+  for (mesh::Vertex &v : mesh->vertices()) {
     v.setGlobalIndex(v.getID() + offset);
   }
 }
 
-
 BOOST_AUTO_TEST_SUITE(Parallel,
-                      * testing::MinRanks(4))
-
+                      *testing::MinRanks(4))
 
 /// Holds rank, owner, position and value of a single vertex
-struct VertexSpecification
-{
-  int rank;
-  int owner;
+struct VertexSpecification {
+  int                 rank;
+  int                 owner;
   std::vector<double> position;
   std::vector<double> value;
 };
@@ -56,20 +53,20 @@ ReferenceSpecification format:
 using MeshSpecification = std::vector<VertexSpecification>;
 
 /// Contains which values are expected on which rank: rank -> vector of data.
-using ReferenceSpecification = std::vector<std::pair<int,std::vector<double>>>;
+using ReferenceSpecification = std::vector<std::pair<int, std::vector<double>>>;
 
-void getDistributedMesh(MeshSpecification const & vertices,
-                          mesh::PtrMesh& mesh,
-                          mesh::PtrData& data,
-                          int globalIndexOffset = 0)
+void getDistributedMesh(MeshSpecification const &vertices,
+                        mesh::PtrMesh &          mesh,
+                        mesh::PtrData &          data,
+                        int                      globalIndexOffset = 0)
 {
   using Par = utils::Parallel;
   Eigen::VectorXd d;
 
   int i = 0;
-  for (auto& vertex : vertices) {
+  for (auto &vertex : vertices) {
     if (vertex.rank == Par::getProcessRank() or vertex.rank == -1) {
-      if (vertex.position.size() == 3)  // 3-dimensional
+      if (vertex.position.size() == 3) // 3-dimensional
         mesh->createVertex(Eigen::Vector3d(vertex.position.data()));
       else if (vertex.position.size() == 2) // 2-dimensional
         mesh->createVertex(Eigen::Vector2d(vertex.position.data()));
@@ -79,38 +76,36 @@ void getDistributedMesh(MeshSpecification const & vertices,
       else
         mesh->vertices().back().setOwner(false);
 
-      d.conservativeResize(i+1);
+      d.conservativeResize(i + 1);
       d[i] = vertex.value[0]; // only 1-d value here for now
       i++;
     }
-
   }
   addGlobalIndex(mesh, globalIndexOffset);
   mesh->allocateDataValues();
   data->values() = d;
 }
 
-
-void testDistributed(Mapping& mapping,
-                     MeshSpecification inMeshSpec,
-                     MeshSpecification outMeshSpec,
+void testDistributed(Mapping &              mapping,
+                     MeshSpecification      inMeshSpec,
+                     MeshSpecification      outMeshSpec,
                      ReferenceSpecification referenceSpec,
-                     int inGlobalIndexOffset = 0)
+                     int                    inGlobalIndexOffset = 0)
 {
   using Par = utils::Parallel;
   BOOST_TEST(Par::getCommunicatorSize() == 4);
-  int meshDimension = inMeshSpec[0].position.size();
+  int meshDimension  = inMeshSpec[0].position.size();
   int valueDimension = inMeshSpec[0].value.size();
 
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData("InData", valueDimension);
-  int inDataID = inData->getID();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", valueDimension);
+  int           inDataID = inData->getID();
 
   getDistributedMesh(inMeshSpec, inMesh, inData, inGlobalIndexOffset);
 
-  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData( "OutData", valueDimension );
-  int outDataID = outData->getID();
+  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", valueDimension);
+  int           outDataID = outData->getID();
 
   getDistributedMesh(outMeshSpec, outMesh, outData);
 
@@ -122,9 +117,9 @@ void testDistributed(Mapping& mapping,
   mapping.map(inDataID, outDataID);
 
   int index = 0;
-  for (auto& referenceVertex : referenceSpec) {
+  for (auto &referenceVertex : referenceSpec) {
     if (referenceVertex.first == Par::getProcessRank() or referenceVertex.first == -1) {
-      for (auto& point : referenceVertex.second) {
+      for (auto &point : referenceVertex.second) {
         // only 1-d here for now
         BOOST_TEST_INFO("index of vertex is " << index);
         BOOST_TEST(outData->values()[index] == point);
@@ -135,523 +130,659 @@ void testDistributed(Mapping& mapping,
   BOOST_TEST(outData->values().size() == index);
 }
 
-
 /// Test with a homogenous distribution of mesh amoung ranks
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV1)
 {
-  utils::Parallel::setGlobalCommunicator(utils::Parallel::getRestrictedCommunicator({0,1,2,3}));
+  utils::Parallel::setGlobalCommunicator(utils::Parallel::getRestrictedCommunicator({0, 1, 2, 3}));
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
-  Gaussian fct(5.0);
+  Gaussian                           fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
-  MPI_Comm comm = utils::Parallel::getRestrictedCommunicator( {0, 1, 2, 3} );
+  MPI_Comm comm = utils::Parallel::getRestrictedCommunicator({0, 1, 2, 3});
   utils::Parallel::setGlobalCommunicator(comm);
 
   testDistributed(mapping,
-                  { // Consistent mapping: The inMesh is communicated
-                    {-1, 0, {0, 0}, {1}},
-                    {-1, 0, {0, 1}, {2}},
-                    {-1, 1, {1, 0}, {3}},
-                    {-1, 1, {1, 1}, {4}},
-                    {-1, 2, {2, 0}, {5}},
-                    {-1, 2, {2, 1}, {6}},
-                    {-1, 3, {3, 0}, {7}},
-                    {-1, 3, {3, 1}, {8}}
-                  },
-                  { // The outMesh is local, distributed amoung all ranks
-                    {0, -1, {0, 0}, {0}},
-                    {0, -1, {0, 1}, {0}},
-                    {1, -1, {1, 0}, {0}},
-                    {1, -1, {1, 1}, {0}},
-                    {2, -1, {2, 0}, {0}},
-                    {2, -1, {2, 1}, {0}},
-                    {3, -1, {3, 0}, {0}},
-                    {3, -1, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 1} on the first rank, {1, 2} on the second, ...
-                    { 0, {1} },
-                    { 0, {2} },
-                    { 1, {3} },
-                    { 1, {4} },
-                    { 2, {5} },
-                    { 2, {6} },
-                    { 3, {7} },
-                    { 3, {8} }
-                  }
-    );
+                  {// Consistent mapping: The inMesh is communicated
+                   {-1, 0, {0, 0}, {1}},
+                   {-1, 0, {0, 1}, {2}},
+                   {-1, 1, {1, 0}, {3}},
+                   {-1, 1, {1, 1}, {4}},
+                   {-1, 2, {2, 0}, {5}},
+                   {-1, 2, {2, 1}, {6}},
+                   {-1, 3, {3, 0}, {7}},
+                   {-1, 3, {3, 1}, {8}}},
+                  {// The outMesh is local, distributed amoung all ranks
+                   {0, -1, {0, 0}, {0}},
+                   {0, -1, {0, 1}, {0}},
+                   {1, -1, {1, 0}, {0}},
+                   {1, -1, {1, 1}, {0}},
+                   {2, -1, {2, 0}, {0}},
+                   {2, -1, {2, 1}, {0}},
+                   {3, -1, {3, 0}, {0}},
+                   {3, -1, {3, 1}, {0}}},
+                  {// Tests for {0, 1} on the first rank, {1, 2} on the second, ...
+                   {0, {1}},
+                   {0, {2}},
+                   {1, {3}},
+                   {1, {4}},
+                   {2, {5}},
+                   {2, {6}},
+                   {3, {7}},
+                   {3, {8}}});
 }
 
 /// Using a more heterogenous distributon of vertices and owner
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV2)
 {
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
-  Gaussian fct(5.0);
+  Gaussian                           fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
   testDistributed(mapping,
-                  { // Consistent mapping: The inMesh is communicated, rank 2 owns no vertices
-                    {-1, 0, {0, 0}, {1}},
-                    {-1, 0, {0, 1}, {2}},
-                    {-1, 1, {1, 0}, {3}},
-                    {-1, 1, {1, 1}, {4}},
-                    {-1, 1, {2, 0}, {5}},
-                    {-1, 3, {2, 1}, {6}},
-                    {-1, 3, {3, 0}, {7}},
-                    {-1, 3, {3, 1}, {8}}
-                  },
-                  { // The outMesh is local, rank 1 is empty
-                    {0, -1, {0, 0}, {0}},
-                    {0, -1, {0, 1}, {0}},
-                    {0, -1, {1, 0}, {0}},
-                    {2, -1, {1, 1}, {0}},
-                    {2, -1, {2, 0}, {0}},
-                    {2, -1, {2, 1}, {0}},
-                    {3, -1, {3, 0}, {0}},
-                    {3, -1, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 1, 2} on the first rank,
-                    // second rank (consistent with the outMesh) is empty, ...
-                    { 0, {1} },
-                    { 0, {2} },
-                    { 0, {3} },
-                    { 2, {4} },
-                    { 2, {5} },
-                    { 2, {6} },
-                    { 3, {7} },
-                    { 3, {8} }
-                  }
-    );
+                  {// Consistent mapping: The inMesh is communicated, rank 2 owns no vertices
+                   {-1, 0, {0, 0}, {1}},
+                   {-1, 0, {0, 1}, {2}},
+                   {-1, 1, {1, 0}, {3}},
+                   {-1, 1, {1, 1}, {4}},
+                   {-1, 1, {2, 0}, {5}},
+                   {-1, 3, {2, 1}, {6}},
+                   {-1, 3, {3, 0}, {7}},
+                   {-1, 3, {3, 1}, {8}}},
+                  {// The outMesh is local, rank 1 is empty
+                   {0, -1, {0, 0}, {0}},
+                   {0, -1, {0, 1}, {0}},
+                   {0, -1, {1, 0}, {0}},
+                   {2, -1, {1, 1}, {0}},
+                   {2, -1, {2, 0}, {0}},
+                   {2, -1, {2, 1}, {0}},
+                   {3, -1, {3, 0}, {0}},
+                   {3, -1, {3, 1}, {0}}},
+                  {// Tests for {0, 1, 2} on the first rank,
+                   // second rank (consistent with the outMesh) is empty, ...
+                   {0, {1}},
+                   {0, {2}},
+                   {0, {3}},
+                   {2, {4}},
+                   {2, {5}},
+                   {2, {6}},
+                   {3, {7}},
+                   {3, {8}}});
 }
 
 /// Test with a very heterogenous distributed and non-continues ownership
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3)
 {
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
-  Gaussian fct(5.0);
+  Gaussian                           fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
   std::vector<int> globalIndexOffsets = {0, 0, 0, 4};
 
   testDistributed(mapping,
-                  { // Rank 0 has part of the mesh, owns a subpart
-                    {0,  0, {0, 0}, {1}}, {0,  0, {0, 1}, {2}},
-                    {0,  0, {1, 0}, {3}}, {0, -1, {1, 1}, {4}},
-                    {0, -1, {2, 0}, {5}}, {0, -1, {2, 1}, {6}},
+                  {
+                      // Rank 0 has part of the mesh, owns a subpart
+                      {0, 0, {0, 0}, {1}},
+                      {0, 0, {0, 1}, {2}},
+                      {0, 0, {1, 0}, {3}},
+                      {0, -1, {1, 1}, {4}},
+                      {0, -1, {2, 0}, {5}},
+                      {0, -1, {2, 1}, {6}},
                       // Rank 1 has no vertices
                       // Rank 2 has the entire mesh, but owns just 3 and 5.
-                    {2, -1, {0, 0}, {1}}, {2, -1, {0, 1}, {2}},
-                    {2, -1, {1, 0}, {3}}, {2,  2, {1, 1}, {4}},
-                    {2, -1, {2, 0}, {5}}, {2,  2, {2, 1}, {6}},
-                    {2, -1, {3, 0}, {7}}, {2, -1, {3, 1}, {8}},
+                      {2, -1, {0, 0}, {1}},
+                      {2, -1, {0, 1}, {2}},
+                      {2, -1, {1, 0}, {3}},
+                      {2, 2, {1, 1}, {4}},
+                      {2, -1, {2, 0}, {5}},
+                      {2, 2, {2, 1}, {6}},
+                      {2, -1, {3, 0}, {7}},
+                      {2, -1, {3, 1}, {8}},
                       // Rank 3 has the last 4 vertices, owns 4, 6 and 7
-                    {3, 3, {2, 0}, {5}}, {3, -1, {2, 1}, {6}},
-                    {3, 3, {3, 0}, {7}}, {3,  3, {3, 1}, {8}},
+                      {3, 3, {2, 0}, {5}},
+                      {3, -1, {2, 1}, {6}},
+                      {3, 3, {3, 0}, {7}},
+                      {3, 3, {3, 1}, {8}},
                   },
-                  { // The outMesh is local, rank 1 is empty
-                    {0, -1, {0, 0}, {0}},
-                    {0, -1, {0, 1}, {0}},
-                    {0, -1, {1, 0}, {0}},
-                    {2, -1, {1, 1}, {0}},
-                    {2, -1, {2, 0}, {0}},
-                    {2, -1, {2, 1}, {0}},
-                    {3, -1, {3, 0}, {0}},
-                    {3, -1, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 1, 2} on the first rank,
-                    // second rank (consistent with the outMesh) is empty, ...
-                    { 0, {1} },
-                    { 0, {2} },
-                    { 0, {3} },
-                    { 2, {4} },
-                    { 2, {5} },
-                    { 2, {6} },
-                    { 3, {7} },
-                    { 3, {8} }
-                  },
-                  globalIndexOffsets[utils::Parallel::getProcessRank()]
-    );
+                  {// The outMesh is local, rank 1 is empty
+                   {0, -1, {0, 0}, {0}},
+                   {0, -1, {0, 1}, {0}},
+                   {0, -1, {1, 0}, {0}},
+                   {2, -1, {1, 1}, {0}},
+                   {2, -1, {2, 0}, {0}},
+                   {2, -1, {2, 1}, {0}},
+                   {3, -1, {3, 0}, {0}},
+                   {3, -1, {3, 1}, {0}}},
+                  {// Tests for {0, 1, 2} on the first rank,
+                   // second rank (consistent with the outMesh) is empty, ...
+                   {0, {1}},
+                   {0, {2}},
+                   {0, {3}},
+                   {2, {4}},
+                   {2, {5}},
+                   {2, {6}},
+                   {3, {7}},
+                   {3, {8}}},
+                  globalIndexOffsets[utils::Parallel::getProcessRank()]);
 }
-
 
 #if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
 /// Some ranks are empty, does not converge
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
 {
-  ThinPlateSplines fct;
+  ThinPlateSplines                           fct;
   PetRadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
   std::vector<int> globalIndexOffsets = {0, 0, 0, 0};
 
   testDistributed(mapping,
-                    {   // Rank 0 has no vertices
-                        // Rank 1 has the entire mesh, owns a subpart
-                      {1,  1, {0, 0}, {1.1}}, {1,  1, {0, 1}, {2.5}},
-                      {1,  1, {1, 0}, {3}}, {1,  1, {1, 1}, {4}},
-                      {1, -1, {2, 0}, {5}}, {1, -1, {2, 1}, {6}},
-                      {1, -1, {3, 0}, {7}}, {1, -1, {3, 1}, {8}},
-                        // Rank 2 has the entire mesh, owns a subpart
-                      {2, -1, {0, 0}, {1.1}}, {2, -1, {0, 1}, {2.5}},
-                      {2, -1, {1, 0}, {3}}, {2, -1, {1, 1}, {4}},
-                      {2,  2, {2, 0}, {5}}, {2,  2, {2, 1}, {6}},
-                      {2,  2, {3, 0}, {7}}, {2,  2, {3, 1}, {8}},
-                        // Rank 3 has no vertices
-                    },
-                    { // The outMesh is local, rank 0 and 3 are empty
-                      // not same order as input mesh and vertex (2,0) appears twice
-                      {1, -1, {2, 0}, {0}},
-                      {1, -1, {1, 0}, {0}},
-                      {1, -1, {0, 1}, {0}},
-                      {1, -1, {1, 1}, {0}},
-                      {1, -1, {0, 0}, {0}},
-                      {2, -1, {2, 0}, {0}},
-                      {2, -1, {2, 1}, {0}},
-                      {2, -1, {3, 0}, {0}},
-                      {2, -1, {3, 1}, {0}}
-                    },
-                    {
-                      { 1, {5} },
-                      { 1, {3} },
-                      { 1, {2.5} },
-                      { 1, {4} },
-                      { 1, {1.1} },
-                      { 2, {5} },
-                      { 2, {6} },
-                      { 2, {7} },
-                      { 2, {8} }
-                    },
-                    globalIndexOffsets[utils::Parallel::getProcessRank()]
-      );
+                  {
+                      // Rank 0 has no vertices
+                      // Rank 1 has the entire mesh, owns a subpart
+                      {1, 1, {0, 0}, {1.1}},
+                      {1, 1, {0, 1}, {2.5}},
+                      {1, 1, {1, 0}, {3}},
+                      {1, 1, {1, 1}, {4}},
+                      {1, -1, {2, 0}, {5}},
+                      {1, -1, {2, 1}, {6}},
+                      {1, -1, {3, 0}, {7}},
+                      {1, -1, {3, 1}, {8}},
+                      // Rank 2 has the entire mesh, owns a subpart
+                      {2, -1, {0, 0}, {1.1}},
+                      {2, -1, {0, 1}, {2.5}},
+                      {2, -1, {1, 0}, {3}},
+                      {2, -1, {1, 1}, {4}},
+                      {2, 2, {2, 0}, {5}},
+                      {2, 2, {2, 1}, {6}},
+                      {2, 2, {3, 0}, {7}},
+                      {2, 2, {3, 1}, {8}},
+                      // Rank 3 has no vertices
+                  },
+                  {// The outMesh is local, rank 0 and 3 are empty
+                   // not same order as input mesh and vertex (2,0) appears twice
+                   {1, -1, {2, 0}, {0}},
+                   {1, -1, {1, 0}, {0}},
+                   {1, -1, {0, 1}, {0}},
+                   {1, -1, {1, 1}, {0}},
+                   {1, -1, {0, 0}, {0}},
+                   {2, -1, {2, 0}, {0}},
+                   {2, -1, {2, 1}, {0}},
+                   {2, -1, {3, 0}, {0}},
+                   {2, -1, {3, 1}, {0}}},
+                  {{1, {5}},
+                   {1, {3}},
+                   {1, {2.5}},
+                   {1, {4}},
+                   {1, {1.1}},
+                   {2, {5}},
+                   {2, {6}},
+                   {2, {7}},
+                   {2, {8}}},
+                  globalIndexOffsets[utils::Parallel::getProcessRank()]);
 }
 #else
-  #warning "Test case MappingTests/PetRadialBasisFunctionMapping/Parallel/DistributedConsistent2DV4 deactivated, due to PETSc version < 3.8"
+#warning "Test case MappingTests/PetRadialBasisFunctionMapping/Parallel/DistributedConsistent2DV4 deactivated, due to PETSc version < 3.8"
 #endif
 
 // same as 2DV4, but all ranks have vertices
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
 {
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
-  ThinPlateSplines fct;
+  ThinPlateSplines                           fct;
   PetRadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
   std::vector<int> globalIndexOffsets = {0, 0, 0, 0};
 
   testDistributed(mapping,
-                    {   // Every rank has the entire mesh and owns a subpart
-                      {0,  0, {0, 0}, {1.1}}, {0,  0, {0, 1}, {2.5}},
-                      {0, -1, {1, 0}, {3}},   {0, -1, {1, 1}, {4}},
-                      {0, -1, {2, 0}, {5}},   {0, -1, {2, 1}, {6}},
-                      {0, -1, {3, 0}, {7}},   {0, -1, {3, 1}, {8}},
-                      {1, -1, {0, 0}, {1.1}}, {1, -1, {0, 1}, {2.5}},
-                      {1,  1, {1, 0}, {3}},   {1,  1, {1, 1}, {4}},
-                      {1, -1, {2, 0}, {5}},   {1, -1, {2, 1}, {6}},
-                      {1, -1, {3, 0}, {7}},   {1, -1, {3, 1}, {8}},
-                      {2, -1, {0, 0}, {1.1}}, {2, -1, {0, 1}, {2.5}},
-                      {2, -1, {1, 0}, {3}},   {2, -1, {1, 1}, {4}},
-                      {2,  2, {2, 0}, {5}},   {2,  2, {2, 1}, {6}},
-                      {2, -1, {3, 0}, {7}},   {2, -1, {3, 1}, {8}},
-                      {3, -1, {0, 0}, {1.1}}, {3, -1, {0, 1}, {2.5}},
-                      {3, -1, {1, 0}, {3}},   {3, -1, {1, 1}, {4}},
-                      {3, -1, {2, 0}, {5}},   {3, -1, {2, 1}, {6}},
-                      {3,  3, {3, 0}, {7}},   {3,  3, {3, 1}, {8}},
-                    },
-                    { // The outMesh is local, rank 0 and 3 are empty
-                      // not same order as input mesh and vertex (2,0) appears twice
-                      {1, -1, {2, 0}, {0}},
-                      {1, -1, {1, 0}, {0}},
-                      {1, -1, {0, 1}, {0}},
-                      {1, -1, {1, 1}, {0}},
-                      {1, -1, {0, 0}, {0}},
-                      {2, -1, {2, 0}, {0}},
-                      {2, -1, {2, 1}, {0}},
-                      {2, -1, {3, 0}, {0}},
-                      {2, -1, {3, 1}, {0}}
-                    },
-                    {
-                      { 1, {5} },
-                      { 1, {3} },
-                      { 1, {2.5} },
-                      { 1, {4} },
-                      { 1, {1.1} },
-                      { 2, {5} },
-                      { 2, {6} },
-                      { 2, {7} },
-                      { 2, {8} }
-                    },
-                    globalIndexOffsets[utils::Parallel::getProcessRank()]
-      );
+                  {
+                      // Every rank has the entire mesh and owns a subpart
+                      {0, 0, {0, 0}, {1.1}},
+                      {0, 0, {0, 1}, {2.5}},
+                      {0, -1, {1, 0}, {3}},
+                      {0, -1, {1, 1}, {4}},
+                      {0, -1, {2, 0}, {5}},
+                      {0, -1, {2, 1}, {6}},
+                      {0, -1, {3, 0}, {7}},
+                      {0, -1, {3, 1}, {8}},
+                      {1, -1, {0, 0}, {1.1}},
+                      {1, -1, {0, 1}, {2.5}},
+                      {1, 1, {1, 0}, {3}},
+                      {1, 1, {1, 1}, {4}},
+                      {1, -1, {2, 0}, {5}},
+                      {1, -1, {2, 1}, {6}},
+                      {1, -1, {3, 0}, {7}},
+                      {1, -1, {3, 1}, {8}},
+                      {2, -1, {0, 0}, {1.1}},
+                      {2, -1, {0, 1}, {2.5}},
+                      {2, -1, {1, 0}, {3}},
+                      {2, -1, {1, 1}, {4}},
+                      {2, 2, {2, 0}, {5}},
+                      {2, 2, {2, 1}, {6}},
+                      {2, -1, {3, 0}, {7}},
+                      {2, -1, {3, 1}, {8}},
+                      {3, -1, {0, 0}, {1.1}},
+                      {3, -1, {0, 1}, {2.5}},
+                      {3, -1, {1, 0}, {3}},
+                      {3, -1, {1, 1}, {4}},
+                      {3, -1, {2, 0}, {5}},
+                      {3, -1, {2, 1}, {6}},
+                      {3, 3, {3, 0}, {7}},
+                      {3, 3, {3, 1}, {8}},
+                  },
+                  {// The outMesh is local, rank 0 and 3 are empty
+                   // not same order as input mesh and vertex (2,0) appears twice
+                   {1, -1, {2, 0}, {0}},
+                   {1, -1, {1, 0}, {0}},
+                   {1, -1, {0, 1}, {0}},
+                   {1, -1, {1, 1}, {0}},
+                   {1, -1, {0, 0}, {0}},
+                   {2, -1, {2, 0}, {0}},
+                   {2, -1, {2, 1}, {0}},
+                   {2, -1, {3, 0}, {0}},
+                   {2, -1, {3, 1}, {0}}},
+                  {{1, {5}},
+                   {1, {3}},
+                   {1, {2.5}},
+                   {1, {4}},
+                   {1, {1.1}},
+                   {2, {5}},
+                   {2, {6}},
+                   {2, {7}},
+                   {2, {8}}},
+                  globalIndexOffsets[utils::Parallel::getProcessRank()]);
 }
 
 /// same as 2DV4, but strictly linear input values, converges and gives correct results
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV6,
-                     * boost::unit_test::tolerance(1e-7))
+                     *boost::unit_test::tolerance(1e-7))
 {
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
-  ThinPlateSplines fct;
+  ThinPlateSplines                           fct;
   PetRadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, 2, fct, false, false, false);
 
   std::vector<int> globalIndexOffsets = {0, 0, 0, 0};
 
   testDistributed(mapping,
-                    {   // Rank 0 has no vertices
-                        // Rank 1 has the entire mesh, owns a subpart
-                      {1,  1, {0, 0}, {1}}, {1,  1, {0, 1}, {2}},
-                      {1,  1, {1, 0}, {3}}, {1,  1, {1, 1}, {4}},
-                      {1, -1, {2, 0}, {5}}, {1, -1, {2, 1}, {6}},
-                      {1, -1, {3, 0}, {7}}, {1, -1, {3, 1}, {8}},
-                        // Rank 2 has the entire mesh, owns a subpart
-                      {2, -1, {0, 0}, {1}}, {2, -1, {0, 1}, {2}},
-                      {2, -1, {1, 0}, {3}}, {2, -1, {1, 1}, {4}},
-                      {2,  2, {2, 0}, {5}}, {2,  2, {2, 1}, {6}},
-                      {2,  2, {3, 0}, {7}}, {2,  2, {3, 1}, {8}},
-                        // Rank 3 has no vertices
-                    },
-                    { // The outMesh is local, rank 0 and 3 are empty
-                      // not same order as input mesh and vertex (2,0) appears twice
-                      {1, -1, {2, 0}, {0}},
-                      {1, -1, {1, 0}, {0}},
-                      {1, -1, {0, 1}, {0}},
-                      {1, -1, {1, 1}, {0}},
-                      {1, -1, {0, 0}, {0}},
-                      {2, -1, {2, 0}, {0}},
-                      {2, -1, {2, 1}, {0}},
-                      {2, -1, {3, 0}, {0}},
-                      {2, -1, {3, 1}, {0}}
-                    },
-                    {
-                      { 1, {5} },
-                      { 1, {3} },
-                      { 1, {2} },
-                      { 1, {4} },
-                      { 1, {1} },
-                      { 2, {5} },
-                      { 2, {6} },
-                      { 2, {7} },
-                      { 2, {8} }
-                    },
-                    globalIndexOffsets[utils::Parallel::getProcessRank()]
-      );
+                  {
+                      // Rank 0 has no vertices
+                      // Rank 1 has the entire mesh, owns a subpart
+                      {1, 1, {0, 0}, {1}},
+                      {1, 1, {0, 1}, {2}},
+                      {1, 1, {1, 0}, {3}},
+                      {1, 1, {1, 1}, {4}},
+                      {1, -1, {2, 0}, {5}},
+                      {1, -1, {2, 1}, {6}},
+                      {1, -1, {3, 0}, {7}},
+                      {1, -1, {3, 1}, {8}},
+                      // Rank 2 has the entire mesh, owns a subpart
+                      {2, -1, {0, 0}, {1}},
+                      {2, -1, {0, 1}, {2}},
+                      {2, -1, {1, 0}, {3}},
+                      {2, -1, {1, 1}, {4}},
+                      {2, 2, {2, 0}, {5}},
+                      {2, 2, {2, 1}, {6}},
+                      {2, 2, {3, 0}, {7}},
+                      {2, 2, {3, 1}, {8}},
+                      // Rank 3 has no vertices
+                  },
+                  {// The outMesh is local, rank 0 and 3 are empty
+                   // not same order as input mesh and vertex (2,0) appears twice
+                   {1, -1, {2, 0}, {0}},
+                   {1, -1, {1, 0}, {0}},
+                   {1, -1, {0, 1}, {0}},
+                   {1, -1, {1, 1}, {0}},
+                   {1, -1, {0, 0}, {0}},
+                   {2, -1, {2, 0}, {0}},
+                   {2, -1, {2, 1}, {0}},
+                   {2, -1, {3, 0}, {0}},
+                   {2, -1, {3, 1}, {0}}},
+                  {{1, {5}},
+                   {1, {3}},
+                   {1, {2}},
+                   {1, {4}},
+                   {1, {1}},
+                   {2, {5}},
+                   {2, {6}},
+                   {2, {7}},
+                   {2, {8}}},
+                  globalIndexOffsets[utils::Parallel::getProcessRank()]);
 }
 
 /// Test with a homogenous distribution of mesh amoung ranks
 BOOST_AUTO_TEST_CASE(DistributedConservative2DV1)
 {
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
-  Gaussian fct(5.0);
+  Gaussian                           fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSERVATIVE, 2, fct, false, false, false);
 
   testDistributed(mapping,
-                  { // Conservative mapping: The inMesh is local
-                    {0, -1, {0, 0}, {1}},
-                    {0, -1, {0, 1}, {2}},
-                    {1, -1, {1, 0}, {3}},
-                    {1, -1, {1, 1}, {4}},
-                    {2, -1, {2, 0}, {5}},
-                    {2, -1, {2, 1}, {6}},
-                    {3, -1, {3, 0}, {7}},
-                    {3, -1, {3, 1}, {8}}
-                  },
-                  { // The outMesh is distributed
-                    {-1, 0, {0, 0}, {0}},
-                    {-1, 0, {0, 1}, {0}},
-                    {-1, 1, {1, 0}, {0}},
-                    {-1, 1, {1, 1}, {0}},
-                    {-1, 2, {2, 0}, {0}},
-                    {-1, 2, {2, 1}, {0}},
-                    {-1, 3, {3, 0}, {0}},
-                    {-1, 3, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
-                    // {0, 0, 2, 3, 0, 0, 0, 0} on the second, ...
-                    {0, {1}}, {0, {2}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}},
-                    {1, {0}}, {1, {0}}, {1, {3}}, {1, {4}}, {1, {0}}, {1, {0}}, {1, {0}}, {1, {0}},
-                    {2, {0}}, {2, {0}}, {2, {0}}, {2, {0}}, {2, {5}}, {2, {6}}, {2, {0}}, {2, {0}},
-                    {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {7}}, {3, {8}}
-                  },
-                  utils::Parallel::getProcessRank()*2
-    );
+                  {// Conservative mapping: The inMesh is local
+                   {0, -1, {0, 0}, {1}},
+                   {0, -1, {0, 1}, {2}},
+                   {1, -1, {1, 0}, {3}},
+                   {1, -1, {1, 1}, {4}},
+                   {2, -1, {2, 0}, {5}},
+                   {2, -1, {2, 1}, {6}},
+                   {3, -1, {3, 0}, {7}},
+                   {3, -1, {3, 1}, {8}}},
+                  {// The outMesh is distributed
+                   {-1, 0, {0, 0}, {0}},
+                   {-1, 0, {0, 1}, {0}},
+                   {-1, 1, {1, 0}, {0}},
+                   {-1, 1, {1, 1}, {0}},
+                   {-1, 2, {2, 0}, {0}},
+                   {-1, 2, {2, 1}, {0}},
+                   {-1, 3, {3, 0}, {0}},
+                   {-1, 3, {3, 1}, {0}}},
+                  {// Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
+                   // {0, 0, 2, 3, 0, 0, 0, 0} on the second, ...
+                   {0, {1}},
+                   {0, {2}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {3}},
+                   {1, {4}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {5}},
+                   {2, {6}},
+                   {2, {0}},
+                   {2, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {7}},
+                   {3, {8}}},
+                  utils::Parallel::getProcessRank() * 2);
 }
 
 /// Using a more heterogenous distribution of vertices and owner
 BOOST_AUTO_TEST_CASE(DistributedConservative2DV2)
 {
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
-  Gaussian fct(5.0);
+  Gaussian                           fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSERVATIVE, 2, fct, false, false, false);
 
   std::vector<int> globalIndexOffsets = {0, 0, 4, 6};
 
   testDistributed(mapping,
-                  { // Conservative mapping: The inMesh is local but rank 0 has no vertices
-                    {1, -1, {0, 0}, {1}},
-                    {1, -1, {0, 1}, {2}},
-                    {1, -1, {1, 0}, {3}},
-                    {1, -1, {1, 1}, {4}},
-                    {2, -1, {2, 0}, {5}},
-                    {2, -1, {2, 1}, {6}},
-                    {3, -1, {3, 0}, {7}},
-                    {3, -1, {3, 1}, {8}}
-                  },
-                  { // The outMesh is distributed, rank 0 owns no vertex
-                    {-1, 1, {0, 0}, {0}},
-                    {-1, 1, {0, 1}, {0}},
-                    {-1, 1, {1, 0}, {0}},
-                    {-1, 1, {1, 1}, {0}},
-                    {-1, 2, {2, 0}, {0}},
-                    {-1, 2, {2, 1}, {0}},
-                    {-1, 3, {3, 0}, {0}},
-                    {-1, 3, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
-                    // {1, 2, 2, 3, 0, 0, 0, 0} on the second, ...
-                    {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}},
-                    {1, {1}}, {1, {2}}, {1, {3}}, {1, {4}}, {1, {0}}, {1, {0}}, {1, {0}}, {1, {0}},
-                    {2, {0}}, {2, {0}}, {2, {0}}, {2, {0}}, {2, {5}}, {2, {6}}, {2, {0}}, {2, {0}},
-                    {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {7}}, {3, {8}}
-                  },
-                  globalIndexOffsets[utils::Parallel::getProcessRank()]
-    );
+                  {// Conservative mapping: The inMesh is local but rank 0 has no vertices
+                   {1, -1, {0, 0}, {1}},
+                   {1, -1, {0, 1}, {2}},
+                   {1, -1, {1, 0}, {3}},
+                   {1, -1, {1, 1}, {4}},
+                   {2, -1, {2, 0}, {5}},
+                   {2, -1, {2, 1}, {6}},
+                   {3, -1, {3, 0}, {7}},
+                   {3, -1, {3, 1}, {8}}},
+                  {// The outMesh is distributed, rank 0 owns no vertex
+                   {-1, 1, {0, 0}, {0}},
+                   {-1, 1, {0, 1}, {0}},
+                   {-1, 1, {1, 0}, {0}},
+                   {-1, 1, {1, 1}, {0}},
+                   {-1, 2, {2, 0}, {0}},
+                   {-1, 2, {2, 1}, {0}},
+                   {-1, 3, {3, 0}, {0}},
+                   {-1, 3, {3, 1}, {0}}},
+                  {// Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
+                   // {1, 2, 2, 3, 0, 0, 0, 0} on the second, ...
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {1, {1}},
+                   {1, {2}},
+                   {1, {3}},
+                   {1, {4}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {5}},
+                   {2, {6}},
+                   {2, {0}},
+                   {2, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {7}},
+                   {3, {8}}},
+                  globalIndexOffsets[utils::Parallel::getProcessRank()]);
 }
 
 /// Using meshes of different sizes, inMesh is smaller then outMesh
 BOOST_AUTO_TEST_CASE(DistributedConservative2DV3)
 {
-  Gaussian fct(2.0);
+  Gaussian                           fct(2.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSERVATIVE, 2, fct, false, false, false);
 
   std::vector<int> globalIndexOffsets = {0, 0, 3, 5};
 
   testDistributed(mapping,
-                  { // Conservative mapping: The inMesh is local but rank 0 has no vertices
-                    {1, -1, {0, 0}, {1}},
-                    {1, -1, {1, 0}, {3}},
-                    {1, -1, {1, 1}, {4}},
-                    {2, -1, {2, 0}, {5}},
-                    {2, -1, {2, 1}, {6}},
-                    {3, -1, {3, 0}, {7}},
-                    {3, -1, {3, 1}, {8}}
-                  }, // Sum of all vertices is 34
-                  { // The outMesh is distributed, rank 0 owns no vertex
-                    {-1, 1, {0, 0}, {0}},
-                    {-1, 1, {0, 1}, {0}},
-                    {-1, 1, {1, 0}, {0}},
-                    {-1, 1, {1, 1}, {0}},
-                    {-1, 2, {2, 0}, {0}},
-                    {-1, 2, {2, 1}, {0}},
-                    {-1, 3, {3, 0}, {0}},
-                    {-1, 3, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
-                    // {1, 2, 2, 3, 0, 0, 0, 0} on the second, ...
-                    {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}},
-                    {1, {1}}, {1, {0}}, {1, {3}}, {1, {4}}, {1, {0}}, {1, {0}}, {1, {0}}, {1, {0}},
-                    {2, {0}}, {2, {0}}, {2, {0}}, {2, {0}}, {2, {5}}, {2, {6}}, {2, {0}}, {2, {0}},
-                    {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {7}}, {3, {8}}
-                  }, // Sum of reference is also 34
-                  globalIndexOffsets[utils::Parallel::getProcessRank()]
-    );
+                  {// Conservative mapping: The inMesh is local but rank 0 has no vertices
+                   {1, -1, {0, 0}, {1}},
+                   {1, -1, {1, 0}, {3}},
+                   {1, -1, {1, 1}, {4}},
+                   {2, -1, {2, 0}, {5}},
+                   {2, -1, {2, 1}, {6}},
+                   {3, -1, {3, 0}, {7}},
+                   {3, -1, {3, 1}, {8}}}, // Sum of all vertices is 34
+                  {                       // The outMesh is distributed, rank 0 owns no vertex
+                   {-1, 1, {0, 0}, {0}},
+                   {-1, 1, {0, 1}, {0}},
+                   {-1, 1, {1, 0}, {0}},
+                   {-1, 1, {1, 1}, {0}},
+                   {-1, 2, {2, 0}, {0}},
+                   {-1, 2, {2, 1}, {0}},
+                   {-1, 3, {3, 0}, {0}},
+                   {-1, 3, {3, 1}, {0}}},
+                  {// Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
+                   // {1, 2, 2, 3, 0, 0, 0, 0} on the second, ...
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {1, {1}},
+                   {1, {0}},
+                   {1, {3}},
+                   {1, {4}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {5}},
+                   {2, {6}},
+                   {2, {0}},
+                   {2, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {7}},
+                   {3, {8}}}, // Sum of reference is also 34
+                  globalIndexOffsets[utils::Parallel::getProcessRank()]);
 }
 
 #if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
 /// Using meshes of different sizes, outMesh is smaller then inMesh
 BOOST_AUTO_TEST_CASE(DistributedConservative2DV4,
-                     * boost::unit_test::tolerance(1e-6))
+                     *boost::unit_test::tolerance(1e-6))
 {
-  Gaussian fct(4.0);
+  Gaussian                           fct(4.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSERVATIVE, 2, fct, false, false, false);
 
   std::vector<int> globalIndexOffsets = {0, 2, 4, 6};
 
   testDistributed(mapping,
-                  { // Conservative mapping: The inMesh is local
-                    {0, -1, {0, 0}, {1}},
-                    {0, -1, {0, 1}, {2}},
-                    {1, -1, {1, 0}, {3}},
-                    {1, -1, {1, 1}, {4}},
-                    {2, -1, {2, 0}, {5}},
-                    {2, -1, {2, 1}, {6}},
-                    {3, -1, {3, 0}, {7}},
-                    {3, -1, {3, 1}, {8}}
-                  }, // Sum is 36
-                  { // The outMesh is distributed, rank 0 has no vertex at all
-                    {-1, 1, {0, 1}, {0}},
-                    {-1, 1, {1, 0}, {0}},
-                    {-1, 1, {1, 1}, {0}},
-                    {-1, 2, {2, 0}, {0}},
-                    {-1, 2, {2, 1}, {0}},
-                    {-1, 3, {3, 0}, {0}},
-                    {-1, 3, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
-                    // {2, 3, 4, 3, 0, 0, 0, 0} on the second, ...
-                    {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}},
-                    {1, {2.4285714526861519}}, {1, {3.61905}}, {1, {4.14286}}, {1, {0}}, {1, {0}}, {1, {0}}, {1, {0}},
-                    {2, {0}}, {2, {0}}, {2, {0}}, {2, {5.333333295}}, {2, {5.85714}}, {2, {0}}, {2, {0}},
-                    {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {7.047619}}, {3, {7.571428}}
-                  }, // Sum is ~36
-                  globalIndexOffsets[utils::Parallel::getProcessRank()]
-    );
+                  {// Conservative mapping: The inMesh is local
+                   {0, -1, {0, 0}, {1}},
+                   {0, -1, {0, 1}, {2}},
+                   {1, -1, {1, 0}, {3}},
+                   {1, -1, {1, 1}, {4}},
+                   {2, -1, {2, 0}, {5}},
+                   {2, -1, {2, 1}, {6}},
+                   {3, -1, {3, 0}, {7}},
+                   {3, -1, {3, 1}, {8}}}, // Sum is 36
+                  {                       // The outMesh is distributed, rank 0 has no vertex at all
+                   {-1, 1, {0, 1}, {0}},
+                   {-1, 1, {1, 0}, {0}},
+                   {-1, 1, {1, 1}, {0}},
+                   {-1, 2, {2, 0}, {0}},
+                   {-1, 2, {2, 1}, {0}},
+                   {-1, 3, {3, 0}, {0}},
+                   {-1, 3, {3, 1}, {0}}},
+                  {// Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
+                   // {2, 3, 4, 3, 0, 0, 0, 0} on the second, ...
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {1, {2.4285714526861519}},
+                   {1, {3.61905}},
+                   {1, {4.14286}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {5.333333295}},
+                   {2, {5.85714}},
+                   {2, {0}},
+                   {2, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {7.047619}},
+                   {3, {7.571428}}}, // Sum is ~36
+                  globalIndexOffsets[utils::Parallel::getProcessRank()]);
 }
 #else
-  #warning "Test case MappingTests/PetRadialBasisFunctionMapping/Parallel/DistributedConservative2DV4 deactivated, due to PETSc version < 3.8."
+#warning "Test case MappingTests/PetRadialBasisFunctionMapping/Parallel/DistributedConservative2DV4 deactivated, due to PETSc version < 3.8."
 #endif
 
 /// Tests a non-contigous owner distributed at the outMesh
 BOOST_AUTO_TEST_CASE(testDistributedConservative2DV5)
 {
-  Gaussian fct(5.0);
+  Gaussian                           fct(5.0);
   PetRadialBasisFctMapping<Gaussian> mapping(Mapping::CONSERVATIVE, 2, fct, false, false, false);
 
   testDistributed(mapping,
-                  { // Conservative mapping: The inMesh is local
-                    {0, -1, {0, 0}, {1}},
-                    {0, -1, {0, 1}, {2}},
-                    {1, -1, {1, 0}, {3}},
-                    {1, -1, {1, 1}, {4}},
-                    {2, -1, {2, 0}, {5}},
-                    {2, -1, {2, 1}, {6}},
-                    {3, -1, {3, 0}, {7}},
-                    {3, -1, {3, 1}, {8}}
-                  },
-                  { // The outMesh is distributed and non-contigous
-                    {-1, 0, {0, 0}, {0}},
-                    {-1, 1, {0, 1}, {0}},
-                    {-1, 1, {1, 0}, {0}},
-                    {-1, 0, {1, 1}, {0}},
-                    {-1, 2, {2, 0}, {0}},
-                    {-1, 2, {2, 1}, {0}},
-                    {-1, 3, {3, 0}, {0}},
-                    {-1, 3, {3, 1}, {0}}
-                  },
-                  { // Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
-                    // {0, 0, 2, 3, 0, 0, 0, 0} on the second, ...
-                    {0, {1}}, {0, {0}}, {0, {0}}, {0, {4}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}},
-                    {1, {0}}, {1, {2}}, {1, {3}}, {1, {0}}, {1, {0}}, {1, {0}}, {1, {0}}, {1, {0}},
-                    {2, {0}}, {2, {0}}, {2, {0}}, {2, {0}}, {2, {5}}, {2, {6}}, {2, {0}}, {2, {0}},
-                    {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {0}}, {3, {7}}, {3, {8}}
-                  },
-                  utils::Parallel::getProcessRank()*2
-    );
+                  {// Conservative mapping: The inMesh is local
+                   {0, -1, {0, 0}, {1}},
+                   {0, -1, {0, 1}, {2}},
+                   {1, -1, {1, 0}, {3}},
+                   {1, -1, {1, 1}, {4}},
+                   {2, -1, {2, 0}, {5}},
+                   {2, -1, {2, 1}, {6}},
+                   {3, -1, {3, 0}, {7}},
+                   {3, -1, {3, 1}, {8}}},
+                  {// The outMesh is distributed and non-contigous
+                   {-1, 0, {0, 0}, {0}},
+                   {-1, 1, {0, 1}, {0}},
+                   {-1, 1, {1, 0}, {0}},
+                   {-1, 0, {1, 1}, {0}},
+                   {-1, 2, {2, 0}, {0}},
+                   {-1, 2, {2, 1}, {0}},
+                   {-1, 3, {3, 0}, {0}},
+                   {-1, 3, {3, 1}, {0}}},
+                  {// Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
+                   // {0, 0, 2, 3, 0, 0, 0, 0} on the second, ...
+                   {0, {1}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {4}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {0, {0}},
+                   {1, {0}},
+                   {1, {2}},
+                   {1, {3}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {1, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {0}},
+                   {2, {5}},
+                   {2, {6}},
+                   {2, {0}},
+                   {2, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {0}},
+                   {3, {7}},
+                   {3, {8}}},
+                  utils::Parallel::getProcessRank() * 2);
 }
 
 void testTagging(MeshSpecification inMeshSpec,
-    MeshSpecification outMeshSpec,
-    MeshSpecification shouldTagFirstRound,
-    MeshSpecification shouldTagSecondRound,
-    bool consistent)
+                 MeshSpecification outMeshSpec,
+                 MeshSpecification shouldTagFirstRound,
+                 MeshSpecification shouldTagSecondRound,
+                 bool              consistent)
 {
-  int meshDimension = inMeshSpec[0].position.size();
+  int meshDimension  = inMeshSpec[0].position.size();
   int valueDimension = inMeshSpec[0].value.size();
 
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()) );
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
   getDistributedMesh(inMeshSpec, inMesh, inData);
 
-  mesh::PtrMesh outMesh ( new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData( "OutData", valueDimension);
+  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrData outData = outMesh->createData("OutData", valueDimension);
   getDistributedMesh(outMeshSpec, outMesh, outData);
 
-  Gaussian fct(4.5); //Support radius approx. 1
-  Mapping::Constraint constr = consistent? Mapping::CONSISTENT : Mapping::CONSERVATIVE;
+  Gaussian                           fct(4.5); //Support radius approx. 1
+  Mapping::Constraint                constr = consistent ? Mapping::CONSISTENT : Mapping::CONSERVATIVE;
   PetRadialBasisFctMapping<Gaussian> mapping(constr, 2, fct, false, false, false);
   inMesh->computeState();
   outMesh->computeState();
@@ -659,11 +790,11 @@ void testTagging(MeshSpecification inMeshSpec,
   mapping.setMeshes(inMesh, outMesh);
   mapping.tagMeshFirstRound();
 
-  for (const auto& v : inMesh->vertices()){
-    auto pos = std::find_if(shouldTagFirstRound.begin(), shouldTagFirstRound.end(),
-        [meshDimension, &v](const VertexSpecification& spec){
-          return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
-        });
+  for (const auto &v : inMesh->vertices()) {
+    auto pos   = std::find_if(shouldTagFirstRound.begin(), shouldTagFirstRound.end(),
+                            [meshDimension, &v](const VertexSpecification &spec) {
+                              return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
+                            });
     bool found = pos != shouldTagFirstRound.end();
     BOOST_TEST(found >= v.isTagged(),
                "FirstRound: Vertex " << v << " is tagged, but should not be.");
@@ -673,27 +804,28 @@ void testTagging(MeshSpecification inMeshSpec,
 
   mapping.tagMeshSecondRound();
 
-  for (const auto& v : inMesh->vertices()){
-    auto posFirst = std::find_if(shouldTagFirstRound.begin(), shouldTagFirstRound.end(),
-        [meshDimension, &v](const VertexSpecification& spec){
-          return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
-        });
-    bool foundFirst = posFirst != shouldTagFirstRound.end();
-    auto posSecond = std::find_if(shouldTagSecondRound.begin(), shouldTagSecondRound.end(),
-        [meshDimension, &v](const VertexSpecification& spec){
-          return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
-        });
+  for (const auto &v : inMesh->vertices()) {
+    auto posFirst    = std::find_if(shouldTagFirstRound.begin(), shouldTagFirstRound.end(),
+                                 [meshDimension, &v](const VertexSpecification &spec) {
+                                   return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
+                                 });
+    bool foundFirst  = posFirst != shouldTagFirstRound.end();
+    auto posSecond   = std::find_if(shouldTagSecondRound.begin(), shouldTagSecondRound.end(),
+                                  [meshDimension, &v](const VertexSpecification &spec) {
+                                    return std::equal(spec.position.data(), spec.position.data() + meshDimension, v.getCoords().data());
+                                  });
     bool foundSecond = posSecond != shouldTagSecondRound.end();
     BOOST_TEST(foundFirst <= v.isTagged(), "SecondRound: Vertex " << v
-        << " is not tagged, but should be from the first round.");
+                                                                  << " is not tagged, but should be from the first round.");
     BOOST_TEST(foundSecond <= v.isTagged(), "SecondRound: Vertex " << v
-        << " is not tagged, but should be.");
-    BOOST_TEST((foundSecond or foundFirst)>= v.isTagged(), "SecondRound: Vertex " << v
-        << " is tagged, but should not be.");
+                                                                   << " is not tagged, but should be.");
+    BOOST_TEST((foundSecond or foundFirst) >= v.isTagged(), "SecondRound: Vertex " << v
+                                                                                   << " is tagged, but should not be.");
   }
 }
 
-BOOST_AUTO_TEST_CASE(testTagFirstRound){
+BOOST_AUTO_TEST_CASE(testTagFirstRound)
+{
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   //    *
   //    + <-- owned
@@ -701,27 +833,24 @@ BOOST_AUTO_TEST_CASE(testTagFirstRound){
   //    *
   //    *
   MeshSpecification outMeshSpec = {
-    {0, -1, {0, 0}, {0}}
-  };
+      {0, -1, {0, 0}, {0}}};
   MeshSpecification inMeshSpec = {
-    { 0, -1, {-1, 0}, {1}}, //inside
-    { 0, -1, {-2, 0}, {1}}, //outside
-    { 0, 0, {1, 0}, {1}},  //inside, owner
-    { 0, -1, {2, 0}, {1}},  //outside
-    { 0, -1, {0, -1}, {1}}, //inside
-    { 0, -1, {0, -2}, {1}}, //outside
-    { 0, -1, {0, 1}, {1}}, //inside
-    { 0, -1, {0, 2}, {1}}  //outside
+      {0, -1, {-1, 0}, {1}}, //inside
+      {0, -1, {-2, 0}, {1}}, //outside
+      {0, 0, {1, 0}, {1}},   //inside, owner
+      {0, -1, {2, 0}, {1}},  //outside
+      {0, -1, {0, -1}, {1}}, //inside
+      {0, -1, {0, -2}, {1}}, //outside
+      {0, -1, {0, 1}, {1}},  //inside
+      {0, -1, {0, 2}, {1}}   //outside
   };
   MeshSpecification shouldTagFirstRound = {
-    { 0, -1, {-1, 0}, {1}},
-    { 0, -1, {1, 0}, {1}},
-    { 0, -1, {0, -1}, {1}},
-    { 0, -1, {0, 1}, {1}}
-  };
+      {0, -1, {-1, 0}, {1}},
+      {0, -1, {1, 0}, {1}},
+      {0, -1, {0, -1}, {1}},
+      {0, -1, {0, 1}, {1}}};
   MeshSpecification shouldTagSecondRound = {
-    { 0, -1, {2, 0}, {1}}
-  };
+      {0, -1, {2, 0}, {1}}};
   testTagging(inMeshSpec, outMeshSpec, shouldTagFirstRound, shouldTagSecondRound, true);
   // For conservative just swap meshes.
   testTagging(outMeshSpec, inMeshSpec, shouldTagFirstRound, shouldTagSecondRound, false);
@@ -730,112 +859,111 @@ BOOST_AUTO_TEST_CASE(testTagFirstRound){
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 BOOST_AUTO_TEST_SUITE(Serial,
-                      * boost::unit_test::fixture<testing::SingleRankFixture>())
+                      *boost::unit_test::fixture<testing::SingleRankFixture>())
 
-
-void perform2DTestConsistentMapping(Mapping& mapping)
+void perform2DTestConsistentMapping(Mapping &mapping)
 {
   int dimensions = 2;
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector2d(0.0, 0.0) );
-  inMesh->createVertex ( Vector2d(1.0, 0.0) );
-  inMesh->createVertex ( Vector2d(1.0, 1.0) );
-  inMesh->createVertex ( Vector2d(0.0, 1.0) );
-  inMesh->allocateDataValues ();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector2d(0.0, 0.0));
+  inMesh->createVertex(Vector2d(1.0, 0.0));
+  inMesh->createVertex(Vector2d(1.0, 1.0));
+  inMesh->createVertex(Vector2d(0.0, 1.0));
+  inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
 
-  auto& values = inData->values();
+  auto &values = inData->values();
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
-  mesh::Vertex& vertex = outMesh->createVertex ( Vector2d(0, 0) );
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
 
   // Setup mapping with mapping coordinates and geometry used
-  mapping.setMeshes ( inMesh, outMesh );
+  mapping.setMeshes(inMesh, outMesh);
   BOOST_TEST(mapping.hasComputedMapping() == false);
 
-  vertex.setCoords ( Vector2d(0.0, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(0.0, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   double value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
-  vertex.setCoords ( Vector2d(0.0, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(0.0, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_TEST(mapping.hasComputedMapping() == true );
+  BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
-  vertex.setCoords ( Vector2d(0.0, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(0.0, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_TEST(mapping.hasComputedMapping() == true );
+  BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
-  vertex.setCoords ( Vector2d(1.0, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(1.0, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
-  vertex.setCoords ( Vector2d(1.0, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(1.0, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
-  vertex.setCoords ( Vector2d(1.0, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(1.0, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
-  vertex.setCoords ( Vector2d(0.5, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(0.5, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
-  vertex.setCoords ( Vector2d(0.5, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(0.5, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
-  vertex.setCoords ( Vector2d(0.5, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Vector2d(0.5, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 }
 
-void perform3DTestConsistentMapping(Mapping& mapping)
+void perform3DTestConsistentMapping(Mapping &mapping)
 {
   int dimensions = 3;
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData inData = inMesh->createData("InData", 1);
-  int inDataID = inData->getID();
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
@@ -847,14 +975,14 @@ void perform3DTestConsistentMapping(Mapping& mapping)
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
 
-  auto& values = inData->values();
+  auto &values = inData->values();
   values << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData outData = outMesh->createData("OutData", 1);
-  int outDataID = outData->getID();
-  mesh::Vertex& vertex = outMesh->createVertex(Eigen::Vector3d::Zero());
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector3d::Zero());
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
 
@@ -961,95 +1089,93 @@ void perform3DTestConsistentMapping(Mapping& mapping)
   BOOST_TEST(value == 1.5);
 }
 
-void perform2DTestConservativeMapping(Mapping& mapping)
+void perform2DTestConservativeMapping(Mapping &mapping)
 {
-  const int dimensions = 2;
-  const double tolerance = 1e-6;
+  const int    dimensions = 2;
+  const double tolerance  = 1e-6;
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  mesh::Vertex& vertex0 = inMesh->createVertex ( Vector2d(0,0) );
-  mesh::Vertex& vertex1 = inMesh->createVertex ( Vector2d(0,0) );
-  inMesh->allocateDataValues ();
-  inData->values() << 1.0, 2.0;
-  addGlobalIndex(inMesh);
-
-  // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID ();
-  outMesh->createVertex ( Vector2d(0.0, 0.0) );
-  outMesh->createVertex ( Vector2d(1.0, 0.0) );
-  outMesh->createVertex ( Vector2d(1.0, 1.0) );
-  outMesh->createVertex ( Vector2d(0.0, 1.0) );
-  outMesh->allocateDataValues ();
-  addGlobalIndex(outMesh);
-
-  auto& values = outData->values();
-
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST(mapping.hasComputedMapping() == false );
-
-  vertex0.setCoords ( Vector2d(0.5, 0.0) );
-  vertex1.setCoords ( Vector2d(0.5, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST(mapping.hasComputedMapping() == true);
-  BOOST_TEST ( testing::equals(values, Eigen::Vector4d(0.5, 0.5, 1.0, 1.0), tolerance) );
-
-  vertex0.setCoords ( Vector2d(0.0, 0.5) );
-  vertex1.setCoords ( Vector2d(1.0, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST(mapping.hasComputedMapping() == true);
-  BOOST_TEST ( testing::equals(values, Eigen::Vector4d(0.5, 1.0, 1.0, 0.5), tolerance) );
-
-  vertex0.setCoords ( Vector2d(0.0, 1.0) );
-  vertex1.setCoords ( Vector2d(1.0, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST(mapping.hasComputedMapping() == true);
-  BOOST_TEST ( testing::equals(values, Eigen::Vector4d(0.0, 2.0, 0.0, 1.0), tolerance) );
-
-  vertex0.setCoords ( Vector2d(0.0, 0.0) );
-  vertex1.setCoords ( Vector2d(1.0, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST(mapping.hasComputedMapping() == true);
-  BOOST_TEST ( testing::equals(values, Eigen::Vector4d(1.0, 0.0, 2.0, 0.0), tolerance) );
-
-  vertex0.setCoords ( Vector2d(0.4, 0.5) );
-  vertex1.setCoords ( Vector2d(0.6, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_TEST(mapping.hasComputedMapping() == true);
-  BOOST_TEST(values.sum() == 3.0 );
-}
-
-
-
-void perform3DTestConservativeMapping(Mapping& mapping)
-{
-  using Eigen::Vector3d;
-  int dimensions = 3;
-
-  // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData inData = inMesh->createData("InData", 1);
-  int inDataID = inData->getID();
-  mesh::Vertex& vertex0 = inMesh->createVertex(Vector3d(0,0,0));
-  mesh::Vertex& vertex1 = inMesh->createVertex(Vector3d(0,0,0));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
+  mesh::Vertex &vertex1  = inMesh->createVertex(Vector2d(0, 0));
   inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0;
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData outData = outMesh->createData("OutData", 1);
-  int outDataID = outData->getID();
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  outMesh->createVertex(Vector2d(0.0, 0.0));
+  outMesh->createVertex(Vector2d(1.0, 0.0));
+  outMesh->createVertex(Vector2d(1.0, 1.0));
+  outMesh->createVertex(Vector2d(0.0, 1.0));
+  outMesh->allocateDataValues();
+  addGlobalIndex(outMesh);
+
+  auto &values = outData->values();
+
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  vertex0.setCoords(Vector2d(0.5, 0.0));
+  vertex1.setCoords(Vector2d(0.5, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST(testing::equals(values, Eigen::Vector4d(0.5, 0.5, 1.0, 1.0), tolerance));
+
+  vertex0.setCoords(Vector2d(0.0, 0.5));
+  vertex1.setCoords(Vector2d(1.0, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST(testing::equals(values, Eigen::Vector4d(0.5, 1.0, 1.0, 0.5), tolerance));
+
+  vertex0.setCoords(Vector2d(0.0, 1.0));
+  vertex1.setCoords(Vector2d(1.0, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST(testing::equals(values, Eigen::Vector4d(0.0, 2.0, 0.0, 1.0), tolerance));
+
+  vertex0.setCoords(Vector2d(0.0, 0.0));
+  vertex1.setCoords(Vector2d(1.0, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST(testing::equals(values, Eigen::Vector4d(1.0, 0.0, 2.0, 0.0), tolerance));
+
+  vertex0.setCoords(Vector2d(0.4, 0.5));
+  vertex1.setCoords(Vector2d(0.6, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST(values.sum() == 3.0);
+}
+
+void perform3DTestConservativeMapping(Mapping &mapping)
+{
+  using Eigen::Vector3d;
+  int dimensions = 3;
+
+  // Create mesh to map from
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  mesh::Vertex &vertex0  = inMesh->createVertex(Vector3d(0, 0, 0));
+  mesh::Vertex &vertex1  = inMesh->createVertex(Vector3d(0, 0, 0));
+  inMesh->allocateDataValues();
+  inData->values() << 1.0, 2.0;
+  addGlobalIndex(inMesh);
+
+  // Create mesh to map to
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 0.0, 0.0));
   outMesh->createVertex(Vector3d(1.0, 0.0, 0.0));
   outMesh->createVertex(Vector3d(1.0, 1.0, 0.0));
@@ -1061,7 +1187,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
 
-  auto& values = outData->values();
+  auto & values      = outData->values();
   double expectedSum = inData->values().sum();
 
   mapping.setMeshes(inMesh, outMesh);
@@ -1075,13 +1201,12 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   BOOST_TEST(values.sum() == expectedSum);
 }
 
-
 BOOST_AUTO_TEST_CASE(MapThinPlateSplines)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  ThinPlateSplines fct;
+  bool                                       xDead = false;
+  bool                                       yDead = false;
+  bool                                       zDead = false;
+  ThinPlateSplines                           fct;
   PetRadialBasisFctMapping<ThinPlateSplines> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   PetRadialBasisFctMapping<ThinPlateSplines> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -1094,10 +1219,10 @@ BOOST_AUTO_TEST_CASE(MapThinPlateSplines)
 
 BOOST_AUTO_TEST_CASE(MapMultiquadrics)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  Multiquadrics fct(1e-3);
+  bool                                    xDead = false;
+  bool                                    yDead = false;
+  bool                                    zDead = false;
+  Multiquadrics                           fct(1e-3);
   PetRadialBasisFctMapping<Multiquadrics> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   PetRadialBasisFctMapping<Multiquadrics> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -1110,10 +1235,10 @@ BOOST_AUTO_TEST_CASE(MapMultiquadrics)
 
 BOOST_AUTO_TEST_CASE(MapInverseMultiquadrics)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  InverseMultiquadrics fct(1e-3);
+  bool                                           xDead = false;
+  bool                                           yDead = false;
+  bool                                           zDead = false;
+  InverseMultiquadrics                           fct(1e-3);
   PetRadialBasisFctMapping<InverseMultiquadrics> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   PetRadialBasisFctMapping<InverseMultiquadrics> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -1126,10 +1251,10 @@ BOOST_AUTO_TEST_CASE(MapInverseMultiquadrics)
 
 BOOST_AUTO_TEST_CASE(MapVolumeSplines)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  VolumeSplines fct;
+  bool                                    xDead = false;
+  bool                                    yDead = false;
+  bool                                    zDead = false;
+  VolumeSplines                           fct;
   PetRadialBasisFctMapping<VolumeSplines> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   PetRadialBasisFctMapping<VolumeSplines> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -1142,10 +1267,10 @@ BOOST_AUTO_TEST_CASE(MapVolumeSplines)
 
 BOOST_AUTO_TEST_CASE(MapGaussian)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  Gaussian fct(1.0);
+  bool                               xDead = false;
+  bool                               yDead = false;
+  bool                               zDead = false;
+  Gaussian                           fct(1.0);
   PetRadialBasisFctMapping<Gaussian> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   PetRadialBasisFctMapping<Gaussian> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -1158,10 +1283,10 @@ BOOST_AUTO_TEST_CASE(MapGaussian)
 
 BOOST_AUTO_TEST_CASE(MapCompactThinPlateSplinesC2)
 {
-  double supportRadius = 1.2;
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
+  double                    supportRadius = 1.2;
+  bool                      xDead         = false;
+  bool                      yDead         = false;
+  bool                      zDead         = false;
   CompactThinPlateSplinesC2 fct(supportRadius);
   using Mapping = PetRadialBasisFctMapping<CompactThinPlateSplinesC2>;
   Mapping consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
@@ -1176,10 +1301,10 @@ BOOST_AUTO_TEST_CASE(MapCompactThinPlateSplinesC2)
 
 BOOST_AUTO_TEST_CASE(MapPetCompactPolynomialC0)
 {
-  double supportRadius = 1.2;
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
+  double              supportRadius = 1.2;
+  bool                xDead         = false;
+  bool                yDead         = false;
+  bool                zDead         = false;
   CompactPolynomialC0 fct(supportRadius);
   using Mapping = PetRadialBasisFctMapping<CompactPolynomialC0>;
   Mapping consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
@@ -1194,10 +1319,10 @@ BOOST_AUTO_TEST_CASE(MapPetCompactPolynomialC0)
 
 BOOST_AUTO_TEST_CASE(MapPetCompactPolynomialC6)
 {
-  double supportRadius = 1.2;
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
+  double              supportRadius = 1.2;
+  bool                xDead         = false;
+  bool                yDead         = false;
+  bool                zDead         = false;
   CompactPolynomialC6 fct(supportRadius);
   using Mapping = PetRadialBasisFctMapping<CompactPolynomialC6>;
   Mapping consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
@@ -1219,42 +1344,42 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
   bool yDead = true;
   bool zDead = false;
 
-  ThinPlateSplines fct;
+  ThinPlateSplines                           fct;
   PetRadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, dimensions, fct,
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector2d(0.0, 1.0) );
-  inMesh->createVertex ( Vector2d(1.0, 1.0) );
-  inMesh->createVertex ( Vector2d(2.0, 1.0) );
-  inMesh->createVertex ( Vector2d(3.0, 1.0) );
-  inMesh->allocateDataValues ();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector2d(0.0, 1.0));
+  inMesh->createVertex(Vector2d(1.0, 1.0));
+  inMesh->createVertex(Vector2d(2.0, 1.0));
+  inMesh->createVertex(Vector2d(3.0, 1.0));
+  inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
 
-  auto& values = inData->values();
+  auto &values = inData->values();
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
-  mesh::Vertex& vertex = outMesh->createVertex ( Vector2d(0,0) );
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
 
   // Setup mapping with mapping coordinates and geometry used
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-  vertex.setCoords ( Vector2d(0.0, 3.0) );
+  vertex.setCoords(Vector2d(0.0, 3.0));
   mapping.computeMapping();
-  mapping.map ( inDataID, outDataID );
+  mapping.map(inDataID, outDataID);
   double value = outData->values()[0];
   BOOST_TEST(mapping.hasComputedMapping() == true);
-  BOOST_TEST ( value == 1.0 );
+  BOOST_TEST(value == 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(DeadAxis3D)
@@ -1262,51 +1387,51 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   using Eigen::Vector3d;
   int dimensions = 3;
 
-  double supportRadius = 1.2;
+  double              supportRadius = 1.2;
   CompactPolynomialC6 fct(supportRadius);
-  bool xDead = false;
-  bool yDead = true;
-  bool zDead = false;
-  using Mapping = PetRadialBasisFctMapping<CompactPolynomialC6>;
+  bool                xDead = false;
+  bool                yDead = true;
+  bool                zDead = false;
+  using Mapping             = PetRadialBasisFctMapping<CompactPolynomialC6>;
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector3d(0.0, 3.0, 0.0) );
-  inMesh->createVertex ( Vector3d(1.0, 3.0, 0.0) );
-  inMesh->createVertex ( Vector3d(0.0, 3.0, 1.0) );
-  inMesh->createVertex ( Vector3d(1.0, 3.0, 1.0) );
-  inMesh->allocateDataValues ();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector3d(0.0, 3.0, 0.0));
+  inMesh->createVertex(Vector3d(1.0, 3.0, 0.0));
+  inMesh->createVertex(Vector3d(0.0, 3.0, 1.0));
+  inMesh->createVertex(Vector3d(1.0, 3.0, 1.0));
+  inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
 
-  auto& values = inData->values();
+  auto &values = inData->values();
   values << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
-  outMesh->createVertex ( Vector3d(0.0, 2.9, 0.0) );
-  outMesh->createVertex ( Vector3d(0.8, 2.9, 0.1) );
-  outMesh->createVertex ( Vector3d(0.1, 2.9, 0.9) );
-  outMesh->createVertex ( Vector3d(1.1, 2.9, 1.1) );
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  outMesh->createVertex(Vector3d(0.0, 2.9, 0.0));
+  outMesh->createVertex(Vector3d(0.8, 2.9, 0.1));
+  outMesh->createVertex(Vector3d(0.1, 2.9, 0.9));
+  outMesh->createVertex(Vector3d(1.1, 2.9, 1.1));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
 
   // Setup mapping with mapping coordinates and geometry used
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  BOOST_TEST ( outData->values()[0] == 1.0 );
-  BOOST_TEST ( outData->values()[1] == 2.0 );
-  BOOST_TEST ( outData->values()[2] == 2.9 );
-  BOOST_TEST ( outData->values()[3] == 4.3 );
+  BOOST_TEST(outData->values()[0] == 1.0);
+  BOOST_TEST(outData->values()[1] == 2.0);
+  BOOST_TEST(outData->values()[2] == 2.9);
+  BOOST_TEST(outData->values()[3] == 4.3);
 }
 
 BOOST_AUTO_TEST_CASE(SolutionCaching)
@@ -1316,38 +1441,40 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
 
   bool xDead = false, yDead = true, zDead = false;
 
-  ThinPlateSplines fct;
+  ThinPlateSplines                           fct;
   PetRadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, dimensions, fct,
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector2d(0.0, 1.0) );  inMesh->createVertex ( Vector2d(1.0, 1.0) );
-  inMesh->createVertex ( Vector2d(2.0, 1.0) );  inMesh->createVertex ( Vector2d(3.0, 1.0) );
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector2d(0.0, 1.0));
+  inMesh->createVertex(Vector2d(1.0, 1.0));
+  inMesh->createVertex(Vector2d(2.0, 1.0));
+  inMesh->createVertex(Vector2d(3.0, 1.0));
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
 
   inData->values() << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData( "OutData", 1 );
-  int outDataID = outData->getID();
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0, 3));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
-  BOOST_TEST(mapping.hasComputedMapping() == false );
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
   mapping.computeMapping();
   BOOST_TEST(mapping.previousSolution.empty());
   mapping.map(inDataID, outDataID);
-  BOOST_TEST(mapping.hasComputedMapping() == true );
-  BOOST_TEST ( outData->values()[0] == 1.0 );
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  BOOST_TEST(outData->values()[0] == 1.0);
 
   PetscInt its;
   KSPGetIterationNumber(mapping._solver, &its);
@@ -1359,7 +1486,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
 }
 
 BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
-                     * boost::unit_test::tolerance(1e-6))
+                     *boost::unit_test::tolerance(1e-6))
 {
   using Eigen::Vector2d;
   int dimensions = 2;
@@ -1369,19 +1496,21 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector2d(1, 1) );  inMesh->createVertex ( Vector2d(1, 0) );
-  inMesh->createVertex ( Vector2d(0, 0) );  inMesh->createVertex ( Vector2d(0, 1) );
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector2d(1, 1));
+  inMesh->createVertex(Vector2d(1, 0));
+  inMesh->createVertex(Vector2d(0, 0));
+  inMesh->createVertex(Vector2d(0, 1));
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData( "OutData", 1 );
-  int outDataID = outData->getID();
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(3, 3)); // Point is outside the inMesh
 
   outMesh->allocateDataValues();
@@ -1389,13 +1518,13 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
 
   // Test deactivated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingOff(Mapping::CONSISTENT, dimensions, fct,
-                                             xDead, yDead, zDead,
-                                             1e-9, Polynomial::OFF);
+                                                xDead, yDead, zDead,
+                                                1e-9, Polynomial::OFF);
   mappingOff.setMeshes(inMesh, outMesh);
   mappingOff.computeMapping();
   mappingOff.map(inDataID, outDataID);
 
-  BOOST_TEST ( outData->values()[0] <= 0.01 ); // Mapping to almost 0 since almost no basis function at (3,3) and no polynomial
+  BOOST_TEST(outData->values()[0] <= 0.01); // Mapping to almost 0 since almost no basis function at (3,3) and no polynomial
 
   // Test integrated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingOn(Mapping::CONSISTENT, dimensions, fct,
@@ -1406,22 +1535,22 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   mappingOn.computeMapping();
   mappingOn.map(inDataID, outDataID);
 
-  BOOST_TEST ( outData->values()[0] == 1.0 ); // Mapping to 1 since there is the polynomial
+  BOOST_TEST(outData->values()[0] == 1.0); // Mapping to 1 since there is the polynomial
 
   // Test separated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingSep(Mapping::CONSISTENT, dimensions, fct,
-                                               xDead, yDead, zDead,
-                                               1e-9, Polynomial::SEPARATE);
+                                                xDead, yDead, zDead,
+                                                1e-9, Polynomial::SEPARATE);
 
   mappingSep.setMeshes(inMesh, outMesh);
   mappingSep.computeMapping();
   mappingSep.map(inDataID, outDataID);
 
-  BOOST_TEST ( outData->values()[0] == 1.0 ); // Mapping to 1 since there is the polynomial
+  BOOST_TEST(outData->values()[0] == 1.0); // Mapping to 1 since there is the polynomial
 }
 
 BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
-                     * boost::unit_test::tolerance(1e-6))
+                     *boost::unit_test::tolerance(1e-6))
 {
   using Eigen::Vector2d;
   int dimensions = 2;
@@ -1431,19 +1560,21 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector2d(0, 0) );  inMesh->createVertex ( Vector2d(1, 0) );
-  inMesh->createVertex ( Vector2d(1, 1) );  inMesh->createVertex ( Vector2d(0, 1) );
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector2d(0, 0));
+  inMesh->createVertex(Vector2d(1, 0));
+  inMesh->createVertex(Vector2d(1, 1));
+  inMesh->createVertex(Vector2d(0, 1));
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData( "OutData", 1 );
-  int outDataID = outData->getID();
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.4, 0));
   outMesh->createVertex(Vector2d(6, 6));
   outMesh->createVertex(Vector2d(7, 7));
@@ -1453,16 +1584,15 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
 
   // Test deactivated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingOff(Mapping::CONSERVATIVE, dimensions, fct,
-                                             xDead, yDead, zDead,
-                                             1e-9, Polynomial::OFF);
+                                                xDead, yDead, zDead,
+                                                1e-9, Polynomial::OFF);
   mappingOff.setMeshes(inMesh, outMesh);
   mappingOff.computeMapping();
   mappingOff.map(inDataID, outDataID);
 
-  BOOST_TEST ( outData->values()[0] == 2.119967 ); // Conservativness is not retained, because no polynomial
-  BOOST_TEST ( outData->values()[1] == 0.0 ); // Mapping to 0 since no basis function at (5,5) and no polynomial
-  BOOST_TEST ( outData->values()[2] == 0.0 ); // Mapping to 0 since no basis function at (5,5) and no polynomial
-
+  BOOST_TEST(outData->values()[0] == 2.119967); // Conservativness is not retained, because no polynomial
+  BOOST_TEST(outData->values()[1] == 0.0);      // Mapping to 0 since no basis function at (5,5) and no polynomial
+  BOOST_TEST(outData->values()[2] == 0.0);      // Mapping to 0 since no basis function at (5,5) and no polynomial
 
   // Test integrated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingOn(Mapping::CONSERVATIVE, dimensions, fct,
@@ -1473,27 +1603,23 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   mappingOn.computeMapping();
   mappingOn.map(inDataID, outDataID);
 
-  BOOST_TEST ( outData->values()[0] == 0 );
-  BOOST_TEST ( outData->values()[1] == 26.0 );
-  BOOST_TEST ( outData->values()[2] == -22.0 );
-
-
+  BOOST_TEST(outData->values()[0] == 0);
+  BOOST_TEST(outData->values()[1] == 26.0);
+  BOOST_TEST(outData->values()[2] == -22.0);
 
   // Test separated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingSep(Mapping::CONSERVATIVE, dimensions, fct,
-                                               xDead, yDead, zDead,
-                                               1e-9, Polynomial::SEPARATE);
+                                                xDead, yDead, zDead,
+                                                1e-9, Polynomial::SEPARATE);
 
   mappingSep.setMeshes(inMesh, outMesh);
   mappingSep.computeMapping();
   mappingSep.map(inDataID, outDataID);
 
-  BOOST_TEST ( outData->values()[0] == 0 );
-  BOOST_TEST ( outData->values()[1] == 26.0 );
-  BOOST_TEST ( outData->values()[2] == -22.0 );
-
+  BOOST_TEST(outData->values()[0] == 0);
+  BOOST_TEST(outData->values()[1] == 26.0);
+  BOOST_TEST(outData->values()[2] == -22.0);
 }
-
 
 BOOST_AUTO_TEST_CASE(NoMapping)
 {
@@ -1513,15 +1639,15 @@ BOOST_AUTO_TEST_CASE(NoMapping)
 
   {
     // Call only computeMapping
-    mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", 2, false, testing::nextMeshID()) );
-    mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-    inMesh->createVertex ( Eigen::Vector2d(0, 0) );
+    mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", 2, false, testing::nextMeshID()));
+    mesh::PtrData inData = inMesh->createData("InData", 1);
+    inMesh->createVertex(Eigen::Vector2d(0, 0));
     inMesh->allocateDataValues();
     addGlobalIndex(inMesh);
 
-    mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", 2, false, testing::nextMeshID()) );
-    mesh::PtrData outData = outMesh->createData( "OutData", 1 );
-    outMesh->createVertex( Eigen::Vector2d(0, 0));
+    mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", 2, false, testing::nextMeshID()));
+    mesh::PtrData outData = outMesh->createData("OutData", 1);
+    outMesh->createVertex(Eigen::Vector2d(0, 0));
     outMesh->allocateDataValues();
     addGlobalIndex(outMesh);
 
@@ -1543,21 +1669,21 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector2d(1, 1) ).setGlobalIndex(2);
-  inMesh->createVertex ( Vector2d(1, 0) ).setGlobalIndex(3);
-  inMesh->createVertex ( Vector2d(0, 0) ).setGlobalIndex(6);
-  inMesh->createVertex ( Vector2d(0, 1) ).setGlobalIndex(5);
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector2d(1, 1)).setGlobalIndex(2);
+  inMesh->createVertex(Vector2d(1, 0)).setGlobalIndex(3);
+  inMesh->createVertex(Vector2d(0, 0)).setGlobalIndex(6);
+  inMesh->createVertex(Vector2d(0, 1)).setGlobalIndex(5);
   inMesh->allocateDataValues();
 
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData( "OutData", 1 );
-  int outDataID = outData->getID();
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.5, 0.5));
 
   outMesh->allocateDataValues();
@@ -1569,20 +1695,20 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   mapping1.computeMapping();
   mapping1.map(inDataID, outDataID);
 
-  BOOST_TEST ( outData->values()[0] == 1 );
+  BOOST_TEST(outData->values()[0] == 1);
 
   PetRadialBasisFctMapping<Gaussian> mapping2(Mapping::CONSERVATIVE, dimensions, fct,
                                               xDead, yDead, zDead);
   inData->values() << 0, 0, 0, 0; // reset
-  outData->values() << 4; // used as inData here
+  outData->values() << 4;         // used as inData here
   mapping2.setMeshes(outMesh, inMesh);
   mapping2.computeMapping();
   mapping2.map(outDataID, inDataID);
 
-  BOOST_TEST ( inData->values()[0] == 1.0 );
-  BOOST_TEST ( inData->values()[1] == 1.0 );
-  BOOST_TEST ( inData->values()[2] == 1.0 );
-  BOOST_TEST ( inData->values()[3] == 1.0 );
+  BOOST_TEST(inData->values()[0] == 1.0);
+  BOOST_TEST(inData->values()[1] == 1.0);
+  BOOST_TEST(inData->values()[2] == 1.0);
+  BOOST_TEST(inData->values()[3] == 1.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Serial

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -1,10 +1,10 @@
 #include "testing/Testing.hpp"
 
 #include "mapping/RadialBasisFctMapping.hpp"
-#include "mesh/Mesh.hpp"
-#include "mesh/Data.hpp"
-#include "mesh/Vertex.hpp"
 #include "math/math.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/Vertex.hpp"
 
 using namespace precice;
 using namespace precice::mapping;
@@ -13,17 +13,17 @@ BOOST_AUTO_TEST_SUITE(MappingTests)
 BOOST_AUTO_TEST_SUITE(RadialBasisFunctionMapping, *testing::OnMaster())
 
 // Forward declarations, see end of file for definitions
-void perform2DTestConsistentMapping(Mapping& mapping);
-void perform2DTestConservativeMapping(Mapping& mapping);
-void perform3DTestConsistentMapping(Mapping& mapping);
-void perform3DTestConservativeMapping(Mapping& mapping);
+void perform2DTestConsistentMapping(Mapping &mapping);
+void perform2DTestConservativeMapping(Mapping &mapping);
+void perform3DTestConsistentMapping(Mapping &mapping);
+void perform3DTestConservativeMapping(Mapping &mapping);
 
 BOOST_AUTO_TEST_CASE(MapThinPlateSplines)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  ThinPlateSplines fct;
+  bool                                    xDead = false;
+  bool                                    yDead = false;
+  bool                                    zDead = false;
+  ThinPlateSplines                        fct;
   RadialBasisFctMapping<ThinPlateSplines> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<ThinPlateSplines> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -36,10 +36,10 @@ BOOST_AUTO_TEST_CASE(MapThinPlateSplines)
 
 BOOST_AUTO_TEST_CASE(MapMultiquadrics)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  Multiquadrics fct(1e-3);
+  bool                                 xDead = false;
+  bool                                 yDead = false;
+  bool                                 zDead = false;
+  Multiquadrics                        fct(1e-3);
   RadialBasisFctMapping<Multiquadrics> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<Multiquadrics> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -52,10 +52,10 @@ BOOST_AUTO_TEST_CASE(MapMultiquadrics)
 
 BOOST_AUTO_TEST_CASE(MapInverseMultiquadrics)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  InverseMultiquadrics fct(1e-3);
+  bool                                        xDead = false;
+  bool                                        yDead = false;
+  bool                                        zDead = false;
+  InverseMultiquadrics                        fct(1e-3);
   RadialBasisFctMapping<InverseMultiquadrics> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<InverseMultiquadrics> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -68,10 +68,10 @@ BOOST_AUTO_TEST_CASE(MapInverseMultiquadrics)
 
 BOOST_AUTO_TEST_CASE(MapVolumeSplines)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  VolumeSplines fct;
+  bool                                 xDead = false;
+  bool                                 yDead = false;
+  bool                                 zDead = false;
+  VolumeSplines                        fct;
   RadialBasisFctMapping<VolumeSplines> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<VolumeSplines> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -84,10 +84,10 @@ BOOST_AUTO_TEST_CASE(MapVolumeSplines)
 
 BOOST_AUTO_TEST_CASE(MapGaussian)
 {
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
-  Gaussian fct(1.0);
+  bool                            xDead = false;
+  bool                            yDead = false;
+  bool                            zDead = false;
+  Gaussian                        fct(1.0);
   RadialBasisFctMapping<Gaussian> consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<Gaussian> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
@@ -98,13 +98,12 @@ BOOST_AUTO_TEST_CASE(MapGaussian)
   perform3DTestConservativeMapping(conservativeMap3D);
 }
 
-
 BOOST_AUTO_TEST_CASE(MapThinPlaceSplinesC2)
 {
-  double supportRadius = 1.2;
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
+  double                    supportRadius = 1.2;
+  bool                      xDead         = false;
+  bool                      yDead         = false;
+  bool                      zDead         = false;
   CompactThinPlateSplinesC2 fct(supportRadius);
   using Mapping = RadialBasisFctMapping<CompactThinPlateSplinesC2>;
   Mapping consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
@@ -119,10 +118,10 @@ BOOST_AUTO_TEST_CASE(MapThinPlaceSplinesC2)
 
 BOOST_AUTO_TEST_CASE(MapCompactPolynomialC0)
 {
-  double supportRadius = 1.2;
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
+  double              supportRadius = 1.2;
+  bool                xDead         = false;
+  bool                yDead         = false;
+  bool                zDead         = false;
   CompactPolynomialC0 fct(supportRadius);
   using Mapping = RadialBasisFctMapping<CompactPolynomialC0>;
   Mapping consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
@@ -137,10 +136,10 @@ BOOST_AUTO_TEST_CASE(MapCompactPolynomialC0)
 
 BOOST_AUTO_TEST_CASE(MapCompactPolynomialC6)
 {
-  double supportRadius = 1.2;
-  bool xDead = false;
-  bool yDead = false;
-  bool zDead = false;
+  double              supportRadius = 1.2;
+  bool                xDead         = false;
+  bool                yDead         = false;
+  bool                zDead         = false;
   CompactPolynomialC6 fct(supportRadius);
   using Mapping = RadialBasisFctMapping<CompactPolynomialC6>;
   Mapping consistentMap2D(Mapping::CONSISTENT, 2, fct, xDead, yDead, zDead);
@@ -156,43 +155,43 @@ BOOST_AUTO_TEST_CASE(MapCompactPolynomialC6)
 BOOST_AUTO_TEST_CASE(DeadAxis2D)
 {
   int dimensions = 2;
-  
+
   bool xDead = false;
   bool yDead = true;
   bool zDead = false;
 
-  ThinPlateSplines fct;
+  ThinPlateSplines                        fct;
   RadialBasisFctMapping<ThinPlateSplines> mapping(Mapping::CONSISTENT, dimensions, fct,
                                                   xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Eigen::Vector2d(0.0, 1.0) );
-  inMesh->createVertex ( Eigen::Vector2d(1.0, 1.0) );
-  inMesh->createVertex ( Eigen::Vector2d(2.0, 1.0) );
-  inMesh->createVertex ( Eigen::Vector2d(3.0, 1.0) );
-  inMesh->allocateDataValues ();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Eigen::Vector2d(0.0, 1.0));
+  inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  inMesh->createVertex(Eigen::Vector2d(2.0, 1.0));
+  inMesh->createVertex(Eigen::Vector2d(3.0, 1.0));
+  inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0, 2.0, 1.0;
-  
+
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
-  mesh::Vertex& vertex = outMesh->createVertex ( Eigen::Vector2d::Zero() );
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector2d::Zero());
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-  vertex.setCoords ( Eigen::Vector2d(0.0, 3.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(0.0, 3.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   double value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 1.0 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(DeadAxis3D)
@@ -200,211 +199,211 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   int dimensions = 3;
   using Eigen::Vector3d;
 
-  double supportRadius = 1.2;
+  double              supportRadius = 1.2;
   CompactPolynomialC6 fct(supportRadius);
-  bool xDead = false;
-  bool yDead = true;
-  bool zDead = false;
-  using Mapping = RadialBasisFctMapping<CompactPolynomialC6>;
+  bool                xDead = false;
+  bool                yDead = true;
+  bool                zDead = false;
+  using Mapping             = RadialBasisFctMapping<CompactPolynomialC6>;
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Vector3d(0.0, 3.0, 0.0) );
-  inMesh->createVertex ( Vector3d(1.0, 3.0, 0.0) );
-  inMesh->createVertex ( Vector3d(0.0, 3.0, 1.0) );
-  inMesh->createVertex ( Vector3d(1.0, 3.0, 1.0) );
-  inMesh->allocateDataValues ();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Vector3d(0.0, 3.0, 0.0));
+  inMesh->createVertex(Vector3d(1.0, 3.0, 0.0));
+  inMesh->createVertex(Vector3d(0.0, 3.0, 1.0));
+  inMesh->createVertex(Vector3d(1.0, 3.0, 1.0));
+  inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0, 3.0, 4.0;
-  
+
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
-  outMesh->createVertex ( Vector3d(0.0, 2.9, 0.0) );
-  outMesh->createVertex ( Vector3d(0.8, 2.9, 0.1) );
-  outMesh->createVertex ( Vector3d(0.1, 2.9, 0.9) );
-  outMesh->createVertex ( Vector3d(1.1, 2.9, 1.1) );
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  outMesh->createVertex(Vector3d(0.0, 2.9, 0.0));
+  outMesh->createVertex(Vector3d(0.8, 2.9, 0.1));
+  outMesh->createVertex(Vector3d(0.1, 2.9, 0.9));
+  outMesh->createVertex(Vector3d(1.1, 2.9, 1.1));
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_CHECK ( mapping.hasComputedMapping() );
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_CHECK(mapping.hasComputedMapping());
 
-  BOOST_TEST ( outData->values()[0] = 1.0 );
-  BOOST_TEST ( outData->values()[1] = 2.0 );
-  BOOST_TEST ( outData->values()[2] = 2.9 );
-  BOOST_TEST ( outData->values()[3] = 4.3 );
+  BOOST_TEST(outData->values()[0] = 1.0);
+  BOOST_TEST(outData->values()[1] = 2.0);
+  BOOST_TEST(outData->values()[2] = 2.9);
+  BOOST_TEST(outData->values()[3] = 4.3);
 }
 
-void perform2DTestConsistentMapping(Mapping& mapping )
+void perform2DTestConsistentMapping(Mapping &mapping)
 {
   int dimensions = 2;
-  
+
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  inMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
-  inMesh->createVertex ( Eigen::Vector2d(1.0, 0.0) );
-  inMesh->createVertex ( Eigen::Vector2d(1.0, 1.0) );
-  inMesh->createVertex ( Eigen::Vector2d(0.0, 1.0) );
-  inMesh->allocateDataValues ();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  inMesh->createVertex(Eigen::Vector2d(1.0, 0.0));
+  inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  inMesh->createVertex(Eigen::Vector2d(0.0, 1.0));
+  inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID();
-  mesh::Vertex& vertex = outMesh->createVertex ( Eigen::Vector2d::Constant(0.0) );
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-  vertex.setCoords ( Eigen::Vector2d(0.0, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(0.0, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   double value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 1.0 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 1.0);
 
-  vertex.setCoords ( Eigen::Vector2d(0.0, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(0.0, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 1.0 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 1.0);
 
-  vertex.setCoords ( Eigen::Vector2d(0.0, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(0.0, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 1.0 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 1.0);
 
-  vertex.setCoords ( Eigen::Vector2d(1.0, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(1.0, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 2.0 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 2.0);
 
-  vertex.setCoords ( Eigen::Vector2d(1.0, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(1.0, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 2.0 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 2.0);
 
-  vertex.setCoords ( Eigen::Vector2d(1.0, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(1.0, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 2.0 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 2.0);
 
-  vertex.setCoords ( Eigen::Vector2d(0.5, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(0.5, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 1.5 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 1.5);
 
-  vertex.setCoords ( Eigen::Vector2d(0.5, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(0.5, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 1.5 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 1.5);
 
-  vertex.setCoords ( Eigen::Vector2d(0.5, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
+  vertex.setCoords(Eigen::Vector2d(0.5, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( value == 1.5 );
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(value == 1.5);
 }
 
-void perform2DTestConservativeMapping(Mapping& mapping)
+void perform2DTestConservativeMapping(Mapping &mapping)
 {
   using testing::equals;
   int dimensions = 2;
-  
+
   // Create mesh to map from
-  mesh::PtrMesh inMesh ( new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData inData = inMesh->createData ( "InData", 1 );
-  int inDataID = inData->getID ();
-  mesh::Vertex& vertex0 = inMesh->createVertex ( Eigen::Vector2d::Zero() );
-  mesh::Vertex& vertex1 = inMesh->createVertex ( Eigen::Vector2d::Zero() );
-  inMesh->allocateDataValues ();
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  mesh::Vertex &vertex0  = inMesh->createVertex(Eigen::Vector2d::Zero());
+  mesh::Vertex &vertex1  = inMesh->createVertex(Eigen::Vector2d::Zero());
+  inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh ( new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()) );
-  mesh::PtrData outData = outMesh->createData ( "OutData", 1 );
-  int outDataID = outData->getID ();
-  outMesh->createVertex ( Eigen::Vector2d(0.0, 0.0) );
-  outMesh->createVertex ( Eigen::Vector2d(1.0, 0.0) );
-  outMesh->createVertex ( Eigen::Vector2d(1.0, 1.0) );
-  outMesh->createVertex ( Eigen::Vector2d(0.0, 1.0) );
-  outMesh->allocateDataValues ();
-  Eigen::VectorXd& values = outData->values();
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  outMesh->createVertex(Eigen::Vector2d(1.0, 0.0));
+  outMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  outMesh->createVertex(Eigen::Vector2d(0.0, 1.0));
+  outMesh->allocateDataValues();
+  Eigen::VectorXd &values = outData->values();
 
-  mapping.setMeshes ( inMesh, outMesh );
-  BOOST_TEST ( mapping.hasComputedMapping() == false );
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
-  vertex0.setCoords ( Eigen::Vector2d(0.5, 0.0) );
-  vertex1.setCoords ( Eigen::Vector2d(0.5, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_CHECK ( equals(values, Eigen::Vector4d(0.5, 0.5, 1.0, 1.0)) );
+  vertex0.setCoords(Eigen::Vector2d(0.5, 0.0));
+  vertex1.setCoords(Eigen::Vector2d(0.5, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_CHECK(equals(values, Eigen::Vector4d(0.5, 0.5, 1.0, 1.0)));
 
-  vertex0.setCoords ( Eigen::Vector2d(0.0, 0.5) );
-  vertex1.setCoords ( Eigen::Vector2d(1.0, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_CHECK ( equals( values, Eigen::Vector4d(0.5, 1.0, 1.0, 0.5)) );
+  vertex0.setCoords(Eigen::Vector2d(0.0, 0.5));
+  vertex1.setCoords(Eigen::Vector2d(1.0, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_CHECK(equals(values, Eigen::Vector4d(0.5, 1.0, 1.0, 0.5)));
 
-  vertex0.setCoords ( Eigen::Vector2d(0.0, 1.0) );
-  vertex1.setCoords ( Eigen::Vector2d(1.0, 0.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_CHECK ( equals(values, Eigen::Vector4d(0.0, 2.0, 0.0, 1.0)) );
+  vertex0.setCoords(Eigen::Vector2d(0.0, 1.0));
+  vertex1.setCoords(Eigen::Vector2d(1.0, 0.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_CHECK(equals(values, Eigen::Vector4d(0.0, 2.0, 0.0, 1.0)));
 
-  vertex0.setCoords ( Eigen::Vector2d(0.0, 0.0) );
-  vertex1.setCoords ( Eigen::Vector2d(1.0, 1.0) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_CHECK ( equals(values, Eigen::Vector4d(1.0, 0.0, 2.0, 0.0)) );
+  vertex0.setCoords(Eigen::Vector2d(0.0, 0.0));
+  vertex1.setCoords(Eigen::Vector2d(1.0, 1.0));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_CHECK(equals(values, Eigen::Vector4d(1.0, 0.0, 2.0, 0.0)));
 
-  vertex0.setCoords ( Eigen::Vector2d(0.4, 0.5) );
-  vertex1.setCoords ( Eigen::Vector2d(0.6, 0.5) );
-  mapping.computeMapping ();
-  mapping.map ( inDataID, outDataID );
-  BOOST_CHECK ( mapping.hasComputedMapping() );
-  BOOST_TEST ( values.sum() == 3.0 );
+  vertex0.setCoords(Eigen::Vector2d(0.4, 0.5));
+  vertex1.setCoords(Eigen::Vector2d(0.6, 0.5));
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+  BOOST_CHECK(mapping.hasComputedMapping());
+  BOOST_TEST(values.sum() == 3.0);
 }
 
-void perform3DTestConsistentMapping(Mapping& mapping )
+void perform3DTestConsistentMapping(Mapping &mapping)
 {
   int dimensions = 3;
-  
+
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData inData = inMesh->createData("InData", 1);
-  int inDataID = inData->getID();
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
@@ -418,131 +417,131 @@ void perform3DTestConsistentMapping(Mapping& mapping )
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData outData = outMesh->createData("OutData", 1);
-  int outDataID = outData->getID();
-  mesh::Vertex& vertex = outMesh->createVertex(Eigen::Vector3d::Zero());
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector3d::Zero());
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
-  BOOST_TEST(mapping.hasComputedMapping() == false );
+  BOOST_TEST(mapping.hasComputedMapping() == false);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   double value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
   value = outData->values()[0];
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(value == 1.5);
 }
 
-void perform3DTestConservativeMapping(Mapping& mapping)
+void perform3DTestConservativeMapping(Mapping &mapping)
 {
   int dimensions = 3;
-  
+
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData inData = inMesh->createData("InData", 1);
-  int inDataID = inData->getID();
-  mesh::Vertex& vertex0 = inMesh->createVertex(Eigen::Vector3d::Zero());
-  mesh::Vertex& vertex1 = inMesh->createVertex(Eigen::Vector3d::Zero());
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  mesh::Vertex &vertex0  = inMesh->createVertex(Eigen::Vector3d::Zero());
+  mesh::Vertex &vertex1  = inMesh->createVertex(Eigen::Vector3d::Zero());
   inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0;
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
-  mesh::PtrData outData = outMesh->createData("OutData", 1);
-  int outDataID = outData->getID();
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
   outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   outMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
   outMesh->createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
@@ -552,8 +551,8 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   outMesh->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
   outMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 1.0));
   outMesh->allocateDataValues();
-  Eigen::VectorXd& values = outData->values();
-  double expectedSum = inData->values().sum();
+  Eigen::VectorXd &values      = outData->values();
+  double           expectedSum = inData->values().sum();
 
   mapping.setMeshes(inMesh, outMesh);
   BOOST_TEST(mapping.hasComputedMapping() == false);
@@ -562,7 +561,7 @@ void perform3DTestConservativeMapping(Mapping& mapping)
   vertex1.setCoords(Eigen::Vector3d(0.5, 1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  BOOST_CHECK(mapping.hasComputedMapping() );
+  BOOST_CHECK(mapping.hasComputedMapping());
   BOOST_TEST(values.sum() == expectedSum);
 }
 

--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -1,11 +1,8 @@
 #include "math/barycenter.hpp"
 
-namespace precice
-{
-namespace math
-{
-namespace barycenter
-{
+namespace precice {
+namespace math {
+namespace barycenter {
 
 BarycentricCoordsAndProjected calcBarycentricCoordsForEdge(
     const Eigen::VectorXd &edgeA,
@@ -19,7 +16,7 @@ BarycentricCoordsAndProjected calcBarycentricCoordsForEdge(
 
   const int dimensions = edgeA.size();
   PRECICE_ASSERT(dimensions == edgeB.size() && dimensions == edgeNormal.size() && dimensions == location.size(),
-            "The inputs need to have the same dimensions.");
+                 "The inputs need to have the same dimensions.");
   PRECICE_ASSERT((dimensions == 2) || (dimensions == 3), dimensions);
 
   Vector2d barycentricCoords;

--- a/src/math/barycenter.hpp
+++ b/src/math/barycenter.hpp
@@ -4,13 +4,10 @@
 #include <Eigen/Dense>
 #include "math/geometry.hpp"
 
-namespace precice
-{
-namespace math
-{
+namespace precice {
+namespace math {
 /// Provides operations to calculate barycentric coordinates and projection from a point to a primitive.
-namespace barycenter
-{
+namespace barycenter {
 
 /// The result of calculating the barycentric coordinates.
 struct BarycentricCoordsAndProjected {

--- a/src/math/constants.hpp
+++ b/src/math/constants.hpp
@@ -2,8 +2,10 @@
 
 #include <boost/math/constants/constants.hpp>
 
-namespace precice { namespace math {
+namespace precice {
+namespace math {
 
 constexpr double PI = boost::math::constants::pi<double>();
 
-}}
+}
+} // namespace precice

--- a/src/math/differences.hpp
+++ b/src/math/differences.hpp
@@ -10,92 +10,87 @@ constexpr double NUMERICAL_ZERO_DIFFERENCE = 1.0e-14;
 
 /// Compares two Eigen::MatrixBase for equality up to tolerance
 template <class DerivedA, class DerivedB>
-constexpr bool equals (const Eigen::MatrixBase<DerivedA>& A,
-                       const Eigen::MatrixBase<DerivedB>& B,
-                       double tolerance = NUMERICAL_ZERO_DIFFERENCE)
+constexpr bool equals(const Eigen::MatrixBase<DerivedA> &A,
+                      const Eigen::MatrixBase<DerivedB> &B,
+                      double                             tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
   return A.isApprox(B, tolerance);
 }
 
 /// Compares two scalar (arithmetic) types
-template<class Scalar>
-typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>
-::type equals(const Scalar a, const Scalar b, const Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
+template <class Scalar>
+typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type equals(const Scalar a, const Scalar b, const Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
   return std::abs(a - b) <= tolerance;
 }
 
-template<class DerivedA, class DerivedB>
-bool oneGreater(const Eigen::MatrixBase<DerivedA> & A,
-                const Eigen::MatrixBase<DerivedB> & B,
-                double tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
+template <class DerivedA, class DerivedB>
+bool oneGreater(const Eigen::MatrixBase<DerivedA> &A,
+                const Eigen::MatrixBase<DerivedB> &B,
+                double                             tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
   PRECICE_ASSERT(A.rows() == B.rows(), "Matrices with different number of rows can't be compared.");
   PRECICE_ASSERT(A.cols() == B.cols(), "Matrices with different number of cols can't be compared.");
-  
-  return ((A-B).array() > tolerance).any();
+
+  return ((A - B).array() > tolerance).any();
 }
 
-template<class DerivedA, class DerivedB>
-bool oneGreaterEquals(const Eigen::MatrixBase<DerivedA> & A,
-                      const Eigen::MatrixBase<DerivedB> & B,
-                      double tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
+template <class DerivedA, class DerivedB>
+bool oneGreaterEquals(const Eigen::MatrixBase<DerivedA> &A,
+                      const Eigen::MatrixBase<DerivedB> &B,
+                      double                             tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
   PRECICE_ASSERT(A.rows() == B.rows(), "Matrices with different number of rows can't be compared.");
   PRECICE_ASSERT(A.cols() == B.cols(), "Matrices with different number of cols can't be compared.");
-  
-  return ((A-B).array() >= -tolerance).any();
+
+  return ((A - B).array() >= -tolerance).any();
 }
 
-template<class DerivedA, class DerivedB>
-bool allGreater(const Eigen::MatrixBase<DerivedA> & A,
-                const Eigen::MatrixBase<DerivedB> & B,
-                double tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
+template <class DerivedA, class DerivedB>
+bool allGreater(const Eigen::MatrixBase<DerivedA> &A,
+                const Eigen::MatrixBase<DerivedB> &B,
+                double                             tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
   PRECICE_ASSERT(A.rows() == B.rows(), "Matrices with different number of rows can't be compared.");
   PRECICE_ASSERT(A.cols() == B.cols(), "Matrices with different number of cols can't be compared.");
-  
-  return ((A-B).array() > tolerance).all();
+
+  return ((A - B).array() > tolerance).all();
 }
 
-template<class DerivedA, class DerivedB>
-bool allGreaterEquals(const Eigen::MatrixBase<DerivedA> & A,
-                      const Eigen::MatrixBase<DerivedB> & B,
-                      double tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
+template <class DerivedA, class DerivedB>
+bool allGreaterEquals(const Eigen::MatrixBase<DerivedA> &A,
+                      const Eigen::MatrixBase<DerivedB> &B,
+                      double                             tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
   PRECICE_ASSERT(A.rows() == B.rows(), "Matrices with different number of rows can't be compared.");
   PRECICE_ASSERT(A.cols() == B.cols(), "Matrices with different number of cols can't be compared.");
-  
-  return ((A-B).array() >= tolerance).all();
+
+  return ((A - B).array() >= tolerance).all();
 }
 
-template<class Scalar>
-typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>
-::type greater(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
+template <class Scalar>
+typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type greater(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
   return A - B > tolerance;
 }
 
-template<class Scalar>
-typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>
-::type greaterEquals(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
+template <class Scalar>
+typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type greaterEquals(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
   return A - B >= -tolerance;
 }
 
-template<class Scalar>
-typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>
-::type smaller(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
+template <class Scalar>
+typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type smaller(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
   return A - B < -tolerance;
 }
 
-template<class Scalar>
-typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>
-::type smallerEquals(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
+template <class Scalar>
+typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type smallerEquals(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
   return A - B <= tolerance;
 }
 
-
-}}
+} // namespace math
+} // namespace precice

--- a/src/math/geometry.cpp
+++ b/src/math/geometry.cpp
@@ -8,30 +8,26 @@ namespace precice {
 namespace math {
 namespace geometry {
 
-bool segmentsIntersect
-(
-  const Eigen::Ref<const Eigen::Vector2d>& a,
-  const Eigen::Ref<const Eigen::Vector2d>& b,
-  const Eigen::Ref<const Eigen::Vector2d>& c,
-  const Eigen::Ref<const Eigen::Vector2d>& d,
-  bool countTouchingAsIntersection)
+bool segmentsIntersect(
+    const Eigen::Ref<const Eigen::Vector2d> &a,
+    const Eigen::Ref<const Eigen::Vector2d> &b,
+    const Eigen::Ref<const Eigen::Vector2d> &c,
+    const Eigen::Ref<const Eigen::Vector2d> &d,
+    bool                                     countTouchingAsIntersection)
 {
-  PRECICE_ASSERT( a.size() == 2, a.size() );
-  PRECICE_ASSERT( b.size() == 2, b.size() );
-  PRECICE_ASSERT( c.size() == 2, c.size() );
-  PRECICE_ASSERT( d.size() == 2, d.size() );
+  PRECICE_ASSERT(a.size() == 2, a.size());
+  PRECICE_ASSERT(b.size() == 2, b.size());
+  PRECICE_ASSERT(c.size() == 2, c.size());
+  PRECICE_ASSERT(d.size() == 2, d.size());
 
-  if ( countTouchingAsIntersection ) {
-    if ( between(a, b, c) ) {
+  if (countTouchingAsIntersection) {
+    if (between(a, b, c)) {
       return true;
-    }
-    else if ( between(a, b, d) ) {
+    } else if (between(a, b, d)) {
       return true;
-    }
-    else if ( between(c, d, a) ) {
+    } else if (between(c, d, a)) {
       return true;
-    }
-    else if ( between(c, d, b) ) {
+    } else if (between(c, d, b)) {
       return true;
     }
   }
@@ -41,10 +37,10 @@ bool segmentsIntersect
   double cda = triangleArea(c, d, a);
   double cdb = triangleArea(c, d, b);
 
-  double circABC = (a-b).norm() + (b-c).norm() + (c-a).norm();
-  double circABD = (a-b).norm() + (b-d).norm() + (d-a).norm();
-  double circCDA = (c-d).norm() + (d-a).norm() + (a-c).norm();
-  double circCDB = (c-d).norm() + (d-b).norm() + (b-c).norm();
+  double circABC = (a - b).norm() + (b - c).norm() + (c - a).norm();
+  double circABD = (a - b).norm() + (b - d).norm() + (d - a).norm();
+  double circCDA = (c - d).norm() + (d - a).norm() + (a - c).norm();
+  double circCDB = (c - d).norm() + (d - b).norm() + (b - c).norm();
 
   abc /= circABC;
   abd /= circABD;
@@ -58,194 +54,186 @@ bool segmentsIntersect
   // of this function, if countTouchingAsIntersection is true. Otherwise,
   // it should not be counted (-> false).
   using utils::xOR;
-  
-  if ( xOR(std::abs(abc) <= math::NUMERICAL_ZERO_DIFFERENCE,
-           std::abs(abd) <= math::NUMERICAL_ZERO_DIFFERENCE) ) {
+
+  if (xOR(std::abs(abc) <= math::NUMERICAL_ZERO_DIFFERENCE,
+          std::abs(abd) <= math::NUMERICAL_ZERO_DIFFERENCE)) {
     return false;
   }
-  if ( xOR(std::abs(cda) <= math::NUMERICAL_ZERO_DIFFERENCE,
-           std::abs(cdb) <= math::NUMERICAL_ZERO_DIFFERENCE) ) {
+  if (xOR(std::abs(cda) <= math::NUMERICAL_ZERO_DIFFERENCE,
+          std::abs(cdb) <= math::NUMERICAL_ZERO_DIFFERENCE)) {
     return false;
   }
 
   // Check, whether the segments are intersecting in the real sense.
-  bool isFirstSegmentBetween = xOR (abc > - math::NUMERICAL_ZERO_DIFFERENCE,
-                                    abd > - math::NUMERICAL_ZERO_DIFFERENCE );
-  bool isSecondSegmentBetween = xOR (cda > - math::NUMERICAL_ZERO_DIFFERENCE,
-                                     cdb > - math::NUMERICAL_ZERO_DIFFERENCE );
-  
+  bool isFirstSegmentBetween  = xOR(abc > -math::NUMERICAL_ZERO_DIFFERENCE,
+                                   abd > -math::NUMERICAL_ZERO_DIFFERENCE);
+  bool isSecondSegmentBetween = xOR(cda > -math::NUMERICAL_ZERO_DIFFERENCE,
+                                    cdb > -math::NUMERICAL_ZERO_DIFFERENCE);
+
   return isFirstSegmentBetween && isSecondSegmentBetween;
 }
 
-bool lineIntersection
-(
-  const Eigen::Ref<const Eigen::Vector2d>& a,
-  const Eigen::Ref<const Eigen::Vector2d>& b,
-  const Eigen::Ref<const Eigen::Vector2d>& c,
-  const Eigen::Ref<const Eigen::Vector2d>& d,
-  Eigen::Ref<Eigen::Vector2d>& intersectionPoint)
+bool lineIntersection(
+    const Eigen::Ref<const Eigen::Vector2d> &a,
+    const Eigen::Ref<const Eigen::Vector2d> &b,
+    const Eigen::Ref<const Eigen::Vector2d> &c,
+    const Eigen::Ref<const Eigen::Vector2d> &d,
+    Eigen::Ref<Eigen::Vector2d> &            intersectionPoint)
 {
-   // Compute denominator for solving 2x2 equation system
-   double D = a(0)*(d(1)-c(1)) +
-              b(0)*(c(1)-d(1)) +
-              d(0)*(b(1)-a(1)) -
-              c(0)*(a(1)-b(1));
+  // Compute denominator for solving 2x2 equation system
+  double D = a(0) * (d(1) - c(1)) +
+             b(0) * (c(1) - d(1)) +
+             d(0) * (b(1) - a(1)) -
+             c(0) * (a(1) - b(1));
 
-   // If D==0, the two lines are parallel
-   if ( math::equals(D, 0.0) ) {
-      return false;
-   }
+  // If D==0, the two lines are parallel
+  if (math::equals(D, 0.0)) {
+    return false;
+  }
 
-   // Compute line segment parameter s, which is in [0, 1], if the
-   // intersection point is within the segment.
-   double s = (a(0)*(d(1)-c(1)) + c(0)*(a(1)-d(1)) + d(0)*(c(1)-a(1))) / D;
+  // Compute line segment parameter s, which is in [0, 1], if the
+  // intersection point is within the segment.
+  double s = (a(0) * (d(1) - c(1)) + c(0) * (a(1) - d(1)) + d(0) * (c(1) - a(1))) / D;
 
-   intersectionPoint = a + s * (b - a);
-   return true;
+  intersectionPoint = a + s * (b - a);
+  return true;
 }
 
-ResultConstants segmentPlaneIntersection
-(
-  const Eigen::Vector3d & pointOnPlane,
-  const Eigen::Vector3d & planeNormal,
-  const Eigen::Vector3d & firstPointSegment,
-  const Eigen::Vector3d & secondPointSegment,
-  Eigen::Vector3d       & intersectionPoint )
+ResultConstants segmentPlaneIntersection(
+    const Eigen::Vector3d &pointOnPlane,
+    const Eigen::Vector3d &planeNormal,
+    const Eigen::Vector3d &firstPointSegment,
+    const Eigen::Vector3d &secondPointSegment,
+    Eigen::Vector3d &      intersectionPoint)
 {
-   // Methodology of "Computation Geometry in C", Joseph O'Rourke, Chapter 7.3.1
+  // Methodology of "Computation Geometry in C", Joseph O'Rourke, Chapter 7.3.1
 
-   // The plane is represented by: p(x,y,z) dot planeNormal = d  (1)
-   // We need to compute d by using pointOnPlane as p(x,y,z):
+  // The plane is represented by: p(x,y,z) dot planeNormal = d  (1)
+  // We need to compute d by using pointOnPlane as p(x,y,z):
   double d = pointOnPlane.dot(planeNormal);
 
-   // The segment is represented by:
-   // firstPointSegment + (secondPointSegment - firstPointSegement) * t (2)
-   // We insert (2) into (1) and reorder for t. The resulting equations reads
-   // t = (d - firstPointSegment dot planeNormal) /
-   //     ((secondPointSegment - firstPointSegment) dot planeNormal). (3)
-   //
-   // If the denominator of (3) equals 0, the segment is parallel to the plane.
-   // If, in addition, the denominator of (3) equals 0, the segment lies in the
-   // plane. Otherwise we can compute a point of intersection.
-   Eigen::Vector3d segmentVec ( secondPointSegment - firstPointSegment );
-   double nominator = d - firstPointSegment.dot(planeNormal);
-   double denominator = segmentVec.dot(planeNormal);
-   if ( math::equals(denominator, 0.0) ) {
-      if ( math::equals(nominator, 0.0) ) {
-         return CONTAINED;
-      }
-      else {
-         return NO_INTERSECTION;
-      }
-   }
-   double t = nominator / denominator;
-
-   // If t is larger than 1 or smaller than zero, the intersection is not within
-   // the line segment
-   if ( math::greater(t, 1.0) || math::greater(0.0, t) ) {
+  // The segment is represented by:
+  // firstPointSegment + (secondPointSegment - firstPointSegement) * t (2)
+  // We insert (2) into (1) and reorder for t. The resulting equations reads
+  // t = (d - firstPointSegment dot planeNormal) /
+  //     ((secondPointSegment - firstPointSegment) dot planeNormal). (3)
+  //
+  // If the denominator of (3) equals 0, the segment is parallel to the plane.
+  // If, in addition, the denominator of (3) equals 0, the segment lies in the
+  // plane. Otherwise we can compute a point of intersection.
+  Eigen::Vector3d segmentVec(secondPointSegment - firstPointSegment);
+  double          nominator   = d - firstPointSegment.dot(planeNormal);
+  double          denominator = segmentVec.dot(planeNormal);
+  if (math::equals(denominator, 0.0)) {
+    if (math::equals(nominator, 0.0)) {
+      return CONTAINED;
+    } else {
       return NO_INTERSECTION;
-   }
+    }
+  }
+  double t = nominator / denominator;
 
-   intersectionPoint = firstPointSegment + segmentVec * t;
+  // If t is larger than 1 or smaller than zero, the intersection is not within
+  // the line segment
+  if (math::greater(t, 1.0) || math::greater(0.0, t)) {
+    return NO_INTERSECTION;
+  }
 
-   // If t equals 1 or 0, the segment is just touching the plane, otherwise, a
-   // real intersection is happening.
-   if ( math::equals(t, 0.0) || math::equals(t, 1.0) ) {
-      return TOUCHING;
-   }
+  intersectionPoint = firstPointSegment + segmentVec * t;
 
-   return INTERSECTION;
+  // If t equals 1 or 0, the segment is just touching the plane, otherwise, a
+  // real intersection is happening.
+  if (math::equals(t, 0.0) || math::equals(t, 1.0)) {
+    return TOUCHING;
+  }
+
+  return INTERSECTION;
 }
 
-double triangleArea
-(
-  const Eigen::VectorXd& a,
-  const Eigen::VectorXd& b,
-  const Eigen::VectorXd& c )
+double triangleArea(
+    const Eigen::VectorXd &a,
+    const Eigen::VectorXd &b,
+    const Eigen::VectorXd &c)
 {
-  PRECICE_ASSERT( a.size() == b.size(), a.size(), b.size() );
-  PRECICE_ASSERT( b.size() == c.size(), b.size(), c.size() );
-  if ( a.size() == 2 ){
+  PRECICE_ASSERT(a.size() == b.size(), a.size(), b.size());
+  PRECICE_ASSERT(b.size() == c.size(), b.size(), c.size());
+  if (a.size() == 2) {
     Eigen::Vector2d A = b;
     A -= a;
     Eigen::Vector2d B = c;
     B -= a;
-    return 0.5 * (A(0)*B(1) - A(1)*B(0));
-  }
-  else {
-    PRECICE_ASSERT( a.size() == 3, a.size() );
-    Eigen::Vector3d A = b; A -= a;
-    Eigen::Vector3d B = c; B -= a;
+    return 0.5 * (A(0) * B(1) - A(1) * B(0));
+  } else {
+    PRECICE_ASSERT(a.size() == 3, a.size());
+    Eigen::Vector3d A = b;
+    A -= a;
+    Eigen::Vector3d B = c;
+    B -= a;
     return 0.5 * A.cross(B).norm();
   }
 }
 
-double tetraVolume
-(
-  const Eigen::Vector3d & a,
-  const Eigen::Vector3d & b,
-  const Eigen::Vector3d & c,
-  const Eigen::Vector3d & d )
+double tetraVolume(
+    const Eigen::Vector3d &a,
+    const Eigen::Vector3d &b,
+    const Eigen::Vector3d &c,
+    const Eigen::Vector3d &d)
 {
-  return std::abs( (a-d).dot((b-d).cross(c-d)) ) / 6.0;
+  return std::abs((a - d).dot((b - d).cross(c - d))) / 6.0;
 }
 
-Eigen::Vector2d projectVector
-(
-  const Eigen::Vector3d & vector,
-  int indexDimensionToRemove )
+Eigen::Vector2d projectVector(
+    const Eigen::Vector3d &vector,
+    int                    indexDimensionToRemove)
 {
-   PRECICE_ASSERT( indexDimensionToRemove >= 0 );
-   PRECICE_ASSERT( indexDimensionToRemove < 3 );
-   Eigen::Vector2d projectedVector;
-   int reducedDim = 0;
-   for (int dim=0; dim < 3; dim++) {
-      if ( indexDimensionToRemove == dim ) {
-         continue;
-      }
-      projectedVector(reducedDim) = vector(dim);
-      reducedDim++;
-   }
-   return projectedVector;
+  PRECICE_ASSERT(indexDimensionToRemove >= 0);
+  PRECICE_ASSERT(indexDimensionToRemove < 3);
+  Eigen::Vector2d projectedVector;
+  int             reducedDim = 0;
+  for (int dim = 0; dim < 3; dim++) {
+    if (indexDimensionToRemove == dim) {
+      continue;
+    }
+    projectedVector(reducedDim) = vector(dim);
+    reducedDim++;
+  }
+  return projectedVector;
 }
 
-int containedInTriangle
-(
-  const Eigen::Vector2d & triangleVertex0,
-  const Eigen::Vector2d & triangleVertex1,
-  const Eigen::Vector2d & triangleVertex2,
-  const Eigen::Vector2d & testPoint )
+int containedInTriangle(
+    const Eigen::Vector2d &triangleVertex0,
+    const Eigen::Vector2d &triangleVertex1,
+    const Eigen::Vector2d &triangleVertex2,
+    const Eigen::Vector2d &testPoint)
 {
-  double area0 = triangleArea ( triangleVertex0, triangleVertex1, testPoint );
-  double area1 = triangleArea ( triangleVertex1, triangleVertex2, testPoint );
-  double area2 = triangleArea ( triangleVertex2, triangleVertex0, testPoint );
+  double area0 = triangleArea(triangleVertex0, triangleVertex1, testPoint);
+  double area1 = triangleArea(triangleVertex1, triangleVertex2, testPoint);
+  double area2 = triangleArea(triangleVertex2, triangleVertex0, testPoint);
 
-  double length01 = ( triangleVertex0 - triangleVertex1 ).norm();
-  double length12 = ( triangleVertex1 - triangleVertex2 ).norm();
-  double length20 = ( triangleVertex2 - triangleVertex0 ).norm();
-  double length1t = ( triangleVertex1 - testPoint ).norm();
-  double length2t = ( triangleVertex2 - testPoint ).norm();
-  double length0t = ( triangleVertex0 - testPoint ).norm();
-  double scale0 = length01 + length1t + length0t;
-  double scale1 = length12 + length2t + length1t;
-  double scale2 = length20 + length0t + length2t;
+  double length01 = (triangleVertex0 - triangleVertex1).norm();
+  double length12 = (triangleVertex1 - triangleVertex2).norm();
+  double length20 = (triangleVertex2 - triangleVertex0).norm();
+  double length1t = (triangleVertex1 - testPoint).norm();
+  double length2t = (triangleVertex2 - testPoint).norm();
+  double length0t = (triangleVertex0 - testPoint).norm();
+  double scale0   = length01 + length1t + length0t;
+  double scale1   = length12 + length2t + length1t;
+  double scale2   = length20 + length0t + length2t;
   area0 /= scale0;
   area1 /= scale1;
   area2 /= scale2;
 
-  int sign0 = math::sign(area0);
-  int sign1 = math::sign(area1);
-  int sign2 = math::sign(area2);
-  int absSumSigns = std::abs( sign0 + sign1 + sign2 );
-  if ( absSumSigns == 3 ) {
+  int sign0       = math::sign(area0);
+  int sign1       = math::sign(area1);
+  int sign2       = math::sign(area2);
+  int absSumSigns = std::abs(sign0 + sign1 + sign2);
+  if (absSumSigns == 3) {
     // In triangle
     return CONTAINED;
-  }
-  else if ( absSumSigns == 2 ) {
+  } else if (absSumSigns == 2) {
     // On triangle edge
     return TOUCHING;
-  }
-  else if ( std::abs(sign0) + std::abs(sign1) + std::abs(sign2) == 1 ) {
+  } else if (std::abs(sign0) + std::abs(sign1) + std::abs(sign2) == 1) {
     // On triangle vertex
     return TOUCHING;
   }
@@ -253,4 +241,6 @@ int containedInTriangle
   return NOT_CONTAINED;
 }
 
-}}} // namespace precice, utils, geometry
+} // namespace geometry
+} // namespace math
+} // namespace precice

--- a/src/math/geometry.hpp
+++ b/src/math/geometry.hpp
@@ -6,7 +6,6 @@
 namespace precice {
 namespace math {
 
-
 /// Provides computational geometry operations.
 namespace geometry {
 
@@ -36,13 +35,12 @@ enum ResultConstants {
  *
  * @return True, if interseting. False, otherwise
  */
-bool segmentsIntersect
-(
-  const Eigen::Ref<const Eigen::Vector2d>& a,
-  const Eigen::Ref<const Eigen::Vector2d>& b,
-  const Eigen::Ref<const Eigen::Vector2d>& c,
-  const Eigen::Ref<const Eigen::Vector2d>& d,
-  bool countTouchingAsIntersection);
+bool segmentsIntersect(
+    const Eigen::Ref<const Eigen::Vector2d> &a,
+    const Eigen::Ref<const Eigen::Vector2d> &b,
+    const Eigen::Ref<const Eigen::Vector2d> &c,
+    const Eigen::Ref<const Eigen::Vector2d> &d,
+    bool                                     countTouchingAsIntersection);
 
 /**
  * @brief Determines the intersection point of two lines, if one exists.
@@ -55,12 +53,12 @@ bool segmentsIntersect
  * @param[out] intersectionPoint Point of intersection.
  * @return True, if an intersection point exists and could be determined.
  */
-bool lineIntersection (
-  const Eigen::Ref<const Eigen::Vector2d>& a,
-  const Eigen::Ref<const Eigen::Vector2d>& b,
-  const Eigen::Ref<const Eigen::Vector2d>& c,
-  const Eigen::Ref<const Eigen::Vector2d>& d,
-  Eigen::Ref<Eigen::Vector2d>& intersectionPoint);
+bool lineIntersection(
+    const Eigen::Ref<const Eigen::Vector2d> &a,
+    const Eigen::Ref<const Eigen::Vector2d> &b,
+    const Eigen::Ref<const Eigen::Vector2d> &c,
+    const Eigen::Ref<const Eigen::Vector2d> &d,
+    Eigen::Ref<Eigen::Vector2d> &            intersectionPoint);
 
 /**
  * @brief Determines the intersection point of a segment with a plane in 3D.
@@ -74,12 +72,12 @@ bool lineIntersection (
  *         - TOUCHING
  *         - CONTAINED
  */
-ResultConstants segmentPlaneIntersection (
-  const Eigen::Vector3d & pointOnPlane,
-  const Eigen::Vector3d & planeNormal,
-  const Eigen::Vector3d & firstPointSegment,
-  const Eigen::Vector3d & secondPointSegment,
-  Eigen::Vector3d       & intersectionPoint );
+ResultConstants segmentPlaneIntersection(
+    const Eigen::Vector3d &pointOnPlane,
+    const Eigen::Vector3d &planeNormal,
+    const Eigen::Vector3d &firstPointSegment,
+    const Eigen::Vector3d &secondPointSegment,
+    Eigen::Vector3d &      intersectionPoint);
 
 /**
  * @brief Determines, if a point lies on the line segment defined by a, b
@@ -92,11 +90,11 @@ ResultConstants segmentPlaneIntersection (
  *
  * @return True, if toCheck lies between a and b. False, otherwise
  */
-template<typename VECTORA_T, typename VECTORB_T, typename VECTORC_T>
-bool between (
-  const VECTORA_T& a,
-  const VECTORB_T& b,
-  const VECTORC_T& toCheck );
+template <typename VECTORA_T, typename VECTORB_T, typename VECTORC_T>
+bool between(
+    const VECTORA_T &a,
+    const VECTORB_T &b,
+    const VECTORC_T &toCheck);
 
 /**
  * @brief Determines, if three points are collinear (on one line)
@@ -109,12 +107,12 @@ bool between (
  *
  * @return True, if collinear. False, otherwise
  */
-template<typename Derived>
-bool collinear (
-  const Eigen::MatrixBase<Derived>& a,
-  const Eigen::MatrixBase<Derived>& b,
-  const Eigen::MatrixBase<Derived>& c );
-    
+template <typename Derived>
+bool collinear(
+    const Eigen::MatrixBase<Derived> &a,
+    const Eigen::MatrixBase<Derived> &b,
+    const Eigen::MatrixBase<Derived> &c);
+
 /**
  * @brief Determines, if two lines are parallel to each other.
  *
@@ -126,12 +124,12 @@ bool collinear (
  * @param[in] d Second point on second line.
  * @return True, if the two lines are parallel to each other.
  */
-template<typename Derived>
-static bool parallel (
-  const Eigen::MatrixBase<Derived>& a,
-  const Eigen::MatrixBase<Derived>& b,
-  const Eigen::MatrixBase<Derived>& c,
-  const Eigen::MatrixBase<Derived>& d );
+template <typename Derived>
+static bool parallel(
+    const Eigen::MatrixBase<Derived> &a,
+    const Eigen::MatrixBase<Derived> &b,
+    const Eigen::MatrixBase<Derived> &c,
+    const Eigen::MatrixBase<Derived> &d);
 
 /**
  * @brief Computes the signed area of a triangle in 2D.
@@ -139,22 +137,22 @@ static bool parallel (
  * The area is negative, if the points a, b, c are given in
  * clockwise ordering, otherwise positive.
  */
-double triangleArea (
-  const Eigen::VectorXd& a,
-  const Eigen::VectorXd& b,
-  const Eigen::VectorXd& c);
-    
+double triangleArea(
+    const Eigen::VectorXd &a,
+    const Eigen::VectorXd &b,
+    const Eigen::VectorXd &c);
+
 /// Computes the (unsigned) area of a triangle in 3D.
-double tetraVolume (
-  const Eigen::Vector3d & a,
-  const Eigen::Vector3d & b,
-  const Eigen::Vector3d & c,
-  const Eigen::Vector3d & d );
+double tetraVolume(
+    const Eigen::Vector3d &a,
+    const Eigen::Vector3d &b,
+    const Eigen::Vector3d &c,
+    const Eigen::Vector3d &d);
 
 /// Projects a 3D vector to a 2D one by removing one dimension.
-Eigen::Vector2d projectVector (
-  const Eigen::Vector3d & vector,
-  const int indexDimensionToRemove );
+Eigen::Vector2d projectVector(
+    const Eigen::Vector3d &vector,
+    const int              indexDimensionToRemove);
 
 /**
  * @brief Tests if a vertex is contained in a triangle.
@@ -164,11 +162,11 @@ Eigen::Vector2d projectVector (
  *         - NOT_CONTAINED
  *         - TOUCHING
  */
-int containedInTriangle (
-  const Eigen::Vector2d & triangleVertex0,
-  const Eigen::Vector2d & triangleVertex1,
-  const Eigen::Vector2d & triangleVertex2,
-  const Eigen::Vector2d & testPoint );
+int containedInTriangle(
+    const Eigen::Vector2d &triangleVertex0,
+    const Eigen::Vector2d &triangleVertex1,
+    const Eigen::Vector2d &triangleVertex2,
+    const Eigen::Vector2d &testPoint);
 
 /**
  * @brief Tests, if a vertex is contained in a hyperrectangle.
@@ -178,90 +176,88 @@ int containedInTriangle (
  *         - NOT_CONTAINED
  *         - TOUCHING
  */
-template<class Derived>
-int containedInHyperrectangle (
-  const Eigen::MatrixBase<Derived> & sidelengths,
-  const Eigen::MatrixBase<Derived> & center,
-  const Eigen::MatrixBase<Derived> & testPoint );
+template <class Derived>
+int containedInHyperrectangle(
+    const Eigen::MatrixBase<Derived> &sidelengths,
+    const Eigen::MatrixBase<Derived> &center,
+    const Eigen::MatrixBase<Derived> &testPoint);
 
 // --------------------------------------------------------- HEADER DEFINITIONS
 
-template<typename VECTORA_T, typename VECTORB_T, typename VECTORC_T>
-bool between
-(
-  const VECTORA_T& a,
-  const VECTORB_T& b,
-  const VECTORC_T& toCheck )
+template <typename VECTORA_T, typename VECTORB_T, typename VECTORC_T>
+bool between(
+    const VECTORA_T &a,
+    const VECTORB_T &b,
+    const VECTORC_T &toCheck)
 {
   if (not collinear(a, b, toCheck)) {
     return false;
   }
 
   if (a(0) != b(0)) {
-    return ( math::greaterEquals(toCheck(0), a(0)) && math::greaterEquals(b(0), toCheck(0)) ) ||
-      ( math::greaterEquals(a(0), toCheck(0)) && math::greaterEquals(toCheck(0), b(0)) );
-  }
-  else {
-    return ( math::greaterEquals(toCheck(1), a(1)) && math::greaterEquals(b(1), toCheck(1)) ) ||
-      ( math::greaterEquals(a(1), toCheck(1)) && math::greaterEquals(toCheck(1), b(1)) );
+    return (math::greaterEquals(toCheck(0), a(0)) && math::greaterEquals(b(0), toCheck(0))) ||
+           (math::greaterEquals(a(0), toCheck(0)) && math::greaterEquals(toCheck(0), b(0)));
+  } else {
+    return (math::greaterEquals(toCheck(1), a(1)) && math::greaterEquals(b(1), toCheck(1))) ||
+           (math::greaterEquals(a(1), toCheck(1)) && math::greaterEquals(toCheck(1), b(1)));
   }
 }
 
-template<typename Derived>
-bool collinear (
-  const Eigen::MatrixBase<Derived>& a,
-  const Eigen::MatrixBase<Derived>& b,
-  const Eigen::MatrixBase<Derived>& c )
+template <typename Derived>
+bool collinear(
+    const Eigen::MatrixBase<Derived> &a,
+    const Eigen::MatrixBase<Derived> &b,
+    const Eigen::MatrixBase<Derived> &c)
 {
-  PRECICE_ASSERT( a.size() == b.size(), a.size(), b.size() );
-  PRECICE_ASSERT( a.size() == c.size(), a.size(), c.size() );
-  double triangleOutline = (b-a).norm() + (c-b).norm() + (a-c).norm();
-  if ( math::equals(triangleArea(a, b, c) / triangleOutline, 0.0) ) {
+  PRECICE_ASSERT(a.size() == b.size(), a.size(), b.size());
+  PRECICE_ASSERT(a.size() == c.size(), a.size(), c.size());
+  double triangleOutline = (b - a).norm() + (c - b).norm() + (a - c).norm();
+  if (math::equals(triangleArea(a, b, c) / triangleOutline, 0.0)) {
     return true;
   }
   return false;
 }
 
-template<class Derived>
-bool parallel
-(
-  const Eigen::MatrixBase<Derived>& a,
-  const Eigen::MatrixBase<Derived>& b,
-  const Eigen::MatrixBase<Derived>& c,
-  const Eigen::MatrixBase<Derived>& d )
+template <class Derived>
+bool parallel(
+    const Eigen::MatrixBase<Derived> &a,
+    const Eigen::MatrixBase<Derived> &b,
+    const Eigen::MatrixBase<Derived> &c,
+    const Eigen::MatrixBase<Derived> &d)
 {
-  if ( math::equals(triangleArea(a, b, c), 0.0) and math::equals(triangleArea(a, b, d), 0.0) )
+  if (math::equals(triangleArea(a, b, c), 0.0) and math::equals(triangleArea(a, b, d), 0.0))
     return true;
-   
+
   return false;
 }
 
-template<class Derived>
-int containedInHyperrectangle
-(
-  const Eigen::MatrixBase<Derived> & sidelengths,
-  const Eigen::MatrixBase<Derived> & center,
-  const Eigen::MatrixBase<Derived> & testPoint)
+template <class Derived>
+int containedInHyperrectangle(
+    const Eigen::MatrixBase<Derived> &sidelengths,
+    const Eigen::MatrixBase<Derived> &center,
+    const Eigen::MatrixBase<Derived> &testPoint)
 {
-  int dim = sidelengths.size();
+  int             dim      = sidelengths.size();
   Eigen::VectorXd toCenter = testPoint - center;
-  toCenter = toCenter.cwiseAbs();
-  
-  double diff = 0.0;
-  bool touching = false;
-  for ( int i=0; i < dim; i++ ) {
+  toCenter                 = toCenter.cwiseAbs();
+
+  double diff     = 0.0;
+  bool   touching = false;
+  for (int i = 0; i < dim; i++) {
     diff = 0.5 * sidelengths(i) - toCenter(i);
-    if ( math::greater(0.0, diff) ) {
+    if (math::greater(0.0, diff)) {
       return NOT_CONTAINED;
     }
-    if ( math::equals(diff, 0.0) ) {
+    if (math::equals(diff, 0.0)) {
       touching = true;
     }
   }
-  if ( touching ) {
+  if (touching) {
     return TOUCHING;
   }
   return CONTAINED;
 }
 
-}}} // namespace precice, math, geometry
+} // namespace geometry
+} // namespace math
+} // namespace precice

--- a/src/math/la.hpp
+++ b/src/math/la.hpp
@@ -11,21 +11,22 @@ namespace math {
  * @param[in, out] result Vector which holds the sum and also defines the block sizes.
  */
 template <typename DerivedA, typename DerivedB>
-void sumSubvectors (const Eigen::MatrixBase<DerivedA>& vector,
-                    Eigen::MatrixBase<DerivedB>& result)
+void sumSubvectors(const Eigen::MatrixBase<DerivedA> &vector,
+                   Eigen::MatrixBase<DerivedB> &      result)
 {
-  int vectorSize = vector.size();
+  int vectorSize    = vector.size();
   int subvectorSize = result.size();
   PRECICE_ASSERT(vectorSize > 0);
   PRECICE_ASSERT(subvectorSize > 0);
   PRECICE_ASSERT(vectorSize % subvectorSize == 0, vectorSize, subvectorSize);
 
   result.setZero();
-  
+
   // Sum up subvectors
-  for (int i = 0; i < vectorSize; i+=subvectorSize) {
+  for (int i = 0; i < vectorSize; i += subvectorSize) {
     result += vector.block(i, 0, subvectorSize, 1);
-  }      
+  }
 }
 
-}}
+} // namespace math
+} // namespace precice

--- a/src/math/math.hpp
+++ b/src/math/math.hpp
@@ -1,23 +1,22 @@
 #pragma once
 
-#include "math/differences.hpp"
 #include "math/constants.hpp"
+#include "math/differences.hpp"
 #include "math/la.hpp"
 
 namespace precice {
 namespace math {
 
 /// Return the sign, one of {-1, 0, 1}
-inline int sign (double number)
+inline int sign(double number)
 {
-  if ( greater(number, 0.0) ) {
+  if (greater(number, 0.0)) {
     return 1;
-  }
-  else if ( greater(0.0, number) ) {
+  } else if (greater(0.0, number)) {
     return -1;
   }
   return 0;
 }
 
-}
-}
+} // namespace math
+} // namespace precice

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle)
   {
     Vector3d l(2.0, 0.0, 0.0);
     auto     ret = calcBarycentricCoordsForTriangle(a, b, c, n, l);
-    BOOST_TEST((ret.barycentricCoords.array() < -precice::math::NUMERICAL_ZERO_DIFFERENCE).any(), "Min 1 coord should be negative "<< ret.barycentricCoords);
+    BOOST_TEST((ret.barycentricCoords.array() < -precice::math::NUMERICAL_ZERO_DIFFERENCE).any(), "Min 1 coord should be negative " << ret.barycentricCoords);
   }
 }
 

--- a/src/math/tests/DifferencesTest.cpp
+++ b/src/math/tests/DifferencesTest.cpp
@@ -10,86 +10,85 @@ BOOST_AUTO_TEST_SUITE(Differences, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Scalar)
 {
-  double a = 1.0;
-  double b = 2.0;
+  double a   = 1.0;
+  double b   = 2.0;
   double eps = 1e-14;
 
-  BOOST_CHECK (greater(b, a, eps));
-  BOOST_CHECK (not greater(a, a - eps, eps));
-  BOOST_CHECK (greater(a, a - 10.0 * eps, eps));
+  BOOST_CHECK(greater(b, a, eps));
+  BOOST_CHECK(not greater(a, a - eps, eps));
+  BOOST_CHECK(greater(a, a - 10.0 * eps, eps));
 
-  BOOST_CHECK (not greaterEquals(a, b, eps));
-  BOOST_CHECK (greaterEquals(b, a, eps));
-  BOOST_CHECK (greaterEquals(a, a, eps));
-  BOOST_CHECK (greaterEquals(a, a + 0.1*eps, eps));
-  BOOST_CHECK (not greaterEquals(a, a + 10*eps, eps));
+  BOOST_CHECK(not greaterEquals(a, b, eps));
+  BOOST_CHECK(greaterEquals(b, a, eps));
+  BOOST_CHECK(greaterEquals(a, a, eps));
+  BOOST_CHECK(greaterEquals(a, a + 0.1 * eps, eps));
+  BOOST_CHECK(not greaterEquals(a, a + 10 * eps, eps));
 
-  BOOST_CHECK (smaller(a, b, eps));
-  BOOST_CHECK (not smaller(a, a + eps, eps));
-  BOOST_CHECK (smaller(a, a + 10.0 * eps, eps));
+  BOOST_CHECK(smaller(a, b, eps));
+  BOOST_CHECK(not smaller(a, a + eps, eps));
+  BOOST_CHECK(smaller(a, a + 10.0 * eps, eps));
 
-  BOOST_CHECK (smallerEquals(a, b, eps));
-  BOOST_CHECK (smallerEquals(a, a + eps, eps));
-  BOOST_CHECK (smallerEquals(a + eps, a, eps));
-  BOOST_CHECK (smallerEquals(a, a + 10.0 * eps, eps));
+  BOOST_CHECK(smallerEquals(a, b, eps));
+  BOOST_CHECK(smallerEquals(a, a + eps, eps));
+  BOOST_CHECK(smallerEquals(a + eps, a, eps));
+  BOOST_CHECK(smallerEquals(a, a + 10.0 * eps, eps));
 
-  BOOST_CHECK (not equals(a, b, eps));
-  BOOST_CHECK (equals(a, a, eps));
-  BOOST_CHECK (equals(a, a + eps, eps));
-  BOOST_CHECK (not equals(a, a + 10.0 * eps, eps));
-  BOOST_CHECK (equals(a, a + 10.0 * eps, 10.0 * eps));
+  BOOST_CHECK(not equals(a, b, eps));
+  BOOST_CHECK(equals(a, a, eps));
+  BOOST_CHECK(equals(a, a + eps, eps));
+  BOOST_CHECK(not equals(a, a + 10.0 * eps, eps));
+  BOOST_CHECK(equals(a, a + 10.0 * eps, 10.0 * eps));
 }
 
 BOOST_AUTO_TEST_CASE(Vector)
 {
   Eigen::Vector3d vec0(1.0, 2.0, 3.0);
   Eigen::Vector3d vec1(vec0);
-  BOOST_CHECK (equals(vec0,vec1));
-  BOOST_CHECK (not oneGreater(vec0,vec1));
-  BOOST_CHECK (oneGreaterEquals(vec0,vec1));
-  BOOST_CHECK (not allGreater(vec0,vec1));
-  
+  BOOST_CHECK(equals(vec0, vec1));
+  BOOST_CHECK(not oneGreater(vec0, vec1));
+  BOOST_CHECK(oneGreaterEquals(vec0, vec1));
+  BOOST_CHECK(not allGreater(vec0, vec1));
+
   vec0 << 2.0, 2.0, 3.0;
-  BOOST_CHECK (not equals(vec0,vec1));
-  BOOST_CHECK (oneGreater(vec0,vec1));
-  BOOST_CHECK (oneGreaterEquals(vec0,vec1));
-  BOOST_CHECK (not allGreater(vec0,vec1));
-  
+  BOOST_CHECK(not equals(vec0, vec1));
+  BOOST_CHECK(oneGreater(vec0, vec1));
+  BOOST_CHECK(oneGreaterEquals(vec0, vec1));
+  BOOST_CHECK(not allGreater(vec0, vec1));
+
   vec0 << 2.0, 3.0, 4.0;
-  BOOST_CHECK (not equals(vec0,vec1));
-  BOOST_CHECK (oneGreater(vec0,vec1));
-  BOOST_CHECK (oneGreaterEquals(vec0,vec1));
-  BOOST_CHECK (allGreater(vec0,vec1));
+  BOOST_CHECK(not equals(vec0, vec1));
+  BOOST_CHECK(oneGreater(vec0, vec1));
+  BOOST_CHECK(oneGreaterEquals(vec0, vec1));
+  BOOST_CHECK(allGreater(vec0, vec1));
 
   // up to here vec1=vec0
   const double tolerance = 1e-14;
-  vec0(0) = vec1(0);
-  vec0(1) = vec1(1);
-  vec0(2) = vec1(2) + 0.99 * tolerance;
-  BOOST_CHECK(equals(vec0,vec1,tolerance));
-  BOOST_CHECK (not oneGreater(vec0,vec1,tolerance));
-  BOOST_CHECK (oneGreaterEquals(vec0,vec1));
-  BOOST_CHECK (not allGreater(vec0,vec1,tolerance));
-  
+  vec0(0)                = vec1(0);
+  vec0(1)                = vec1(1);
+  vec0(2)                = vec1(2) + 0.99 * tolerance;
+  BOOST_CHECK(equals(vec0, vec1, tolerance));
+  BOOST_CHECK(not oneGreater(vec0, vec1, tolerance));
+  BOOST_CHECK(oneGreaterEquals(vec0, vec1));
+  BOOST_CHECK(not allGreater(vec0, vec1, tolerance));
+
   vec0(2) = vec1(2) + 10.0 * tolerance;
-  BOOST_CHECK (not equals(vec0,vec1,tolerance));
-  BOOST_CHECK (oneGreater(vec0,vec1,tolerance));
-  BOOST_CHECK (oneGreaterEquals(vec0,vec1));
-  BOOST_CHECK (not allGreater(vec0,vec1,tolerance));
-  
+  BOOST_CHECK(not equals(vec0, vec1, tolerance));
+  BOOST_CHECK(oneGreater(vec0, vec1, tolerance));
+  BOOST_CHECK(oneGreaterEquals(vec0, vec1));
+  BOOST_CHECK(not allGreater(vec0, vec1, tolerance));
+
   vec0 << 1.0, 2.0, 3.0;
   vec0 = vec0.array() + (10.0 * tolerance);
-  BOOST_CHECK (not equals(vec0,vec1,tolerance));
-  BOOST_CHECK (oneGreater(vec0,vec1,tolerance));
-  BOOST_CHECK (oneGreaterEquals(vec0,vec1));
-  BOOST_CHECK (allGreater(vec0,vec1,tolerance));
-  
+  BOOST_CHECK(not equals(vec0, vec1, tolerance));
+  BOOST_CHECK(oneGreater(vec0, vec1, tolerance));
+  BOOST_CHECK(oneGreaterEquals(vec0, vec1));
+  BOOST_CHECK(allGreater(vec0, vec1, tolerance));
+
   vec0 << 1.0, 2.0, 3.0;
   vec0 = vec0.array() - 0.99 * tolerance;
-  BOOST_CHECK (oneGreaterEquals(vec0,vec1));
+  BOOST_CHECK(oneGreaterEquals(vec0, vec1));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Differences
 
 BOOST_AUTO_TEST_SUITE_END() // Math
-

--- a/src/math/tests/GeometryTest.cpp
+++ b/src/math/tests/GeometryTest.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(Collinear)
 }
 
 BOOST_AUTO_TEST_CASE(TetraVolume,
-                     * boost::unit_test::tolerance(1e-3))
+                     *boost::unit_test::tolerance(1e-3))
 {
   Eigen::Vector3d a(1, 2, 3);
   Eigen::Vector3d b(3, 2, 1);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(TriangleArea)
 {
   { // 2D
     Eigen::Vector2d a, b, c;
-    double area;
+    double          area;
     a << 0.0, 0.0;
     b << 1.0, 0.0;
     c << 0.0, 1.0;
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(TriangleArea)
   }
   { // 3D
     Eigen::Vector3d a, b, c;
-    double area;
+    double          area;
     a << 0.0, 0.0, 0.0;
     b << 1.0, 0.0, 1.0;
     c << 1.0, 1.0, 1.0;
@@ -135,12 +135,12 @@ BOOST_AUTO_TEST_CASE(SegmentsIntersect)
 BOOST_AUTO_TEST_CASE(SegmentPlaneIntersection)
 {
   using Eigen::Vector3d;
-  Vector3d planeNormal = Vector3d::Constant(1.0);
-  Vector3d pointOnPlane = Vector3d::Constant(0.0);
-  Vector3d firstSegmentPoint = Vector3d::Constant(1.0);
+  Vector3d planeNormal        = Vector3d::Constant(1.0);
+  Vector3d pointOnPlane       = Vector3d::Constant(0.0);
+  Vector3d firstSegmentPoint  = Vector3d::Constant(1.0);
   Vector3d secondSegmentPoint = Vector3d::Constant(-1.0);
-  Vector3d intersectionPoint = Vector3d::Constant(1.0);
-  Vector3d expected = Vector3d::Constant(0.0);
+  Vector3d intersectionPoint  = Vector3d::Constant(1.0);
+  Vector3d expected           = Vector3d::Constant(0.0);
 
   // True intersection
   int result = geometry::segmentPlaneIntersection(
@@ -151,16 +151,16 @@ BOOST_AUTO_TEST_CASE(SegmentPlaneIntersection)
 
   // Touching second segment vertex
   secondSegmentPoint = Vector3d::Constant(0.0);
-  result = geometry::segmentPlaneIntersection(
+  result             = geometry::segmentPlaneIntersection(
       pointOnPlane, planeNormal, firstSegmentPoint,
       secondSegmentPoint, intersectionPoint);
   BOOST_TEST(result == geometry::TOUCHING);
   BOOST_CHECK(equals(intersectionPoint, expected));
 
   // Touching first segment vertex
-  firstSegmentPoint = Vector3d::Constant(0.0);
+  firstSegmentPoint  = Vector3d::Constant(0.0);
   secondSegmentPoint = Vector3d::Constant(-1.0);
-  result = geometry::segmentPlaneIntersection(
+  result             = geometry::segmentPlaneIntersection(
       pointOnPlane, planeNormal, firstSegmentPoint,
       secondSegmentPoint, intersectionPoint);
   BOOST_TEST(result == geometry::TOUCHING);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(SegmentPlaneIntersection)
   firstSegmentPoint << 0.0, 0.0, -3.0;
   intersectionPoint << 1.0, 2.0, 3.0; // should not be modified
   expected = intersectionPoint;
-  result = geometry::segmentPlaneIntersection(
+  result   = geometry::segmentPlaneIntersection(
       pointOnPlane, planeNormal, firstSegmentPoint,
       secondSegmentPoint, intersectionPoint);
   BOOST_TEST(result == geometry::NO_INTERSECTION);
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(ContainedInHyperrectangle)
 
   // Not contained 2D
   Eigen::Vector2d testPoint2D(2, 2);
-  int result = geometry::containedInHyperrectangle(
+  int             result = geometry::containedInHyperrectangle(
       sidelengths2D, center2D, testPoint2D);
   BOOST_TEST(result == geometry::NOT_CONTAINED);
 
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(ContainedInHyperrectangle)
   BOOST_TEST(result == geometry::TOUCHING);
 
   // 3D
-  Eigen::Vector3d center3D = Eigen::Vector3d::Zero();
+  Eigen::Vector3d center3D      = Eigen::Vector3d::Zero();
   Eigen::Vector3d sidelengths3D = Eigen::Vector3d::Constant(1.0);
 
   // Not contained 3D

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -4,70 +4,68 @@
 namespace precice {
 namespace mesh {
 
-size_t Data:: _dataCount = 0;
+size_t Data::_dataCount = 0;
 
-Data:: Data()
-:
-  _name ( "" ),
-  _id ( -1 ),
-  _dimensions ( 0 )
+Data::Data()
+    : _name(""),
+      _id(-1),
+      _dimensions(0)
 {
-  PRECICE_ASSERT( false );
+  PRECICE_ASSERT(false);
 }
 
-Data:: Data
-(
-  const std::string& name,
-  int                id,
-  int                dimensions )
-:
-  _values(),
-  _name ( name ),
-  _id ( id ),
-  _dimensions ( dimensions )
+Data::Data(
+    const std::string &name,
+    int                id,
+    int                dimensions)
+    : _values(),
+      _name(name),
+      _id(id),
+      _dimensions(dimensions)
 {
-  PRECICE_ASSERT( dimensions > 0, dimensions );
-  _dataCount ++;
+  PRECICE_ASSERT(dimensions > 0, dimensions);
+  _dataCount++;
 }
 
-Data:: ~Data()
+Data::~Data()
 {
-  _dataCount --;
+  _dataCount--;
 }
 
-Eigen::VectorXd& Data:: values()
+Eigen::VectorXd &Data::values()
 {
   return _values;
 }
 
-const Eigen::VectorXd& Data:: values() const
+const Eigen::VectorXd &Data::values() const
 {
   return _values;
 }
 
-const std::string& Data:: getName() const
+const std::string &Data::getName() const
 {
   return _name;
 }
 
-int Data:: getID() const
+int Data::getID() const
 {
   return _id;
 }
 
-int Data:: getDimensions() const
+int Data::getDimensions() const
 {
-   return _dimensions;
+  return _dimensions;
 }
 
-size_t Data:: getDataCount()
+size_t Data::getDataCount()
 {
   return _dataCount;
 }
 
-void Data:: resetDataCount()
+void Data::resetDataCount()
 {
   _dataCount = 0;
 }
 
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "logging/Logger.hpp"
 #include <Eigen/Core>
 #include <string>
+#include "logging/Logger.hpp"
 
 namespace precice {
-  namespace mesh {
-    class Mesh;
-  }
+namespace mesh {
+class Mesh;
 }
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
@@ -18,16 +18,14 @@ namespace mesh {
 /**
  * @brief Describes a set of data values belonging to the vertices of a mesh.
  */
-class Data
-{
+class Data {
 public:
-
   // @brief Possible types of data values.
-//  enum DataType {
-//    TYPE_UNDEFINED,
-//    TYPE_DOUBLE,
-//    TYPE_VECTOR
-//  };
+  //  enum DataType {
+  //    TYPE_UNDEFINED,
+  //    TYPE_DOUBLE,
+  //    TYPE_VECTOR
+  //  };
 
   // @brief Name of an undefined data type.
   //static const std::string TYPE_NAME_UNDEFINED;
@@ -41,54 +39,52 @@ public:
    *
    * Used to give Data objects unique IDs.
    */
-  static size_t getDataCount ();
+  static size_t getDataCount();
 
   /**
    * @brief Sets the data counter to zero.
    *
    * Used in test cases where multiple scenarios with data are run.
    */
-  static void resetDataCount ();
+  static void resetDataCount();
 
   /**
    * @brief Do not use this constructor! Only there for compatibility with std::map.
    */
-  Data ();
+  Data();
 
   /**
    * @brief Constructor.
    */
-  Data (
-    const std::string& name,
-    int                id,
-    int                dimension );
+  Data(
+      const std::string &name,
+      int                id,
+      int                dimension);
 
   /// Destructor, decrements data count.
   ~Data();
 
   /// Returns a reference to the data values.
-  Eigen::VectorXd& values ();
+  Eigen::VectorXd &values();
 
   /// Returns a const reference to the data values.
-  const Eigen::VectorXd& values () const;
+  const Eigen::VectorXd &values() const;
 
   /// Returns the name of the data set, as set in the config file.
-  const std::string& getName () const;
+  const std::string &getName() const;
 
   /// Returns the ID of the data set (supposed to be unique).
-  int getID () const;
+  int getID() const;
 
   /**
    * @brief Returns the type constant of the data set.
    */
-//  DataType getType () const;
+  //  DataType getType () const;
 
   /// Returns the dimension (i.e., number of components) of one data value.
-     int getDimensions () const;
-
+  int getDimensions() const;
 
 private:
-
   logging::Logger _log{"mesh::Data"};
 
   /// Counter for existing Data objects.
@@ -102,13 +98,12 @@ private:
   /// ID of the data set (supposed to be unique).
   int _id;
 
-//  // @brief Type of data (scalar or vector).
-//  DataType _type;
+  //  // @brief Type of data (scalar or vector).
+  //  DataType _type;
 
   /// Dimensionality of one data value.
   int _dimensions;
-
 };
 
-}} // namespace precice, mesh
-
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -4,74 +4,71 @@
 namespace precice {
 namespace mesh {
 
-Edge:: Edge
-(
-  Vertex& vertexOne,
-  Vertex& vertexTwo,
-  int     id )
-:
-  _vertices( {&vertexOne, &vertexTwo} ),
-  _id ( id ),
-  _normal ( Eigen::VectorXd::Constant(vertexOne.getDimensions(), 0.0) )
+Edge::Edge(
+    Vertex &vertexOne,
+    Vertex &vertexTwo,
+    int     id)
+    : _vertices({&vertexOne, &vertexTwo}),
+      _id(id),
+      _normal(Eigen::VectorXd::Constant(vertexOne.getDimensions(), 0.0))
 {
-  PRECICE_ASSERT( vertexOne.getDimensions() == vertexTwo.getDimensions(),
-              vertexOne.getDimensions(), vertexTwo.getDimensions() );
+  PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),
+                 vertexOne.getDimensions(), vertexTwo.getDimensions());
 }
 
-int Edge:: getID () const
+int Edge::getID() const
 {
   return _id;
 }
 
 const Eigen::VectorXd Edge::computeNormal(bool flip)
 {
-    // Compute normal
-    Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
-    Eigen::VectorXd normal = Eigen::Vector2d(-edgeVector[1], edgeVector[0]);
-    if (not flip){
-        normal *= -1.0; // Invert direction if counterclockwise
-    }
-    _normal = normal.normalized();   // Scale normal vector to length 1
+  // Compute normal
+  Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
+  Eigen::VectorXd normal     = Eigen::Vector2d(-edgeVector[1], edgeVector[0]);
+  if (not flip) {
+    normal *= -1.0; // Invert direction if counterclockwise
+  }
+  _normal = normal.normalized(); // Scale normal vector to length 1
 
-    return normal * getEnclosingRadius() * 2.0; // Weight by length
+  return normal * getEnclosingRadius() * 2.0; // Weight by length
 }
 
-const Eigen::VectorXd Edge::getCenter () const
+const Eigen::VectorXd Edge::getCenter() const
 {
   return 0.5 * (_vertices[0]->getCoords() + _vertices[1]->getCoords());
 }
 
-double Edge:: getEnclosingRadius () const
+double Edge::getEnclosingRadius() const
 {
   return (_vertices[0]->getCoords() - getCenter()).norm();
 }
 
-bool Edge::connectedTo(const Edge& other) const
+bool Edge::connectedTo(const Edge &other) const
 {
-    return _vertices[0] == other._vertices[0]
-        || _vertices[0] == other._vertices[1]
-        || _vertices[1] == other._vertices[0]
-        || _vertices[1] == other._vertices[1];
+  return _vertices[0] == other._vertices[0] || _vertices[0] == other._vertices[1] || _vertices[1] == other._vertices[0] || _vertices[1] == other._vertices[1];
 }
 
-bool Edge::operator==(const Edge& other) const
+bool Edge::operator==(const Edge &other) const
 {
-    return math::equals(_normal, other._normal) &&
-        std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin(),
-                [](const Vertex* a, const Vertex* b){return *a == *b;});
+  return math::equals(_normal, other._normal) &&
+         std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin(),
+                             [](const Vertex *a, const Vertex *b) { return *a == *b; });
 }
-bool Edge::operator!=(const Edge& other) const
+bool Edge::operator!=(const Edge &other) const
 {
   return !(*this == other);
 }
 
-std::ostream& operator<<(std::ostream& stream, const Edge& edge){
-    using utils::eigenio::wkt;
-    return stream << "LINESTRING ("
-                  << edge.vertex(0).getCoords().transpose().format(wkt())
-                  << ", "
-                  << edge.vertex(1).getCoords().transpose().format(wkt())
-                  << ')';
+std::ostream &operator<<(std::ostream &stream, const Edge &edge)
+{
+  using utils::eigenio::wkt;
+  return stream << "LINESTRING ("
+                << edge.vertex(0).getCoords().transpose().format(wkt())
+                << ", "
+                << edge.vertex(1).getCoords().transpose().format(wkt())
+                << ')';
 }
 
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -3,21 +3,20 @@
 #include <Eigen/Core>
 #include <iostream>
 
-#include "mesh/Vertex.hpp"
 #include "math/differences.hpp"
+#include "mesh/Vertex.hpp"
 
 namespace precice {
 namespace mesh {
 
 struct ConstEdgeIteratorTypes;
 struct EdgeIteratorTypes;
-template<typename Types> class EdgeIterator;
+template <typename Types>
+class EdgeIterator;
 
 /// Linear edge of a mesh, defined by two Vertex objects.
-class Edge
-{
+class Edge {
 public:
-
   /**
    * @brief Constructor.
    *
@@ -25,41 +24,41 @@ public:
    * @param[in] vertexTwo Second Vertex object defining the edge.
    * @param[in] id Unique (among edges in one mesh) ID.
    */
-  Edge (
-    Vertex& vertexOne,
-    Vertex& vertexTwo,
-    int     id );
+  Edge(
+      Vertex &vertexOne,
+      Vertex &vertexTwo,
+      int     id);
 
   /// Returns number of spatial dimensions (2 or 3) the edge is embedded to.
   int getDimensions() const;
 
   /// Returns the edge's vertex with index 0 or 1.
-  Vertex& vertex ( int i );
+  Vertex &vertex(int i);
 
   /// Returns the edge's vertex as const object with index 0 or 1.
-  const Vertex& vertex ( int i ) const;
+  const Vertex &vertex(int i) const;
 
   /// Sets the normal of the edge.
-  template<typename VECTOR_T>
-  void setNormal ( const VECTOR_T& normal );
+  template <typename VECTOR_T>
+  void setNormal(const VECTOR_T &normal);
 
   /// Computes and sets the normal of the edge, returns the area-weighted normal.
   const Eigen::VectorXd computeNormal(bool flip = false);
 
   /// Returns the (among edges) unique ID of the edge.
-  int getID () const;
+  int getID() const;
 
   /// Returns the normal of the edge.
-  const Eigen::VectorXd& getNormal () const;
+  const Eigen::VectorXd &getNormal() const;
 
   /// Returns the center of the edge.
-  const Eigen::VectorXd getCenter () const;
+  const Eigen::VectorXd getCenter() const;
 
   /// Returns the radius of the enclosing circle of the edge.
-  double getEnclosingRadius () const;
+  double getEnclosingRadius() const;
 
   /// Checks whether both edges share a vertex.
-  bool connectedTo(const Edge& other) const;
+  bool connectedTo(const Edge &other) const;
 
   /**
    * @brief Compares two Edges for equality
@@ -67,15 +66,14 @@ public:
    * Two Edges are equal if their normal vector is equal AND
    * if the two vertices are equal, whereas the order of vertices is NOT important.
    */
-  bool operator==(const Edge& other) const;
+  bool operator==(const Edge &other) const;
 
   /// Not equal, implemented in terms of equal.
-  bool operator!=(const Edge& other) const;
+  bool operator!=(const Edge &other) const;
 
 private:
-
   /// Pointers to Vertex objects defining the edge.
-  std::array<Vertex*,2> _vertices;
+  std::array<Vertex *, 2> _vertices;
 
   /// Unique (among edges) ID of the edge.
   int _id;
@@ -86,42 +84,40 @@ private:
 
 // ------------------------------------------------------ HEADER IMPLEMENTATION
 
-inline Vertex& Edge:: vertex
-(
-  int i )
+inline Vertex &Edge::vertex(
+    int i)
 {
-  PRECICE_ASSERT( (i == 0) || (i == 1), i );
+  PRECICE_ASSERT((i == 0) || (i == 1), i);
   return *_vertices[i];
 }
 
-inline const Vertex& Edge:: vertex
-(
-  int i ) const
+inline const Vertex &Edge::vertex(
+    int i) const
 {
-  PRECICE_ASSERT( (i==0) || (i==1), i );
+  PRECICE_ASSERT((i == 0) || (i == 1), i);
   return *_vertices[i];
 }
 
-inline int Edge:: getDimensions() const
+inline int Edge::getDimensions() const
 {
   return _vertices[0]->getDimensions();
 }
 
-template<typename VECTOR_T>
-void Edge:: setNormal
-(
-  const VECTOR_T& normal )
+template <typename VECTOR_T>
+void Edge::setNormal(
+    const VECTOR_T &normal)
 {
-  PRECICE_ASSERT( normal.size() == _vertices[0]->getDimensions(), normal,
-               _vertices[0]->getDimensions() );
+  PRECICE_ASSERT(normal.size() == _vertices[0]->getDimensions(), normal,
+                 _vertices[0]->getDimensions());
   _normal = normal;
 }
 
-inline const Eigen::VectorXd& Edge::getNormal () const
+inline const Eigen::VectorXd &Edge::getNormal() const
 {
   return _normal;
 }
 
-std::ostream& operator<<(std::ostream& stream, const Edge& edge);
+std::ostream &operator<<(std::ostream &stream, const Edge &edge);
 
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "mesh/Mesh.hpp"
 #include <boost/container/flat_map.hpp>
+#include "mesh/Mesh.hpp"
 
 namespace precice {
 namespace mesh {
@@ -41,7 +41,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
     int vertexIndex2 = edge.vertex(1).getID();
     if (vertexMap.count(vertexIndex1) == 1 &&
         vertexMap.count(vertexIndex2) == 1) {
-      Edge &e         = destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
+      Edge &e               = destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
       edgeMap[edge.getID()] = &e;
     }
   }

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -1,24 +1,24 @@
 #include "Mesh.hpp"
-#include "Edge.hpp"
-#include "Triangle.hpp"
-#include "Quad.hpp"
-#include "utils/EigenHelperFunctions.hpp"
-#include "math/math.hpp"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include "RTree.hpp"
-#include <array>
 #include <algorithm>
+#include <array>
 #include <boost/container/flat_map.hpp>
+#include "Edge.hpp"
+#include "Quad.hpp"
+#include "RTree.hpp"
+#include "Triangle.hpp"
+#include "math/math.hpp"
+#include "utils/EigenHelperFunctions.hpp"
 
 namespace precice {
 namespace mesh {
 
 Mesh::Mesh(
-    const std::string &     name,
-    int                     dimensions,
-    bool                    flipNormals,
-    int                     id)
+    const std::string &name,
+    int                dimensions,
+    bool               flipNormals,
+    int                id)
     : _name(name),
       _dimensions(dimensions),
       _flipNormals(flipNormals),
@@ -27,276 +27,269 @@ Mesh::Mesh(
   PRECICE_ASSERT((_dimensions == 2) || (_dimensions == 3), _dimensions);
   PRECICE_ASSERT(_name != std::string(""));
 
-  meshChanged.connect([](Mesh & m){rtree::clear(m);});
-  meshDestroyed.connect([](Mesh & m){rtree::clear(m);});
+  meshChanged.connect([](Mesh &m) { rtree::clear(m); });
+  meshDestroyed.connect([](Mesh &m) { rtree::clear(m); });
 }
 
-Mesh:: ~Mesh()
+Mesh::~Mesh()
 {
   meshDestroyed(*this); // emit signal
 }
 
-Mesh::VertexContainer& Mesh:: vertices()
+Mesh::VertexContainer &Mesh::vertices()
 {
-   return _vertices;
+  return _vertices;
 }
 
-const Mesh::VertexContainer& Mesh:: vertices() const
+const Mesh::VertexContainer &Mesh::vertices() const
 {
-   return _vertices;
+  return _vertices;
 }
 
-Mesh::EdgeContainer& Mesh:: edges()
+Mesh::EdgeContainer &Mesh::edges()
 {
-   return _edges;
+  return _edges;
 }
 
-const Mesh::EdgeContainer& Mesh:: edges() const
+const Mesh::EdgeContainer &Mesh::edges() const
 {
-   return _edges;
+  return _edges;
 }
 
-Mesh::TriangleContainer& Mesh:: triangles()
-{
-   return _triangles;
-}
-
-const Mesh::TriangleContainer& Mesh:: triangles() const
+Mesh::TriangleContainer &Mesh::triangles()
 {
   return _triangles;
 }
 
-Mesh::QuadContainer& Mesh:: quads()
+const Mesh::TriangleContainer &Mesh::triangles() const
 {
-   return _quads;
+  return _triangles;
 }
 
-const Mesh::QuadContainer& Mesh:: quads() const
+Mesh::QuadContainer &Mesh::quads()
 {
   return _quads;
 }
 
-int Mesh:: getDimensions() const
+const Mesh::QuadContainer &Mesh::quads() const
+{
+  return _quads;
+}
+
+int Mesh::getDimensions() const
 {
   return _dimensions;
 }
 
-Edge& Mesh:: createEdge
-(
-  Vertex& vertexOne,
-  Vertex& vertexTwo )
+Edge &Mesh::createEdge(
+    Vertex &vertexOne,
+    Vertex &vertexTwo)
 {
   _edges.emplace_back(vertexOne, vertexTwo, _manageEdgeIDs.getFreeID());
   return _edges.back();
 }
 
-Edge& Mesh::createUniqueEdge
-(
-    Vertex& vertexOne,
-    Vertex& vertexTwo
-)
-{ 
-    const std::array<int, 2> vids{vertexOne.getID(), vertexTwo.getID()};
-    const auto eend = edges().end();
-    auto pos = std::find_if(edges().begin(), eend,
-            [&vids](const Edge& e) -> bool {
-                const std::array<int, 2> eids{e.vertex(0).getID(), e.vertex(1).getID()};
-                return std::is_permutation(vids.begin(), vids.end(), eids.begin());
-            });
-    if (pos != eend) {
-        return *pos;
-    } else {
-        return createEdge(vertexOne, vertexTwo);
-    }
+Edge &Mesh::createUniqueEdge(
+    Vertex &vertexOne,
+    Vertex &vertexTwo)
+{
+  const std::array<int, 2> vids{vertexOne.getID(), vertexTwo.getID()};
+  const auto               eend = edges().end();
+  auto                     pos  = std::find_if(edges().begin(), eend,
+                          [&vids](const Edge &e) -> bool {
+                            const std::array<int, 2> eids{e.vertex(0).getID(), e.vertex(1).getID()};
+                            return std::is_permutation(vids.begin(), vids.end(), eids.begin());
+                          });
+  if (pos != eend) {
+    return *pos;
+  } else {
+    return createEdge(vertexOne, vertexTwo);
+  }
 }
 
-Triangle& Mesh:: createTriangle
-(
-  Edge& edgeOne,
-  Edge& edgeTwo,
-  Edge& edgeThree )
+Triangle &Mesh::createTriangle(
+    Edge &edgeOne,
+    Edge &edgeTwo,
+    Edge &edgeThree)
 {
   PRECICE_CHECK(
-          edgeOne.connectedTo(edgeTwo) &&
+      edgeOne.connectedTo(edgeTwo) &&
           edgeTwo.connectedTo(edgeThree) &&
           edgeThree.connectedTo(edgeOne),
-          "Edges are not connected!");
+      "Edges are not connected!");
   _triangles.emplace_back(edgeOne, edgeTwo, edgeThree, _manageTriangleIDs.getFreeID());
   return _triangles.back();
 }
 
-Quad& Mesh:: createQuad
-(
-  Edge& edgeOne,
-  Edge& edgeTwo,
-  Edge& edgeThree,
-  Edge& edgeFour )
+Quad &Mesh::createQuad(
+    Edge &edgeOne,
+    Edge &edgeTwo,
+    Edge &edgeThree,
+    Edge &edgeFour)
 {
   _quads.emplace_back(edgeOne, edgeTwo, edgeThree, edgeFour, _manageQuadIDs.getFreeID());
   return _quads.back();
 }
 
-PtrData& Mesh:: createData
-(
-  const std::string& name,
-  int                dimension )
+PtrData &Mesh::createData(
+    const std::string &name,
+    int                dimension)
 {
   PRECICE_TRACE(name, dimension);
   for (const PtrData data : _data) {
     PRECICE_CHECK(data->getName() != name,
-          "Data \"" << name << "\" cannot be created twice for " << "mesh \"" << _name << "\"!");
+                  "Data \"" << name << "\" cannot be created twice for "
+                            << "mesh \"" << _name << "\"!");
   }
-  int id = Data::getDataCount();
+  int     id = Data::getDataCount();
   PtrData data(new Data(name, id, dimension));
   _data.push_back(data);
   return _data.back();
 }
 
-const Mesh::DataContainer& Mesh:: data() const
+const Mesh::DataContainer &Mesh::data() const
 {
   return _data;
 }
 
-const PtrData& Mesh:: data
-(
-  int dataID ) const
+const PtrData &Mesh::data(
+    int dataID) const
 {
-  for (const PtrData& data : _data) {
+  for (const PtrData &data : _data) {
     if (data->getID() == dataID) {
       return data;
     }
   }
-  PRECICE_ERROR("Data with ID = " << dataID << " not found in mesh \"" << _name << "\"!" );
+  PRECICE_ERROR("Data with ID = " << dataID << " not found in mesh \"" << _name << "\"!");
 }
 
-const std::string& Mesh:: getName() const
+const std::string &Mesh::getName() const
 {
   return _name;
 }
 
-bool Mesh:: isFlipNormals() const
+bool Mesh::isFlipNormals() const
 {
   return _flipNormals;
 }
 
-void Mesh:: setFlipNormals
-(
-  bool flipNormals )
+void Mesh::setFlipNormals(
+    bool flipNormals)
 {
   _flipNormals = flipNormals;
 }
 
-int Mesh:: getID() const
+int Mesh::getID() const
 {
   return _id;
 }
 
 bool Mesh::isValidVertexID(int vertexID) const
 {
-    return (0 <= vertexID) && (static_cast<size_t>(vertexID) < vertices().size());
+  return (0 <= vertexID) && (static_cast<size_t>(vertexID) < vertices().size());
 }
 
 bool Mesh::isValidEdgeID(int edgeID) const
 {
-    return (0 <= edgeID) && (static_cast<size_t>(edgeID) < edges().size());
+  return (0 <= edgeID) && (static_cast<size_t>(edgeID) < edges().size());
 }
 
-void Mesh:: allocateDataValues()
+void Mesh::allocateDataValues()
 {
   PRECICE_TRACE(_vertices.size());
   for (PtrData data : _data) {
-    int total = _vertices.size() * data->getDimensions();
+    int total          = _vertices.size() * data->getDimensions();
     int leftToAllocate = total - data->values().size();
-    if (leftToAllocate > 0){
+    if (leftToAllocate > 0) {
       utils::append(data->values(), (Eigen::VectorXd) Eigen::VectorXd::Zero(leftToAllocate));
     }
     PRECICE_DEBUG("Data " << data->getName() << " now has " << data->values().size() << " values");
   }
 }
 
-void Mesh:: computeNormals()
+void Mesh::computeNormals()
 {
   PRECICE_TRACE(_name);
   // Compute normals only if faces to derive normal information are available
   size_t size2DFaces = _edges.size();
   size_t size3DFaces = _triangles.size() + _quads.size();
-  if (_dimensions == 2 && size2DFaces == 0){
-      return;
+  if (_dimensions == 2 && size2DFaces == 0) {
+    return;
   }
-  if (_dimensions == 3 && size3DFaces == 0){
+  if (_dimensions == 3 && size3DFaces == 0) {
     return;
   }
 
   // Compute (in 2D) edge normals
   if (_dimensions == 2) {
-      for (Edge& edge : _edges) {
-          Eigen::VectorXd weightednormal = edge.computeNormal(_flipNormals);
+    for (Edge &edge : _edges) {
+      Eigen::VectorXd weightednormal = edge.computeNormal(_flipNormals);
 
-          // Accumulate normal in associated vertices
-          for (int i=0; i < 2; i++){
-              Eigen::VectorXd vertexNormal = edge.vertex(i).getNormal();
-              vertexNormal += weightednormal;
-              edge.vertex(i).setNormal(vertexNormal);
-          }
+      // Accumulate normal in associated vertices
+      for (int i = 0; i < 2; i++) {
+        Eigen::VectorXd vertexNormal = edge.vertex(i).getNormal();
+        vertexNormal += weightednormal;
+        edge.vertex(i).setNormal(vertexNormal);
       }
+    }
   }
 
-  if (_dimensions == 3){
+  if (_dimensions == 3) {
+    // Compute normals
+    for (Triangle &triangle : _triangles) {
+      PRECICE_ASSERT(triangle.vertex(0) != triangle.vertex(1),
+                     triangle.vertex(0), triangle.getID());
+      PRECICE_ASSERT(triangle.vertex(1) != triangle.vertex(2),
+                     triangle.vertex(1), triangle.getID());
+      PRECICE_ASSERT(triangle.vertex(2) != triangle.vertex(0),
+                     triangle.vertex(2), triangle.getID());
+
       // Compute normals
-      for (Triangle& triangle : _triangles) {
-          PRECICE_ASSERT(triangle.vertex(0) != triangle.vertex(1),
-                  triangle.vertex(0), triangle.getID());
-          PRECICE_ASSERT(triangle.vertex(1) != triangle.vertex(2),
-                  triangle.vertex(1), triangle.getID());
-          PRECICE_ASSERT(triangle.vertex(2) != triangle.vertex(0),
-                  triangle.vertex(2), triangle.getID());
+      Eigen::VectorXd weightednormal = triangle.computeNormal(_flipNormals);
 
-          // Compute normals
-          Eigen::VectorXd weightednormal = triangle.computeNormal(_flipNormals);
-
-          // Accumulate area-weighted normal in associated vertices and edges
-          for (int i=0; i < 3; i++){
-              triangle.edge(i).setNormal(triangle.edge(i).getNormal() + weightednormal);
-              triangle.vertex(i).setNormal(triangle.vertex(i).getNormal() + weightednormal);
-          }
+      // Accumulate area-weighted normal in associated vertices and edges
+      for (int i = 0; i < 3; i++) {
+        triangle.edge(i).setNormal(triangle.edge(i).getNormal() + weightednormal);
+        triangle.vertex(i).setNormal(triangle.vertex(i).getNormal() + weightednormal);
       }
+    }
 
-      // Compute quad normals
-      for (Quad& quad : _quads) {
-          PRECICE_ASSERT(quad.vertex(0) != quad.vertex(1), quad.vertex(0).getCoords(), quad.getID());
-          PRECICE_ASSERT(quad.vertex(1) != quad.vertex(2), quad.vertex(1).getCoords(), quad.getID());
-          PRECICE_ASSERT(quad.vertex(2) != quad.vertex(3), quad.vertex(2).getCoords(), quad.getID());
-          PRECICE_ASSERT(quad.vertex(3) != quad.vertex(0), quad.vertex(3).getCoords(), quad.getID());
+    // Compute quad normals
+    for (Quad &quad : _quads) {
+      PRECICE_ASSERT(quad.vertex(0) != quad.vertex(1), quad.vertex(0).getCoords(), quad.getID());
+      PRECICE_ASSERT(quad.vertex(1) != quad.vertex(2), quad.vertex(1).getCoords(), quad.getID());
+      PRECICE_ASSERT(quad.vertex(2) != quad.vertex(3), quad.vertex(2).getCoords(), quad.getID());
+      PRECICE_ASSERT(quad.vertex(3) != quad.vertex(0), quad.vertex(3).getCoords(), quad.getID());
 
-          // Compute normals (assuming all vertices are on same plane)
-          Eigen::VectorXd weightednormal = quad.computeNormal(_flipNormals);
-          // Accumulate area-weighted normal in associated vertices and edges
-          for (int i=0; i < 4; i++){
-              quad.edge(i).setNormal(quad.edge(i).getNormal() + weightednormal);
-              quad.vertex(i).setNormal(quad.vertex(i).getNormal() + weightednormal);
-          }
+      // Compute normals (assuming all vertices are on same plane)
+      Eigen::VectorXd weightednormal = quad.computeNormal(_flipNormals);
+      // Accumulate area-weighted normal in associated vertices and edges
+      for (int i = 0; i < 4; i++) {
+        quad.edge(i).setNormal(quad.edge(i).getNormal() + weightednormal);
+        quad.vertex(i).setNormal(quad.vertex(i).getNormal() + weightednormal);
       }
+    }
 
-      // Normalize edge normals (only done in 3D)
-      for (Edge& edge : _edges) {
-          // there can be cases when an edge has no adjacent triangle though triangles exist in general (e.g. after filtering)
-          edge.setNormal(edge.getNormal().normalized());
-      }
+    // Normalize edge normals (only done in 3D)
+    for (Edge &edge : _edges) {
+      // there can be cases when an edge has no adjacent triangle though triangles exist in general (e.g. after filtering)
+      edge.setNormal(edge.getNormal().normalized());
+    }
   }
 
-  for (Vertex& vertex : _vertices) {
-      // there can be cases when a vertex has no edge though edges exist in general (e.g. after filtering)
-      vertex.setNormal(vertex.getNormal().normalized());
+  for (Vertex &vertex : _vertices) {
+    // there can be cases when a vertex has no edge though edges exist in general (e.g. after filtering)
+    vertex.setNormal(vertex.getNormal().normalized());
   }
 }
 
-void Mesh:: computeBoundingBox()
+void Mesh::computeBoundingBox()
 {
   PRECICE_TRACE(_name);
   BoundingBox boundingBox(_dimensions,
-                              std::make_pair(std::numeric_limits<double>::max(),
-                                             std::numeric_limits<double>::lowest()));
-  for (const Vertex& vertex : _vertices) {
+                          std::make_pair(std::numeric_limits<double>::max(),
+                                         std::numeric_limits<double>::lowest()));
+  for (const Vertex &vertex : _vertices) {
     for (int d = 0; d < _dimensions; d++) {
       boundingBox[d].first  = std::min(vertex.getCoords()[d], boundingBox[d].first);
       boundingBox[d].second = std::max(vertex.getCoords()[d], boundingBox[d].second);
@@ -308,17 +301,16 @@ void Mesh:: computeBoundingBox()
   _boundingBox = std::move(boundingBox);
 }
 
-void Mesh:: computeState()
+void Mesh::computeState()
 {
   PRECICE_TRACE(_name);
-  PRECICE_ASSERT(_dimensions==2 || _dimensions==3, _dimensions);
+  PRECICE_ASSERT(_dimensions == 2 || _dimensions == 3, _dimensions);
 
   computeNormals();
   computeBoundingBox();
 }
 
-    
-void Mesh:: clear()
+void Mesh::clear()
 {
   _quads.clear();
   _triangles.clear();
@@ -330,7 +322,7 @@ void Mesh:: clear()
   _manageVertexIDs.resetIDs();
 
   meshChanged(*this);
-  
+
   for (mesh::PtrData data : _data) {
     data->values().resize(0);
   }
@@ -371,48 +363,49 @@ void Mesh::setGlobalNumberOfVertices(int num)
   _globalNumberOfVertices = num;
 }
 
-void Mesh:: addMesh(
-    Mesh& deltaMesh)
+void Mesh::addMesh(
+    Mesh &deltaMesh)
 {
   PRECICE_TRACE();
-  PRECICE_ASSERT(_dimensions==deltaMesh.getDimensions());
+  PRECICE_ASSERT(_dimensions == deltaMesh.getDimensions());
 
-  boost::container::flat_map<int, Vertex*> vertexMap;
+  boost::container::flat_map<int, Vertex *> vertexMap;
   vertexMap.reserve(deltaMesh.vertices().size());
   Eigen::VectorXd coords(_dimensions);
-  for ( const Vertex& vertex : deltaMesh.vertices() ){
-    coords = vertex.getCoords();
-    Vertex& v = createVertex (coords);
+  for (const Vertex &vertex : deltaMesh.vertices()) {
+    coords    = vertex.getCoords();
+    Vertex &v = createVertex(coords);
     v.setGlobalIndex(vertex.getGlobalIndex());
-    if(vertex.isTagged()) v.tag();
+    if (vertex.isTagged())
+      v.tag();
     v.setOwner(vertex.isOwner());
-    PRECICE_ASSERT( vertex.getID() >= 0, vertex.getID() );
+    PRECICE_ASSERT(vertex.getID() >= 0, vertex.getID());
     vertexMap[vertex.getID()] = &v;
   }
 
-  boost::container::flat_map<int, Edge*> edgeMap;
+  boost::container::flat_map<int, Edge *> edgeMap;
   edgeMap.reserve(deltaMesh.edges().size());
   // you cannot just take the vertices from the edge and add them,
   // since you need the vertices from the new mesh
   // (which may differ in IDs)
-  for (const Edge& edge : deltaMesh.edges()) {
+  for (const Edge &edge : deltaMesh.edges()) {
     int vertexIndex1 = edge.vertex(0).getID();
     int vertexIndex2 = edge.vertex(1).getID();
-    PRECICE_ASSERT((vertexMap.count(vertexIndex1) ==  1) &&
-                   (vertexMap.count(vertexIndex2) ==  1));
-    Edge& e = createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
+    PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
+                   (vertexMap.count(vertexIndex2) == 1));
+    Edge &e               = createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
     edgeMap[edge.getID()] = &e;
   }
 
-  if(_dimensions==3){
-    for (const Triangle& triangle : deltaMesh.triangles() ) {
+  if (_dimensions == 3) {
+    for (const Triangle &triangle : deltaMesh.triangles()) {
       int edgeIndex1 = triangle.edge(0).getID();
       int edgeIndex2 = triangle.edge(1).getID();
       int edgeIndex3 = triangle.edge(2).getID();
       PRECICE_ASSERT((edgeMap.count(edgeIndex1) == 1) &&
                      (edgeMap.count(edgeIndex2) == 1) &&
                      (edgeMap.count(edgeIndex3) == 1));
-      createTriangle(*edgeMap[edgeIndex1],*edgeMap[edgeIndex2],*edgeMap[edgeIndex3]);
+      createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
     }
   }
   meshChanged(*this);
@@ -432,52 +425,53 @@ const std::vector<double> Mesh::getCOG() const
   return cog;
 }
 
-bool Mesh::operator==(const Mesh& other) const
+bool Mesh::operator==(const Mesh &other) const
 {
-    bool equal = true;
-    equal &= _vertices.size() == other._vertices.size() &&
-        std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin());
-    equal &= _edges.size() == other._edges.size() &&
-        std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin());
-    equal &= _triangles.size() == other._triangles.size() &&
-        std::is_permutation(_triangles.begin(), _triangles.end(), other._triangles.begin());
-    equal &= _quads.size() == other._quads.size() &&
-        std::is_permutation(_quads.begin(), _quads.end(), other._quads.begin());
-    return equal;
+  bool equal = true;
+  equal &= _vertices.size() == other._vertices.size() &&
+           std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin());
+  equal &= _edges.size() == other._edges.size() &&
+           std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin());
+  equal &= _triangles.size() == other._triangles.size() &&
+           std::is_permutation(_triangles.begin(), _triangles.end(), other._triangles.begin());
+  equal &= _quads.size() == other._quads.size() &&
+           std::is_permutation(_quads.begin(), _quads.end(), other._quads.begin());
+  return equal;
 }
 
-bool Mesh::operator!=(const Mesh& other) const
+bool Mesh::operator!=(const Mesh &other) const
 {
-    return !(*this == other);
+  return !(*this == other);
 }
 
-std::ostream& operator<<(std::ostream& os, const Mesh& m)
+std::ostream &operator<<(std::ostream &os, const Mesh &m)
 {
   os << "Mesh \"" << m.getName() << "\", dimensionality = " << m.getDimensions() << ":\n";
   os << "GEOMETRYCOLLECTION(\n";
-  const auto token = ", ";
-  const auto* sep = "";
-  for (auto& vertex : m.vertices()){
-      os << sep << vertex; 
-      sep = token;
+  const auto  token = ", ";
+  const auto *sep   = "";
+  for (auto &vertex : m.vertices()) {
+    os << sep << vertex;
+    sep = token;
   }
   sep = ",\n";
-  for (auto& edge : m.edges()){
-      os << sep << edge;
-      sep = token;
+  for (auto &edge : m.edges()) {
+    os << sep << edge;
+    sep = token;
   }
   sep = ",\n";
-  for (auto& triangle : m.triangles()){
-      os << sep << triangle;
-      sep = token;
+  for (auto &triangle : m.triangles()) {
+    os << sep << triangle;
+    sep = token;
   }
   sep = ",\n";
-  for (auto& quad : m.quads()){
-      os << sep << quad;
-      sep = token;
+  for (auto &quad : m.quads()) {
+    os << sep << quad;
+    sep = token;
   }
   os << "\n)";
   return os;
 }
 
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -1,22 +1,21 @@
 #pragma once
 
-#include "mesh/SharedPointer.hpp"
-#include "mesh/Data.hpp"
-#include "mesh/Vertex.hpp"
-#include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
-#include "mesh/Quad.hpp"
-#include "utils/PointerVector.hpp"
-#include "utils/ManageUniqueIDs.hpp"
-#include <map>
-#include <list>
-#include <vector>
-#include <deque>
 #include <boost/signals2.hpp>
+#include <deque>
+#include <list>
+#include <map>
+#include <vector>
+#include "mesh/Data.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Quad.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
+#include "utils/ManageUniqueIDs.hpp"
+#include "utils/PointerVector.hpp"
 
 namespace precice {
 namespace mesh {
-
 
 /**
  * @brief Container and creator for meshes.
@@ -29,17 +28,15 @@ namespace mesh {
  *
  * Usage example: precice::mesh::tests::MeshTest::testDemonstration()
  */
-class Mesh
-{
+class Mesh {
 public:
-
-  using VertexContainer            = std::deque<Vertex>;
-  using EdgeContainer              = std::deque<Edge>;
-  using TriangleContainer          = std::deque<Triangle>;
-  using QuadContainer              = std::deque<Quad>;
-  using DataContainer              = std::vector<PtrData>;
-  using BoundingBox                = std::vector<std::pair<double, double>>;
-  using BoundingBoxMap             = std::map<int,BoundingBox>; 
+  using VertexContainer   = std::deque<Vertex>;
+  using EdgeContainer     = std::deque<Edge>;
+  using TriangleContainer = std::deque<Triangle>;
+  using QuadContainer     = std::deque<Quad>;
+  using DataContainer     = std::vector<PtrData>;
+  using BoundingBox       = std::vector<std::pair<double, double>>;
+  using BoundingBoxMap    = std::map<int, BoundingBox>;
 
   /// A mapping from rank to used (not necessarily owned) vertex IDs
   using VertexDistribution = std::map<int, std::vector<int>>;
@@ -65,42 +62,42 @@ public:
    * @param[in] id The id of this mesh
    */
   Mesh(
-      const std::string &     name,
-      int                     dimensions,
-      bool                    flipNormals,
-      int                     id);
+      const std::string &name,
+      int                dimensions,
+      bool               flipNormals,
+      int                id);
 
   /// Destructor, deletes created objects.
   ~Mesh();
 
   /// Returns modifieable container holding all vertices.
-  VertexContainer& vertices();
+  VertexContainer &vertices();
 
   /// Returns const container holding all vertices.
-  const VertexContainer& vertices() const;
+  const VertexContainer &vertices() const;
 
   /// Returns modifiable container holding all edges.
-  EdgeContainer& edges();
+  EdgeContainer &edges();
 
   /// Returns const container holding all edges.
-  const EdgeContainer& edges() const;
+  const EdgeContainer &edges() const;
 
   /// Returns modifiable container holding all triangles.
-  TriangleContainer& triangles();
+  TriangleContainer &triangles();
 
   /// Returns const container holding all triangles.
-  const TriangleContainer& triangles() const;
+  const TriangleContainer &triangles() const;
 
   /// Returns modifiable container holding all quads.
-  QuadContainer& quads();
+  QuadContainer &quads();
 
   /// Returns const container holding all quads.
-  const QuadContainer& quads() const;
+  const QuadContainer &quads() const;
 
   int getDimensions() const;
 
-  template<typename VECTOR_T>
-  Vertex& createVertex ( const VECTOR_T& coords )
+  template <typename VECTOR_T>
+  Vertex &createVertex(const VECTOR_T &coords)
   {
     PRECICE_ASSERT(coords.size() == _dimensions, coords.size(), _dimensions);
     _vertices.emplace_back(coords, _manageVertexIDs.getFreeID());
@@ -113,9 +110,9 @@ public:
    * @param[in] vertexOne Reference to first Vertex defining the Edge.
    * @param[in] vertexTwo Reference to second Vertex defining the Edge.
    */
-  Edge& createEdge (
-    Vertex& vertexOne,
-    Vertex& vertexTwo );
+  Edge &createEdge(
+      Vertex &vertexOne,
+      Vertex &vertexTwo);
 
   /**
    * @brief Creates and initializes an Edge object or returns an already existing one.
@@ -123,9 +120,9 @@ public:
    * @param[in] vertexOne Reference to first Vertex defining the Edge.
    * @param[in] vertexTwo Reference to second Vertex defining the Edge.
    */
-  Edge& createUniqueEdge (
-    Vertex& vertexOne,
-    Vertex& vertexTwo );
+  Edge &createUniqueEdge(
+      Vertex &vertexOne,
+      Vertex &vertexTwo);
 
   /**
    * @brief Creates and initializes a Triangle object.
@@ -134,10 +131,10 @@ public:
    * @param[in] edgeTwo Reference to second edge defining the Triangle.
    * @param[in] edgeThree Reference to third edge defining the Triangle.
    */
-  Triangle& createTriangle (
-    Edge& edgeOne,
-    Edge& edgeTwo,
-    Edge& edgeThree );
+  Triangle &createTriangle(
+      Edge &edgeOne,
+      Edge &edgeTwo,
+      Edge &edgeThree);
 
   /**
    * @brief Creates and initializes a Quad object.
@@ -147,26 +144,26 @@ public:
    * @param[in] edgeThree Reference to third edge defining the Quad.
    * @param[in] edgeFour Reference to fourth edge defining the Quad.
    */
-  Quad& createQuad (
-    Edge& edgeOne,
-    Edge& edgeTwo,
-    Edge& edgeThree,
-    Edge& edgeFour);
+  Quad &createQuad(
+      Edge &edgeOne,
+      Edge &edgeTwo,
+      Edge &edgeThree,
+      Edge &edgeFour);
 
-  PtrData& createData (
-    const std::string& name,
-    int                dimension );
+  PtrData &createData(
+      const std::string &name,
+      int                dimension);
 
-  const DataContainer& data() const;
+  const DataContainer &data() const;
 
-  const PtrData& data ( int dataID ) const;
+  const PtrData &data(int dataID) const;
 
   /// Returns the name of the mesh, as set in the config file.
-  const std::string& getName() const;
+  const std::string &getName() const;
 
   bool isFlipNormals() const;
 
-  void setFlipNormals ( bool flipNormals );
+  void setFlipNormals(bool flipNormals);
 
   /// Returns the base ID of the mesh.
   int getID() const;
@@ -202,34 +199,34 @@ public:
   void clear();
 
   /// Returns a mapping from rank to used (not necessarily owned) vertex IDs
-  VertexDistribution & getVertexDistribution();
+  VertexDistribution &getVertexDistribution();
 
-  VertexDistribution const & getVertexDistribution() const;
+  VertexDistribution const &getVertexDistribution() const;
 
-  std::vector<int>& getVertexOffsets();
+  std::vector<int> &getVertexOffsets();
 
-  const std::vector<int>& getVertexOffsets() const;
+  const std::vector<int> &getVertexOffsets() const;
 
   /// Only used for tests
-  void setVertexOffsets(std::vector<int> & vertexOffsets);
+  void setVertexOffsets(std::vector<int> &vertexOffsets);
 
   int getGlobalNumberOfVertices() const;
 
   void setGlobalNumberOfVertices(int num);
 
   /// Returns a vector of connected ranks
-  std::vector<int> & getConnectedRanks()
+  std::vector<int> &getConnectedRanks()
   {
     return _connectedRanks;
   }
-  
+
   /// Returns a mapping from remote local connected ranks to the corresponding vertex IDs
-  CommunicationMap & getCommunicationMap()
+  CommunicationMap &getCommunicationMap()
   {
     return _communicationMap;
   }
 
-  void addMesh(Mesh& deltaMesh);
+  void addMesh(Mesh &deltaMesh);
 
   /**
    * @brief Returns the bounding box of the mesh.
@@ -246,13 +243,12 @@ public:
    * cog =  (max - min) / 2 + min
    */
   const std::vector<double> getCOG() const;
-  
-  bool operator==(const Mesh& other) const;
-  
-  bool operator!=(const Mesh& other) const;
+
+  bool operator==(const Mesh &other) const;
+
+  bool operator!=(const Mesh &other) const;
 
 private:
-
   /// Computes the normals for all primitives.
   void computeNormals();
 
@@ -274,10 +270,10 @@ private:
   int _id;
 
   /// Holds vertices, edges, and triangles.
-  VertexContainer _vertices;
-  EdgeContainer _edges;
+  VertexContainer   _vertices;
+  EdgeContainer     _edges;
   TriangleContainer _triangles;
-  QuadContainer _quads;
+  QuadContainer     _quads;
 
   /// Data hold by the vertices of the mesh.
   DataContainer _data;
@@ -304,7 +300,6 @@ private:
    */
   std::vector<int> _vertexOffsets;
 
-
   /**
    * @brief Number of unique vertices for complete distributed mesh.
    *
@@ -325,9 +320,9 @@ private:
   CommunicationMap _communicationMap;
 
   BoundingBox _boundingBox;
-
 };
 
-std::ostream& operator<<(std::ostream& os, const Mesh& q);
+std::ostream &operator<<(std::ostream &os, const Mesh &q);
 
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Quad.cpp
+++ b/src/mesh/Quad.cpp
@@ -1,15 +1,13 @@
 #include "Quad.hpp"
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <boost/range/concepts.hpp>
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
 #include "utils/EigenIO.hpp"
-#include <boost/range/concepts.hpp>
-#include <Eigen/Dense>
-#include <Eigen/Geometry>
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 
 BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::iterator>) );
 BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Quad::const_iterator>) );
@@ -22,16 +20,16 @@ Quad::Quad(
     Edge &edgeThree,
     Edge &edgeFour,
     int   id)
-  : _edges({&edgeOne, &edgeTwo, &edgeThree, &edgeFour}),
-    _id(id),
-    _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions()))
+    : _edges({&edgeOne, &edgeTwo, &edgeThree, &edgeFour}),
+      _id(id),
+      _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions()))
 {
   PRECICE_ASSERT(edgeOne.getDimensions() == edgeTwo.getDimensions(),
-            edgeOne.getDimensions(), edgeTwo.getDimensions());
+                 edgeOne.getDimensions(), edgeTwo.getDimensions());
   PRECICE_ASSERT(edgeTwo.getDimensions() == edgeThree.getDimensions(),
-            edgeTwo.getDimensions(), edgeThree.getDimensions());
+                 edgeTwo.getDimensions(), edgeThree.getDimensions());
   PRECICE_ASSERT(edgeThree.getDimensions() == edgeFour.getDimensions(),
-            edgeThree.getDimensions(), edgeFour.getDimensions());
+                 edgeThree.getDimensions(), edgeFour.getDimensions());
   PRECICE_ASSERT(getDimensions() == 3, getDimensions());
 
   // Determine vertex map
@@ -103,32 +101,32 @@ Quad::Quad(
 
 const Eigen::VectorXd Quad::computeNormal(bool flip)
 {
-    // Two triangles are thought by splitting the quad from vertex 0 to 2.
-    // The cross prodcut of the outer edges of the triangles is used to compute
-    // the normal direction and area of the triangles. The direction must be
-    // the same, while the areas differ in general. The normals are added up
-    // and divided by 2 to get the area of the overall quad, since the length
-    // does correspond to the parallelogram spanned by the vectors of the
-    // cross product, which is twice the area of the corresponding triangles.
-    Eigen::Vector3d vectorA = vertex(2).getCoords() - vertex(1).getCoords();
-    Eigen::Vector3d vectorB = vertex(0).getCoords() - vertex(1).getCoords();
-    // Compute cross-product of vector A and vector B
-    auto normal = vectorA.cross(vectorB);
+  // Two triangles are thought by splitting the quad from vertex 0 to 2.
+  // The cross prodcut of the outer edges of the triangles is used to compute
+  // the normal direction and area of the triangles. The direction must be
+  // the same, while the areas differ in general. The normals are added up
+  // and divided by 2 to get the area of the overall quad, since the length
+  // does correspond to the parallelogram spanned by the vectors of the
+  // cross product, which is twice the area of the corresponding triangles.
+  Eigen::Vector3d vectorA = vertex(2).getCoords() - vertex(1).getCoords();
+  Eigen::Vector3d vectorB = vertex(0).getCoords() - vertex(1).getCoords();
+  // Compute cross-product of vector A and vector B
+  auto normal = vectorA.cross(vectorB);
 
-    vectorA = vertex(0).getCoords() - vertex(3).getCoords();
-    vectorB = vertex(2).getCoords() - vertex(3).getCoords();
-    auto normalSecondPart = vectorA.cross(vectorB);
+  vectorA               = vertex(0).getCoords() - vertex(3).getCoords();
+  vectorB               = vertex(2).getCoords() - vertex(3).getCoords();
+  auto normalSecondPart = vectorA.cross(vectorB);
 
-    PRECICE_ASSERT(math::equals(normal.normalized(), normalSecondPart.normalized()),
-            normal, normalSecondPart);
-    normal += normalSecondPart;
-    normal *= 0.5;
+  PRECICE_ASSERT(math::equals(normal.normalized(), normalSecondPart.normalized()),
+                 normal, normalSecondPart);
+  normal += normalSecondPart;
+  normal *= 0.5;
 
-    if (flip){
-        normal *= -1.0; // Invert direction if counterclockwise
-    }
-    _normal = normal.normalized();
-    return normal;
+  if (flip) {
+    normal *= -1.0; // Invert direction if counterclockwise
+  }
+  _normal = normal.normalized();
+  return normal;
 }
 
 int Quad::getDimensions() const
@@ -155,27 +153,27 @@ double Quad::getEnclosingRadius() const
                    (center - vertex(3).getCoords()).norm()});
 }
 
-bool Quad::operator==(const Quad& other) const
+bool Quad::operator==(const Quad &other) const
 {
-    return math::equals(_normal, other._normal) &&
-        std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin(),
-                [](const Edge* e1, const Edge* e2){return *e1 == *e2;});
+  return math::equals(_normal, other._normal) &&
+         std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin(),
+                             [](const Edge *e1, const Edge *e2) { return *e1 == *e2; });
 }
 
-bool Quad::operator!=(const Quad& other) const
+bool Quad::operator!=(const Quad &other) const
 {
   return !(*this == other);
 }
 
-std::ostream& operator<<(std::ostream& os, const Quad& q)
+std::ostream &operator<<(std::ostream &os, const Quad &q)
 {
-    using utils::eigenio::wkt;
-    return os << "POLYGON (("
-              << q.vertex(0).getCoords().transpose().format(wkt()) << ", "
-              << q.vertex(1).getCoords().transpose().format(wkt()) << ", "
-              << q.vertex(2).getCoords().transpose().format(wkt()) << ", "
-              << q.vertex(3).getCoords().transpose().format(wkt()) << ", "
-              << q.vertex(0).getCoords().transpose().format(wkt()) << "))";
+  using utils::eigenio::wkt;
+  return os << "POLYGON (("
+            << q.vertex(0).getCoords().transpose().format(wkt()) << ", "
+            << q.vertex(1).getCoords().transpose().format(wkt()) << ", "
+            << q.vertex(2).getCoords().transpose().format(wkt()) << ", "
+            << q.vertex(3).getCoords().transpose().format(wkt()) << ", "
+            << q.vertex(0).getCoords().transpose().format(wkt()) << "))";
 }
 
 } // namespace mesh

--- a/src/mesh/Quad.hpp
+++ b/src/mesh/Quad.hpp
@@ -1,18 +1,15 @@
 #pragma once
 
-#include <iostream>
 #include <algorithm>
+#include <iostream>
 #include "mesh/Edge.hpp"
 #include "mesh/RangeAccessor.hpp"
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 
 /// Quadrilateral (or Quadrangle) geometric primitive.
-class Quad
-{
+class Quad {
 public:
   /// Type of the read-only const random-access iterator over Vertex coords
   /**
@@ -115,10 +112,10 @@ public:
    * Two Quads are equal if their normal vector is equal AND
    * if the four edges are equal, whereas the order of edges is NOT important.
    */
-  bool operator==(const Quad& other) const;
+  bool operator==(const Quad &other) const;
 
   /// Not equal, implemented in terms of equal.
-  bool operator!=(const Quad& other) const;
+  bool operator!=(const Quad &other) const;
 
 private:
   /// Edges defining the quad.
@@ -170,12 +167,12 @@ inline Quad::const_iterator Quad::end() const
 
 inline Quad::const_iterator Quad::cbegin() const
 {
-    return begin();
+  return begin();
 }
 
 inline Quad::const_iterator Quad::cend() const
 {
-    return end();
+  return end();
 }
 
 inline Edge &Quad::edge(int i)
@@ -200,7 +197,7 @@ inline int Quad::getID() const
   return _id;
 }
 
-std::ostream& operator<<(std::ostream& os, const Quad& q);
+std::ostream &operator<<(std::ostream &os, const Quad &q);
 
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -1,8 +1,8 @@
 #include "mesh/impl/RTree.hpp"
 #include "mesh/impl/RTreeAdapter.hpp"
 
-#include "mesh/RTree.hpp"
 #include <boost/range/irange.hpp>
+#include "mesh/RTree.hpp"
 
 namespace precice {
 namespace mesh {
@@ -11,63 +11,60 @@ namespace bg = boost::geometry;
 
 // Initialize static member
 std::map<int, rtree::MeshIndices> precice::mesh::rtree::_cached_trees;
-std::map<int, PtrPrimitiveRTree> precice::mesh::rtree::_primitive_trees;
+std::map<int, PtrPrimitiveRTree>  precice::mesh::rtree::_primitive_trees;
 
-rtree::MeshIndices& rtree::cacheEntry(int meshID)
+rtree::MeshIndices &rtree::cacheEntry(int meshID)
 {
-    auto result = _cached_trees.emplace(std::make_pair(meshID, rtree::MeshIndices{}));
-    return result.first->second;
+  auto result = _cached_trees.emplace(std::make_pair(meshID, rtree::MeshIndices{}));
+  return result.first->second;
 }
 
-
-rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh& mesh)
+rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh &mesh)
 {
   PRECICE_ASSERT(mesh);
-  auto& cache = cacheEntry(mesh->getID());
+  auto &cache = cacheEntry(mesh->getID());
   if (cache.vertices) {
-      return cache.vertices;
+    return cache.vertices;
   }
 
   // Generating the rtree is expensive, so passing everything in the ctor is
-  // the best we can do. Even passing an index range instead of calling 
+  // the best we can do. Even passing an index range instead of calling
   // tree->insert repeatedly is about 10x faster.
-  RTreeParameters params;
+  RTreeParameters            params;
   vertex_traits::IndexGetter ind(mesh->vertices());
-  auto tree = std::make_shared<vertex_traits::RTree>(
-          boost::irange<std::size_t>(0lu, mesh->vertices().size()), params, ind);
+  auto                       tree = std::make_shared<vertex_traits::RTree>(
+      boost::irange<std::size_t>(0lu, mesh->vertices().size()), params, ind);
 
   cache.vertices = tree;
   return tree;
 }
 
-
-rtree::edge_traits::Ptr rtree::getEdgeRTree(const PtrMesh& mesh)
+rtree::edge_traits::Ptr rtree::getEdgeRTree(const PtrMesh &mesh)
 {
   PRECICE_ASSERT(mesh);
-  auto& cache = cacheEntry(mesh->getID());
+  auto &cache = cacheEntry(mesh->getID());
   if (cache.edges) {
-      return cache.edges;
+    return cache.edges;
   }
 
   // Generating the rtree is expensive, so passing everything in the ctor is
-  // the best we can do. Even passing an index range instead of calling 
+  // the best we can do. Even passing an index range instead of calling
   // tree->insert repeatedly is about 10x faster.
-  RTreeParameters params;
+  RTreeParameters          params;
   edge_traits::IndexGetter ind(mesh->edges());
-  auto tree = std::make_shared<edge_traits::RTree>(
-          boost::irange<std::size_t>(0lu, mesh->edges().size()), params, ind);
+  auto                     tree = std::make_shared<edge_traits::RTree>(
+      boost::irange<std::size_t>(0lu, mesh->edges().size()), params, ind);
 
   cache.edges = tree;
   return tree;
 }
 
-
-rtree::triangle_traits::Ptr rtree::getTriangleRTree(const PtrMesh& mesh)
+rtree::triangle_traits::Ptr rtree::getTriangleRTree(const PtrMesh &mesh)
 {
   PRECICE_ASSERT(mesh);
-  auto& cache = cacheEntry(mesh->getID());
+  auto &cache = cacheEntry(mesh->getID());
   if (cache.triangles) {
-      return cache.triangles;
+    return cache.triangles;
   }
 
   // We first generate the values for the triangle rtree.
@@ -76,21 +73,20 @@ rtree::triangle_traits::Ptr rtree::getTriangleRTree(const PtrMesh& mesh)
   std::vector<triangle_traits::IndexType> elements;
   elements.reserve(mesh->triangles().size());
   for (size_t i = 0; i < mesh->triangles().size(); ++i) {
-      auto box = bg::return_envelope<RTreeBox>(mesh->triangles()[i]);
-      elements.emplace_back(std::move(box) , i);
+    auto box = bg::return_envelope<RTreeBox>(mesh->triangles()[i]);
+    elements.emplace_back(std::move(box), i);
   }
 
   // Generating the rtree is expensive, so passing everything in the ctor is
   // the best we can do.
-  RTreeParameters params;
+  RTreeParameters              params;
   triangle_traits::IndexGetter ind;
-  auto tree = std::make_shared<triangle_traits::RTree>(elements, params, ind);
-  cache.triangles = tree;
+  auto                         tree = std::make_shared<triangle_traits::RTree>(elements, params, ind);
+  cache.triangles                   = tree;
   return tree;
 }
 
-
-PtrPrimitiveRTree rtree::getPrimitiveRTree(const PtrMesh& mesh)
+PtrPrimitiveRTree rtree::getPrimitiveRTree(const PtrMesh &mesh)
 {
   PRECICE_ASSERT(mesh, "Empty meshes are not allowed.");
   auto iter = _primitive_trees.find(mesh->getID());
@@ -99,11 +95,10 @@ PtrPrimitiveRTree rtree::getPrimitiveRTree(const PtrMesh& mesh)
   }
   auto treeptr = std::make_shared<PrimitiveRTree>(indexMesh(*mesh));
   _primitive_trees.emplace(std::piecewise_construct,
-          std::forward_as_tuple(mesh->getID()),
-          std::forward_as_tuple(treeptr));
+                           std::forward_as_tuple(mesh->getID()),
+                           std::forward_as_tuple(treeptr));
   return treeptr;
 }
-
 
 void rtree::clear(Mesh &mesh)
 {
@@ -117,10 +112,10 @@ void rtree::clear()
   _primitive_trees.clear();
 }
 
-Box3d getEnclosingBox(Vertex const & middlePoint, double sphereRadius)
+Box3d getEnclosingBox(Vertex const &middlePoint, double sphereRadius)
 {
   namespace bg = boost::geometry;
-  auto & coords = middlePoint.getCoords();
+  auto &coords = middlePoint.getCoords();
 
   Box3d box;
   bg::set<bg::min_corner, 0>(box, bg::get<0>(coords) - sphereRadius);
@@ -130,10 +125,9 @@ Box3d getEnclosingBox(Vertex const & middlePoint, double sphereRadius)
   bg::set<bg::max_corner, 0>(box, bg::get<0>(coords) + sphereRadius);
   bg::set<bg::max_corner, 1>(box, bg::get<1>(coords) + sphereRadius);
   bg::set<bg::max_corner, 2>(box, bg::get<2>(coords) + sphereRadius);
-  
+
   return box;
 }
-
 
 PrimitiveRTree indexMesh(const Mesh &mesh)
 {
@@ -167,20 +161,21 @@ std::ostream &operator<<(std::ostream &out, Primitive val)
   return out;
 }
 
-std::ostream& operator<<(std::ostream& out, PrimitiveIndex val) {
-    return out << val.type << ":" << val.index;
+std::ostream &operator<<(std::ostream &out, PrimitiveIndex val)
+{
+  return out << val.type << ":" << val.index;
 }
 
-bool operator==(const PrimitiveIndex& lhs, const PrimitiveIndex& rhs)
+bool operator==(const PrimitiveIndex &lhs, const PrimitiveIndex &rhs)
 {
-    return lhs.type == rhs.type && lhs.index == rhs.index;
+  return lhs.type == rhs.type && lhs.index == rhs.index;
 }
 
 /// Standard non-equality test for PrimitiveIndex
-bool operator!=(const PrimitiveIndex& lhs, const PrimitiveIndex& rhs)
+bool operator!=(const PrimitiveIndex &lhs, const PrimitiveIndex &rhs)
 {
-    return !(lhs == rhs);
+  return !(lhs == rhs);
 }
 
-}}
-
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -1,18 +1,19 @@
 #pragma once
 
+#include <boost/geometry.hpp>
 #include <map>
 #include <memory>
-#include "mesh/impl/RTreeAdapter.hpp"
 #include "mesh/Mesh.hpp"
-#include <boost/geometry.hpp>
-#include "mesh/Triangle.hpp"
 #include "mesh/Quad.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/impl/RTreeAdapter.hpp"
 
 // Forward declaration to friend the boost test struct
 namespace MeshTests {
 namespace RTree {
 struct CacheClearing;
-}}
+}
+} // namespace MeshTests
 
 namespace precice {
 namespace mesh {
@@ -29,7 +30,7 @@ enum class Primitive {
 };
 
 /// A standard print operator for Primitive
-std::ostream& operator<<(std::ostream& out, Primitive val);
+std::ostream &operator<<(std::ostream &out, Primitive val);
 
 /// The type traits to return the enum value of a primitive type.
 template <class T>
@@ -62,13 +63,13 @@ struct PrimitiveIndex {
 };
 
 /// Standard equality test for PrimitiveIndex
-bool operator==(const PrimitiveIndex& lhs, const PrimitiveIndex& rhs);
+bool operator==(const PrimitiveIndex &lhs, const PrimitiveIndex &rhs);
 
 /// Standard non-equality test for PrimitiveIndex
-bool operator!=(const PrimitiveIndex& lhs, const PrimitiveIndex& rhs);
+bool operator!=(const PrimitiveIndex &lhs, const PrimitiveIndex &rhs);
 
 /// A standard print operator for PrimitiveIndex
-std::ostream& operator<<(std::ostream& out, PrimitiveIndex val);
+std::ostream &operator<<(std::ostream &out, PrimitiveIndex val);
 
 /// The axis aligned bounding box based on the Vertex Type
 using AABB = boost::geometry::model::box<Eigen::VectorXd>;
@@ -93,32 +94,31 @@ PrimitiveRTree indexMesh(const Mesh &mesh);
 using RTreeBox = boost::geometry::model::box<Eigen::VectorXd>;
 
 /// Type trait to extract information based on the type of a Primitive
-template<class T>
+template <class T>
 struct PrimitiveTraits;
 
-template<>
+template <>
 struct PrimitiveTraits<pm::Vertex> {
-    using MeshContainer = Mesh::VertexContainer;
+  using MeshContainer = Mesh::VertexContainer;
 };
 
-template<>
+template <>
 struct PrimitiveTraits<pm::Edge> {
-    using MeshContainer = Mesh::EdgeContainer;
+  using MeshContainer = Mesh::EdgeContainer;
 };
 
-template<>
+template <>
 struct PrimitiveTraits<pm::Triangle> {
-    using MeshContainer = Mesh::TriangleContainer;
+  using MeshContainer = Mesh::TriangleContainer;
 };
 
-template<>
+template <>
 struct PrimitiveTraits<pm::Quad> {
-    using MeshContainer = Mesh::VertexContainer;
+  using MeshContainer = Mesh::VertexContainer;
 };
 
 /// The general rtree parameter type used in precice
 using RTreeParameters = boost::geometry::index::rstar<16>;
-
 
 namespace impl {
 template <typename Primitive>
@@ -149,16 +149,16 @@ private:
 public:
   using type = decltype(test<Primitive>(nullptr));
 };
-} // impl
+} // namespace impl
 
 template <class Primitive>
-struct IsDirectIndexable : impl::IsDirectIndexableHelper<Primitive>::type {};
-
+struct IsDirectIndexable : impl::IsDirectIndexableHelper<Primitive>::type {
+};
 
 /// The type traits of a rtree based on a Primitive
 template <class Primitive>
 struct RTreeTraits {
-  using MeshContainer = typename PrimitiveTraits<Primitive>::MeshContainer;
+  using MeshContainer      = typename PrimitiveTraits<Primitive>::MeshContainer;
   using MeshContainerIndex = typename MeshContainer::size_type;
 
   using IndexType = typename std::conditional<
@@ -175,7 +175,6 @@ struct RTreeTraits {
   using Ptr   = std::shared_ptr<RTree>;
 };
 
-
 class rtree {
 public:
   using vertex_traits   = RTreeTraits<Vertex>;
@@ -186,42 +185,43 @@ public:
   /*
    * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
    */
-  static vertex_traits::Ptr getVertexRTree(const PtrMesh& mesh);
+  static vertex_traits::Ptr getVertexRTree(const PtrMesh &mesh);
 
-  static edge_traits::Ptr getEdgeRTree(const PtrMesh& mesh);
+  static edge_traits::Ptr getEdgeRTree(const PtrMesh &mesh);
 
-  static triangle_traits::Ptr getTriangleRTree(const PtrMesh& mesh);
-  
+  static triangle_traits::Ptr getTriangleRTree(const PtrMesh &mesh);
+
   /// Returns the pointer to boost::geometry::rtree for the given mesh primitives
   /*
    * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
    */
-  static PtrPrimitiveRTree getPrimitiveRTree(const PtrMesh& mesh);
+  static PtrPrimitiveRTree getPrimitiveRTree(const PtrMesh &mesh);
 
   /// Only clear the trees of that specific mesh
-  static void clear(Mesh & mesh);
+  static void clear(Mesh &mesh);
 
   /// Clear the complete cache
   static void clear();
 
   friend struct MeshTests::RTree::CacheClearing;
+
 private:
   struct MeshIndices {
-      vertex_traits::Ptr vertices;
-      edge_traits::Ptr edges;
-      triangle_traits::Ptr triangles;
+    vertex_traits::Ptr   vertices;
+    edge_traits::Ptr     edges;
+    triangle_traits::Ptr triangles;
   };
 
-  static MeshIndices& cacheEntry(int MeshID);
+  static MeshIndices &cacheEntry(int MeshID);
 
-  static std::map<int, MeshIndices> _cached_trees; ///< Cache for all index trees
+  static std::map<int, MeshIndices>       _cached_trees;    ///< Cache for all index trees
   static std::map<int, PtrPrimitiveRTree> _primitive_trees; ///< Cache for the primitive trees
 };
-
 
 using Box3d = boost::geometry::model::box<boost::geometry::model::point<double, 3, boost::geometry::cs::cartesian>>;
 
 /// Returns a boost::geometry box that encloses a sphere of given radius around a middle point
-Box3d getEnclosingBox(Vertex const & middlePoint, double sphereRadius);
+Box3d getEnclosingBox(Vertex const &middlePoint, double sphereRadius);
 
-}}
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/RangeAccessor.hpp
+++ b/src/mesh/RangeAccessor.hpp
@@ -2,10 +2,8 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 /** random-access iterator over an indexable Source.
  * 
  * @tparam Source the underlying container to index into
@@ -17,8 +15,7 @@ template <typename Source, typename Value>
 class IndexRangeIterator : public boost::iterator_facade<
                                IndexRangeIterator<Source, const Value>,
                                const Value,
-                               boost::random_access_traversal_tag>
-{
+                               boost::random_access_traversal_tag> {
 public:
   IndexRangeIterator() = default;
   IndexRangeIterator(Source *src, size_t index)
@@ -28,11 +25,11 @@ public:
   {
     using Coord = decltype(src_->vertex(idx_).getCoords());
     static_assert(
-            std::is_reference<Coord>::value,
-            "Coordinate type must be a reference!");
+        std::is_reference<Coord>::value,
+        "Coordinate type must be a reference!");
     static_assert(
-            std::is_convertible<Coord, Value>::value,
-            "Exposed and accessed types must match!");
+        std::is_convertible<Coord, Value>::value,
+        "Exposed and accessed types must match!");
     return static_cast<const Value &>(src_->vertex(idx_).getCoords());
   }
 
@@ -63,7 +60,7 @@ public:
 
 private:
   Source *src_{nullptr}; ///< the source to access
-  size_t  idx_{0}; ///< the current index to access
+  size_t  idx_{0};       ///< the current index to access
 };
 
 } // namespace mesh

--- a/src/mesh/SharedPointer.hpp
+++ b/src/mesh/SharedPointer.hpp
@@ -17,4 +17,5 @@ using PtrMesh              = std::shared_ptr<Mesh>;
 using PtrDataConfiguration = std::shared_ptr<DataConfiguration>;
 using PtrMeshConfiguration = std::shared_ptr<MeshConfiguration>;
 
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -1,20 +1,18 @@
 #include "Triangle.hpp"
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <boost/range/concepts.hpp>
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
 #include "utils/EigenIO.hpp"
-#include <boost/range/concepts.hpp>
-#include <Eigen/Dense>
-#include <Eigen/Geometry>
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 
-BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::iterator>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::const_iterator>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Triangle>));
-BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>));
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::iterator>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Triangle::const_iterator>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Triangle>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>) );
 
 Triangle::Triangle(
     Edge &edgeOne,
@@ -26,9 +24,9 @@ Triangle::Triangle(
       _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions()))
 {
   PRECICE_ASSERT(edgeOne.getDimensions() == edgeTwo.getDimensions(),
-            edgeOne.getDimensions(), edgeTwo.getDimensions());
+                 edgeOne.getDimensions(), edgeTwo.getDimensions());
   PRECICE_ASSERT(edgeTwo.getDimensions() == edgeThree.getDimensions(),
-            edgeTwo.getDimensions(), edgeThree.getDimensions());
+                 edgeTwo.getDimensions(), edgeThree.getDimensions());
   PRECICE_ASSERT(getDimensions() == 3, getDimensions());
 
   // Determine vertex map
@@ -67,23 +65,23 @@ Triangle::Triangle(
   }
 
   PRECICE_ASSERT(
-          (&edge(0).vertex(_vertexMap[0]) != &edge(1).vertex(_vertexMap[1])) &&
+      (&edge(0).vertex(_vertexMap[0]) != &edge(1).vertex(_vertexMap[1])) &&
           (&edge(0).vertex(_vertexMap[0]) != &edge(2).vertex(_vertexMap[2])) &&
           (&edge(1).vertex(_vertexMap[1]) != &edge(2).vertex(_vertexMap[2])),
-          "Triangle vertices are not unique!");
+      "Triangle vertices are not unique!");
 }
 
 const Eigen::VectorXd Triangle::computeNormal(bool flip)
 {
-    Eigen::Vector3d vectorA = edge(1).getCenter() - edge(0).getCenter();
-    Eigen::Vector3d vectorB = edge(2).getCenter() - edge(0).getCenter();
-    // Compute cross-product of vector A and vector B
-    auto normal = vectorA.cross(vectorB);
-    if (flip){
-      normal *= -1.0; // Invert direction if counterclockwise
-    }
-    _normal = normal.normalized();
-    return normal;
+  Eigen::Vector3d vectorA = edge(1).getCenter() - edge(0).getCenter();
+  Eigen::Vector3d vectorB = edge(2).getCenter() - edge(0).getCenter();
+  // Compute cross-product of vector A and vector B
+  auto normal = vectorA.cross(vectorB);
+  if (flip) {
+    normal *= -1.0; // Invert direction if counterclockwise
+  }
+  _normal = normal.normalized();
+  return normal;
 }
 
 int Triangle::getDimensions() const
@@ -98,7 +96,7 @@ const Eigen::VectorXd &Triangle::getNormal() const
 
 const Eigen::VectorXd Triangle::getCenter() const
 {
-  return (_edges[0]->getCenter() +_edges[1]->getCenter() + _edges[2]->getCenter()) / 3.0;
+  return (_edges[0]->getCenter() + _edges[1]->getCenter() + _edges[2]->getCenter()) / 3.0;
 }
 
 double Triangle::getEnclosingRadius() const
@@ -109,26 +107,26 @@ double Triangle::getEnclosingRadius() const
                    (center - vertex(2).getCoords()).norm()});
 }
 
-bool Triangle::operator==(const Triangle& other) const
+bool Triangle::operator==(const Triangle &other) const
 {
-    return math::equals(_normal, other._normal) &&
-        std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin(),
-                [](const Edge* e1, const Edge* e2){return *e1 == *e2;});
+  return math::equals(_normal, other._normal) &&
+         std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin(),
+                             [](const Edge *e1, const Edge *e2) { return *e1 == *e2; });
 }
 
-bool Triangle::operator!=(const Triangle& other) const
+bool Triangle::operator!=(const Triangle &other) const
 {
-    return !(*this == other);
+  return !(*this == other);
 }
 
-std::ostream& operator<<(std::ostream& os, const Triangle& t)
+std::ostream &operator<<(std::ostream &os, const Triangle &t)
 {
-    using utils::eigenio::wkt;
-    return os << "POLYGON (("
-              << t.vertex(0).getCoords().transpose().format(wkt()) << ", "
-              << t.vertex(1).getCoords().transpose().format(wkt()) << ", "
-              << t.vertex(2).getCoords().transpose().format(wkt()) << ", "
-              << t.vertex(0).getCoords().transpose().format(wkt()) << "))";
+  using utils::eigenio::wkt;
+  return os << "POLYGON (("
+            << t.vertex(0).getCoords().transpose().format(wkt()) << ", "
+            << t.vertex(1).getCoords().transpose().format(wkt()) << ", "
+            << t.vertex(2).getCoords().transpose().format(wkt()) << ", "
+            << t.vertex(0).getCoords().transpose().format(wkt()) << "))";
 }
 
 } // namespace mesh

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -1,32 +1,27 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <iostream>
 #include <algorithm>
+#include <iostream>
 
+#include "math/differences.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/RangeAccessor.hpp"
 #include "utils/assertion.hpp"
-#include "math/differences.hpp"
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 class Vertex;
 }
 } // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 
 /// Triangle of a mesh, defined by three edges (and vertices).
-class Triangle
-{
+class Triangle {
 public:
   /// Type of the read-only const random-access iterator over Vertex coords
   /**
@@ -128,10 +123,10 @@ public:
    * Two Triangles are equal if their normal vector is equal AND
    * if the three edges are equal, whereas the order of edges is NOT important.
    */
-  bool operator==(const Triangle& other) const;
+  bool operator==(const Triangle &other) const;
 
   /// Not equal, implemented in terms of equal.
-  bool operator!=(const Triangle& other) const;
+  bool operator!=(const Triangle &other) const;
 
 private:
   /// Edges defining the triangle.
@@ -210,13 +205,12 @@ void Triangle::setNormal(
   _normal = normal;
 }
 
-
 inline int Triangle::getID() const
 {
   return _id;
 }
 
-std::ostream& operator<<(std::ostream& os, const Triangle& t);
+std::ostream &operator<<(std::ostream &os, const Triangle &t);
 
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -1,10 +1,8 @@
 #include "Vertex.hpp"
 #include "utils/EigenIO.hpp"
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 
 int Vertex::getDimensions() const
 {

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -5,14 +5,11 @@
 
 #include "math/differences.hpp"
 
-namespace precice
-{
-namespace mesh
-{
+namespace precice {
+namespace mesh {
 
 /// Vertex of a mesh.
-class Vertex
-{
+class Vertex {
 public:
   /// Constructor for vertex
   template <typename VECTOR_T>

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -5,11 +5,11 @@
 namespace precice {
 namespace mesh {
 
-DataConfiguration:: DataConfiguration(xml::XMLTag& parent)
+DataConfiguration::DataConfiguration(xml::XMLTag &parent)
 {
   using namespace xml;
   std::string doc;
-  XMLTag tagScalar(*this, VALUE_SCALAR, XMLTag::OCCUR_ARBITRARY, TAG);
+  XMLTag      tagScalar(*this, VALUE_SCALAR, XMLTag::OCCUR_ARBITRARY, TAG);
   doc = "Defines a scalar data set to be assigned to meshes.";
   tagScalar.setDocumentation(doc);
   XMLTag tagVector(*this, VALUE_VECTOR, XMLTag::OCCUR_ARBITRARY, TAG);
@@ -18,8 +18,8 @@ DataConfiguration:: DataConfiguration(xml::XMLTag& parent)
   doc += "in tag <solver-interface>.";
   tagVector.setDocumentation(doc);
 
- auto attrName = XMLAttribute<std::string>(ATTR_NAME)
-      .setDocumentation("Unique name for the data set.");
+  auto attrName = XMLAttribute<std::string>(ATTR_NAME)
+                      .setDocumentation("Unique name for the data set.");
   tagScalar.addAttribute(attrName);
   tagVector.addAttribute(attrName);
 
@@ -27,80 +27,72 @@ DataConfiguration:: DataConfiguration(xml::XMLTag& parent)
   parent.addSubtag(tagVector);
 }
 
-void DataConfiguration:: setDimensions
-(
-  int dimensions )
+void DataConfiguration::setDimensions(
+    int dimensions)
 {
   PRECICE_TRACE(dimensions);
   PRECICE_ASSERT((dimensions == 2) || (dimensions == 3), dimensions);
   _dimensions = dimensions;
 }
 
-const std::vector<DataConfiguration::ConfiguredData>&
-DataConfiguration:: data() const
+const std::vector<DataConfiguration::ConfiguredData> &
+DataConfiguration::data() const
 {
-   return _data;
+  return _data;
 }
 
-DataConfiguration::ConfiguredData DataConfiguration:: getRecentlyConfiguredData() const
+DataConfiguration::ConfiguredData DataConfiguration::getRecentlyConfiguredData() const
 {
   PRECICE_ASSERT(_data.size() > 0);
   PRECICE_ASSERT(_indexLastConfigured >= 0);
-  PRECICE_ASSERT(_indexLastConfigured < (int)_data.size());
+  PRECICE_ASSERT(_indexLastConfigured < (int) _data.size());
   return _data[_indexLastConfigured];
 }
 
-void DataConfiguration:: xmlTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void DataConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
-  if (tag.getNamespace() == TAG){
+  if (tag.getNamespace() == TAG) {
     PRECICE_ASSERT(_dimensions != 0);
-    std::string name = tag.getStringAttributeValue(ATTR_NAME);
-    std::string typeName = tag.getName();
-    int dataDimensions = getDataDimensions(typeName);
+    std::string name           = tag.getStringAttributeValue(ATTR_NAME);
+    std::string typeName       = tag.getName();
+    int         dataDimensions = getDataDimensions(typeName);
     addData(name, dataDimensions);
-  }
-  else {
+  } else {
     PRECICE_ERROR("Received callback from tag " << tag.getName());
   }
 }
 
-void DataConfiguration:: xmlEndTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void DataConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
 }
 
-void DataConfiguration:: addData
-(
-  const std::string& name,
-  int                dataDimensions )
+void DataConfiguration::addData(
+    const std::string &name,
+    int                dataDimensions)
 {
   ConfiguredData data(name, dataDimensions);
 
   // Check, if data with same name has been added already
-  for (auto & elem : _data) {
-    PRECICE_CHECK( elem.name != data.name, "Data \"" << data.name << "\" uses non-unique name!" );
+  for (auto &elem : _data) {
+    PRECICE_CHECK(elem.name != data.name, "Data \"" << data.name << "\" uses non-unique name!");
   }
-  _data.push_back ( data );
+  _data.push_back(data);
 }
 
-int DataConfiguration:: getDataDimensions
-(
-  const std::string& typeName ) const
+int DataConfiguration::getDataDimensions(
+    const std::string &typeName) const
 {
   if (typeName == VALUE_VECTOR) {
     return _dimensions;
-  }
-  else if (typeName == VALUE_SCALAR) {
+  } else if (typeName == VALUE_SCALAR) {
     return 1;
   }
-  PRECICE_ERROR("Unknown data type!" );
+  PRECICE_ERROR("Unknown data type!");
 }
 
-
-
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -1,45 +1,42 @@
 #pragma once
 
+#include <string>
+#include <vector>
+#include "logging/Logger.hpp"
 #include "mesh/Data.hpp"
 #include "xml/XMLTag.hpp"
-#include "logging/Logger.hpp"
-#include <vector>
-#include <string>
 
 namespace precice {
 namespace mesh {
 
 /// Performs and provides configuration for Data objects from XML files.
-class DataConfiguration : public xml::XMLTag::Listener
-{
+class DataConfiguration : public xml::XMLTag::Listener {
 public:
-
-  struct ConfiguredData
-  {
+  struct ConfiguredData {
     std::string name;
-    int dimensions;
+    int         dimensions;
 
-    ConfiguredData (
-      const std::string& name,
-      int                dimensions )
-    : name(name), dimensions(dimensions) {}
+    ConfiguredData(
+        const std::string &name,
+        int                dimensions)
+        : name(name), dimensions(dimensions) {}
   };
 
-  DataConfiguration ( xml::XMLTag& parent );
+  DataConfiguration(xml::XMLTag &parent);
 
-  void setDimensions ( int dimensions );
+  void setDimensions(int dimensions);
 
-  const std::vector<ConfiguredData>& data() const;
+  const std::vector<ConfiguredData> &data() const;
 
   ConfiguredData getRecentlyConfiguredData() const;
 
   virtual void xmlTagCallback(
-          const xml::ConfigurationContext& context,
-          xml::XMLTag& callingTag);
+      const xml::ConfigurationContext &context,
+      xml::XMLTag &                    callingTag);
 
   virtual void xmlEndTagCallback(
-          const xml::ConfigurationContext& context,
-          xml::XMLTag& callingTag);
+      const xml::ConfigurationContext &context,
+      xml::XMLTag &                    callingTag);
 
   /**
    * @brief Adds data manually.
@@ -47,18 +44,17 @@ public:
    * @param[in] name Unqiue name of the data.
    * @param[in] dataDimensions Dimensionality (1: scalar, 2,3: vector) of data.
    */
-  void addData (
-    const std::string& name,
-    int                dataDimensions );
+  void addData(
+      const std::string &name,
+      int                dataDimensions);
 
   //int getDimensions() const;
 
 private:
-  
   mutable logging::Logger _log{"mesh::DataConfiguration"};
 
-  const std::string TAG = "data";
-  const std::string ATTR_NAME = "name";
+  const std::string TAG          = "data";
+  const std::string ATTR_NAME    = "name";
   const std::string VALUE_VECTOR = "vector";
   const std::string VALUE_SCALAR = "scalar";
 
@@ -69,7 +65,8 @@ private:
 
   int _indexLastConfigured = -1;
 
-  int getDataDimensions(const std::string& typeName) const;
+  int getDataDimensions(const std::string &typeName) const;
 };
 
-}} // namespace precice, mesh
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -1,44 +1,42 @@
 #include "MeshConfiguration.hpp"
-#include "mesh/config/DataConfiguration.hpp"
-#include "mesh/Mesh.hpp"
-#include "xml/XMLAttribute.hpp"
-#include "utils/Helpers.hpp"
 #include <sstream>
+#include "mesh/Mesh.hpp"
+#include "mesh/config/DataConfiguration.hpp"
+#include "utils/Helpers.hpp"
+#include "xml/XMLAttribute.hpp"
 
 namespace precice {
 namespace mesh {
 
-MeshConfiguration:: MeshConfiguration
-(
-  xml::XMLTag&       parent,
-  PtrDataConfiguration config )
-:
-  TAG("mesh"),
-  ATTR_NAME("name"),
-  ATTR_FLIP_NORMALS("flip-normals"),
-  TAG_DATA("use-data"),
-  ATTR_SIDE_INDEX("side"),
-  _dimensions(0),
-  _dataConfig(config),
-  _meshes(),
-  _neededMeshes(),
-  _meshIdManager(new utils::ManageUniqueIDs())
+MeshConfiguration::MeshConfiguration(
+    xml::XMLTag &        parent,
+    PtrDataConfiguration config)
+    : TAG("mesh"),
+      ATTR_NAME("name"),
+      ATTR_FLIP_NORMALS("flip-normals"),
+      TAG_DATA("use-data"),
+      ATTR_SIDE_INDEX("side"),
+      _dimensions(0),
+      _dataConfig(config),
+      _meshes(),
+      _neededMeshes(),
+      _meshIdManager(new utils::ManageUniqueIDs())
 {
   using namespace xml;
   std::string doc;
-  XMLTag tag(*this, TAG, xml::XMLTag::OCCUR_ONCE_OR_MORE);
+  XMLTag      tag(*this, TAG, xml::XMLTag::OCCUR_ONCE_OR_MORE);
   doc = "Surface mesh consisting of vertices and (optional) of edges and ";
   doc += "triangles (only in 3D). The vertices of a mesh can carry data, ";
   doc += "configured by tag <use-data>. The mesh coordinates have to be ";
   doc += "defined by a participant (see tag <use-mesh>).";
   tag.setDocumentation(doc);
 
- auto attrName = XMLAttribute<std::string>(ATTR_NAME)
-      .setDocumentation("Unique name for the mesh.");
+  auto attrName = XMLAttribute<std::string>(ATTR_NAME)
+                      .setDocumentation("Unique name for the mesh.");
   tag.addAttribute(attrName);
 
   auto attrFlipNormals = makeXMLAttribute(ATTR_FLIP_NORMALS, false)
-      .setDocumentation("Flips mesh normal vector directions.");
+                             .setDocumentation("Flips mesh normal vector directions.");
   tag.addAttribute(attrFlipNormals);
 
   XMLTag subtagData(*this, TAG_DATA, XMLTag::OCCUR_ARBITRARY);
@@ -51,39 +49,36 @@ MeshConfiguration:: MeshConfiguration
   parent.addSubtag(tag);
 }
 
-void MeshConfiguration:: setDimensions
-(
-  int dimensions )
+void MeshConfiguration::setDimensions(
+    int dimensions)
 {
   PRECICE_TRACE(dimensions);
   PRECICE_ASSERT((dimensions == 2) || (dimensions == 3), dimensions);
   _dimensions = dimensions;
 }
 
-void MeshConfiguration:: xmlTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void MeshConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getName());
-  if (tag.getName() == TAG){
+  if (tag.getName() == TAG) {
     PRECICE_ASSERT(_dimensions != 0);
-    std::string name = tag.getStringAttributeValue(ATTR_NAME);
-    bool flipNormals = tag.getBooleanAttributeValue(ATTR_FLIP_NORMALS);
+    std::string name        = tag.getStringAttributeValue(ATTR_NAME);
+    bool        flipNormals = tag.getBooleanAttributeValue(ATTR_FLIP_NORMALS);
     PRECICE_ASSERT(_meshIdManager);
     _meshes.push_back(PtrMesh(new Mesh(name, _dimensions, flipNormals, _meshIdManager->getFreeID())));
-  }
-  else if (tag.getName() == TAG_DATA){
-    std::string name = tag.getStringAttributeValue(ATTR_NAME);
-    bool found = false;
-    for (const DataConfiguration::ConfiguredData& data : _dataConfig->data()){
-      if (data.name == name){
+  } else if (tag.getName() == TAG_DATA) {
+    std::string name  = tag.getStringAttributeValue(ATTR_NAME);
+    bool        found = false;
+    for (const DataConfiguration::ConfiguredData &data : _dataConfig->data()) {
+      if (data.name == name) {
         _meshes.back()->createData(data.name, data.dimensions);
         found = true;
         break;
       }
     }
-    if (not found){
+    if (not found) {
       std::ostringstream stream;
       stream << "Data with name \"" << name << "\" is not available during "
              << "configuration of mesh \"" << _meshes.back()->getName() << "\"";
@@ -92,28 +87,24 @@ void MeshConfiguration:: xmlTagCallback
   }
 }
 
-void MeshConfiguration:: xmlEndTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void MeshConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
 }
 
-const PtrDataConfiguration& MeshConfiguration:: getDataConfiguration() const
+const PtrDataConfiguration &MeshConfiguration::getDataConfiguration() const
 {
   return _dataConfig;
 }
 
-void MeshConfiguration:: addMesh
-(
-  const mesh::PtrMesh& mesh  )
+void MeshConfiguration::addMesh(
+    const mesh::PtrMesh &mesh)
 {
-  for (PtrData dataNewMesh : mesh->data()){
+  for (PtrData dataNewMesh : mesh->data()) {
     bool found = false;
-    for (const DataConfiguration::ConfiguredData & data : _dataConfig->data()){
-      if ((dataNewMesh->getName() == data.name)
-          && (dataNewMesh->getDimensions() == data.dimensions))
-      {
+    for (const DataConfiguration::ConfiguredData &data : _dataConfig->data()) {
+      if ((dataNewMesh->getName() == data.name) && (dataNewMesh->getDimensions() == data.dimensions)) {
         found = true;
         break;
       }
@@ -123,42 +114,40 @@ void MeshConfiguration:: addMesh
   _meshes.push_back(mesh);
 }
 
-const std::vector<PtrMesh>& MeshConfiguration:: meshes() const
+const std::vector<PtrMesh> &MeshConfiguration::meshes() const
 {
   return _meshes;
 }
 
-std::vector<PtrMesh>& MeshConfiguration:: meshes()
+std::vector<PtrMesh> &MeshConfiguration::meshes()
 {
   return _meshes;
 }
 
-mesh::PtrMesh MeshConfiguration:: getMesh
-(
-  const std::string& meshName ) const
+mesh::PtrMesh MeshConfiguration::getMesh(
+    const std::string &meshName) const
 {
-  for ( const mesh::PtrMesh & mesh : _meshes ) {
-    if ( mesh->getName() == meshName ) {
+  for (const mesh::PtrMesh &mesh : _meshes) {
+    if (mesh->getName() == meshName) {
       return mesh;
     }
   }
   return mesh::PtrMesh();
 }
 
-void MeshConfiguration:: addNeededMesh(
-  const std::string& participant,
-  const std::string& mesh)
+void MeshConfiguration::addNeededMesh(
+    const std::string &participant,
+    const std::string &mesh)
 {
-  PRECICE_TRACE(participant, mesh );
-  if(_neededMeshes.count(participant)==0){
+  PRECICE_TRACE(participant, mesh);
+  if (_neededMeshes.count(participant) == 0) {
     std::vector<std::string> meshes;
     meshes.push_back(mesh);
-    _neededMeshes.insert(std::pair<std::string,std::vector<std::string> >(participant, meshes));
-  }
-  else if(not utils::contained(mesh,_neededMeshes.find(participant)->second)){
+    _neededMeshes.insert(std::pair<std::string, std::vector<std::string>>(participant, meshes));
+  } else if (not utils::contained(mesh, _neededMeshes.find(participant)->second)) {
     _neededMeshes.find(participant)->second.push_back(mesh);
   }
 }
 
-}} // namespace precice, mesh
-
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -1,69 +1,68 @@
 #pragma once
 
-#include "mesh/SharedPointer.hpp"
-#include "logging/Logger.hpp"
-#include "xml/XMLTag.hpp"
-#include "utils/ManageUniqueIDs.hpp"
-#include <vector>
 #include <list>
 #include <map>
 #include <string>
+#include <vector>
+#include "logging/Logger.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "utils/ManageUniqueIDs.hpp"
+#include "xml/XMLTag.hpp"
 
 namespace precice {
-  namespace mesh {
-    class DataConfiguration;
-  }
+namespace mesh {
+class DataConfiguration;
 }
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
 namespace precice {
 namespace mesh {
 
-class MeshConfiguration : public xml::XMLTag::Listener
-{
+class MeshConfiguration : public xml::XMLTag::Listener {
 public:
-
   /// Constructor, takes a valid data configuration as argument.
-  MeshConfiguration (
-    xml::XMLTag&       parent,
-    PtrDataConfiguration config );
+  MeshConfiguration(
+      xml::XMLTag &        parent,
+      PtrDataConfiguration config);
 
-  void setDimensions ( int dimensions );
-
-  /// Returns all configured meshes.
-  const std::vector<PtrMesh>& meshes() const;
+  void setDimensions(int dimensions);
 
   /// Returns all configured meshes.
-  std::vector<PtrMesh>& meshes();
+  const std::vector<PtrMesh> &meshes() const;
+
+  /// Returns all configured meshes.
+  std::vector<PtrMesh> &meshes();
 
   /// Returns the configured mesh with given name, or NULL.
-  mesh::PtrMesh getMesh ( const std::string& meshName ) const;
+  mesh::PtrMesh getMesh(const std::string &meshName) const;
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag);
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   virtual void xmlEndTagCallback(
-          const xml::ConfigurationContext& context,
-          xml::XMLTag& callingTag);
+      const xml::ConfigurationContext &context,
+      xml::XMLTag &                    callingTag);
 
-  const PtrDataConfiguration& getDataConfiguration() const;
+  const PtrDataConfiguration &getDataConfiguration() const;
 
-  void addMesh ( const mesh::PtrMesh& mesh );
+  void addMesh(const mesh::PtrMesh &mesh);
 
-  std::map<std::string, std::vector<std::string> >& getNeededMeshes(){
+  std::map<std::string, std::vector<std::string>> &getNeededMeshes()
+  {
     return _neededMeshes;
   }
 
   void addNeededMesh(
-    const std::string& participant,
-    const std::string& mesh);
+      const std::string &participant,
+      const std::string &mesh);
 
-  std::unique_ptr<utils::ManageUniqueIDs> extractMeshIdManager() {
-      return std::move(_meshIdManager);
+  std::unique_ptr<utils::ManageUniqueIDs> extractMeshIdManager()
+  {
+    return std::move(_meshIdManager);
   }
 
 private:
-
   logging::Logger _log{"mesh::MeshConfiguration"};
 
   const std::string TAG;
@@ -81,10 +80,10 @@ private:
   std::vector<PtrMesh> _meshes;
 
   /// to check later if all meshes that any coupling scheme needs are actually used by the participants
-  std::map<std::string,std::vector<std::string> > _neededMeshes;
+  std::map<std::string, std::vector<std::string>> _neededMeshes;
 
   std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
 };
 
-}} // namespace precice, mesh
-
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/impl/RTree.hpp
+++ b/src/mesh/impl/RTree.hpp
@@ -6,12 +6,10 @@ namespace precice {
 namespace mesh {
 namespace impl {
 
-
 /** Holding a reference to a Mesh it is a functor for packing
  *  PrimitiveIndex into AABBs.
  */
-class AABBGenerator
-{
+class AABBGenerator {
 public:
   /// Constructs a generator for a given mesh
   explicit AABBGenerator(const mesh::Mesh &mesh)
@@ -56,7 +54,7 @@ private:
  * @param conti the Container to index
  */
 template <typename Container, typename Generator = AABBGenerator>
-void indexPrimitive(PrimitiveRTree &rtree, const Generator& gen, const Container &conti)
+void indexPrimitive(PrimitiveRTree &rtree, const Generator &gen, const Container &conti)
 {
   using ValueType = typename std::remove_reference<typename std::remove_cv<typename Container::value_type>::type>::type;
   for (size_t i = 0; i < conti.size(); ++i) {
@@ -65,4 +63,6 @@ void indexPrimitive(PrimitiveRTree &rtree, const Generator& gen, const Container
   }
 }
 
-}}}
+} // namespace impl
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/impl/RTreeAdapter.hpp
+++ b/src/mesh/impl/RTreeAdapter.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <boost/geometry.hpp>
 #include <Eigen/Core>
-#include "mesh/Vertex.hpp"
+#include <boost/geometry.hpp>
 #include "mesh/Edge.hpp"
+#include "mesh/Vertex.hpp"
 
 namespace precice {
 namespace mesh {
@@ -23,63 +23,83 @@ namespace traits {
 /*
  * This adapts every VectorXd to a 3d point. For non-existing dimensions, zero is returned.
  */
-template<> struct tag<Eigen::VectorXd>               { using type = point_tag; };
-template<> struct coordinate_type<Eigen::VectorXd>   { using type = double; };
-template<> struct coordinate_system<Eigen::VectorXd> { using type = cs::cartesian; };
-template<> struct dimension<Eigen::VectorXd> : boost::mpl::int_<3> {};
+template <>
+struct tag<Eigen::VectorXd> {
+  using type = point_tag;
+};
+template <>
+struct coordinate_type<Eigen::VectorXd> {
+  using type = double;
+};
+template <>
+struct coordinate_system<Eigen::VectorXd> {
+  using type = cs::cartesian;
+};
+template <>
+struct dimension<Eigen::VectorXd> : boost::mpl::int_<3> {
+};
 
-template<size_t Dimension>
-struct access<Eigen::VectorXd, Dimension>
-{
-  static double get(Eigen::VectorXd const& p)
+template <size_t Dimension>
+struct access<Eigen::VectorXd, Dimension> {
+  static double get(Eigen::VectorXd const &p)
   {
-    if (Dimension > static_cast<size_t>(p.rows())-1)
+    if (Dimension > static_cast<size_t>(p.rows()) - 1)
       return 0;
-   
+
     return p[Dimension];
   }
-  
-  static void set(Eigen::VectorXd& p, double const& value)
+
+  static void set(Eigen::VectorXd &p, double const &value)
   {
     // This handles default initialized VectorXd
     if (p.size() == 0) {
-        p = Eigen::VectorXd::Zero(3);
+      p = Eigen::VectorXd::Zero(3);
     }
     p[Dimension] = value;
   }
 };
 
-BOOST_CONCEPT_ASSERT( (bg::concepts::Point<Eigen::VectorXd>));
+BOOST_CONCEPT_ASSERT((bg::concepts::Point<Eigen::VectorXd>) );
 
 /// Provides the necessary template specialisations to adapt precice's Vertex to boost.geometry
 /*
 * This adapts every Vertex to a 3d point. For non-existing dimensions, zero is returned.
 */
-template<> struct tag<pm::Vertex>               { using type = point_tag; };
-template<> struct coordinate_type<pm::Vertex>   { using type = double; };
-template<> struct coordinate_system<pm::Vertex> { using type = cs::cartesian; };
-template<> struct dimension<pm::Vertex> : boost::mpl::int_<3> {};
+template <>
+struct tag<pm::Vertex> {
+  using type = point_tag;
+};
+template <>
+struct coordinate_type<pm::Vertex> {
+  using type = double;
+};
+template <>
+struct coordinate_system<pm::Vertex> {
+  using type = cs::cartesian;
+};
+template <>
+struct dimension<pm::Vertex> : boost::mpl::int_<3> {
+};
 
-template<size_t Dimension>
-struct access<pm::Vertex, Dimension>
-{
-  static double get(pm::Vertex const& p)
+template <size_t Dimension>
+struct access<pm::Vertex, Dimension> {
+  static double get(pm::Vertex const &p)
   {
-    if (Dimension > static_cast<size_t>(p.getDimensions())-1)
+    if (Dimension > static_cast<size_t>(p.getDimensions()) - 1)
       return 0;
-   
+
     return p.getCoords()[Dimension];
   }
-  
-  static void set(pm::Vertex& p, double const& value)
+
+  static void set(pm::Vertex &p, double const &value)
   {
     Eigen::VectorXd vec = p.getCoords();
-    vec[Dimension] = value;
+    vec[Dimension]      = value;
     p.setCoords(vec);
   }
 };
 
-BOOST_CONCEPT_ASSERT( (concepts::Point<pm::Vertex>));
+BOOST_CONCEPT_ASSERT((concepts::Point<pm::Vertex>) );
 
 /** @brief Provides the necessary template specialisations to adapt precice's Edge to boost.geometry
 *
@@ -159,56 +179,54 @@ struct closure<pm::Quad> {
 using BoundingBox = std::vector<std::pair<double, double>>;
 
 template <>
-struct tag<BoundingBox>
-{
+struct tag<BoundingBox> {
   using type = box_tag;
 };
 
 namespace bg = ::boost::geometry;
 template <>
-struct point_type<BoundingBox>
-{
+struct point_type<BoundingBox> {
   using point_t = bg::model::point<double, 3, bg::cs::cartesian>; //fake point type.
-  using type = point_t; //BoundingBox does not consist of this point type, actually.
+  using type    = point_t;                                        //BoundingBox does not consist of this point type, actually.
 };
 
 template <std::size_t Dimension>
-struct indexed_access<BoundingBox, min_corner, Dimension>
-{
-  static inline double get(const BoundingBox& bb)
+struct indexed_access<BoundingBox, min_corner, Dimension> {
+  static inline double get(const BoundingBox &bb)
   {
     if (Dimension >= bb.size())
-        return std::numeric_limits<double>::lowest();
+      return std::numeric_limits<double>::lowest();
     return bb[Dimension].first;
   }
-  static inline void set(BoundingBox& bb, double value)
+  static inline void set(BoundingBox &bb, double value)
   {
     if (Dimension >= bb.size())
-        return;
+      return;
     bb[Dimension].first = value;
   }
 };
 
 template <std::size_t Dimension>
-struct indexed_access<BoundingBox, max_corner, Dimension>
-{
-  static inline double get(const BoundingBox& bb)
+struct indexed_access<BoundingBox, max_corner, Dimension> {
+  static inline double get(const BoundingBox &bb)
   {
     if (Dimension >= bb.size())
-        return std::numeric_limits<double>::max();
+      return std::numeric_limits<double>::max();
     return bb[Dimension].second;
   }
-  static inline void set(BoundingBox& bb, const double& value)
+  static inline void set(BoundingBox &bb, const double &value)
   {
     if (Dimension >= bb.size())
-        return;
+      return;
     bb[Dimension].second = value;
   }
 };
 
-BOOST_CONCEPT_ASSERT( (bg::concepts::Box<BoundingBox>) );
+BOOST_CONCEPT_ASSERT((bg::concepts::Box<BoundingBox>) );
 
-}}}
+} // namespace traits
+} // namespace geometry
+} // namespace boost
 
 namespace precice {
 namespace mesh {
@@ -216,17 +234,18 @@ namespace impl {
 
 /// Makes a utils::PtrVector indexable and thus be usable in boost::geometry::rtree
 template <typename Container>
-class PtrVectorIndexable
-{
+class PtrVectorIndexable {
   using size_type = typename Container::container::size_type;
-  using cref = const typename Container::value_type&;
-  Container const& container;
+  using cref      = const typename Container::value_type &;
+  Container const &container;
 
 public:
   using result_type = cref;
 
-  explicit PtrVectorIndexable(Container const& c) : container(c)
-  {}
+  explicit PtrVectorIndexable(Container const &c)
+      : container(c)
+  {
+  }
 
   result_type operator()(size_type i) const
   {
@@ -236,17 +255,18 @@ public:
 
 /// Makes a std::vector indexable and thus be usable in boost::geometry::rtree
 template <typename Container>
-class VectorIndexable
-{
+class VectorIndexable {
   using size_type = typename Container::size_type;
-  using cref = const typename Container::value_type&;
-  Container const& container;
+  using cref      = const typename Container::value_type &;
+  Container const &container;
 
 public:
   using result_type = cref;
 
-  explicit VectorIndexable(Container const& c) : container(c)
-  {}
+  explicit VectorIndexable(Container const &c)
+      : container(c)
+  {
+  }
 
   result_type operator()(size_type i) const
   {
@@ -254,5 +274,6 @@ public:
   }
 };
 
-
-}}}
+} // namespace impl
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/tests/DataConfigurationTest.cpp
+++ b/src/mesh/tests/DataConfigurationTest.cpp
@@ -8,10 +8,10 @@ BOOST_AUTO_TEST_SUITE(MeshTests)
 
 BOOST_AUTO_TEST_CASE(DataConfig, *testing::OnMaster())
 {
-  std::string filename(testing::getPathToSources()  + "/mesh/tests/data-config.xml");
-  int dim = 3;
+  std::string filename(testing::getPathToSources() + "/mesh/tests/data-config.xml");
+  int         dim = 3;
   using xml::XMLTag;
-  XMLTag tag = xml::getRootTag();
+  XMLTag                  tag = xml::getRootTag();
   mesh::DataConfiguration dataConfig(tag);
   dataConfig.setDimensions(dim);
   xml::configure(tag, xml::ConfigurationContext{}, filename);

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -1,7 +1,7 @@
+#include <Eigen/Core>
+#include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
-#include "mesh/Edge.hpp"
-#include <Eigen/Core>
 
 using namespace precice;
 using namespace precice::mesh;
@@ -11,68 +11,67 @@ BOOST_AUTO_TEST_SUITE(EdgeTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(Edges)
 {
-   Vertex v1 ( Eigen::Vector3d::Constant(0.0), 0 );
-   Vertex v2 ( Eigen::Vector3d::Constant(1.0), 1 );
-   Edge edge ( v1, v2, 0 );
+  Vertex v1(Eigen::Vector3d::Constant(0.0), 0);
+  Vertex v2(Eigen::Vector3d::Constant(1.0), 1);
+  Edge   edge(v1, v2, 0);
 
-   Eigen::VectorXd coords1 = edge.vertex(0).getCoords();
-   Eigen::VectorXd coords2 = edge.vertex(1).getCoords();
-   BOOST_TEST ( coords1 == Eigen::Vector3d::Constant(0.0) );
-   BOOST_TEST ( coords2 == Eigen::Vector3d::Constant(1.0) );
+  Eigen::VectorXd coords1 = edge.vertex(0).getCoords();
+  Eigen::VectorXd coords2 = edge.vertex(1).getCoords();
+  BOOST_TEST(coords1 == Eigen::Vector3d::Constant(0.0));
+  BOOST_TEST(coords2 == Eigen::Vector3d::Constant(1.0));
 }
 
 BOOST_AUTO_TEST_CASE(EdgeEquality)
 {
-   Vertex v1 (Eigen::Vector3d(0,0,0), 0);
-   Vertex v2 (Eigen::Vector3d(0,0,1), 0);
-   Vertex v3 (Eigen::Vector3d(0,0,2), 0);
-   Edge edge1(v1, v2, 0);
-   Edge edge2(v2, v1, 1);
-   Edge edge3(v1, v3, 0);
-   Edge edge4(v1, v3, 0);
-   edge4.setNormal(Eigen::Vector3d(Eigen::Vector3d(0,1,0)));
-   BOOST_TEST(edge1 == edge2);
-   BOOST_TEST(edge1 != edge3);
-   BOOST_TEST(edge3 != edge4);
+  Vertex v1(Eigen::Vector3d(0, 0, 0), 0);
+  Vertex v2(Eigen::Vector3d(0, 0, 1), 0);
+  Vertex v3(Eigen::Vector3d(0, 0, 2), 0);
+  Edge   edge1(v1, v2, 0);
+  Edge   edge2(v2, v1, 1);
+  Edge   edge3(v1, v3, 0);
+  Edge   edge4(v1, v3, 0);
+  edge4.setNormal(Eigen::Vector3d(Eigen::Vector3d(0, 1, 0)));
+  BOOST_TEST(edge1 == edge2);
+  BOOST_TEST(edge1 != edge3);
+  BOOST_TEST(edge3 != edge4);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeWKTPrint)
 {
-    Vertex v1(Eigen::Vector2d(1., 2.), 0);
-    Vertex v2(Eigen::Vector2d(2., 3.), 0);
-    Edge e1(v1, v2, 0);
-    std::stringstream e1stream;
-    e1stream << e1;
-    std::string e1str("LINESTRING (1 2, 2 3)");
-    BOOST_TEST(e1str == e1stream.str());
-    Vertex v3(Eigen::Vector3d(1.,2.,3.), 0);
-    Vertex v4(Eigen::Vector3d(3.,2.,1.), 0);
-    Edge e2(v3, v4, 0);
-    std::stringstream e2stream;
-    e2stream << e2;
-    std::string e2str("LINESTRING (1 2 3, 3 2 1)");
-    BOOST_TEST(e2str == e2stream.str());
+  Vertex            v1(Eigen::Vector2d(1., 2.), 0);
+  Vertex            v2(Eigen::Vector2d(2., 3.), 0);
+  Edge              e1(v1, v2, 0);
+  std::stringstream e1stream;
+  e1stream << e1;
+  std::string e1str("LINESTRING (1 2, 2 3)");
+  BOOST_TEST(e1str == e1stream.str());
+  Vertex            v3(Eigen::Vector3d(1., 2., 3.), 0);
+  Vertex            v4(Eigen::Vector3d(3., 2., 1.), 0);
+  Edge              e2(v3, v4, 0);
+  std::stringstream e2stream;
+  e2stream << e2;
+  std::string e2str("LINESTRING (1 2 3, 3 2 1)");
+  BOOST_TEST(e2str == e2stream.str());
 }
 
 BOOST_AUTO_TEST_CASE(EdgeConnectedTo)
 {
-   Vertex v1 (Eigen::Vector3d(0,0,1), 0);
-   Vertex v2 (Eigen::Vector3d(0,0,2), 0);
-   Vertex v3 (Eigen::Vector3d(0,0,3), 0);
-   Vertex v4 (Eigen::Vector3d(0,0,4), 0);
+  Vertex v1(Eigen::Vector3d(0, 0, 1), 0);
+  Vertex v2(Eigen::Vector3d(0, 0, 2), 0);
+  Vertex v3(Eigen::Vector3d(0, 0, 3), 0);
+  Vertex v4(Eigen::Vector3d(0, 0, 4), 0);
 
-   Edge edge1(v1, v2, 0);
-   Edge edge2(v2, v3, 0);
-   BOOST_TEST(edge1.connectedTo(edge2));
-   BOOST_TEST(edge2.connectedTo(edge1));
+  Edge edge1(v1, v2, 0);
+  Edge edge2(v2, v3, 0);
+  BOOST_TEST(edge1.connectedTo(edge2));
+  BOOST_TEST(edge2.connectedTo(edge1));
 
-   Edge edge3(v3, v4, 0);
-   BOOST_TEST(!edge1.connectedTo(edge3));
-   BOOST_TEST(!edge3.connectedTo(edge1));
-   BOOST_TEST(edge2.connectedTo(edge3));
-   BOOST_TEST(edge3.connectedTo(edge2));
+  Edge edge3(v3, v4, 0);
+  BOOST_TEST(!edge1.connectedTo(edge3));
+  BOOST_TEST(!edge3.connectedTo(edge1));
+  BOOST_TEST(edge2.connectedTo(edge3));
+  BOOST_TEST(edge3.connectedTo(edge2));
 }
-
 
 BOOST_AUTO_TEST_SUITE_END() // Edge
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -1,134 +1,132 @@
-#include "mesh/Vertex.hpp"
-#include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
-#include "mesh/Quad.hpp"
-#include "mesh/Mesh.hpp"
-#include "mesh/Data.hpp"
 #include <Eigen/Core>
+#include "mesh/Data.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/Quad.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
 #include "utils/Helpers.hpp"
 
 using namespace precice;
 using namespace precice::mesh;
-using precice::testing::equals;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
+using precice::testing::equals;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 
 BOOST_AUTO_TEST_SUITE(MeshTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(ComputeState_2D)
-{  
-  mesh::Mesh mesh ( "MyMesh", 2, true , testing::nextMeshID());
+{
+  mesh::Mesh mesh("MyMesh", 2, true, testing::nextMeshID());
   // Create mesh
-  Vertex& v1 = mesh.createVertex ( Vector2d(0.0, 0.0) );
-  Vertex& v2 = mesh.createVertex ( Vector2d(1.0, 0.0) );
-  Vertex& v3 = mesh.createVertex ( Vector2d(1.0, 1.0) );
+  Vertex &v1 = mesh.createVertex(Vector2d(0.0, 0.0));
+  Vertex &v2 = mesh.createVertex(Vector2d(1.0, 0.0));
+  Vertex &v3 = mesh.createVertex(Vector2d(1.0, 1.0));
   //
   //
   // *****
-  Edge& e1 = mesh.createEdge ( v1, v2 );
+  Edge &e1 = mesh.createEdge(v1, v2);
   //     *
   //     *  <---
   // *****
-  Edge& e2 = mesh.createEdge ( v2, v3 );
+  Edge &e2 = mesh.createEdge(v2, v3);
   mesh.computeState();
 
   // Perform test validations
-  BOOST_TEST ( equals(e1.getCenter(), Vector2d(0.5, 0.0)) );
-  BOOST_TEST ( equals(e2.getCenter(), Vector2d(1.0, 0.5)) );
-  BOOST_TEST ( e1.getEnclosingRadius() == 0.5 );
-  BOOST_TEST ( e2.getEnclosingRadius() == 0.5 );
-  BOOST_TEST ( equals(e1.getNormal(), Vector2d(0.0, 1.0)) );
-  BOOST_TEST ( equals(e2.getNormal(), Vector2d(-1.0, 0.0)) );
-  BOOST_TEST ( equals(v1.getNormal(), Vector2d(0.0, 1.0)) );
-  BOOST_TEST ( equals(v2.getNormal(), Vector2d(-std::sqrt(0.5), std::sqrt(0.5))) );
-  BOOST_TEST ( equals(v3.getNormal(), Vector2d(-1.0, 0.0)) );
+  BOOST_TEST(equals(e1.getCenter(), Vector2d(0.5, 0.0)));
+  BOOST_TEST(equals(e2.getCenter(), Vector2d(1.0, 0.5)));
+  BOOST_TEST(e1.getEnclosingRadius() == 0.5);
+  BOOST_TEST(e2.getEnclosingRadius() == 0.5);
+  BOOST_TEST(equals(e1.getNormal(), Vector2d(0.0, 1.0)));
+  BOOST_TEST(equals(e2.getNormal(), Vector2d(-1.0, 0.0)));
+  BOOST_TEST(equals(v1.getNormal(), Vector2d(0.0, 1.0)));
+  BOOST_TEST(equals(v2.getNormal(), Vector2d(-std::sqrt(0.5), std::sqrt(0.5))));
+  BOOST_TEST(equals(v3.getNormal(), Vector2d(-1.0, 0.0)));
 }
-
 
 BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
 {
-  precice::mesh::Mesh mesh ( "MyMesh", 3, true , testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());
   // Create mesh
-  Vertex& v1 = mesh.createVertex ( Vector3d(0.0, 0.0, 0.0) );
-  Vertex& v2 = mesh.createVertex ( Vector3d(1.0, 0.0, 1.0) );
-  Vertex& v3 = mesh.createVertex ( Vector3d(1.0, 1.0, 1.0) );
-  Vertex& v4 = mesh.createVertex ( Vector3d(2.0, 0.0, 2.0) );
-  Edge& e1 = mesh.createEdge ( v1, v2 );
-  Edge& e2 = mesh.createEdge ( v2, v3 );
-  Edge& e3 = mesh.createEdge ( v3, v1 );
-  Edge& e4 = mesh.createEdge ( v2, v4 );
-  Edge& e5 = mesh.createEdge ( v4, v3 );
+  Vertex &v1 = mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
+  Vertex &v2 = mesh.createVertex(Vector3d(1.0, 0.0, 1.0));
+  Vertex &v3 = mesh.createVertex(Vector3d(1.0, 1.0, 1.0));
+  Vertex &v4 = mesh.createVertex(Vector3d(2.0, 0.0, 2.0));
+  Edge &  e1 = mesh.createEdge(v1, v2);
+  Edge &  e2 = mesh.createEdge(v2, v3);
+  Edge &  e3 = mesh.createEdge(v3, v1);
+  Edge &  e4 = mesh.createEdge(v2, v4);
+  Edge &  e5 = mesh.createEdge(v4, v3);
 
   //       *
   //     * *
   //   *   *
   // *******
-  Triangle& t1 = mesh.createTriangle ( e1, e2, e3 );
+  Triangle &t1 = mesh.createTriangle(e1, e2, e3);
   //       *
   //     * * *     <---
   //   *   *   *
   // *************
-  Triangle& t2 = mesh.createTriangle ( e4, e5, e2 );
+  Triangle &t2 = mesh.createTriangle(e4, e5, e2);
   mesh.computeState();
 
   // Perform test validations
-  BOOST_TEST ( equals(e1.getCenter(), Vector3d(0.5, 0.0, 0.5)) );
-  BOOST_TEST ( equals(e2.getCenter(), Vector3d(1.0, 0.5, 1.0)) );
-  BOOST_TEST ( equals(e3.getCenter(), Vector3d(0.5, 0.5, 0.5)) );
-  BOOST_TEST ( equals(e4.getCenter(), Vector3d(1.5, 0.0, 1.5)) );
-  BOOST_TEST ( equals(e5.getCenter(), Vector3d(1.5, 0.5, 1.5)) );
-  BOOST_TEST ( e1.getEnclosingRadius() == std::sqrt(2.0)*0.5 );
-  BOOST_TEST ( e2.getEnclosingRadius() == 0.5 );
-  BOOST_TEST ( e3.getEnclosingRadius() == std::sqrt(3.0)*0.5 );
-  BOOST_TEST ( e4.getEnclosingRadius() == std::sqrt(2.0)*0.5 );
-  BOOST_TEST ( e5.getEnclosingRadius() == std::sqrt(3.0)*0.5 );
+  BOOST_TEST(equals(e1.getCenter(), Vector3d(0.5, 0.0, 0.5)));
+  BOOST_TEST(equals(e2.getCenter(), Vector3d(1.0, 0.5, 1.0)));
+  BOOST_TEST(equals(e3.getCenter(), Vector3d(0.5, 0.5, 0.5)));
+  BOOST_TEST(equals(e4.getCenter(), Vector3d(1.5, 0.0, 1.5)));
+  BOOST_TEST(equals(e5.getCenter(), Vector3d(1.5, 0.5, 1.5)));
+  BOOST_TEST(e1.getEnclosingRadius() == std::sqrt(2.0) * 0.5);
+  BOOST_TEST(e2.getEnclosingRadius() == 0.5);
+  BOOST_TEST(e3.getEnclosingRadius() == std::sqrt(3.0) * 0.5);
+  BOOST_TEST(e4.getEnclosingRadius() == std::sqrt(2.0) * 0.5);
+  BOOST_TEST(e5.getEnclosingRadius() == std::sqrt(3.0) * 0.5);
 
-  BOOST_TEST ( equals(t1.getCenter(), Vector3d(2.0/3.0, 1.0/3.0, 2.0/3.0)) );
-  BOOST_TEST ( equals(t2.getCenter(), Vector3d(4.0/3.0, 1.0/3.0, 4.0/3.0)) );
-  BOOST_TEST ( t1.getEnclosingRadius() == 1.0 );
-  BOOST_TEST ( t2.getEnclosingRadius() == 1.0 );
-  Vector3d normal ( 1.0, 0.0, -1.0 );
+  BOOST_TEST(equals(t1.getCenter(), Vector3d(2.0 / 3.0, 1.0 / 3.0, 2.0 / 3.0)));
+  BOOST_TEST(equals(t2.getCenter(), Vector3d(4.0 / 3.0, 1.0 / 3.0, 4.0 / 3.0)));
+  BOOST_TEST(t1.getEnclosingRadius() == 1.0);
+  BOOST_TEST(t2.getEnclosingRadius() == 1.0);
+  Vector3d normal(1.0, 0.0, -1.0);
   normal = normal.normalized();
-  BOOST_TEST ( normal.norm() == 1.0 );
-  BOOST_TEST ( equals(t1.getNormal(), normal) );
-  BOOST_TEST ( equals(t2.getNormal(), normal) );
+  BOOST_TEST(normal.norm() == 1.0);
+  BOOST_TEST(equals(t1.getNormal(), normal));
+  BOOST_TEST(equals(t2.getNormal(), normal));
 
-  BOOST_TEST ( equals(e1.getNormal(), normal) );
-  BOOST_TEST ( equals(e2.getNormal(), normal) );
-  BOOST_TEST ( equals(e3.getNormal(), normal) );
-  BOOST_TEST ( equals(e4.getNormal(), normal) );
-  BOOST_TEST ( equals(e5.getNormal(), normal) );
-  BOOST_TEST ( equals(v1.getNormal(), normal) );
-  BOOST_TEST ( equals(v2.getNormal(), normal) );
-  BOOST_TEST ( equals(v3.getNormal(), normal) );
-  BOOST_TEST ( equals(v4.getNormal(), normal) );
+  BOOST_TEST(equals(e1.getNormal(), normal));
+  BOOST_TEST(equals(e2.getNormal(), normal));
+  BOOST_TEST(equals(e3.getNormal(), normal));
+  BOOST_TEST(equals(e4.getNormal(), normal));
+  BOOST_TEST(equals(e5.getNormal(), normal));
+  BOOST_TEST(equals(v1.getNormal(), normal));
+  BOOST_TEST(equals(v2.getNormal(), normal));
+  BOOST_TEST(equals(v3.getNormal(), normal));
+  BOOST_TEST(equals(v4.getNormal(), normal));
 }
-
 
 BOOST_AUTO_TEST_CASE(ComputeState_3D_Quad)
 {
   mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());
   // Create mesh (Two rectangles with a common edge at z-axis. One extends in
   // x-y-plane (2 long), the other in y-z-plane (1 long))
-  Vertex& v0 = mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
-  Vertex& v1 = mesh.createVertex(Vector3d(2.0, 0.0, 0.0));
-  Vertex& v2 = mesh.createVertex(Vector3d(2.0, 1.0, 0.0));
-  Vertex& v3 = mesh.createVertex(Vector3d(0.0, 1.0, 0.0));
-  Vertex& v4 = mesh.createVertex(Vector3d(0.0, 0.0, 1.0));
-  Vertex& v5 = mesh.createVertex(Vector3d(0.0, 1.0, 1.0));
-  Edge& e0 = mesh.createEdge(v0, v1);
-  Edge& e1 = mesh.createEdge(v1, v2);
-  Edge& e2 = mesh.createEdge(v2, v3);
-  Edge& e3 = mesh.createEdge(v3, v0);
-  Edge& e4 = mesh.createEdge(v0, v4);
-  Edge& e5 = mesh.createEdge(v4, v5);
-  Edge& e6 = mesh.createEdge(v5, v3);
+  Vertex &v0 = mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
+  Vertex &v1 = mesh.createVertex(Vector3d(2.0, 0.0, 0.0));
+  Vertex &v2 = mesh.createVertex(Vector3d(2.0, 1.0, 0.0));
+  Vertex &v3 = mesh.createVertex(Vector3d(0.0, 1.0, 0.0));
+  Vertex &v4 = mesh.createVertex(Vector3d(0.0, 0.0, 1.0));
+  Vertex &v5 = mesh.createVertex(Vector3d(0.0, 1.0, 1.0));
+  Edge &  e0 = mesh.createEdge(v0, v1);
+  Edge &  e1 = mesh.createEdge(v1, v2);
+  Edge &  e2 = mesh.createEdge(v2, v3);
+  Edge &  e3 = mesh.createEdge(v3, v0);
+  Edge &  e4 = mesh.createEdge(v0, v4);
+  Edge &  e5 = mesh.createEdge(v4, v5);
+  Edge &  e6 = mesh.createEdge(v5, v3);
 
-  Quad& q0 = mesh.createQuad(e0, e1, e2, e3); // in x-y-plane
-  Quad& q1 = mesh.createQuad(e4, e5, e6, e3); // in z-y-plane
+  Quad &q0 = mesh.createQuad(e0, e1, e2, e3); // in x-y-plane
+  Quad &q1 = mesh.createQuad(e4, e5, e6, e3); // in z-y-plane
   mesh.computeState();
 
   // Perform test validations
@@ -162,7 +160,7 @@ BOOST_AUTO_TEST_CASE(ComputeState_3D_Quad)
   BOOST_TEST(equals(e0.getNormal(), normal0));
   BOOST_TEST(equals(e1.getNormal(), normal0));
   BOOST_TEST(equals(e2.getNormal(), normal0));
-  Vector3d normal0and1(2.0*normal0 + normal1);
+  Vector3d normal0and1(2.0 * normal0 + normal1);
   normal0and1 = normal0and1.normalized();
   BOOST_TEST(equals(e3.getNormal(), normal0and1));
   BOOST_TEST(equals(e4.getNormal(), normal1));
@@ -177,14 +175,13 @@ BOOST_AUTO_TEST_CASE(ComputeState_3D_Quad)
   BOOST_TEST(equals(v5.getNormal(), normal1));
 }
 
-
 BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
 {
   Eigen::Vector2d coords0(2, 0);
   Eigen::Vector2d coords1(-1, 4);
   Eigen::Vector2d coords2(0, 1);
 
-  mesh::Mesh mesh ("2D Testmesh", 2, false , testing::nextMeshID());
+  mesh::Mesh mesh("2D Testmesh", 2, false, testing::nextMeshID());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -192,12 +189,12 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
   mesh.computeState();
 
   mesh::Mesh::BoundingBox bBox = mesh.getBoundingBox();
-  auto cog = mesh.getCOG();
+  auto                    cog  = mesh.getCOG();
 
-  mesh::Mesh::BoundingBox referenceBox =  { {-1.0, 2.0},
-                                            { 0.0, 4.0} };
+  mesh::Mesh::BoundingBox referenceBox = {{-1.0, 2.0},
+                                          {0.0, 4.0}};
 
-  std::vector<double> referenceCOG =  { 0.5, 2.0 };
+  std::vector<double> referenceCOG = {0.5, 2.0};
 
   BOOST_TEST(bBox.size() == 2);
   BOOST_TEST(cog.size() == 2);
@@ -211,7 +208,6 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
   }
 }
 
-
 BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
 {
   Eigen::Vector3d coords0(2, 0, -3);
@@ -219,7 +215,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
   Eigen::Vector3d coords2(0, 1, -2);
   Eigen::Vector3d coords3(3.5, 2, -2);
 
-  mesh::Mesh mesh ("3D Testmesh", 3, false , testing::nextMeshID());
+  mesh::Mesh mesh("3D Testmesh", 3, false, testing::nextMeshID());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -228,13 +224,13 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
   mesh.computeState();
 
   mesh::Mesh::BoundingBox bBox = mesh.getBoundingBox();
-  auto cog = mesh.getCOG();
+  auto                    cog  = mesh.getCOG();
 
-  mesh::Mesh::BoundingBox referenceBox =  { {-1.0, 3.5},
-                                            { 0.0, 4.0},
-                                            {-3.0, 8.0} };
+  mesh::Mesh::BoundingBox referenceBox = {{-1.0, 3.5},
+                                          {0.0, 4.0},
+                                          {-3.0, 8.0}};
 
-  std::vector<double> referenceCOG =  { 1.25, 2.0, 2.5 };
+  std::vector<double> referenceCOG = {1.25, 2.0, 2.5};
 
   BOOST_TEST(bBox.size() == 3);
   BOOST_TEST(cog.size() == 3);
@@ -248,14 +244,13 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
   }
 }
 
-
 BOOST_AUTO_TEST_CASE(Demonstration)
 {
-  for ( int dim=2; dim <= 3; dim++ ){
+  for (int dim = 2; dim <= 3; dim++) {
     // Create mesh object
-    std::string meshName ( "MyMesh" );
-    bool flipNormals = false; // The normals of triangles, edges, vertices
-    precice::mesh::Mesh mesh ( meshName, dim, flipNormals , testing::nextMeshID());
+    std::string         meshName("MyMesh");
+    bool                flipNormals = false; // The normals of triangles, edges, vertices
+    precice::mesh::Mesh mesh(meshName, dim, flipNormals, testing::nextMeshID());
 
     // Validate mesh object state
     BOOST_TEST(mesh.getName() == meshName);
@@ -265,88 +260,80 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     Eigen::VectorXd coords0(dim);
     Eigen::VectorXd coords1(dim);
     Eigen::VectorXd coords2(dim);
-    if (dim == 2){
+    if (dim == 2) {
       coords0 << 0.0, 0.0;
       coords1 << 1.0, 0.0;
       coords2 << 0.0, 1.0;
-    }
-    else {
+    } else {
       coords0 << 0.0, 0.0, 0.0;
       coords1 << 1.0, 0.0, 0.0;
       coords2 << 0.0, 0.0, 1.0;
     }
-    Vertex& v0 = mesh.createVertex(coords0);
-    Vertex& v1 = mesh.createVertex(coords1);
-    Vertex& v2 = mesh.createVertex(coords2);
+    Vertex &v0 = mesh.createVertex(coords0);
+    Vertex &v1 = mesh.createVertex(coords1);
+    Vertex &v2 = mesh.createVertex(coords2);
 
     // Validate mesh vertices state
     // This is the preferred way to iterate over elements in a mesh, it hides
     // the details of the vertex container in class Mesh.
     size_t index = 0;
-    for (Vertex& vertex : mesh.vertices()) {
-      if ( index == 0 ) {
-        BOOST_TEST ( vertex.getID() == v0.getID() );
-      }
-      else if ( index == 1 ) {
-        BOOST_TEST ( vertex.getID() == v1.getID() );
-      }
-      else if ( index == 2 ) {
-        BOOST_TEST ( vertex.getID() == v2.getID() );
-      }
-      else {
-        BOOST_TEST ( false );
+    for (Vertex &vertex : mesh.vertices()) {
+      if (index == 0) {
+        BOOST_TEST(vertex.getID() == v0.getID());
+      } else if (index == 1) {
+        BOOST_TEST(vertex.getID() == v1.getID());
+      } else if (index == 2) {
+        BOOST_TEST(vertex.getID() == v2.getID());
+      } else {
+        BOOST_TEST(false);
       }
       index++;
     }
 
     // Create mesh edges
-    Edge& e0 = mesh.createEdge ( v0, v1 );
-    Edge& e1 = mesh.createEdge ( v1, v2 );
-    Edge& e2 = mesh.createEdge ( v2, v0 );
+    Edge &e0 = mesh.createEdge(v0, v1);
+    Edge &e1 = mesh.createEdge(v1, v2);
+    Edge &e2 = mesh.createEdge(v2, v0);
 
     // Validate mesh edges state
     index = 0;
-    for (Edge & edge : mesh.edges()) {
-      if ( index == 0 ) {
-        BOOST_TEST ( edge.getID() == e0.getID() );
-      }
-      else if ( index == 1 ) {
-        BOOST_TEST ( edge.getID() == e1.getID() );
-      }
-      else if ( index == 2 ) {
-        BOOST_TEST ( edge.getID() == e2.getID() );
-      }
-      else {
-        BOOST_TEST ( false );
+    for (Edge &edge : mesh.edges()) {
+      if (index == 0) {
+        BOOST_TEST(edge.getID() == e0.getID());
+      } else if (index == 1) {
+        BOOST_TEST(edge.getID() == e1.getID());
+      } else if (index == 2) {
+        BOOST_TEST(edge.getID() == e2.getID());
+      } else {
+        BOOST_TEST(false);
       }
       index++;
     }
 
-    Triangle* t = nullptr;
-    if ( dim == 3 ){
+    Triangle *t = nullptr;
+    if (dim == 3) {
       // Create triangle
-      t = & mesh.createTriangle ( e0, e1, e2 );
+      t = &mesh.createTriangle(e0, e1, e2);
 
       // Validate mesh triangle
-      BOOST_TEST ( (*mesh.triangles().begin()).getID() == t->getID() );
+      BOOST_TEST((*mesh.triangles().begin()).getID() == t->getID());
     }
 
     // Create vertex data
-    std::string dataName ( "MyData" );
-    int dataDimensions = dim;
+    std::string dataName("MyData");
+    int         dataDimensions = dim;
     // Add a data set to the mesh. Every data value is associated to a vertex in
     // the mesh via the vertex ID. The data values are created when
     // Mesh::computeState() is called by the mesh holding the data.
-    PtrData data = mesh.createData ( dataName, dataDimensions );
+    PtrData data = mesh.createData(dataName, dataDimensions);
 
     // Validate data state
-    BOOST_TEST ( data->getName() == dataName );
-    BOOST_TEST ( data->getDimensions() == dataDimensions );
-
+    BOOST_TEST(data->getName() == dataName);
+    BOOST_TEST(data->getDimensions() == dataDimensions);
 
     // Validate state of mesh with data
-    BOOST_TEST ( mesh.data().size() == 1 );
-    BOOST_TEST ( mesh.data()[0]->getName() == dataName );
+    BOOST_TEST(mesh.data().size() == 1);
+    BOOST_TEST(mesh.data()[0]->getName() == dataName);
 
     // Compute the state of the mesh elements (vertices, edges, triangles)
     mesh.computeState();
@@ -356,11 +343,11 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     mesh.allocateDataValues();
 
     // Access data values
-    Eigen::VectorXd& dataValues = data->values();
-    BOOST_TEST ( dataValues.size() == 3 * dim );
-    BOOST_TEST ( v0.getID() == 0 );
+    Eigen::VectorXd &dataValues = data->values();
+    BOOST_TEST(dataValues.size() == 3 * dim);
+    BOOST_TEST(v0.getID() == 0);
     Eigen::VectorXd value = Eigen::VectorXd::Zero(dim);
-    for ( int i=0; i < dim; i++ ){
+    for (int i = 0; i < dim; i++) {
       value(i) = dataValues(v0.getID() * dim + i);
     }
   }
@@ -368,93 +355,93 @@ BOOST_AUTO_TEST_CASE(Demonstration)
 
 BOOST_AUTO_TEST_CASE(MeshEquality)
 {
-    int dim = 3;
-    Mesh mesh1 ( "Mesh1", dim, false, testing::nextMeshID());
-    Mesh mesh1flipped ( "Mesh1flipped", dim, true, testing::nextMeshID());
-    Mesh mesh2 ( "Mesh2", dim, false, testing::nextMeshID());
-    Mesh *meshes[3] = {&mesh1, &mesh1flipped, &mesh2};
-    for (auto ptr : meshes){
-        auto& mesh = *ptr;
-        Eigen::VectorXd coords0(dim);
-        Eigen::VectorXd coords1(dim);
-        Eigen::VectorXd coords2(dim);
-        Eigen::VectorXd coords3(dim);
-        coords0 << 0.0, 0.0, 0.0;
-        coords1 << 1.0, 0.0, 0.0;
-        coords2 << 0.0, 0.0, 1.0;
-        coords3 << 1.0, 0.0, 1.0;
-        Vertex& v0 = mesh.createVertex(coords0);
-        Vertex& v1 = mesh.createVertex(coords1);
-        Vertex& v2 = mesh.createVertex(coords2);
-        Vertex& v3 = mesh.createVertex(coords3);
-        Edge& e0 = mesh.createEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
-        Edge& e1 = mesh.createEdge ( v1, v2 ); // LINESTRING (1 0 0, 0 0 1)
-        Edge& e2 = mesh.createEdge ( v2, v0 ); // LINESTRING (0 0 1, 0 0 0)
-        Edge& e3 = mesh.createEdge ( v1, v3 ); // LINESTRING (1 0 0, 1 0 1)
-        Edge& e4 = mesh.createEdge ( v3, v2 ); // LINESTRING (1 0 1, 0 0 1)
-        mesh.createTriangle ( e0, e1, e2 );
-        mesh.createQuad (e0, e3, e4, e2);
-        mesh.computeState();
-    }
-    BOOST_TEST(mesh1 != mesh1flipped);
-    BOOST_TEST(mesh1 == mesh2);
+  int   dim = 3;
+  Mesh  mesh1("Mesh1", dim, false, testing::nextMeshID());
+  Mesh  mesh1flipped("Mesh1flipped", dim, true, testing::nextMeshID());
+  Mesh  mesh2("Mesh2", dim, false, testing::nextMeshID());
+  Mesh *meshes[3] = {&mesh1, &mesh1flipped, &mesh2};
+  for (auto ptr : meshes) {
+    auto &          mesh = *ptr;
+    Eigen::VectorXd coords0(dim);
+    Eigen::VectorXd coords1(dim);
+    Eigen::VectorXd coords2(dim);
+    Eigen::VectorXd coords3(dim);
+    coords0 << 0.0, 0.0, 0.0;
+    coords1 << 1.0, 0.0, 0.0;
+    coords2 << 0.0, 0.0, 1.0;
+    coords3 << 1.0, 0.0, 1.0;
+    Vertex &v0 = mesh.createVertex(coords0);
+    Vertex &v1 = mesh.createVertex(coords1);
+    Vertex &v2 = mesh.createVertex(coords2);
+    Vertex &v3 = mesh.createVertex(coords3);
+    Edge &  e0 = mesh.createEdge(v0, v1); // LINESTRING (0 0 0, 1 0 0)
+    Edge &  e1 = mesh.createEdge(v1, v2); // LINESTRING (1 0 0, 0 0 1)
+    Edge &  e2 = mesh.createEdge(v2, v0); // LINESTRING (0 0 1, 0 0 0)
+    Edge &  e3 = mesh.createEdge(v1, v3); // LINESTRING (1 0 0, 1 0 1)
+    Edge &  e4 = mesh.createEdge(v3, v2); // LINESTRING (1 0 1, 0 0 1)
+    mesh.createTriangle(e0, e1, e2);
+    mesh.createQuad(e0, e3, e4, e2);
+    mesh.computeState();
+  }
+  BOOST_TEST(mesh1 != mesh1flipped);
+  BOOST_TEST(mesh1 == mesh2);
 }
 
 BOOST_AUTO_TEST_CASE(MeshWKTPrint)
 {
-    Mesh mesh ("WKTMesh", 3, false, testing::nextMeshID());
-    Vertex& v0 = mesh.createVertex(Eigen::Vector3d(0., 0., 0.));
-    Vertex& v1 = mesh.createVertex(Eigen::Vector3d(1., 0., 0.));
-    Vertex& v2 = mesh.createVertex(Eigen::Vector3d(0., 0., 1.));
-    Vertex& v3 = mesh.createVertex(Eigen::Vector3d(1., 0., 1.));
-    Edge& e0 = mesh.createEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
-    Edge& e1 = mesh.createEdge ( v1, v2 ); // LINESTRING (1 0 0, 0 0 1)
-    Edge& e2 = mesh.createEdge ( v2, v0 ); // LINESTRING (0 0 1, 0 0 0)
-    Edge& e3 = mesh.createEdge ( v1, v3 ); // LINESTRING (1 0 0, 1 0 1)
-    Edge& e4 = mesh.createEdge ( v3, v2 ); // LINESTRING (1 0 1, 0 0 1)
-    mesh.createTriangle ( e0, e1, e2 );
-    mesh.createQuad (e0, e3, e4, e2);
-    mesh.computeState();
-    std::stringstream sstream;
-    sstream << mesh;
-    std::string reference(
-            "Mesh \"WKTMesh\", dimensionality = 3:\n"
-            "GEOMETRYCOLLECTION(\n"
-            "POINT (0 0 0), POINT (1 0 0), POINT (0 0 1), POINT (1 0 1),\n"
-            "LINESTRING (0 0 0, 1 0 0), LINESTRING (1 0 0, 0 0 1), LINESTRING (0 0 1, 0 0 0), LINESTRING (1 0 0, 1 0 1), LINESTRING (1 0 1, 0 0 1),\n"
-            "POLYGON ((0 0 0, 1 0 0, 0 0 1, 0 0 0)),\n"
-            "POLYGON ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0))\n"
-            ")");
-    BOOST_TEST(reference == sstream.str());
+  Mesh    mesh("WKTMesh", 3, false, testing::nextMeshID());
+  Vertex &v0 = mesh.createVertex(Eigen::Vector3d(0., 0., 0.));
+  Vertex &v1 = mesh.createVertex(Eigen::Vector3d(1., 0., 0.));
+  Vertex &v2 = mesh.createVertex(Eigen::Vector3d(0., 0., 1.));
+  Vertex &v3 = mesh.createVertex(Eigen::Vector3d(1., 0., 1.));
+  Edge &  e0 = mesh.createEdge(v0, v1); // LINESTRING (0 0 0, 1 0 0)
+  Edge &  e1 = mesh.createEdge(v1, v2); // LINESTRING (1 0 0, 0 0 1)
+  Edge &  e2 = mesh.createEdge(v2, v0); // LINESTRING (0 0 1, 0 0 0)
+  Edge &  e3 = mesh.createEdge(v1, v3); // LINESTRING (1 0 0, 1 0 1)
+  Edge &  e4 = mesh.createEdge(v3, v2); // LINESTRING (1 0 1, 0 0 1)
+  mesh.createTriangle(e0, e1, e2);
+  mesh.createQuad(e0, e3, e4, e2);
+  mesh.computeState();
+  std::stringstream sstream;
+  sstream << mesh;
+  std::string reference(
+      "Mesh \"WKTMesh\", dimensionality = 3:\n"
+      "GEOMETRYCOLLECTION(\n"
+      "POINT (0 0 0), POINT (1 0 0), POINT (0 0 1), POINT (1 0 1),\n"
+      "LINESTRING (0 0 0, 1 0 0), LINESTRING (1 0 0, 0 0 1), LINESTRING (0 0 1, 0 0 0), LINESTRING (1 0 0, 1 0 1), LINESTRING (1 0 1, 0 0 1),\n"
+      "POLYGON ((0 0 0, 1 0 0, 0 0 1, 0 0 0)),\n"
+      "POLYGON ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0))\n"
+      ")");
+  BOOST_TEST(reference == sstream.str());
 }
 
 BOOST_AUTO_TEST_CASE(CreateUniqueEdge)
 {
-    int dim = 3;
-    Mesh mesh1 ( "Mesh1", dim, false, testing::nextMeshID() );
-    auto& mesh = mesh1;
-    Eigen::VectorXd coords0(dim);
-    Eigen::VectorXd coords1(dim);
-    Eigen::VectorXd coords2(dim);
-    coords0 << 0.0, 0.0, 0.0;
-    coords1 << 1.0, 0.0, 0.0;
-    coords2 << 0.0, 0.0, 1.0;
-    Vertex& v0 = mesh.createVertex(coords0);
-    Vertex& v1 = mesh.createVertex(coords1);
-    Vertex& v2 = mesh.createVertex(coords2);
+  int             dim = 3;
+  Mesh            mesh1("Mesh1", dim, false, testing::nextMeshID());
+  auto &          mesh = mesh1;
+  Eigen::VectorXd coords0(dim);
+  Eigen::VectorXd coords1(dim);
+  Eigen::VectorXd coords2(dim);
+  coords0 << 0.0, 0.0, 0.0;
+  coords1 << 1.0, 0.0, 0.0;
+  coords2 << 0.0, 0.0, 1.0;
+  Vertex &v0 = mesh.createVertex(coords0);
+  Vertex &v1 = mesh.createVertex(coords1);
+  Vertex &v2 = mesh.createVertex(coords2);
 
-    Edge& e01a = mesh.createEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
-    mesh.createEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
-    BOOST_TEST(mesh.edges().size() == 2);
+  Edge &e01a = mesh.createEdge(v0, v1); // LINESTRING (0 0 0, 1 0 0)
+  mesh.createEdge(v0, v1);              // LINESTRING (0 0 0, 1 0 0)
+  BOOST_TEST(mesh.edges().size() == 2);
 
-    Edge& e01c = mesh.createUniqueEdge ( v0, v1 ); // LINESTRING (0 0 0, 1 0 0)
-    BOOST_TEST(mesh.edges().size() == 2);
-    BOOST_TEST(e01a == e01c);
+  Edge &e01c = mesh.createUniqueEdge(v0, v1); // LINESTRING (0 0 0, 1 0 0)
+  BOOST_TEST(mesh.edges().size() == 2);
+  BOOST_TEST(e01a == e01c);
 
-    mesh.createUniqueEdge ( v1, v2 ); // LINESTRING (0 0 0, 1 0 0)
-    BOOST_TEST(mesh.edges().size() == 3);
-    mesh.createUniqueEdge ( v1, v2 ); // LINESTRING (0 0 0, 1 0 0)
-    BOOST_TEST(mesh.edges().size() == 3);
+  mesh.createUniqueEdge(v1, v2); // LINESTRING (0 0 0, 1 0 0)
+  BOOST_TEST(mesh.edges().size() == 3);
+  mesh.createUniqueEdge(v1, v2); // LINESTRING (0 0 0, 1 0 0)
+  BOOST_TEST(mesh.edges().size() == 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/QuadTest.cpp
+++ b/src/mesh/tests/QuadTest.cpp
@@ -13,7 +13,6 @@ using namespace precice::mesh;
 BOOST_AUTO_TEST_SUITE(MeshTests)
 BOOST_AUTO_TEST_SUITE(QuadTests, *testing::OnMaster())
 
-
 BOOST_AUTO_TEST_CASE(Quads)
 {
   using Eigen::Vector3d;
@@ -152,9 +151,9 @@ BOOST_AUTO_TEST_CASE(Quads)
     }
     {
       // Test begin(), end() for const
-      const Quad &cquad = quad;
-      auto            ibegin    = cquad.begin();
-      const auto      iend      = cquad.end();
+      const Quad &cquad  = quad;
+      auto        ibegin = cquad.begin();
+      const auto  iend   = cquad.end();
       BOOST_TEST(std::distance(ibegin, iend) == 4);
       BOOST_TEST(*ibegin == v0.getCoords());
       ++ibegin;
@@ -221,25 +220,25 @@ BOOST_AUTO_TEST_CASE(QuadEquality)
   //*    *
   Quad quad2(e4, e5, e6, e7, 0);
   Quad quad2n(e4, e5, e6, e7, 0);
-  quad2n.setNormal(Vector3d(0.,0.,1.));
+  quad2n.setNormal(Vector3d(0., 0., 1.));
   BOOST_TEST(quad2 != quad1);
   BOOST_TEST(quad2 != quad2n);
 }
 BOOST_AUTO_TEST_CASE(QuadWKTPrint)
 {
-    Vertex v1(Eigen::Vector3d(0.,0.,0.), 0);
-    Vertex v2(Eigen::Vector3d(0.,1.,0.), 0);
-    Vertex v3(Eigen::Vector3d(1.,1.,0.), 0);
-    Vertex v4(Eigen::Vector3d(1.,0.,0.), 0);
-    Edge e1(v1, v2, 0);
-    Edge e2(v2, v3, 0);
-    Edge e3(v3, v4, 0);
-    Edge e4(v4, v1, 0);
-    Quad q1(e1, e2, e3, e4, 0);
-    std::stringstream stream;
-    stream << q1;
-    std::string q1string("POLYGON ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0))");
-    BOOST_TEST(q1string == stream.str());
+  Vertex            v1(Eigen::Vector3d(0., 0., 0.), 0);
+  Vertex            v2(Eigen::Vector3d(0., 1., 0.), 0);
+  Vertex            v3(Eigen::Vector3d(1., 1., 0.), 0);
+  Vertex            v4(Eigen::Vector3d(1., 0., 0.), 0);
+  Edge              e1(v1, v2, 0);
+  Edge              e2(v2, v3, 0);
+  Edge              e3(v3, v4, 0);
+  Edge              e4(v4, v1, 0);
+  Quad              q1(e1, e2, e3, e4, 0);
+  std::stringstream stream;
+  stream << q1;
+  std::string q1string("POLYGON ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0))");
+  BOOST_TEST(q1string == stream.str());
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Quad

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -1,13 +1,13 @@
-#include "testing/Testing.hpp"
+#include "math/geometry.hpp"
 #include "mesh/RTree.hpp"
 #include "mesh/impl/RTree.hpp"
 #include "mesh/impl/RTreeAdapter.hpp"
-#include "math/geometry.hpp"
+#include "testing/Testing.hpp"
 
 using namespace precice;
 using namespace precice::mesh;
 
-namespace bg = boost::geometry;
+namespace bg  = boost::geometry;
 namespace bgi = boost::geometry::index;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(VectorAdapter)
 BOOST_AUTO_TEST_CASE(VertexAdapter)
 {
   precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::nextMeshID());
-  auto & v = mesh.createVertex(Eigen::Vector2d(1, 2));
+  auto &              v = mesh.createVertex(Eigen::Vector2d(1, 2));
   BOOST_TEST(bg::get<0>(v) == 1);
   BOOST_TEST(bg::get<1>(v) == 2);
   BOOST_TEST(bg::get<2>(v) == 0);
@@ -38,79 +38,77 @@ BOOST_AUTO_TEST_CASE(VertexAdapter)
 BOOST_AUTO_TEST_CASE(EdgeAdapter)
 {
   precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::nextMeshID());
-  auto & v1 = mesh.createVertex(Eigen::Vector2d(1, 2));
-  auto & v2 = mesh.createVertex(Eigen::Vector2d(3, 4));
-  auto & e = mesh.createEdge(v1, v2);
-  BOOST_TEST((bg::get<0,0>(e)) == 1.0);
-  BOOST_TEST((bg::get<0,1>(e)) == 2.0);
-  BOOST_TEST((bg::get<0,2>(e)) == 0.0);
-  BOOST_TEST((bg::get<1,0>(e)) == 3.0);
-  BOOST_TEST((bg::get<1,1>(e)) == 4.0);
-  BOOST_TEST((bg::get<1,2>(e)) == 0.0);
-  bg::set<1,1>(e, 5.0);
-  BOOST_TEST((bg::get<1,1>(e)) == 5.0);
+  auto &              v1 = mesh.createVertex(Eigen::Vector2d(1, 2));
+  auto &              v2 = mesh.createVertex(Eigen::Vector2d(3, 4));
+  auto &              e  = mesh.createEdge(v1, v2);
+  BOOST_TEST((bg::get<0, 0>(e)) == 1.0);
+  BOOST_TEST((bg::get<0, 1>(e)) == 2.0);
+  BOOST_TEST((bg::get<0, 2>(e)) == 0.0);
+  BOOST_TEST((bg::get<1, 0>(e)) == 3.0);
+  BOOST_TEST((bg::get<1, 1>(e)) == 4.0);
+  BOOST_TEST((bg::get<1, 2>(e)) == 0.0);
+  bg::set<1, 1>(e, 5.0);
+  BOOST_TEST((bg::get<1, 1>(e)) == 5.0);
 }
 
 BOOST_AUTO_TEST_CASE(TriangleAdapter)
 {
   precice::mesh::Mesh mesh("MyMesh", 3, false, precice::testing::nextMeshID());
-  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
-  auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
-  auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
-  auto & e1 = mesh.createEdge(v1, v2);
-  auto & e2 = mesh.createEdge(v2, v3);
-  auto & e3 = mesh.createEdge(v3, v1);
-  auto & t = mesh.createTriangle(e1, e2, e3);
+  auto &              v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+  auto &              v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+  auto &              v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto &              e1 = mesh.createEdge(v1, v2);
+  auto &              e2 = mesh.createEdge(v2, v3);
+  auto &              e3 = mesh.createEdge(v3, v1);
+  auto &              t  = mesh.createTriangle(e1, e2, e3);
 
   std::vector<Eigen::VectorXd> vertices(t.begin(), t.end());
-  std::vector<Eigen::VectorXd> refs{ v1.getCoords(), v2.getCoords(), v3.getCoords()};
+  std::vector<Eigen::VectorXd> refs{v1.getCoords(), v2.getCoords(), v3.getCoords()};
   BOOST_TEST(vertices.size() == refs.size());
   BOOST_TEST((std::is_permutation(
-                  vertices.begin(), vertices.end(),
-                  refs.begin(),
-                  []( const Eigen::VectorXd& lhs, const Eigen::VectorXd& rhs) {
-                     return precice::math::equals(lhs, rhs);
-                  }
-            )));
+      vertices.begin(), vertices.end(),
+      refs.begin(),
+      [](const Eigen::VectorXd &lhs, const Eigen::VectorXd &rhs) {
+        return precice::math::equals(lhs, rhs);
+      })));
 }
 
 BOOST_AUTO_TEST_CASE(QuadAdapter)
 {
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
-  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
-  auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
-  auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
-  auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
-  auto & e1 = mesh.createEdge(v1, v2);
-  auto & e2 = mesh.createEdge(v2, v3);
-  auto & e3 = mesh.createEdge(v3, v4);
-  auto & e4 = mesh.createEdge(v4, v1);
-  auto & t = mesh.createQuad(e1, e2, e3, e4);
+  auto &              v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+  auto &              v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+  auto &              v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
+  auto &              v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto &              e1 = mesh.createEdge(v1, v2);
+  auto &              e2 = mesh.createEdge(v2, v3);
+  auto &              e3 = mesh.createEdge(v3, v4);
+  auto &              e4 = mesh.createEdge(v4, v1);
+  auto &              t  = mesh.createQuad(e1, e2, e3, e4);
 
   std::vector<Eigen::VectorXd> vertices(t.begin(), t.end());
-  std::vector<Eigen::VectorXd> refs{ v1.getCoords(), v2.getCoords(), v3.getCoords(), v4.getCoords()};
+  std::vector<Eigen::VectorXd> refs{v1.getCoords(), v2.getCoords(), v3.getCoords(), v4.getCoords()};
   BOOST_TEST(vertices.size() == refs.size());
   BOOST_TEST((std::is_permutation(
-                  vertices.begin(), vertices.end(),
-                  refs.begin(),
-                  []( const Eigen::VectorXd& lhs, const Eigen::VectorXd& rhs) {
-                     return precice::math::equals(lhs, rhs);
-                  }
-            )));
+      vertices.begin(), vertices.end(),
+      refs.begin(),
+      [](const Eigen::VectorXd &lhs, const Eigen::VectorXd &rhs) {
+        return precice::math::equals(lhs, rhs);
+      })));
 }
 
 BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 {
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
-  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
-  auto & v2 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
-  auto & v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
-  auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
-  auto & v5 = mesh.createVertex(Eigen::Vector3d(0.2, 0.2, 0));
-  auto & e1 = mesh.createEdge(v1, v2);
-  auto & e2 = mesh.createEdge(v2, v3);
-  auto & e3 = mesh.createEdge(v3, v1);
-  auto & t = mesh.createTriangle(e1, e2, e3);
+  auto &              v1 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
+  auto &              v2 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &              v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto &              v4 = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
+  auto &              v5 = mesh.createVertex(Eigen::Vector3d(0.2, 0.2, 0));
+  auto &              e1 = mesh.createEdge(v1, v2);
+  auto &              e2 = mesh.createEdge(v2, v3);
+  auto &              e3 = mesh.createEdge(v3, v1);
+  auto &              t  = mesh.createTriangle(e1, e2, e3);
 
   BOOST_TEST(bg::comparable_distance(v1, v2) > 0.5);
   BOOST_TEST(bg::comparable_distance(v1, v1) < 0.01);
@@ -124,25 +122,25 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 {
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
-  auto & lv1 = mesh.createVertex(Eigen::Vector3d(-1, 1, 0.1));
-  auto & lv2 = mesh.createVertex(Eigen::Vector3d( 0,-1, 0));
-  auto & lv3 = mesh.createVertex(Eigen::Vector3d(-2, 0,-0.1));
-  auto & le1 = mesh.createEdge(lv1, lv2);
-  auto & le2 = mesh.createEdge(lv2, lv3);
-  auto & le3 = mesh.createEdge(lv3, lv1);
-  auto & lt = mesh.createTriangle(le1, le2, le3);
+  auto &              lv1 = mesh.createVertex(Eigen::Vector3d(-1, 1, 0.1));
+  auto &              lv2 = mesh.createVertex(Eigen::Vector3d(0, -1, 0));
+  auto &              lv3 = mesh.createVertex(Eigen::Vector3d(-2, 0, -0.1));
+  auto &              le1 = mesh.createEdge(lv1, lv2);
+  auto &              le2 = mesh.createEdge(lv2, lv3);
+  auto &              le3 = mesh.createEdge(lv3, lv1);
+  auto &              lt  = mesh.createTriangle(le1, le2, le3);
 
-  auto & rv1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0.1));
-  auto & rv2 = mesh.createVertex(Eigen::Vector3d(2, 0,-0.1));
-  auto & rv3 = mesh.createVertex(Eigen::Vector3d(1,-1, 0));
-  auto & re1 = mesh.createEdge(rv1, rv2);
-  auto & re2 = mesh.createEdge(rv2, rv3);
-  auto & re3 = mesh.createEdge(rv3, rv1);
-  auto & rt = mesh.createTriangle(re1, re2, re3);
+  auto &rv1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0.1));
+  auto &rv2 = mesh.createVertex(Eigen::Vector3d(2, 0, -0.1));
+  auto &rv3 = mesh.createVertex(Eigen::Vector3d(1, -1, 0));
+  auto &re1 = mesh.createEdge(rv1, rv2);
+  auto &re2 = mesh.createEdge(rv2, rv3);
+  auto &re3 = mesh.createEdge(rv3, rv1);
+  auto &rt  = mesh.createTriangle(re1, re2, re3);
 
-  auto & v1 = mesh.createVertex(Eigen::Vector3d(-2, 1, 0));
-  auto & v2 = mesh.createVertex(Eigen::Vector3d( 2,-1, 0));
-  auto & v3 = mesh.createVertex(Eigen::Vector3d( 0, 0, 0));
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(-2, 1, 0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(2, -1, 0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
 
   auto lt_v1 = bg::comparable_distance(lt, v1);
   auto lt_v2 = bg::comparable_distance(lt, v2);
@@ -159,48 +157,48 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
 {
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
-  auto & a = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
-  auto & b = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
-  auto & c = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
-  auto & d = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &              a = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
+  auto &              b = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto &              c = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
+  auto &              d = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
 
-  auto & ab = mesh.createEdge(a, b);
-  auto & bd = mesh.createEdge(b, d);
-  auto & da = mesh.createEdge(d, a);
-  auto & dc = mesh.createEdge(d, c);
-  auto & cb = mesh.createEdge(c, b);
+  auto &ab = mesh.createEdge(a, b);
+  auto &bd = mesh.createEdge(b, d);
+  auto &da = mesh.createEdge(d, a);
+  auto &dc = mesh.createEdge(d, c);
+  auto &cb = mesh.createEdge(c, b);
 
-  auto & lt = mesh.createTriangle(ab, bd, da);
-  auto & rt = mesh.createTriangle(bd, dc, cb);
+  auto &lt = mesh.createTriangle(ab, bd, da);
+  auto &rt = mesh.createTriangle(bd, dc, cb);
   BOOST_TEST_MESSAGE("Left  Triangle:" << lt);
   BOOST_TEST_MESSAGE("Right Triangle:" << rt);
 
-  auto & lv = mesh.createVertex(Eigen::Vector3d(.25,.25,0));
-  auto & rv = mesh.createVertex(Eigen::Vector3d(.75,.75,0));
+  auto &lv = mesh.createVertex(Eigen::Vector3d(.25, .25, 0));
+  auto &rv = mesh.createVertex(Eigen::Vector3d(.75, .75, 0));
 
   auto lv_lt = bg::comparable_distance(lv, lt);
   auto lv_rt = bg::comparable_distance(lv, rt);
-  BOOST_TEST( precice::testing::equals(lv_lt, 0.0), lv_lt << " == 0.0");
+  BOOST_TEST(precice::testing::equals(lv_lt, 0.0), lv_lt << " == 0.0");
   BOOST_TEST(!precice::testing::equals(lv_rt, 0.0), lv_rt << " != 0.0");
 
   auto rv_lt = bg::comparable_distance(rv, lt);
   auto rv_rt = bg::comparable_distance(rv, rt);
   BOOST_TEST(!precice::testing::equals(rv_lt, 0.0), rv_lt << " != 0.0");
-  BOOST_TEST( precice::testing::equals(rv_rt, 0.0), rv_rt << " == 0.0");
+  BOOST_TEST(precice::testing::equals(rv_rt, 0.0), rv_rt << " == 0.0");
 }
 
 BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 {
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
-  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
-  auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
-  auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
-  auto & v4 = mesh.createVertex(Eigen::Vector3d(0, 1, 1));
-  auto & v5 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
-  auto & e1 = mesh.createEdge(v1, v2);
-  auto & e2 = mesh.createEdge(v2, v3);
-  auto & e3 = mesh.createEdge(v3, v1);
-  auto & t = mesh.createTriangle(e1, e2, e3);
+  auto &              v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &              v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
+  auto &              v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
+  auto &              v4 = mesh.createVertex(Eigen::Vector3d(0, 1, 1));
+  auto &              v5 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  auto &              e1 = mesh.createEdge(v1, v2);
+  auto &              e2 = mesh.createEdge(v2, v3);
+  auto &              e3 = mesh.createEdge(v3, v1);
+  auto &              t  = mesh.createTriangle(e1, e2, e3);
 
   auto t_v4 = bg::comparable_distance(t, v4);
   auto v4_t = bg::comparable_distance(v4, t);
@@ -221,49 +219,51 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 {
   using precice::testing::equals;
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
-  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
-  auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
-  auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
-  auto & e1 = mesh.createEdge(v1, v2);
-  auto & e2 = mesh.createEdge(v2, v3);
-  auto & e3 = mesh.createEdge(v3, v1);
-  auto & t = mesh.createTriangle(e1, e2, e3);
-  auto box = bg::return_envelope<precice::mesh::RTreeBox>(t);
-  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0,0,0}));
-  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1,1,1}));
+  auto &              v1  = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &              v2  = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
+  auto &              v3  = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
+  auto &              e1  = mesh.createEdge(v1, v2);
+  auto &              e2  = mesh.createEdge(v2, v3);
+  auto &              e3  = mesh.createEdge(v3, v1);
+  auto &              t   = mesh.createTriangle(e1, e2, e3);
+  auto                box = bg::return_envelope<precice::mesh::RTreeBox>(t);
+  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0, 0, 0}));
+  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1, 1, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
 {
   using precice::testing::equals;
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
-  auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
-  auto & v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
-  auto & v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
-  auto & e1 = mesh.createEdge(v1, v3);
-  auto & e2 = mesh.createEdge(v3, v2);
-  auto & e3 = mesh.createEdge(v2, v1);
-  auto & t = mesh.createTriangle(e1, e2, e3);
-  auto box = bg::return_envelope<precice::mesh::RTreeBox>(t);
-  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0,0,0}));
-  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1,1,1}));
+  auto &              v1  = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &              v2  = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
+  auto &              v3  = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
+  auto &              e1  = mesh.createEdge(v1, v3);
+  auto &              e2  = mesh.createEdge(v3, v2);
+  auto &              e3  = mesh.createEdge(v2, v1);
+  auto &              t   = mesh.createTriangle(e1, e2, e3);
+  auto                box = bg::return_envelope<precice::mesh::RTreeBox>(t);
+  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0, 0, 0}));
+  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1, 1, 1}));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // BG Adapters
 
 struct MeshFixture {
-  MeshFixture() : mesh("MyMesh", 3, false, testing::nextMeshID()) {
-    auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
-    auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
-    auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
-    auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+  MeshFixture()
+      : mesh("MyMesh", 3, false, testing::nextMeshID())
+  {
+    auto &v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+    auto &v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+    auto &v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
+    auto &v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
     // Quad Borders
-    auto & e1 = mesh.createEdge(v1, v2);
-    auto & e2 = mesh.createEdge(v2, v3);
-    auto & e3 = mesh.createEdge(v3, v4);
-    auto & e4 = mesh.createEdge(v4, v1);
+    auto &e1 = mesh.createEdge(v1, v2);
+    auto &e2 = mesh.createEdge(v2, v3);
+    auto &e3 = mesh.createEdge(v3, v4);
+    auto &e4 = mesh.createEdge(v4, v1);
     // Diagonal
-    auto & e5 = mesh.createEdge(v2, v4);
+    auto &e5 = mesh.createEdge(v2, v4);
     // Triangles
     mesh.createTriangle(e1, e5, e4);
     mesh.createTriangle(e2, e3, e5);
@@ -279,11 +279,11 @@ struct MeshFixture {
 
   Mesh mesh;
 
-  const int vertex_cnt = 4;
-  const int edge_cnt = 5;
-  const int triangle_cnt = 2;
-  const int quad_cnt = 1;
-  const int primitive_cnt = 4+5+2+1;
+  const int vertex_cnt    = 4;
+  const int edge_cnt      = 5;
+  const int triangle_cnt  = 2;
+  const int quad_cnt      = 1;
+  const int primitive_cnt = 4 + 5 + 2 + 1;
 };
 
 BOOST_AUTO_TEST_CASE(Query_2D)
@@ -291,22 +291,22 @@ BOOST_AUTO_TEST_CASE(Query_2D)
   PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
   mesh->createVertex(Eigen::Vector2d(0, 1));
-  auto& v1 = mesh->createVertex(Eigen::Vector2d(1, 0));
-  auto& v2 = mesh->createVertex(Eigen::Vector2d(1, 1));
+  auto &v1 = mesh->createVertex(Eigen::Vector2d(1, 0));
+  auto &v2 = mesh->createVertex(Eigen::Vector2d(1, 1));
   mesh->createEdge(v1, v2);
-  
+
   {
     auto tree = rtree::getVertexRTree(mesh);
 
     BOOST_TEST(tree->size() == 4);
 
-    Eigen::VectorXd searchVector(Eigen::Vector2d(0.2, 0.8));
+    Eigen::VectorXd     searchVector(Eigen::Vector2d(0.2, 0.8));
     std::vector<size_t> results;
 
     tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
 
     BOOST_TEST(results.size() == 1);
-    BOOST_TEST( mesh->vertices()[results[0]].getCoords() == Eigen::Vector2d(0, 1) );
+    BOOST_TEST(mesh->vertices()[results[0]].getCoords() == Eigen::Vector2d(0, 1));
   }
 
   {
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(Query_2D)
 
     BOOST_TEST(tree->size() == 5);
 
-    Eigen::VectorXd searchVector(Eigen::Vector2d(0.2, 0.8));
+    Eigen::VectorXd                         searchVector(Eigen::Vector2d(0.2, 0.8));
     std::vector<PrimitiveRTree::value_type> results;
 
     tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(Query_2D)
     auto pi = results.front().second;
     BOOST_TEST(pi.type == Primitive::Vertex);
     BOOST_TEST(pi.index < mesh->vertices().size());
-    BOOST_TEST(mesh->vertices()[pi.index].getCoords() == Eigen::Vector2d(0, 1) );
+    BOOST_TEST(mesh->vertices()[pi.index].getCoords() == Eigen::Vector2d(0, 1));
   }
 }
 
@@ -336,8 +336,8 @@ BOOST_AUTO_TEST_CASE(Query_3D)
   mesh->createVertex(Eigen::Vector3d(0, 1, 1));
   mesh->createVertex(Eigen::Vector3d(1, 0, 0));
   mesh->createVertex(Eigen::Vector3d(1, 0, 1));
-  auto& v1 = mesh->createVertex(Eigen::Vector3d(1, 1, 0));
-  auto& v2 = mesh->createVertex(Eigen::Vector3d(1, 1, 1));
+  auto &v1 = mesh->createVertex(Eigen::Vector3d(1, 1, 0));
+  auto &v2 = mesh->createVertex(Eigen::Vector3d(1, 1, 1));
   mesh->createEdge(v1, v2);
 
   {
@@ -345,13 +345,13 @@ BOOST_AUTO_TEST_CASE(Query_3D)
 
     BOOST_TEST(tree->size() == 8);
 
-    Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 0.0, 0.8));
+    Eigen::VectorXd     searchVector(Eigen::Vector3d(0.8, 0.0, 0.8));
     std::vector<size_t> results;
 
     tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
 
     BOOST_TEST(results.size() == 1);
-    BOOST_TEST( mesh->vertices()[results[0]].getCoords() == Eigen::Vector3d(1, 0, 1) );
+    BOOST_TEST(mesh->vertices()[results[0]].getCoords() == Eigen::Vector3d(1, 0, 1));
   }
 
   {
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(Query_3D)
 
     BOOST_TEST(tree->size() == 9);
 
-    Eigen::VectorXd searchVector(Eigen::Vector3d(1.8, 0.0, 0.8));
+    Eigen::VectorXd                         searchVector(Eigen::Vector3d(1.8, 0.0, 0.8));
     std::vector<PrimitiveRTree::value_type> results;
 
     tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(Query_3D)
     auto pi = results.front().second;
     BOOST_TEST(pi.type == Primitive::Vertex);
     BOOST_TEST(pi.index < mesh->vertices().size());
-    BOOST_TEST(mesh->vertices()[pi.index].getCoords() == Eigen::Vector3d(1, 0, 1) );
+    BOOST_TEST(mesh->vertices()[pi.index].getCoords() == Eigen::Vector3d(1, 0, 1));
   }
 
   {
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(Query_3D)
 
     BOOST_TEST(tree->size() == 9);
 
-    Eigen::VectorXd searchVector((v1.getCoords()+v2.getCoords())/2);
+    Eigen::VectorXd searchVector((v1.getCoords() + v2.getCoords()) / 2);
     searchVector += Eigen::Vector3d(0.001, -0.03, 0.005); // "noise"
     std::vector<PrimitiveRTree::value_type> results;
 
@@ -391,36 +391,36 @@ BOOST_AUTO_TEST_CASE(Query_3D)
 
 BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
-  const double z1 = 0.1;
-  const double z2 = -0.1;
-  auto& v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
-  auto& v01 = mesh->createVertex(Eigen::Vector3d(0, 1, 0));
-  auto& v10 = mesh->createVertex(Eigen::Vector3d(1, 0, z1));
-  auto& v11 = mesh->createVertex(Eigen::Vector3d(1, 1, z1));
-  auto& v20 = mesh->createVertex(Eigen::Vector3d(2, 0, z2));
-  auto& v21 = mesh->createVertex(Eigen::Vector3d(2, 1, z2));
-  auto& ell = mesh->createEdge(v00, v01);
-  auto& elt = mesh->createEdge(v01, v11);
-  auto& elr = mesh->createEdge(v11, v10);
-  auto& elb = mesh->createEdge(v10, v00);
-  auto& eld = mesh->createEdge(v00, v11);
-  auto& erl = elr;
-  auto& ert = mesh->createEdge(v11, v21);
-  auto& err = mesh->createEdge(v21, v20);
-  auto& erb = mesh->createEdge(v20, v10);
-  auto& erd = mesh->createEdge(v10, v21);
-  auto& tlt = mesh->createTriangle(ell, elt, eld);
-  auto& tlb = mesh->createTriangle(eld, elb, elr);
-  auto& trt = mesh->createTriangle(erl, ert, erd);
-  auto& trb = mesh->createTriangle(erd, erb, err);
+  PtrMesh      mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
+  const double z1  = 0.1;
+  const double z2  = -0.1;
+  auto &       v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
+  auto &       v01 = mesh->createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &       v10 = mesh->createVertex(Eigen::Vector3d(1, 0, z1));
+  auto &       v11 = mesh->createVertex(Eigen::Vector3d(1, 1, z1));
+  auto &       v20 = mesh->createVertex(Eigen::Vector3d(2, 0, z2));
+  auto &       v21 = mesh->createVertex(Eigen::Vector3d(2, 1, z2));
+  auto &       ell = mesh->createEdge(v00, v01);
+  auto &       elt = mesh->createEdge(v01, v11);
+  auto &       elr = mesh->createEdge(v11, v10);
+  auto &       elb = mesh->createEdge(v10, v00);
+  auto &       eld = mesh->createEdge(v00, v11);
+  auto &       erl = elr;
+  auto &       ert = mesh->createEdge(v11, v21);
+  auto &       err = mesh->createEdge(v21, v20);
+  auto &       erb = mesh->createEdge(v20, v10);
+  auto &       erd = mesh->createEdge(v10, v21);
+  auto &       tlt = mesh->createTriangle(ell, elt, eld);
+  auto &       tlb = mesh->createTriangle(eld, elb, elr);
+  auto &       trt = mesh->createTriangle(erl, ert, erd);
+  auto &       trb = mesh->createTriangle(erd, erb, err);
 
   {
     auto tree = rtree::getVertexRTree(mesh);
 
     BOOST_TEST(tree->size() == 6);
 
-    Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 0.0, 0.8));
+    Eigen::VectorXd     searchVector(Eigen::Vector3d(0.8, 0.0, 0.8));
     std::vector<size_t> results;
 
     tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
 
     BOOST_TEST(tree->size() == 9);
 
-    Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 0.5, 0.0));
+    Eigen::VectorXd  searchVector(Eigen::Vector3d(0.8, 0.5, 0.0));
     std::set<size_t> results;
 
     tree->query(bgi::nearest(searchVector, 2), std::inserter(results, results.begin()));
@@ -448,16 +448,15 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
 
     BOOST_TEST(tree->size() == 4);
 
-    Eigen::VectorXd searchVector(Eigen::Vector3d(0.7, 0.5, 0.0));
+    Eigen::VectorXd                        searchVector(Eigen::Vector3d(0.7, 0.5, 0.0));
     std::vector<std::pair<double, size_t>> results;
 
-    tree->query(bgi::nearest(searchVector, 3), boost::make_function_output_iterator([&](const precice::mesh::rtree::triangle_traits::IndexType & val){
-                results.push_back(std::make_pair(
-                            boost::geometry::distance(
-                                searchVector,
-                                mesh->triangles()[val.second]
-                                ),
-                            val.second));
+    tree->query(bgi::nearest(searchVector, 3), boost::make_function_output_iterator([&](const precice::mesh::rtree::triangle_traits::IndexType &val) {
+                  results.push_back(std::make_pair(
+                      boost::geometry::distance(
+                          searchVector,
+                          mesh->triangles()[val.second]),
+                      val.second));
                 }));
 
     std::sort(results.begin(), results.end());
@@ -469,7 +468,6 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
     BOOST_TEST(results[2].second != trb.getID());
   }
 }
-
 
 /// Resembles how boost geometry is used inside the PetRBF
 BOOST_AUTO_TEST_CASE(QueryWithBox)
@@ -486,50 +484,47 @@ BOOST_AUTO_TEST_CASE(QueryWithBox)
 
   auto tree = rtree::getVertexRTree(mesh);
   BOOST_TEST(tree->size() == 8);
-  
+
   Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 1, 0));
 
   {
-    std::vector<size_t> results;
-    double radius = 0.1; // No vertices in radius
+    std::vector<size_t>             results;
+    double                          radius = 0.1; // No vertices in radius
     bg::model::box<Eigen::VectorXd> search_box(
-      searchVector - Eigen::VectorXd::Constant(3, radius),
-      searchVector + Eigen::VectorXd::Constant(3, radius));
-    
-    tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i){
-          return bg::distance(searchVector, mesh->vertices()[i]) <= radius;}),
-      std::back_inserter(results));
-  
+        searchVector - Eigen::VectorXd::Constant(3, radius),
+        searchVector + Eigen::VectorXd::Constant(3, radius));
+
+    tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+                std::back_inserter(results));
+
     BOOST_TEST(results.empty());
   }
 
   {
-    std::vector<size_t> results;
-    double radius = 0.81; // Two vertices in radius
+    std::vector<size_t>             results;
+    double                          radius = 0.81; // Two vertices in radius
     bg::model::box<Eigen::VectorXd> search_box(
-      searchVector - Eigen::VectorXd::Constant(3, radius),
-      searchVector + Eigen::VectorXd::Constant(3, radius));
-    
-    tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i){
-          return bg::distance(searchVector, mesh->vertices()[i]) <= radius;}),
-      std::back_inserter(results));
-    
+        searchVector - Eigen::VectorXd::Constant(3, radius),
+        searchVector + Eigen::VectorXd::Constant(3, radius));
+
+    tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+                std::back_inserter(results));
+
     BOOST_TEST(results.size() == 2);
     BOOST_TEST(mesh->vertices()[results[0]].getCoords() == Eigen::Vector3d(0, 1, 0));
     BOOST_TEST(mesh->vertices()[results[1]].getCoords() == Eigen::Vector3d(1, 1, 0));
   }
 
   {
-    std::vector<size_t> results;
-    double radius = std::numeric_limits<double>::max();
+    std::vector<size_t>             results;
+    double                          radius = std::numeric_limits<double>::max();
     bg::model::box<Eigen::VectorXd> search_box(
-      searchVector - Eigen::VectorXd::Constant(3, radius),
-      searchVector + Eigen::VectorXd::Constant(3, radius));
-    
-    tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i){
-          return bg::distance(searchVector, mesh->vertices()[i]) <= radius;}),
-      std::back_inserter(results));
-    
+        searchVector - Eigen::VectorXd::Constant(3, radius),
+        searchVector + Eigen::VectorXd::Constant(3, radius));
+
+    tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+                std::back_inserter(results));
+
     BOOST_TEST(results.size() == 8);
   }
 }
@@ -539,7 +534,6 @@ BOOST_AUTO_TEST_CASE(CacheClearing)
   PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
 
-  
   // The Cache should clear whenever a mesh changes
   auto vTree1 = rtree::getVertexRTree(mesh);
   auto pTree1 = rtree::getPrimitiveRTree(mesh);
@@ -559,7 +553,8 @@ BOOST_AUTO_TEST_CASE(CacheClearing)
   BOOST_TEST(rtree::_primitive_trees.empty());
 }
 
-BOOST_AUTO_TEST_CASE(PrimitveIndexComparison) {
+BOOST_AUTO_TEST_CASE(PrimitveIndexComparison)
+{
   PrimitiveIndex a{Primitive::Vertex, 2lu};
   PrimitiveIndex b{Primitive::Vertex, 2lu};
   PrimitiveIndex c{Primitive::Edge, 2lu};
@@ -571,8 +566,9 @@ BOOST_AUTO_TEST_CASE(PrimitveIndexComparison) {
   BOOST_TEST(c != d);
 }
 
-BOOST_FIXTURE_TEST_CASE(IndexSinglePrimitiveType, MeshFixture) {
-  PrimitiveRTree rtree;
+BOOST_FIXTURE_TEST_CASE(IndexSinglePrimitiveType, MeshFixture)
+{
+  PrimitiveRTree            rtree;
   mesh::impl::AABBGenerator gen{mesh};
 
   using mesh::impl::indexPrimitive;
@@ -580,30 +576,31 @@ BOOST_FIXTURE_TEST_CASE(IndexSinglePrimitiveType, MeshFixture) {
   indexPrimitive(rtree, gen, mesh.vertices());
   BOOST_TEST(rtree.size() == vertex_cnt);
   indexPrimitive(rtree, gen, mesh.edges());
-  BOOST_TEST(rtree.size() == vertex_cnt+edge_cnt);
+  BOOST_TEST(rtree.size() == vertex_cnt + edge_cnt);
   indexPrimitive(rtree, gen, mesh.triangles());
-  BOOST_TEST(rtree.size() == vertex_cnt+edge_cnt+triangle_cnt);
+  BOOST_TEST(rtree.size() == vertex_cnt + edge_cnt + triangle_cnt);
   indexPrimitive(rtree, gen, mesh.quads());
   BOOST_TEST(rtree.size() == primitive_cnt);
 }
 
-BOOST_FIXTURE_TEST_CASE(IndexMesh, MeshFixture) {
+BOOST_FIXTURE_TEST_CASE(IndexMesh, MeshFixture)
+{
   auto tree = indexMesh(mesh);
   BOOST_TEST(tree.size() == primitive_cnt);
 }
 
-BOOST_FIXTURE_TEST_CASE(CacheFunctionality, MeshFixture) {
-    PtrMesh ptr{&mesh, [](Mesh*){}}; // Use an empty deleter to prevent double-free
+BOOST_FIXTURE_TEST_CASE(CacheFunctionality, MeshFixture)
+{
+  PtrMesh ptr{&mesh, [](Mesh *) {}}; // Use an empty deleter to prevent double-free
 
-    auto vt1 = rtree::getVertexRTree(ptr);
-    auto vt2 = rtree::getVertexRTree(ptr);
-    BOOST_TEST(vt1 == vt2);
+  auto vt1 = rtree::getVertexRTree(ptr);
+  auto vt2 = rtree::getVertexRTree(ptr);
+  BOOST_TEST(vt1 == vt2);
 
-    auto pt1 = rtree::getPrimitiveRTree(ptr);
-    auto pt2 = rtree::getPrimitiveRTree(ptr);
-    BOOST_TEST(pt1 == pt2);
+  auto pt1 = rtree::getPrimitiveRTree(ptr);
+  auto pt2 = rtree::getPrimitiveRTree(ptr);
+  BOOST_TEST(pt1 == pt2);
 }
-
 
 BOOST_AUTO_TEST_SUITE_END() // RTree
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -174,9 +174,9 @@ BOOST_AUTO_TEST_CASE(TriangleEquality)
   using Eigen::Vector3d;
   Vector3d coords1(0.0, 0.0, 0.0);
   Vector3d coords2(1.0, 0.0, 0.0);
-  Vector3d coords3(1.0, 1.0, 0.0);  
+  Vector3d coords3(1.0, 1.0, 0.0);
   Vector3d coords4(2.0, 0.0, 0.0);
- 
+
   Vertex v1(coords1, 0);
   Vertex v2(coords2, 1);
   Vertex v3(coords3, 2);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(TriangleEquality)
   //    ****
   Triangle triangle3(e2, e4, e5, 0);
   Triangle triangle4(e2, e4, e5, 0);
-  triangle4.setNormal(Vector3d(0.,0.,1.));
+  triangle4.setNormal(Vector3d(0., 0., 1.));
   BOOST_TEST(triangle1 == triangle2);
   BOOST_TEST(triangle1 != triangle3);
   BOOST_TEST(triangle4 != triangle3);
@@ -207,17 +207,17 @@ BOOST_AUTO_TEST_CASE(TriangleEquality)
 
 BOOST_AUTO_TEST_CASE(TriangleWKTPrint)
 {
-    Vertex v1(Eigen::Vector3d(0.,0.,0.), 0);
-    Vertex v2(Eigen::Vector3d(0.,1.,0.), 0);
-    Vertex v3(Eigen::Vector3d(1.,0.,0.), 0);
-    Edge e1(v1, v2, 0);
-    Edge e2(v2, v3, 0);
-    Edge e3(v3, v1, 0);
-    Triangle t1(e1, e2, e3, 0);
-    std::stringstream stream;
-    stream << t1;
-    std::string t1string("POLYGON ((0 0 0, 0 1 0, 1 0 0, 0 0 0))");
-    BOOST_TEST(t1string == stream.str());
+  Vertex            v1(Eigen::Vector3d(0., 0., 0.), 0);
+  Vertex            v2(Eigen::Vector3d(0., 1., 0.), 0);
+  Vertex            v3(Eigen::Vector3d(1., 0., 0.), 0);
+  Edge              e1(v1, v2, 0);
+  Edge              e2(v2, v3, 0);
+  Edge              e3(v3, v1, 0);
+  Triangle          t1(e1, e2, e3, 0);
+  std::stringstream stream;
+  stream << t1;
+  std::string t1string("POLYGON ((0 0 0, 0 1 0, 1 0 0, 0 0 0))");
+  BOOST_TEST(t1string == stream.str());
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Triangle

--- a/src/mesh/tests/VertexTest.cpp
+++ b/src/mesh/tests/VertexTest.cpp
@@ -1,6 +1,6 @@
+#include <Eigen/Core>
 #include "mesh/Vertex.hpp"
 #include "testing/Testing.hpp"
-#include <Eigen/Core>
 
 using namespace precice;
 
@@ -23,28 +23,28 @@ BOOST_AUTO_TEST_CASE(Vertices)
 
 BOOST_AUTO_TEST_CASE(VertexEquality)
 {
-    using namespace mesh;
-    using namespace Eigen;
-    Vertex v1(Vector3d::Constant(4.0), 0);
-    Vertex v2(Vector3d::Constant(4.0), 1);
-    Vertex v3(Vector3d::Constant(2.0), 0);
-    BOOST_TEST(v1 == v2);
-    BOOST_TEST(v1 != v3);
-    BOOST_TEST(v2 != v3);
+  using namespace mesh;
+  using namespace Eigen;
+  Vertex v1(Vector3d::Constant(4.0), 0);
+  Vertex v2(Vector3d::Constant(4.0), 1);
+  Vertex v3(Vector3d::Constant(2.0), 0);
+  BOOST_TEST(v1 == v2);
+  BOOST_TEST(v1 != v3);
+  BOOST_TEST(v2 != v3);
 }
 BOOST_AUTO_TEST_CASE(VertexWKTPrint)
 {
-    using namespace mesh;
-    Vertex v1(Eigen::Vector2d(1., 2.), 0);
-    std::stringstream v1stream;
-    v1stream << v1;
-    std::string v1str("POINT (1 2)");
-    BOOST_TEST(v1str == v1stream.str());
-    Vertex v2(Eigen::Vector3d(1., 2., 3.), 0);
-    std::stringstream v2stream;
-    v2stream << v2;
-    std::string v2str("POINT (1 2 3)");
-    BOOST_TEST(v2str == v2stream.str());
+  using namespace mesh;
+  Vertex            v1(Eigen::Vector2d(1., 2.), 0);
+  std::stringstream v1stream;
+  v1stream << v1;
+  std::string v1str("POINT (1 2)");
+  BOOST_TEST(v1str == v1stream.str());
+  Vertex            v2(Eigen::Vector3d(1., 2., 3.), 0);
+  std::stringstream v2stream;
+  v2stream << v2;
+  std::string v2str("POINT (1 2 3)");
+  BOOST_TEST(v2str == v2stream.str());
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Vertex

--- a/src/partition/Partition.cpp
+++ b/src/partition/Partition.cpp
@@ -3,10 +3,8 @@
 #include "mesh/Mesh.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace partition
-{
+namespace precice {
+namespace partition {
 
 Partition::Partition(mesh::PtrMesh mesh)
     : _mesh(mesh)
@@ -20,7 +18,7 @@ void Partition::computeVertexOffsets()
   if (utils::MasterSlave::isSlave()) {
     utils::MasterSlave::_communication->broadcast(_mesh->getVertexOffsets(), 0);
     PRECICE_DEBUG("My vertex offsets: " << _mesh->getVertexOffsets());
-    
+
   } else if (utils::MasterSlave::isMaster()) {
     _mesh->getVertexOffsets().resize(utils::MasterSlave::getSize());
     _mesh->getVertexOffsets()[0] = _mesh->getVertexDistribution()[0].size();
@@ -29,7 +27,7 @@ void Partition::computeVertexOffsets()
     }
     PRECICE_DEBUG("My vertex offsets: " << _mesh->getVertexOffsets());
     utils::MasterSlave::_communication->broadcast(_mesh->getVertexOffsets());
-    
+
   } else { //coupling mode
     _mesh->getVertexOffsets().push_back(_mesh->vertices().size());
   }

--- a/src/partition/Partition.hpp
+++ b/src/partition/Partition.hpp
@@ -9,10 +9,8 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice
-{
-namespace partition
-{
+namespace precice {
+namespace partition {
 
 /**
  * @brief Abstract base class for partitions.
@@ -29,13 +27,12 @@ namespace partition
  * Access to the associated mesh, to both mappings (from and to this mesh),
  * and to an m2n communication to another participant is necessary.
  */
-class Partition
-{
+class Partition {
 public:
   /// Constructor.
   Partition(mesh::PtrMesh mesh);
 
-  Partition& operator=(Partition &&) = delete;
+  Partition &operator=(Partition &&) = delete;
 
   virtual ~Partition() {}
 

--- a/src/partition/ProvidedBoundingBox.hpp
+++ b/src/partition/ProvidedBoundingBox.hpp
@@ -6,7 +6,6 @@
 namespace precice {
 namespace partition {
 
-
 /**
  * @brief this class is supposed to:
  * 1- gather bounding boxes around the mesh partition of each rank in the master
@@ -14,15 +13,13 @@ namespace partition {
  * 3- receive the feedback map from the other master (i.e. who is connected to whom from the other participant's perspective)
  * 4- create own initial connection map (i.e. who is connected to whom from this participant's perspective)
  */
-class ProvidedBoundingBox :  public Partition 
-{
+class ProvidedBoundingBox : public Partition {
 public:
-
-   /// Constructor
+  /// Constructor
   ProvidedBoundingBox(mesh::PtrMesh mesh, bool hasToSend, double safetyFactor);
 
   virtual ~ProvidedBoundingBox() {}
-  
+
   /// The bounding box is gathered and sent to another participant (if required)
   virtual void communicateBoundingBox();
 
@@ -38,15 +35,14 @@ public:
   virtual void createOwnerInformation();
 
 private:
-
   logging::Logger _log{"partition::ProvidedBoundingBox"};
-  
+
   bool _hasToSend;
-   
+
   int _dimensions;
-  
+
   double _safetyFactor;
-  
 };
 
-}} // namespace precice, partition
+} // namespace partition
+} // namespace precice

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -22,7 +22,7 @@ void ProvidedPartition::communicate()
 {
   PRECICE_TRACE();
 
-  if(_m2ns.size()>0){ // if there is no connected participant we also don't need to gather the mesh
+  if (_m2ns.size() > 0) { // if there is no connected participant we also don't need to gather the mesh
     Event e1("partition.gatherMesh." + _mesh->getName(), precice::syncMode);
 
     // Temporary globalMesh such that the master also keeps his local mesh
@@ -34,10 +34,10 @@ void ProvidedPartition::communicate()
 
     // Gather Mesh
     PRECICE_INFO("Gather mesh " + _mesh->getName());
-    if (utils::MasterSlave::isSlave() ) {
-        com::CommunicateMesh(utils::MasterSlave::_communication).sendMesh(*_mesh, 0);
+    if (utils::MasterSlave::isSlave()) {
+      com::CommunicateMesh(utils::MasterSlave::_communication).sendMesh(*_mesh, 0);
     }
-    if (utils::MasterSlave::isMaster())  {
+    if (utils::MasterSlave::isMaster()) {
       PRECICE_ASSERT(utils::MasterSlave::getRank() == 0);
       PRECICE_ASSERT(utils::MasterSlave::getSize() > 1);
 
@@ -62,14 +62,13 @@ void ProvidedPartition::communicate()
     PRECICE_INFO("Send global mesh " << _mesh->getName());
     Event e2("partition.sendGlobalMesh." + _mesh->getName(), precice::syncMode);
 
-    for(auto m2n : _m2ns) {
+    for (auto m2n : _m2ns) {
       if (not utils::MasterSlave::isSlave()) {
         PRECICE_CHECK(globalMesh.vertices().size() > 0, "The provided mesh " << globalMesh.getName() << " is invalid (possibly empty).");
         com::CommunicateMesh(m2n->getMasterCommunication()).sendMesh(globalMesh, 0);
       }
     }
     e2.stop();
-
   }
 }
 
@@ -120,7 +119,7 @@ void ProvidedPartition::compute()
     PRECICE_DEBUG("broadcast global number of vertices: " << vertexCounter);
     utils::MasterSlave::_communication->broadcast(vertexCounter);
   } else { // Coupling mode
-    
+
     for (int i = 0; i < numberOfVertices; i++) {
       _mesh->getVertexDistribution()[0].push_back(i);
       _mesh->vertices()[i].setGlobalIndex(i);

--- a/src/partition/ProvidedPartition.hpp
+++ b/src/partition/ProvidedPartition.hpp
@@ -3,10 +3,8 @@
 #include "Partition.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice
-{
-namespace partition
-{
+namespace precice {
+namespace partition {
 
 /**
  * @brief A partition that is provided by the participant.
@@ -15,10 +13,8 @@ namespace partition
  * If required the mesh needs to be sent to another participant.
  * Furthermore, distribution data structures need to be set up.
  */
-class ProvidedPartition : public Partition
-{
+class ProvidedPartition : public Partition {
 public:
-
   ProvidedPartition(mesh::PtrMesh mesh);
 
   virtual ~ProvidedPartition() {}
@@ -34,7 +30,6 @@ private:
   virtual void createOwnerInformation() override;
 
   logging::Logger _log{"partition::ProvidedPartition"};
-
 };
 
 } // namespace partition

--- a/src/partition/ReceivedBoundingBox.cpp
+++ b/src/partition/ReceivedBoundingBox.cpp
@@ -5,18 +5,16 @@
 #include "com/Communication.hpp"
 #include "m2n/M2N.hpp"
 #include "mapping/Mapping.hpp"
-#include "mesh/Mesh.hpp"
-#include "mesh/Vertex.hpp"
 #include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
 #include "mesh/Filter.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/MasterSlave.hpp"
 
-namespace precice
-{
-namespace partition
-{
+namespace precice {
+namespace partition {
 
 ReceivedBoundingBox::ReceivedBoundingBox(
     mesh::PtrMesh mesh, double safetyFactor)
@@ -44,7 +42,7 @@ void ReceivedBoundingBox::communicateBoundingBox()
     }
 
     // master receives global_bb from other master
-    com::CommunicateBoundingBox(_m2ns[0]->getMasterCommunication()).receiveBoundingBoxMap(_remoteBBM, 0);   
+    com::CommunicateBoundingBox(_m2ns[0]->getMasterCommunication()).receiveBoundingBoxMap(_remoteBBM, 0);
   }
 }
 
@@ -60,12 +58,12 @@ void ReceivedBoundingBox::computeBoundingBox()
     PRECICE_ASSERT(utils::MasterSlave::getRank() == 0);
     PRECICE_ASSERT(utils::MasterSlave::getSize() > 1);
 
-    // broadcast _remoteBBM to all slaves    
-    utils::MasterSlave::_communication->broadcast(_remoteParComSize);    
+    // broadcast _remoteBBM to all slaves
+    utils::MasterSlave::_communication->broadcast(_remoteParComSize);
     com::CommunicateBoundingBox(utils::MasterSlave::_communication).broadcastSendBoundingBoxMap(_remoteBBM);
 
     std::map<int, std::vector<int>> connectionMap;
-    std::vector<int> connectedRanksList;
+    std::vector<int>                connectedRanksList;
 
     // connected ranks for master
     for (auto &remoteBB : _remoteBBM) {
@@ -73,12 +71,11 @@ void ReceivedBoundingBox::computeBoundingBox()
         _mesh->getConnectedRanks().push_back(remoteBB.first);
       }
     }
-    if (!_mesh->getConnectedRanks().empty())
-    {
-     connectionMap[0] = _mesh->getConnectedRanks();
-     connectedRanksList.push_back(0);
+    if (!_mesh->getConnectedRanks().empty()) {
+      connectionMap[0] = _mesh->getConnectedRanks();
+      connectedRanksList.push_back(0);
     }
-      
+
     // receive connected ranks from slaves and add them to the connection map
     std::vector<int> slaveConnectedRanks;
     for (int rank = 1; rank < utils::MasterSlave::getSize(); rank++) {
@@ -86,7 +83,7 @@ void ReceivedBoundingBox::computeBoundingBox()
       utils::MasterSlave::_communication->receive(connectedRanksSize, rank);
       if (connectedRanksSize != 0) {
         connectedRanksList.push_back(rank);
-        connectionMap[rank].push_back(-1);        
+        connectionMap[rank].push_back(-1);
         utils::MasterSlave::_communication->receive(slaveConnectedRanks, rank);
         connectionMap[rank] = slaveConnectedRanks;
         slaveConnectedRanks.clear();
@@ -95,15 +92,14 @@ void ReceivedBoundingBox::computeBoundingBox()
 
     // send connectionMap to other master
     _m2ns[0]->getMasterCommunication()->send(connectedRanksList, 0);
-    if (!connectionMap.empty()) { 
+    if (!connectionMap.empty()) {
       com::CommunicateBoundingBox(_m2ns[0]->getMasterCommunication()).sendConnectionMap(connectionMap, 0);
-    } else
-    {
+    } else {
       PRECICE_ERROR("This participant has no rank in the interface! Please check your test case and make sure that the mesh partition given to preCICE is loacted in the interface");
     }
-  } else if ( utils::MasterSlave::isSlave()) {    
+  } else if (utils::MasterSlave::isSlave()) {
     utils::MasterSlave::_communication->broadcast(_remoteParComSize, 0);
-    
+
     for (int remoteRank = 0; remoteRank < _remoteParComSize; remoteRank++) {
       _remoteBBM[remoteRank] = mesh::Mesh::BoundingBox(_dimensions);
     }
@@ -115,7 +111,7 @@ void ReceivedBoundingBox::computeBoundingBox()
       if (overlapping(_bb, remoteBB.second)) {
         _mesh->getConnectedRanks().push_back(remoteBB.first);
       }
-    }    
+    }
 
     // send feedback size to master
     utils::MasterSlave::_communication->send((int) _mesh->getConnectedRanks().size(), 0);
@@ -127,13 +123,12 @@ void ReceivedBoundingBox::computeBoundingBox()
 }
 
 void ReceivedBoundingBox::communicate()
-{  
-  if (utils::MasterSlave::isMaster())
-  {
+{
+  if (utils::MasterSlave::isMaster()) {
     // Master receives remote mesh's global vertex number
     int globalNumberOfVertices = -1;
-     _m2ns[0]->getMasterCommunication()->receive(globalNumberOfVertices, 0);
-     _mesh->setGlobalNumberOfVertices(globalNumberOfVertices);
+    _m2ns[0]->getMasterCommunication()->receive(globalNumberOfVertices, 0);
+    _mesh->setGlobalNumberOfVertices(globalNumberOfVertices);
   }
 
   // each rank receives max/min global vertex indexes from connected remote ranks
@@ -142,46 +137,44 @@ void ReceivedBoundingBox::communicate()
 
   // each rank receives mesh partition from connected ranks
   _m2ns[0]->broadcastReceiveLocalMesh(*_mesh);
-
 }
 
 void ReceivedBoundingBox::compute()
 {
   if (not utils::MasterSlave::isSlave()) {
     PRECICE_CHECK(_fromMapping.use_count() > 0 || _toMapping.use_count() > 0,
-          "The received mesh " << _mesh->getName()
-          << " needs a mapping, either from it, to it, or both. Maybe you don't want to receive this mesh at all?")
+                  "The received mesh " << _mesh->getName()
+                                       << " needs a mapping, either from it, to it, or both. Maybe you don't want to receive this mesh at all?")
   }
-  
+
   // _mesh->buildBoundingBox();
-  prepareBoundingBox();  
+  prepareBoundingBox();
   mesh::Mesh filteredMesh{"FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED};
-  
+
   // (1) Bounding Box Filter
 
-  PRECICE_INFO("Filter mesh " << _mesh->getName() << " by bounding-box");  
-  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return isVertexInBB(v);});
+  PRECICE_INFO("Filter mesh " << _mesh->getName() << " by bounding-box");
+  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return isVertexInBB(v); });
   PRECICE_DEBUG("Filtered mesh. #vertices: " << filteredMesh.vertices().size()
-          << ", #edges: " << filteredMesh.edges().size()
-          << ", #triangles: " << filteredMesh.triangles().size()
-          << ", rank: " << utils::MasterSlave::getRank());
-    
+                                             << ", #edges: " << filteredMesh.edges().size()
+                                             << ", #triangles: " << filteredMesh.triangles().size()
+                                             << ", rank: " << utils::MasterSlave::getRank());
+
   if ((_fromMapping.use_count() > 0 && _fromMapping->getOutputMesh()->vertices().size() > 0) ||
-      (_toMapping.use_count() > 0 && _toMapping->getInputMesh()->vertices().size() > 0))
-  {
-      // this rank has vertices at the coupling interface
-      // then, also the filtered mesh should still have vertices
+      (_toMapping.use_count() > 0 && _toMapping->getInputMesh()->vertices().size() > 0)) {
+    // this rank has vertices at the coupling interface
+    // then, also the filtered mesh should still have vertices
     std::string msg = "The re-partitioning completely filtered out the mesh " + _mesh->getName() + " received on this rank at the coupling interface. "
-      "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
-      "Please check your geometry setup again. Small overlaps or gaps are no problem. "
-      "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
-      "of the decomposition strategy might be necessary.";
+                                                                                                   "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
+                                                                                                   "Please check your geometry setup again. Small overlaps or gaps are no problem. "
+                                                                                                   "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
+                                                                                                   "of the decomposition strategy might be necessary.";
     //PRECICE_CHECK(filteredMesh.vertices().size() > 0, msg);
   }
   PRECICE_DEBUG("Bounding box filter, filtered from "
-          << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
-          << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
-          << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
+                << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+                << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+                << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
   _mesh->clear();
   _mesh->addMesh(filteredMesh);
   _mesh->computeState();
@@ -194,33 +187,32 @@ void ReceivedBoundingBox::compute()
     _fromMapping->tagMeshFirstRound();
   if (_toMapping.use_count() > 0)
     _toMapping->tagMeshFirstRound();
-  
+
   // (3) Define which vertices are owned by this rank
   PRECICE_DEBUG("Create owner information.");
   createOwnerInformation();
-  
+
   // (4) Tag vertices 2nd round (what should be filtered out)
   PRECICE_DEBUG("Tag vertices for filtering: 2nd round.");
   if (_fromMapping.use_count() > 0)
     _fromMapping->tagMeshSecondRound();
   if (_toMapping.use_count() > 0)
     _toMapping->tagMeshSecondRound();
-  
-  
+
   // (5) Filter mesh according to tag
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by mappings");
   filteredMesh.clear();
-  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return v.isTagged();});
+  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return v.isTagged(); });
   PRECICE_DEBUG("Mapping filter, filtered from "
-          << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
-          << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
-          << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
+                << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+                << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+                << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
   _mesh->clear();
   _mesh->addMesh(filteredMesh);
   _mesh->computeState();
 
   // (6) Compute and feedback local communication map
-  PRECICE_INFO("Feedback Communication Map "); 
+  PRECICE_INFO("Feedback Communication Map ");
   std::map<int, std::vector<int>> localCommunicationMap;
 
   /*
@@ -235,10 +227,10 @@ void ReceivedBoundingBox::compute()
    * remore rank, this vertex belongs to that rank
    */
 
-  std::vector<int> vertexIDs;  
+  std::vector<int> vertexIDs;
 
-  int rank = 0;
-  int index= 0;
+  int rank  = 0;
+  int index = 0;
   for (auto &remoteVertex : _mesh->vertices()) {
     vertexIDs.push_back(remoteVertex.getGlobalIndex());
     rank = 0;
@@ -251,16 +243,15 @@ void ReceivedBoundingBox::compute()
     }
     index++;
   }
-  
+
   // communicate communication map to all remote conneceted ranks
   _m2ns[0]->broadcastSendLCM(localCommunicationMap, *_mesh);
 
   /* 
    * master broadcasts remote mesh's golbal vertex number to slaves.
    * This data is needed later for implicit coupling schemes.
-   */  
-  if (utils::MasterSlave::isMaster())
-  {
+   */
+  if (utils::MasterSlave::isMaster()) {
     _mesh->getVertexDistribution()[0] = vertexIDs;
 
     for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
@@ -273,8 +264,7 @@ void ReceivedBoundingBox::compute()
       _mesh->getVertexDistribution()[rankSlave] = vertexIDs;
     }
     utils::MasterSlave::_communication->broadcast(_mesh->getGlobalNumberOfVertices());
-  } else
-  {  
+  } else {
     int numberOfVertices = _mesh->vertices().size();
     utils::MasterSlave::_communication->send(numberOfVertices, 0);
     if (numberOfVertices != 0) {
@@ -289,11 +279,10 @@ void ReceivedBoundingBox::compute()
     _mesh->setGlobalNumberOfVertices(globalNumberOfVertices);
   }
 
-  computeVertexOffsets();    
-  
+  computeVertexOffsets();
 }
 
-bool ReceivedBoundingBox::overlapping(mesh::Mesh::BoundingBox const & currentBB, mesh::Mesh::BoundingBox const & receivedBB)
+bool ReceivedBoundingBox::overlapping(mesh::Mesh::BoundingBox const &currentBB, mesh::Mesh::BoundingBox const &receivedBB)
 {
   /*
    * Here two bounding boxes are compared to check whether they overlap or not!
@@ -328,7 +317,7 @@ void ReceivedBoundingBox::prepareBoundingBox()
         _bb[d].second = other_bb[d].second;
     }
   }
-  
+
   if (_toMapping.use_count() > 0) {
     auto other_bb = _toMapping->getInputMesh()->getBoundingBox();
     for (int d = 0; d < _dimensions; d++) {
@@ -338,14 +327,14 @@ void ReceivedBoundingBox::prepareBoundingBox()
         _bb[d].second = other_bb[d].second;
     }
   }
-  
+
   //enlarge BB
   PRECICE_ASSERT(_safetyFactor >= 0.0);
 
   double maxSideLength = 1e-6; // we need some minimum > 0 here
 
   for (int d = 0; d < _dimensions; d++) {
-    if(_bb[d].second > _bb[d].first)
+    if (_bb[d].second > _bb[d].first)
       maxSideLength = std::max(maxSideLength, _bb[d].second - _bb[d].first);
   }
   for (int d = 0; d < _dimensions; d++) {
@@ -355,9 +344,10 @@ void ReceivedBoundingBox::prepareBoundingBox()
   }
 }
 
-bool ReceivedBoundingBox::isVertexInBB(const mesh::Vertex& vertex) {
-  for (int d=0; d<_dimensions; d++) {
-    if (vertex.getCoords()[d] < _bb[d].first || vertex.getCoords()[d] > _bb[d].second ) {
+bool ReceivedBoundingBox::isVertexInBB(const mesh::Vertex &vertex)
+{
+  for (int d = 0; d < _dimensions; d++) {
+    if (vertex.getCoords()[d] < _bb[d].first || vertex.getCoords()[d] > _bb[d].second) {
       return false;
     }
   }
@@ -365,30 +355,24 @@ bool ReceivedBoundingBox::isVertexInBB(const mesh::Vertex& vertex) {
 }
 
 void ReceivedBoundingBox::createOwnerInformation()
-{ 
+{
 
-  int numberOfVertices = _mesh->vertices().size();    
-  if (numberOfVertices != 0)
-  {
+  int numberOfVertices = _mesh->vertices().size();
+  if (numberOfVertices != 0) {
     std::vector<int> tags(numberOfVertices, -1);
     std::vector<int> globalIDs(numberOfVertices, -1);
-    for (int i = 0; i < numberOfVertices; i++)
-    {
+    for (int i = 0; i < numberOfVertices; i++) {
       globalIDs[i] = _mesh->vertices()[i].getGlobalIndex();
-      if (_mesh->vertices()[i].isTagged())
-      {
-        tags[i]     = 1;
-      }
-      else
-      {
+      if (_mesh->vertices()[i].isTagged()) {
+        tags[i] = 1;
+      } else {
         tags[i] = 0;
       }
     }
     PRECICE_DEBUG("My tags: " << tags);
-    PRECICE_DEBUG("My global IDs: " << globalIDs); 
-  }    
+    PRECICE_DEBUG("My global IDs: " << globalIDs);
+  }
 }
-
 
 } // namespace partition
 } // namespace precice

--- a/src/partition/ReceivedBoundingBox.hpp
+++ b/src/partition/ReceivedBoundingBox.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
+#include <vector>
 #include "Partition.hpp"
 #include "logging/Logger.hpp"
-#include <vector>
-#include "mesh/Vertex.hpp"
 #include "mesh/Mesh.hpp"
-
+#include "mesh/Vertex.hpp"
 
 namespace precice {
 namespace partition {
@@ -17,12 +16,10 @@ namespace partition {
  * 4- connection map sent to the other participant  
  * @todo add documentation
  */
-class ReceivedBoundingBox : public Partition
-{
+class ReceivedBoundingBox : public Partition {
 public:
-
   /// Constructor
-  ReceivedBoundingBox (mesh::PtrMesh mesh, double safetyFactor);
+  ReceivedBoundingBox(mesh::PtrMesh mesh, double safetyFactor);
   virtual ~ReceivedBoundingBox() {}
 
   /// bounding box map is received from other participant
@@ -32,18 +29,17 @@ public:
   virtual void computeBoundingBox();
 
   /// receive mesh partition of remote connected ranks
-  virtual void communicate () override;
+  virtual void communicate() override;
 
   /// filter the received mesh partitions, fill in communication map and feed back to remote
   /// connected ranks
-  virtual void compute () override;     
+  virtual void compute() override;
 
 private:
-
   logging::Logger _log{"partition::ReceivedBoundingBox"};
 
   /// compares to bounding box and if they have intersection, returns true, otherwise flase!
-  static bool overlapping(mesh::Mesh::BoundingBox const & currentBB, mesh::Mesh::BoundingBox const & receivedBB);
+  static bool overlapping(mesh::Mesh::BoundingBox const &currentBB, mesh::Mesh::BoundingBox const &receivedBB);
 
   /// Sets _bb to the union with the mesh from fromMapping resp. toMapping, also enlage by _safetyFactor
   void prepareBoundingBox();
@@ -56,7 +52,7 @@ private:
 
   /// number of other particpant ranks
   int _remoteParComSize = 0;
-  
+
   mesh::Mesh::BoundingBox _bb;
 
   int _dimensions;
@@ -66,12 +62,12 @@ private:
   /// bounding box map of other participant
   mesh::Mesh::BoundingBoxMap _remoteBBM;
 
-  /// Max global veretex IDs owned by remote connected ranks 
+  /// Max global veretex IDs owned by remote connected ranks
   std::vector<int> _remoteVertexMaxGlobalIDs;
 
-  /// Min global veretex IDs owned by remote connected ranks 
+  /// Min global veretex IDs owned by remote connected ranks
   std::vector<int> _remoteVertexMinGlobalIDs;
-
 };
 
-}} // namespace precice, partition
+} // namespace partition
+} // namespace precice

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -4,10 +4,10 @@
 #include "m2n/M2N.hpp"
 #include "mapping/Mapping.hpp"
 #include "mesh/Edge.hpp"
+#include "mesh/Filter.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
-#include "mesh/Filter.hpp"
 #include "utils/Event.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/MasterSlave.hpp"
@@ -63,14 +63,12 @@ void ReceivedPartition::compute()
   // check to prevent false configuration
   if (not utils::MasterSlave::isSlave()) {
     PRECICE_CHECK(_fromMapping || _toMapping,
-          "The received mesh " << _mesh->getName()
-          << " needs a mapping, either from it, to it, or both. Maybe you don't want to receive this mesh at all?")
+                  "The received mesh " << _mesh->getName()
+                                       << " needs a mapping, either from it, to it, or both. Maybe you don't want to receive this mesh at all?")
   }
-
 
   // To understand the following steps, it is recommended to look at BU's thesis, especially Figure 69 on page 89
   // for RBF-based filtering. https://mediatum.ub.tum.de/doc/1320661/document.pdf
-
 
   // (0) set global number of vertices before filtering
   if (utils::MasterSlave::isMaster()) {
@@ -92,13 +90,13 @@ void ReceivedPartition::compute()
       PRECICE_DEBUG("Receive filtered mesh");
       com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(*_mesh, 0);
 
-      if(areProvidedMeshesEmpty()) {
+      if (areProvidedMeshesEmpty()) {
         std::string msg = "The re-partitioning completely filtered out the mesh " + _mesh->getName() +
-          " received on this rank at the coupling interface. "
-          "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
-          "Please check your geometry setup again. Small overlaps or gaps are no problem. "
-          "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
-          "of the decomposition strategy might be necessary.";
+                          " received on this rank at the coupling interface. "
+                          "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
+                          "Please check your geometry setup again. Small overlaps or gaps are no problem. "
+                          "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
+                          "of the decomposition strategy might be necessary.";
         PRECICE_CHECK(not _mesh->vertices().empty(), msg);
       }
 
@@ -110,9 +108,9 @@ void ReceivedPartition::compute()
         com::CommunicateMesh(utils::MasterSlave::_communication).receiveBoundingBox(_bb, rankSlave);
 
         PRECICE_DEBUG("From slave " << rankSlave << ", bounding mesh: " << _bb[0].first
-              << ", " << _bb[0].second << " and " << _bb[1].first << ", " << _bb[1].second);
+                                    << ", " << _bb[0].second << " and " << _bb[1].first << ", " << _bb[1].second);
         mesh::Mesh slaveMesh("SlaveMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
-        mesh::filterMesh(slaveMesh, *_mesh, [&](const mesh::Vertex& v){ return isVertexInBB(v);});
+        mesh::filterMesh(slaveMesh, *_mesh, [&](const mesh::Vertex &v) { return isVertexInBB(v); });
         PRECICE_DEBUG("Send filtered mesh to slave: " << rankSlave);
         com::CommunicateMesh(utils::MasterSlave::_communication).sendMesh(slaveMesh, rankSlave);
       }
@@ -120,21 +118,21 @@ void ReceivedPartition::compute()
       // Now also filter the remaining master mesh
       prepareBoundingBox();
       mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
-      mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return isVertexInBB(v);});
+      mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return isVertexInBB(v); });
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
       _mesh->computeState();
       PRECICE_DEBUG("Master mesh, filtered from "
-              << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
-              << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
-              << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
+                    << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+                    << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+                    << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
 
-      if(areProvidedMeshesEmpty()) {
+      if (areProvidedMeshesEmpty()) {
         std::string msg = "The re-partitioning completely filtered out the mesh " + _mesh->getName() + " received on this rank at the coupling interface. "
-          "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
-          "Please check your geometry setup again. Small overlaps or gaps are no problem. "
-          "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
-          "of the decomposition strategy might be necessary.";
+                                                                                                       "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
+                                                                                                       "Please check your geometry setup again. Small overlaps or gaps are no problem. "
+                                                                                                       "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
+                                                                                                       "of the decomposition strategy might be necessary.";
         PRECICE_CHECK(not _mesh->vertices().empty(), msg);
       }
     }
@@ -159,21 +157,21 @@ void ReceivedPartition::compute()
 
       prepareBoundingBox();
       mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
-      mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return isVertexInBB(v);});
+      mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return isVertexInBB(v); });
 
-      if(areProvidedMeshesEmpty()) {
+      if (areProvidedMeshesEmpty()) {
         std::string msg = "The re-partitioning completely filtered out the mesh " + _mesh->getName() + " received on this rank at the coupling interface. "
-          "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
-          "Please check your geometry setup again. Small overlaps or gaps are no problem. "
-          "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
-          "of the decomposition strategy might be necessary.";
+                                                                                                       "Most probably, the coupling interfaces of your coupled participants do not match geometry-wise. "
+                                                                                                       "Please check your geometry setup again. Small overlaps or gaps are no problem. "
+                                                                                                       "If your geometry setup is correct and if you have very different mesh resolutions on both sides, increasing the safety-factor "
+                                                                                                       "of the decomposition strategy might be necessary.";
         PRECICE_CHECK(not filteredMesh.vertices().empty(), msg);
       }
 
       PRECICE_DEBUG("Bounding box filter, filtered from "
-              << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
-              << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
-              << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
+                    << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+                    << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+                    << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
 
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
@@ -205,13 +203,13 @@ void ReceivedPartition::compute()
 
   // (5) Filter mesh according to tag
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by mappings");
-  Event e5("partition.filterMeshMappings" + _mesh->getName(), precice::syncMode);
+  Event      e5("partition.filterMeshMappings" + _mesh->getName(), precice::syncMode);
   mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
-  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex& v){ return v.isTagged();});
+  mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return v.isTagged(); });
   PRECICE_DEBUG("Mapping filter, filtered from "
-          << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
-          << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
-          << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
+                << _mesh->vertices().size() << " to " << filteredMesh.vertices().size() << " vertices, "
+                << _mesh->edges().size() << " to " << filteredMesh.edges().size() << " edges, and "
+                << _mesh->triangles().size() << " to " << filteredMesh.triangles().size() << " triangles.");
 
   _mesh->clear();
   _mesh->addMesh(filteredMesh);
@@ -275,15 +273,15 @@ void ReceivedPartition::prepareBoundingBox()
   if (_fromMapping) {
     auto other_bb = _fromMapping->getOutputMesh()->getBoundingBox();
     for (int d = 0; d < _dimensions; d++) {
-      _bb[d].first = std::min(_bb[d].first, other_bb[d].first);
+      _bb[d].first  = std::min(_bb[d].first, other_bb[d].first);
       _bb[d].second = std::max(_bb[d].second, other_bb[d].second);
     }
   }
   if (_toMapping) {
     auto other_bb = _toMapping->getInputMesh()->getBoundingBox();
-      for (int d = 0; d < _dimensions; d++) {
-        _bb[d].first = std::min(_bb[d].first, other_bb[d].first);
-        _bb[d].second = std::max(_bb[d].second, other_bb[d].second);
+    for (int d = 0; d < _dimensions; d++) {
+      _bb[d].first  = std::min(_bb[d].first, other_bb[d].first);
+      _bb[d].second = std::max(_bb[d].second, other_bb[d].second);
     }
   }
 
@@ -293,7 +291,7 @@ void ReceivedPartition::prepareBoundingBox()
   double maxSideLength = 1e-6; // we need some minimum > 0 here
 
   for (int d = 0; d < _dimensions; d++) {
-    if(_bb[d].second > _bb[d].first)
+    if (_bb[d].second > _bb[d].first)
       maxSideLength = std::max(maxSideLength, _bb[d].second - _bb[d].first);
   }
   for (int d = 0; d < _dimensions; d++) {
@@ -409,7 +407,7 @@ void ReceivedPartition::createOwnerInformation()
     for (int rank = 0; rank < utils::MasterSlave::getSize(); rank++) {
       int counter = 0;
       for (size_t i = 0; i < slaveOwnerVecs[rank].size(); i++) {
-         // Vertex has no owner yet and rank could be owner
+        // Vertex has no owner yet and rank could be owner
         if (globalOwnerVec[slaveGlobalIDs[rank][i]] == 0 && slaveTags[rank][i] == 1) {
           slaveOwnerVecs[rank][i]                 = 1; // Now rank is owner
           globalOwnerVec[slaveGlobalIDs[rank][i]] = 1; // Vertex now has owner
@@ -435,7 +433,7 @@ void ReceivedPartition::createOwnerInformation()
     for (int rank = 1; rank < utils::MasterSlave::getSize(); rank++) {
       if (not slaveTags[rank].empty())
         PRECICE_DEBUG("Send owner information to slave rank " << rank);
-        utils::MasterSlave::_communication->send(slaveOwnerVecs[rank], rank);
+      utils::MasterSlave::_communication->send(slaveOwnerVecs[rank], rank);
     }
     // Master data
     PRECICE_DEBUG("My owner information: " << slaveOwnerVecs[0]);
@@ -445,22 +443,22 @@ void ReceivedPartition::createOwnerInformation()
     for (size_t i = 0; i < globalOwnerVec.size(); i++) {
       if (globalOwnerVec[i] == 0) {
         PRECICE_DEBUG("The Vertex with global index " << i << " of mesh: " << _mesh->getName()
-              << " was completely filtered out, since it has no influence on any mapping.");
+                                                      << " was completely filtered out, since it has no influence on any mapping.");
       }
     }
 #endif
     auto filteredVertices = std::count(globalOwnerVec.begin(), globalOwnerVec.end(), 0);
     if (filteredVertices)
       PRECICE_WARN(filteredVertices << " of " << _mesh->getGlobalNumberOfVertices()
-           << " vertices of mesh " << _mesh->getName() << " have been filtered out "
-           << "since they have no influence on the mapping.");
-
+                                    << " vertices of mesh " << _mesh->getName() << " have been filtered out "
+                                    << "since they have no influence on the mapping.");
   }
 }
 
-bool ReceivedPartition::areProvidedMeshesEmpty() const {
-    return (_fromMapping && not _fromMapping->getOutputMesh()->vertices().empty()) ||
-           (_toMapping   && not _toMapping->getInputMesh()->vertices().empty());
+bool ReceivedPartition::areProvidedMeshesEmpty() const
+{
+  return (_fromMapping && not _fromMapping->getOutputMesh()->vertices().empty()) ||
+         (_toMapping && not _toMapping->getInputMesh()->vertices().empty());
 }
 
 void ReceivedPartition::setOwnerInformation(const std::vector<int> &ownerVec)

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -6,10 +6,8 @@
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
 
-namespace precice
-{
-namespace partition
-{
+namespace precice {
+namespace partition {
 
 /**
  * @brief A partition that is computed from a mesh received from another participant.
@@ -17,8 +15,7 @@ namespace partition
  * A mesh is received by the master rank and re-partitioned among all slave ranks.
  * Afterwards necessary distribution data structures are set up.
  */
-class ReceivedPartition : public Partition
-{
+class ReceivedPartition : public Partition {
 public:
   /// Defines the typ of geometric filter used
   enum GeometricFilter {

--- a/src/partition/SharedPointer.hpp
+++ b/src/partition/SharedPointer.hpp
@@ -2,10 +2,8 @@
 
 #include <memory>
 
-namespace precice
-{
-namespace partition
-{
+namespace precice {
+namespace partition {
 
 class Partition;
 

--- a/src/partition/tests/ProvidedBoundingBoxTest.cpp
+++ b/src/partition/tests/ProvidedBoundingBoxTest.cpp
@@ -1,22 +1,22 @@
 #ifndef PRECICE_NO_MPI
-#include "testing/Testing.hpp"
-#include "testing/Fixtures.hpp"
-#include "partition/ProvidedBoundingBox.hpp"
-#include "partition/ReceivedBoundingBox.hpp"
-#include "partition/SharedPointer.hpp"
-#include "utils/Parallel.hpp"
+#include "com/CommunicateBoundingBox.hpp"
 #include "com/CommunicationFactory.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "com/MPIPortsCommunicationFactory.hpp"
 #include "com/SocketCommunication.hpp"
 #include "com/SocketCommunicationFactory.hpp"
-#include "com/CommunicateBoundingBox.hpp"
+#include "m2n/PointToPointComFactory.hpp"
 #include "mapping/NearestNeighborMapping.hpp"
 #include "mapping/NearestProjectionMapping.hpp"
 #include "mapping/PetRadialBasisFctMapping.hpp"
+#include "partition/ProvidedBoundingBox.hpp"
+#include "partition/ReceivedBoundingBox.hpp"
+#include "partition/SharedPointer.hpp"
+#include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 #include "utils/MasterSlave.hpp"
-#include "m2n/PointToPointComFactory.hpp"
+#include "utils/Parallel.hpp"
 
 using namespace precice;
 using namespace partition;
@@ -31,7 +31,7 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
   com::PtrCommunication masterSlaveCom = com::PtrCommunication(new com::MPIDirectCommunication());
   utils::MasterSlave::_communication   = masterSlaveCom;
 
-  if (utils::Parallel::getProcessRank() == 0) { 
+  if (utils::Parallel::getProcessRank() == 0) {
     utils::Parallel::splitCommunicator("Fluid");
     m2n->acceptMasterConnection("Fluid", "SolidMaster");
   } else if (utils::Parallel::getProcessRank() == 1) { //Master
@@ -46,8 +46,8 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
     utils::MasterSlave::configure(2, 3);
   }
 
-  if(utils::Parallel::getProcessRank() == 1){//Master
-    masterSlaveCom->acceptConnection ( "SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
+  if (utils::Parallel::getProcessRank() == 1) { //Master
+    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
     masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 0, 2);
@@ -59,50 +59,46 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
 // create a communciator with two participants: each one has one master and one slave ranks
 // only master-master and master-slave channels are created here
 // Point to Point slave-slave channels must be created in the test.
-void setupM2NBaseEnvironment(m2n::PtrM2N p2p){
+void setupM2NBaseEnvironment(m2n::PtrM2N p2p)
+{
   PRECICE_ASSERT(utils::Parallel::getCommunicatorSize() == 4);
 
   com::PtrCommunication masterSlaveCom = com::PtrCommunication(new com::MPIDirectCommunication());
-  utils::MasterSlave::_communication = masterSlaveCom;
+  utils::MasterSlave::_communication   = masterSlaveCom;
 
   utils::Parallel::synchronizeProcesses();
 
-  if (utils::Parallel::getProcessRank() == 0){ //Master Fluid
+  if (utils::Parallel::getProcessRank() == 0) { //Master Fluid
     utils::Parallel::splitCommunicator("FluidMaster");
     p2p->acceptMasterConnection("FluidMaster", "SolidMaster");
-    utils::MasterSlave::configure(0, 2);    
-  }
-  else if(utils::Parallel::getProcessRank() == 1){//Slave1
+    utils::MasterSlave::configure(0, 2);
+  } else if (utils::Parallel::getProcessRank() == 1) { //Slave1
     utils::Parallel::splitCommunicator("FluidSlave");
-    utils::MasterSlave::configure(1, 2);    
-  }
-  else if(utils::Parallel::getProcessRank() == 2){//Master Solid
+    utils::MasterSlave::configure(1, 2);
+  } else if (utils::Parallel::getProcessRank() == 2) { //Master Solid
     utils::Parallel::splitCommunicator("SolidMaster");
     p2p->requestMasterConnection("FluidMaster", "SolidMaster");
-    utils::MasterSlave::configure(0, 2);    
-  }
-  else if(utils::Parallel::getProcessRank() == 3){//Slave2
+    utils::MasterSlave::configure(0, 2);
+  } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
     utils::Parallel::splitCommunicator("SolidSlave");
-    utils::MasterSlave::configure(1, 2);    
- }
+    utils::MasterSlave::configure(1, 2);
+  }
 
-  if (utils::Parallel::getProcessRank() == 0){ //Master Fluid
-     utils::MasterSlave::_communication->acceptConnection("FluidMaster", "FluidSlave", utils::Parallel::getProcessRank());
-    utils::MasterSlave::_communication->setRankOffset(1);   
-  }
-  else if (utils::Parallel::getProcessRank() == 1){ //Slave Fluid
+  if (utils::Parallel::getProcessRank() == 0) { //Master Fluid
+    utils::MasterSlave::_communication->acceptConnection("FluidMaster", "FluidSlave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->setRankOffset(1);
+  } else if (utils::Parallel::getProcessRank() == 1) { //Slave Fluid
     utils::MasterSlave::_communication->requestConnection("FluidMaster", "FluidSlave", 0, 1);
-  }
-  else if(utils::Parallel::getProcessRank() == 2){//Master Solid
+  } else if (utils::Parallel::getProcessRank() == 2) { //Master Solid
     utils::MasterSlave::_communication->acceptConnection("SolidMaster", "SolidSlave", utils::Parallel::getProcessRank());
-    utils::MasterSlave::_communication->setRankOffset(1);   
-  }
-  else if (utils::Parallel::getProcessRank() == 3){ //Slave Solis
+    utils::MasterSlave::_communication->setRankOffset(1);
+  } else if (utils::Parallel::getProcessRank() == 3) { //Slave Solis
     utils::MasterSlave::_communication->requestConnection("SolidMaster", "SolidSlave", 0, 1);
-  }  
+  }
 }
 
-void tearDownParallelEnvironment(){
+void tearDownParallelEnvironment()
+{
   utils::MasterSlave::_communication = nullptr;
   utils::MasterSlave::reset();
   // utils::Parallel::synchronizeProcesses();
@@ -111,8 +107,7 @@ void tearDownParallelEnvironment(){
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
 
-
-BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox2D, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox2D, *testing::OnSize(4))
 {
   com::PtrCommunication participantCom =
       com::PtrCommunication(new com::SocketCommunication());
@@ -122,77 +117,74 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox2D, * testing::OnSize(4))
 
   setupParallelEnvironment(m2n);
 
-  int dimensions = 2;
+  int  dimensions  = 2;
   bool flipNormals = true;
 
-  BOOST_TEST(utils::Parallel::getCommunicatorSize()==4); 
-  
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
   if (utils::Parallel::getProcessRank() != 0) { //NASTIN
-  
+
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
-    if(utils::Parallel::getProcessRank() == 1){//Master
+    if (utils::Parallel::getProcessRank() == 1) { //Master
       Eigen::VectorXd position(dimensions);
       position << -1.0, 0.0;
-      mesh::Vertex& v0 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v0 = pSolidzMesh->createVertex(position);
       position << 1.0, 2.0;
-      mesh::Vertex& v1 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v1 = pSolidzMesh->createVertex(position);
       position << 5.0, 3.0;
-      mesh::Vertex& v2 = pSolidzMesh->createVertex(position);
-      pSolidzMesh->createEdge(v0,v1);
-      pSolidzMesh->createEdge(v1,v2);      
-    }   
-  
-    else if(utils::Parallel::getProcessRank() == 2){//Slave1
+      mesh::Vertex &v2 = pSolidzMesh->createVertex(position);
+      pSolidzMesh->createEdge(v0, v1);
+      pSolidzMesh->createEdge(v1, v2);
+    }
+
+    else if (utils::Parallel::getProcessRank() == 2) { //Slave1
       Eigen::VectorXd position(dimensions);
       position << 1.0, 3.5;
-      mesh::Vertex& v3 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v3 = pSolidzMesh->createVertex(position);
       position << 0.0, 4.5;
-      mesh::Vertex& v4 = pSolidzMesh->createVertex(position);
-      pSolidzMesh->createEdge(v3,v4);
-    }
-    else if(utils::Parallel::getProcessRank() == 3){//Slave2
+      mesh::Vertex &v4 = pSolidzMesh->createVertex(position);
+      pSolidzMesh->createEdge(v3, v4);
+    } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
       Eigen::VectorXd position(dimensions);
       position << 2.5, 5.5;
-      mesh::Vertex& v5 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v5 = pSolidzMesh->createVertex(position);
       position << 4.5, 7.0;
-      mesh::Vertex& v6 = pSolidzMesh->createVertex(position); 
-      pSolidzMesh->createEdge(v5,v6);
+      mesh::Vertex &v6 = pSolidzMesh->createVertex(position);
+      pSolidzMesh->createEdge(v5, v6);
     }
- 
+
     double safetyFactor = 0.0;
-    bool hasToSend = true;    
+    bool   hasToSend    = true;
     pSolidzMesh->computeState();
-    
+
     ProvidedBoundingBox part(pSolidzMesh, hasToSend, safetyFactor);
     part.addM2N(m2n);
     part.communicateBoundingBox();
-    
-  }
-  else{//SOLIDZ    
-    
-    mesh::Mesh::BoundingBoxMap receivedGlobalBB;    
-    mesh::Mesh::BoundingBox localBB;
+
+  } else { //SOLIDZ
+
+    mesh::Mesh::BoundingBoxMap receivedGlobalBB;
+    mesh::Mesh::BoundingBox    localBB;
 
     // we receive other participants communicator size
-    int receivedFeedbackSize = 3;    
+    int receivedFeedbackSize = 3;
     m2n->getMasterCommunication()->receive(receivedFeedbackSize, 0);
 
-    for (int j=0; j < dimensions; j++) {
-      localBB.push_back(std::make_pair(-1,-1));
+    for (int j = 0; j < dimensions; j++) {
+      localBB.push_back(std::make_pair(-1, -1));
     }
-    for (int i=0; i < receivedFeedbackSize; i++) {
-      receivedGlobalBB[i]=localBB;      
-    } 
+    for (int i = 0; i < receivedFeedbackSize; i++) {
+      receivedGlobalBB[i] = localBB;
+    }
 
     // we receive golbal bounding box from othe participant!
-     com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveBoundingBoxMap(receivedGlobalBB, 0 );
+    com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveBoundingBoxMap(receivedGlobalBB, 0);
 
     // check wether we have received the correct com size
     BOOST_TEST(receivedFeedbackSize == 3);
 
-    //check the validity of received golbal bounding box (globalBB) 
+    //check the validity of received golbal bounding box (globalBB)
     BOOST_TEST(receivedGlobalBB[0][0].first == -1);
     BOOST_TEST(receivedGlobalBB[0][0].second == 5);
     BOOST_TEST(receivedGlobalBB[0][1].first == 0);
@@ -204,14 +196,13 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox2D, * testing::OnSize(4))
     BOOST_TEST(receivedGlobalBB[2][0].first == 2.5);
     BOOST_TEST(receivedGlobalBB[2][0].second == 4.5);
     BOOST_TEST(receivedGlobalBB[2][1].first == 5.5);
-    BOOST_TEST(receivedGlobalBB[2][1].second == 7.0);      
-    
+    BOOST_TEST(receivedGlobalBB[2][1].second == 7.0);
   }
-  
+
   tearDownParallelEnvironment();
 }
 
-BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox3D, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox3D, *testing::OnSize(4))
 {
   com::PtrCommunication participantCom =
       com::PtrCommunication(new com::SocketCommunication());
@@ -221,77 +212,74 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox3D, * testing::OnSize(4))
 
   setupParallelEnvironment(m2n);
 
-  int dimensions = 3;
+  int  dimensions  = 3;
   bool flipNormals = true;
 
-  BOOST_TEST(utils::Parallel::getCommunicatorSize()==4); 
-  
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
   if (utils::Parallel::getProcessRank() != 0) { //NASTIN
-  
+
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
-    if(utils::Parallel::getProcessRank() == 1){//Master
+    if (utils::Parallel::getProcessRank() == 1) { //Master
       Eigen::VectorXd position(dimensions);
       position << -1.0, 0.0, -1.0;
-      mesh::Vertex& v0 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v0 = pSolidzMesh->createVertex(position);
       position << 1.0, 2.0, 1.0;
-      mesh::Vertex& v1 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v1 = pSolidzMesh->createVertex(position);
       position << 5.0, 3.0, 5.0;
-      mesh::Vertex& v2 = pSolidzMesh->createVertex(position);
-      pSolidzMesh->createEdge(v0,v1);
-      pSolidzMesh->createEdge(v1,v2);      
-    }   
-  
-    else if(utils::Parallel::getProcessRank() == 2){//Slave1
+      mesh::Vertex &v2 = pSolidzMesh->createVertex(position);
+      pSolidzMesh->createEdge(v0, v1);
+      pSolidzMesh->createEdge(v1, v2);
+    }
+
+    else if (utils::Parallel::getProcessRank() == 2) { //Slave1
       Eigen::VectorXd position(dimensions);
       position << 1.0, 3.5, 1.0;
-      mesh::Vertex& v3 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v3 = pSolidzMesh->createVertex(position);
       position << 0.0, 4.5, 0.0;
-      mesh::Vertex& v4 = pSolidzMesh->createVertex(position);
-      pSolidzMesh->createEdge(v3,v4);
-    }
-    else if(utils::Parallel::getProcessRank() == 3){//Slave2
+      mesh::Vertex &v4 = pSolidzMesh->createVertex(position);
+      pSolidzMesh->createEdge(v3, v4);
+    } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
       Eigen::VectorXd position(dimensions);
       position << 2.5, 5.5, 2.5;
-      mesh::Vertex& v5 = pSolidzMesh->createVertex(position);
+      mesh::Vertex &v5 = pSolidzMesh->createVertex(position);
       position << 4.5, 7.0, 4.5;
-      mesh::Vertex& v6 = pSolidzMesh->createVertex(position); 
-      pSolidzMesh->createEdge(v5,v6);
+      mesh::Vertex &v6 = pSolidzMesh->createVertex(position);
+      pSolidzMesh->createEdge(v5, v6);
     }
- 
+
     double safetyFactor = 0.0;
-    bool hasToSend = true;    
+    bool   hasToSend    = true;
     pSolidzMesh->computeState();
-    
+
     ProvidedBoundingBox part(pSolidzMesh, hasToSend, safetyFactor);
     part.addM2N(m2n);
     part.communicateBoundingBox();
-    
-  }
-  else{//SOLIDZ    
-    
-    mesh::Mesh::BoundingBoxMap receivedGlobalBB;    
-    mesh::Mesh::BoundingBox localBB;
+
+  } else { //SOLIDZ
+
+    mesh::Mesh::BoundingBoxMap receivedGlobalBB;
+    mesh::Mesh::BoundingBox    localBB;
 
     // we receive other participants communicator size
-    int remoteParComSize = 3;    
+    int remoteParComSize = 3;
     m2n->getMasterCommunication()->receive(remoteParComSize, 0);
 
-    for (int j=0; j < dimensions; j++) {
-      localBB.push_back(std::make_pair(-1,-1));
+    for (int j = 0; j < dimensions; j++) {
+      localBB.push_back(std::make_pair(-1, -1));
     }
-    for (int i=0; i < remoteParComSize; i++) {
-      receivedGlobalBB[i]=localBB;      
-    } 
+    for (int i = 0; i < remoteParComSize; i++) {
+      receivedGlobalBB[i] = localBB;
+    }
 
     // we receive golbal bounding box from othe participant!
-    com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveBoundingBoxMap(receivedGlobalBB, 0 );
+    com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveBoundingBoxMap(receivedGlobalBB, 0);
 
     // check wether we have received the correct com size
     BOOST_TEST(remoteParComSize == 3);
 
-    //check the validity of received golbal bounding box (globalBB) 
+    //check the validity of received golbal bounding box (globalBB)
     BOOST_TEST(receivedGlobalBB[0][0].first == -1);
     BOOST_TEST(receivedGlobalBB[0][0].second == 5);
     BOOST_TEST(receivedGlobalBB[0][1].first == 0);
@@ -305,18 +293,17 @@ BOOST_AUTO_TEST_CASE(TestCommunicateBoundingBox3D, * testing::OnSize(4))
     BOOST_TEST(receivedGlobalBB[1][2].first == 0);
     BOOST_TEST(receivedGlobalBB[1][2].second == 1);
     BOOST_TEST(receivedGlobalBB[2][0].first == 2.5);
-    BOOST_TEST(receivedGlobalBB[2][0].second == 4.5);    
+    BOOST_TEST(receivedGlobalBB[2][0].second == 4.5);
     BOOST_TEST(receivedGlobalBB[2][1].first == 5.5);
     BOOST_TEST(receivedGlobalBB[2][1].second == 7.0);
     BOOST_TEST(receivedGlobalBB[2][2].first == 2.5);
-    BOOST_TEST(receivedGlobalBB[2][2].second == 4.5);    
+    BOOST_TEST(receivedGlobalBB[2][2].second == 4.5);
   }
-  
+
   tearDownParallelEnvironment();
 }
 
-
-BOOST_AUTO_TEST_CASE(TestComputeBoundingBox, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestComputeBoundingBox, *testing::OnSize(4))
 {
   com::PtrCommunication participantCom =
       com::PtrCommunication(new com::SocketCommunication());
@@ -326,14 +313,12 @@ BOOST_AUTO_TEST_CASE(TestComputeBoundingBox, * testing::OnSize(4))
 
   setupParallelEnvironment(m2n);
 
-  int dimensions = 2;
+  int  dimensions  = 2;
   bool flipNormals = true;
 
-  BOOST_TEST(utils::Parallel::getCommunicatorSize()==4); 
-  
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
-  if (utils::Parallel::getProcessRank() == 0)
-  {
+  if (utils::Parallel::getProcessRank() == 0) {
     std::vector<int> connectedRanks = {0, 1, 2};
     m2n->getMasterCommunication()->send(connectedRanks, 0);
 
@@ -345,93 +330,84 @@ BOOST_AUTO_TEST_CASE(TestComputeBoundingBox, * testing::OnSize(4))
     sendConnectionMap[1].push_back(2);
     sendConnectionMap[2].push_back(0);
     sendConnectionMap[2].push_back(1);
-    
-    com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendConnectionMap(sendConnectionMap, 0 );
-  }
-  else
-  { //NASTIN
-  
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));    
- 
+
+    com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendConnectionMap(sendConnectionMap, 0);
+  } else { //NASTIN
+
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+
     double safetyFactor = 0.0;
-    bool hasToSend = true;    
+    bool   hasToSend    = true;
     pSolidzMesh->computeState();
-    
+
     ProvidedBoundingBox part(pSolidzMesh, hasToSend, safetyFactor);
     part.addM2N(m2n);
     part.computeBoundingBox();
 
-    if(utils::Parallel::getProcessRank() == 1)
-    {//Master
+    if (utils::Parallel::getProcessRank() == 1) { //Master
       BOOST_TEST(pSolidzMesh->getConnectedRanks().size() == 2);
       BOOST_TEST(pSolidzMesh->getConnectedRanks()[0] == 1);
       BOOST_TEST(pSolidzMesh->getConnectedRanks()[1] == 2);
-    }   
-    else if(utils::Parallel::getProcessRank() == 2)
-    {//Slave1
+    } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
       BOOST_TEST(pSolidzMesh->getConnectedRanks().size() == 2);
       BOOST_TEST(pSolidzMesh->getConnectedRanks()[0] == 0);
       BOOST_TEST(pSolidzMesh->getConnectedRanks()[1] == 2);
-    }
-    else if(utils::Parallel::getProcessRank() == 3)
-    {//Slave2
+    } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
       BOOST_TEST(pSolidzMesh->getConnectedRanks().size() == 2);
       BOOST_TEST(pSolidzMesh->getConnectedRanks()[0] == 0);
       BOOST_TEST(pSolidzMesh->getConnectedRanks()[1] == 1);
     }
-    
-  }  
+  }
   tearDownParallelEnvironment();
 }
 
-
-BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions, *testing::OnSize(4))
 {
   //mesh creation
-  int dimensions = 2;
-  bool flipNormals = true;
-  double safetyFactor = 0.1;
-  bool hasToSend=true;
+  int           dimensions   = 2;
+  bool          flipNormals  = true;
+  double        safetyFactor = 0.1;
+  bool          hasToSend    = true;
   mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
 
-  // create second communicator for m2n mesh and communciation map exchange 
-  com::PtrCommunication participantsCom =  com::PtrCommunication(new com::SocketCommunication());
-  com::PtrCommunicationFactory participantComFactory =  com::PtrCommunicationFactory(new com::SocketCommunicationFactory);
-  m2n::DistributedComFactory::SharedPointer distributionFactory = m2n::DistributedComFactory::SharedPointer(new m2n::PointToPointComFactory(participantComFactory));
-  m2n::PtrM2N p2p = m2n::PtrM2N(new m2n::M2N(participantsCom, distributionFactory));
+  // create second communicator for m2n mesh and communciation map exchange
+  com::PtrCommunication                     participantsCom       = com::PtrCommunication(new com::SocketCommunication());
+  com::PtrCommunicationFactory              participantComFactory = com::PtrCommunicationFactory(new com::SocketCommunicationFactory);
+  m2n::DistributedComFactory::SharedPointer distributionFactory   = m2n::DistributedComFactory::SharedPointer(new m2n::PointToPointComFactory(participantComFactory));
+  m2n::PtrM2N                               p2p                   = m2n::PtrM2N(new m2n::M2N(participantsCom, distributionFactory));
 
   setupM2NBaseEnvironment(p2p);
-  
+
   switch (utils::Parallel::getProcessRank()) {
   case 0: {
     Eigen::VectorXd position(dimensions);
-    position <<0.5, 0.0;
-    mesh::Vertex& v1 = mesh->createVertex(position);
+    position << 0.5, 0.0;
+    mesh::Vertex &v1 = mesh->createVertex(position);
     position << 1.5, 0.0;
-    mesh::Vertex& v2 = mesh->createVertex(position);
-    position <<2.0, 1.0;
-    mesh::Vertex& v3 = mesh->createVertex(position);
+    mesh::Vertex &v2 = mesh->createVertex(position);
+    position << 2.0, 1.0;
+    mesh::Vertex &v3 = mesh->createVertex(position);
     position << 0.5, 1.0;
-    mesh::Vertex& v4 = mesh->createVertex(position);
+    mesh::Vertex &v4 = mesh->createVertex(position);
     mesh->createEdge(v1, v2);
     mesh->createEdge(v2, v3);
     mesh->createEdge(v3, v4);
     mesh->createEdge(v4, v1);
 
     mesh->getConnectedRanks().push_back(0);
-    
+
     break;
   }
   case 1: {
     Eigen::VectorXd position(dimensions);
-    position <<2.5, 0.0;
-    mesh::Vertex& v1 = mesh->createVertex(position);
+    position << 2.5, 0.0;
+    mesh::Vertex &v1 = mesh->createVertex(position);
     position << 3.5, 0.0;
-    mesh::Vertex& v2 = mesh->createVertex(position);
-    position <<3.5, 1.0;
-    mesh::Vertex& v3 = mesh->createVertex(position);
+    mesh::Vertex &v2 = mesh->createVertex(position);
+    position << 3.5, 1.0;
+    mesh::Vertex &v3 = mesh->createVertex(position);
     position << 2.0, 1.0;
-    mesh::Vertex& v4 = mesh->createVertex(position);
+    mesh::Vertex &v4 = mesh->createVertex(position);
     mesh->createEdge(v1, v2);
     mesh->createEdge(v2, v3);
     mesh->createEdge(v3, v4);
@@ -441,13 +417,13 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions, * testing::OnSize(4))
 
     break;
   }
-  case 2: {    
+  case 2: {
 
     mesh->getConnectedRanks().push_back(0);
-    
+
     break;
   }
-  case 3: {    
+  case 3: {
 
     mesh->getConnectedRanks().push_back(1);
 
@@ -456,67 +432,58 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions, * testing::OnSize(4))
   }
 
   mesh->computeState();
-    
-  if(utils::Parallel::getProcessRank() < 2)
-  {
+
+  if (utils::Parallel::getProcessRank() < 2) {
     p2p->createDistributedCommunication(mesh);
     ProvidedBoundingBox part(mesh, hasToSend, safetyFactor);
     p2p->acceptSlavesPreConnection("SolidSlaves", "FluidSlaves");
     part.addM2N(p2p);
-    
+
     part.communicate();
-  }
-  else
-  {
+  } else {
     p2p->createDistributedCommunication(mesh);
     ReceivedBoundingBox part(mesh, safetyFactor);
-    p2p->requestSlavesPreConnection("SolidSlaves", "FluidSlaves");    
-    part.addM2N(p2p);    
+    p2p->requestSlavesPreConnection("SolidSlaves", "FluidSlaves");
+    part.addM2N(p2p);
 
     part.communicate();
 
-    BOOST_TEST(mesh->vertices().size()==4);
+    BOOST_TEST(mesh->vertices().size() == 4);
 
-
-    if(utils::Parallel::getProcessRank() == 2)
-    {
-      BOOST_TEST(mesh->vertices()[0].getCoords()[0]==0.5);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[1]==0.0);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[0]==1.5);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[1]==0.0);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[0]==2.0);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[1]==1.0);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[0]==0.5);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[1]==1.0);
-    } else
-    {
-      BOOST_TEST(mesh->vertices()[0].getCoords()[0]==2.5);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[1]==0.0);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[0]==3.5);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[1]==0.0);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[0]==3.5);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[1]==1.0);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[0]==2.0);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[1]==1.0);
+    if (utils::Parallel::getProcessRank() == 2) {
+      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 0.5);
+      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 1.5);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 0.0);
+      BOOST_TEST(mesh->vertices()[2].getCoords()[0] == 2.0);
+      BOOST_TEST(mesh->vertices()[2].getCoords()[1] == 1.0);
+      BOOST_TEST(mesh->vertices()[3].getCoords()[0] == 0.5);
+      BOOST_TEST(mesh->vertices()[3].getCoords()[1] == 1.0);
+    } else {
+      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 2.5);
+      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 3.5);
+      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 0.0);
+      BOOST_TEST(mesh->vertices()[2].getCoords()[0] == 3.5);
+      BOOST_TEST(mesh->vertices()[2].getCoords()[1] == 1.0);
+      BOOST_TEST(mesh->vertices()[3].getCoords()[0] == 2.0);
+      BOOST_TEST(mesh->vertices()[3].getCoords()[1] == 1.0);
     }
-
   }
-  
+
   tearDownParallelEnvironment();
 }
 
-
-BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestCompute2D, *testing::OnSize(4))
 {
   //mesh creation
-  int dimensions = 2;
-  bool flipNormals = true;
-  double safetyFactor = 0;
-  bool hasToSend=true;
+  int           dimensions   = 2;
+  bool          flipNormals  = true;
+  double        safetyFactor = 0;
+  bool          hasToSend    = true;
   mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
   mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
 
-  
   switch (utils::Parallel::getProcessRank()) {
   case 0: {
     Eigen::VectorXd position(dimensions);
@@ -524,7 +491,7 @@ BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
     mesh->createVertex(position);
     position << -1.0, 0.0;
     mesh->createVertex(position);
-    position <<  0.0, 1.0;
+    position << 0.0, 1.0;
     mesh->createVertex(position);
     position << -1.0, 1.0;
     mesh->createVertex(position);
@@ -534,7 +501,7 @@ BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
     mesh->createVertex(position);
     position << -1.0, 2.0;
     mesh->createVertex(position);
-    position <<  0.0, 2.0;
+    position << 0.0, 2.0;
     mesh->createVertex(position);
 
     break;
@@ -543,28 +510,28 @@ BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
     Eigen::VectorXd position(dimensions);
     position << -0.5, 0.0;
     mesh->createVertex(position);
-    position <<  1.0, 0.0;
+    position << 1.0, 0.0;
     mesh->createVertex(position);
-    position <<  2.0, 0.0;
+    position << 2.0, 0.0;
     mesh->createVertex(position);
-    position <<  2.0, 1.0;
+    position << 2.0, 1.0;
     mesh->createVertex(position);
-    position <<  1.0, 1.0;
+    position << 1.0, 1.0;
     mesh->createVertex(position);
-    position <<  1.0, 2.0;
+    position << 1.0, 2.0;
     mesh->createVertex(position);
-    position <<  2.0, 2.0;
+    position << 2.0, 2.0;
     mesh->createVertex(position);
-    
+
     break;
   }
-  case 2: { 
+  case 2: {
     Eigen::VectorXd position(dimensions);
-    position <<  0.0,  0.0;
+    position << 0.0, 0.0;
     mesh->createVertex(position);
-    position <<  0.0, -1.0;
+    position << 0.0, -1.0;
     mesh->createVertex(position);
-    position << -1.0,  0.0;
+    position << -1.0, 0.0;
     mesh->createVertex(position);
     position << -1.0, -1.0;
     mesh->createVertex(position);
@@ -572,39 +539,38 @@ BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
     mesh->createVertex(position);
     position << -2.0, -1.0;
     mesh->createVertex(position);
-    
+
     break;
   }
   case 3: {
     Eigen::VectorXd position(dimensions);
-    position << 0.0,  0.0;
+    position << 0.0, 0.0;
     mesh->createVertex(position);
-    position << 1.0,  0.0;
+    position << 1.0, 0.0;
     mesh->createVertex(position);
     position << 0.0, -1.0;
     mesh->createVertex(position);
     position << 1.0, -1.0;
     mesh->createVertex(position);
-    position << 2.0,  0.0;
+    position << 2.0, 0.0;
     mesh->createVertex(position);
     position << 2.0, -1.0;
-    mesh->createVertex(position);    
-    break;    
+    mesh->createVertex(position);
+    break;
   }
   }
 
   mesh->computeState();
 
-  // create the communicator for m2n mesh and communciation map exchange 
-  com::PtrCommunication participantsCom =  com::PtrCommunication(new com::SocketCommunication());
-  com::PtrCommunicationFactory participantComFactory =  com::PtrCommunicationFactory(new com::SocketCommunicationFactory);
-  m2n::DistributedComFactory::SharedPointer distributionFactory = m2n::DistributedComFactory::SharedPointer(new m2n::PointToPointComFactory(participantComFactory));
-  m2n::PtrM2N p2p = m2n::PtrM2N(new m2n::M2N(participantsCom, distributionFactory));
+  // create the communicator for m2n mesh and communciation map exchange
+  com::PtrCommunication                     participantsCom       = com::PtrCommunication(new com::SocketCommunication());
+  com::PtrCommunicationFactory              participantComFactory = com::PtrCommunicationFactory(new com::SocketCommunicationFactory);
+  m2n::DistributedComFactory::SharedPointer distributionFactory   = m2n::DistributedComFactory::SharedPointer(new m2n::PointToPointComFactory(participantComFactory));
+  m2n::PtrM2N                               p2p                   = m2n::PtrM2N(new m2n::M2N(participantsCom, distributionFactory));
 
   setupM2NBaseEnvironment(p2p);
-  
-  if(utils::Parallel::getProcessRank() < 2)
-  {
+
+  if (utils::Parallel::getProcessRank() < 2) {
     p2p->createDistributedCommunication(mesh);
     ProvidedBoundingBox part(mesh, hasToSend, safetyFactor);
     part.addM2N(p2p);
@@ -612,77 +578,66 @@ BOOST_AUTO_TEST_CASE(TestCompute2D, * testing::OnSize(4))
     part.communicateBoundingBox();
     part.computeBoundingBox();
 
-    if(utils::Parallel::getProcessRank() == 0 )
-    {      
+    if (utils::Parallel::getProcessRank() == 0) {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
       BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
       BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
-    }
-    else
-    {
+    } else {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
       BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
       BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
     }
 
-     p2p->acceptSlavesPreConnection("FluidSlaves", "SolidSlaves");
-    
-     part.communicate();
-     part.compute();
-    
+    p2p->acceptSlavesPreConnection("FluidSlaves", "SolidSlaves");
 
-    if(utils::Parallel::getProcessRank() == 0 )
-    {
+    part.communicate();
+    part.compute();
+
+    if (utils::Parallel::getProcessRank() == 0) {
       BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
-      BOOST_TEST(mesh->getCommunicationMap()[0][1] == 1);      
-    }
-    else
-    {
+      BOOST_TEST(mesh->getCommunicationMap()[0][1] == 1);
+    } else {
       BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
       BOOST_TEST(mesh->getCommunicationMap()[1][0] == 1);
       BOOST_TEST(mesh->getCommunicationMap()[1][1] == 2);
-    } 
-    
-  }
-  else
-  {
+    }
+
+  } else {
     p2p->createDistributedCommunication(receivedMesh);
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
-    mapping::PtrMapping boundingToMapping = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSERVATIVE, dimensions));
+    mapping::PtrMapping boundingToMapping   = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSERVATIVE, dimensions));
     boundingFromMapping->setMeshes(receivedMesh, mesh);
     boundingToMapping->setMeshes(mesh, receivedMesh);
 
-    ReceivedBoundingBox part(receivedMesh, safetyFactor);  
-   
+    ReceivedBoundingBox part(receivedMesh, safetyFactor);
+
     part.addM2N(p2p);
 
     part.setFromMapping(boundingFromMapping);
     part.setToMapping(boundingToMapping);
 
-    part.communicateBoundingBox();    
-    part.computeBoundingBox(); 
+    part.communicateBoundingBox();
+    part.computeBoundingBox();
 
     p2p->requestSlavesPreConnection("FluidSlaves", "SolidSlaves");
-    
+
     part.communicate();
     part.compute();
   }
   tearDownParallelEnvironment();
 }
 
-
-
-BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestCompute3D, *testing::OnSize(4))
 {
 
   //mesh creation
-  int dimensions = 3;
-  bool flipNormals = true;
-  double safetyFactor = 0.0;
-  bool hasToSend=true;
+  int           dimensions   = 3;
+  bool          flipNormals  = true;
+  double        safetyFactor = 0.0;
+  bool          hasToSend    = true;
   mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
   mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
-  
+
   switch (utils::Parallel::getProcessRank()) {
   case 0: {
     Eigen::VectorXd position(dimensions);
@@ -690,7 +645,7 @@ BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
     mesh->createVertex(position);
     position << -1.0, 0.0, 0.0;
     mesh->createVertex(position);
-    position <<  0.0, 1.0, 1.0;
+    position << 0.0, 1.0, 1.0;
     mesh->createVertex(position);
     position << -1.0, 1.0, 1.0;
     mesh->createVertex(position);
@@ -703,23 +658,23 @@ BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
     Eigen::VectorXd position(dimensions);
     position << -0.5, 0.0, 0.0;
     mesh->createVertex(position);
-    position <<  1.0, 0.0, 0.0;
+    position << 1.0, 0.0, 0.0;
     mesh->createVertex(position);
-    position <<  2.0, 0.0, 0.0;
+    position << 2.0, 0.0, 0.0;
     mesh->createVertex(position);
-    position <<  2.0, 1.0, 1.0;
+    position << 2.0, 1.0, 1.0;
     mesh->createVertex(position);
-    position <<  1.0, 1.0, 1.0;
+    position << 1.0, 1.0, 1.0;
     mesh->createVertex(position);
     break;
   }
-  case 2: { 
+  case 2: {
     Eigen::VectorXd position(dimensions);
-    position <<  0.0,  0.0, 0.0;
+    position << 0.0, 0.0, 0.0;
     mesh->createVertex(position);
-    position <<  0.0, -1.0, 1.0;
+    position << 0.0, -1.0, 1.0;
     mesh->createVertex(position);
-    position << -1.0,  0.0, 0.0;
+    position << -1.0, 0.0, 0.0;
     mesh->createVertex(position);
     position << -1.0, -1.0, 1.0;
     mesh->createVertex(position);
@@ -727,55 +682,50 @@ BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
     mesh->createVertex(position);
     position << -2.0, -1.0, 1.0;
     mesh->createVertex(position);
-    
+
     break;
   }
   case 3: {
     Eigen::VectorXd position(dimensions);
-    position << 0.0,  0.0, 0.0;
+    position << 0.0, 0.0, 0.0;
     mesh->createVertex(position);
-    position << 1.0,  0.0, 0.0;
+    position << 1.0, 0.0, 0.0;
     mesh->createVertex(position);
     position << 0.0, -1.0, 1.0;
     mesh->createVertex(position);
     position << 1.0, -1.0, 1.0;
     mesh->createVertex(position);
-    position << 2.0,  0.0, 0.0;
+    position << 2.0, 0.0, 0.0;
     mesh->createVertex(position);
     position << 2.0, -1.0, 0.0;
-    mesh->createVertex(position);    
-    break;    
+    mesh->createVertex(position);
+    break;
   }
   }
 
   mesh->computeState();
 
-
-  // create the communicator for m2n mesh and communciation map exchange 
-  com::PtrCommunication participantsCom =  com::PtrCommunication(new com::SocketCommunication());
-  com::PtrCommunicationFactory participantComFactory =  com::PtrCommunicationFactory(new com::SocketCommunicationFactory);
-  m2n::DistributedComFactory::SharedPointer distributionFactory = m2n::DistributedComFactory::SharedPointer(new m2n::PointToPointComFactory(participantComFactory));
-  m2n::PtrM2N p2p = m2n::PtrM2N(new m2n::M2N(participantsCom, distributionFactory));
+  // create the communicator for m2n mesh and communciation map exchange
+  com::PtrCommunication                     participantsCom       = com::PtrCommunication(new com::SocketCommunication());
+  com::PtrCommunicationFactory              participantComFactory = com::PtrCommunicationFactory(new com::SocketCommunicationFactory);
+  m2n::DistributedComFactory::SharedPointer distributionFactory   = m2n::DistributedComFactory::SharedPointer(new m2n::PointToPointComFactory(participantComFactory));
+  m2n::PtrM2N                               p2p                   = m2n::PtrM2N(new m2n::M2N(participantsCom, distributionFactory));
 
   setupM2NBaseEnvironment(p2p);
-  
-  if(utils::Parallel::getProcessRank() < 2)
-  {
+
+  if (utils::Parallel::getProcessRank() < 2) {
     p2p->createDistributedCommunication(mesh);
     ProvidedBoundingBox part(mesh, hasToSend, safetyFactor);
     part.addM2N(p2p);
-    
+
     part.communicateBoundingBox();
     part.computeBoundingBox();
 
-    if(utils::Parallel::getProcessRank() == 0 )
-    {      
+    if (utils::Parallel::getProcessRank() == 0) {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
       BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
       BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
-    }
-    else
-    {
+    } else {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
       BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
       BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
@@ -785,24 +735,19 @@ BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
 
     part.communicate();
     part.compute();
-    
-    if(utils::Parallel::getProcessRank() == 0 )
-    {
+
+    if (utils::Parallel::getProcessRank() == 0) {
       BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
-      BOOST_TEST(mesh->getCommunicationMap()[0][1] == 1);      
-    }
-    else
-    {
+      BOOST_TEST(mesh->getCommunicationMap()[0][1] == 1);
+    } else {
       BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
       BOOST_TEST(mesh->getCommunicationMap()[1][0] == 1);
       BOOST_TEST(mesh->getCommunicationMap()[1][1] == 2);
-    }     
-  }
-  else
-  {
+    }
+  } else {
     p2p->createDistributedCommunication(receivedMesh);
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
-    mapping::PtrMapping boundingToMapping = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSERVATIVE, dimensions));
+    mapping::PtrMapping boundingToMapping   = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSERVATIVE, dimensions));
     boundingFromMapping->setMeshes(receivedMesh, mesh);
     boundingToMapping->setMeshes(mesh, receivedMesh);
 
@@ -811,18 +756,16 @@ BOOST_AUTO_TEST_CASE(TestCompute3D, * testing::OnSize(4))
 
     part.setFromMapping(boundingFromMapping);
     part.setToMapping(boundingToMapping);
-    part.communicateBoundingBox();    
+    part.communicateBoundingBox();
     part.computeBoundingBox();
 
     p2p->requestSlavesPreConnection("FluidSlaves", "SolidSlaves");
-     
+
     part.communicate();
     part.compute();
   }
   tearDownParallelEnvironment();
 }
-
-
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -41,8 +41,8 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
     utils::MasterSlave::configure(3, 2);
   }
 
-  if(utils::Parallel::getProcessRank() == 1){//Master
-    masterSlaveCom->acceptConnection ( "SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
+  if (utils::Parallel::getProcessRank() == 1) { //Master
+    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
     masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 0, 2);

--- a/src/partition/tests/ReceivedBoundingBoxTest.cpp
+++ b/src/partition/tests/ReceivedBoundingBoxTest.cpp
@@ -1,22 +1,22 @@
 #ifndef PRECICE_NO_MPI
-#include "testing/Testing.hpp"
 #include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 
-#include "partition/ProvidedBoundingBox.hpp"
-#include "partition/ReceivedBoundingBox.hpp"
-#include "partition/SharedPointer.hpp"
-#include "utils/Parallel.hpp"
+#include "com/CommunicateBoundingBox.hpp"
+#include "com/CommunicationFactory.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "com/MPIPortsCommunicationFactory.hpp"
 #include "com/SocketCommunication.hpp"
 #include "com/SocketCommunicationFactory.hpp"
-#include "com/CommunicateBoundingBox.hpp"
 #include "mapping/NearestNeighborMapping.hpp"
 #include "mapping/NearestProjectionMapping.hpp"
 #include "mapping/PetRadialBasisFctMapping.hpp"
+#include "partition/ProvidedBoundingBox.hpp"
+#include "partition/ReceivedBoundingBox.hpp"
+#include "partition/SharedPointer.hpp"
 #include "utils/MasterSlave.hpp"
-#include "com/CommunicationFactory.hpp"
+#include "utils/Parallel.hpp"
 
 using namespace precice;
 using namespace partition;
@@ -31,7 +31,7 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
   com::PtrCommunication masterSlaveCom = com::PtrCommunication(new com::MPIDirectCommunication());
   utils::MasterSlave::_communication   = masterSlaveCom;
 
-  if (utils::Parallel::getProcessRank() == 0) { 
+  if (utils::Parallel::getProcessRank() == 0) {
     utils::Parallel::splitCommunicator("Fluid");
     m2n->acceptMasterConnection("Fluid", "SolidMaster");
   } else if (utils::Parallel::getProcessRank() == 1) { //Master
@@ -46,8 +46,8 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
     utils::MasterSlave::configure(2, 3);
   }
 
-  if(utils::Parallel::getProcessRank() == 1){//Master
-    masterSlaveCom->acceptConnection ( "SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
+  if (utils::Parallel::getProcessRank() == 1) { //Master
+    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
     masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 0, 2);
@@ -56,8 +56,8 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
   }
 }
 
-
-void tearDownParallelEnvironment(){
+void tearDownParallelEnvironment()
+{
   utils::MasterSlave::_communication = nullptr;
   utils::MasterSlave::reset();
   //utils::Parallel::synchronizeProcesses();
@@ -65,7 +65,6 @@ void tearDownParallelEnvironment(){
   mesh::Data::resetDataCount();
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
 }
-
 
 void createNastinMesh2D(mesh::PtrMesh pNastinMesh)
 {
@@ -80,7 +79,7 @@ void createNastinMesh2D(mesh::PtrMesh pNastinMesh)
     pNastinMesh->createVertex(position);
     position << 0.90, 0.90;
     pNastinMesh->createVertex(position);
-  } else if (utils::Parallel::getProcessRank() == 2) {    
+  } else if (utils::Parallel::getProcessRank() == 2) {
     // not at interface
   } else if (utils::Parallel::getProcessRank() == 3) {
 
@@ -105,7 +104,7 @@ void createNastinMesh3D(mesh::PtrMesh pNastinMesh)
     pNastinMesh->createVertex(position);
     position << 0.90, 0.90, 0.9;
     pNastinMesh->createVertex(position);
-  } else if (utils::Parallel::getProcessRank() == 2) {    
+  } else if (utils::Parallel::getProcessRank() == 2) {
     // not at interface
   } else if (utils::Parallel::getProcessRank() == 3) {
 
@@ -117,8 +116,7 @@ void createNastinMesh3D(mesh::PtrMesh pNastinMesh)
   }
 }
 
-
-BOOST_AUTO_TEST_CASE(TestConnectionMap2D, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestConnectionMap2D, *testing::OnSize(4))
 {
   com::PtrCommunication participantCom =
       com::PtrCommunication(new com::SocketCommunication());
@@ -128,51 +126,46 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap2D, * testing::OnSize(4))
 
   setupParallelEnvironment(m2n);
 
-  int dimensions = 2;
+  int  dimensions  = 2;
   bool flipNormals = true;
 
-  BOOST_TEST(utils::Parallel::getCommunicatorSize()==4); 
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
   // construct send global boundingbox
   mesh::Mesh::BoundingBoxMap sendGlobalBB;
-  mesh::Mesh::BoundingBox initialBB;  
-  for (int remoteRank = 0; remoteRank < 3; remoteRank++ )
-  {
-    for (int i=0; i < dimensions; i++) {
-      initialBB.push_back(std::make_pair(3-remoteRank-1,3-remoteRank));
-    }    
-    sendGlobalBB[remoteRank]= initialBB;
+  mesh::Mesh::BoundingBox    initialBB;
+  for (int remoteRank = 0; remoteRank < 3; remoteRank++) {
+    for (int i = 0; i < dimensions; i++) {
+      initialBB.push_back(std::make_pair(3 - remoteRank - 1, 3 - remoteRank));
+    }
+    sendGlobalBB[remoteRank] = initialBB;
     initialBB.clear();
   }
-    
-  if (utils::Parallel::getProcessRank() == 0)
-  {
-    std::vector<int> connectedRanksList;
-    int connectionMapSize = 0;
+
+  if (utils::Parallel::getProcessRank() == 0) {
+    std::vector<int>                connectedRanksList;
+    int                             connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));     
-    m2n->getMasterCommunication()->send(3, 0);     
-    com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0 );
+    mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    m2n->getMasterCommunication()->send(3, 0);
+    com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0);
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
     connectionMapSize = connectedRanksList.size();
     BOOST_TEST(connectionMapSize == 2);
 
     std::vector<int> connectedRanks;
     connectedRanks.push_back(-1);
-    for (auto &rank : connectedRanksList)
-    {      
-      receivedConnectionMap[rank]=connectedRanks;
+    for (auto &rank : connectedRanksList) {
+      receivedConnectionMap[rank] = connectedRanks;
     }
-    
-    com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveConnectionMap(receivedConnectionMap, 0 );
+
+    com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveConnectionMap(receivedConnectionMap, 0);
 
     // test whether we receive correct connection map
     BOOST_TEST(receivedConnectionMap[0][0] == 2);
     BOOST_TEST(receivedConnectionMap[2][0] == 0);
 
-  }  
-  else
-  {
+  } else {
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
     mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
@@ -184,22 +177,22 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap2D, * testing::OnSize(4))
     boundingFromMapping->setMeshes(pSolidzMesh, pNastinMesh);
     boundingToMapping->setMeshes(pNastinMesh, pSolidzMesh);
 
-    createNastinMesh2D(pNastinMesh);   
+    createNastinMesh2D(pNastinMesh);
     pNastinMesh->computeState();
 
     double safetyFactor = 0.0;
-    
+
     ReceivedBoundingBox part(pSolidzMesh, safetyFactor);
     part.addM2N(m2n);
     part.setFromMapping(boundingFromMapping);
     part.setToMapping(boundingToMapping);
     part.communicateBoundingBox();
-    part.computeBoundingBox();    
-  }  
+    part.computeBoundingBox();
+  }
   tearDownParallelEnvironment();
 }
 
-BOOST_AUTO_TEST_CASE(TestConnectionMap3D, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestConnectionMap3D, *testing::OnSize(4))
 {
   com::PtrCommunication participantCom =
       com::PtrCommunication(new com::SocketCommunication());
@@ -209,51 +202,46 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap3D, * testing::OnSize(4))
 
   setupParallelEnvironment(m2n);
 
-  int dimensions = 3;
+  int  dimensions  = 3;
   bool flipNormals = true;
 
-  BOOST_TEST(utils::Parallel::getCommunicatorSize()==4); 
+  BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
 
   // construct send global boundingbox
   mesh::Mesh::BoundingBoxMap sendGlobalBB;
-  mesh::Mesh::BoundingBox initialBB;  
-  for (int remoteRank = 0; remoteRank < 3; remoteRank++ )
-  {
-    for (int i=0; i < dimensions; i++) {
-      initialBB.push_back(std::make_pair(3-remoteRank-1,3-remoteRank));
-    }    
-    sendGlobalBB[remoteRank]= initialBB;
+  mesh::Mesh::BoundingBox    initialBB;
+  for (int remoteRank = 0; remoteRank < 3; remoteRank++) {
+    for (int i = 0; i < dimensions; i++) {
+      initialBB.push_back(std::make_pair(3 - remoteRank - 1, 3 - remoteRank));
+    }
+    sendGlobalBB[remoteRank] = initialBB;
     initialBB.clear();
   }
-    
-  if (utils::Parallel::getProcessRank() == 0)
-  {
-    std::vector<int> connectedRanksList;
-    int connectionMapSize = 0;
+
+  if (utils::Parallel::getProcessRank() == 0) {
+    std::vector<int>                connectedRanksList;
+    int                             connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));     
-    m2n->getMasterCommunication()->send(3, 0);     
-    com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0 );
+    mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    m2n->getMasterCommunication()->send(3, 0);
+    com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0);
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
     connectionMapSize = connectedRanksList.size();
     BOOST_TEST(connectionMapSize == 2);
 
     std::vector<int> connectedRanks;
     connectedRanks.push_back(-1);
-    for (auto &rank : connectedRanksList)
-    {      
-      receivedConnectionMap[rank]=connectedRanks;
+    for (auto &rank : connectedRanksList) {
+      receivedConnectionMap[rank] = connectedRanks;
     }
-    
-    com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveConnectionMap(receivedConnectionMap, 0 );
+
+    com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveConnectionMap(receivedConnectionMap, 0);
 
     // test whether we receive correct connection map
     BOOST_TEST(receivedConnectionMap[0][0] == 2);
     BOOST_TEST(receivedConnectionMap[2][0] == 0);
 
-  }  
-  else
-  {
+  } else {
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
     mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
 
@@ -265,18 +253,18 @@ BOOST_AUTO_TEST_CASE(TestConnectionMap3D, * testing::OnSize(4))
     boundingFromMapping->setMeshes(pSolidzMesh, pNastinMesh);
     boundingToMapping->setMeshes(pNastinMesh, pSolidzMesh);
 
-    createNastinMesh3D(pNastinMesh);   
+    createNastinMesh3D(pNastinMesh);
     pNastinMesh->computeState();
 
     double safetyFactor = 0.0;
-    
+
     ReceivedBoundingBox part(pSolidzMesh, safetyFactor);
     part.addM2N(m2n);
     part.setFromMapping(boundingFromMapping);
     part.setToMapping(boundingToMapping);
     part.communicateBoundingBox();
-    part.computeBoundingBox();    
-  }  
+    part.computeBoundingBox();
+  }
   tearDownParallelEnvironment();
 }
 

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -45,8 +45,8 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
     utils::MasterSlave::configure(2, 3);
   }
 
-  if(utils::Parallel::getProcessRank() == 1){//Master
-    masterSlaveCom->acceptConnection ( "FluidMaster", "FluidSlaves", utils::Parallel::getProcessRank());
+  if (utils::Parallel::getProcessRank() == 1) { //Master
+    masterSlaveCom->acceptConnection("FluidMaster", "FluidSlaves", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
     masterSlaveCom->requestConnection("FluidMaster", "FluidSlaves", 0, 2);

--- a/src/precice/MeshHandle.cpp
+++ b/src/precice/MeshHandle.cpp
@@ -1,25 +1,25 @@
 #include "precice/MeshHandle.hpp"
-#include "mesh/Vertex.hpp"
 #include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
 
 namespace precice {
-  namespace impl {
+namespace impl {
 
-    struct VertexIteratorImplementation {
-      mesh::Mesh::VertexContainer::const_iterator iterator;
-    };
+struct VertexIteratorImplementation {
+  mesh::Mesh::VertexContainer::const_iterator iterator;
+};
 
-    struct EdgeIteratorImplementation {
-      mesh::Mesh::EdgeContainer::const_iterator iterator;
-    };
+struct EdgeIteratorImplementation {
+  mesh::Mesh::EdgeContainer::const_iterator iterator;
+};
 
-    struct TriangleIteratorImplementation {
-      mesh::Mesh::TriangleContainer::const_iterator iterator;
-    };
-  }
-}
+struct TriangleIteratorImplementation {
+  mesh::Mesh::TriangleContainer::const_iterator iterator;
+};
+} // namespace impl
+} // namespace precice
 
 namespace precice {
 
@@ -33,46 +33,43 @@ VertexIterator::~VertexIterator()
   delete _impl;
 }
 
-VertexIterator:: VertexIterator
-(
-  const mesh::Mesh& content,
-  bool               begin )
+VertexIterator::VertexIterator(
+    const mesh::Mesh &content,
+    bool              begin)
 {
-  if ( begin ) {
+  if (begin) {
     _impl = new Impl{content.vertices().begin()};
-  }
-  else  {
+  } else {
     _impl = new Impl{content.vertices().end()};
   }
 }
 
-VertexIterator:: VertexIterator
-(
-  const VertexIterator& toCopy ) : _impl(NULL)
+VertexIterator::VertexIterator(
+    const VertexIterator &toCopy)
+    : _impl(NULL)
 {
-    if (toCopy._impl) {
-        this->_impl = new Impl{toCopy._impl->iterator};
-    }
+  if (toCopy._impl) {
+    this->_impl = new Impl{toCopy._impl->iterator};
+  }
 }
 
-VertexIterator & VertexIterator:: operator=
-(
-  const VertexIterator& toAssign )
+VertexIterator &VertexIterator::operator=(
+    const VertexIterator &toAssign)
 {
-    VertexIterator cpy(toAssign);
-    using std::swap;
-    swap(*this, cpy);
-    return *this;
+  VertexIterator cpy(toAssign);
+  using std::swap;
+  swap(*this, cpy);
+  return *this;
 }
 
-VertexIterator VertexIterator:: operator++(int unused)
+VertexIterator VertexIterator::operator++(int unused)
 {
   VertexIterator cpy(*this);
-  this->operator++();
+  this->         operator++();
   return cpy;
 }
 
-VertexIterator& VertexIterator::operator++()
+VertexIterator &VertexIterator::operator++()
 {
   _impl->iterator.operator++();
   return *this;
@@ -83,56 +80,55 @@ const VertexIterator VertexIterator::operator*() const
   return *this;
 }
 
-bool VertexIterator::operator==(const VertexIterator& other) const
+bool VertexIterator::operator==(const VertexIterator &other) const
 {
   return _impl->iterator == other._impl->iterator;
 }
 
-bool VertexIterator::operator!=(const VertexIterator& other) const
+bool VertexIterator::operator!=(const VertexIterator &other) const
 {
   return !((*this) == other);
 }
 
-const double* VertexIterator:: vertexCoords() const
+const double *VertexIterator::vertexCoords() const
 {
   return (*_impl->iterator).getCoords().data();
 }
 
-int VertexIterator:: vertexID() const
+int VertexIterator::vertexID() const
 {
   return (*_impl->iterator).getID();
 }
 
-void VertexIterator::swap(VertexIterator& other)
+void VertexIterator::swap(VertexIterator &other)
 {
-    std::swap(_impl, other._impl);
+  std::swap(_impl, other._impl);
 }
 
-void swap(VertexIterator& lhs, VertexIterator& rhs)
+void swap(VertexIterator &lhs, VertexIterator &rhs)
 {
-    lhs.swap(rhs);
+  lhs.swap(rhs);
 }
 
 // VertexHandle
 
-VertexHandle:: VertexHandle
-(
-  const mesh::Mesh& mesh )
-:
-  _content ( mesh )
-{}
+VertexHandle::VertexHandle(
+    const mesh::Mesh &mesh)
+    : _content(mesh)
+{
+}
 
-VertexIterator VertexHandle:: begin() const
+VertexIterator VertexHandle::begin() const
 {
   return VertexIterator(_content, true);
 }
 
-VertexIterator VertexHandle:: end() const
+VertexIterator VertexHandle::end() const
 {
   return VertexIterator(_content, false);
 }
 
-std::size_t VertexHandle:: size() const
+std::size_t VertexHandle::size() const
 {
   return _content.vertices().size();
 }
@@ -147,42 +143,41 @@ EdgeIterator::~EdgeIterator()
   delete _impl;
 }
 
-EdgeIterator:: EdgeIterator
-(
-  const mesh::Mesh& content,
-  bool               begin )
+EdgeIterator::EdgeIterator(
+    const mesh::Mesh &content,
+    bool              begin)
 {
-  if ( begin ) {
-    _impl=new Impl{content.edges().begin()};
-  }
-  else  {
-    _impl=new Impl{content.edges().end()};
+  if (begin) {
+    _impl = new Impl{content.edges().begin()};
+  } else {
+    _impl = new Impl{content.edges().end()};
   }
 }
 
-EdgeIterator:: EdgeIterator(const EdgeIterator& toCopy) : _impl(NULL)
+EdgeIterator::EdgeIterator(const EdgeIterator &toCopy)
+    : _impl(NULL)
 {
-    if (toCopy._impl) {
-        this->_impl = new Impl{toCopy._impl->iterator};
-    }
+  if (toCopy._impl) {
+    this->_impl = new Impl{toCopy._impl->iterator};
+  }
 }
 
-EdgeIterator & EdgeIterator:: operator=(const EdgeIterator& other)
+EdgeIterator &EdgeIterator::operator=(const EdgeIterator &other)
 {
-    EdgeIterator cpy(other);
-    using std::swap;
-    swap(*this, cpy);
-    return *this;
+  EdgeIterator cpy(other);
+  using std::swap;
+  swap(*this, cpy);
+  return *this;
 }
 
-EdgeIterator EdgeIterator:: operator++(int unused)
+EdgeIterator EdgeIterator::operator++(int unused)
 {
   EdgeIterator cpy(*this);
-  this->operator++();
+  this->       operator++();
   return cpy;
 }
 
-EdgeIterator& EdgeIterator::operator++()
+EdgeIterator &EdgeIterator::operator++()
 {
   _impl->iterator.operator++();
   return *this;
@@ -193,57 +188,55 @@ const EdgeIterator EdgeIterator::operator*() const
   return *this;
 }
 
-bool EdgeIterator::operator==(const EdgeIterator& other) const
+bool EdgeIterator::operator==(const EdgeIterator &other) const
 {
   return _impl->iterator == other._impl->iterator;
 }
 
-bool EdgeIterator::operator!=(const EdgeIterator& other) const
+bool EdgeIterator::operator!=(const EdgeIterator &other) const
 {
   return !((*this) == other);
 }
 
-
-const double* EdgeIterator:: vertexCoords(int vertexIndex) const
+const double *EdgeIterator::vertexCoords(int vertexIndex) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getCoords().data();
 }
 
-int EdgeIterator:: vertexID(int vertexIndex) const
+int EdgeIterator::vertexID(int vertexIndex) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getID();
 }
 
-void EdgeIterator::swap(EdgeIterator& other)
+void EdgeIterator::swap(EdgeIterator &other)
 {
-    std::swap(_impl, other._impl);
+  std::swap(_impl, other._impl);
 }
 
-void swap(EdgeIterator& lhs, EdgeIterator& rhs)
+void swap(EdgeIterator &lhs, EdgeIterator &rhs)
 {
-    lhs.swap(rhs);
+  lhs.swap(rhs);
 }
 
 // EdgeHandle
 
-EdgeHandle:: EdgeHandle
-(
-  const mesh::Mesh & content )
-:
-  _content ( content )
-{}
-
-EdgeIterator EdgeHandle:: begin () const
+EdgeHandle::EdgeHandle(
+    const mesh::Mesh &content)
+    : _content(content)
 {
-  return EdgeIterator ( _content, true );
 }
 
-EdgeIterator EdgeHandle:: end () const
+EdgeIterator EdgeHandle::begin() const
 {
-  return EdgeIterator ( _content, false );
+  return EdgeIterator(_content, true);
 }
 
-std::size_t EdgeHandle:: size () const
+EdgeIterator EdgeHandle::end() const
+{
+  return EdgeIterator(_content, false);
+}
+
+std::size_t EdgeHandle::size() const
 {
   return _content.edges().size();
 }
@@ -258,42 +251,41 @@ TriangleIterator::~TriangleIterator()
   delete _impl;
 }
 
-TriangleIterator:: TriangleIterator
-(
-  const mesh::Mesh& content,
-  bool               begin )
+TriangleIterator::TriangleIterator(
+    const mesh::Mesh &content,
+    bool              begin)
 {
-  if ( begin ) {
+  if (begin) {
     _impl = new Impl{content.triangles().begin()};
-  }
-  else  {
+  } else {
     _impl = new Impl{content.triangles().end()};
   }
 }
 
-TriangleIterator:: TriangleIterator(const TriangleIterator& toCopy) : _impl(NULL)
+TriangleIterator::TriangleIterator(const TriangleIterator &toCopy)
+    : _impl(NULL)
 {
-    if (toCopy._impl) {
-        this->_impl = new Impl{toCopy._impl->iterator};
-    }
+  if (toCopy._impl) {
+    this->_impl = new Impl{toCopy._impl->iterator};
+  }
 }
 
-TriangleIterator & TriangleIterator:: operator=(const TriangleIterator& other)
+TriangleIterator &TriangleIterator::operator=(const TriangleIterator &other)
 {
-    TriangleIterator cpy(other);
-    using std::swap;
-    swap(*this, cpy);
-    return *this;
+  TriangleIterator cpy(other);
+  using std::swap;
+  swap(*this, cpy);
+  return *this;
 }
 
-TriangleIterator TriangleIterator:: operator++(int unused)
+TriangleIterator TriangleIterator::operator++(int unused)
 {
   TriangleIterator cpy(*this);
-  this->operator++();
+  this->           operator++();
   return cpy;
 }
 
-TriangleIterator& TriangleIterator::operator++()
+TriangleIterator &TriangleIterator::operator++()
 {
   _impl->iterator.operator++();
   return *this;
@@ -304,87 +296,82 @@ const TriangleIterator TriangleIterator::operator*() const
   return *this;
 }
 
-bool TriangleIterator::operator==(const TriangleIterator& other) const
+bool TriangleIterator::operator==(const TriangleIterator &other) const
 {
   return _impl->iterator == other._impl->iterator;
 }
 
-bool TriangleIterator::operator!= ( const TriangleIterator& other ) const
+bool TriangleIterator::operator!=(const TriangleIterator &other) const
 {
   return !((*this) == other);
 }
 
-
-const double* TriangleIterator:: vertexCoords ( int vertexIndex ) const
+const double *TriangleIterator::vertexCoords(int vertexIndex) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getCoords().data();
 }
 
-int TriangleIterator:: vertexID ( int vertexIndex ) const
+int TriangleIterator::vertexID(int vertexIndex) const
 {
   return (*_impl->iterator).vertex(vertexIndex).getID();
 }
 
-void TriangleIterator::swap(TriangleIterator& other)
+void TriangleIterator::swap(TriangleIterator &other)
 {
-    std::swap(_impl, other._impl);
+  std::swap(_impl, other._impl);
 }
 
-void swap(TriangleIterator& lhs, TriangleIterator& rhs)
+void swap(TriangleIterator &lhs, TriangleIterator &rhs)
 {
-    lhs.swap(rhs);
+  lhs.swap(rhs);
 }
 
 // TriangleHandle
 
-TriangleHandle:: TriangleHandle
-(
-  const mesh::Mesh & content )
-:
-  _content ( content )
-{}
-
-
-TriangleIterator TriangleHandle:: begin () const
+TriangleHandle::TriangleHandle(
+    const mesh::Mesh &content)
+    : _content(content)
 {
-  return TriangleIterator ( _content, true );
 }
 
-
-TriangleIterator TriangleHandle:: end () const
+TriangleIterator TriangleHandle::begin() const
 {
-  return TriangleIterator ( _content, false );
+  return TriangleIterator(_content, true);
 }
 
-std::size_t TriangleHandle:: size () const
+TriangleIterator TriangleHandle::end() const
+{
+  return TriangleIterator(_content, false);
+}
+
+std::size_t TriangleHandle::size() const
 {
   return _content.triangles().size();
 }
 
 // MeshHandle
 
-MeshHandle:: MeshHandle
-(
-  const mesh::Mesh & content )
-:
-  _vertexHandle ( content ),
-  _edgeHandle ( content ),
-  _triangleHandle ( content )
-{}
+MeshHandle::MeshHandle(
+    const mesh::Mesh &content)
+    : _vertexHandle(content),
+      _edgeHandle(content),
+      _triangleHandle(content)
+{
+}
 
-const VertexHandle & MeshHandle:: vertices () const
+const VertexHandle &MeshHandle::vertices() const
 {
   return _vertexHandle;
 }
 
-const EdgeHandle & MeshHandle:: edges () const
+const EdgeHandle &MeshHandle::edges() const
 {
   return _edgeHandle;
 }
 
-const TriangleHandle & MeshHandle:: triangles () const
+const TriangleHandle &MeshHandle::triangles() const
 {
   return _triangleHandle;
 }
 
-} // nammespace precice
+} // namespace precice

--- a/src/precice/MeshHandle.hpp
+++ b/src/precice/MeshHandle.hpp
@@ -1,29 +1,27 @@
 #pragma once
 
-#include <vector>
 #include <cstddef>
 #include <iterator>
+#include <vector>
 
 namespace precice {
-  namespace mesh {
-    class Mesh;
-  }
-  namespace impl {
-    struct VertexIteratorImplementation;
-    struct EdgeIteratorImplementation;
-    struct TriangleIteratorImplementation;
-    // no quad iterator yet
-  }
+namespace mesh {
+class Mesh;
 }
-
+namespace impl {
+struct VertexIteratorImplementation;
+struct EdgeIteratorImplementation;
+struct TriangleIteratorImplementation;
+// no quad iterator yet
+} // namespace impl
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
 namespace precice {
 
 /// Iterator over vertex coordinates and IDs.
-class VertexIterator
-{
+class VertexIterator {
 public:
   using value_type        = VertexIterator;
   using reference         = VertexIterator &;
@@ -39,19 +37,19 @@ public:
    * @param[in] content the group of a mesh
    * @param[in] begin true for the begin, and false for the end-iterator
    */
-  VertexIterator (
-    const mesh::Mesh& content,
-    bool               begin );
+  VertexIterator(
+      const mesh::Mesh &content,
+      bool              begin);
 
-  VertexIterator ( const VertexIterator& other );
+  VertexIterator(const VertexIterator &other);
 
-  VertexIterator& operator= ( const VertexIterator& other );
+  VertexIterator &operator=(const VertexIterator &other);
 
   /// Postfix operator
   VertexIterator operator++(int unused);
 
   /// Prefix operator
-  VertexIterator& operator++();
+  VertexIterator &operator++();
 
   const VertexIterator operator*() const;
 
@@ -59,30 +57,28 @@ public:
   int vertexID() const;
 
   /// Returns the coordinates of the current vertex
-  const double* vertexCoords() const;
+  const double *vertexCoords() const;
 
-  bool operator== ( const VertexIterator& other ) const;
+  bool operator==(const VertexIterator &other) const;
 
-  bool operator!= ( const VertexIterator& other ) const;
+  bool operator!=(const VertexIterator &other) const;
 
-  void swap(VertexIterator& other);
+  void swap(VertexIterator &other);
 
 private:
   using Impl = impl::VertexIteratorImplementation;
-  Impl* _impl;
+  Impl *_impl;
 };
 
-void swap(VertexIterator& lhs, VertexIterator& rhs);
+void swap(VertexIterator &lhs, VertexIterator &rhs);
 
 /// Offers methods begin() and end() to iterate over all vertices.
-class VertexHandle
-{
+class VertexHandle {
 public:
-
   using const_iterator = VertexIterator;
 
   /// Constructor, reference to mesh object holding vertices required.
-  VertexHandle ( const mesh::Mesh& content );
+  VertexHandle(const mesh::Mesh &content);
 
   /// Returns iterator to begin of the geometry's vertices.
   VertexIterator begin() const;
@@ -93,13 +89,11 @@ public:
   std::size_t size() const;
 
 private:
-
   /// Group instance holding vertices.
-  const mesh::Mesh& _content;
+  const mesh::Mesh &_content;
 };
 
-class EdgeIterator
-{
+class EdgeIterator {
 public:
   using value_type        = EdgeIterator;
   using reference         = EdgeIterator &;
@@ -107,86 +101,81 @@ public:
   using difference_type   = std::size_t;
   using iterator_category = std::forward_iterator_tag;
 
-  EdgeIterator ();
+  EdgeIterator();
 
-  ~EdgeIterator ();
+  ~EdgeIterator();
 
   /** Constructs a edge iterator from a given group.
    * @param[in] content the group of a mesh
    * @param[in] begin true for the begin, and false for the end-iterator
    */
-  EdgeIterator (
-    const mesh::Mesh& mesh,
-    bool              begin );
+  EdgeIterator(
+      const mesh::Mesh &mesh,
+      bool              begin);
 
+  EdgeIterator(const EdgeIterator &other);
 
-  EdgeIterator (const EdgeIterator& other);
-
-  EdgeIterator& operator=(const EdgeIterator& other);
+  EdgeIterator &operator=(const EdgeIterator &other);
 
   EdgeIterator operator++(int);
 
-  EdgeIterator& operator++();
+  EdgeIterator &operator++();
 
   const EdgeIterator operator*() const;
 
   /** Returns the vertex coordinates of a vertex of the current edge
    * @param[in] vertexIndex index of the vertex (0 or 1)
    */
-  const double* vertexCoords ( int vertexIndex ) const;
+  const double *vertexCoords(int vertexIndex) const;
 
   /** Returns the vertex ID of a vertex of the current edge
    * @param[in] vertexIndex index of the vertex (0 or 1)
    */
-  int vertexID ( int vertexIndex ) const;
+  int vertexID(int vertexIndex) const;
 
-  bool operator== ( const EdgeIterator& other ) const;
+  bool operator==(const EdgeIterator &other) const;
 
-  bool operator!= ( const EdgeIterator& other ) const;
+  bool operator!=(const EdgeIterator &other) const;
 
-  void swap(EdgeIterator& other);
+  void swap(EdgeIterator &other);
 
 private:
   using Impl = impl::EdgeIteratorImplementation;
-  Impl* _impl;
+  Impl *_impl;
 };
 
-void swap(EdgeIterator& lhs, EdgeIterator& rhs);
+void swap(EdgeIterator &lhs, EdgeIterator &rhs);
 
 /**
  * @brief Offers methods begin() and end() to iterate over all edges.
  */
-class EdgeHandle
-{
+class EdgeHandle {
 public:
-
   using const_iterator = EdgeIterator;
 
-   /**
+  /**
     * @brief Constructor, reference to mesh object holding edges required.
     */
-   EdgeHandle ( const mesh::Mesh& mesh );
+  EdgeHandle(const mesh::Mesh &mesh);
 
-   /**
+  /**
     * @brief Returns iterator to begin of the geometry's edges.
     */
-   EdgeIterator begin() const;
+  EdgeIterator begin() const;
 
-   /**
+  /**
     * @brief Returns iterator to end of the geometry's edges.
     */
-   EdgeIterator end() const;
+  EdgeIterator end() const;
 
   std::size_t size() const;
 
 private:
-
-   // @brief Mesh instance holding edges.
-   const mesh::Mesh& _content;
+  // @brief Mesh instance holding edges.
+  const mesh::Mesh &_content;
 };
 
-class TriangleIterator
-{
+class TriangleIterator {
 public:
   using value_type        = TriangleIterator;
   using reference         = TriangleIterator &;
@@ -202,73 +191,70 @@ public:
    * @param[in] content the group of a mesh
    * @param[in] begin true for the begin, and false for the end-iterator
    */
-  TriangleIterator (
-    const mesh::Mesh& content,
-    bool               begin );
+  TriangleIterator(
+      const mesh::Mesh &content,
+      bool              begin);
 
-  TriangleIterator (const TriangleIterator& other);
+  TriangleIterator(const TriangleIterator &other);
 
-  TriangleIterator& operator=(const TriangleIterator& other);
+  TriangleIterator &operator=(const TriangleIterator &other);
 
   TriangleIterator operator++(int);
 
-  TriangleIterator& operator++();
+  TriangleIterator &operator++();
 
   const TriangleIterator operator*() const;
 
   /** Returns the vertex coordinates of a vertex of the current traingle
    * @param[in] vertexIndex index of the vertex (0, 1 or 2)
    */
-  const double* vertexCoords ( int vertexIndex ) const;
+  const double *vertexCoords(int vertexIndex) const;
 
   /** Returns the vertex ID of a vertex of the current triangle
    * @param[in] vertexIndex index of the vertex (0, 1 or 2)
    */
-  int vertexID ( int vertexIndex ) const;
+  int vertexID(int vertexIndex) const;
 
-  bool operator== ( const TriangleIterator& other ) const;
+  bool operator==(const TriangleIterator &other) const;
 
-  bool operator!= ( const TriangleIterator& other ) const;
+  bool operator!=(const TriangleIterator &other) const;
 
-  void swap(TriangleIterator& other);
+  void swap(TriangleIterator &other);
 
 private:
   using Impl = impl::TriangleIteratorImplementation;
-  Impl* _impl;
+  Impl *_impl;
 };
 
-void swap(TriangleIterator& lhs, TriangleIterator& rhs);
+void swap(TriangleIterator &lhs, TriangleIterator &rhs);
 
 /**
  * @brief Offers methods begin() and end() to iterate over all triangles.
  */
-class TriangleHandle
-{
+class TriangleHandle {
 public:
-
   using const_iterator = TriangleIterator;
 
-   /**
+  /**
     * @brief Constructor, reference to mesh object holding triangles required.
     */
-   TriangleHandle ( const mesh::Mesh& content );
+  TriangleHandle(const mesh::Mesh &content);
 
-   /**
+  /**
     * @brief Returns iterator to begin of the geometry's triangles.
     */
-   TriangleIterator begin() const;
+  TriangleIterator begin() const;
 
-   /**
+  /**
     * @brief Returns iterator to end of the geometry's triangles.
     */
-   TriangleIterator end() const;
+  TriangleIterator end() const;
 
   std::size_t size() const;
 
 private:
-
-   /// Mesh instance holding triangles.
-   const mesh::Mesh& _content;
+  /// Mesh instance holding triangles.
+  const mesh::Mesh &_content;
 };
 
 /**
@@ -286,44 +272,41 @@ private:
  * by using operator*(). The operator -> is not supported, and does only return
  * pointers to the objects.
  */
-class MeshHandle
-{
+class MeshHandle {
 public:
-
-   /**
+  /**
     * @brief Standard constructor, not meant to be used by a solver.
     *
     * @param[in] content The mesh representing the geometry.
     *
     * @API precice::SolverInterface::getMeshHandle()
     */
-   MeshHandle ( const mesh::Mesh& mesh );
+  MeshHandle(const mesh::Mesh &mesh);
 
-   /**
+  /**
     * @brief Returns handle for Vertex objects.
     */
-   const VertexHandle& vertices () const;
+  const VertexHandle &vertices() const;
 
-   /**
+  /**
     * @brief Returns handle for Edge objects.
     */
-   const EdgeHandle& edges () const;
+  const EdgeHandle &edges() const;
 
-   /**
+  /**
     * @brief Returns handle for Triangle objects.
     */
-   const TriangleHandle& triangles () const;
+  const TriangleHandle &triangles() const;
 
 private:
+  /// Handle for vertices.
+  VertexHandle _vertexHandle;
 
-   /// Handle for vertices.
-   VertexHandle _vertexHandle;
+  /// Handle for edges.
+  EdgeHandle _edgeHandle;
 
-   /// Handle for edges.
-   EdgeHandle _edgeHandle;
-
-   /// Handle for triangles.
-   TriangleHandle _triangleHandle;
+  /// Handle for triangles.
+  TriangleHandle _triangleHandle;
 };
 
 } // namespace precice

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -1,132 +1,121 @@
 #include "precice/SolverInterface.hpp"
-#include "precice/impl/SolverInterfaceImpl.hpp"
 #include "cplscheme/Constants.hpp"
+#include "precice/impl/SolverInterfaceImpl.hpp"
 #include "precice/impl/versions.hpp"
 
 namespace precice {
 
-SolverInterface:: SolverInterface
-(
-  const std::string& participantName,
-  int                solverProcessIndex,
-  int                solverProcessSize )
-:
-  _impl ( new impl::SolverInterfaceImpl(participantName, solverProcessIndex, solverProcessSize, false) )
-{}
+SolverInterface::SolverInterface(
+    const std::string &participantName,
+    int                solverProcessIndex,
+    int                solverProcessSize)
+    : _impl(new impl::SolverInterfaceImpl(participantName, solverProcessIndex, solverProcessSize, false))
+{
+}
 
-SolverInterface:: SolverInterface
-(
-  const std::string& participantName,
-  int                solverProcessIndex,
-  int                solverProcessSize,
-  void*              communicator)
-:
-  _impl ( new impl::SolverInterfaceImpl(participantName, solverProcessIndex, solverProcessSize, false, communicator) )
-{}
+SolverInterface::SolverInterface(
+    const std::string &participantName,
+    int                solverProcessIndex,
+    int                solverProcessSize,
+    void *             communicator)
+    : _impl(new impl::SolverInterfaceImpl(participantName, solverProcessIndex, solverProcessSize, false, communicator))
+{
+}
 
 SolverInterface::~SolverInterface() = default;
 
-void SolverInterface:: configure
-(
-  const std::string& configurationFileName )
+void SolverInterface::configure(
+    const std::string &configurationFileName)
 {
-  _impl->configure ( configurationFileName );
+  _impl->configure(configurationFileName);
 }
 
-double SolverInterface:: initialize()
+double SolverInterface::initialize()
 {
   return _impl->initialize();
 }
 
-void SolverInterface:: initializeData()
+void SolverInterface::initializeData()
 {
   _impl->initializeData();
 }
 
-double SolverInterface:: advance
-(
-  double computedTimestepLength )
+double SolverInterface::advance(
+    double computedTimestepLength)
 {
-  return _impl->advance ( computedTimestepLength );
+  return _impl->advance(computedTimestepLength);
 }
 
-void SolverInterface:: finalize()
+void SolverInterface::finalize()
 {
   return _impl->finalize();
 }
 
-int SolverInterface:: getDimensions() const
+int SolverInterface::getDimensions() const
 {
   return _impl->getDimensions();
 }
 
-bool SolverInterface:: isCouplingOngoing() const
+bool SolverInterface::isCouplingOngoing() const
 {
   return _impl->isCouplingOngoing();
 }
 
-bool SolverInterface:: isReadDataAvailable() const
+bool SolverInterface::isReadDataAvailable() const
 {
   return _impl->isReadDataAvailable();
 }
 
-bool SolverInterface:: isWriteDataRequired
-(
-  double computedTimestepLength ) const
+bool SolverInterface::isWriteDataRequired(
+    double computedTimestepLength) const
 {
   return _impl->isWriteDataRequired(computedTimestepLength);
 }
 
-bool SolverInterface:: isTimestepComplete() const
+bool SolverInterface::isTimestepComplete() const
 {
   return _impl->isTimestepComplete();
 }
 
-bool SolverInterface:: isActionRequired
-(
-  const std::string& action ) const
+bool SolverInterface::isActionRequired(
+    const std::string &action) const
 {
-  return _impl->isActionRequired ( action );
+  return _impl->isActionRequired(action);
 }
 
-void SolverInterface:: fulfilledAction
-(
-  const std::string& action )
+void SolverInterface::fulfilledAction(
+    const std::string &action)
 {
-  _impl->fulfilledAction ( action );
+  _impl->fulfilledAction(action);
 }
 
-bool SolverInterface:: hasMesh
-(
-  const std::string& meshName ) const
+bool SolverInterface::hasMesh(
+    const std::string &meshName) const
 {
-  return _impl->hasMesh ( meshName );
+  return _impl->hasMesh(meshName);
 }
 
-int SolverInterface:: getMeshID
-(
-  const std::string& meshName ) const
+int SolverInterface::getMeshID(
+    const std::string &meshName) const
 {
-  return _impl->getMeshID ( meshName );
+  return _impl->getMeshID(meshName);
 }
 
-std::set<int> SolverInterface:: getMeshIDs() const
+std::set<int> SolverInterface::getMeshIDs() const
 {
   return _impl->getMeshIDs();
 }
 
-bool SolverInterface:: hasData
-(
-  const std::string& dataName, int meshID ) const
+bool SolverInterface::hasData(
+    const std::string &dataName, int meshID) const
 {
-  return _impl->hasData ( dataName, meshID );
+  return _impl->hasData(dataName, meshID);
 }
 
-int SolverInterface:: getDataID
-(
-  const std::string& dataName, int meshID ) const
+int SolverInterface::getDataID(
+    const std::string &dataName, int meshID) const
 {
-  return _impl->getDataID ( dataName, meshID );
+  return _impl->getDataID(dataName, meshID);
 }
 
 bool SolverInterface::hasToEvaluateSurrogateModel() const
@@ -146,224 +135,201 @@ bool SolverInterface::hasToEvaluateFineModel() const
 //  _impl->resetMesh(meshID);
 //}
 
-
-int SolverInterface:: setMeshVertex
-(
-  int           meshID,
-  const double* position )
+int SolverInterface::setMeshVertex(
+    int           meshID,
+    const double *position)
 {
-  return _impl->setMeshVertex ( meshID, position );
+  return _impl->setMeshVertex(meshID, position);
 }
 
-int SolverInterface:: getMeshVertexSize
-(
-  int meshID) const
+int SolverInterface::getMeshVertexSize(
+    int meshID) const
 {
   return _impl->getMeshVertexSize(meshID);
 }
 
-void SolverInterface:: setMeshVertices
-(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids )
+void SolverInterface::setMeshVertices(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids)
 {
   _impl->setMeshVertices(meshID, size, positions, ids);
 }
 
-void SolverInterface:: getMeshVertices
-(
-  int        meshID,
-  int        size,
-  const int* ids,
-  double*    positions ) const
+void SolverInterface::getMeshVertices(
+    int        meshID,
+    int        size,
+    const int *ids,
+    double *   positions) const
 {
   _impl->getMeshVertices(meshID, size, ids, positions);
 }
 
-void SolverInterface:: getMeshVertexIDsFromPositions
-(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids ) const
+void SolverInterface::getMeshVertexIDsFromPositions(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids) const
 {
   _impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
 }
 
-int SolverInterface:: setMeshEdge
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID )
+int SolverInterface::setMeshEdge(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID)
 {
-  return _impl->setMeshEdge ( meshID, firstVertexID, secondVertexID );
+  return _impl->setMeshEdge(meshID, firstVertexID, secondVertexID);
 }
 
-void SolverInterface:: setMeshTriangle
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID )
+void SolverInterface::setMeshTriangle(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID)
 {
-  _impl->setMeshTriangle ( meshID, firstEdgeID, secondEdgeID, thirdEdgeID );
+  _impl->setMeshTriangle(meshID, firstEdgeID, secondEdgeID, thirdEdgeID);
 }
 
-void SolverInterface:: setMeshTriangleWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID )
+void SolverInterface::setMeshTriangleWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID)
 {
-  _impl->setMeshTriangleWithEdges ( meshID, firstVertexID, secondVertexID, thirdVertexID );
+  _impl->setMeshTriangleWithEdges(meshID, firstVertexID, secondVertexID, thirdVertexID);
 }
 
-void SolverInterface:: setMeshQuad
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID,
-  int fourthEdgeID )
+void SolverInterface::setMeshQuad(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID,
+    int fourthEdgeID)
 {
   _impl->setMeshQuad(meshID, firstEdgeID, secondEdgeID, thirdEdgeID, fourthEdgeID);
 }
 
-void SolverInterface:: setMeshQuadWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID,
-  int fourthVertexID )
+void SolverInterface::setMeshQuadWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID,
+    int fourthVertexID)
 {
   _impl->setMeshQuadWithEdges(meshID, firstVertexID, secondVertexID, thirdVertexID,
                               fourthVertexID);
 }
 
-void SolverInterface:: mapReadDataTo
-(
-  int toMeshID )
+void SolverInterface::mapReadDataTo(
+    int toMeshID)
 {
   _impl->mapReadDataTo(toMeshID);
 }
 
-void SolverInterface:: mapWriteDataFrom
-(
-  int fromMeshID )
+void SolverInterface::mapWriteDataFrom(
+    int fromMeshID)
 {
   _impl->mapWriteDataFrom(fromMeshID);
 }
 
-
-void SolverInterface:: writeBlockVectorData
-(
-  int     dataID,
-  int     size,
-  const int*    valueIndices,
-  const double* values )
+void SolverInterface::writeBlockVectorData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   _impl->writeBlockVectorData(dataID, size, valueIndices, values);
 }
 
-void SolverInterface:: writeVectorData
-(
-  int           dataID,
-  int           valueIndex,
-  const double* value )
+void SolverInterface::writeVectorData(
+    int           dataID,
+    int           valueIndex,
+    const double *value)
 {
   _impl->writeVectorData(dataID, valueIndex, value);
 }
 
-void SolverInterface:: writeBlockScalarData
-(
-  int           dataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values )
+void SolverInterface::writeBlockScalarData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   _impl->writeBlockScalarData(dataID, size, valueIndices, values);
 }
 
-void SolverInterface:: writeScalarData
-(
-  int    dataID,
-  int    valueIndex,
-  double value )
+void SolverInterface::writeScalarData(
+    int    dataID,
+    int    valueIndex,
+    double value)
 {
-  _impl->writeScalarData ( dataID, valueIndex, value );
+  _impl->writeScalarData(dataID, valueIndex, value);
 }
 
-void SolverInterface:: readBlockVectorData
-(
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values ) const
+void SolverInterface::readBlockVectorData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values) const
 {
   _impl->readBlockVectorData(dataID, size, valueIndices, values);
 }
 
-void SolverInterface:: readVectorData
-(
-  int     dataID,
-  int     valueIndex,
-  double* value ) const
+void SolverInterface::readVectorData(
+    int     dataID,
+    int     valueIndex,
+    double *value) const
 {
-  return _impl->readVectorData ( dataID, valueIndex, value );
+  return _impl->readVectorData(dataID, valueIndex, value);
 }
 
-void SolverInterface:: readBlockScalarData
-(
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values ) const
+void SolverInterface::readBlockScalarData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values) const
 {
   _impl->readBlockScalarData(dataID, size, valueIndices, values);
 }
 
-void SolverInterface:: readScalarData
-(
-  int     dataID,
-  int     valueIndex,
-  double& value ) const
+void SolverInterface::readScalarData(
+    int     dataID,
+    int     valueIndex,
+    double &value) const
 {
-  return _impl->readScalarData ( dataID, valueIndex, value );
+  return _impl->readScalarData(dataID, valueIndex, value);
 }
 
-MeshHandle SolverInterface:: getMeshHandle
-(
-  const std::string & meshName )
+MeshHandle SolverInterface::getMeshHandle(
+    const std::string &meshName)
 {
-  return _impl->getMeshHandle ( meshName );
+  return _impl->getMeshHandle(meshName);
 }
 
 std::string getVersionInformation()
 {
-    return {precice::versionInformation};
+  return {precice::versionInformation};
 }
 
 namespace constants {
 
-const std::string& actionWriteInitialData()
+const std::string &actionWriteInitialData()
 {
   return cplscheme::constants::actionWriteInitialData();
 }
 
-const std::string& actionWriteIterationCheckpoint()
+const std::string &actionWriteIterationCheckpoint()
 {
   return cplscheme::constants::actionWriteIterationCheckpoint();
 }
 
-const std::string& actionReadIterationCheckpoint()
+const std::string &actionReadIterationCheckpoint()
 {
   return cplscheme::constants::actionReadIterationCheckpoint();
 }
 
-} // namespace precice, constants
+} // namespace constants
 
 } // namespace precice

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -1,22 +1,22 @@
 #pragma once
 
-#include "MeshHandle.hpp"
+#include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
-#include <memory>
+#include "MeshHandle.hpp"
 
 /**
  * forward declarations.
  */
 namespace precice {
-  namespace impl {
-    class SolverInterfaceImpl;
-  }
-  namespace testing {
-      struct WhiteboxAccessor;
-  }
+namespace impl {
+class SolverInterfaceImpl;
 }
+namespace testing {
+struct WhiteboxAccessor;
+}
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
@@ -37,10 +37,8 @@ namespace precice {
  *  We use solver, simulation code, and participant as synonyms.
  *  The preferred name in the documentation is participant.
  */
-class SolverInterface
-{
+class SolverInterface {
 public:
-
   ///@name Construction and Configuration
   ///@{
 
@@ -52,11 +50,10 @@ public:
    *        from 0 and end with solverProcessSize - 1.
    * @param[in] solverProcessSize The number of solver processes using preCICE.
    */
-  SolverInterface (
-    const std::string& participantName,
-    int                solverProcessIndex,
-    int                solverProcessSize);
-
+  SolverInterface(
+      const std::string &participantName,
+      int                solverProcessIndex,
+      int                solverProcessSize);
 
   /**
    * @param[in] participantName Name of the participant using the interface. Has to
@@ -67,11 +64,11 @@ public:
    * @param[in] solverProcessSize The number of solver processes using preCICE.
    * @param[in] communicator A pointer to an MPI_Comm to use as MPI_COMM_WORLD.
    */
-  SolverInterface (
-    const std::string& participantName,
-    int                solverProcessIndex,
-    int                solverProcessSize,
-    void*              communicator);
+  SolverInterface(
+      const std::string &participantName,
+      int                solverProcessIndex,
+      int                solverProcessSize,
+      void *             communicator);
 
   ~SolverInterface();
 
@@ -92,7 +89,7 @@ public:
    *
    * @param[in] configurationFileName Name (with path) of the xml configuration file to be read.
    */
-  void configure ( const std::string& configurationFileName );
+  void configure(const std::string &configurationFileName);
 
   ///@}
 
@@ -161,7 +158,7 @@ public:
    *
    * @return Maximum length of next timestep to be computed by solver.
    */
-  double advance ( double computedTimestepLength );
+  double advance(double computedTimestepLength);
 
   /**
    * @brief Finalizes preCICE.
@@ -176,7 +173,7 @@ public:
   void finalize();
 
   ///@}
-  
+
   ///@name Status Queries
   ///@{
 
@@ -248,7 +245,7 @@ public:
    * This is not recommended due to performance reasons.
    * Use this function to prevent unnecessary writes.
    */
-  bool isWriteDataRequired ( double computedTimestepLength ) const;
+  bool isWriteDataRequired(double computedTimestepLength) const;
 
   /**
    * @brief Checks if the current coupling timestep is completed.
@@ -314,7 +311,7 @@ public:
    * @see fulfilledAction()
    * @see cplscheme::constants
    */
-  bool isActionRequired ( const std::string& action ) const;
+  bool isActionRequired(const std::string &action) const;
 
   /**
    * @brief Indicates preCICE that a required action has been fulfilled by a solver.
@@ -326,7 +323,7 @@ public:
    * @see requireAction()
    * @see cplscheme::constants
    */
-  void fulfilledAction ( const std::string& action );
+  void fulfilledAction(const std::string &action);
 
   ///@}
 
@@ -341,7 +338,7 @@ public:
    * changes. Only has an effect, if the mapping used is non-stationary and
    * non-incremental.
    */
-//  void resetMesh ( int meshID );
+  //  void resetMesh ( int meshID );
 
   /**
    * @brief Checks if the mesh with given name is used by a solver.
@@ -349,7 +346,7 @@ public:
    * @param[in] meshName the name of the mesh
    * @returns whether the mesh is used.
    */
-  bool hasMesh ( const std::string& meshName ) const;
+  bool hasMesh(const std::string &meshName) const;
 
   /**
    * @brief Returns the ID belonging to the mesh with given name.
@@ -357,7 +354,7 @@ public:
    * @param[in] meshName the name of the mesh
    * @returns the id of the corresponding mesh
    */
-  int getMeshID ( const std::string& meshName ) const;
+  int getMeshID(const std::string &meshName) const;
 
   /**
    * @brief Returns a id-set of all used meshes by this participant.
@@ -374,7 +371,7 @@ public:
    *
    * @see precice::MeshHandle
    */
-  MeshHandle getMeshHandle ( const std::string& meshName );
+  MeshHandle getMeshHandle(const std::string &meshName);
 
   /**
    * @brief Creates a mesh vertex
@@ -388,9 +385,9 @@ public:
    *
    * @see getDimensions()
    */
-  int setMeshVertex (
-    int           meshID,
-    const double* position );
+  int setMeshVertex(
+      int           meshID,
+      const double *position);
 
   /**
    * @brief Returns the number of vertices of a mesh.
@@ -417,11 +414,11 @@ public:
    *
    * @see getDimensions()
    */
-  void setMeshVertices (
-    int           meshID,
-    int           size,
-    const double* positions,
-    int*          ids );
+  void setMeshVertices(
+      int           meshID,
+      int           size,
+      const double *positions,
+      int *         ids);
 
   /**
    * @brief Get vertex positions for multiple vertex ids from a given mesh
@@ -438,11 +435,11 @@ public:
    *
    * @see getDimensions()
    */
-  void getMeshVertices (
-    int        meshID,
-    int        size,
-    const int* ids,
-    double*    positions ) const;
+  void getMeshVertices(
+      int        meshID,
+      int        size,
+      const int *ids,
+      double *   positions) const;
 
   /**
    * @brief Gets mesh vertex IDs from positions.
@@ -459,11 +456,11 @@ public:
    *
    * @note prefer to reuse the IDs returned from calls to setMeshVertex() and setMeshVertices().
    */
-  void getMeshVertexIDsFromPositions (
-    int           meshID,
-    int           size,
-    const double* positions,
-    int*          ids ) const;
+  void getMeshVertexIDsFromPositions(
+      int           meshID,
+      int           size,
+      const double *positions,
+      int *         ids) const;
 
   /**
    * @brief Sets mesh edge from vertex IDs, returns edge ID.
@@ -476,10 +473,10 @@ public:
    *
    * @pre vertices with firstVertexID and secondVertexID were added to the mesh with the ID meshID
    */
-  int setMeshEdge (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID );
+  int setMeshEdge(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID);
 
   /**
    * @brief Sets mesh triangle from edge IDs
@@ -491,11 +488,11 @@ public:
    *
    * @pre edges with firstEdgeID, secondEdgeID, and thirdEdgeID were added to the mesh with the ID meshID
    */
-  void setMeshTriangle (
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID );
+  void setMeshTriangle(
+      int meshID,
+      int firstEdgeID,
+      int secondEdgeID,
+      int thirdEdgeID);
 
   /**
    * @brief Sets mesh triangle from vertex IDs.
@@ -513,11 +510,11 @@ public:
    *
    * @pre edges with firstVertexID, secondVertexID, and thirdVertexID were added to the mesh with the ID meshID
    */
-  void setMeshTriangleWithEdges (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID );
+  void setMeshTriangleWithEdges(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID,
+      int thirdVertexID);
 
   /**
    * @brief Sets mesh Quad from edge IDs.
@@ -532,12 +529,12 @@ public:
    *
    * @warning Quads are not fully implemented yet.
    */
-  void setMeshQuad (
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID,
-    int fourthEdgeID );
+  void setMeshQuad(
+      int meshID,
+      int firstEdgeID,
+      int secondEdgeID,
+      int thirdEdgeID,
+      int fourthEdgeID);
 
   /**
    * @brief Sets surface mesh quadrangle from vertex IDs.
@@ -557,12 +554,12 @@ public:
    * @pre edges with firstVertexID, secondVertexID, thirdVertexID, and fourthVertexID were added to the mesh with the ID meshID
    *
    */
-  void setMeshQuadWithEdges (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID,
-    int fourthVertexID );
+  void setMeshQuadWithEdges(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID,
+      int thirdVertexID,
+      int fourthVertexID);
 
   ///@}
 
@@ -576,7 +573,7 @@ public:
    * @param[in] meshID the id of the associated mesh
    * @returns whether the mesh is used.
    */
-  bool hasData ( const std::string& dataName, int meshID ) const;
+  bool hasData(const std::string &dataName, int meshID) const;
 
   /**
    * @brief Returns the ID of the data associated with the given name and mesh.
@@ -586,7 +583,7 @@ public:
    *
    * @returns the id of the corresponding data
    */
-  int getDataID ( const std::string& dataName, int meshID ) const;
+  int getDataID(const std::string &dataName, int meshID) const;
 
   /**
    * @brief Computes and maps all read data mapped to the mesh with given ID.
@@ -596,7 +593,7 @@ public:
    *
    * @pre A mapping to toMeshID was configured.
    */
-  void mapReadDataTo ( int toMeshID );
+  void mapReadDataTo(int toMeshID);
 
   /**
    * @brief Computes and maps all write data mapped from the mesh with given ID.
@@ -606,7 +603,7 @@ public:
    *
    * @pre A mapping from fromMeshID was configured.
    */
-  void mapWriteDataFrom ( int fromMeshID );
+  void mapWriteDataFrom(int fromMeshID);
 
   /**
    * @brief Writes vector data given as block.
@@ -629,11 +626,11 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void writeBlockVectorData (
-    int           dataID,
-    int           size,
-    const int*    valueIndices,
-    const double* values );
+  void writeBlockVectorData(
+      int           dataID,
+      int           size,
+      const int *   valueIndices,
+      const double *values);
 
   /**
    * @brief Writes vector data to a vertex
@@ -653,11 +650,10 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void writeVectorData (
-    int           dataID,
-    int           valueIndex,
-    const double* value );
-
+  void writeVectorData(
+      int           dataID,
+      int           valueIndex,
+      const double *value);
 
   /**
    * @brief Writes scalar data given as block.
@@ -677,11 +673,11 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void writeBlockScalarData (
-    int           dataID,
-    int           size,
-    const int*    valueIndices,
-    const double* values );
+  void writeBlockScalarData(
+      int           dataID,
+      int           size,
+      const int *   valueIndices,
+      const double *values);
 
   /**
    * @brief Writes scalar data to a vertex
@@ -696,10 +692,10 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void writeScalarData (
-    int    dataID,
-    int    valueIndex,
-    double value );
+  void writeScalarData(
+      int    dataID,
+      int    valueIndex,
+      double value);
 
   /**
    * @brief Reads vector data into a provided block.
@@ -724,11 +720,11 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void readBlockVectorData (
-    int        dataID,
-    int        size,
-    const int* valueIndices,
-    double*    values ) const;
+  void readBlockVectorData(
+      int        dataID,
+      int        size,
+      const int *valueIndices,
+      double *   values) const;
 
   /**
    * @brief Reads vector data form a vertex
@@ -750,10 +746,10 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void readVectorData (
-    int     dataID,
-    int     valueIndex,
-    double* value ) const;
+  void readVectorData(
+      int     dataID,
+      int     valueIndex,
+      double *value) const;
 
   /**
    * @brief Reads scalar data as a block.
@@ -775,11 +771,11 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void readBlockScalarData (
-    int        dataID,
-    int        size,
-    const int* valueIndices,
-    double*    values ) const;
+  void readBlockScalarData(
+      int        dataID,
+      int        size,
+      const int *valueIndices,
+      double *   values) const;
 
   /**
    * @brief Reads scalar data of a vertex.
@@ -796,24 +792,22 @@ public:
    *
    * @see SolverInterface::setMeshVertex()
    */
-  void readScalarData (
-    int     dataID,
-    int     valueIndex,
-    double& value ) const;
+  void readScalarData(
+      int     dataID,
+      int     valueIndex,
+      double &value) const;
 
   ///@}
 
-  /// Disable copy construction 
-  SolverInterface ( const SolverInterface& copy ) = delete;
+  /// Disable copy construction
+  SolverInterface(const SolverInterface &copy) = delete;
 
   /// Disable assignment construction
-  SolverInterface& operator= ( const SolverInterface& assign ) = delete;
+  SolverInterface &operator=(const SolverInterface &assign) = delete;
 
 private:
-
   /// Pointer to implementation of SolverInterface.
   std::unique_ptr<impl::SolverInterfaceImpl> _impl;
-
 
   // @brief To allow white box tests.
   friend struct testing::WhiteboxAccessor;
@@ -833,13 +827,13 @@ std::string getVersionInformation();
 namespace constants {
 
 // @brief Name of action for writing initial data.
-const std::string& actionWriteInitialData();
+const std::string &actionWriteInitialData();
 
 // @brief Name of action for writing iteration checkpoint
-const std::string& actionWriteIterationCheckpoint();
+const std::string &actionWriteIterationCheckpoint();
 
 // @brief Name of action for reading iteration checkpoint.
-const std::string& actionReadIterationCheckpoint();
+const std::string &actionReadIterationCheckpoint();
 
 } // namespace constants
 

--- a/src/precice/bindings/c/SolverInterfaceC.cpp
+++ b/src/precice/bindings/c/SolverInterfaceC.cpp
@@ -1,60 +1,59 @@
 extern "C" {
 #include "SolverInterfaceC.h"
 }
+#include <string>
 #include "precice/impl/SolverInterfaceImpl.hpp"
 #include "utils/assertion.hpp"
-#include <string>
 
-static precice::impl::SolverInterfaceImpl* impl = nullptr;
+static precice::impl::SolverInterfaceImpl *impl = nullptr;
 
-void precicec_createSolverInterface
-(
-  const char* participantName,
-  const char* configFileName,
-  int         solverProcessIndex,
-  int         solverProcessSize )
+void precicec_createSolverInterface(
+    const char *participantName,
+    const char *configFileName,
+    int         solverProcessIndex,
+    int         solverProcessSize)
 {
-  std::string stringAccessorName ( participantName );
-  impl = new precice::impl::SolverInterfaceImpl ( stringAccessorName,
-      solverProcessIndex, solverProcessSize, false );
-  std::string stringConfigFileName ( configFileName );
-  impl->configure ( stringConfigFileName );
+  std::string stringAccessorName(participantName);
+  impl = new precice::impl::SolverInterfaceImpl(stringAccessorName,
+                                                solverProcessIndex, solverProcessSize, false);
+  std::string stringConfigFileName(configFileName);
+  impl->configure(stringConfigFileName);
 }
 
 double precicec_initialize()
 {
-  PRECICE_ASSERT( impl != nullptr );
-  return impl->initialize ();
+  PRECICE_ASSERT(impl != nullptr);
+  return impl->initialize();
 }
 
 void precicec_initialize_data()
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->initializeData ();
+  PRECICE_ASSERT(impl != nullptr);
+  impl->initializeData();
 }
 
-double precicec_advance( double computedTimestepLength )
+double precicec_advance(double computedTimestepLength)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  return impl->advance ( computedTimestepLength );
+  PRECICE_ASSERT(impl != nullptr);
+  return impl->advance(computedTimestepLength);
 }
 
 void precicec_finalize()
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->finalize ();
+  PRECICE_ASSERT(impl != nullptr);
+  impl->finalize();
 }
 
 int precicec_getDimensions()
 {
-  PRECICE_ASSERT( impl != nullptr );
+  PRECICE_ASSERT(impl != nullptr);
   return impl->getDimensions();
 }
 
 int precicec_isCouplingOngoing()
 {
-  PRECICE_ASSERT( impl != nullptr );
-  if ( impl->isCouplingOngoing() ) {
+  PRECICE_ASSERT(impl != nullptr);
+  if (impl->isCouplingOngoing()) {
     return 1;
   }
   return 0;
@@ -62,8 +61,8 @@ int precicec_isCouplingOngoing()
 
 int precicec_isCouplingTimestepComplete()
 {
-  PRECICE_ASSERT( impl != nullptr );
-  if ( impl->isTimestepComplete() ){
+  PRECICE_ASSERT(impl != nullptr);
+  if (impl->isTimestepComplete()) {
     return 1;
   }
   return 0;
@@ -71,8 +70,8 @@ int precicec_isCouplingTimestepComplete()
 
 int precicec_hasToEvaluateSurrogateModel()
 {
-  PRECICE_ASSERT( impl != nullptr);
-  if (impl->hasToEvaluateSurrogateModel() ){
+  PRECICE_ASSERT(impl != nullptr);
+  if (impl->hasToEvaluateSurrogateModel()) {
     return 1;
   }
   return 0;
@@ -80,8 +79,8 @@ int precicec_hasToEvaluateSurrogateModel()
 
 int precicec_hasToEvaluateFineModel()
 {
-  PRECICE_ASSERT( impl != nullptr);
-  if (impl->hasToEvaluateFineModel() ){
+  PRECICE_ASSERT(impl != nullptr);
+  if (impl->hasToEvaluateFineModel()) {
     return 1;
   }
   return 0;
@@ -89,284 +88,265 @@ int precicec_hasToEvaluateFineModel()
 
 int precicec_isReadDataAvailable()
 {
-  PRECICE_ASSERT( impl != nullptr );
-  if ( impl->isReadDataAvailable() ){
-     return 1;
-  }
-  return 0;
-}
-
-int precicec_isWriteDataRequired ( double computedTimestepLength )
-{
-  PRECICE_ASSERT( impl != nullptr );
-  if ( impl->isWriteDataRequired(computedTimestepLength) ){
-     return 1;
-  }
-  return 0;
-}
-
-int precicec_isActionRequired ( const char* action )
-{
-  PRECICE_ASSERT( impl != nullptr );
-  PRECICE_ASSERT( action != nullptr );
-  if ( impl->isActionRequired(std::string(action)) ){
+  PRECICE_ASSERT(impl != nullptr);
+  if (impl->isReadDataAvailable()) {
     return 1;
   }
   return 0;
 }
 
-void precicec_fulfilledAction ( const char* action )
+int precicec_isWriteDataRequired(double computedTimestepLength)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  PRECICE_ASSERT( action != nullptr );
-  impl->fulfilledAction ( std::string(action) );
-}
-
-int precicec_hasMesh ( const char* meshName)
-{
-  PRECICE_ASSERT( impl != nullptr );
-  std::string stringMeshName (meshName);
-  if ( impl->hasMesh (stringMeshName) ){
+  PRECICE_ASSERT(impl != nullptr);
+  if (impl->isWriteDataRequired(computedTimestepLength)) {
     return 1;
   }
   return 0;
 }
 
-int precicec_getMeshID ( const char* meshName )
+int precicec_isActionRequired(const char *action)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  std::string stringMeshName (meshName);
-  return impl->getMeshID (stringMeshName);
+  PRECICE_ASSERT(impl != nullptr);
+  PRECICE_ASSERT(action != nullptr);
+  if (impl->isActionRequired(std::string(action))) {
+    return 1;
+  }
+  return 0;
 }
 
-int precicec_hasData ( const char* dataName, int meshID )
+void precicec_fulfilledAction(const char *action)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  std::string stringDataName (dataName);
-  return impl->hasData (stringDataName, meshID);
+  PRECICE_ASSERT(impl != nullptr);
+  PRECICE_ASSERT(action != nullptr);
+  impl->fulfilledAction(std::string(action));
 }
 
-int precicec_getDataID ( const char* dataName, int meshID )
+int precicec_hasMesh(const char *meshName)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  std::string stringDataName (dataName);
-  return impl->getDataID (stringDataName, meshID);
+  PRECICE_ASSERT(impl != nullptr);
+  std::string stringMeshName(meshName);
+  if (impl->hasMesh(stringMeshName)) {
+    return 1;
+  }
+  return 0;
 }
 
-int precicec_setMeshVertex
-(
-  int           meshID,
-  const double* position )
+int precicec_getMeshID(const char *meshName)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  return impl->setMeshVertex ( meshID, position );
+  PRECICE_ASSERT(impl != nullptr);
+  std::string stringMeshName(meshName);
+  return impl->getMeshID(stringMeshName);
 }
 
+int precicec_hasData(const char *dataName, int meshID)
+{
+  PRECICE_ASSERT(impl != nullptr);
+  std::string stringDataName(dataName);
+  return impl->hasData(stringDataName, meshID);
+}
 
-void precicec_getMeshVertices
-(
-  int        meshID,
-  int        size,
-  const int* ids,
-  double*    positions )
+int precicec_getDataID(const char *dataName, int meshID)
+{
+  PRECICE_ASSERT(impl != nullptr);
+  std::string stringDataName(dataName);
+  return impl->getDataID(stringDataName, meshID);
+}
+
+int precicec_setMeshVertex(
+    int           meshID,
+    const double *position)
+{
+  PRECICE_ASSERT(impl != nullptr);
+  return impl->setMeshVertex(meshID, position);
+}
+
+void precicec_getMeshVertices(
+    int        meshID,
+    int        size,
+    const int *ids,
+    double *   positions)
 {
   PRECICE_ASSERT(impl != nullptr);
   impl->getMeshVertices(meshID, size, ids, positions);
 }
 
-void precicec_setMeshVertices
-(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids)
+void precicec_setMeshVertices(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids)
 {
   PRECICE_ASSERT(impl != nullptr);
-  impl->setMeshVertices(meshID, size, positions, ids );
+  impl->setMeshVertices(meshID, size, positions, ids);
 }
 
-int precicec_getMeshVertexSize
-(
-  int meshID )
+int precicec_getMeshVertexSize(
+    int meshID)
 {
   PRECICE_ASSERT(impl != nullptr);
   return impl->getMeshVertexSize(meshID);
 }
 
-void precicec_getMeshVertexIDsFromPositions
-(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids)
+void precicec_getMeshVertexIDsFromPositions(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids)
 {
   PRECICE_ASSERT(impl != nullptr);
-  impl->getMeshVertexIDsFromPositions(meshID,size,positions,ids);
+  impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
 }
 
-int precicec_setMeshEdge
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID )
+int precicec_setMeshEdge(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  return impl->setMeshEdge ( meshID, firstVertexID, secondVertexID );
+  PRECICE_ASSERT(impl != nullptr);
+  return impl->setMeshEdge(meshID, firstVertexID, secondVertexID);
 }
 
-void precicec_setMeshTriangle
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID )
+void precicec_setMeshTriangle(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->setMeshTriangle ( meshID, firstEdgeID, secondEdgeID, thirdEdgeID );
+  PRECICE_ASSERT(impl != nullptr);
+  impl->setMeshTriangle(meshID, firstEdgeID, secondEdgeID, thirdEdgeID);
 }
 
-void precicec_setMeshTriangleWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID )
+void precicec_setMeshTriangleWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->setMeshTriangleWithEdges ( meshID, firstVertexID, secondVertexID, thirdVertexID );
+  PRECICE_ASSERT(impl != nullptr);
+  impl->setMeshTriangleWithEdges(meshID, firstVertexID, secondVertexID, thirdVertexID);
 }
 
-void precicec_setMeshQuad
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID,
-  int fourthEdgeID )
+void precicec_setMeshQuad(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID,
+    int fourthEdgeID)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->setMeshQuad(meshID,firstEdgeID,secondEdgeID,thirdEdgeID,fourthEdgeID);
+  PRECICE_ASSERT(impl != nullptr);
+  impl->setMeshQuad(meshID, firstEdgeID, secondEdgeID, thirdEdgeID, fourthEdgeID);
 }
 
-void precicec_setMeshQuadWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID,
-  int fourthVertexID )
+void precicec_setMeshQuadWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID,
+    int fourthVertexID)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->setMeshQuadWithEdges(meshID,firstVertexID,secondVertexID,thirdVertexID,fourthVertexID);
+  PRECICE_ASSERT(impl != nullptr);
+  impl->setMeshQuadWithEdges(meshID, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
 }
 
-void precicec_writeBlockVectorData
-(
-  int           dataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values )
+void precicec_writeBlockVectorData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   PRECICE_ASSERT(impl != nullptr);
   impl->writeBlockVectorData(dataID, size, valueIndices, values);
 }
 
-void precicec_writeVectorData
-(
-  int           dataID,
-  int           valueIndex,
-  const double* dataValue )
+void precicec_writeVectorData(
+    int           dataID,
+    int           valueIndex,
+    const double *dataValue)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->writeVectorData ( dataID, valueIndex, dataValue );
+  PRECICE_ASSERT(impl != nullptr);
+  impl->writeVectorData(dataID, valueIndex, dataValue);
 }
 
-void precicec_writeBlockScalarData
-(
-  int           dataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values )
+void precicec_writeBlockScalarData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   PRECICE_ASSERT(impl != nullptr);
   impl->writeBlockScalarData(dataID, size, valueIndices, values);
 }
 
-void precicec_writeScalarData
-(
-  int    dataID,
-  int    valueIndex,
-  double dataValue )
+void precicec_writeScalarData(
+    int    dataID,
+    int    valueIndex,
+    double dataValue)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->writeScalarData ( dataID, valueIndex, dataValue );
+  PRECICE_ASSERT(impl != nullptr);
+  impl->writeScalarData(dataID, valueIndex, dataValue);
 }
 
-void precicec_readBlockVectorData
-(
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values )
+void precicec_readBlockVectorData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values)
 {
   PRECICE_ASSERT(impl != nullptr);
   impl->readBlockVectorData(dataID, size, valueIndices, values);
 }
 
-void precicec_readVectorData
-(
-  int     dataID,
-  int     valueIndex,
-  double* dataValue )
+void precicec_readVectorData(
+    int     dataID,
+    int     valueIndex,
+    double *dataValue)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->readVectorData (dataID, valueIndex, dataValue);
+  PRECICE_ASSERT(impl != nullptr);
+  impl->readVectorData(dataID, valueIndex, dataValue);
 }
 
-void precicec_readBlockScalarData
-(
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values )
+void precicec_readBlockScalarData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values)
 {
   PRECICE_ASSERT(impl != nullptr);
   impl->readBlockScalarData(dataID, size, valueIndices, values);
 }
 
-void precicec_readScalarData
-(
-  int     dataID,
-  int     valueIndex,
-  double* dataValue )
+void precicec_readScalarData(
+    int     dataID,
+    int     valueIndex,
+    double *dataValue)
 {
-  PRECICE_ASSERT( impl != nullptr );
-  impl->readScalarData (dataID, valueIndex, *dataValue);
+  PRECICE_ASSERT(impl != nullptr);
+  impl->readScalarData(dataID, valueIndex, *dataValue);
 }
 
-void precicec_mapWriteDataFrom ( int fromMeshID )
+void precicec_mapWriteDataFrom(int fromMeshID)
 {
-  PRECICE_ASSERT( impl != nullptr );
+  PRECICE_ASSERT(impl != nullptr);
   impl->mapWriteDataFrom(fromMeshID);
 }
 
-void precicec_mapReadDataTo ( int toMeshID )
+void precicec_mapReadDataTo(int toMeshID)
 {
-  PRECICE_ASSERT( impl != nullptr );
+  PRECICE_ASSERT(impl != nullptr);
   impl->mapReadDataTo(toMeshID);
 }
 
-const char* precicec_actionWriteInitialData()
+const char *precicec_actionWriteInitialData()
 {
   return precice::constants::actionWriteInitialData().c_str();
 }
 
-const char* precicec_actionWriteIterationCheckpoint()
+const char *precicec_actionWriteIterationCheckpoint()
 {
   return precice::constants::actionWriteIterationCheckpoint().c_str();
 }
 
-const char* precicec_actionReadIterationCheckpoint()
+const char *precicec_actionReadIterationCheckpoint()
 {
   return precice::constants::actionReadIterationCheckpoint().c_str();
 }

--- a/src/precice/bindings/c/SolverInterfaceC.h
+++ b/src/precice/bindings/c/SolverInterfaceC.h
@@ -27,11 +27,11 @@ extern "C" {
  *                               from 0 and end with solverProcessSize - 1.
  * @param[in] solverProcessSize The number of solver processes using preCICE.
  */
-void precicec_createSolverInterface (
-  const char* participantName,
-  const char* configFileName,
-  int         solverProcessIndex,
-  int         solverProcessSize );
+void precicec_createSolverInterface(
+    const char *participantName,
+    const char *configFileName,
+    int         solverProcessIndex,
+    int         solverProcessSize);
 
 ///@}
 
@@ -56,7 +56,7 @@ void precicec_initialize_data();
  * @param[in] computedTimestepLength Length of timestep computed by solver.
  * @return Maximal length of next timestep to be computed by solver.
  */
-double precicec_advance ( double computedTimestepLength );
+double precicec_advance(double computedTimestepLength);
 
 /**
  * @brief Finalizes the coupling to the coupling supervisor.
@@ -90,7 +90,7 @@ int precicec_isReadDataAvailable();
  *
  * @return true (->1) if new data has to be written.
  */
-int precicec_isWriteDataRequired ( double computedTimestepLength );
+int precicec_isWriteDataRequired(double computedTimestepLength);
 
 /**
  * @brief Returns true (->1), if the coupling timestep is completed.
@@ -117,7 +117,7 @@ int precicec_hasToEvaluateFineModel();
  * @param[in] action the name of the action
  * @returns whether the action is required
  */
-int precicec_isActionRequired ( const char* action );
+int precicec_isActionRequired(const char *action);
 
 /**
  * @brief Indicates preCICE that a required action has been fulfilled by a solver.
@@ -125,7 +125,7 @@ int precicec_isActionRequired ( const char* action );
  *
  * @param[in] action the name of the action
  */
-void precicec_fulfilledAction ( const char* action );
+void precicec_fulfilledAction(const char *action);
 
 ///@}
 
@@ -139,12 +139,12 @@ void precicec_fulfilledAction ( const char* action );
  * @param[in] meshName the name of the mesh
  * @returns whether the mesh is used.
  */
-int precicec_hasMesh ( const char* meshName );
+int precicec_hasMesh(const char *meshName);
 
 /**
  * @brief Returns id belonging to the given mesh name
  */
-int precicec_getMeshID ( const char* meshName );
+int precicec_getMeshID(const char *meshName);
 
 /**
  * @brief Creates a mesh vertex
@@ -153,9 +153,9 @@ int precicec_getMeshID ( const char* meshName );
  * @param[in] position a pointer to the coordinates of the vertex.
  * @returns the id of the created vertex
  */
-int precicec_setMeshVertex (
-  int           meshID,
-  const double* position );
+int precicec_setMeshVertex(
+    int           meshID,
+    const double *position);
 
 /**
  * @brief Returns the number of vertices of a mesh.
@@ -163,7 +163,7 @@ int precicec_setMeshVertex (
  * @param[in] meshID the id of the mesh
  * @returns the amount of the vertices of the mesh
  */
-int precicec_getMeshVertexSize ( int meshID );
+int precicec_getMeshVertexSize(int meshID);
 
 /**
  * @brief Creates multiple mesh vertices
@@ -176,11 +176,11 @@ int precicec_getMeshVertexSize ( int meshID );
  *
  * @param[out] ids The ids of the created vertices
  */
-void precicec_setMeshVertices (
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids );
+void precicec_setMeshVertices(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids);
 
 /**
  * @brief Get vertex positions for multiple vertex ids from a given mesh
@@ -192,11 +192,11 @@ void precicec_setMeshVertices (
  *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
  *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
  */
-void precicec_getMeshVertices (
-  int        meshID,
-  int        size,
-  const int* ids,
-  double*    positions );
+void precicec_getMeshVertices(
+    int        meshID,
+    int        size,
+    const int *ids,
+    double *   positions);
 
 /**
  * @brief Gets mesh vertex IDs from positions.
@@ -209,10 +209,10 @@ void precicec_getMeshVertices (
  * @param[out] ids IDs corresponding to positions.
  */
 void precicec_getMeshVertexIDsFromPositions(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids );
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids);
 
 /**
  * @brief Sets mesh edge from vertex IDs, returns edge ID.
@@ -223,10 +223,10 @@ void precicec_getMeshVertexIDsFromPositions(
  *
  * @return the ID of the edge
  */
-int precicec_setMeshEdge (
-  int meshID,
-  int firstVertexID,
-  int secondVertexID );
+int precicec_setMeshEdge(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID);
 
 /**
  * @brief Sets mesh triangle from edge IDs
@@ -236,20 +236,20 @@ int precicec_setMeshEdge (
  * @param[in] secondEdgeID ID of the second edge of the triangle
  * @param[in] thirdEdgeID ID of the third edge of the triangle
  */
-void precicec_setMeshTriangle (
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID );
+void precicec_setMeshTriangle(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID);
 
 /**
  * @brief Sets a triangle from vertex IDs. Creates missing edges.
  */
-void precicec_setMeshTriangleWithEdges (
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID );
+void precicec_setMeshTriangleWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID);
 
 /**
  * @brief Sets mesh Quad from edge IDs.
@@ -260,13 +260,12 @@ void precicec_setMeshTriangleWithEdges (
  * @param[in] thirdEdgeID ID of the third edge of the Quad
  * @param[in] fourthEdgeID ID of the forth edge of the Quad
  */
-void precicec_setMeshQuad (
-   int meshID,
-   int firstEdgeID,
-   int secondEdgeID,
-   int thirdEdgeID,
-   int fourthEdgeID );
-
+void precicec_setMeshQuad(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID,
+    int fourthEdgeID);
 
 /**
   * @brief Sets surface mesh quadrangle from vertex IDs.
@@ -277,12 +276,12 @@ void precicec_setMeshQuad (
   * @param[in] thirdVertexID ID of the third vertex of the Quad
   * @param[in] fourthVertexID ID of the fourth vertex of the Quad
  */
-void precicec_setMeshQuadWithEdges (
-     int meshID,
-     int firstVertexID,
-     int secondVertexID,
-     int thirdVertexID,
-     int fourthVertexID );
+void precicec_setMeshQuadWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID,
+    int fourthVertexID);
 
 ///@}
 
@@ -292,7 +291,7 @@ void precicec_setMeshQuadWithEdges (
 /**
  * @brief Returns true (!=0), if data with given name is available.
  */
-int precicec_hasData ( const char* dataName, int meshID );
+int precicec_hasData(const char *dataName, int meshID);
 
 /**
  * @brief Returns the data id belonging to the given name.
@@ -301,17 +300,17 @@ int precicec_hasData ( const char* dataName, int meshID );
  * configuration file. The data id obtained can be used to read and write
  * data to and from the coupling mesh.
  */
-int precicec_getDataID ( const char* dataName, int meshID );
+int precicec_getDataID(const char *dataName, int meshID);
 
 /**
  * @brief Computes and maps all read data mapped to mesh with given ID.
  */
-void precicec_mapReadDataTo ( int toMeshID );
+void precicec_mapReadDataTo(int toMeshID);
 
 /**
  * @brief Computes and maps all write data mapped from mesh with given ID.
  */
-void precicec_mapWriteDataFrom ( int fromMeshID );
+void precicec_mapWriteDataFrom(int fromMeshID);
 
 /**
  * @brief Writes vector data values given as block.
@@ -324,11 +323,11 @@ void precicec_mapWriteDataFrom ( int fromMeshID );
  * @param[in] size Number of indices, and number of values * dimensions.
  * @param[in] values Values of the data to be written.
  */
-void precicec_writeBlockVectorData (
-  int           dataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values );
+void precicec_writeBlockVectorData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values);
 
 /**
  * @brief Writes vectorial foating point data to the coupling mesh.
@@ -337,19 +336,19 @@ void precicec_writeBlockVectorData (
  * @param[in] dataPosition Spatial position of the data to be written.
  * @param[in] dataValue Vectorial data value to be written.
  */
-void precicec_writeVectorData (
-  int           dataID,
-  int           valueIndex,
-  const double* dataValue );
+void precicec_writeVectorData(
+    int           dataID,
+    int           valueIndex,
+    const double *dataValue);
 
 /**
  * @brief See precice::SolverInterface::writeBlockScalarData().
  */
-void precicec_writeBlockScalarData (
-  int           dataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values );
+void precicec_writeBlockScalarData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values);
 
 /**
  * @brief Writes scalar floating point data to the coupling mesh.
@@ -358,10 +357,10 @@ void precicec_writeBlockScalarData (
  * @param[in] dataPosition Spatial position of the data to be written.
  * @param[in] dataValue Scalar data value to be written.
  */
-void precicec_writeScalarData (
-  int    dataID,
-  int    valueIndex,
-  double dataValue );
+void precicec_writeScalarData(
+    int    dataID,
+    int    valueIndex,
+    double dataValue);
 
 /**
  * @brief Reads vector data values given as block.
@@ -375,11 +374,11 @@ void precicec_writeScalarData (
  * @param[in] valueIndices Indices (from setReadPosition()) of data values.
  * @param[in] values Values of the data to be read.
  */
-void precicec_readBlockVectorData (
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values );
+void precicec_readBlockVectorData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values);
 
 /**
  * @brief Reads vectorial foating point data from the coupling mesh.
@@ -388,19 +387,19 @@ void precicec_readBlockVectorData (
  * @param[in] dataPosition Position where the read data should be mapped to.
  * @param[out] dataValue Vectorial data value read.
  */
-void precicec_readVectorData (
-  int     dataID,
-  int     valueIndex,
-  double* dataValue );
+void precicec_readVectorData(
+    int     dataID,
+    int     valueIndex,
+    double *dataValue);
 
 /**
  * @brief See precice::SolverInterface::readBlockScalarData().
  */
-void precicec_readBlockScalarData (
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values );
+void precicec_readBlockScalarData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values);
 
 /**
  * @brief Reads scalar foating point data from the coupling mesh.
@@ -409,19 +408,19 @@ void precicec_readBlockScalarData (
  * @param[in] dataPosition Position where the read data should be mapped to.
  * @param[out] dataValue Scalar data value read.
  */
-void precicec_readScalarData (
-  int     dataID,
-  int     valueIndex,
-  double* dataValue );
+void precicec_readScalarData(
+    int     dataID,
+    int     valueIndex,
+    double *dataValue);
 
 // @brief Name of action for writing initial data.
-const char* precicec_actionWriteInitialData();
+const char *precicec_actionWriteInitialData();
 
 // @brief Name of action for writing iteration checkpoint
-const char* precicec_actionWriteIterationCheckpoint();
+const char *precicec_actionWriteIterationCheckpoint();
 
 // @brief Name of action for reading iteration checkpoint.
-const char* precicec_actionReadIterationCheckpoint();
+const char *precicec_actionReadIterationCheckpoint();
 
 #ifdef __cplusplus
 }

--- a/src/precice/bindings/fortran/SolverInterfaceFASTEST.cpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFASTEST.cpp
@@ -1,379 +1,340 @@
 #include "SolverInterfaceFASTEST.hpp"
-#include "SolverInterfaceFortran.hpp"
-#include "precice/SolverInterface.hpp"
 #include <iostream>
 #include <string>
+#include "SolverInterfaceFortran.hpp"
 #include "logging/Logger.hpp"
+#include "precice/SolverInterface.hpp"
 
 using namespace std;
 
-static precice::SolverInterface* implAcoustic = nullptr;
-static precice::SolverInterface* implFluid = nullptr;
+static precice::SolverInterface *implAcoustic = nullptr;
+static precice::SolverInterface *implFluid    = nullptr;
 
-static precice::logging::Logger _log ("SolverInterfaceFASTEST");
+static precice::logging::Logger _log("SolverInterfaceFASTEST");
 
 namespace precice {
-  namespace impl {
-    /**
+namespace impl {
+/**
      * @brief Returns length of string without trailing whitespaces.
      */
-    int strippedLength( const char* string, int length );
-    void checkCorrectUsage(int useFluid);
-  }
-}
+int  strippedLength(const char *string, int length);
+void checkCorrectUsage(int useFluid);
+} // namespace impl
+} // namespace precice
 
-void precice_fastest_create_
-(
-  const char* participantNameAcoustic,
-  const int*  isAcousticUsed,
-  const char* participantNameFluid,
-  const int*  isFluidUsed,
-  const char* configFileName,
-  const int*  solverProcessIndex,
-  const int*  solverProcessSize,
-  int   lengthAccessorNameAcoustic,
-  int   lengthAccessorNameFluid,
-  int   lengthConfigFileName )
+void precice_fastest_create_(
+    const char *participantNameAcoustic,
+    const int * isAcousticUsed,
+    const char *participantNameFluid,
+    const int * isFluidUsed,
+    const char *configFileName,
+    const int * solverProcessIndex,
+    const int * solverProcessSize,
+    int         lengthAccessorNameAcoustic,
+    int         lengthAccessorNameFluid,
+    int         lengthConfigFileName)
 {
-  int strippedLength = precice::impl::strippedLength(participantNameAcoustic,lengthAccessorNameAcoustic);
+  int    strippedLength = precice::impl::strippedLength(participantNameAcoustic, lengthAccessorNameAcoustic);
   string stringAccessorNameAcoustic(participantNameAcoustic, strippedLength);
-  strippedLength = precice::impl::strippedLength(participantNameFluid,lengthAccessorNameFluid);
+  strippedLength = precice::impl::strippedLength(participantNameFluid, lengthAccessorNameFluid);
   string stringAccessorNameFluid(participantNameFluid, strippedLength);
-  strippedLength = precice::impl::strippedLength(configFileName,lengthConfigFileName);
+  strippedLength = precice::impl::strippedLength(configFileName, lengthConfigFileName);
   string stringConfigFileName(configFileName, strippedLength);
   //cout << "Accessor: " << stringAccessorName << "!" << '\n';
   //cout << "Config  : " << stringConfigFileName << "!" << '\n';
-  if(isAcousticUsed){
-    implAcoustic = new precice::SolverInterface (stringAccessorNameAcoustic,
-           *solverProcessIndex, *solverProcessSize);
+  if (isAcousticUsed) {
+    implAcoustic = new precice::SolverInterface(stringAccessorNameAcoustic,
+                                                *solverProcessIndex, *solverProcessSize);
     implAcoustic->configure(stringConfigFileName);
   }
-  if(isFluidUsed){
-    implFluid = new precice::SolverInterface (stringAccessorNameFluid,
-           *solverProcessIndex, *solverProcessSize);
+  if (isFluidUsed) {
+    implFluid = new precice::SolverInterface(stringAccessorNameFluid,
+                                             *solverProcessIndex, *solverProcessSize);
     implFluid->configure(stringConfigFileName);
   }
-  PRECICE_CHECK(implAcoustic != nullptr || implFluid != nullptr ,"Either the Fluid interface or the Acoustic"
-      " interface or both need to be used");
+  PRECICE_CHECK(implAcoustic != nullptr || implFluid != nullptr, "Either the Fluid interface or the Acoustic"
+                                                                 " interface or both need to be used");
 }
 
-void precice_fastest_initialize_
-(
-  double* timestepLengthLimit,
-  const int*  useFluid)
+void precice_fastest_initialize_(
+    double *   timestepLengthLimit,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     *timestepLengthLimit = implAcoustic->initialize();
-  }
-  else{
+  } else {
     *timestepLengthLimit = implFluid->initialize();
   }
 }
 
 void precice_fastest_initialize_data_(
-  const int*  useFluid)
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->initializeData();
-  }
-  else{
+  } else {
     implFluid->initializeData();
   }
 }
 
-void precice_fastest_advance_
-(
-  double* timestepLengthLimit,
-  const int*  useFluid)
+void precice_fastest_advance_(
+    double *   timestepLengthLimit,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     *timestepLengthLimit = implAcoustic->advance(*timestepLengthLimit);
-  }
-  else{
+  } else {
     *timestepLengthLimit = implFluid->advance(*timestepLengthLimit);
   }
 }
 
 void precice_fastest_finalize_(
-  const int*  useFluid)
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->finalize();
     delete implAcoustic;
-  }
-  else{
+  } else {
     implFluid->finalize();
     delete implFluid;
   }
 }
 
-void precice_fastest_action_required_
-(
-  const char* action,
-  int*        isRequired,
-  const int*  useFluid,
-  int         lengthAction )
+void precice_fastest_action_required_(
+    const char *action,
+    int *       isRequired,
+    const int * useFluid,
+    int         lengthAction)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-
-  int strippedLength = precice::impl::strippedLength(action, lengthAction);
+  int    strippedLength = precice::impl::strippedLength(action, lengthAction);
   string stringAction(action, strippedLength);
-  if(*useFluid==0){
-    if (implAcoustic->isActionRequired(stringAction)){
+  if (*useFluid == 0) {
+    if (implAcoustic->isActionRequired(stringAction)) {
       *isRequired = 1;
-    }
-    else {
+    } else {
       *isRequired = 0;
     }
-  }
-  else{
-    if (implFluid->isActionRequired(stringAction)){
+  } else {
+    if (implFluid->isActionRequired(stringAction)) {
       *isRequired = 1;
-    }
-    else {
+    } else {
       *isRequired = 0;
     }
   }
 }
 
-void precice_fastest_fulfilled_action_
-(
-  const char* action,
-  const int*  useFluid,
-  int         lengthAction )
+void precice_fastest_fulfilled_action_(
+    const char *action,
+    const int * useFluid,
+    int         lengthAction)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  int strippedLength = precice::impl::strippedLength(action, lengthAction);
+  int    strippedLength = precice::impl::strippedLength(action, lengthAction);
   string stringAction(action, strippedLength);
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->fulfilledAction(stringAction);
-  }
-  else{
+  } else {
     implFluid->fulfilledAction(stringAction);
   }
 }
 
-void precice_fastest_get_mesh_id_
-(
-  const char* meshName,
-  int*        meshID,
-  const int*  useFluid,
-  int         lengthMeshName )
+void precice_fastest_get_mesh_id_(
+    const char *meshName,
+    int *       meshID,
+    const int * useFluid,
+    int         lengthMeshName)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  int strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
+  int    strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
   string stringMeshName(meshName, strippedLength);
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     *meshID = implAcoustic->getMeshID(stringMeshName);
-  }
-  else{
+  } else {
     *meshID = implFluid->getMeshID(stringMeshName);
   }
 }
 
-void precice_fastest_get_data_id_
-(
-  const char* dataName,
-  const int*  meshID,
-  int*        dataID,
-  const int*  useFluid,
-  int         lengthDataName
-)
+void precice_fastest_get_data_id_(
+    const char *dataName,
+    const int * meshID,
+    int *       dataID,
+    const int * useFluid,
+    int         lengthDataName)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  int strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
+  int    strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
   string stringDataName(dataName, strippedLength);
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     *dataID = implAcoustic->getDataID(stringDataName, *meshID);
-  }
-  else{
+  } else {
     *dataID = implFluid->getDataID(stringDataName, *meshID);
   }
 }
 
-void precice_fastest_set_vertex_
-(
-  const int*    meshID,
-  const double* position,
-  int*          vertexID,
-  const int*    useFluid)
+void precice_fastest_set_vertex_(
+    const int *   meshID,
+    const double *position,
+    int *         vertexID,
+    const int *   useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     *vertexID = implAcoustic->setMeshVertex(*meshID, position);
-  }
-  else{
+  } else {
     *vertexID = implFluid->setMeshVertex(*meshID, position);
   }
 }
 
-void precice_fastest_set_vertices_
-(
-  const int*    meshID,
-  const int*    size,
-  double*       positions,
-  int*          positionIDs,
-  const int*    useFluid)
+void precice_fastest_set_vertices_(
+    const int *meshID,
+    const int *size,
+    double *   positions,
+    int *      positionIDs,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->setMeshVertices(*meshID, *size, positions, positionIDs);
-  }
-  else{
+  } else {
     implFluid->setMeshVertices(*meshID, *size, positions, positionIDs);
   }
 }
 
-void precice_fastest_write_bvdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid)
+void precice_fastest_write_bvdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->writeBlockVectorData(*dataID, *size, valueIndices, values);
-  }
-  else{
+  } else {
     implFluid->writeBlockVectorData(*dataID, *size, valueIndices, values);
   }
 }
 
-void precice_fastest_write_vdata_
-(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue,
-  const int*    useFluid)
+void precice_fastest_write_vdata_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue,
+    const int *   useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->writeVectorData(*dataID, *valueIndex, dataValue);
-  }
-  else{
+  } else {
     implFluid->writeVectorData(*dataID, *valueIndex, dataValue);
   }
 }
 
-void precice_fastest_write_bsdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid)
+void precice_fastest_write_bsdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->writeBlockScalarData(*dataID, *size, valueIndices, values);
-  }
-  else{
+  } else {
     implFluid->writeBlockScalarData(*dataID, *size, valueIndices, values);
   }
 }
 
-void precice_fastest_write_sdata_
-(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue,
-  const int*    useFluid)
+void precice_fastest_write_sdata_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue,
+    const int *   useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->writeScalarData(*dataID, *valueIndex, *dataValue);
-  }
-  else{
+  } else {
     implFluid->writeScalarData(*dataID, *valueIndex, *dataValue);
   }
 }
 
-void precice_fastest_read_bvdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid)
+void precice_fastest_read_bvdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->readBlockVectorData(*dataID, *size, valueIndices, values);
-  }
-  else{
+  } else {
     implFluid->readBlockVectorData(*dataID, *size, valueIndices, values);
   }
 }
 
-void precice_fastest_read_vdata_
-(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue,
-  const int* useFluid)
+void precice_fastest_read_vdata_(
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->readVectorData(*dataID, *valueIndex, dataValue);
-  }
-  else{
+  } else {
     implFluid->readVectorData(*dataID, *valueIndex, dataValue);
   }
 }
 
-void precice_fastest_read_bsdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid)
+void precice_fastest_read_bsdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->readBlockScalarData(*dataID, *size, valueIndices, values);
-  }
-  else{
+  } else {
     implFluid->readBlockScalarData(*dataID, *size, valueIndices, values);
   }
 }
 
-void precice_fastest_read_sdata_
-(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue,
-  const int* useFluid)
+void precice_fastest_read_sdata_(
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue,
+    const int *useFluid)
 {
   precice::impl::checkCorrectUsage(*useFluid);
 
-  if(*useFluid==0){
+  if (*useFluid == 0) {
     implAcoustic->readScalarData(*dataID, *valueIndex, *dataValue);
-  }
-  else{
+  } else {
     implFluid->readScalarData(*dataID, *valueIndex, *dataValue);
   }
 }
@@ -382,12 +343,11 @@ void precice::impl::checkCorrectUsage(int useFluid)
 {
   PRECICE_CHECK(useFluid == 0 || useFluid == 1, "useFluid needs to be either 0 or 1.");
 
-  if(useFluid==1){
+  if (useFluid == 1) {
     PRECICE_CHECK(implFluid != nullptr, "The fluid interface has not been created properly. Be sure to call "
-        "\"precicef_create\" with \"useFluid=1\" before any other call to preCICE if \"isFluid=1\".");
-  }
-  else if (useFluid==0){
+                                        "\"precicef_create\" with \"useFluid=1\" before any other call to preCICE if \"isFluid=1\".");
+  } else if (useFluid == 0) {
     PRECICE_CHECK(implAcoustic != nullptr, "The acoustic interface has not been created properly. Be sure to call "
-        "\"precicef_create\" with \"useAcoustic=1\" before any other call to preCICE if \"isFluid=0\".");
+                                           "\"precicef_create\" with \"useAcoustic=1\" before any other call to preCICE if \"isFluid=0\".");
   }
 }

--- a/src/precice/bindings/fortran/SolverInterfaceFASTEST.hpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFASTEST.hpp
@@ -16,7 +16,7 @@
  */
 
 #ifdef __cplusplus
-extern"C" {
+extern "C" {
 #endif
 
 /**
@@ -42,16 +42,16 @@ extern"C" {
  * OUT: -
  */
 void precice_fastest_create_(
-  const char* participantNameAcoustic,
-  const int*  isAcousticUsed,
-  const char*  participantNameFluid,
-  const int*  isFluidUsed,
-  const char* configFileName,
-  const int*  solverProcessIndex,
-  const int*  solverProcessSize,
-  int   lengthAccessorNameAcoustic,
-  int   lengthAccessorNameFluid,
-  int   lengthConfigFileName);
+    const char *participantNameAcoustic,
+    const int * isAcousticUsed,
+    const char *participantNameFluid,
+    const int * isFluidUsed,
+    const char *configFileName,
+    const int * solverProcessIndex,
+    const int * solverProcessSize,
+    int         lengthAccessorNameAcoustic,
+    int         lengthAccessorNameFluid,
+    int         lengthConfigFileName);
 
 /**
  * @brief See precice::SolverInterface::initialize().
@@ -62,7 +62,7 @@ void precice_fastest_create_(
  * IN: useFluid (1: use the Fluid interface , 0: use the Acoustic interface)
  * OUT: timestepLengthLimit
  */
-void precice_fastest_initialize_( double* timestepLengthLimit, const int*  useFluid );
+void precice_fastest_initialize_(double *timestepLengthLimit, const int *useFluid);
 
 /**
  * @brief See precice::SolverInterface::initializeData().
@@ -73,7 +73,7 @@ void precice_fastest_initialize_( double* timestepLengthLimit, const int*  useFl
  * IN: useFluid (1: use the Fluid interface , 0: use the Acoustic interface)
  * OUT: -
  */
-void precice_fastest_initialize_data_(const int*  useFluid);
+void precice_fastest_initialize_data_(const int *useFluid);
 
 /**
  * @brief See precice::SolverInterface::advance().
@@ -85,8 +85,7 @@ void precice_fastest_initialize_data_(const int*  useFluid);
  * IN:  useFluid (1: use the Fluid interface , 0: use the Acoustic interface)
  * OUT: timestepLengthLimit
  */
-void precice_fastest_advance_( double* timestepLengthLimit, const int*  useFluid );
-
+void precice_fastest_advance_(double *timestepLengthLimit, const int *useFluid);
 
 /**
  * @brief See precice::SolverInterface::finalize().
@@ -96,7 +95,7 @@ void precice_fastest_advance_( double* timestepLengthLimit, const int*  useFluid
  *
  * IN:  useFluid (1: use the Fluid interface , 0: use the Acoustic interface)
  */
-void precice_fastest_finalize_(const int*  useFluid);
+void precice_fastest_finalize_(const int *useFluid);
 
 /**
  * @brief See precice::SolverInterface::isActionRequired().
@@ -112,10 +111,10 @@ void precice_fastest_finalize_(const int*  useFluid);
  * OUT: isRequired(1:true, 0:false)
  */
 void precice_fastest_action_required_(
-  const char* action,
-  int*        isRequired,
-  const int*  useFluid,
-  int         lengthAction );
+    const char *action,
+    int *       isRequired,
+    const int * useFluid,
+    int         lengthAction);
 
 /**
  * @brief See precice::SolverInterface::fulfilledAction().
@@ -128,9 +127,9 @@ void precice_fastest_action_required_(
  * OUT: -
  */
 void precice_fastest_fulfilled_action_(
-  const char* action,
-  const int*  useFluid,
-  int         lengthAction );
+    const char *action,
+    const int * useFluid,
+    int         lengthAction);
 
 /**
  * @brief See precice::SolverInterface::getMeshID().
@@ -146,11 +145,10 @@ void precice_fastest_fulfilled_action_(
  * OUT: meshID
  */
 void precice_fastest_get_mesh_id_(
-  const char* meshName,
-  int*        meshID,
-  const int*  useFluid,
-  int         lengthMeshName );
-
+    const char *meshName,
+    int *       meshID,
+    const int * useFluid,
+    int         lengthMeshName);
 
 /**
  * @brief See precice::SolverInterface::getDataID().
@@ -172,11 +170,11 @@ void precice_fastest_get_mesh_id_(
  * OUT: dataID
  */
 void precice_fastest_get_data_id_(
-  const char* dataName,
-  const int*  meshID,
-  int*        dataID,
-  const int*  useFluid,
-  int         lengthDataName);
+    const char *dataName,
+    const int * meshID,
+    int *       dataID,
+    const int * useFluid,
+    int         lengthDataName);
 
 /**
  * @brief See precice::SolverInterface::setMeshVertex().
@@ -193,10 +191,10 @@ void precice_fastest_get_data_id_(
  * OUT: vertexID
  */
 void precice_fastest_set_vertex_(
-  const int*    meshID,
-  const double* position,
-  int*          vertexID,
-  const int*    useFluid);
+    const int *   meshID,
+    const double *position,
+    int *         vertexID,
+    const int *   useFluid);
 
 /**
  * @brief See precice::SolverInterface::setMeshVertices().
@@ -214,12 +212,11 @@ void precice_fastest_set_vertex_(
  * OUT: positionIDs
  */
 void precice_fastest_set_vertices_(
-  const int*    meshID,
-  const int*    size,
-  double*       positions,
-  int*          positionIDs,
-  const int*    useFluid);
-
+    const int *meshID,
+    const int *size,
+    double *   positions,
+    int *      positionIDs,
+    const int *useFluid);
 
 /**
  * @brief See precice::SolverInterface::writeBlockVectorData.
@@ -237,11 +234,11 @@ void precice_fastest_set_vertices_(
  * OUT: -
  */
 void precice_fastest_write_bvdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid);
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid);
 
 /**
  * @brief precice::SolverInterface::writeVectorData.
@@ -258,10 +255,10 @@ void precice_fastest_write_bvdata_(
  * OUT: -
  */
 void precice_fastest_write_vdata_(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue,
-  const int*    useFluid);
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue,
+    const int *   useFluid);
 
 /**
  * @brief See precice::SolverInterface::writeBlockScalarData.
@@ -279,11 +276,11 @@ void precice_fastest_write_vdata_(
  * OUT: -
  */
 void precice_fastest_write_bsdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid);
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid);
 
 /**
  * @brief precice::SolverInterface::writeScalarData.
@@ -300,10 +297,10 @@ void precice_fastest_write_bsdata_(
  * OUT: -
  */
 void precice_fastest_write_sdata_(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue,
-  const int*    useFluid);
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue,
+    const int *   useFluid);
 
 /**
  * @brief See precice::SolverInterface::readBlockVectorData.
@@ -321,11 +318,11 @@ void precice_fastest_write_sdata_(
  * OUT: values
  */
 void precice_fastest_read_bvdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid);
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid);
 
 /**
  * @brief precice::SolverInterface::readVectorData.
@@ -342,10 +339,10 @@ void precice_fastest_read_bvdata_(
  * OUT: dataValue
  */
 void precice_fastest_read_vdata_(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue,
-  const int* useFluid);
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue,
+    const int *useFluid);
 
 /**
  * @brief See precice::SolverInterface::readBlockScalarData.
@@ -363,11 +360,11 @@ void precice_fastest_read_vdata_(
  * OUT: values
  */
 void precice_fastest_read_bsdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values,
-  const int* useFluid);
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values,
+    const int *useFluid);
 
 /**
  * @brief precice::SolverInterface::readScalarData.
@@ -384,11 +381,10 @@ void precice_fastest_read_bsdata_(
  * OUT: dataValue
  */
 void precice_fastest_read_sdata_(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue,
-  const int* useFluid);
-
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue,
+    const int *useFluid);
 
 #ifdef __cplusplus
 }

--- a/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
@@ -1,5 +1,4 @@
 #include "SolverInterfaceFortran.hpp"
-#include "precice/SolverInterface.hpp"
 #include <iostream>
 #include <string>
 #include "logging/Logger.hpp"
@@ -8,165 +7,151 @@
 
 using namespace std;
 
-static precice::SolverInterface* impl = nullptr;
+static precice::SolverInterface *impl = nullptr;
 
-static precice::logging::Logger _log ("SolverInterfaceFortran");
+static precice::logging::Logger _log("SolverInterfaceFortran");
 
 static std::string errormsg = "preCICE has not been created properly. Be sure to call \"precicef_create\" before any other call to preCICE.";
 
 namespace precice {
-  namespace impl {
-    /**
+namespace impl {
+/**
      * @brief Returns length of string without trailing whitespaces.
      */
-    int strippedLength( const char* string, int length );
-  }
-}
+int strippedLength(const char *string, int length);
+} // namespace impl
+} // namespace precice
 
-void precicef_create_
-(
-  const char* participantName,
-  const char* configFileName,
-  const int*  solverProcessIndex,
-  const int*  solverProcessSize,
-  int   lengthAccessorName,
-  int   lengthConfigFileName )
+void precicef_create_(
+    const char *participantName,
+    const char *configFileName,
+    const int * solverProcessIndex,
+    const int * solverProcessSize,
+    int         lengthAccessorName,
+    int         lengthConfigFileName)
 {
   //cout << "lengthAccessorName: " << lengthAccessorName << '\n';
   //cout << "lengthConfigFileName: " << lengthConfigFileName << '\n';
   //cout << "solverProcessIndex: " << *solverProcessIndex << '\n';
   //cout << "solverProcessSize: " << *solverProcessSize << '\n';
-  int strippedLength = precice::impl::strippedLength(participantName,lengthAccessorName);
+  int    strippedLength = precice::impl::strippedLength(participantName, lengthAccessorName);
   string stringAccessorName(participantName, strippedLength);
-  strippedLength = precice::impl::strippedLength(configFileName,lengthConfigFileName);
+  strippedLength = precice::impl::strippedLength(configFileName, lengthConfigFileName);
   string stringConfigFileName(configFileName, strippedLength);
   //cout << "Accessor: " << stringAccessorName << "!" << '\n';
   //cout << "Config  : " << stringConfigFileName << "!" << '\n';
-  impl = new precice::SolverInterface (stringAccessorName,
-         *solverProcessIndex, *solverProcessSize);
+  impl = new precice::SolverInterface(stringAccessorName,
+                                      *solverProcessIndex, *solverProcessSize);
   impl->configure(stringConfigFileName);
 }
 
-void precicef_initialize_
-(
-  double* timestepLengthLimit)
+void precicef_initialize_(
+    double *timestepLengthLimit)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   *timestepLengthLimit = impl->initialize();
 }
 
 void precicef_initialize_data_()
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->initializeData();
 }
 
-void precicef_advance_
-(
-  double* timestepLengthLimit)
+void precicef_advance_(
+    double *timestepLengthLimit)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   *timestepLengthLimit = impl->advance(*timestepLengthLimit);
 }
 
 void precicef_finalize_()
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->finalize();
   delete impl;
 }
 
-void precicef_get_dims_
-(
-  int* dimensions )
+void precicef_get_dims_(
+    int *dimensions)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   *dimensions = impl->getDimensions();
 }
 
-void precicef_ongoing_
-(
-  int* isOngoing )
+void precicef_ongoing_(
+    int *isOngoing)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  if (impl->isCouplingOngoing()){
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  if (impl->isCouplingOngoing()) {
     *isOngoing = 1;
-  }
-  else {
+  } else {
     *isOngoing = 0;
   }
 }
 
-void precicef_write_data_required_
-(
-  const double* computedTimestepLength,
-  int*          isRequired )
+void precicef_write_data_required_(
+    const double *computedTimestepLength,
+    int *         isRequired)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  if (impl->isWriteDataRequired(*computedTimestepLength)){
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  if (impl->isWriteDataRequired(*computedTimestepLength)) {
     *isRequired = 1;
-  }
-  else {
+  } else {
     *isRequired = 0;
   }
 }
 
-void precicef_read_data_available_
-(
-  int* isAvailable )
+void precicef_read_data_available_(
+    int *isAvailable)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  if (impl->isReadDataAvailable()){
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  if (impl->isReadDataAvailable()) {
     *isAvailable = 1;
-  }
-  else {
+  } else {
     *isAvailable = 0;
   }
 }
 
 void precicef_is_timestep_complete_(
-    int* isComplete )
+    int *isComplete)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  if (impl->isTimestepComplete()){
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  if (impl->isTimestepComplete()) {
     *isComplete = 1;
-  }
-  else {
+  } else {
     *isComplete = 0;
   }
 }
 
 void precicef_has_to_evaluate_surrogate_model_(
-    int* hasToEvaluate)
+    int *hasToEvaluate)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  if (impl->hasToEvaluateSurrogateModel()){
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  if (impl->hasToEvaluateSurrogateModel()) {
     *hasToEvaluate = 1;
-  }
-  else {
+  } else {
     *hasToEvaluate = 0;
   }
 }
 
 void precicef_has_to_evaluate_fine_model_(
-    int* hasToEvaluate)
+    int *hasToEvaluate)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  if (impl->hasToEvaluateFineModel()){
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  if (impl->hasToEvaluateFineModel()) {
     *hasToEvaluate = 1;
-  }
-  else {
+  } else {
     *hasToEvaluate = 0;
   }
 }
 
-void precicef_action_required_
-(
-  const char* action,
-  int*        isRequired,
-  int         lengthAction )
+void precicef_action_required_(
+    const char *action,
+    int *       isRequired,
+    int         lengthAction)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   //PRECICE_ASSERT(lengthAction > 1);
   //std::cout << "lengthAction: " << lengthAction << '\n';
   //std::cout << "Action:";
@@ -178,333 +163,306 @@ void precicef_action_required_
   //std::cout << "strippedLength: " << strippedLength << '\n';
   //PRECICE_ASSERT(strippedLength > 1);
   string stringAction(action, strippedLength);
-  if (impl->isActionRequired(stringAction)){
+  if (impl->isActionRequired(stringAction)) {
     *isRequired = 1;
-  }
-  else {
+  } else {
     *isRequired = 0;
   }
 }
 
-void precicef_fulfilled_action_
-(
-  const char* action,
-  int         lengthAction )
+void precicef_fulfilled_action_(
+    const char *action,
+    int         lengthAction)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  int strippedLength = precice::impl::strippedLength(action, lengthAction);
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  int    strippedLength = precice::impl::strippedLength(action, lengthAction);
   string stringAction(action, strippedLength);
   impl->fulfilledAction(stringAction);
 }
 
 void precicef_has_mesh_(
-  const char* meshName,
-  int*        hasMesh,
-  int         lengthMeshName)
+    const char *meshName,
+    int *       hasMesh,
+    int         lengthMeshName)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  int strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  int    strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
   string stringMeshName(meshName, strippedLength);
-  if (impl->hasMesh(meshName)){
+  if (impl->hasMesh(meshName)) {
     *hasMesh = 1;
-  }
-  else {
+  } else {
     *hasMesh = 0;
   }
 }
 
-void precicef_get_mesh_id_
-(
-  const char* meshName,
-  int*        meshID,
-  int         lengthMeshName )
+void precicef_get_mesh_id_(
+    const char *meshName,
+    int *       meshID,
+    int         lengthMeshName)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  int strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  int    strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
   string stringMeshName(meshName, strippedLength);
   *meshID = impl->getMeshID(stringMeshName);
 }
 
-void precicef_has_data_
-(
-  const char* dataName,
-  const int*  meshID,
-  int*        hasData,
-  int         lengthDataName)
+void precicef_has_data_(
+    const char *dataName,
+    const int * meshID,
+    int *       hasData,
+    int         lengthDataName)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  int strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  int    strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
   string stringDataName(dataName, strippedLength);
-  if (impl->hasData(stringDataName, *meshID)){
+  if (impl->hasData(stringDataName, *meshID)) {
     *hasData = 1;
-  }
-  else {
+  } else {
     *hasData = 0;
   }
 }
 
-void precicef_get_data_id_
-(
-  const char* dataName,
-  const int*  meshID,
-  int*        dataID,
-  int         lengthDataName
-)
+void precicef_get_data_id_(
+    const char *dataName,
+    const int * meshID,
+    int *       dataID,
+    int         lengthDataName)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
-  int strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  int    strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
   string stringDataName(dataName, strippedLength);
   *dataID = impl->getDataID(stringDataName, *meshID);
 }
 
-void precicef_set_vertex_
-(
-  const int*    meshID,
-  const double* position,
-  int*          vertexID )
+void precicef_set_vertex_(
+    const int *   meshID,
+    const double *position,
+    int *         vertexID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   *vertexID = impl->setMeshVertex(*meshID, position);
 }
 
 void precicef_get_mesh_vertex_size_(
-    const int* meshID,
-    int* meshSize)
+    const int *meshID,
+    int *      meshSize)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   *meshSize = impl->getMeshVertexSize(*meshID);
 }
 
-void precicef_set_vertices_
-(
-  const int*    meshID,
-  const int*    size,
-  double*       positions,
-  int*          positionIDs )
+void precicef_set_vertices_(
+    const int *meshID,
+    const int *size,
+    double *   positions,
+    int *      positionIDs)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshVertices(*meshID, *size, positions, positionIDs);
 }
 
 void precicef_get_vertices_(
-  const int* meshID,
-  const int* size,
-  int*       ids,
-  double*    positions )
+    const int *meshID,
+    const int *size,
+    int *      ids,
+    double *   positions)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->getMeshVertices(*meshID, *size, ids, positions);
 }
 
 void precicef_get_vertex_ids_from_positions_(
-  const int* meshID,
-  const int* size,
-  double*    positions,
-  int*       ids )
+    const int *meshID,
+    const int *size,
+    double *   positions,
+    int *      ids)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->getMeshVertexIDsFromPositions(*meshID, *size, positions, ids);
 }
 
-void precicef_set_edge_
-(
-  const int* meshID,
-  const int* firstVertexID,
-  const int* secondVertexID,
-  int* edgeID )
+void precicef_set_edge_(
+    const int *meshID,
+    const int *firstVertexID,
+    const int *secondVertexID,
+    int *      edgeID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   *edgeID = impl->setMeshEdge(*meshID, *firstVertexID, *secondVertexID);
 }
 
-void precicef_set_triangle_
-(
-  const int* meshID,
-  const int* firstEdgeID,
-  const int* secondEdgeID,
-  const int* thirdEdgeID )
+void precicef_set_triangle_(
+    const int *meshID,
+    const int *firstEdgeID,
+    const int *secondEdgeID,
+    const int *thirdEdgeID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshTriangle(*meshID, *firstEdgeID, *secondEdgeID, *thirdEdgeID);
 }
 
-void precicef_set_triangle_we_
-(
-  const int* meshID,
-  const int* firstVertexID,
-  const int* secondVertexID,
-  const int* thirdVertexID )
+void precicef_set_triangle_we_(
+    const int *meshID,
+    const int *firstVertexID,
+    const int *secondVertexID,
+    const int *thirdVertexID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshTriangleWithEdges(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID);
 }
 
 void precicef_set_quad_(
-  const int* meshID,
-  const int* firstEdgeID,
-  const int* secondEdgeID,
-  const int* thirdEdgeID,
-  const int* fourthEdgeID)
+    const int *meshID,
+    const int *firstEdgeID,
+    const int *secondEdgeID,
+    const int *thirdEdgeID,
+    const int *fourthEdgeID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshQuad(*meshID, *firstEdgeID, *secondEdgeID, *thirdEdgeID, *fourthEdgeID);
 }
 
 void precicef_set_quad_we_(
-  const int* meshID,
-  const int* firstVertexID,
-  const int* secondVertexID,
-  const int* thirdVertexID,
-  const int* fourthVertexID)
+    const int *meshID,
+    const int *firstVertexID,
+    const int *secondVertexID,
+    const int *thirdVertexID,
+    const int *fourthVertexID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshQuadWithEdges(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID, *fourthVertexID);
 }
 
-void precicef_write_bvdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values )
+void precicef_write_bvdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->writeBlockVectorData(*dataID, *size, valueIndices, values);
 }
 
-void precicef_write_vdata_
-(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue )
+void precicef_write_vdata_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->writeVectorData(*dataID, *valueIndex, dataValue);
 }
 
-void precicef_write_bsdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values )
+void precicef_write_bsdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->writeBlockScalarData(*dataID, *size, valueIndices, values);
 }
 
-void precicef_write_sdata_
-(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue )
+void precicef_write_sdata_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->writeScalarData(*dataID, *valueIndex, *dataValue);
 }
 
-void precicef_read_bvdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values )
+void precicef_read_bvdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->readBlockVectorData(*dataID, *size, valueIndices, values);
 }
 
-void precicef_read_vdata_
-(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue )
+void precicef_read_vdata_(
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->readVectorData(*dataID, *valueIndex, dataValue);
 }
 
-void precicef_read_bsdata_
-(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values )
+void precicef_read_bsdata_(
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->readBlockScalarData(*dataID, *size, valueIndices, values);
 }
 
-void precicef_read_sdata_
-(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue )
+void precicef_read_sdata_(
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->readScalarData(*dataID, *valueIndex, *dataValue);
 }
 
-void precicef_map_write_data_from_
-(
-  const int* meshID )
+void precicef_map_write_data_from_(
+    const int *meshID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->mapWriteDataFrom(*meshID);
 }
 
-void precicef_map_read_data_to_
-(
-  const int* meshID )
+void precicef_map_read_data_to_(
+    const int *meshID)
 {
-  PRECICE_CHECK(impl != nullptr,errormsg);
+  PRECICE_CHECK(impl != nullptr, errormsg);
   impl->mapReadDataTo(*meshID);
 }
 
-int precice::impl::strippedLength
-(
-  const char* string,
-  int         length )
+int precice::impl::strippedLength(
+    const char *string,
+    int         length)
 {
-  int i=length-1;
-  while (((string[i] == ' ') || (string[i] == 0)) && (i >= 0)){
+  int i = length - 1;
+  while (((string[i] == ' ') || (string[i] == 0)) && (i >= 0)) {
     i--;
   }
-  return i+1;
+  return i + 1;
 }
 
-void precicef_action_write_iter_checkp_
-(
-  char*  nameAction,
-  int lengthNameAction )
+void precicef_action_write_iter_checkp_(
+    char *nameAction,
+    int   lengthNameAction)
 {
-  const std::string& name = precice::constants::actionWriteIterationCheckpoint();
+  const std::string &name = precice::constants::actionWriteIterationCheckpoint();
   PRECICE_ASSERT(name.size() < (size_t) lengthNameAction, name.size(), lengthNameAction);
-  for (size_t i=0; i < name.size(); i++){
+  for (size_t i = 0; i < name.size(); i++) {
     nameAction[i] = name[i];
   }
 }
 
 void precicef_action_write_initial_data_(
-  char*  nameAction,
-  int lengthNameAction )
+    char *nameAction,
+    int   lengthNameAction)
 {
-  const std::string& name = precice::constants::actionWriteInitialData();
+  const std::string &name = precice::constants::actionWriteInitialData();
   PRECICE_ASSERT(name.size() < (size_t) lengthNameAction, name.size(), lengthNameAction);
-  for (size_t i=0; i < name.size(); i++){
+  for (size_t i = 0; i < name.size(); i++) {
     nameAction[i] = name[i];
   }
 }
 
-void precicef_action_read_iter_checkp_
-(
-  char*  nameAction,
-  int lengthNameAction )
+void precicef_action_read_iter_checkp_(
+    char *nameAction,
+    int   lengthNameAction)
 {
-  const std::string& name = precice::constants::actionReadIterationCheckpoint();
+  const std::string &name = precice::constants::actionReadIterationCheckpoint();
   PRECICE_ASSERT(name.size() < (size_t) lengthNameAction, name.size(), lengthNameAction);
-  for (size_t i=0; i < name.size(); i++){
+  for (size_t i = 0; i < name.size(); i++) {
     nameAction[i] = name[i];
   }
 }
-

--- a/src/precice/bindings/fortran/SolverInterfaceFortran.hpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFortran.hpp
@@ -10,7 +10,7 @@
  */
 
 #ifdef __cplusplus
-extern"C" {
+extern "C" {
 #endif
 
 /**
@@ -27,12 +27,12 @@ extern"C" {
  * OUT: -
  */
 void precicef_create_(
-  const char* participantName,
-  const char* configFileName,
-  const int*  solverProcessIndex,
-  const int*  solverProcessSize,
-  int   lengthAccessorName,
-  int   lengthConfigFileName );
+    const char *participantName,
+    const char *configFileName,
+    const int * solverProcessIndex,
+    const int * solverProcessSize,
+    int         lengthAccessorName,
+    int         lengthConfigFileName);
 
 /**
  * @brief See precice::SolverInterface::initialize().
@@ -43,7 +43,7 @@ void precicef_create_(
  * IN:  -
  * OUT: timestepLengthLimit
  */
-void precicef_initialize_( double* timestepLengthLimit );
+void precicef_initialize_(double *timestepLengthLimit);
 
 /**
  * @brief See precice::SolverInterface::initializeData().
@@ -65,8 +65,7 @@ void precicef_initialize_data_();
  * IN:  timestepLengthLimit
  * OUT: timestepLengthLimit
  */
-void precicef_advance_( double* timestepLengthLimit );
-
+void precicef_advance_(double *timestepLengthLimit);
 
 /**
  * @brief See precice::SolverInterface::finalize().
@@ -85,7 +84,7 @@ void precicef_finalize_();
  * IN:  -
  * OUT: dimensions
  */
-void precicef_get_dims_( int* dimensions );
+void precicef_get_dims_(int *dimensions);
 
 /**
  * @brief See precice::SolverInterface::isOngoing().
@@ -96,7 +95,7 @@ void precicef_get_dims_( int* dimensions );
  * IN:  -
  * OUT: isOngoing(1:true, 0:false)
  */
-void precicef_ongoing_( int* isOngoing );
+void precicef_ongoing_(int *isOngoing);
 
 /**
  * @brief See precice::SolverInterface::isWriteDataRequired().
@@ -110,8 +109,8 @@ void precicef_ongoing_( int* isOngoing );
  * OUT: isRequired(1:true, 0:false)
  */
 void precicef_write_data_required_(
-  const double* computedTimestepLength,
-  int*          isRequired );
+    const double *computedTimestepLength,
+    int *         isRequired);
 
 /**
  * @brief See precice::SolverInterface::isReadDataAvailable().
@@ -122,7 +121,7 @@ void precicef_write_data_required_(
  * IN:  -
  * OUT: isAvailable(1:true, 0:false)
  */
-void precicef_read_data_available_( int* isAvailable );
+void precicef_read_data_available_(int *isAvailable);
 
 /**
  * @brief See precice::SolverInterface::isTimestepComplete().
@@ -133,7 +132,7 @@ void precicef_read_data_available_( int* isAvailable );
  * IN:  -
  * OUT: isComplete(1:true, 0:false)
  */
-void precicef_is_timestep_complete_( int* isComplete );
+void precicef_is_timestep_complete_(int *isComplete);
 
 /**
  * @brief See precice::SolverInterface::hasToEvaluateSurrogateModel().
@@ -144,7 +143,7 @@ void precicef_is_timestep_complete_( int* isComplete );
  * IN:  -
  * OUT: hasToEvaluate(1:true, 0:false)
  */
-void precicef_has_to_evaluate_surrogate_model_ ( int* hasToEvaluate );
+void precicef_has_to_evaluate_surrogate_model_(int *hasToEvaluate);
 
 /**
  * @brief See precice::SolverInterface::hasToEvaluateFineModel().
@@ -155,7 +154,7 @@ void precicef_has_to_evaluate_surrogate_model_ ( int* hasToEvaluate );
  * IN:  -
  * OUT: hasToEvaluate(1:true, 0:false)
  */
-void precicef_has_to_evaluate_fine_model_ ( int* hasToEvaluate );
+void precicef_has_to_evaluate_fine_model_(int *hasToEvaluate);
 
 /**
  * @brief See precice::SolverInterface::isActionRequired().
@@ -169,9 +168,9 @@ void precicef_has_to_evaluate_fine_model_ ( int* hasToEvaluate );
  * OUT: isRequired(1:true, 0:false)
  */
 void precicef_action_required_(
-  const char* action,
-  int*        isRequired,
-  int         lengthAction );
+    const char *action,
+    int *       isRequired,
+    int         lengthAction);
 
 /**
  * @brief See precice::SolverInterface::fulfilledAction().
@@ -183,8 +182,8 @@ void precicef_action_required_(
  * OUT: -
  */
 void precicef_fulfilled_action_(
-  const char* action,
-  int         lengthAction );
+    const char *action,
+    int         lengthAction);
 
 /**
  * @brief See precice::SolverInterface::hasMesh().
@@ -198,8 +197,8 @@ void precicef_fulfilled_action_(
  * OUT: hasMesh(1:true, 0:false)
  */
 void precicef_has_mesh_(
-    const char* meshName,
-    int*        hasMesh,
+    const char *meshName,
+    int *       hasMesh,
     int         lengthMeshName);
 
 /**
@@ -214,9 +213,9 @@ void precicef_has_mesh_(
  * OUT: meshID
  */
 void precicef_get_mesh_id_(
-  const char* meshName,
-  int*        meshID,
-  int         lengthMeshName );
+    const char *meshName,
+    int *       meshID,
+    int         lengthMeshName);
 
 /**
  * @brief See precice::SolverInterface::hasData().
@@ -232,10 +231,10 @@ void precicef_get_mesh_id_(
  * OUT: hasData(1:true, 0:false)
  */
 void precicef_has_data_(
-  const char* dataName,
-  const int*  meshID,
-  int*        hasData,
-  int         lengthDataName);
+    const char *dataName,
+    const int * meshID,
+    int *       hasData,
+    int         lengthDataName);
 
 /**
  * @brief See precice::SolverInterface::getDataID().
@@ -256,10 +255,10 @@ void precicef_has_data_(
  * OUT: dataID
  */
 void precicef_get_data_id_(
-  const char* dataName,
-  const int*  meshID,
-  int*        dataID,
-  int         lengthDataName);
+    const char *dataName,
+    const int * meshID,
+    int *       dataID,
+    int         lengthDataName);
 
 /**
  * @brief See precice::SolverInterface::setMeshVertex().
@@ -274,9 +273,9 @@ void precicef_get_data_id_(
  * OUT: vertexID
  */
 void precicef_set_vertex_(
-  const int*    meshID,
-  const double* position,
-  int*          vertexID );
+    const int *   meshID,
+    const double *position,
+    int *         vertexID);
 
 /**
  * @brief See precice::SolverInterface::getMeshVertexSize().
@@ -290,8 +289,8 @@ void precicef_set_vertex_(
  * OUT: meshSize
  */
 void precicef_get_mesh_vertex_size_(
-    int* meshID,
-    int* meshSize);
+    int *meshID,
+    int *meshSize);
 
 /**
  * @brief See precice::SolverInterface::setMeshVertices().
@@ -307,10 +306,10 @@ void precicef_get_mesh_vertex_size_(
  * OUT: positionIDs
  */
 void precicef_set_vertices_(
-  const int*    meshID,
-  const int*    size,
-  double*       positions,
-  int*          positionIDs );
+    const int *meshID,
+    const int *size,
+    double *   positions,
+    int *      positionIDs);
 
 /**
  * @brief See precice::SolverInterface::getMeshVertices().
@@ -326,10 +325,10 @@ void precicef_set_vertices_(
  * OUT: positions
  */
 void precicef_get_vertices_(
-    const int* meshID,
-    const int* size,
-    int*       ids,
-    double*    positions );
+    const int *meshID,
+    const int *size,
+    int *      ids,
+    double *   positions);
 
 /**
  * @brief See precice::SolverInterface::getMeshVertexIDsFromPositions().
@@ -345,10 +344,10 @@ void precicef_get_vertices_(
  * OUT: ids
  */
 void precicef_get_vertex_ids_from_positions_(
-    const int* meshID,
-    const int* size,
-    double*    positions,
-    int*       ids );
+    const int *meshID,
+    const int *size,
+    double *   positions,
+    int *      ids);
 
 /**
  * @brief See precice::SolverInterface::setMeshEdge().
@@ -364,10 +363,10 @@ void precicef_get_vertex_ids_from_positions_(
  * OUT: edgeID
  */
 void precicef_set_edge_(
-  const int* meshID,
-  const int* firstVertexID,
-  const int* secondVertexID,
-  int*       edgeID );
+    const int *meshID,
+    const int *firstVertexID,
+    const int *secondVertexID,
+    int *      edgeID);
 
 /**
  * @brief See precice::SolverInterface::setMeshTriangle().
@@ -383,10 +382,10 @@ void precicef_set_edge_(
  * OUT: -
  */
 void precicef_set_triangle_(
-  const int* meshID,
-  const int* firstEdgeID,
-  const int* secondEdgeID,
-  const int* thirdEdgeID );
+    const int *meshID,
+    const int *firstEdgeID,
+    const int *secondEdgeID,
+    const int *thirdEdgeID);
 
 /**
  * @brief See precice::SolverInterface::setMeshTriangleWithEdges().
@@ -402,10 +401,10 @@ void precicef_set_triangle_(
  * OUT: -
  */
 void precicef_set_triangle_we_(
-  const int* meshID,
-  const int* firstVertexID,
-  const int* secondVertexID,
-  const int* thirdVertexID );
+    const int *meshID,
+    const int *firstVertexID,
+    const int *secondVertexID,
+    const int *thirdVertexID);
 
 /**
  * @brief See precice::SolverInterface::setMeshQuad().
@@ -422,11 +421,11 @@ void precicef_set_triangle_we_(
  * OUT: -
  */
 void precicef_set_quad_(
-    const int* meshID,
-    const int* firstEdgeID,
-    const int* secondEdgeID,
-    const int* thirdEdgeID,
-    const int* fourthEdgeID);
+    const int *meshID,
+    const int *firstEdgeID,
+    const int *secondEdgeID,
+    const int *thirdEdgeID,
+    const int *fourthEdgeID);
 
 /**
  * @brief See precice::SolverInterface::setMeshQuadWithEdges().
@@ -443,11 +442,11 @@ void precicef_set_quad_(
  * OUT: -
  */
 void precicef_set_quad_we_(
-    const int* meshID,
-    const int* firstVertexID,
-    const int* secondVertexID,
-    const int* thirdVertexID,
-    const int* fourthVertexID);
+    const int *meshID,
+    const int *firstVertexID,
+    const int *secondVertexID,
+    const int *thirdVertexID,
+    const int *fourthVertexID);
 
 /**
  * @brief See precice::SolverInterface::writeBlockVectorData.
@@ -463,10 +462,10 @@ void precicef_set_quad_we_(
  * OUT: -
  */
 void precicef_write_bvdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values );
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values);
 
 /**
  * @brief precice::SolverInterface::writeVectorData.
@@ -481,9 +480,9 @@ void precicef_write_bvdata_(
  * OUT: -
  */
 void precicef_write_vdata_(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue );
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue);
 
 /**
  * @brief See precice::SolverInterface::writeBlockScalarData.
@@ -499,10 +498,10 @@ void precicef_write_vdata_(
  * OUT: -
  */
 void precicef_write_bsdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values );
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values);
 
 /**
  * @brief precice::SolverInterface::writeScalarData.
@@ -517,9 +516,9 @@ void precicef_write_bsdata_(
  * OUT: -
  */
 void precicef_write_sdata_(
-  const int*    dataID,
-  const int*    valueIndex,
-  const double* dataValue );
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *dataValue);
 
 /**
  * @brief See precice::SolverInterface::readBlockVectorData.
@@ -535,10 +534,10 @@ void precicef_write_sdata_(
  * OUT: values
  */
 void precicef_read_bvdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values );
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values);
 
 /**
  * @brief precice::SolverInterface::readVectorData.
@@ -553,9 +552,9 @@ void precicef_read_bvdata_(
  * OUT: dataValue
  */
 void precicef_read_vdata_(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue );
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue);
 
 /**
  * @brief See precice::SolverInterface::readBlockScalarData.
@@ -571,10 +570,10 @@ void precicef_read_vdata_(
  * OUT: values
  */
 void precicef_read_bsdata_(
-  const int* dataID,
-  const int* size,
-  int*       valueIndices,
-  double*    values );
+    const int *dataID,
+    const int *size,
+    int *      valueIndices,
+    double *   values);
 
 /**
  * @brief precice::SolverInterface::readScalarData.
@@ -589,9 +588,9 @@ void precicef_read_bsdata_(
  * OUT: dataValue
  */
 void precicef_read_sdata_(
-  const int* dataID,
-  const int* valueIndex,
-  double*    dataValue );
+    const int *dataID,
+    const int *valueIndex,
+    double *   dataValue);
 
 /**
  * @brief See precice::SolverInterface::mapWriteDataFrom().
@@ -602,7 +601,7 @@ void precicef_read_sdata_(
  * IN:  meshID
  * OUT: -
  */
-void precicef_map_write_data_from_( const int* meshID );
+void precicef_map_write_data_from_(const int *meshID);
 
 /**
  * @brief See precice::SolverInterface::mapReadDataTo().
@@ -613,7 +612,7 @@ void precicef_map_write_data_from_( const int* meshID );
  * IN:  meshID
  * OUT: -
  */
-void precicef_map_read_data_to_( const int* meshID );
+void precicef_map_read_data_to_(const int *meshID);
 
 /**
  * @brief Name of action for writing iteration checkpoint.
@@ -622,8 +621,8 @@ void precicef_map_read_data_to_( const int* meshID );
  * precicef_action_write_iter_checkpoint( CHARACTER nameAction(*) )
  */
 void precicef_action_write_iter_checkp_(
-  char* nameAction,
-  int   lengthNameAction );
+    char *nameAction,
+    int   lengthNameAction);
 
 /**
  * @brief Name of action for writing initial data.
@@ -632,8 +631,8 @@ void precicef_action_write_iter_checkp_(
  * precicef_action_write_initial_data( CHARACTER nameAction(*) )
  */
 void precicef_action_write_initial_data_(
-  char* nameAction,
-  int   lengthNameAction );
+    char *nameAction,
+    int   lengthNameAction);
 
 /**
  * @brief Name of action for reading iteration checkpoint.
@@ -642,8 +641,8 @@ void precicef_action_write_initial_data_(
  * precicef_action_read_iter_checkpoint( CHARACTER nameAction(*) )
  */
 void precicef_action_read_iter_checkp_(
-  char* nameAction,
-  int   lengthNameAction );
+    char *nameAction,
+    int   lengthNameAction);
 
 #ifdef __cplusplus
 }

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -1,18 +1,16 @@
 #include "Configuration.hpp"
 #include "xml/XMLAttribute.hpp"
 
-
 namespace precice {
 
 extern bool syncMode;
 
 namespace config {
 
-Configuration:: Configuration()
-:
-  _tag(*this, "precice-configuration", xml::XMLTag::OCCUR_ONCE),
-  _logConfig(_tag),
-  _solverInterfaceConfig(_tag)
+Configuration::Configuration()
+    : _tag(*this, "precice-configuration", xml::XMLTag::OCCUR_ONCE),
+      _logConfig(_tag),
+      _solverInterfaceConfig(_tag)
 {
   _tag.setDocumentation("Main tag containing preCICE configuration.");
   _tag.addNamespace("data");
@@ -25,17 +23,16 @@ Configuration:: Configuration()
   _tag.addNamespace("acceleration");
 
   auto attrSyncMode = xml::makeXMLAttribute("sync-mode", false)
-      .setDocumentation("sync-mode enabled additional inter- and intra-participant synchronizations");
+                          .setDocumentation("sync-mode enabled additional inter- and intra-participant synchronizations");
   _tag.addAttribute(attrSyncMode);
-
 }
 
-xml::XMLTag& Configuration:: getXMLTag()
+xml::XMLTag &Configuration::getXMLTag()
 {
   return _tag;
 }
 
-void Configuration::xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& tag)
+void Configuration::xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag)
 {
   PRECICE_TRACE(tag.getName());
   if (tag.getName() == "precice-configuration") {
@@ -43,18 +40,18 @@ void Configuration::xmlTagCallback(const xml::ConfigurationContext& context, xml
   }
 }
 
-void Configuration:: xmlEndTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void Configuration::xmlEndTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getName());
 }
 
-const SolverInterfaceConfiguration&
-Configuration:: getSolverInterfaceConfiguration() const
+const SolverInterfaceConfiguration &
+Configuration::getSolverInterfaceConfiguration() const
 {
   return _solverInterfaceConfig;
 }
 
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "precice/config/SolverInterfaceConfiguration.hpp"
-#include "logging/config/LogConfiguration.hpp"
-#include "xml/XMLTag.hpp"
 #include "logging/Logger.hpp"
+#include "logging/config/LogConfiguration.hpp"
+#include "precice/config/SolverInterfaceConfiguration.hpp"
+#include "xml/XMLTag.hpp"
 
 namespace precice {
 namespace config {
@@ -14,10 +14,8 @@ namespace config {
  * The configuration process is triggered by fetching the root tag with method
  * getXMLTag() and calling its parse() method.
  */
-class Configuration : public xml::XMLTag::Listener
-{
+class Configuration : public xml::XMLTag::Listener {
 public:
-
   Configuration();
 
   /**
@@ -28,29 +26,28 @@ public:
   /**
    * @brief Returns root xml tag to start the automatic configuration process.
    */
-  xml::XMLTag& getXMLTag();
+  xml::XMLTag &getXMLTag();
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback (const xml::ConfigurationContext& context, xml::XMLTag& tag );
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback (const xml::ConfigurationContext& context, xml::XMLTag& tag );
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
 
   /**
    * @brief Returns solver interface configuration.
    */
-  const SolverInterfaceConfiguration& getSolverInterfaceConfiguration() const;
+  const SolverInterfaceConfiguration &getSolverInterfaceConfiguration() const;
 
 private:
-
   logging::Logger _log{"config::Configuration"};
 
   // @brief Root tag of preCICE configuration.
@@ -59,7 +56,7 @@ private:
   LogConfiguration _logConfig;
 
   SolverInterfaceConfiguration _solverInterfaceConfig;
-
 };
 
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -1,45 +1,43 @@
 #include "ParticipantConfiguration.hpp"
-#include "precice/impl/MeshContext.hpp"
-#include "precice/impl/MappingContext.hpp"
-#include "precice/impl/DataContext.hpp"
-#include "precice/impl/WatchPoint.hpp"
-#include "com/config/CommunicationConfiguration.hpp"
 #include "action/config/ActionConfiguration.hpp"
-#include "mesh/config/MeshConfiguration.hpp"
-#include "mapping/Mapping.hpp"
-#include "mapping/config/MappingConfiguration.hpp"
-#include "xml/XMLAttribute.hpp"
-#include "utils/MasterSlave.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "com/MPIPortsCommunication.hpp"
+#include "com/config/CommunicationConfiguration.hpp"
+#include "io/ExportContext.hpp"
 #include "io/ExportVTK.hpp"
 #include "io/ExportVTKXML.hpp"
-#include "io/ExportContext.hpp"
 #include "io/SharedPointer.hpp"
+#include "mapping/Mapping.hpp"
+#include "mapping/config/MappingConfiguration.hpp"
+#include "mesh/config/MeshConfiguration.hpp"
 #include "partition/ReceivedPartition.hpp"
+#include "precice/impl/DataContext.hpp"
+#include "precice/impl/MappingContext.hpp"
+#include "precice/impl/MeshContext.hpp"
+#include "precice/impl/WatchPoint.hpp"
+#include "utils/MasterSlave.hpp"
+#include "xml/XMLAttribute.hpp"
 
 namespace precice {
 namespace config {
 
-ParticipantConfiguration:: ParticipantConfiguration
-(
-  xml::XMLTag&                      parent,
-  const mesh::PtrMeshConfiguration& meshConfiguration)
-:
-  _meshConfig(meshConfiguration)
+ParticipantConfiguration::ParticipantConfiguration(
+    xml::XMLTag &                     parent,
+    const mesh::PtrMeshConfiguration &meshConfiguration)
+    : _meshConfig(meshConfiguration)
 {
   PRECICE_ASSERT(_meshConfig);
   using namespace xml;
   std::string doc;
-  XMLTag tag(*this, TAG, XMLTag::OCCUR_ONCE_OR_MORE);
+  XMLTag      tag(*this, TAG, XMLTag::OCCUR_ONCE_OR_MORE);
   doc = "Represents one solver using preCICE. At least two ";
   doc += "participants have to be defined.";
   tag.setDocumentation(doc);
 
- auto attrName = XMLAttribute<std::string>(ATTR_NAME)
-      .setDocumentation(
-              "Name of the participant. Has to match the name given on construction "
-              "of the precice::SolverInterface object used by the participant.");
+  auto attrName = XMLAttribute<std::string>(ATTR_NAME)
+                      .setDocumentation(
+                          "Name of the participant. Has to match the name given on construction "
+                          "of the precice::SolverInterface object used by the participant.");
   tag.addAttribute(attrName);
 
   XMLTag tagWriteData(*this, TAG_WRITE, XMLTag::OCCUR_ARBITRARY);
@@ -50,24 +48,24 @@ ParticipantConfiguration:: ParticipantConfiguration
   doc = "Sets data to be read by the participant from preCICE. ";
   doc += "Data is defined by using the <data> tag.";
   tagReadData.setDocumentation(doc);
- auto attrDataName = XMLAttribute<std::string>(ATTR_NAME)
-      .setDocumentation("Name of the data.");
+  auto attrDataName = XMLAttribute<std::string>(ATTR_NAME)
+                          .setDocumentation("Name of the data.");
   tagWriteData.addAttribute(attrDataName);
   tagReadData.addAttribute(attrDataName);
- auto attrMesh = XMLAttribute<std::string>(ATTR_MESH)
-      .setDocumentation(
-              "Mesh the data belongs to. If data should be read/written to several "
-              "meshes, this has to be specified separately for each mesh.");
+  auto attrMesh = XMLAttribute<std::string>(ATTR_MESH)
+                      .setDocumentation(
+                          "Mesh the data belongs to. If data should be read/written to several "
+                          "meshes, this has to be specified separately for each mesh.");
   tagWriteData.addAttribute(attrMesh);
   tagReadData.addAttribute(attrMesh);
   tag.addSubtag(tagWriteData);
   tag.addSubtag(tagReadData);
 
   _mappingConfig = mapping::PtrMappingConfiguration(
-                   new mapping::MappingConfiguration(tag, _meshConfig));
+      new mapping::MappingConfiguration(tag, _meshConfig));
 
   _actionConfig = action::PtrActionConfiguration(
-                  new action::ActionConfiguration(tag, _meshConfig));
+      new action::ActionConfiguration(tag, _meshConfig));
 
   _exportConfig = io::PtrExportConfiguration(new io::ExportConfiguration(tag));
 
@@ -82,12 +80,12 @@ ParticipantConfiguration:: ParticipantConfiguration
   doc = "Mesh to be watched.";
   attrMesh.setDocumentation(doc);
   tagWatchPoint.addAttribute(attrMesh);
- auto attrCoordinate = XMLAttribute<Eigen::VectorXd>(ATTR_COORDINATE)
-      .setDocumentation(
-              "The coordinates of the watch point. If the watch point is not put exactly "
-              "on the mesh to observe, the closest projection of the point onto the "
-              "mesh is considered instead, and values/coordinates are interpolated "
-              "linearly to that point.");
+  auto attrCoordinate = XMLAttribute<Eigen::VectorXd>(ATTR_COORDINATE)
+                            .setDocumentation(
+                                "The coordinates of the watch point. If the watch point is not put exactly "
+                                "on the mesh to observe, the closest projection of the point onto the "
+                                "mesh is considered instead, and values/coordinates are interpolated "
+                                "linearly to that point.");
   tagWatchPoint.addAttribute(attrCoordinate);
   tag.addSubtag(tagWatchPoint);
 
@@ -96,51 +94,51 @@ ParticipantConfiguration:: ParticipantConfiguration
   tagUseMesh.setDocumentation(doc);
   attrName.setDocumentation("Name of the mesh.");
   tagUseMesh.addAttribute(attrName);
-//  XMLAttribute<Eigen::VectorXd> attrLocalOffset(ATTR_LOCAL_OFFSET);
-//  doc = "The mesh can have an offset only applied for the local participant. ";
-//  doc += "Vector-valued example: '1.0; 0.0; 0.0'";
-//  attrLocalOffset.setDocumentation(doc);
-//  attrLocalOffset.setDefaultValue(Eigen::VectorXd::Constant(3, 0));
-//  tagUseMesh.addAttribute(attrLocalOffset);
+  //  XMLAttribute<Eigen::VectorXd> attrLocalOffset(ATTR_LOCAL_OFFSET);
+  //  doc = "The mesh can have an offset only applied for the local participant. ";
+  //  doc += "Vector-valued example: '1.0; 0.0; 0.0'";
+  //  attrLocalOffset.setDocumentation(doc);
+  //  attrLocalOffset.setDefaultValue(Eigen::VectorXd::Constant(3, 0));
+  //  tagUseMesh.addAttribute(attrLocalOffset);
 
- auto attrFrom = XMLAttribute<std::string>(ATTR_FROM, "")
-      .setDocumentation(
-              "If a created mesh should be used by "
-              "another solver, this attribute has to specify the creating participant's"
-              " name. The creator has to use the attribute \"provide\" to signal he is "
-              "providing the mesh geometry.");
+  auto attrFrom = XMLAttribute<std::string>(ATTR_FROM, "")
+                      .setDocumentation(
+                          "If a created mesh should be used by "
+                          "another solver, this attribute has to specify the creating participant's"
+                          " name. The creator has to use the attribute \"provide\" to signal he is "
+                          "providing the mesh geometry.");
   tagUseMesh.addAttribute(attrFrom);
   auto attrSafetyFactor = makeXMLAttribute(ATTR_SAFETY_FACTOR, 0.5)
-      .setDocumentation(
-              "If a mesh is received from another partipant (see tag <from>), it needs to be"
-              "decomposed at the receiving participant. To speed up this process, "
-              "a geometric filter (see tag <geometric-filter>), i.e. filtering by bounding boxes around the local mesh, can be used. "
-              "This safety factor defines by which factor this local information is "
-              "increased. An example: 0.5 means that the bounding box is 150% of its original size.");
+                              .setDocumentation(
+                                  "If a mesh is received from another partipant (see tag <from>), it needs to be"
+                                  "decomposed at the receiving participant. To speed up this process, "
+                                  "a geometric filter (see tag <geometric-filter>), i.e. filtering by bounding boxes around the local mesh, can be used. "
+                                  "This safety factor defines by which factor this local information is "
+                                  "increased. An example: 0.5 means that the bounding box is 150% of its original size.");
   tagUseMesh.addAttribute(attrSafetyFactor);
 
- auto attrGeoFilter = XMLAttribute<std::string>(ATTR_GEOMETRIC_FILTER)
-      .setDocumentation(
-              "If a mesh is received from another partipant (see tag <from>), it needs to be"
-              "decomposed at the receiving participant. To speed up this process, "
-              "a geometric filter, i.e. filtering by bounding boxes around the local mesh, can be used. "
-              "2 different variants are implemented: a \"filter-first\" strategy, "
-              "which is beneficial for a huge mesh and a low number of processors, and a "
-              "\"broadcast/filter\" strategy, which performs better for a very high number of "
-              "processors. Both result in the same distribution (if the safety factor is sufficiently large)."
-              "For very asymmetric cases, the filter can also be switched off completely (\"no-filter\").")
-      .setOptions({ VALUE_FILTER_FIRST, VALUE_BROADCAST_FILTER, VALUE_NO_FILTER })
-      .setDefaultValue(VALUE_BROADCAST_FILTER);
+  auto attrGeoFilter = XMLAttribute<std::string>(ATTR_GEOMETRIC_FILTER)
+                           .setDocumentation(
+                               "If a mesh is received from another partipant (see tag <from>), it needs to be"
+                               "decomposed at the receiving participant. To speed up this process, "
+                               "a geometric filter, i.e. filtering by bounding boxes around the local mesh, can be used. "
+                               "2 different variants are implemented: a \"filter-first\" strategy, "
+                               "which is beneficial for a huge mesh and a low number of processors, and a "
+                               "\"broadcast/filter\" strategy, which performs better for a very high number of "
+                               "processors. Both result in the same distribution (if the safety factor is sufficiently large)."
+                               "For very asymmetric cases, the filter can also be switched off completely (\"no-filter\").")
+                           .setOptions({VALUE_FILTER_FIRST, VALUE_BROADCAST_FILTER, VALUE_NO_FILTER})
+                           .setDefaultValue(VALUE_BROADCAST_FILTER);
   tagUseMesh.addAttribute(attrGeoFilter);
 
   auto attrProvide = makeXMLAttribute(ATTR_PROVIDE, false)
-      .setDocumentation(
-              "If this attribute is set to \"on\", the "
-              "participant has to create the mesh geometry before initializing preCICE.");
+                         .setDocumentation(
+                             "If this attribute is set to \"on\", the "
+                             "participant has to create the mesh geometry before initializing preCICE.");
   tagUseMesh.addAttribute(attrProvide);
   tag.addSubtag(tagUseMesh);
 
-  std::list<XMLTag> serverTags;
+  std::list<XMLTag>  serverTags;
   XMLTag::Occurrence serverOcc = XMLTag::OCCUR_NOT_OR_ONCE;
   {
     XMLTag tagServer(*this, "sockets", serverOcc, TAG_SERVER);
@@ -150,24 +148,24 @@ ParticipantConfiguration:: ParticipantConfiguration
     tagServer.setDocumentation(doc);
 
     auto attrPort = makeXMLAttribute("port", 0)
-        .setDocumentation(
-                "Port number (16-bit unsigned integer) to be used for socket "
-                "communiation. The default is \"0\", what means that OS will "
-                "dynamically search for a free port (if at least one exists) and "
-                "bind it automatically.");
+                        .setDocumentation(
+                            "Port number (16-bit unsigned integer) to be used for socket "
+                            "communiation. The default is \"0\", what means that OS will "
+                            "dynamically search for a free port (if at least one exists) and "
+                            "bind it automatically.");
     tagServer.addAttribute(attrPort);
 
     auto attrNetwork = makeXMLAttribute(ATTR_NETWORK, "lo")
-        .setDocumentation(
-                "Network name to be used for socket communiation. "
-                "Default is \"lo\", i.e., the local host loopback.");
+                           .setDocumentation(
+                               "Network name to be used for socket communiation. "
+                               "Default is \"lo\", i.e., the local host loopback.");
     tagServer.addAttribute(attrNetwork);
 
-   auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-        .setDocumentation(
-                "Directory where connection information is exchanged. By default, the "
-                "directory of startup is chosen, and both solvers have to be started "
-                "in the same directory.");
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen, and both solvers have to be started "
+                                         "in the same directory.");
     tagServer.addAttribute(attrExchangeDirectory);
 
     serverTags.push_back(tagServer);
@@ -180,11 +178,11 @@ ParticipantConfiguration:: ParticipantConfiguration
     doc += "with startup in separated communication spaces.";
     tagServer.setDocumentation(doc);
 
-   auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-        .setDocumentation(
-                "Directory where connection information is exchanged. By default, the "
-                "directory of startup is chosen, and both solvers have to be started "
-                "in the same directory.");
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen, and both solvers have to be started "
+                                         "in the same directory.");
     tagServer.addAttribute(attrExchangeDirectory);
 
     serverTags.push_back(tagServer);
@@ -198,11 +196,11 @@ ParticipantConfiguration:: ParticipantConfiguration
     tagServer.setDocumentation(doc);
     serverTags.push_back(tagServer);
   }
-  for (XMLTag& tagServer : serverTags){
+  for (XMLTag &tagServer : serverTags) {
     tag.addSubtag(tagServer);
   }
 
-  std::list<XMLTag> masterTags;
+  std::list<XMLTag>  masterTags;
   XMLTag::Occurrence masterOcc = XMLTag::OCCUR_NOT_OR_ONCE;
   {
     XMLTag tagMaster(*this, "sockets", masterOcc, TAG_MASTER);
@@ -215,23 +213,23 @@ ParticipantConfiguration:: ParticipantConfiguration
     tagMaster.setDocumentation(doc);
 
     auto attrPort = makeXMLAttribute("port", 0)
-        .setDocumentation(
-                "Port number (16-bit unsigned integer) to be used for socket "
-                "communiation. The default is \"0\", what means that OS will "
-                "dynamically search for a free port (if at least one exists) and "
-                "bind it automatically.");
+                        .setDocumentation(
+                            "Port number (16-bit unsigned integer) to be used for socket "
+                            "communiation. The default is \"0\", what means that OS will "
+                            "dynamically search for a free port (if at least one exists) and "
+                            "bind it automatically.");
     tagMaster.addAttribute(attrPort);
 
     auto attrNetwork = makeXMLAttribute(ATTR_NETWORK, "lo")
-        .setDocumentation(
-          "Network name to be used for socket communiation. "
-          "Default is \"lo\", i.e., the local host loopback.");
+                           .setDocumentation(
+                               "Network name to be used for socket communiation. "
+                               "Default is \"lo\", i.e., the local host loopback.");
     tagMaster.addAttribute(attrNetwork);
 
-   auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-        .setDocumentation(
-                "Directory where connection information is exchanged. By default, the "
-                "directory of startup is chosen.");
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen.");
     tagMaster.addAttribute(attrExchangeDirectory);
 
     masterTags.push_back(tagMaster);
@@ -247,10 +245,10 @@ ParticipantConfiguration:: ParticipantConfiguration
     doc += "with startup in separated communication spaces.";
     tagMaster.setDocumentation(doc);
 
-   auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-        .setDocumentation(
-                "Directory where connection information is exchanged. By default, the "
-                "directory of startup is chosen.");
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen.");
     tagMaster.addAttribute(attrExchangeDirectory);
 
     masterTags.push_back(tagMaster);
@@ -268,321 +266,304 @@ ParticipantConfiguration:: ParticipantConfiguration
 
     masterTags.push_back(tagMaster);
   }
-  for (XMLTag& tagMaster : masterTags){
+  for (XMLTag &tagMaster : masterTags) {
     tag.addSubtag(tagMaster);
   }
 
   parent.addSubtag(tag);
 }
 
-void ParticipantConfiguration:: setDimensions
-(
-  int dimensions )
+void ParticipantConfiguration::setDimensions(
+    int dimensions)
 {
   PRECICE_TRACE(dimensions);
   PRECICE_ASSERT((dimensions == 2) || (dimensions == 3), dimensions);
   _dimensions = dimensions;
 }
 
-
-void ParticipantConfiguration:: xmlTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void ParticipantConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
-  PRECICE_TRACE(tag.getName() );
-  if (tag.getName() == TAG){
-    std::string name = tag.getStringAttributeValue(ATTR_NAME);
+  PRECICE_TRACE(tag.getName());
+  if (tag.getName() == TAG) {
+    std::string          name = tag.getStringAttributeValue(ATTR_NAME);
     impl::PtrParticipant p(new impl::Participant(name, _meshConfig));
     _participants.push_back(p);
-  }
-  else if (tag.getName() == TAG_USE_MESH){
+  } else if (tag.getName() == TAG_USE_MESH) {
     PRECICE_ASSERT(_dimensions != 0); // setDimensions() has been called
-    std::string name = tag.getStringAttributeValue(ATTR_NAME);
+    std::string     name = tag.getStringAttributeValue(ATTR_NAME);
     Eigen::VectorXd offset(_dimensions);
     /// @todo offset currently not supported
     //offset = tag.getEigenVectorXdAttributeValue(ATTR_LOCAL_OFFSET, _dimensions);
-    std::string from = tag.getStringAttributeValue(ATTR_FROM);
-    double safetyFactor = tag.getDoubleAttributeValue(ATTR_SAFETY_FACTOR);
-    partition::ReceivedPartition::GeometricFilter geoFilter = getGeoFilter(tag.getStringAttributeValue(ATTR_GEOMETRIC_FILTER));
-    if (safetyFactor < 0){
+    std::string                                   from         = tag.getStringAttributeValue(ATTR_FROM);
+    double                                        safetyFactor = tag.getDoubleAttributeValue(ATTR_SAFETY_FACTOR);
+    partition::ReceivedPartition::GeometricFilter geoFilter    = getGeoFilter(tag.getStringAttributeValue(ATTR_GEOMETRIC_FILTER));
+    if (safetyFactor < 0) {
       std::ostringstream stream;
       stream << "Safety Factor must be positive or 0";
       throw std::runtime_error{stream.str()};
     }
-    bool provide = tag.getBooleanAttributeValue(ATTR_PROVIDE);
-    mesh::PtrMesh mesh = _meshConfig->getMesh(name);
-    if (mesh.get() == nullptr){
+    bool          provide = tag.getBooleanAttributeValue(ATTR_PROVIDE);
+    mesh::PtrMesh mesh    = _meshConfig->getMesh(name);
+    if (mesh.get() == nullptr) {
       std::ostringstream stream;
       stream << "Participant \"" << _participants.back()->getName()
              << "\" uses mesh \"" << name << "\" which is not defined";
       throw std::runtime_error{stream.str()};
     }
-    if ((geoFilter != partition::ReceivedPartition::GeometricFilter::BROADCAST_FILTER || safetyFactor != 0.5) && from==""){
+    if ((geoFilter != partition::ReceivedPartition::GeometricFilter::BROADCAST_FILTER || safetyFactor != 0.5) && from == "") {
       std::ostringstream stream;
       stream << "Participant \"" << _participants.back()->getName()
              << "\" uses mesh \"" << name << "\" which is not received (no \"from\"), but has a geometric-filter and/or"
              << " a safety factor defined. This is not valid.";
       throw std::runtime_error{stream.str()};
     }
-    _participants.back()->useMesh ( mesh, offset, false, from, safetyFactor, provide, geoFilter );
-  }
-  else if ( tag.getName() == TAG_WRITE ) {
-    std::string dataName = tag.getStringAttributeValue(ATTR_NAME);
-    std::string meshName = tag.getStringAttributeValue(ATTR_MESH);
-    mesh::PtrMesh mesh = _meshConfig->getMesh ( meshName );
+    _participants.back()->useMesh(mesh, offset, false, from, safetyFactor, provide, geoFilter);
+  } else if (tag.getName() == TAG_WRITE) {
+    std::string   dataName = tag.getStringAttributeValue(ATTR_NAME);
+    std::string   meshName = tag.getStringAttributeValue(ATTR_MESH);
+    mesh::PtrMesh mesh     = _meshConfig->getMesh(meshName);
     PRECICE_CHECK(mesh, "Participant "
-          << "\"" << _participants.back()->getName() << "\" has to use "
-          << "mesh \"" << meshName << "\" in order to write data to it!" );
-    mesh::PtrData data = getData ( mesh, dataName );
-    _participants.back()->addWriteData ( data, mesh );
-  }
-  else if ( tag.getName() == TAG_READ ) {
-    std::string dataName = tag.getStringAttributeValue(ATTR_NAME);
-    std::string meshName = tag.getStringAttributeValue(ATTR_MESH);
-    mesh::PtrMesh mesh = _meshConfig->getMesh ( meshName );
+                            << "\"" << _participants.back()->getName() << "\" has to use "
+                            << "mesh \"" << meshName << "\" in order to write data to it!");
+    mesh::PtrData data = getData(mesh, dataName);
+    _participants.back()->addWriteData(data, mesh);
+  } else if (tag.getName() == TAG_READ) {
+    std::string   dataName = tag.getStringAttributeValue(ATTR_NAME);
+    std::string   meshName = tag.getStringAttributeValue(ATTR_MESH);
+    mesh::PtrMesh mesh     = _meshConfig->getMesh(meshName);
     PRECICE_CHECK(mesh, "Participant "
-          << "\"" << _participants.back()->getName() << "\" has to use "
-          << "mesh \"" << meshName << "\" in order to read data from it!" );
-    mesh::PtrData data = getData ( mesh, dataName );
-    _participants.back()->addReadData ( data, mesh );
-  }
-  else if ( tag.getName() == TAG_WATCH_POINT ){
+                            << "\"" << _participants.back()->getName() << "\" has to use "
+                            << "mesh \"" << meshName << "\" in order to read data from it!");
+    mesh::PtrData data = getData(mesh, dataName);
+    _participants.back()->addReadData(data, mesh);
+  } else if (tag.getName() == TAG_WATCH_POINT) {
     PRECICE_ASSERT(_dimensions != 0); // setDimensions() has been called
     WatchPointConfig config;
-    config.name = tag.getStringAttributeValue(ATTR_NAME);
-    config.nameMesh = tag.getStringAttributeValue(ATTR_MESH);
+    config.name        = tag.getStringAttributeValue(ATTR_NAME);
+    config.nameMesh    = tag.getStringAttributeValue(ATTR_MESH);
     config.coordinates = tag.getEigenVectorXdAttributeValue(ATTR_COORDINATE, _dimensions);
     _watchPointConfigs.push_back(config);
-  }
-  else if (tag.getNamespace() == TAG_SERVER){
+  } else if (tag.getNamespace() == TAG_SERVER) {
     com::CommunicationConfiguration comConfig;
-    com::PtrCommunication com = comConfig.createCommunication(tag);
+    com::PtrCommunication           com = comConfig.createCommunication(tag);
     _participants.back()->setClientServerCommunication(com);
     _isParallelSolutionDefined = true;
-  }
-  else if (tag.getNamespace() == TAG_MASTER){
+  } else if (tag.getNamespace() == TAG_MASTER) {
     com::CommunicationConfiguration comConfig;
-    com::PtrCommunication com = comConfig.createCommunication(tag);
-    utils::MasterSlave::_communication = com;
-    _isParallelSolutionDefined = true;
+    com::PtrCommunication           com = comConfig.createCommunication(tag);
+    utils::MasterSlave::_communication  = com;
+    _isParallelSolutionDefined          = true;
     _participants.back()->setUseMaster(true);
   }
 }
 
-void ParticipantConfiguration:: xmlEndTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void ParticipantConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
-  if (tag.getName() == TAG){
+  if (tag.getName() == TAG) {
     finishParticipantConfiguration(context, _participants.back());
   }
 }
 
-const std::vector<impl::PtrParticipant>&
-ParticipantConfiguration:: getParticipants() const
+const std::vector<impl::PtrParticipant> &
+ParticipantConfiguration::getParticipants() const
 {
   return _participants;
 }
 
-partition::ReceivedPartition::GeometricFilter ParticipantConfiguration:: getGeoFilter(const std::string& geoFilter) const
+partition::ReceivedPartition::GeometricFilter ParticipantConfiguration::getGeoFilter(const std::string &geoFilter) const
 {
-  if (geoFilter == VALUE_FILTER_FIRST){
+  if (geoFilter == VALUE_FILTER_FIRST) {
     return partition::ReceivedPartition::GeometricFilter::FILTER_FIRST;
-  }
-  else if (geoFilter == VALUE_BROADCAST_FILTER){
+  } else if (geoFilter == VALUE_BROADCAST_FILTER) {
     return partition::ReceivedPartition::GeometricFilter::BROADCAST_FILTER;
-  }
-  else {
+  } else {
     PRECICE_ASSERT(geoFilter == VALUE_NO_FILTER);
     return partition::ReceivedPartition::GeometricFilter::NO_FILTER;
   }
 }
 
 /// @todo remove
-mesh::PtrMesh ParticipantConfiguration:: copy
-(
-  const mesh::PtrMesh& mesh ) const
+mesh::PtrMesh ParticipantConfiguration::copy(
+    const mesh::PtrMesh &mesh) const
 {
-  int dim = mesh->getDimensions();
+  int         dim = mesh->getDimensions();
   std::string name(mesh->getName());
-  bool flipNormals = mesh->isFlipNormals();
-  mesh::Mesh* meshCopy = new mesh::Mesh("Local_" + name, dim, flipNormals, mesh::Mesh::MESH_ID_UNDEFINED);
-  for (const mesh::PtrData& data : mesh->data()){
+  bool        flipNormals = mesh->isFlipNormals();
+  mesh::Mesh *meshCopy    = new mesh::Mesh("Local_" + name, dim, flipNormals, mesh::Mesh::MESH_ID_UNDEFINED);
+  for (const mesh::PtrData &data : mesh->data()) {
     meshCopy->createData(data->getName(), data->getDimensions());
   }
   return mesh::PtrMesh(meshCopy);
 }
 
-const mesh::PtrData & ParticipantConfiguration:: getData
-(
-  const mesh::PtrMesh& mesh,
-  const std::string&   nameData ) const
+const mesh::PtrData &ParticipantConfiguration::getData(
+    const mesh::PtrMesh &mesh,
+    const std::string &  nameData) const
 {
-  for ( const mesh::PtrData & data : mesh->data() ){
-    if ( data->getName() == nameData ) {
+  for (const mesh::PtrData &data : mesh->data()) {
+    if (data->getName() == nameData) {
       return data;
     }
   }
   PRECICE_ERROR("Participant \"" << _participants.back()->getName()
-                 << "\" assignes data \"" << nameData << "\" wrongly to mesh \""
-                 << mesh->getName() << "\"!" );
+                                 << "\" assignes data \"" << nameData << "\" wrongly to mesh \""
+                                 << mesh->getName() << "\"!");
 }
 
-void ParticipantConfiguration:: finishParticipantConfiguration
-(
-  const xml::ConfigurationContext& context,
-  const impl::PtrParticipant& participant )
+void ParticipantConfiguration::finishParticipantConfiguration(
+    const xml::ConfigurationContext &context,
+    const impl::PtrParticipant &     participant)
 {
   PRECICE_TRACE(participant->getName());
 
   // Set input/output meshes for data mappings and mesh requirements
   using ConfMapping = mapping::MappingConfiguration::ConfiguredMapping;
-  for (const ConfMapping& confMapping : _mappingConfig->mappings()){
+  for (const ConfMapping &confMapping : _mappingConfig->mappings()) {
     int fromMeshID = confMapping.fromMesh->getID();
-    int toMeshID = confMapping.toMesh->getID();
+    int toMeshID   = confMapping.toMesh->getID();
 
     PRECICE_CHECK(participant->isMeshUsed(fromMeshID),
-          "Participant \"" << participant->getName() << "\" has mapping"
-          << " from mesh \"" << confMapping.fromMesh->getName() << "\" which he does not use!");
+                  "Participant \"" << participant->getName() << "\" has mapping"
+                                   << " from mesh \"" << confMapping.fromMesh->getName() << "\" which he does not use!");
     PRECICE_CHECK(participant->isMeshUsed(toMeshID),
-          "Participant \"" << participant->getName() << "\" has mapping"
-          << " to mesh \"" << confMapping.toMesh->getName() << "\" which he does not use!");
-    if(context.size > 1){
-      if((confMapping.direction == mapping::MappingConfiguration::WRITE &&
-          confMapping.mapping->getConstraint()==mapping::Mapping::CONSISTENT) ||
-         (confMapping.direction == mapping::MappingConfiguration::READ &&
-          confMapping.mapping->getConstraint()==mapping::Mapping::CONSERVATIVE)){
+                  "Participant \"" << participant->getName() << "\" has mapping"
+                                   << " to mesh \"" << confMapping.toMesh->getName() << "\" which he does not use!");
+    if (context.size > 1) {
+      if ((confMapping.direction == mapping::MappingConfiguration::WRITE &&
+           confMapping.mapping->getConstraint() == mapping::Mapping::CONSISTENT) ||
+          (confMapping.direction == mapping::MappingConfiguration::READ &&
+           confMapping.mapping->getConstraint() == mapping::Mapping::CONSERVATIVE)) {
         PRECICE_ERROR(
-                       "If a participant uses a master parallelization, only the mapping"
-                    << " combinations read-consistent and write-conservative are allowed");
+            "If a participant uses a master parallelization, only the mapping"
+            << " combinations read-consistent and write-conservative are allowed");
       }
     }
 
+    impl::MeshContext &fromMeshContext = participant->meshContext(fromMeshID);
+    impl::MeshContext &toMeshContext   = participant->meshContext(toMeshID);
 
-
-    impl::MeshContext& fromMeshContext = participant->meshContext(fromMeshID);
-    impl::MeshContext& toMeshContext = participant->meshContext(toMeshID);
-
-    if(confMapping.direction == mapping::MappingConfiguration::READ){
+    if (confMapping.direction == mapping::MappingConfiguration::READ) {
       PRECICE_CHECK(toMeshContext.provideMesh, "A read mapping of participant " << participant->getName() << " needs to map TO a provided mesh. "
-          "Mesh " << confMapping.toMesh->getName() << " is not provided.");
+                                                                                                             "Mesh "
+                                                                                << confMapping.toMesh->getName() << " is not provided.");
       PRECICE_CHECK(not fromMeshContext.receiveMeshFrom.empty(), "A read mapping of participant " << participant->getName() << " needs to map FROM a received mesh. "
-          "Mesh " << confMapping.fromMesh->getName() << " is not received.");
-    }
-    else{
+                                                                                                                               "Mesh "
+                                                                                                  << confMapping.fromMesh->getName() << " is not received.");
+    } else {
       PRECICE_CHECK(fromMeshContext.provideMesh, "A write mapping of participant " << participant->getName() << " needs to map FROM a provided mesh. "
-          "Mesh " << confMapping.fromMesh->getName() << " is not provided.");
+                                                                                                                "Mesh "
+                                                                                   << confMapping.fromMesh->getName() << " is not provided.");
       PRECICE_CHECK(not toMeshContext.receiveMeshFrom.empty(), "A write mapping of participant " << participant->getName() << " needs to map TO a received mesh. "
-          "Mesh " << confMapping.toMesh->getName() << " is not received.");
+                                                                                                                              "Mesh "
+                                                                                                 << confMapping.toMesh->getName() << " is not received.");
     }
 
-    if(confMapping.isRBF){
+    if (confMapping.isRBF) {
       fromMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
-      toMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
+      toMeshContext.geoFilter   = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
     }
 
-    precice::impl::MappingContext* mappingContext = new precice::impl::MappingContext();
-    mappingContext->fromMeshID = fromMeshID;
-    mappingContext->toMeshID = toMeshID;
-    mappingContext->timing = confMapping.timing;
+    precice::impl::MappingContext *mappingContext = new precice::impl::MappingContext();
+    mappingContext->fromMeshID                    = fromMeshID;
+    mappingContext->toMeshID                      = toMeshID;
+    mappingContext->timing                        = confMapping.timing;
 
-    mapping::PtrMapping& map = mappingContext->mapping;
+    mapping::PtrMapping &map = mappingContext->mapping;
     PRECICE_ASSERT(map.get() == nullptr);
     map = confMapping.mapping;
 
-    const mesh::PtrMesh& input = fromMeshContext.mesh;
-    const mesh::PtrMesh& output = toMeshContext.mesh;
+    const mesh::PtrMesh &input  = fromMeshContext.mesh;
+    const mesh::PtrMesh &output = toMeshContext.mesh;
     PRECICE_DEBUG("Configure mapping for input=" << input->getName()
-           << ", output=" << output->getName());
+                                                 << ", output=" << output->getName());
     map->setMeshes(input, output);
 
-    if (confMapping.direction == mapping::MappingConfiguration::WRITE){
+    if (confMapping.direction == mapping::MappingConfiguration::WRITE) {
       participant->addWriteMappingContext(mappingContext);
-    }
-    else {
+    } else {
       PRECICE_ASSERT(confMapping.direction == mapping::MappingConfiguration::READ);
       participant->addReadMappingContext(mappingContext);
     }
 
     fromMeshContext.meshRequirement = std::max(
-            fromMeshContext.meshRequirement, map->getInputRequirement());
+        fromMeshContext.meshRequirement, map->getInputRequirement());
     toMeshContext.meshRequirement = std::max(
-            toMeshContext.meshRequirement, map->getOutputRequirement());
+        toMeshContext.meshRequirement, map->getOutputRequirement());
 
     fromMeshContext.fromMappingContext = *mappingContext;
-    toMeshContext.toMappingContext = *mappingContext;
+    toMeshContext.toMappingContext     = *mappingContext;
   }
   _mappingConfig->resetMappings();
 
   // Set participant data for data contexts
-  for (impl::DataContext& dataContext : participant->writeDataContexts()){
+  for (impl::DataContext &dataContext : participant->writeDataContexts()) {
     int fromMeshID = dataContext.mesh->getID();
     PRECICE_CHECK(participant->isMeshUsed(fromMeshID),
-          "Participant \"" << participant->getName() << "\" has to use mesh \""
-          << dataContext.mesh->getName() << "\" when writing data to it!");
+                  "Participant \"" << participant->getName() << "\" has to use mesh \""
+                                   << dataContext.mesh->getName() << "\" when writing data to it!");
 
-    for (impl::MappingContext& mappingContext : participant->writeMappingContexts()){
-      if(mappingContext.fromMeshID==fromMeshID){
-        dataContext.mappingContext = mappingContext;
-        impl::MeshContext& meshContext = participant->meshContext(mappingContext.toMeshID);
-        for (mesh::PtrData data : meshContext.mesh->data()){
-          if(data->getName()==dataContext.fromData->getName()){
+    for (impl::MappingContext &mappingContext : participant->writeMappingContexts()) {
+      if (mappingContext.fromMeshID == fromMeshID) {
+        dataContext.mappingContext     = mappingContext;
+        impl::MeshContext &meshContext = participant->meshContext(mappingContext.toMeshID);
+        for (mesh::PtrData data : meshContext.mesh->data()) {
+          if (data->getName() == dataContext.fromData->getName()) {
             dataContext.toData = data;
           }
         }
-        PRECICE_CHECK(dataContext.fromData!=dataContext.toData,
-              "The mesh \"" << meshContext.mesh->getName() << "\" needs to use the data \""
-              << dataContext.fromData->getName() << "\"! to allow the write mapping");
+        PRECICE_CHECK(dataContext.fromData != dataContext.toData,
+                      "The mesh \"" << meshContext.mesh->getName() << "\" needs to use the data \""
+                                    << dataContext.fromData->getName() << "\"! to allow the write mapping");
       }
     }
   }
 
-  for (impl::DataContext& dataContext : participant->readDataContexts()){
+  for (impl::DataContext &dataContext : participant->readDataContexts()) {
     int toMeshID = dataContext.mesh->getID();
     PRECICE_CHECK(participant->isMeshUsed(toMeshID),
-          "Participant \"" << participant->getName() << "\" has to use mesh \""
-          << dataContext.mesh->getName() << "\" when writing data to it!");
+                  "Participant \"" << participant->getName() << "\" has to use mesh \""
+                                   << dataContext.mesh->getName() << "\" when writing data to it!");
 
-    for (impl::MappingContext& mappingContext : participant->readMappingContexts()){
-      if(mappingContext.toMeshID==toMeshID){
-        dataContext.mappingContext = mappingContext;
-        impl::MeshContext& meshContext = participant->meshContext(mappingContext.fromMeshID);
-        for (mesh::PtrData data : meshContext.mesh->data()){
-          if(data->getName()==dataContext.toData->getName()){
+    for (impl::MappingContext &mappingContext : participant->readMappingContexts()) {
+      if (mappingContext.toMeshID == toMeshID) {
+        dataContext.mappingContext     = mappingContext;
+        impl::MeshContext &meshContext = participant->meshContext(mappingContext.fromMeshID);
+        for (mesh::PtrData data : meshContext.mesh->data()) {
+          if (data->getName() == dataContext.toData->getName()) {
             dataContext.fromData = data;
           }
         }
-        PRECICE_CHECK(dataContext.toData!=dataContext.fromData,
-              "The mesh \"" << meshContext.mesh->getName() << "\" needs to use the data \""
-              << dataContext.toData->getName() << "\"! to allow the read mapping");
+        PRECICE_CHECK(dataContext.toData != dataContext.fromData,
+                      "The mesh \"" << meshContext.mesh->getName() << "\" needs to use the data \""
+                                    << dataContext.toData->getName() << "\"! to allow the read mapping");
       }
     }
   }
 
   // Add actions
-  for (const action::PtrAction& action : _actionConfig->actions()){
+  for (const action::PtrAction &action : _actionConfig->actions()) {
     bool used = _participants.back()->isMeshUsed(action->getMesh()->getID());
     PRECICE_CHECK(used, "Data action of participant "
-          << _participants.back()->getName()
-          << "\" uses mesh which is not used by the participant!");
+                            << _participants.back()->getName()
+                            << "\" uses mesh which is not used by the participant!");
     _participants.back()->addAction(action);
   }
   _actionConfig->resetActions();
 
   // Add export contexts
-  for (io::ExportContext& exportContext : _exportConfig->exportContexts()){
+  for (io::ExportContext &exportContext : _exportConfig->exportContexts()) {
     io::PtrExport exporter;
-    if (exportContext.type == VALUE_VTK){
-      if(context.size > 1){
+    if (exportContext.type == VALUE_VTK) {
+      if (context.size > 1) {
         exporter = io::PtrExport(new io::ExportVTKXML(exportContext.plotNormals));
-      }
-      else{
+      } else {
         exporter = io::PtrExport(new io::ExportVTK(exportContext.plotNormals));
       }
-    }
-    else {
+    } else {
       PRECICE_ERROR("Unknown export type!");
     }
     exportContext.exporter = exporter;
@@ -592,39 +573,37 @@ void ParticipantConfiguration:: finishParticipantConfiguration
   _exportConfig->resetExports();
 
   // Create watch points
-  for ( const WatchPointConfig & config : _watchPointConfigs ){
+  for (const WatchPointConfig &config : _watchPointConfigs) {
     mesh::PtrMesh mesh;
-    for ( const impl::MeshContext* context : participant->usedMeshContexts() ){
-      if ( context->mesh->getName() == config.nameMesh ){
+    for (const impl::MeshContext *context : participant->usedMeshContexts()) {
+      if (context->mesh->getName() == config.nameMesh) {
         mesh = context->mesh;
       }
     }
     PRECICE_CHECK(mesh,
-          "Participant \"" << participant->getName()
-          << "\" defines watchpoint \"" << config.name
-          << "\" for mesh \"" << config.nameMesh
-          << "\" which is not used by him!" );
-    std::string filename = "precice-" + participant->getName() + "-watchpoint-" + config.name + ".log";
-    impl::PtrWatchPoint watchPoint( new impl::WatchPoint(config.coordinates, mesh, filename) );
-    participant->addWatchPoint ( watchPoint );
+                  "Participant \"" << participant->getName()
+                                   << "\" defines watchpoint \"" << config.name
+                                   << "\" for mesh \"" << config.nameMesh
+                                   << "\" which is not used by him!");
+    std::string         filename = "precice-" + participant->getName() + "-watchpoint-" + config.name + ".log";
+    impl::PtrWatchPoint watchPoint(new impl::WatchPoint(config.coordinates, mesh, filename));
+    participant->addWatchPoint(watchPoint);
   }
-  _watchPointConfigs.clear ();
-
+  _watchPointConfigs.clear();
 
   // create default master communication if needed
-  if(context.size > 1 && not _isParallelSolutionDefined && participant->getName() == context.name){
-    #ifdef PRECICE_NO_MPI
-        throw std::runtime_error{ "When building with \"mpi=off\", you need to specify an alternative \"master\" "
-                      "communication (e.g. sockets) for every parallel participant"};
-    #else
-        com::PtrCommunication com = std::make_shared<com::MPIDirectCommunication>();
-        utils::MasterSlave::_communication = com;
-        participant->setUseMaster(true);
-    #endif
+  if (context.size > 1 && not _isParallelSolutionDefined && participant->getName() == context.name) {
+#ifdef PRECICE_NO_MPI
+    throw std::runtime_error{"When building with \"mpi=off\", you need to specify an alternative \"master\" "
+                             "communication (e.g. sockets) for every parallel participant"};
+#else
+    com::PtrCommunication com          = std::make_shared<com::MPIDirectCommunication>();
+    utils::MasterSlave::_communication = com;
+    participant->setUseMaster(true);
+#endif
   }
   _isParallelSolutionDefined = false; // to not mess up with previous participant
-
 }
 
-
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "precice/impl/Participant.hpp"
-#include "mesh/SharedPointer.hpp"
-#include "mapping/SharedPointer.hpp"
+#include <string>
 #include "io/SharedPointer.hpp"
 #include "logging/Logger.hpp"
+#include "mapping/SharedPointer.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "precice/impl/Participant.hpp"
 #include "xml/XMLTag.hpp"
-#include <string>
 
 namespace precice {
 namespace config {
@@ -14,77 +14,73 @@ namespace config {
 /**
  * @brief Performs XML configuration of a participant.
  */
-class ParticipantConfiguration : public xml::XMLTag::Listener
-{
+class ParticipantConfiguration : public xml::XMLTag::Listener {
 public:
+  ParticipantConfiguration(
+      xml::XMLTag &                     parent,
+      const mesh::PtrMeshConfiguration &meshConfiguration);
 
-  ParticipantConfiguration (
-    xml::XMLTag&                      parent,
-    const mesh::PtrMeshConfiguration& meshConfiguration);
-
-  void setDimensions ( int dimensions );
-
-  /**
-   * @brief Callback function required for use of automatic configuration.
-   *
-   * @return True, if successful.
-   */
-  virtual void xmlTagCallback (
-          const xml::ConfigurationContext& context,
-          xml::XMLTag& callingTag );
+  void setDimensions(int dimensions);
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback (
-          const xml::ConfigurationContext& context,
-          xml::XMLTag& callingTag );
+  virtual void xmlTagCallback(
+      const xml::ConfigurationContext &context,
+      xml::XMLTag &                    callingTag);
+
+  /**
+   * @brief Callback function required for use of automatic configuration.
+   *
+   * @return True, if successful.
+   */
+  virtual void xmlEndTagCallback(
+      const xml::ConfigurationContext &context,
+      xml::XMLTag &                    callingTag);
 
   /// Returns all configured participants.
-  const std::vector<impl::PtrParticipant>& getParticipants() const;
+  const std::vector<impl::PtrParticipant> &getParticipants() const;
 
 private:
-
-  struct WatchPointConfig
-  {
-    std::string name;
-    std::string nameMesh;
+  struct WatchPointConfig {
+    std::string     name;
+    std::string     nameMesh;
     Eigen::VectorXd coordinates;
   };
 
   mutable logging::Logger _log{"config::ParticipantConfiguration"};
 
-  const std::string TAG = "participant";
-  const std::string TAG_WRITE = "write-data";
-  const std::string TAG_READ = "read-data";
+  const std::string TAG             = "participant";
+  const std::string TAG_WRITE       = "write-data";
+  const std::string TAG_READ        = "read-data";
   const std::string TAG_DATA_ACTION = "data-action";
-  const std::string TAG_USE_MESH = "use-mesh";
+  const std::string TAG_USE_MESH    = "use-mesh";
   const std::string TAG_WATCH_POINT = "watch-point";
-  const std::string TAG_SERVER = "server";
-  const std::string TAG_MASTER = "master";
+  const std::string TAG_SERVER      = "server";
+  const std::string TAG_MASTER      = "master";
 
-  const std::string ATTR_NAME = "name";
-  const std::string ATTR_SOURCE_DATA = "source-data";
-  const std::string ATTR_TARGET_DATA = "target-data";
-  const std::string ATTR_TIMING = "timing";
-  const std::string ATTR_LOCAL_OFFSET = "offset";
-  const std::string ATTR_ACTION_TYPE = "type";
-  const std::string ATTR_FROM = "from";
-  const std::string ATTR_SAFETY_FACTOR = "safety-factor";
-  const std::string ATTR_GEOMETRIC_FILTER = "geometric-filter";
-  const std::string ATTR_PROVIDE = "provide";
-  const std::string ATTR_MESH = "mesh";
-  const std::string ATTR_COORDINATE = "coordinate";
-  const std::string ATTR_COMMUNICATION = "communication";
-  const std::string ATTR_CONTEXT = "context";
-  const std::string ATTR_NETWORK = "network";
+  const std::string ATTR_NAME               = "name";
+  const std::string ATTR_SOURCE_DATA        = "source-data";
+  const std::string ATTR_TARGET_DATA        = "target-data";
+  const std::string ATTR_TIMING             = "timing";
+  const std::string ATTR_LOCAL_OFFSET       = "offset";
+  const std::string ATTR_ACTION_TYPE        = "type";
+  const std::string ATTR_FROM               = "from";
+  const std::string ATTR_SAFETY_FACTOR      = "safety-factor";
+  const std::string ATTR_GEOMETRIC_FILTER   = "geometric-filter";
+  const std::string ATTR_PROVIDE            = "provide";
+  const std::string ATTR_MESH               = "mesh";
+  const std::string ATTR_COORDINATE         = "coordinate";
+  const std::string ATTR_COMMUNICATION      = "communication";
+  const std::string ATTR_CONTEXT            = "context";
+  const std::string ATTR_NETWORK            = "network";
   const std::string ATTR_EXCHANGE_DIRECTORY = "exchange-directory";
 
-  const std::string VALUE_FILTER_FIRST = "filter-first";
+  const std::string VALUE_FILTER_FIRST     = "filter-first";
   const std::string VALUE_BROADCAST_FILTER = "broadcast-filter";
-  const std::string VALUE_NO_FILTER = "no-filter";
+  const std::string VALUE_NO_FILTER        = "no-filter";
 
   const std::string VALUE_VTK = "vtk";
 
@@ -102,25 +98,25 @@ private:
 
   std::vector<WatchPointConfig> _watchPointConfigs;
 
-  partition::ReceivedPartition::GeometricFilter getGeoFilter(const std::string& geoFilter) const;
+  partition::ReceivedPartition::GeometricFilter getGeoFilter(const std::string &geoFilter) const;
 
-  mesh::PtrMesh copy ( const mesh::PtrMesh& mesh ) const;
+  mesh::PtrMesh copy(const mesh::PtrMesh &mesh) const;
 
-  const mesh::PtrData& getData (
-    const mesh::PtrMesh& mesh,
-    const std::string&   nameData ) const;
+  const mesh::PtrData &getData(
+      const mesh::PtrMesh &mesh,
+      const std::string &  nameData) const;
 
-  mapping::PtrMapping getMapping ( const std::string& mappingName );
+  mapping::PtrMapping getMapping(const std::string &mappingName);
 
   // Does this participant already define a master or server tag?
   // This context information is needed in xmlEndTagCallback to create a default
   // master com if required (i.e. no solution yet defined and parallel).
   bool _isParallelSolutionDefined = false;
 
-  void finishParticipantConfiguration (
-         const xml::ConfigurationContext& context,
-         const impl::PtrParticipant& participant );
-
+  void finishParticipantConfiguration(
+      const xml::ConfigurationContext &context,
+      const impl::PtrParticipant &     participant);
 };
 
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/precice/config/SharedPointer.hpp
+++ b/src/precice/config/SharedPointer.hpp
@@ -9,4 +9,5 @@ class ParticipantConfiguration;
 
 using PtrParticipantConfiguration = std::shared_ptr<ParticipantConfiguration>;
 
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/precice/config/SolverInterfaceConfiguration.cpp
+++ b/src/precice/config/SolverInterfaceConfiguration.cpp
@@ -1,84 +1,78 @@
 #include "SolverInterfaceConfiguration.hpp"
 #include "ParticipantConfiguration.hpp"
-#include "precice/impl/Participant.hpp"
-#include "precice/impl/SharedPointer.hpp"
+#include "cplscheme/config/CouplingSchemeConfiguration.hpp"
+#include "m2n/config/M2NConfiguration.hpp"
+#include "mapping/SharedPointer.hpp"
 #include "mesh/config/DataConfiguration.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
-#include "m2n/config/M2NConfiguration.hpp"
-#include "cplscheme/config/CouplingSchemeConfiguration.hpp"
-#include "mapping/SharedPointer.hpp"
-#include "cplscheme/config/CouplingSchemeConfiguration.hpp"
+#include "precice/impl/Participant.hpp"
+#include "precice/impl/SharedPointer.hpp"
 
 namespace precice {
 namespace config {
 
-SolverInterfaceConfiguration:: SolverInterfaceConfiguration(xml::XMLTag& parent )
+SolverInterfaceConfiguration::SolverInterfaceConfiguration(xml::XMLTag &parent)
 {
   using namespace xml;
   XMLTag tag(*this, "solver-interface", XMLTag::OCCUR_ONCE);
   tag.setDocumentation("Configuration of simulation relevant features.");
   auto attrDimensions = makeXMLAttribute("dimensions", 2)
-                             .setDocumentation("Determines the spatial dimensionality of the configuration")
-                             .setOptions({2, 3});
+                            .setDocumentation("Determines the spatial dimensionality of the configuration")
+                            .setOptions({2, 3});
   tag.addAttribute(attrDimensions);
 
-  _dataConfiguration = mesh::PtrDataConfiguration (
-      new mesh::DataConfiguration(tag) );
-  _meshConfiguration = mesh::PtrMeshConfiguration (
-      new mesh::MeshConfiguration(tag, _dataConfiguration) );
-  _m2nConfiguration = m2n::M2NConfiguration::SharedPointer (
-      new m2n::M2NConfiguration(tag) );
-  _participantConfiguration = config::PtrParticipantConfiguration (
-    new ParticipantConfiguration(tag, _meshConfiguration) );
-  _couplingSchemeConfiguration = cplscheme::PtrCouplingSchemeConfiguration (
-    new cplscheme::CouplingSchemeConfiguration(tag, _meshConfiguration,
-    _m2nConfiguration) );
+  _dataConfiguration = mesh::PtrDataConfiguration(
+      new mesh::DataConfiguration(tag));
+  _meshConfiguration = mesh::PtrMeshConfiguration(
+      new mesh::MeshConfiguration(tag, _dataConfiguration));
+  _m2nConfiguration = m2n::M2NConfiguration::SharedPointer(
+      new m2n::M2NConfiguration(tag));
+  _participantConfiguration = config::PtrParticipantConfiguration(
+      new ParticipantConfiguration(tag, _meshConfiguration));
+  _couplingSchemeConfiguration = cplscheme::PtrCouplingSchemeConfiguration(
+      new cplscheme::CouplingSchemeConfiguration(tag, _meshConfiguration,
+                                                 _m2nConfiguration));
 
   parent.addSubtag(tag);
 }
 
-void SolverInterfaceConfiguration:: xmlTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void SolverInterfaceConfiguration::xmlTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE();
-  if (tag.getName() == "solver-interface"){
+  if (tag.getName() == "solver-interface") {
     _dimensions = tag.getIntAttributeValue("dimensions");
     _dataConfiguration->setDimensions(_dimensions);
     _meshConfiguration->setDimensions(_dimensions);
     _participantConfiguration->setDimensions(_dimensions);
-  }
-  else {
+  } else {
     PRECICE_ERROR("Received callback from tag " << tag.getName());
   }
 }
 
-void SolverInterfaceConfiguration:: xmlEndTagCallback
-(
-  const xml::ConfigurationContext& context,
-  xml::XMLTag& tag )
+void SolverInterfaceConfiguration::xmlEndTagCallback(
+    const xml::ConfigurationContext &context,
+    xml::XMLTag &                    tag)
 {
   PRECICE_TRACE();
-  if (tag.getName() == "solver-interface"){
+  if (tag.getName() == "solver-interface") {
     //test if both participants do have the exchange meshes
-    typedef std::map<std::string, std::vector<std::string> >::value_type neededMeshPair;
-    for (const neededMeshPair& neededMeshes : _meshConfiguration->getNeededMeshes()){
+    typedef std::map<std::string, std::vector<std::string>>::value_type neededMeshPair;
+    for (const neededMeshPair &neededMeshes : _meshConfiguration->getNeededMeshes()) {
       bool participantFound = false;
-      for (const impl::PtrParticipant& participant : _participantConfiguration->getParticipants()){
-        if(participant->getName()==neededMeshes.first){
-          for (const std::string& neededMesh  : neededMeshes.second){
+      for (const impl::PtrParticipant &participant : _participantConfiguration->getParticipants()) {
+        if (participant->getName() == neededMeshes.first) {
+          for (const std::string &neededMesh : neededMeshes.second) {
             bool meshFound = false;
-            for (impl::MeshContext* meshContext : participant->usedMeshContexts()){
-              if(meshContext->mesh->getName()==neededMesh){
+            for (impl::MeshContext *meshContext : participant->usedMeshContexts()) {
+              if (meshContext->mesh->getName() == neededMesh) {
                 meshFound = true;
                 break;
               }
             }
             PRECICE_CHECK(meshFound,
-                  "The participant "<< neededMeshes.first <<
-                  " needs to use the mesh " << neededMesh <<
-                  " if he wants to use it in the coupling scheme.");
+                          "The participant " << neededMeshes.first << " needs to use the mesh " << neededMesh << " if he wants to use it in the coupling scheme.");
           }
           participantFound = true;
           break;
@@ -86,20 +80,19 @@ void SolverInterfaceConfiguration:: xmlEndTagCallback
       }
       PRECICE_ASSERT(participantFound);
     }
-
   }
 }
 
-int SolverInterfaceConfiguration:: getDimensions() const
+int SolverInterfaceConfiguration::getDimensions() const
 {
   return _dimensions;
 }
 
 const PtrParticipantConfiguration &
-SolverInterfaceConfiguration:: getParticipantConfiguration() const
+SolverInterfaceConfiguration::getParticipantConfiguration() const
 {
   return _participantConfiguration;
 }
 
-}} // close namespaces
-
+} // namespace config
+} // namespace precice

--- a/src/precice/config/SolverInterfaceConfiguration.hpp
+++ b/src/precice/config/SolverInterfaceConfiguration.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
+#include <string>
 #include "SharedPointer.hpp"
-#include "precice/impl/Participant.hpp"
-#include "precice/impl/SharedPointer.hpp"
-#include "mesh/SharedPointer.hpp"
+#include "boost/smart_ptr.hpp"
 #include "cplscheme/SharedPointer.hpp"
-#include "mapping/SharedPointer.hpp"
+#include "logging/Logger.hpp"
 #include "m2n/M2N.hpp"
 #include "m2n/config/M2NConfiguration.hpp"
-#include "logging/Logger.hpp"
+#include "mapping/SharedPointer.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "precice/impl/Participant.hpp"
+#include "precice/impl/SharedPointer.hpp"
 #include "xml/XMLTag.hpp"
-#include <string>
-#include "boost/smart_ptr.hpp"
 
 namespace precice {
 namespace config {
@@ -19,11 +19,9 @@ namespace config {
 /**
  * @brief Configures class SolverInterfaceImpl from XML.
  */
-class SolverInterfaceConfiguration : public xml::XMLTag::Listener
-{
+class SolverInterfaceConfiguration : public xml::XMLTag::Listener {
 public:
-
-  SolverInterfaceConfiguration(xml::XMLTag& parent);
+  SolverInterfaceConfiguration(xml::XMLTag &parent);
 
   /**
    * @brief Destructor.
@@ -35,12 +33,12 @@ public:
   /**
    * @brief Callback method required when using xml::XMLTag.
    */
-  virtual void xmlTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag );
+  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /**
    * @brief Callback method required when using xml::XMLTag.
    */
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext& context, xml::XMLTag& callingTag );
+  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /**
    * @brief Returns number of spatial dimensions configured.
@@ -62,7 +60,7 @@ public:
     return _m2nConfiguration;
   }
 
-  const PtrParticipantConfiguration& getParticipantConfiguration() const;
+  const PtrParticipantConfiguration &getParticipantConfiguration() const;
 
   const cplscheme::PtrCouplingSchemeConfiguration
   getCouplingSchemeConfiguration() const
@@ -73,7 +71,7 @@ public:
   /**
    * @brief For manual configuration in test cases.
    */
-  void setDataConfiguration ( mesh::PtrDataConfiguration config )
+  void setDataConfiguration(mesh::PtrDataConfiguration config)
   {
     _dataConfiguration = config;
   }
@@ -81,7 +79,7 @@ public:
   /**
    * @brief For manual configuration in test cases.
    */
-  void setMeshConfiguration ( mesh::PtrMeshConfiguration config )
+  void setMeshConfiguration(mesh::PtrMeshConfiguration config)
   {
     _meshConfiguration = config;
   }
@@ -89,13 +87,12 @@ public:
   /**
     * @brief For manual configuration in test cases.
     */
-   void setParticipantConfiguration ( PtrParticipantConfiguration config )
-   {
-     _participantConfiguration = config;
-   }
+  void setParticipantConfiguration(PtrParticipantConfiguration config)
+  {
+    _participantConfiguration = config;
+  }
 
 private:
-
   logging::Logger _log{"config::SolverInterfaceConfiguration"};
 
   /// Spatial dimension of problem to be solved. Either 2 or 3.
@@ -118,4 +115,5 @@ private:
   cplscheme::PtrCouplingSchemeConfiguration _couplingSchemeConfiguration;
 };
 
-}} // namespace precice, config
+} // namespace config
+} // namespace precice

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -10,8 +10,7 @@ namespace impl {
  * @brief Stores one Data object with related context. If this dataContext is not associated with a mapping,
  * fromData and toData refer to the same data object.
  */
-struct DataContext
-{
+struct DataContext {
   bool used = false;
 
   mesh::PtrData fromData;
@@ -23,4 +22,5 @@ struct DataContext
   MappingContext mappingContext;
 };
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -7,14 +7,13 @@ namespace precice {
 namespace impl {
 
 /// Holds a data mapping and related information.
-struct MappingContext
-{
+struct MappingContext {
   /// Data mapping.
   mapping::PtrMapping mapping;
 
   /// id of mesh from which is mapped
   int fromMeshID = -1;
-  
+
   /// id of mesh to which is mapped
   int toMeshID = -1;
 
@@ -25,8 +24,8 @@ struct MappingContext
   //bool isIncremental;
 
   /// True, if data has been mapped already.
-  bool hasMappedData = false;  
+  bool hasMappedData = false;
 };
 
-
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -1,67 +1,67 @@
 #pragma once
 
+#include <vector>
 #include "MappingContext.hpp"
-#include "partition/SharedPointer.hpp"
-#include "mesh/SharedPointer.hpp"
+#include "SharedPointer.hpp"
 #include "com/Communication.hpp"
 #include "mapping/Mapping.hpp"
-#include "SharedPointer.hpp"
+#include "mesh/SharedPointer.hpp"
 #include "partition/ReceivedPartition.hpp"
-#include <vector>
+#include "partition/SharedPointer.hpp"
 
 namespace precice {
 namespace impl {
 
 /// Stores a mesh and related objects and data.
-struct MeshContext
-{
-  MeshContext ( int dimensions )
-   :
-    localOffset ( Eigen::VectorXd::Zero(dimensions) )
-  {}
+struct MeshContext {
+  MeshContext(int dimensions)
+      : localOffset(Eigen::VectorXd::Zero(dimensions))
+  {
+  }
 
-   /** Upgrades the mesh requirement to a more specific level.
+  /** Upgrades the mesh requirement to a more specific level.
     * @param[in] requirement The requirement to upgrade to.
     */
-   void require(mapping::Mapping::MeshRequirement requirement);
-  
-   /// Mesh holding the geometry data structure.
-   mesh::PtrMesh mesh;
+  void require(mapping::Mapping::MeshRequirement requirement);
 
-   /// Data IDs of properties the geometry does possess.
-   std::vector<int> associatedData;
+  /// Mesh holding the geometry data structure.
+  mesh::PtrMesh mesh;
 
-   /// Determines which mesh type has to be provided by the accessor.
-   mapping::Mapping::MeshRequirement meshRequirement = mapping::Mapping::MeshRequirement::UNDEFINED;
+  /// Data IDs of properties the geometry does possess.
+  std::vector<int> associatedData;
 
-   /// Name of participant that creates the mesh.
-   std::string receiveMeshFrom;
+  /// Determines which mesh type has to be provided by the accessor.
+  mapping::Mapping::MeshRequirement meshRequirement = mapping::Mapping::MeshRequirement::UNDEFINED;
 
-   /// bounding box to speed up decomposition of received mesh is increased by this safety factor
-   double safetyFactor = -1;
+  /// Name of participant that creates the mesh.
+  std::string receiveMeshFrom;
 
-   /// True, if accessor does create the mesh.
-   bool provideMesh = false;
+  /// bounding box to speed up decomposition of received mesh is increased by this safety factor
+  double safetyFactor = -1;
 
-   /// type of geometric filter
-   partition::ReceivedPartition::GeometricFilter geoFilter = partition::ReceivedPartition::GeometricFilter::UNDEFINED;
+  /// True, if accessor does create the mesh.
+  bool provideMesh = false;
 
-   /// Offset only applied to meshes local to the accessor.
-   Eigen::VectorXd localOffset;
+  /// type of geometric filter
+  partition::ReceivedPartition::GeometricFilter geoFilter = partition::ReceivedPartition::GeometricFilter::UNDEFINED;
 
-   /// Partition creating the parallel decomposition of the mesh
-   partition::PtrPartition partition;
+  /// Offset only applied to meshes local to the accessor.
+  Eigen::VectorXd localOffset;
 
-   /// Mapping used when mapping data from the mesh. Can be empty.
-   MappingContext fromMappingContext;
+  /// Partition creating the parallel decomposition of the mesh
+  partition::PtrPartition partition;
 
-   /// Mapping used when mapping data to the mesh. Can be empty.
-   MappingContext toMappingContext;
-   
+  /// Mapping used when mapping data from the mesh. Can be empty.
+  MappingContext fromMappingContext;
+
+  /// Mapping used when mapping data to the mesh. Can be empty.
+  MappingContext toMappingContext;
 };
 
-inline void MeshContext::require(mapping::Mapping::MeshRequirement requirement) {
-    meshRequirement = std::max(meshRequirement, requirement);
+inline void MeshContext::require(mapping::Mapping::MeshRequirement requirement)
+{
+  meshRequirement = std::max(meshRequirement, requirement);
 }
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -1,40 +1,38 @@
 #include "Participant.hpp"
-#include "DataContext.hpp"
-#include "MeshContext.hpp"
-#include "MappingContext.hpp"
-#include "action/Action.hpp"
-#include "WatchPoint.hpp"
-#include "mesh/config/MeshConfiguration.hpp"
-#include "mesh/config/DataConfiguration.hpp"
-#include <utility>
 #include <algorithm>
+#include <utility>
+#include "DataContext.hpp"
+#include "MappingContext.hpp"
+#include "MeshContext.hpp"
+#include "WatchPoint.hpp"
+#include "action/Action.hpp"
+#include "mesh/config/DataConfiguration.hpp"
+#include "mesh/config/MeshConfiguration.hpp"
 
 namespace precice {
 namespace impl {
 
-int Participant:: _participantsSize = 0;
+int Participant::_participantsSize = 0;
 
-void Participant:: resetParticipantCount()
+void Participant::resetParticipantCount()
 {
   _participantsSize = 0;
 }
 
-Participant:: Participant
-(
-  std::string                 name,
-  mesh::PtrMeshConfiguration& meshConfig )
-:
-  _name (std::move(name)),
-  _id ( _participantsSize ),
-  _meshContexts ( meshConfig->meshes().size(), nullptr ),
-  _dataContexts ( meshConfig->getDataConfiguration()->data().size()*meshConfig->meshes().size(), nullptr )
+Participant::Participant(
+    std::string                 name,
+    mesh::PtrMeshConfiguration &meshConfig)
+    : _name(std::move(name)),
+      _id(_participantsSize),
+      _meshContexts(meshConfig->meshes().size(), nullptr),
+      _dataContexts(meshConfig->getDataConfiguration()->data().size() * meshConfig->meshes().size(), nullptr)
 {
   _participantsSize++;
 }
 
-Participant:: ~Participant()
+Participant::~Participant()
 {
-  for(MeshContext* context : _usedMeshContexts){
+  for (MeshContext *context : _usedMeshContexts) {
     delete context;
   }
   _usedMeshContexts.clear();
@@ -45,298 +43,279 @@ Participant:: ~Participant()
   _participantsSize--;
 }
 
-const std::string& Participant:: getName() const
+const std::string &Participant::getName() const
 {
   return _name;
 }
 
-int Participant:: getID() const
+int Participant::getID() const
 {
   return _id;
 }
 
-void Participant:: addWatchPoint
-(
-  const PtrWatchPoint& watchPoint )
+void Participant::addWatchPoint(
+    const PtrWatchPoint &watchPoint)
 {
-  _watchPoints.push_back ( watchPoint );
+  _watchPoints.push_back(watchPoint);
 }
 
-std::vector<PtrWatchPoint>& Participant:: watchPoints()
+std::vector<PtrWatchPoint> &Participant::watchPoints()
 {
   return _watchPoints;
 }
 
-void Participant:: useMesh
-(
-  const mesh::PtrMesh&                          mesh,
-  const Eigen::VectorXd&                        localOffset,
-  bool                                          remote,
-  const std::string&                            fromParticipant,
-  double                                        safetyFactor,
-  bool                                          provideMesh,
-  partition::ReceivedPartition::GeometricFilter geoFilter)
+void Participant::useMesh(
+    const mesh::PtrMesh &                         mesh,
+    const Eigen::VectorXd &                       localOffset,
+    bool                                          remote,
+    const std::string &                           fromParticipant,
+    double                                        safetyFactor,
+    bool                                          provideMesh,
+    partition::ReceivedPartition::GeometricFilter geoFilter)
 {
-  PRECICE_TRACE(_name,  mesh->getName(), mesh->getID() );
+  PRECICE_TRACE(_name, mesh->getName(), mesh->getID());
   checkDuplicatedUse(mesh);
-  PRECICE_ASSERT( mesh->getID() < (int)_meshContexts.size() );
-  auto context = new MeshContext(mesh->getDimensions());
-  context->mesh = mesh;
+  PRECICE_ASSERT(mesh->getID() < (int) _meshContexts.size());
+  auto context         = new MeshContext(mesh->getDimensions());
+  context->mesh        = mesh;
   context->localOffset = localOffset;
-  PRECICE_ASSERT( mesh->getDimensions() == context->localOffset.size(),
-               mesh->getDimensions(), context->localOffset.size() );
+  PRECICE_ASSERT(mesh->getDimensions() == context->localOffset.size(),
+                 mesh->getDimensions(), context->localOffset.size());
   context->receiveMeshFrom = fromParticipant;
-  context->safetyFactor = safetyFactor;
-  context->provideMesh = provideMesh;
-  context->geoFilter = geoFilter;
+  context->safetyFactor    = safetyFactor;
+  context->provideMesh     = provideMesh;
+  context->geoFilter       = geoFilter;
 
   _meshContexts[mesh->getID()] = context;
 
-  _usedMeshContexts.push_back ( context );
+  _usedMeshContexts.push_back(context);
 
-  PRECICE_CHECK( fromParticipant.empty() || (! provideMesh),
-         "Participant " << _name << " cannot receive and provide mesh "
-         << mesh->getName() << " at the same time!" );
+  PRECICE_CHECK(fromParticipant.empty() || (!provideMesh),
+                "Participant " << _name << " cannot receive and provide mesh "
+                               << mesh->getName() << " at the same time!");
 }
 
-void Participant:: addWriteData
-(
-  const mesh::PtrData& data,
-  const mesh::PtrMesh& mesh )
+void Participant::addWriteData(
+    const mesh::PtrData &data,
+    const mesh::PtrMesh &mesh)
 {
-  checkDuplicatedData ( data );
-  PRECICE_ASSERT( data->getID() < (int)_dataContexts.size() );
-  auto context = new DataContext ();
+  checkDuplicatedData(data);
+  PRECICE_ASSERT(data->getID() < (int) _dataContexts.size());
+  auto context      = new DataContext();
   context->fromData = data;
-  context->mesh = mesh;
+  context->mesh     = mesh;
   // will be overwritten later if a mapping exists
-  context->toData = context->fromData;
+  context->toData              = context->fromData;
   _dataContexts[data->getID()] = context;
-  _writeDataContexts.push_back ( context );
+  _writeDataContexts.push_back(context);
 }
 
-void Participant:: addReadData
-(
-  const mesh::PtrData& data,
-  const mesh::PtrMesh& mesh )
+void Participant::addReadData(
+    const mesh::PtrData &data,
+    const mesh::PtrMesh &mesh)
 {
-  checkDuplicatedData ( data );
-  PRECICE_ASSERT( data->getID() < (int)_dataContexts.size() );
-  auto context = new DataContext ();
+  checkDuplicatedData(data);
+  PRECICE_ASSERT(data->getID() < (int) _dataContexts.size());
+  auto context    = new DataContext();
   context->toData = data;
-  context->mesh = mesh;
+  context->mesh   = mesh;
   // will be overwritten later if a mapping exists
-  context->fromData = context->toData;
+  context->fromData            = context->toData;
   _dataContexts[data->getID()] = context;
-  _readDataContexts.push_back ( context );
+  _readDataContexts.push_back(context);
 }
 
-void Participant::addReadMappingContext
-(
-  MappingContext* mappingContext)
+void Participant::addReadMappingContext(
+    MappingContext *mappingContext)
 {
   _readMappingContexts.push_back(mappingContext);
 }
 
-void Participant::addWriteMappingContext
-(
-  MappingContext* mappingContext)
+void Participant::addWriteMappingContext(
+    MappingContext *mappingContext)
 {
   _writeMappingContexts.push_back(mappingContext);
 }
 
-const utils::ptr_vector<MappingContext>& Participant::readMappingContexts() const
+const utils::ptr_vector<MappingContext> &Participant::readMappingContexts() const
 {
   return _readMappingContexts;
 }
 
-const utils::ptr_vector<MappingContext>& Participant::writeMappingContexts() const
+const utils::ptr_vector<MappingContext> &Participant::writeMappingContexts() const
 {
   return _writeMappingContexts;
 }
 
-const DataContext& Participant:: dataContext
-(
-  int dataID ) const
+const DataContext &Participant::dataContext(
+    int dataID) const
 {
-  PRECICE_ASSERT( (dataID >= 0) && (dataID < (int)_dataContexts.size()) );
-  PRECICE_ASSERT( _dataContexts[dataID] != nullptr );
+  PRECICE_ASSERT((dataID >= 0) && (dataID < (int) _dataContexts.size()));
+  PRECICE_ASSERT(_dataContexts[dataID] != nullptr);
   return *_dataContexts[dataID];
 }
 
-DataContext& Participant:: dataContext
-(
-  int dataID )
+DataContext &Participant::dataContext(
+    int dataID)
 {
-  PRECICE_TRACE(dataID, _dataContexts.size() );
-  PRECICE_ASSERT( (dataID >= 0) && (dataID < (int)_dataContexts.size()) );
-  PRECICE_ASSERT( _dataContexts[dataID] != nullptr );
+  PRECICE_TRACE(dataID, _dataContexts.size());
+  PRECICE_ASSERT((dataID >= 0) && (dataID < (int) _dataContexts.size()));
+  PRECICE_ASSERT(_dataContexts[dataID] != nullptr);
   return *_dataContexts[dataID];
 }
 
-const utils::ptr_vector<DataContext>& Participant:: writeDataContexts() const
+const utils::ptr_vector<DataContext> &Participant::writeDataContexts() const
 {
   return _writeDataContexts;
 }
 
-utils::ptr_vector<DataContext>& Participant:: writeDataContexts()
+utils::ptr_vector<DataContext> &Participant::writeDataContexts()
 {
   return _writeDataContexts;
 }
 
-const utils::ptr_vector<DataContext>& Participant:: readDataContexts() const
+const utils::ptr_vector<DataContext> &Participant::readDataContexts() const
 {
   return _readDataContexts;
 }
 
-utils::ptr_vector<DataContext>& Participant:: readDataContexts()
+utils::ptr_vector<DataContext> &Participant::readDataContexts()
 {
   return _readDataContexts;
 }
 
-bool Participant:: isMeshUsed
-(
-  int meshID ) const
+bool Participant::isMeshUsed(
+    int meshID) const
 {
-  PRECICE_ASSERT( (meshID >= 0) && (meshID < (int)_meshContexts.size()) );
+  PRECICE_ASSERT((meshID >= 0) && (meshID < (int) _meshContexts.size()));
   return _meshContexts[meshID] != nullptr;
 }
 
-bool Participant:: isDataUsed
-(
-  int dataID ) const
+bool Participant::isDataUsed(
+    int dataID) const
 {
-  PRECICE_ASSERT( (dataID >= 0) && (dataID < (int)_dataContexts.size()), dataID, (int)_dataContexts.size() );
+  PRECICE_ASSERT((dataID >= 0) && (dataID < (int) _dataContexts.size()), dataID, (int) _dataContexts.size());
   return _dataContexts[dataID] != nullptr;
 }
 
-bool Participant:: isDataRead
-(
-  int dataID ) const
+bool Participant::isDataRead(
+    int dataID) const
 {
-    return std::any_of(_readDataContexts.begin(), _readDataContexts.end(), [dataID](const DataContext& context) {
-            return context.toData->getID() == dataID;
-            });
+  return std::any_of(_readDataContexts.begin(), _readDataContexts.end(), [dataID](const DataContext &context) {
+    return context.toData->getID() == dataID;
+  });
 }
 
-bool Participant:: isDataWrite
-(
-  int dataID ) const
+bool Participant::isDataWrite(
+    int dataID) const
 {
-    return std::any_of(_writeDataContexts.begin(), _writeDataContexts.end(), [dataID](const DataContext& context) {
-            return context.fromData->getID() == dataID;
-            });
+  return std::any_of(_writeDataContexts.begin(), _writeDataContexts.end(), [dataID](const DataContext &context) {
+    return context.fromData->getID() == dataID;
+  });
 }
 
-const MeshContext& Participant:: meshContext
-(
-  int meshID ) const
+const MeshContext &Participant::meshContext(
+    int meshID) const
 {
-  PRECICE_ASSERT((meshID >= 0) && (meshID < (int)_meshContexts.size()));
+  PRECICE_ASSERT((meshID >= 0) && (meshID < (int) _meshContexts.size()));
   PRECICE_ASSERT(_meshContexts[meshID] != nullptr);
   return *_meshContexts[meshID];
 }
 
-MeshContext& Participant:: meshContext
-(
-  int meshID )
+MeshContext &Participant::meshContext(
+    int meshID)
 {
   PRECICE_TRACE(meshID, _meshContexts.size());
-  PRECICE_ASSERT((meshID >= 0) && (meshID < (int)_meshContexts.size()),
-             meshID, _meshContexts.size());
+  PRECICE_ASSERT((meshID >= 0) && (meshID < (int) _meshContexts.size()),
+                 meshID, _meshContexts.size());
   PRECICE_ASSERT(_meshContexts[meshID] != nullptr);
   return *_meshContexts[meshID];
 }
 
-const std::vector<MeshContext*>& Participant:: usedMeshContexts() const
+const std::vector<MeshContext *> &Participant::usedMeshContexts() const
 {
   return _usedMeshContexts;
 }
 
-std::vector<MeshContext*>& Participant:: usedMeshContexts()
+std::vector<MeshContext *> &Participant::usedMeshContexts()
 {
   return _usedMeshContexts;
 }
 
-void Participant:: addAction
-(
-  const action::PtrAction& action )
+void Participant::addAction(
+    const action::PtrAction &action)
 {
-  _actions.push_back ( action );
-  auto& context = meshContext(action->getMesh()->getID());
+  _actions.push_back(action);
+  auto &context = meshContext(action->getMesh()->getID());
   context.require(action->getMeshRequirement());
 }
 
-std::vector<action::PtrAction>& Participant:: actions()
+std::vector<action::PtrAction> &Participant::actions()
 {
   return _actions;
 }
 
-const std::vector<action::PtrAction>& Participant:: actions() const
+const std::vector<action::PtrAction> &Participant::actions() const
 {
   return _actions;
 }
 
-void Participant:: addExportContext
-(
-  const io::ExportContext& exportContext )
+void Participant::addExportContext(
+    const io::ExportContext &exportContext)
 {
   _exportContexts.push_back(exportContext);
 }
 
-const std::vector<io::ExportContext>& Participant:: exportContexts() const
+const std::vector<io::ExportContext> &Participant::exportContexts() const
 {
   return _exportContexts;
 }
 
-void Participant:: checkDuplicatedUse
-(
-  const mesh::PtrMesh& mesh )
+void Participant::checkDuplicatedUse(
+    const mesh::PtrMesh &mesh)
 {
-  PRECICE_ASSERT( (int)_meshContexts.size() > mesh->getID() );
-  PRECICE_CHECK( _meshContexts[mesh->getID()] == nullptr,
-         "Mesh \"" << mesh->getName() << " cannot be used twice by "
-         << "participant " << _name << "!" );
+  PRECICE_ASSERT((int) _meshContexts.size() > mesh->getID());
+  PRECICE_CHECK(_meshContexts[mesh->getID()] == nullptr,
+                "Mesh \"" << mesh->getName() << " cannot be used twice by "
+                          << "participant " << _name << "!");
 }
 
-void Participant:: checkDuplicatedData
-(
-  const mesh::PtrData& data )
+void Participant::checkDuplicatedData(
+    const mesh::PtrData &data)
 {
-  PRECICE_TRACE(data->getID(), _dataContexts.size() );
-  PRECICE_ASSERT( data->getID() < (int)_dataContexts.size(), data->getID(), _dataContexts.size() );
-  PRECICE_CHECK( _dataContexts[data->getID()] == nullptr,
-          "Participant \"" << _name << "\" can read/write data \""
-          << data->getName() << "\" only once!" );
+  PRECICE_TRACE(data->getID(), _dataContexts.size());
+  PRECICE_ASSERT(data->getID() < (int) _dataContexts.size(), data->getID(), _dataContexts.size());
+  PRECICE_CHECK(_dataContexts[data->getID()] == nullptr,
+                "Participant \"" << _name << "\" can read/write data \""
+                                 << data->getName() << "\" only once!");
 }
 
-bool Participant:: useServer()
+bool Participant::useServer()
 {
   return static_cast<bool>(_clientServerCommunication);
 }
 
-void Participant:: setClientServerCommunication
-(
-  com::PtrCommunication communication )
+void Participant::setClientServerCommunication(
+    com::PtrCommunication communication)
 {
-  PRECICE_ASSERT( communication );
+  PRECICE_ASSERT(communication);
   _clientServerCommunication = std::move(communication);
 }
 
-com::PtrCommunication Participant:: getClientServerCommunication() const
+com::PtrCommunication Participant::getClientServerCommunication() const
 {
   return _clientServerCommunication;
 }
 
-bool Participant:: useMaster()
+bool Participant::useMaster()
 {
   return _useMaster;
 }
 
-void Participant:: setUseMaster(bool useMaster)
+void Participant::setUseMaster(bool useMaster)
 {
   _useMaster = useMaster;
 }
 
-
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -1,43 +1,40 @@
 #pragma once
 
+#include <string>
 #include "SharedPointer.hpp"
 #include "action/SharedPointer.hpp"
-#include "mesh/SharedPointer.hpp"
-#include "mapping/SharedPointer.hpp"
-#include "io/config/ExportConfiguration.hpp"
-#include "io/ExportContext.hpp"
 #include "cplscheme/SharedPointer.hpp"
+#include "io/ExportContext.hpp"
+#include "io/config/ExportConfiguration.hpp"
 #include "logging/Logger.hpp"
-#include "utils/PointerVector.hpp"
+#include "mapping/SharedPointer.hpp"
+#include "mesh/SharedPointer.hpp"
 #include "partition/ReceivedPartition.hpp"
-#include "utils/MasterSlave.hpp"
 #include "utils/ManageUniqueIDs.hpp"
-#include <string>
+#include "utils/MasterSlave.hpp"
+#include "utils/PointerVector.hpp"
 
 namespace precice {
-  namespace impl {
-    struct DataContext;
-    struct MeshContext;
-    struct MappingContext;
-  }
-}
+namespace impl {
+struct DataContext;
+struct MeshContext;
+struct MappingContext;
+} // namespace impl
+} // namespace precice
 
 // Forward declaration to friend the boost test struct
 namespace PreciceTests {
-  namespace Serial {
-    struct TestConfiguration;
-  }
+namespace Serial {
+struct TestConfiguration;
 }
-
+} // namespace PreciceTests
 
 namespace precice {
 namespace impl {
 
 /// Holds coupling state of one participating solver in coupled simulation.
-class Participant
-{
+class Participant {
 public:
-
   enum MappingConstants {
     MAPPING_LINEAR_CONSERVATIVE,
     MAPPING_LINEAR_CONSISTENT,
@@ -51,92 +48,92 @@ public:
    *
    * @param[in] name Name of the participant. Has to be unique.
    */
-  Participant (
-    std::string                 name,
-    mesh::PtrMeshConfiguration& meshConfig );
+  Participant(
+      std::string                 name,
+      mesh::PtrMeshConfiguration &meshConfig);
 
   virtual ~Participant();
 
   /// Returns the name of the participant.
-  const std::string& getName() const;
+  const std::string &getName() const;
 
   int getID() const;
 
-  void addWriteData (
-    const mesh::PtrData& data,
-    const mesh::PtrMesh& mesh );
+  void addWriteData(
+      const mesh::PtrData &data,
+      const mesh::PtrMesh &mesh);
 
-  void addReadData (
-    const mesh::PtrData& data,
-    const mesh::PtrMesh& mesh );
+  void addReadData(
+      const mesh::PtrData &data,
+      const mesh::PtrMesh &mesh);
 
-  const DataContext& dataContext ( int dataID ) const;
+  const DataContext &dataContext(int dataID) const;
 
-  DataContext& dataContext ( int dataID );
+  DataContext &dataContext(int dataID);
 
-  const utils::ptr_vector<DataContext>& writeDataContexts() const;
+  const utils::ptr_vector<DataContext> &writeDataContexts() const;
 
-  utils::ptr_vector<DataContext>& writeDataContexts();
+  utils::ptr_vector<DataContext> &writeDataContexts();
 
-  const utils::ptr_vector<DataContext>& readDataContexts() const;
+  const utils::ptr_vector<DataContext> &readDataContexts() const;
 
-  utils::ptr_vector<DataContext>& readDataContexts();
+  utils::ptr_vector<DataContext> &readDataContexts();
 
-  bool isMeshUsed ( int meshID ) const;
+  bool isMeshUsed(int meshID) const;
 
-  bool isDataUsed ( int dataID ) const;
+  bool isDataUsed(int dataID) const;
 
-  bool isDataRead ( int dataID ) const;
+  bool isDataRead(int dataID) const;
 
-  bool isDataWrite ( int dataID ) const;
+  bool isDataWrite(int dataID) const;
 
-  const MeshContext& meshContext ( int meshID ) const;
+  const MeshContext &meshContext(int meshID) const;
 
-  MeshContext& meshContext ( int meshID );
+  MeshContext &meshContext(int meshID);
 
-  const std::vector<MeshContext*>& usedMeshContexts() const;
+  const std::vector<MeshContext *> &usedMeshContexts() const;
 
-  std::vector<MeshContext*>& usedMeshContexts();
+  std::vector<MeshContext *> &usedMeshContexts();
 
-  void addReadMappingContext(MappingContext* mappingContext);
+  void addReadMappingContext(MappingContext *mappingContext);
 
-  void addWriteMappingContext(MappingContext* mappingContext);
+  void addWriteMappingContext(MappingContext *mappingContext);
 
-  const utils::ptr_vector<MappingContext>& readMappingContexts() const;
+  const utils::ptr_vector<MappingContext> &readMappingContexts() const;
 
-  const utils::ptr_vector<MappingContext>& writeMappingContexts() const;
+  const utils::ptr_vector<MappingContext> &writeMappingContexts() const;
 
-  void addWatchPoint ( const PtrWatchPoint& watchPoint );
+  void addWatchPoint(const PtrWatchPoint &watchPoint);
 
-  std::vector<PtrWatchPoint>& watchPoints();
+  std::vector<PtrWatchPoint> &watchPoints();
 
   /// Adds a mesh to be used by the participant.
-  void useMesh (
-    const mesh::PtrMesh&                          mesh,
-    const Eigen::VectorXd&                        localOffset,
-    bool                                          remote,
-    const std::string&                            fromParticipant,
-    double                                        safetyFactor,
-    bool                                          provideMesh,
-    partition::ReceivedPartition::GeometricFilter geoFilter);
+  void useMesh(
+      const mesh::PtrMesh &                         mesh,
+      const Eigen::VectorXd &                       localOffset,
+      bool                                          remote,
+      const std::string &                           fromParticipant,
+      double                                        safetyFactor,
+      bool                                          provideMesh,
+      partition::ReceivedPartition::GeometricFilter geoFilter);
 
-  void addAction ( const action::PtrAction& action );
+  void addAction(const action::PtrAction &action);
 
-  std::vector<action::PtrAction>& actions();
+  std::vector<action::PtrAction> &actions();
 
-  const std::vector<action::PtrAction>& actions() const;
+  const std::vector<action::PtrAction> &actions() const;
 
   /// Adds an export context to export meshes and data.
-  void addExportContext ( const io::ExportContext& context );
+  void addExportContext(const io::ExportContext &context);
 
   /// Returns all export contexts for exporting meshes and data.
-  const std::vector<io::ExportContext>& exportContexts() const;
+  const std::vector<io::ExportContext> &exportContexts() const;
 
   /// Returns true, if the participant uses a precice in form of a server.
   bool useServer();
 
   /// Sets the client-server com. for the participant.
-  void setClientServerCommunication ( com::PtrCommunication communication );
+  void setClientServerCommunication(com::PtrCommunication communication);
 
   com::PtrCommunication getClientServerCommunication() const;
 
@@ -145,8 +142,9 @@ public:
 
   void setUseMaster(bool useMaster);
 
-  void setMeshIdManager(std::unique_ptr<utils::ManageUniqueIDs>&& idm) {
-      _meshIdManager = std::move(idm);
+  void setMeshIdManager(std::unique_ptr<utils::ManageUniqueIDs> &&idm)
+  {
+    _meshIdManager = std::move(idm);
   }
 
   /**
@@ -157,7 +155,6 @@ public:
   //void setIsServer ( bool value );
 
 private:
-
   logging::Logger _log{"impl::Participant"};
 
   static int _participantsSize;
@@ -174,7 +171,7 @@ private:
   std::vector<action::PtrAction> _actions;
 
   /// All mesh contexts involved in a simulation, mesh ID == index.
-  std::vector<MeshContext*> _meshContexts;
+  std::vector<MeshContext *> _meshContexts;
 
   /// Read mapping contexts used by the participant.
   utils::ptr_vector<MappingContext> _readMappingContexts;
@@ -183,9 +180,9 @@ private:
   utils::ptr_vector<MappingContext> _writeMappingContexts;
 
   /// Mesh contexts used by the participant.
-  std::vector<MeshContext*> _usedMeshContexts;
+  std::vector<MeshContext *> _usedMeshContexts;
 
-  std::vector<DataContext*> _dataContexts;
+  std::vector<DataContext *> _dataContexts;
 
   utils::ptr_vector<DataContext> _writeDataContexts;
 
@@ -199,35 +196,33 @@ private:
 
   std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
 
-  template<typename ELEMENT_T>
-  bool isDataValid (
-    const std::vector<ELEMENT_T>& data,
-    const ELEMENT_T&              newElement ) const;
+  template <typename ELEMENT_T>
+  bool isDataValid(
+      const std::vector<ELEMENT_T> &data,
+      const ELEMENT_T &             newElement) const;
 
-  void checkDuplicatedUse ( const mesh::PtrMesh& mesh );
+  void checkDuplicatedUse(const mesh::PtrMesh &mesh);
 
-  void checkDuplicatedData ( const mesh::PtrData& data );
+  void checkDuplicatedData(const mesh::PtrData &data);
 
   /// To allow white box tests.
   friend struct PreciceTests::Serial::TestConfiguration;
 };
 
-
 // --------------------------------------------------------- HEADER DEFINITIONS
 
-
-template< typename ELEMENT_T >
-bool Participant:: isDataValid
-(
-  const std::vector<ELEMENT_T>& data,
-  const ELEMENT_T&              newElement ) const
+template <typename ELEMENT_T>
+bool Participant::isDataValid(
+    const std::vector<ELEMENT_T> &data,
+    const ELEMENT_T &             newElement) const
 {
-  for ( size_t i=0; i < data.size(); i++ ) {
-    if ( data[i].name == newElement.name ) {
+  for (size_t i = 0; i < data.size(); i++) {
+    if (data[i].name == newElement.name) {
       return false;
     }
   }
   return true;
 }
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/RequestManager.cpp
+++ b/src/precice/impl/RequestManager.cpp
@@ -1,64 +1,63 @@
 #include "RequestManager.hpp"
-#include "com/Communication.hpp"
-#include "cplscheme/CouplingScheme.hpp"
-#include "precice/impl/SolverInterfaceImpl.hpp"
 #include <algorithm>
 #include <utility>
 #include <vector>
+#include "com/Communication.hpp"
+#include "cplscheme/CouplingScheme.hpp"
+#include "precice/impl/SolverInterfaceImpl.hpp"
 
 namespace precice {
 namespace impl {
 
-RequestManager:: RequestManager
-(
-  SolverInterfaceImpl&  solverInterfaceImpl,
-  com::PtrCommunication clientServerCommunication,
-  cplscheme::PtrCouplingScheme couplingScheme)
-:
-  _interface(solverInterfaceImpl),
-  _com(std::move(clientServerCommunication)),
-  _couplingScheme(std::move(couplingScheme))
-{}
+RequestManager::RequestManager(
+    SolverInterfaceImpl &        solverInterfaceImpl,
+    com::PtrCommunication        clientServerCommunication,
+    cplscheme::PtrCouplingScheme couplingScheme)
+    : _interface(solverInterfaceImpl),
+      _com(std::move(clientServerCommunication)),
+      _couplingScheme(std::move(couplingScheme))
+{
+}
 
-void RequestManager:: handleRequests()
+void RequestManager::handleRequests()
 {
   PRECICE_TRACE();
-  int clientCommSize = _com->getRemoteCommunicatorSize();
-  int clientCounter = 0;
+  int            clientCommSize = _com->getRemoteCommunicatorSize();
+  int            clientCounter  = 0;
   std::list<int> clientRanks;
   PRECICE_DEBUG("ClientCommSize " << clientCommSize);
 
   std::vector<com::PtrRequest> requests(clientCommSize);
-  std::vector<int> requestIDs(clientCommSize,-1);
+  std::vector<int>             requestIDs(clientCommSize, -1);
 
-  for(int clientRank = 0; clientRank<clientCommSize; clientRank++){
-     requests[clientRank] = _com->aReceive(requestIDs[clientRank], clientRank);
+  for (int clientRank = 0; clientRank < clientCommSize; clientRank++) {
+    requests[clientRank] = _com->aReceive(requestIDs[clientRank], clientRank);
   }
 
-  int rankSender = 0;
-  int requestID = -1;
+  int  rankSender        = 0;
+  int  requestID         = -1;
   bool collectiveRequest = false;
-  bool singleRequest = false;
-  while(true){
-    if((std::find(clientRanks.begin(), clientRanks.end(), rankSender) == clientRanks.end()) &&
-       requests[rankSender]->test()){
+  bool singleRequest     = false;
+  while (true) {
+    if ((std::find(clientRanks.begin(), clientRanks.end(), rankSender) == clientRanks.end()) &&
+        requests[rankSender]->test()) {
       requestID = requestIDs[rankSender];
       PRECICE_CHECK(requestID != -1, "Receiving of request ID failed");
       PRECICE_DEBUG("Received request ID " << requestID << " from rank " << rankSender);
-    }
-    else{
+    } else {
       rankSender++;
-      if(rankSender==clientCommSize) rankSender = 0;
+      if (rankSender == clientCommSize)
+        rankSender = 0;
       continue;
     }
 
-    switch (requestID){
+    switch (requestID) {
     case REQUEST_INITIALIZE:
       PRECICE_DEBUG("Request initialize by rank " << rankSender);
       clientCounter++;
       PRECICE_ASSERT(clientCounter <= clientCommSize, clientCounter, clientCommSize);
       clientRanks.push_front(rankSender);
-      if (clientCounter == clientCommSize){
+      if (clientCounter == clientCommSize) {
         handleRequestInitialze(clientRanks);
         collectiveRequest = true;
       }
@@ -68,7 +67,7 @@ void RequestManager:: handleRequests()
       clientCounter++;
       PRECICE_ASSERT(clientCounter <= clientCommSize, clientCounter, clientCommSize);
       clientRanks.push_front(rankSender);
-      if (clientCounter == clientCommSize){
+      if (clientCounter == clientCommSize) {
         handleRequestInitialzeData(clientRanks);
         collectiveRequest = true;
       }
@@ -78,7 +77,7 @@ void RequestManager:: handleRequests()
       clientCounter++;
       PRECICE_ASSERT(clientCounter <= clientCommSize, clientCounter, clientCommSize);
       clientRanks.push_front(rankSender);
-      if (clientCounter == clientCommSize){
+      if (clientCounter == clientCommSize) {
         handleRequestAdvance(clientRanks);
         collectiveRequest = true;
       }
@@ -88,7 +87,7 @@ void RequestManager:: handleRequests()
       clientCounter++;
       PRECICE_ASSERT(clientCounter <= clientCommSize, clientCounter, clientCommSize);
       clientRanks.push_front(rankSender);
-      if (clientCounter == clientCommSize){
+      if (clientCounter == clientCommSize) {
         handleRequestFinalize();
         clientCounter = 0;
         clientRanks.clear();
@@ -179,7 +178,7 @@ void RequestManager:: handleRequests()
       clientCounter++;
       PRECICE_ASSERT(clientCounter <= clientCommSize, clientCounter, clientCommSize);
       clientRanks.push_front(rankSender);
-      if (clientCounter == clientCommSize){
+      if (clientCounter == clientCommSize) {
         handleRequestMapWriteDataFrom(clientRanks);
         collectiveRequest = true;
       }
@@ -189,7 +188,7 @@ void RequestManager:: handleRequests()
       clientCounter++;
       PRECICE_ASSERT(clientCounter <= clientCommSize, clientCounter, clientCommSize);
       clientRanks.push_front(rankSender);
-      if (clientCounter == clientCommSize){
+      if (clientCounter == clientCommSize) {
         handleRequestMapReadDataTo(clientRanks);
         collectiveRequest = true;
       }
@@ -205,14 +204,13 @@ void RequestManager:: handleRequests()
     }
 
     // open receive again and clean up
-    if(singleRequest){
+    if (singleRequest) {
       requestIDs[rankSender] = -1;
-      requests[rankSender] = _com->aReceive(requestIDs[rankSender], rankSender);
-      singleRequest = false;
-    }
-    else if(collectiveRequest){
-      PRECICE_ASSERT(clientRanks.size()== static_cast<size_t>(clientCommSize));
-      for(int rank : clientRanks){
+      requests[rankSender]   = _com->aReceive(requestIDs[rankSender], rankSender);
+      singleRequest          = false;
+    } else if (collectiveRequest) {
+      PRECICE_ASSERT(clientRanks.size() == static_cast<size_t>(clientCommSize));
+      for (int rank : clientRanks) {
         requests[rank] = _com->aReceive(requestIDs[rank], rank);
       }
       clientCounter = 0;
@@ -223,10 +221,11 @@ void RequestManager:: handleRequests()
     requestID = -1;
 
     rankSender++;
-    if(rankSender==clientCommSize) rankSender = 0;
+    if (rankSender == clientCommSize)
+      rankSender = 0;
   }
 }
-void RequestManager:: requestPing()
+void RequestManager::requestPing()
 {
   PRECICE_TRACE();
   _com->send(REQUEST_PING, 0);
@@ -234,23 +233,22 @@ void RequestManager:: requestPing()
   _com->receive(dummy, 0);
 }
 
-void RequestManager:: requestInitialize()
+void RequestManager::requestInitialize()
 {
   PRECICE_TRACE();
   _com->send(REQUEST_INITIALIZE, 0);
   _couplingScheme->receiveState(_com, 0);
 }
 
-void RequestManager:: requestInitialzeData()
+void RequestManager::requestInitialzeData()
 {
   PRECICE_TRACE();
   _com->send(REQUEST_INITIALIZE_DATA, 0);
   _couplingScheme->receiveState(_com, 0);
 }
 
-void RequestManager:: requestAdvance
-(
-  double dt )
+void RequestManager::requestAdvance(
+    double dt)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_ADVANCE, 0);
@@ -258,26 +256,23 @@ void RequestManager:: requestAdvance
   _couplingScheme->receiveState(_com, 0);
 }
 
-void RequestManager:: requestFinalize()
+void RequestManager::requestFinalize()
 {
   PRECICE_TRACE();
   _com->send(REQUEST_FINALIZE, 0);
 }
 
-
-void RequestManager:: requestFulfilledAction
-(
-  const std::string& action )
+void RequestManager::requestFulfilledAction(
+    const std::string &action)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_FULFILLED_ACTION, 0);
   _com->send(action, 0);
 }
 
-int RequestManager:: requestSetMeshVertex
-(
-  int              meshID,
-  Eigen::VectorXd& position )
+int RequestManager::requestSetMeshVertex(
+    int              meshID,
+    Eigen::VectorXd &position)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_SET_MESH_VERTEX, 0);
@@ -288,9 +283,8 @@ int RequestManager:: requestSetMeshVertex
   return index;
 }
 
-int RequestManager:: requestGetMeshVertexSize
-(
-  int meshID )
+int RequestManager::requestGetMeshVertexSize(
+    int meshID)
 {
   PRECICE_TRACE(meshID);
   _com->send(REQUEST_GET_MESH_VERTEX_SIZE, 0);
@@ -300,82 +294,75 @@ int RequestManager:: requestGetMeshVertexSize
   return size;
 }
 
-void RequestManager:: requestResetMesh
-(
-  int meshID )
+void RequestManager::requestResetMesh(
+    int meshID)
 {
   PRECICE_TRACE(meshID);
   _com->send(REQUEST_RESET_MESH, 0);
   _com->send(meshID, 0);
 }
 
-void RequestManager:: requestSetMeshVertices
-(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids )
+void RequestManager::requestSetMeshVertices(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_SET_MESH_VERTICES, 0);
   _com->send(meshID, 0);
   _com->send(size, 0);
-  _com->send(positions, size*_interface.getDimensions(), 0);
+  _com->send(positions, size * _interface.getDimensions(), 0);
   _com->receive(ids, size, 0);
 }
 
-void RequestManager:: requestGetMeshVertices
-(
-  int        meshID,
-  int        size,
-  const int* ids,
-  double*    positions )
+void RequestManager::requestGetMeshVertices(
+    int        meshID,
+    int        size,
+    const int *ids,
+    double *   positions)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_GET_MESH_VERTICES, 0);
   _com->send(meshID, 0);
   _com->send(size, 0);
   _com->send(ids, size, 0);
-  _com->receive(positions, size*_interface.getDimensions(), 0);
+  _com->receive(positions, size * _interface.getDimensions(), 0);
 }
 
-void RequestManager:: requestGetMeshVertexIDsFromPositions
-(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids )
+void RequestManager::requestGetMeshVertexIDsFromPositions(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids)
 {
   PRECICE_TRACE(size);
   _com->send(REQUEST_GET_MESH_VERTEX_IDS_FROM_POSITIONS, 0);
   _com->send(meshID, 0);
   _com->send(size, 0);
-  _com->send(positions, size*_interface.getDimensions(), 0);
+  _com->send(positions, size * _interface.getDimensions(), 0);
   _com->receive(ids, size, 0);
 }
 
-
-int RequestManager:: requestSetMeshEdge
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID )
+int RequestManager::requestSetMeshEdge(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID, secondVertexID);
   _com->send(REQUEST_SET_MESH_EDGE, 0);
-  int data[3] = { meshID, firstVertexID, secondVertexID };
+  int data[3] = {meshID, firstVertexID, secondVertexID};
   _com->send(data, 3, 0);
   int createdEdgeID = -1;
   _com->receive(createdEdgeID, 0);
   return createdEdgeID;
 }
 
-void RequestManager:: requestSetMeshTriangle
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID )
+void RequestManager::requestSetMeshTriangle(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID)
 {
   PRECICE_TRACE(meshID, firstEdgeID, secondEdgeID, thirdEdgeID);
   _com->send(REQUEST_SET_MESH_TRIANGLE, 0);
@@ -383,12 +370,11 @@ void RequestManager:: requestSetMeshTriangle
   _com->send(data, 4, 0);
 }
 
-void RequestManager:: requestSetMeshTriangleWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID )
+void RequestManager::requestSetMeshTriangleWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID,
                 secondVertexID, thirdVertexID);
@@ -397,13 +383,12 @@ void RequestManager:: requestSetMeshTriangleWithEdges
   _com->send(data, 4, 0);
 }
 
-void RequestManager:: requestSetMeshQuad
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID,
-  int fourthEdgeID )
+void RequestManager::requestSetMeshQuad(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID,
+    int fourthEdgeID)
 {
   PRECICE_TRACE(meshID, firstEdgeID, secondEdgeID, thirdEdgeID, fourthEdgeID);
   _com->send(REQUEST_SET_MESH_QUAD, 0);
@@ -411,13 +396,12 @@ void RequestManager:: requestSetMeshQuad
   _com->send(data, 5, 0);
 }
 
-void RequestManager:: requestSetMeshQuadWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID,
-  int fourthVertexID )
+void RequestManager::requestSetMeshQuadWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID,
+    int fourthVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
   _com->send(REQUEST_SET_MESH_QUAD_WITH_EDGES, 0);
@@ -425,11 +409,11 @@ void RequestManager:: requestSetMeshQuadWithEdges
   _com->send(data, 5, 0);
 }
 
-void RequestManager:: requestWriteBlockScalarData (
-  int           dataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values )
+void RequestManager::requestWriteBlockScalarData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   PRECICE_TRACE(dataID, size);
   _com->send(REQUEST_WRITE_BLOCK_SCALAR_DATA, 0);
@@ -439,11 +423,10 @@ void RequestManager:: requestWriteBlockScalarData (
   _com->send(values, size, 0);
 }
 
-void RequestManager:: requestWriteScalarData
-(
-  int    dataID,
-  int    valueIndex,
-  double value )
+void RequestManager::requestWriteScalarData(
+    int    dataID,
+    int    valueIndex,
+    double value)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_WRITE_SCALAR_DATA, 0);
@@ -452,25 +435,24 @@ void RequestManager:: requestWriteScalarData
   _com->send(value, 0);
 }
 
-void RequestManager:: requestWriteBlockVectorData (
-  int           dataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values )
+void RequestManager::requestWriteBlockVectorData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   PRECICE_TRACE(dataID);
   _com->send(REQUEST_WRITE_BLOCK_VECTOR_DATA, 0);
   _com->send(dataID, 0);
   _com->send(size, 0);
   _com->send(valueIndices, size, 0);
-  _com->send(values, size*_interface.getDimensions(), 0);
+  _com->send(values, size * _interface.getDimensions(), 0);
 }
 
-void RequestManager:: requestWriteVectorData
-(
-  int           dataID,
-  int           valueIndex,
-  const double* value )
+void RequestManager::requestWriteVectorData(
+    int           dataID,
+    int           valueIndex,
+    const double *value)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_WRITE_VECTOR_DATA, 0);
@@ -479,11 +461,11 @@ void RequestManager:: requestWriteVectorData
   _com->send(value, _interface.getDimensions(), 0);
 }
 
-void RequestManager:: requestReadBlockScalarData (
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values )
+void RequestManager::requestReadBlockScalarData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values)
 {
   PRECICE_TRACE(dataID, size);
   _com->send(REQUEST_READ_BLOCK_SCALAR_DATA, 0);
@@ -493,11 +475,10 @@ void RequestManager:: requestReadBlockScalarData (
   _com->receive(values, size, 0);
 }
 
-void RequestManager:: requestReadScalarData
-(
-  int     dataID,
-  int     valueIndex,
-  double& value )
+void RequestManager::requestReadScalarData(
+    int     dataID,
+    int     valueIndex,
+    double &value)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_READ_SCALAR_DATA, 0);
@@ -506,26 +487,24 @@ void RequestManager:: requestReadScalarData
   _com->receive(value, 0);
 }
 
-void RequestManager:: requestReadBlockVectorData
-(
-  int        dataID,
-  int        size,
-  const int* valueIndices,
-  double*    values )
+void RequestManager::requestReadBlockVectorData(
+    int        dataID,
+    int        size,
+    const int *valueIndices,
+    double *   values)
 {
   PRECICE_TRACE(dataID, size);
   _com->send(REQUEST_READ_BLOCK_VECTOR_DATA, 0);
   _com->send(dataID, 0);
   _com->send(size, 0);
   _com->send(valueIndices, size, 0);
-  _com->receive(values, size*_interface.getDimensions(), 0);
+  _com->receive(values, size * _interface.getDimensions(), 0);
 }
 
-void RequestManager:: requestReadVectorData
-(
-  int     dataID,
-  int     valueIndex,
-  double* value )
+void RequestManager::requestReadVectorData(
+    int     dataID,
+    int     valueIndex,
+    double *value)
 {
   PRECICE_TRACE();
   _com->send(REQUEST_READ_VETOR_DATA, 0);
@@ -534,9 +513,8 @@ void RequestManager:: requestReadVectorData
   _com->receive(value, _interface.getDimensions(), 0);
 }
 
-void RequestManager:: requestMapWriteDataFrom
-(
-  int fromMeshID )
+void RequestManager::requestMapWriteDataFrom(
+    int fromMeshID)
 {
   PRECICE_TRACE(fromMeshID);
   _com->send(REQUEST_MAP_WRITE_DATA_FROM, 0);
@@ -545,9 +523,8 @@ void RequestManager:: requestMapWriteDataFrom
   _com->send(fromMeshID, 0);
 }
 
-void RequestManager:: requestMapReadDataTo
-(
-  int toMeshID )
+void RequestManager::requestMapReadDataTo(
+    int toMeshID)
 {
   PRECICE_TRACE(toMeshID);
   _com->send(REQUEST_MAP_READ_DATA_TO, 0);
@@ -556,9 +533,8 @@ void RequestManager:: requestMapReadDataTo
   _com->send(toMeshID, 0);
 }
 
-void RequestManager:: handleRequestInitialze
-(
-  const std::list<int>& clientRanks )
+void RequestManager::handleRequestInitialze(
+    const std::list<int> &clientRanks)
 {
   PRECICE_TRACE()
   _interface.initialize();
@@ -567,9 +543,8 @@ void RequestManager:: handleRequestInitialze
   }
 }
 
-void RequestManager:: handleRequestInitialzeData
-(
-  const std::list<int>& clientRanks )
+void RequestManager::handleRequestInitialzeData(
+    const std::list<int> &clientRanks)
 {
   PRECICE_TRACE();
   _interface.initializeData();
@@ -578,20 +553,19 @@ void RequestManager:: handleRequestInitialzeData
   }
 }
 
-void RequestManager:: handleRequestAdvance
-(
-  const std::list<int>& clientRanks )
+void RequestManager::handleRequestAdvance(
+    const std::list<int> &clientRanks)
 {
   PRECICE_TRACE();
-  auto iter = clientRanks.begin();
+  auto   iter = clientRanks.begin();
   double oldDt;
   _com->receive(oldDt, *iter);
   iter++;
-  for (; iter != clientRanks.end(); iter++){
+  for (; iter != clientRanks.end(); iter++) {
     double dt;
     _com->receive(dt, *iter);
     PRECICE_CHECK(math::equals(dt, oldDt),
-          "Ambiguous timestep length when calling request advance from several processes!");
+                  "Ambiguous timestep length when calling request advance from several processes!");
     oldDt = dt;
   }
   _interface.advance(oldDt);
@@ -600,15 +574,14 @@ void RequestManager:: handleRequestAdvance
   }
 }
 
-void RequestManager:: handleRequestFinalize()
+void RequestManager::handleRequestFinalize()
 {
   PRECICE_TRACE();
   _interface.finalize();
 }
 
-void RequestManager:: handleRequestFulfilledAction
-(
-  int rankSender )
+void RequestManager::handleRequestFulfilledAction(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   std::string action;
@@ -616,9 +589,8 @@ void RequestManager:: handleRequestFulfilledAction
   _interface.fulfilledAction(action);
 }
 
-void RequestManager:: handleRequestSetMeshVertex
-(
-  int rankSender )
+void RequestManager::handleRequestSetMeshVertex(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int meshID = -1;
@@ -629,9 +601,8 @@ void RequestManager:: handleRequestSetMeshVertex
   _com->send(index, rankSender);
 }
 
-void RequestManager:: handleRequestGetMeshVertexSize
-(
-  int rankSender )
+void RequestManager::handleRequestGetMeshVertexSize(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int meshID = -1;
@@ -640,9 +611,8 @@ void RequestManager:: handleRequestGetMeshVertexSize
   _com->send(size, rankSender);
 }
 
-void RequestManager:: handleRequestResetMesh
-(
-  int rankSender )
+void RequestManager::handleRequestResetMesh(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int meshID = -1;
@@ -650,10 +620,8 @@ void RequestManager:: handleRequestResetMesh
   _interface.resetMesh(meshID);
 }
 
-
-void RequestManager:: handleRequestSetMeshVertices
-(
-  int rankSender )
+void RequestManager::handleRequestSetMeshVertices(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int meshID = -1;
@@ -661,50 +629,47 @@ void RequestManager:: handleRequestSetMeshVertices
   int size = -1;
   _com->receive(size, rankSender);
   PRECICE_CHECK(size > 0, "You cannot call setMeshVertices with size=0.");
-  std::vector<double> positions(static_cast<size_t>(size)*_interface.getDimensions());
+  std::vector<double> positions(static_cast<size_t>(size) * _interface.getDimensions());
   _com->receive(positions, rankSender);
   std::vector<int> ids(size);
   _interface.setMeshVertices(meshID, size, positions.data(), ids.data());
   _com->send(ids, rankSender);
 }
 
-void RequestManager:: handleRequestGetMeshVertices
-(
-  int rankSender )
+void RequestManager::handleRequestGetMeshVertices(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int meshID = -1;
-  int size = -1;
+  int size   = -1;
   _com->receive(meshID, rankSender);
   _com->receive(size, rankSender);
   PRECICE_ASSERT(size > 0, size);
-  std::vector<int> ids(size);
-  std::vector<double> positions(static_cast<size_t>(size)*_interface.getDimensions());
+  std::vector<int>    ids(size);
+  std::vector<double> positions(static_cast<size_t>(size) * _interface.getDimensions());
   _com->receive(ids, rankSender);
   _interface.getMeshVertices(meshID, size, ids.data(), positions.data());
   _com->send(positions, rankSender);
 }
 
-void RequestManager:: handleRequestGetMeshVertexIDsFromPositions
-(
-  int rankSender )
+void RequestManager::handleRequestGetMeshVertexIDsFromPositions(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int meshID = -1;
-  int size = -1;
+  int size   = -1;
   _com->receive(meshID, rankSender);
   _com->receive(size, rankSender);
   PRECICE_ASSERT(size > 0, size);
-  std::vector<int> ids(size);
-  std::vector<double> positions(static_cast<size_t>(size)*_interface.getDimensions());
+  std::vector<int>    ids(size);
+  std::vector<double> positions(static_cast<size_t>(size) * _interface.getDimensions());
   _com->receive(positions, rankSender);
   _interface.getMeshVertexIDsFromPositions(meshID, size, positions.data(), ids.data());
   _com->send(ids, rankSender);
 }
 
-void RequestManager:: handleRequestSetMeshEdge
-(
-  int rankSender )
+void RequestManager::handleRequestSetMeshEdge(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int data[3]; // 0: meshID, 1: firstVertexID, 2: secondVertexID
@@ -713,9 +678,8 @@ void RequestManager:: handleRequestSetMeshEdge
   _com->send(createEdgeID, rankSender);
 }
 
-void RequestManager:: handleRequestSetMeshTriangle
-(
-  int rankSender )
+void RequestManager::handleRequestSetMeshTriangle(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int data[4]; // 0: meshID, 1,2,3: edge IDs
@@ -723,9 +687,8 @@ void RequestManager:: handleRequestSetMeshTriangle
   _interface.setMeshTriangle(data[0], data[1], data[2], data[3]);
 }
 
-void RequestManager:: handleRequestSetMeshTriangleWithEdges
-(
-  int rankSender )
+void RequestManager::handleRequestSetMeshTriangleWithEdges(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int data[4]; // 0: meshID, 1,2,3: vertex IDs
@@ -733,9 +696,8 @@ void RequestManager:: handleRequestSetMeshTriangleWithEdges
   _interface.setMeshTriangleWithEdges(data[0], data[1], data[2], data[3]);
 }
 
-void RequestManager:: handleRequestSetMeshQuad
-(
-  int rankSender )
+void RequestManager::handleRequestSetMeshQuad(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int data[5]; // 0: meshID, 1,2,3,4: edge IDs
@@ -743,9 +705,8 @@ void RequestManager:: handleRequestSetMeshQuad
   _interface.setMeshQuad(data[0], data[1], data[2], data[3], data[4]);
 }
 
-void RequestManager:: handleRequestSetMeshQuadWithEdges
-(
-  int rankSender )
+void RequestManager::handleRequestSetMeshQuadWithEdges(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int data[5]; // 0: meshID, 1,2,3,4: vertex IDs
@@ -753,9 +714,8 @@ void RequestManager:: handleRequestSetMeshQuadWithEdges
   _interface.setMeshQuadWithEdges(data[0], data[1], data[2], data[3], data[4]);
 }
 
-void RequestManager:: handleRequestWriteScalarData
-(
-  int rankSender )
+void RequestManager::handleRequestWriteScalarData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
@@ -767,9 +727,8 @@ void RequestManager:: handleRequestWriteScalarData
   _interface.writeScalarData(dataID, index, data);
 }
 
-void RequestManager:: handleRequestWriteBlockScalarData
-(
-  int rankSender )
+void RequestManager::handleRequestWriteBlockScalarData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
@@ -783,9 +742,8 @@ void RequestManager:: handleRequestWriteBlockScalarData
   _interface.writeBlockScalarData(dataID, size, indices.data(), data.data());
 }
 
-void RequestManager:: handleRequestWriteBlockVectorData
-(
-  int rankSender )
+void RequestManager::handleRequestWriteBlockVectorData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
@@ -794,28 +752,26 @@ void RequestManager:: handleRequestWriteBlockVectorData
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
   _com->receive(indices, rankSender);
-  std::vector<double> data(static_cast<size_t>(size)*_interface.getDimensions());
+  std::vector<double> data(static_cast<size_t>(size) * _interface.getDimensions());
   _com->receive(data, rankSender);
   _interface.writeBlockVectorData(dataID, size, indices.data(), data.data());
 }
 
-void RequestManager:: handleRequestWriteVectorData
-(
-  int rankSender )
+void RequestManager::handleRequestWriteVectorData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
   _com->receive(dataID, rankSender);
   int index = -1;
-  _com->receive( index, rankSender);
+  _com->receive(index, rankSender);
   std::vector<double> data(_interface.getDimensions());
   _com->receive(data.data(), _interface.getDimensions(), rankSender);
   _interface.writeVectorData(dataID, index, data.data());
 }
 
-void RequestManager:: handleRequestReadScalarData
-(
-  int rankSender )
+void RequestManager::handleRequestReadScalarData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
@@ -827,9 +783,8 @@ void RequestManager:: handleRequestReadScalarData
   _com->send(data, rankSender); // Send back result
 }
 
-void RequestManager:: handleRequestReadBlockScalarData
-(
-  int rankSender )
+void RequestManager::handleRequestReadBlockScalarData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
@@ -843,9 +798,8 @@ void RequestManager:: handleRequestReadBlockScalarData
   _com->send(data, rankSender);
 }
 
-void RequestManager:: handleRequestReadBlockVectorData
-(
-  int rankSender )
+void RequestManager::handleRequestReadBlockVectorData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
@@ -854,14 +808,13 @@ void RequestManager:: handleRequestReadBlockVectorData
   _com->receive(size, rankSender);
   std::vector<int> indices(size);
   _com->receive(indices, rankSender);
-  std::vector<double> data(static_cast<size_t>(size)*_interface.getDimensions());
+  std::vector<double> data(static_cast<size_t>(size) * _interface.getDimensions());
   _interface.readBlockVectorData(dataID, size, indices.data(), data.data());
   _com->send(data, rankSender);
 }
 
-void RequestManager:: handleRequestReadVectorData
-(
-  int rankSender )
+void RequestManager::handleRequestReadVectorData(
+    int rankSender)
 {
   PRECICE_TRACE(rankSender);
   int dataID = -1;
@@ -873,49 +826,48 @@ void RequestManager:: handleRequestReadVectorData
   _com->send(data.data(), _interface.getDimensions(), rankSender);
 }
 
-void RequestManager:: handleRequestMapWriteDataFrom
-(
-  const std::list<int>& clientRanks )
+void RequestManager::handleRequestMapWriteDataFrom(
+    const std::list<int> &clientRanks)
 {
   PRECICE_TRACE();
   auto iter = clientRanks.begin();
-  int ping = 0;
+  int  ping = 0;
   _com->send(ping, *iter);
   int oldMeshID;
   _com->receive(oldMeshID, *iter);
   iter++;
-  for (; iter != clientRanks.end(); iter++){
+  for (; iter != clientRanks.end(); iter++) {
     _com->send(ping, *iter);
     int meshID;
     _com->receive(meshID, *iter);
     PRECICE_CHECK(meshID == oldMeshID,
-          "Ambiguous mesh ID when calling map written data from several processes!");
+                  "Ambiguous mesh ID when calling map written data from several processes!");
     oldMeshID = meshID;
   }
   _interface.mapWriteDataFrom(oldMeshID);
 }
 
-void RequestManager:: handleRequestMapReadDataTo
-(
-  const std::list<int>& clientRanks )
+void RequestManager::handleRequestMapReadDataTo(
+    const std::list<int> &clientRanks)
 {
   PRECICE_TRACE();
   auto iter = clientRanks.begin();
-  int ping = 0;
+  int  ping = 0;
   _com->send(ping, *iter);
   int oldMeshID;
   _com->receive(oldMeshID, *iter);
   iter++;
-  for (; iter != clientRanks.end(); iter++){
+  for (; iter != clientRanks.end(); iter++) {
     _com->send(ping, *iter);
     int meshID;
     _com->receive(meshID, *iter);
     PRECICE_CHECK(meshID == oldMeshID,
-          "Ambiguous mesh IDs (" << meshID << " and " << oldMeshID
-          <<  ") when calling map read data from several processes!");
+                  "Ambiguous mesh IDs (" << meshID << " and " << oldMeshID
+                                         << ") when calling map read data from several processes!");
     oldMeshID = meshID;
   }
   _interface.mapReadDataTo(oldMeshID);
 }
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/RequestManager.hpp
+++ b/src/precice/impl/RequestManager.hpp
@@ -1,30 +1,28 @@
 #pragma once
 
-#include "cplscheme/SharedPointer.hpp"
-#include "com/SharedPointer.hpp"
-#include "logging/Logger.hpp"
-#include <set>
-#include <list>
 #include <Eigen/Core>
+#include <list>
+#include <set>
+#include "com/SharedPointer.hpp"
+#include "cplscheme/SharedPointer.hpp"
+#include "logging/Logger.hpp"
 
 namespace precice {
-  namespace impl {
-    class SolverInterfaceImpl;
-  }
+namespace impl {
+class SolverInterfaceImpl;
 }
+} // namespace precice
 
 namespace precice {
 namespace impl {
 
 /// Takes requests from clients and handles requests on server side.
-class RequestManager
-{
+class RequestManager {
 public:
-
-  RequestManager (
-    SolverInterfaceImpl&  solverInterfaceImpl,
-    com::PtrCommunication clientServerCommunication,
-    cplscheme::PtrCouplingScheme couplingScheme);
+  RequestManager(
+      SolverInterfaceImpl &        solverInterfaceImpl,
+      com::PtrCommunication        clientServerCommunication,
+      cplscheme::PtrCouplingScheme couplingScheme);
 
   /// Redirects all requests from client to corresponding handle methods.
   void handleRequests();
@@ -39,18 +37,18 @@ public:
   void requestInitialzeData();
 
   /// Requests advance from server.
-  void requestAdvance ( double dt );
+  void requestAdvance(double dt);
 
   /// Requests finalize from server.
   void requestFinalize();
 
   /// Requests fulfilled action from server.
-  void requestFulfilledAction ( const std::string& action );
+  void requestFulfilledAction(const std::string &action);
 
   /// Requests set position of solver mesh from server.
-  int requestSetMeshVertex (
-    int               meshID,
-    Eigen::VectorXd&  position );
+  int requestSetMeshVertex(
+      int              meshID,
+      Eigen::VectorXd &position);
 
   /// Requests get size of vertices of preCICE mesh.
   int requestGetMeshVertexSize(int meshID);
@@ -59,122 +57,121 @@ public:
   void requestResetMesh(int meshID);
 
   /// Requests set vertex positions from server.
-  void requestSetMeshVertices (
-    int           meshID,
-    int           size,
-    const double* positions,
-    int*          ids );
+  void requestSetMeshVertices(
+      int           meshID,
+      int           size,
+      const double *positions,
+      int *         ids);
 
   /// Requests get vertex positions from server.
-  void requestGetMeshVertices (
-    int        meshID,
-    int        size,
-    const int* ids,
-    double*    positions );
+  void requestGetMeshVertices(
+      int        meshID,
+      int        size,
+      const int *ids,
+      double *   positions);
 
   /// Requests get vertex ids from server.
-  void requestGetMeshVertexIDsFromPositions (
-    int           meshID,
-    int           size,
-    const double* positions,
-    int*          ids );
+  void requestGetMeshVertexIDsFromPositions(
+      int           meshID,
+      int           size,
+      const double *positions,
+      int *         ids);
 
   /// Requests set mesh edge from server.
-  int requestSetMeshEdge (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID );
+  int requestSetMeshEdge(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID);
 
   /// Requests set mesh triangle from server.
-  void requestSetMeshTriangle (
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID );
+  void requestSetMeshTriangle(
+      int meshID,
+      int firstEdgeID,
+      int secondEdgeID,
+      int thirdEdgeID);
 
   /// Requests set mesh triangle with edges from server.
-  void requestSetMeshTriangleWithEdges (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID );
+  void requestSetMeshTriangleWithEdges(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID,
+      int thirdVertexID);
 
   /// Requests set mesh quad from server.
-  void requestSetMeshQuad (
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID,
-    int fourthEdgeID );
+  void requestSetMeshQuad(
+      int meshID,
+      int firstEdgeID,
+      int secondEdgeID,
+      int thirdEdgeID,
+      int fourthEdgeID);
 
   /// Requests set mesh quad with edges from server.
-  void requestSetMeshQuadWithEdges (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID,
-    int fourthVertexID );
+  void requestSetMeshQuadWithEdges(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID,
+      int thirdVertexID,
+      int fourthVertexID);
 
   /// Requests write block scalar data from server.
-  void requestWriteBlockScalarData (
-    int           dataID,
-    int           size,
-    const int*    valueIndices,
-    const double* values );
+  void requestWriteBlockScalarData(
+      int           dataID,
+      int           size,
+      const int *   valueIndices,
+      const double *values);
 
   /// Requests write scalar data from server.
-  void requestWriteScalarData (
-    int    dataID,
-    int    valueIndex,
-    double value );
+  void requestWriteScalarData(
+      int    dataID,
+      int    valueIndex,
+      double value);
 
   /// Requests write block vector data from server.
-  void requestWriteBlockVectorData (
-    int           dataID,
-    int           size,
-    const int*    valueIndices,
-    const double* values );
+  void requestWriteBlockVectorData(
+      int           dataID,
+      int           size,
+      const int *   valueIndices,
+      const double *values);
 
   /// Requests write vector data from server.
-  void requestWriteVectorData (
-    int           dataID,
-    int           valueIndex,
-    const double* value );
+  void requestWriteVectorData(
+      int           dataID,
+      int           valueIndex,
+      const double *value);
 
   /// Requests read block scalar data from server.
-  void requestReadBlockScalarData (
-    int        dataID,
-    int        size,
-    const int* valueIndices,
-    double*    values );
+  void requestReadBlockScalarData(
+      int        dataID,
+      int        size,
+      const int *valueIndices,
+      double *   values);
 
   /// Requests read scalar data from server.
-  void requestReadScalarData (
-    int     dataID,
-    int     valueIndex,
-    double& value );
+  void requestReadScalarData(
+      int     dataID,
+      int     valueIndex,
+      double &value);
 
   /// Requests read block vector data from server.
-  void requestReadBlockVectorData (
-    int        dataID,
-    int        size,
-    const int* valueIndices,
-    double*    values );
+  void requestReadBlockVectorData(
+      int        dataID,
+      int        size,
+      const int *valueIndices,
+      double *   values);
 
   /// Requests read vector data from server.
-  void requestReadVectorData (
-    int     dataID,
-    int     valueIndex,
-    double* value );
+  void requestReadVectorData(
+      int     dataID,
+      int     valueIndex,
+      double *value);
 
   /// Requests write mapping data from server.
-  void requestMapWriteDataFrom ( int fromMeshID );
+  void requestMapWriteDataFrom(int fromMeshID);
 
   /// Requests read mapping data from server.
-  void requestMapReadDataTo( int toMeshID );
+  void requestMapReadDataTo(int toMeshID);
 
 private:
-
   /// IDs for requests from clients.
   enum Request {
     REQUEST_INITIALIZE,
@@ -208,29 +205,29 @@ private:
 
   logging::Logger _log{"impl::RequestManager"};
 
-  SolverInterfaceImpl& _interface;
+  SolverInterfaceImpl &_interface;
 
   com::PtrCommunication _com;
 
   cplscheme::PtrCouplingScheme _couplingScheme;
 
   /// Handles request initialize from client.
-  void handleRequestInitialze ( const std::list<int>& clientRanks );
+  void handleRequestInitialze(const std::list<int> &clientRanks);
 
   /// Handles request initialize data from client.
-  void handleRequestInitialzeData ( const std::list<int>& clientRanks );
+  void handleRequestInitialzeData(const std::list<int> &clientRanks);
 
   /// Handles request advance from client.
-  void handleRequestAdvance ( const std::list<int>& clientRanks );
+  void handleRequestAdvance(const std::list<int> &clientRanks);
 
   /// Handles request finalize from client.
   void handleRequestFinalize();
 
   /// Handles request fulfilled action from client.
-  void handleRequestFulfilledAction ( int rankSender );
+  void handleRequestFulfilledAction(int rankSender);
 
   /// Handles request set mesh vertex from client.
-  void handleRequestSetMeshVertex ( int rankSender );
+  void handleRequestSetMeshVertex(int rankSender);
 
   /// Handles request get mesh vertex size from client.
   void handleRequestGetMeshVertexSize(int rankSender);
@@ -239,59 +236,59 @@ private:
   void handleRequestResetMesh(int rankSender);
 
   /// Handles request set vertex positions from client.
-  void handleRequestSetMeshVertices ( int rankSender );
+  void handleRequestSetMeshVertices(int rankSender);
 
   /// Handles request get vertex positions from client.
-  void handleRequestGetMeshVertices ( int rankSender );
+  void handleRequestGetMeshVertices(int rankSender);
 
   /// Handles request get vertex IDs from client.
-  void handleRequestGetMeshVertexIDsFromPositions ( int rankSender );
+  void handleRequestGetMeshVertexIDsFromPositions(int rankSender);
 
   /// Handles request set mesh edge from client.
-  void handleRequestSetMeshEdge ( int rankSender );
+  void handleRequestSetMeshEdge(int rankSender);
 
   /// Handles request set mesh triangle from client.
-  void handleRequestSetMeshTriangle ( int rankSender );
+  void handleRequestSetMeshTriangle(int rankSender);
 
   /// Handles request set mesh triangle with edges from client.
-  void handleRequestSetMeshTriangleWithEdges ( int rankSender );
+  void handleRequestSetMeshTriangleWithEdges(int rankSender);
 
   /// Handles request set mesh quad from client.
-  void handleRequestSetMeshQuad ( int rankSender );
+  void handleRequestSetMeshQuad(int rankSender);
 
   /// Handles request set mesh quad with edges from client.
-  void handleRequestSetMeshQuadWithEdges ( int rankSender );
+  void handleRequestSetMeshQuadWithEdges(int rankSender);
 
   /// Handles request write block scalar data from client.
-  void handleRequestWriteBlockScalarData ( int rankSender );
+  void handleRequestWriteBlockScalarData(int rankSender);
 
   /// Handles request write scalar data from client.
-  void handleRequestWriteScalarData ( int rankSender );
+  void handleRequestWriteScalarData(int rankSender);
 
   /// Handles request write block vector data from client.
-  void handleRequestWriteBlockVectorData ( int rankSender );
+  void handleRequestWriteBlockVectorData(int rankSender);
 
   /// Handles request write vector data from client.
-  void handleRequestWriteVectorData ( int rankSender );
+  void handleRequestWriteVectorData(int rankSender);
 
   /// Handles request read block scalar data from client.
-  void handleRequestReadBlockScalarData ( int rankSender );
+  void handleRequestReadBlockScalarData(int rankSender);
 
   /// Handles request read scalar data from client.
-  void handleRequestReadScalarData ( int rankSender );
+  void handleRequestReadScalarData(int rankSender);
 
   /// Handles request read block vector data from client.
-  void handleRequestReadBlockVectorData ( int rankSender );
+  void handleRequestReadBlockVectorData(int rankSender);
 
   /// Handles request read vector data from client.
-  void handleRequestReadVectorData ( int rankSender );
+  void handleRequestReadVectorData(int rankSender);
 
   /// Handles request map written data from client.
-  void handleRequestMapWriteDataFrom ( const std::list<int>& clientRanks );
+  void handleRequestMapWriteDataFrom(const std::list<int> &clientRanks);
 
   /// Handles request map read data from client.
-  void handleRequestMapReadDataTo ( const std::list<int>& clientRanks );
-
+  void handleRequestMapReadDataTo(const std::list<int> &clientRanks);
 };
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/SharedPointer.hpp
+++ b/src/precice/impl/SharedPointer.hpp
@@ -10,9 +10,10 @@ class Coupling;
 class WatchPoint;
 struct MeshContext;
 
-using PtrParticipant        = std::shared_ptr<Participant>;
-using PtrCoupling           = std::shared_ptr<Coupling>;
-using PtrWatchPoint         = std::shared_ptr<WatchPoint>;
-using PtrMeshContext        = std::shared_ptr<MeshContext>;
+using PtrParticipant = std::shared_ptr<Participant>;
+using PtrCoupling    = std::shared_ptr<Coupling>;
+using PtrWatchPoint  = std::shared_ptr<WatchPoint>;
+using PtrMeshContext = std::shared_ptr<MeshContext>;
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1,43 +1,42 @@
 #include "SolverInterfaceImpl.hpp"
-#include "precice/impl/Participant.hpp"
-#include "precice/impl/WatchPoint.hpp"
-#include "precice/impl/RequestManager.hpp"
-#include "precice/impl/ValidationMacros.hpp"
-#include "precice/config/Configuration.hpp"
-#include "precice/config/SolverInterfaceConfiguration.hpp"
-#include "precice/config/ParticipantConfiguration.hpp"
-#include "mesh/config/DataConfiguration.hpp"
-#include "mesh/config/MeshConfiguration.hpp"
-#include "mesh/Mesh.hpp"
-#include "mesh/Vertex.hpp"
-#include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
-#include "io/ExportContext.hpp"
-#include "io/Export.hpp"
-#include "m2n/config/M2NConfiguration.hpp"
-#include "m2n/M2N.hpp"
-#include "m2n/BoundM2N.hpp"
+#include <Eigen/Core>
 #include "cplscheme/CouplingScheme.hpp"
 #include "cplscheme/config/CouplingSchemeConfiguration.hpp"
+#include "io/Export.hpp"
+#include "io/ExportContext.hpp"
+#include "m2n/BoundM2N.hpp"
+#include "m2n/M2N.hpp"
+#include "m2n/config/M2NConfiguration.hpp"
+#include "mapping/Mapping.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
+#include "mesh/config/DataConfiguration.hpp"
+#include "mesh/config/MeshConfiguration.hpp"
+#include "partition/ProvidedPartition.hpp"
+#include "partition/ReceivedPartition.hpp"
+#include "precice/config/Configuration.hpp"
+#include "precice/config/ParticipantConfiguration.hpp"
+#include "precice/config/SolverInterfaceConfiguration.hpp"
+#include "precice/impl/Participant.hpp"
+#include "precice/impl/RequestManager.hpp"
+#include "precice/impl/ValidationMacros.hpp"
+#include "precice/impl/WatchPoint.hpp"
+#include "precice/impl/versions.hpp"
+#include "utils/EigenHelperFunctions.hpp"
 #include "utils/EventUtils.hpp"
 #include "utils/Helpers.hpp"
+#include "utils/MasterSlave.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/Petsc.hpp"
-#include "utils/MasterSlave.hpp"
-#include "utils/EigenHelperFunctions.hpp"
 #include "utils/algorithm.hpp"
-#include "mapping/Mapping.hpp"
-#include <Eigen/Core>
-#include "partition/ReceivedPartition.hpp"
-#include "partition/ProvidedPartition.hpp"
-#include "precice/impl/versions.hpp"
 
-#include <utility>
 #include <algorithm>
+#include <utility>
 
-#include "logging/Logger.hpp"
 #include "logging/LogConfiguration.hpp"
-
+#include "logging/Logger.hpp"
 
 using precice::utils::Event;
 using precice::utils::EventRegistry;
@@ -52,75 +51,70 @@ bool syncMode = false;
 
 namespace impl {
 
-SolverInterfaceImpl:: SolverInterfaceImpl
-(
-  std::string participantName,
-  int         accessorProcessRank,
-  int         accessorCommunicatorSize,
-  bool        serverMode,
-  void*       communicator)
-:
-  _accessorName(std::move(participantName)),
-  _accessorProcessRank(accessorProcessRank),
-  _accessorCommunicatorSize(accessorCommunicatorSize),
-  _serverMode(serverMode)
+SolverInterfaceImpl::SolverInterfaceImpl(
+    std::string participantName,
+    int         accessorProcessRank,
+    int         accessorCommunicatorSize,
+    bool        serverMode,
+    void *      communicator)
+    : _accessorName(std::move(participantName)),
+      _accessorProcessRank(accessorProcessRank),
+      _accessorCommunicatorSize(accessorCommunicatorSize),
+      _serverMode(serverMode)
 {
   PRECICE_CHECK(!_accessorName.empty(), "Accessor has to be named!");
   PRECICE_CHECK(_accessorProcessRank >= 0, "Accessor process index has to be >= 0!");
   PRECICE_CHECK(_accessorCommunicatorSize >= 0, "Accessor process size has to be >= 0!");
   PRECICE_CHECK(_accessorProcessRank < _accessorCommunicatorSize,
-        "Accessor process index has to be smaller than accessor process "
-        << "size (given as " << _accessorProcessRank << ")!");
+                "Accessor process index has to be smaller than accessor process "
+                    << "size (given as " << _accessorProcessRank << ")!");
 
-  // Set the global communicator to the passed communicator.
-  // This is a noop if preCICE is not configured with MPI.
-  // nullpointer signals to use MPI_COMM_WORLD
-  #ifndef PRECICE_NO_MPI
+// Set the global communicator to the passed communicator.
+// This is a noop if preCICE is not configured with MPI.
+// nullpointer signals to use MPI_COMM_WORLD
+#ifndef PRECICE_NO_MPI
   if (communicator != nullptr) {
-      auto commptr = static_cast<utils::Parallel::Communicator*>(communicator);
-      utils::Parallel::setGlobalCommunicator(*commptr);
+    auto commptr = static_cast<utils::Parallel::Communicator *>(communicator);
+    utils::Parallel::setGlobalCommunicator(*commptr);
   }
-  #endif
+#endif
 
   logging::setParticipant(_accessorName);
 }
 
-SolverInterfaceImpl:: SolverInterfaceImpl
-(
-  std::string participantName,
-  int         accessorProcessRank,
-  int         accessorCommunicatorSize,
-  bool        serverMode )
+SolverInterfaceImpl::SolverInterfaceImpl(
+    std::string participantName,
+    int         accessorProcessRank,
+    int         accessorCommunicatorSize,
+    bool        serverMode)
     : SolverInterfaceImpl::SolverInterfaceImpl(std::move(participantName), accessorProcessRank, accessorCommunicatorSize, serverMode, nullptr)
-{}
+{
+}
 
-void SolverInterfaceImpl:: configure
-(
-  const std::string& configurationFileName )
+void SolverInterfaceImpl::configure(
+    const std::string &configurationFileName)
 {
   utils::Parallel::initializeMPI(nullptr, nullptr);
-  config::Configuration config;
+  config::Configuration     config;
   xml::ConfigurationContext context{
       _accessorName,
       _accessorProcessRank,
-      _accessorCommunicatorSize
-  };
+      _accessorCommunicatorSize};
   xml::configure(config.getXMLTag(), context, configurationFileName);
-  if(_accessorProcessRank==0){
+  if (_accessorProcessRank == 0) {
     PRECICE_INFO("This is preCICE version " << PRECICE_VERSION);
     PRECICE_INFO("Revision info: " << precice::preciceRevision);
-    PRECICE_INFO("Configuring preCICE with configuration: \"" << configurationFileName << "\"" );
+    PRECICE_INFO("Configuring preCICE with configuration: \"" << configurationFileName << "\"");
   }
   configure(config.getSolverInterfaceConfiguration());
 }
 
-void SolverInterfaceImpl:: configure
-(
-  const config::SolverInterfaceConfiguration& config )
+void SolverInterfaceImpl::configure(
+    const config::SolverInterfaceConfiguration &config)
 {
   PRECICE_TRACE();
 
-  Event e("configure"); // no precice::syncMode as this is not yet configured here
+  Event                    e("configure"); // no precice::syncMode as this is not yet configured here
   utils::ScopedEventPrefix sep("configure/");
 
   mesh::Data::resetDataCount();
@@ -128,15 +122,15 @@ void SolverInterfaceImpl:: configure
   _meshLock.clear();
 
   _dimensions = config.getDimensions();
-  _accessor = determineAccessingParticipant(config);
+  _accessor   = determineAccessingParticipant(config);
   _accessor->setMeshIdManager(config.getMeshConfiguration()->extractMeshIdManager());
 
-  PRECICE_CHECK(not (_accessor->useServer() && _accessor->useMaster()),
-        "You cannot use a server and a master.");
-  PRECICE_ASSERT(_accessorCommunicatorSize==1 || _accessor->useMaster() || _accessor->useServer(),
-        "A parallel participant needs either a master or a server communication");
-  PRECICE_CHECK(not (_accessorCommunicatorSize==1 && _accessor->useMaster()),
-        "You cannot use a master with a serial participant.");
+  PRECICE_CHECK(not(_accessor->useServer() && _accessor->useMaster()),
+                "You cannot use a server and a master.");
+  PRECICE_ASSERT(_accessorCommunicatorSize == 1 || _accessor->useMaster() || _accessor->useServer(),
+                 "A parallel participant needs either a master or a server communication");
+  PRECICE_CHECK(not(_accessorCommunicatorSize == 1 && _accessor->useMaster()),
+                "You cannot use a master with a serial participant.");
 
   _clientMode = (not _serverMode) && _accessor->useServer();
 
@@ -145,14 +139,14 @@ void SolverInterfaceImpl:: configure
   _participants = config.getParticipantConfiguration()->getParticipants();
   configureM2Ns(config.getM2NConfiguration());
 
-  if (_serverMode){
+  if (_serverMode) {
     PRECICE_INFO("Run in server mode");
   }
-  if (_clientMode){
+  if (_clientMode) {
     PRECICE_INFO("Run in client mode");
   }
 
-  if (not _clientMode){
+  if (not _clientMode) {
     PRECICE_INFO("Run in coupling mode");
     PRECICE_CHECK(_participants.size() > 1, "At least two participants need to be defined!");
     configurePartitions(config.getM2NConfiguration());
@@ -162,97 +156,96 @@ void SolverInterfaceImpl:: configure
       config.getCouplingSchemeConfiguration();
   _couplingScheme = cplSchemeConfig->getCouplingScheme(_accessorName);
 
-  if (_serverMode || _clientMode){
+  if (_serverMode || _clientMode) {
     com::PtrCommunication com = _accessor->getClientServerCommunication();
     PRECICE_ASSERT(com.get() != nullptr);
     _requestManager = std::make_shared<RequestManager>(*this, com, _couplingScheme);
   }
 
   // Add meshIDs and data IDs
-  for (const MeshContext* meshContext : _accessor->usedMeshContexts()) {
-    const mesh::PtrMesh& mesh = meshContext->mesh;
-    const auto meshID = mesh->getID();
-    _meshIDs[mesh->getName()] = meshID;
-    PRECICE_ASSERT(_dataIDs.find(meshID)==_dataIDs.end());
-    _dataIDs[meshID] = std::map<std::string,int>();
-    PRECICE_ASSERT(_dataIDs.find(meshID)!=_dataIDs.end());
-    for (const mesh::PtrData& data : mesh->data()) {
-      PRECICE_ASSERT(_dataIDs[meshID].find(data->getName())==_dataIDs[meshID].end());
+  for (const MeshContext *meshContext : _accessor->usedMeshContexts()) {
+    const mesh::PtrMesh &mesh   = meshContext->mesh;
+    const auto           meshID = mesh->getID();
+    _meshIDs[mesh->getName()]   = meshID;
+    PRECICE_ASSERT(_dataIDs.find(meshID) == _dataIDs.end());
+    _dataIDs[meshID] = std::map<std::string, int>();
+    PRECICE_ASSERT(_dataIDs.find(meshID) != _dataIDs.end());
+    for (const mesh::PtrData &data : mesh->data()) {
+      PRECICE_ASSERT(_dataIDs[meshID].find(data->getName()) == _dataIDs[meshID].end());
       _dataIDs[meshID][data->getName()] = data->getID();
     }
-    std::string meshName = mesh->getName();
+    std::string                meshName   = mesh->getName();
     mesh::PtrMeshConfiguration meshConfig = config.getMeshConfiguration();
   }
   // Register all MeshIds to the lock, but unlock them straight away as
   // writing is allowed after configuration.
-  for (const auto& meshID : _meshIDs) {
-      _meshLock.add(meshID.second, false);
+  for (const auto &meshID : _meshIDs) {
+    _meshLock.add(meshID.second, false);
   }
 
   logging::setMPIRank(utils::Parallel::getProcessRank());
   utils::EventRegistry::instance().initialize("precice-" + _accessorName, "", utils::Parallel::getGlobalCommunicator());
 
   // Setup communication to server
-  if (_clientMode){
+  if (_clientMode) {
     initializeClientServerCommunication();
   }
   PRECICE_DEBUG("Initialize master-slave communication");
-  if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()){
+  if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
     initializeMasterSlaveCommunication();
   }
 
-  auto & solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
+  auto &solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
   solverInitEvent.start(precice::syncMode);
 }
 
-double SolverInterfaceImpl:: initialize()
+double SolverInterfaceImpl::initialize()
 {
   PRECICE_TRACE();
-  auto & solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
+  auto &solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
   solverInitEvent.pause(precice::syncMode);
-  Event e("initialize", precice::syncMode);
+  Event                    e("initialize", precice::syncMode);
   utils::ScopedEventPrefix sep("initialize/");
 
-  if (_clientMode){
+  if (_clientMode) {
     PRECICE_DEBUG("Request perform initializations");
     _requestManager->requestInitialize();
-  }
-  else {
+  } else {
     // Setup communication
 
-    PRECICE_INFO("Setting up master communication to coupling partner/s" );
-    for (auto& m2nPair : _m2ns) {
-        auto& bm2n = m2nPair.second;
-        PRECICE_DEBUG((bm2n.isRequesting?"Awaiting master connection from ":"Establishing master connection to ") << bm2n.remoteName);
-        bm2n.prepareEstablishment();
-        bm2n.connectMasters();
-        PRECICE_DEBUG("Established master connection " << (bm2n.isRequesting?"from ":"to ") << bm2n.remoteName);
+    PRECICE_INFO("Setting up master communication to coupling partner/s");
+    for (auto &m2nPair : _m2ns) {
+      auto &bm2n = m2nPair.second;
+      PRECICE_DEBUG((bm2n.isRequesting ? "Awaiting master connection from " : "Establishing master connection to ") << bm2n.remoteName);
+      bm2n.prepareEstablishment();
+      bm2n.connectMasters();
+      PRECICE_DEBUG("Established master connection " << (bm2n.isRequesting ? "from " : "to ") << bm2n.remoteName);
     }
     PRECICE_INFO("Masters are connected");
 
     computePartitions();
 
-    PRECICE_INFO("Setting up slaves communication to coupling partner/s" );
-    for (auto& m2nPair : _m2ns) {
-      auto& bm2n = m2nPair.second;
-      PRECICE_DEBUG((bm2n.isRequesting?"Awaiting slaves connection from ":"Establishing slaves connection to ") << bm2n.remoteName);
+    PRECICE_INFO("Setting up slaves communication to coupling partner/s");
+    for (auto &m2nPair : _m2ns) {
+      auto &bm2n = m2nPair.second;
+      PRECICE_DEBUG((bm2n.isRequesting ? "Awaiting slaves connection from " : "Establishing slaves connection to ") << bm2n.remoteName);
       bm2n.connectSlaves();
       bm2n.cleanupEstablishment();
-      PRECICE_DEBUG("Established slaves connection " << (bm2n.isRequesting?"from ":"to ") << bm2n.remoteName);
+      PRECICE_DEBUG("Established slaves connection " << (bm2n.isRequesting ? "from " : "to ") << bm2n.remoteName);
     }
     PRECICE_INFO("Slaves are connected");
 
     std::set<action::Action::Timing> timings;
-    double dt = 0.0;
+    double                           dt = 0.0;
 
     PRECICE_DEBUG("Initialize watchpoints");
-    for (PtrWatchPoint& watchPoint : _accessor->watchPoints()){
+    for (PtrWatchPoint &watchPoint : _accessor->watchPoints()) {
       watchPoint->initialize();
     }
 
     // Initialize coupling state, overwrite these values for restart
-    double time = 0.0;
-    int timestep = 1;
+    double time     = 0.0;
+    int    timestep = 1;
 
     PRECICE_DEBUG("Initialize coupling schemes");
     _couplingScheme->initialize(time, timestep);
@@ -261,7 +254,7 @@ double SolverInterfaceImpl:: initialize()
 
     timings.insert(action::Action::ALWAYS_POST);
 
-    if (_couplingScheme->hasDataBeenExchanged()){
+    if (_couplingScheme->hasDataBeenExchanged()) {
       timings.insert(action::Action::ON_EXCHANGE_POST);
       mapReadData();
     }
@@ -278,42 +271,41 @@ double SolverInterfaceImpl:: initialize()
   return _couplingScheme->getNextTimestepMaxLength();
 }
 
-void SolverInterfaceImpl:: initializeData ()
+void SolverInterfaceImpl::initializeData()
 {
   PRECICE_TRACE();
 
-  auto & solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
+  auto &solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
   solverInitEvent.pause(precice::syncMode);
 
-  Event e("initializeData", precice::syncMode);
+  Event                    e("initializeData", precice::syncMode);
   utils::ScopedEventPrefix sep("initializeData/");
 
   PRECICE_DEBUG("Initialize data");
 
   PRECICE_CHECK(_couplingScheme->isInitialized(),
-        "initialize() has to be called before initializeData()");
-  if (_clientMode){
+                "initialize() has to be called before initializeData()");
+  if (_clientMode) {
     _requestManager->requestInitialzeData();
-  }
-  else {
+  } else {
     mapWrittenData();
     _couplingScheme->initializeData();
-    double dt = _couplingScheme->getNextTimestepMaxLength();
+    double                           dt = _couplingScheme->getNextTimestepMaxLength();
     std::set<action::Action::Timing> timings;
-    if (_couplingScheme->hasDataBeenExchanged()){
+    if (_couplingScheme->hasDataBeenExchanged()) {
       timings.insert(action::Action::ON_EXCHANGE_POST);
       mapReadData();
     }
     performDataActions(timings, 0.0, 0.0, 0.0, dt);
     resetWrittenData();
     PRECICE_DEBUG("Plot output");
-    for (const io::ExportContext& context : _accessor->exportContexts()){
-      if (context.timestepInterval != -1){
+    for (const io::ExportContext &context : _accessor->exportContexts()) {
+      if (context.timestepInterval != -1) {
         std::ostringstream suffix;
         suffix << _accessorName << ".init";
         exportMesh(suffix.str());
-        if (context.triggerSolverPlot){
-          _couplingScheme->requireAction(std::string ("plot-output"));
+        if (context.triggerSolverPlot) {
+          _couplingScheme->requireAction(std::string("plot-output"));
         }
       }
     }
@@ -321,60 +313,55 @@ void SolverInterfaceImpl:: initializeData ()
   solverInitEvent.start(precice::syncMode);
 }
 
-double SolverInterfaceImpl:: advance
-(
-  double computedTimestepLength )
+double SolverInterfaceImpl::advance(
+    double computedTimestepLength)
 {
   PRECICE_TRACE(computedTimestepLength);
 
   // Events for the solver time, stopped when we enter, restarted when we leave advance
-  auto & solverEvent = EventRegistry::instance().getStoredEvent("solver.advance");
+  auto &solverEvent = EventRegistry::instance().getStoredEvent("solver.advance");
   solverEvent.stop(precice::syncMode);
-  auto & solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
+  auto &solverInitEvent = EventRegistry::instance().getStoredEvent("solver.initialize");
   solverInitEvent.stop(precice::syncMode);
 
-  Event e("advance", precice::syncMode);
+  Event                    e("advance", precice::syncMode);
   utils::ScopedEventPrefix sep("advance/");
 
   PRECICE_CHECK(_couplingScheme->isInitialized(), "initialize() has to be called before advance()");
   PRECICE_CHECK(isCouplingOngoing(), "advance() cannot be called when isCouplingOngoing() returns false");
   _numberAdvanceCalls++;
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestAdvance(computedTimestepLength);
-  }
-  else {
-#   ifndef NDEBUG
+  } else {
+#ifndef NDEBUG
     PRECICE_DEBUG("Synchronize timestep length");
-    if(utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()){
+    if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
       syncTimestep(computedTimestepLength);
     }
-#   endif
+#endif
 
     double timestepLength = 0.0; // Length of (full) current dt
-    double timestepPart = 0.0;   // Length of computed part of (full) curr. dt
-    double time = 0.0;
-
+    double timestepPart   = 0.0; // Length of computed part of (full) curr. dt
+    double time           = 0.0;
 
     // Update the coupling scheme time state. Necessary to get correct remainder.
     _couplingScheme->addComputedTime(computedTimestepLength);
 
     //double timestepLength = 0.0;
-    if (_couplingScheme->hasTimestepLength()){
+    if (_couplingScheme->hasTimestepLength()) {
       timestepLength = _couplingScheme->getTimestepLength();
-    }
-    else {
+    } else {
       timestepLength = computedTimestepLength;
     }
     timestepPart = timestepLength - _couplingScheme->getThisTimestepRemainder();
-    time = _couplingScheme->getTime();
-
+    time         = _couplingScheme->getTime();
 
     mapWrittenData();
 
     std::set<action::Action::Timing> timings;
 
     timings.insert(action::Action::ALWAYS_PRIOR);
-    if (_couplingScheme->willDataBeExchanged(0.0)){
+    if (_couplingScheme->willDataBeExchanged(0.0)) {
       timings.insert(action::Action::ON_EXCHANGE_PRIOR);
     }
     performDataActions(timings, time, computedTimestepLength, timestepPart, timestepLength);
@@ -384,15 +371,15 @@ double SolverInterfaceImpl:: advance
 
     timings.clear();
     timings.insert(action::Action::ALWAYS_POST);
-    if (_couplingScheme->hasDataBeenExchanged()){
+    if (_couplingScheme->hasDataBeenExchanged()) {
       timings.insert(action::Action::ON_EXCHANGE_POST);
     }
-    if (_couplingScheme->isCouplingTimestepComplete()){
+    if (_couplingScheme->isCouplingTimestepComplete()) {
       timings.insert(action::Action::ON_TIMESTEP_COMPLETE_POST);
     }
     performDataActions(timings, time, computedTimestepLength, timestepPart, timestepLength);
 
-    if (_couplingScheme->hasDataBeenExchanged()){
+    if (_couplingScheme->hasDataBeenExchanged()) {
       mapReadData();
     }
 
@@ -404,22 +391,21 @@ double SolverInterfaceImpl:: advance
     // deactivated the reset of written data, as it deletes all data that is not communicated
     // within this cycle in the coupling data. This is not wanted forthe manifold mapping.
     //resetWrittenData();
-
   }
   _meshLock.lockAll();
   solverEvent.start(precice::syncMode);
   return _couplingScheme->getNextTimestepMaxLength();
 }
 
-void SolverInterfaceImpl:: finalize()
+void SolverInterfaceImpl::finalize()
 {
   PRECICE_TRACE();
 
   // Events for the solver time, finally stopped here
-  auto & solverEvent = EventRegistry::instance().getStoredEvent("solver.advance");
+  auto &solverEvent = EventRegistry::instance().getStoredEvent("solver.advance");
   solverEvent.stop(precice::syncMode);
 
-  Event e("finalize"); // no precice::syncMode here as MPI is already finalized at destruction of this event
+  Event                    e("finalize"); // no precice::syncMode here as MPI is already finalized at destruction of this event
   utils::ScopedEventPrefix sep("finalize/");
 
   PRECICE_CHECK(_couplingScheme->isInitialized(), "initialize() has to be called before finalize()");
@@ -427,19 +413,18 @@ void SolverInterfaceImpl:: finalize()
   _couplingScheme->finalize();
   _couplingScheme.reset();
 
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestFinalize();
     _accessor->getClientServerCommunication()->closeConnection();
-  }
-  else {
+  } else {
     PRECICE_DEBUG("Handle exports");
-    for (const io::ExportContext& context : _accessor->exportContexts()){
-      if ( context.timestepInterval != -1 ){
+    for (const io::ExportContext &context : _accessor->exportContexts()) {
+      if (context.timestepInterval != -1) {
         std::ostringstream suffix;
         suffix << _accessorName << ".final";
-        exportMesh ( suffix.str() );
-        if ( context.triggerSolverPlot ) {
-          _couplingScheme->requireAction ( std::string ("plot-output") );
+        exportMesh(suffix.str());
+        if (context.triggerSolverPlot) {
+          _couplingScheme->requireAction(std::string("plot-output"));
         }
       }
     }
@@ -449,18 +434,17 @@ void SolverInterfaceImpl:: finalize()
     std::string ping = "ping";
     std::string pong = "pong";
     for (auto &iter : _m2ns) {
-      if( not utils::MasterSlave::isSlave()){
-        if(iter.second.isRequesting){
-          iter.second.m2n->getMasterCommunication()->send(ping,0);
+      if (not utils::MasterSlave::isSlave()) {
+        if (iter.second.isRequesting) {
+          iter.second.m2n->getMasterCommunication()->send(ping, 0);
           std::string receive = "init";
-          iter.second.m2n->getMasterCommunication()->receive(receive,0);
-          PRECICE_ASSERT(receive==pong);
-        }
-        else{
+          iter.second.m2n->getMasterCommunication()->receive(receive, 0);
+          PRECICE_ASSERT(receive == pong);
+        } else {
           std::string receive = "init";
-          iter.second.m2n->getMasterCommunication()->receive(receive,0);
-          PRECICE_ASSERT(receive==ping);
-          iter.second.m2n->getMasterCommunication()->send(pong,0);
+          iter.second.m2n->getMasterCommunication()->receive(receive, 0);
+          PRECICE_ASSERT(receive == ping);
+          iter.second.m2n->getMasterCommunication()->send(pong, 0);
         }
       }
       iter.second.m2n->closeConnection();
@@ -468,12 +452,12 @@ void SolverInterfaceImpl:: finalize()
   }
 
   PRECICE_DEBUG("Close master-slave communication");
-  if(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster()){
+  if (utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster()) {
     utils::MasterSlave::_communication->closeConnection();
     utils::MasterSlave::_communication = nullptr;
   }
 
-  if(_serverMode){
+  if (_serverMode) {
     _accessor->getClientServerCommunication()->closeConnection();
   }
 
@@ -485,7 +469,7 @@ void SolverInterfaceImpl:: finalize()
   }
 
   // Tear down MPI and PETSc
-  if (not precice::testMode && not _serverMode ) {
+  if (not precice::testMode && not _serverMode) {
     utils::Petsc::finalize();
     utils::Parallel::finalizeMPI();
   }
@@ -493,52 +477,49 @@ void SolverInterfaceImpl:: finalize()
   utils::EventRegistry::instance().clear();
 }
 
-int SolverInterfaceImpl:: getDimensions() const
+int SolverInterfaceImpl::getDimensions() const
 {
-  PRECICE_TRACE(_dimensions );
+  PRECICE_TRACE(_dimensions);
   return _dimensions;
 }
 
-bool SolverInterfaceImpl:: isCouplingOngoing() const
+bool SolverInterfaceImpl::isCouplingOngoing() const
 {
   PRECICE_TRACE();
   return _couplingScheme->isCouplingOngoing();
 }
 
-bool SolverInterfaceImpl:: isReadDataAvailable() const
+bool SolverInterfaceImpl::isReadDataAvailable() const
 {
   PRECICE_TRACE();
   return _couplingScheme->hasDataBeenExchanged();
 }
 
-bool SolverInterfaceImpl:: isWriteDataRequired
-(
-  double computedTimestepLength ) const
+bool SolverInterfaceImpl::isWriteDataRequired(
+    double computedTimestepLength) const
 {
   PRECICE_TRACE(computedTimestepLength);
   return _couplingScheme->willDataBeExchanged(computedTimestepLength);
 }
 
-bool SolverInterfaceImpl:: isTimestepComplete() const
+bool SolverInterfaceImpl::isTimestepComplete() const
 {
   PRECICE_TRACE();
   return _couplingScheme->isCouplingTimestepComplete();
 }
 
-bool SolverInterfaceImpl:: isActionRequired
-(
-  const std::string& action ) const
+bool SolverInterfaceImpl::isActionRequired(
+    const std::string &action) const
 {
   PRECICE_TRACE(action, _couplingScheme->isActionRequired(action));
   return _couplingScheme->isActionRequired(action);
 }
 
-void SolverInterfaceImpl:: fulfilledAction
-(
-  const std::string& action )
+void SolverInterfaceImpl::fulfilledAction(
+    const std::string &action)
 {
   PRECICE_TRACE(action);
-  if ( _clientMode ) {
+  if (_clientMode) {
     _requestManager->requestFulfilledAction(action);
   }
   _couplingScheme->performedAction(action);
@@ -546,7 +527,7 @@ void SolverInterfaceImpl:: fulfilledAction
 
 bool SolverInterfaceImpl::hasToEvaluateSurrogateModel() const
 {
- // std::cout<<"_isCoarseModelOptimizationActive() = "<<_couplingScheme->isCoarseModelOptimizationActive();
+  // std::cout<<"_isCoarseModelOptimizationActive() = "<<_couplingScheme->isCoarseModelOptimizationActive();
   return _couplingScheme->isCoarseModelOptimizationActive();
 }
 
@@ -555,67 +536,61 @@ bool SolverInterfaceImpl::hasToEvaluateFineModel() const
   return not _couplingScheme->isCoarseModelOptimizationActive();
 }
 
-bool SolverInterfaceImpl:: hasMesh
-(
-  const std::string& meshName ) const
+bool SolverInterfaceImpl::hasMesh(
+    const std::string &meshName) const
 {
   PRECICE_TRACE(meshName);
-  return utils::contained ( meshName, _meshIDs );
+  return utils::contained(meshName, _meshIDs);
 }
 
-int SolverInterfaceImpl:: getMeshID
-(
-  const std::string& meshName ) const
+int SolverInterfaceImpl::getMeshID(
+    const std::string &meshName) const
 {
   PRECICE_TRACE(meshName);
   const auto pos = _meshIDs.find(meshName);
-  PRECICE_CHECK(pos != _meshIDs.end(), "Mesh with name \""<< meshName << "\" is not defined!" );
+  PRECICE_CHECK(pos != _meshIDs.end(), "Mesh with name \"" << meshName << "\" is not defined!");
   return pos->second;
 }
 
-std::set<int> SolverInterfaceImpl:: getMeshIDs() const
+std::set<int> SolverInterfaceImpl::getMeshIDs() const
 {
   PRECICE_TRACE();
   std::set<int> ids;
-  for (const impl::MeshContext* context : _accessor->usedMeshContexts()) {
-    ids.insert ( context->mesh->getID() );
+  for (const impl::MeshContext *context : _accessor->usedMeshContexts()) {
+    ids.insert(context->mesh->getID());
   }
   return ids;
 }
 
-bool SolverInterfaceImpl:: hasData
-(
-  const std::string& dataName, int meshID ) const
+bool SolverInterfaceImpl::hasData(
+    const std::string &dataName, int meshID) const
 {
-  PRECICE_TRACE(dataName, meshID );
+  PRECICE_TRACE(dataName, meshID);
   PRECICE_VALIDATE_MESH_ID(meshID);
-  const auto & sub_dataIDs = _dataIDs.at(meshID);
-  return sub_dataIDs.find(dataName)!= sub_dataIDs.end();
+  const auto &sub_dataIDs = _dataIDs.at(meshID);
+  return sub_dataIDs.find(dataName) != sub_dataIDs.end();
 }
 
-int SolverInterfaceImpl:: getDataID
-(
-  const std::string& dataName, int meshID ) const
+int SolverInterfaceImpl::getDataID(
+    const std::string &dataName, int meshID) const
 {
-  PRECICE_TRACE(dataName, meshID );
+  PRECICE_TRACE(dataName, meshID);
   PRECICE_VALIDATE_MESH_ID(meshID);
   PRECICE_CHECK(hasData(dataName, meshID),
-        "Data with name \"" << dataName << "\" is not defined on mesh with ID \"" << meshID << "\".");
+                "Data with name \"" << dataName << "\" is not defined on mesh with ID \"" << meshID << "\".");
   return _dataIDs.at(meshID).at(dataName);
 }
 
-int SolverInterfaceImpl:: getMeshVertexSize
-(
-  int meshID ) const
+int SolverInterfaceImpl::getMeshVertexSize(
+    int meshID) const
 {
   PRECICE_TRACE(meshID);
   int size = 0;
-  if (_clientMode){
+  if (_clientMode) {
     size = _requestManager->requestGetMeshVertexSize(meshID);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_MESH_USE(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
+    MeshContext &context = _accessor->meshContext(meshID);
     PRECICE_ASSERT(context.mesh.get() != nullptr);
     size = context.mesh->vertices().size();
   }
@@ -624,48 +599,43 @@ int SolverInterfaceImpl:: getMeshVertexSize
 }
 
 /// @todo Currently not supported as we would need to re-compute the re-partition
-void SolverInterfaceImpl:: resetMesh
-(
-  int meshID )
+void SolverInterfaceImpl::resetMesh(
+    int meshID)
 {
   PRECICE_TRACE(meshID);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestResetMesh(meshID);
-  }
-  else {
+  } else {
     PRECICE_VALIDATE_MESH_ID(meshID);
-    impl::MeshContext& context = _accessor->meshContext(meshID);
-    bool hasMapping = context.fromMappingContext.mapping
-              || context.toMappingContext.mapping;
-    bool isStationary =
-          context.fromMappingContext.timing == mapping::MappingConfiguration::INITIAL &&
-              context.toMappingContext.timing == mapping::MappingConfiguration::INITIAL;
+    impl::MeshContext &context    = _accessor->meshContext(meshID);
+    bool               hasMapping = context.fromMappingContext.mapping || context.toMappingContext.mapping;
+    bool               isStationary =
+        context.fromMappingContext.timing == mapping::MappingConfiguration::INITIAL &&
+        context.toMappingContext.timing == mapping::MappingConfiguration::INITIAL;
 
     PRECICE_CHECK(!isStationary, "A mesh with only initial mappings  must not be reseted");
     PRECICE_CHECK(hasMapping, "A mesh with no mappings must not be reseted");
 
-    PRECICE_DEBUG( "Clear mesh positions for mesh \"" << context.mesh->getName() << "\"" );
+    PRECICE_DEBUG("Clear mesh positions for mesh \"" << context.mesh->getName() << "\"");
     _meshLock.unlock(meshID);
-    context.mesh->clear ();
+    context.mesh->clear();
   }
 }
 
-int SolverInterfaceImpl:: setMeshVertex
-(
-  int           meshID,
-  const double* position )
+int SolverInterfaceImpl::setMeshVertex(
+    int           meshID,
+    const double *position)
 {
   PRECICE_TRACE(meshID);
   Eigen::VectorXd internalPosition{
       Eigen::Map<const Eigen::VectorXd>{position, _dimensions}};
   PRECICE_DEBUG("Position = " << internalPosition);
   int index = -1;
-  if ( _clientMode ){
-    index = _requestManager->requestSetMeshVertex ( meshID, internalPosition);
-  }
-  else {
+  if (_clientMode) {
+    index = _requestManager->requestSetMeshVertex(meshID, internalPosition);
+  } else {
     PRECICE_REQUIRE_MESH_MODIFY(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
+    MeshContext & context = _accessor->meshContext(meshID);
     mesh::PtrMesh mesh(context.mesh);
     PRECICE_DEBUG("MeshRequirement: " << context.meshRequirement);
     index = mesh->createVertex(internalPosition).getID();
@@ -674,25 +644,23 @@ int SolverInterfaceImpl:: setMeshVertex
   return index;
 }
 
-void SolverInterfaceImpl:: setMeshVertices
-(
-  int           meshID,
-  int           size,
-  const double* positions,
-  int*          ids )
+void SolverInterfaceImpl::setMeshVertices(
+    int           meshID,
+    int           size,
+    const double *positions,
+    int *         ids)
 {
   PRECICE_TRACE(meshID, size);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestSetMeshVertices(meshID, size, positions, ids);
-  }
-  else { //couplingMode
+  } else { //couplingMode
     PRECICE_REQUIRE_MESH_MODIFY(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
+    MeshContext & context = _accessor->meshContext(meshID);
     mesh::PtrMesh mesh(context.mesh);
     PRECICE_DEBUG("Set positions");
     const Eigen::Map<const Eigen::MatrixXd> posMatrix{
         positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
-    for (int i=0; i < size; ++i){
+    for (int i = 0; i < size; ++i) {
       Eigen::VectorXd current(posMatrix.col(i));
       ids[i] = mesh->createVertex(current).getID();
     }
@@ -700,27 +668,25 @@ void SolverInterfaceImpl:: setMeshVertices
   }
 }
 
-void SolverInterfaceImpl:: getMeshVertices
-(
-  int        meshID,
-  size_t     size,
-  const int* ids,
-  double*    positions ) const
+void SolverInterfaceImpl::getMeshVertices(
+    int        meshID,
+    size_t     size,
+    const int *ids,
+    double *   positions) const
 {
   PRECICE_TRACE(meshID, size);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestGetMeshVertices(meshID, size, ids, positions);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_MESH_USE(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
+    MeshContext & context = _accessor->meshContext(meshID);
     mesh::PtrMesh mesh(context.mesh);
     PRECICE_DEBUG("Get positions");
-    auto & vertices = mesh->vertices();
+    auto &vertices = mesh->vertices();
     PRECICE_ASSERT(size <= vertices.size(), size, vertices.size());
     Eigen::Map<Eigen::MatrixXd> posMatrix{
         positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
-    for (size_t i=0; i < size; i++){
+    for (size_t i = 0; i < size; i++) {
       const size_t id = ids[i];
       PRECICE_ASSERT(id < vertices.size(), id, vertices.size());
       posMatrix.col(i) = vertices[id].getCoords();
@@ -728,31 +694,30 @@ void SolverInterfaceImpl:: getMeshVertices
   }
 }
 
-void SolverInterfaceImpl:: getMeshVertexIDsFromPositions (
-  int           meshID,
-  size_t        size,
-  const double* positions,
-  int*          ids ) const
+void SolverInterfaceImpl::getMeshVertexIDsFromPositions(
+    int           meshID,
+    size_t        size,
+    const double *positions,
+    int *         ids) const
 {
   PRECICE_TRACE(meshID, size);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestGetMeshVertexIDsFromPositions(meshID, size, positions, ids);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_MESH_USE(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
+    MeshContext & context = _accessor->meshContext(meshID);
     mesh::PtrMesh mesh(context.mesh);
     PRECICE_DEBUG("Get IDs");
-    const auto &vertices = mesh->vertices();
+    const auto &                      vertices = mesh->vertices();
     Eigen::Map<const Eigen::MatrixXd> posMatrix{
         positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
     const auto vsize = vertices.size();
     for (size_t i = 0; i < size; i++) {
-      size_t j=0;
+      size_t j = 0;
       for (; j < vsize; j++) {
-          if(math::equals(posMatrix.col(i), vertices[j].getCoords())) {
-              break;
-          }
+        if (math::equals(posMatrix.col(i), vertices[j].getCoords())) {
+          break;
+        }
       }
       PRECICE_CHECK(j != vsize, "Position " << i << "=" << ids[i] << " unknown!");
       ids[i] = j;
@@ -760,74 +725,67 @@ void SolverInterfaceImpl:: getMeshVertexIDsFromPositions (
   }
 }
 
-
-
-int SolverInterfaceImpl:: setMeshEdge
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID )
+int SolverInterfaceImpl::setMeshEdge(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID)
 {
-  PRECICE_TRACE(meshID, firstVertexID, secondVertexID );
-  if ( _clientMode ){
-    return _requestManager->requestSetMeshEdge ( meshID, firstVertexID, secondVertexID );
-  }
-  else {
+  PRECICE_TRACE(meshID, firstVertexID, secondVertexID);
+  if (_clientMode) {
+    return _requestManager->requestSetMeshEdge(meshID, firstVertexID, secondVertexID);
+  } else {
     PRECICE_REQUIRE_MESH_MODIFY(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
-    if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
+    MeshContext &context = _accessor->meshContext(meshID);
+    if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
       PRECICE_DEBUG("Full mesh required.");
-      mesh::PtrMesh& mesh = context.mesh;
-      PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  "Given VertexID is invalid!");
+      mesh::PtrMesh &mesh = context.mesh;
+      PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), "Given VertexID is invalid!");
       PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), "Given VertexID is invalid!");
-      mesh::Vertex& v0 = mesh->vertices()[firstVertexID];
-      mesh::Vertex& v1 = mesh->vertices()[secondVertexID];
-      return mesh->createEdge(v0, v1).getID ();
+      mesh::Vertex &v0 = mesh->vertices()[firstVertexID];
+      mesh::Vertex &v1 = mesh->vertices()[secondVertexID];
+      return mesh->createEdge(v0, v1).getID();
     }
   }
   return -1;
 }
 
-void SolverInterfaceImpl:: setMeshTriangle
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID )
+void SolverInterfaceImpl::setMeshTriangle(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID)
 {
   PRECICE_TRACE(meshID, firstEdgeID,
-                  secondEdgeID, thirdEdgeID );
-  if ( _clientMode ){
-    _requestManager->requestSetMeshTriangle ( meshID, firstEdgeID, secondEdgeID, thirdEdgeID );
-  }
-  else {
+                secondEdgeID, thirdEdgeID);
+  if (_clientMode) {
+    _requestManager->requestSetMeshTriangle(meshID, firstEdgeID, secondEdgeID, thirdEdgeID);
+  } else {
     PRECICE_REQUIRE_MESH_MODIFY(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
-    if ( context.meshRequirement == mapping::Mapping::MeshRequirement::FULL ){
-      mesh::PtrMesh& mesh = context.mesh;
-      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID),  "Given EdgeID is invalid!");
+    MeshContext &context = _accessor->meshContext(meshID);
+    if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+      mesh::PtrMesh &mesh = context.mesh;
+      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID), "Given EdgeID is invalid!");
       PRECICE_CHECK(mesh->isValidEdgeID(secondEdgeID), "Given EdgeID is invalid!");
-      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID),  "Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID), "Given EdgeID is invalid!");
       PRECICE_CHECK(utils::unique_elements(utils::make_array(firstEdgeID, secondEdgeID, thirdEdgeID)),
-              "Given EdgeIDs must be unique!");
-      mesh::Edge& e0 = mesh->edges()[firstEdgeID];
-      mesh::Edge& e1 = mesh->edges()[secondEdgeID];
-      mesh::Edge& e2 = mesh->edges()[thirdEdgeID];
-      mesh->createTriangle ( e0, e1, e2 );
+                    "Given EdgeIDs must be unique!");
+      mesh::Edge &e0 = mesh->edges()[firstEdgeID];
+      mesh::Edge &e1 = mesh->edges()[secondEdgeID];
+      mesh::Edge &e2 = mesh->edges()[thirdEdgeID];
+      mesh->createTriangle(e0, e1, e2);
     }
   }
 }
 
-void SolverInterfaceImpl:: setMeshTriangleWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID )
+void SolverInterfaceImpl::setMeshTriangleWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID,
                 secondVertexID, thirdVertexID);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestSetMeshTriangleWithEdges(meshID,
                                                      firstVertexID,
                                                      secondVertexID,
@@ -835,165 +793,159 @@ void SolverInterfaceImpl:: setMeshTriangleWithEdges
     return;
   }
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
-  MeshContext& context = _accessor->meshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
-    mesh::PtrMesh& mesh = context.mesh;
-    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  "Given VertexID is invalid!");
+  MeshContext &context = _accessor->meshContext(meshID);
+  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+    mesh::PtrMesh &mesh = context.mesh;
+    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), "Given VertexID is invalid!");
     PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), "Given VertexID is invalid!");
-    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  "Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID), "Given VertexID is invalid!");
     PRECICE_CHECK(utils::unique_elements(utils::make_array(firstVertexID, secondVertexID, thirdVertexID)),
-            "Given VertexIDs must be unique!");
-    mesh::Vertex* vertices[3];
+                  "Given VertexIDs must be unique!");
+    mesh::Vertex *vertices[3];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];
     vertices[2] = &mesh->vertices()[thirdVertexID];
     PRECICE_CHECK(utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
-                vertices[1]->getCoords(), vertices[2]->getCoords())),
-            "The coordinates of the vertices must be unique!");
-    mesh::Edge* edges[3];
-    edges[0] = & mesh->createUniqueEdge(*vertices[0], *vertices[1]);
-    edges[1] = & mesh->createUniqueEdge(*vertices[1], *vertices[2]);
-    edges[2] = & mesh->createUniqueEdge(*vertices[2], *vertices[0]);
+                                                           vertices[1]->getCoords(), vertices[2]->getCoords())),
+                  "The coordinates of the vertices must be unique!");
+    mesh::Edge *edges[3];
+    edges[0] = &mesh->createUniqueEdge(*vertices[0], *vertices[1]);
+    edges[1] = &mesh->createUniqueEdge(*vertices[1], *vertices[2]);
+    edges[2] = &mesh->createUniqueEdge(*vertices[2], *vertices[0]);
 
     mesh->createTriangle(*edges[0], *edges[1], *edges[2]);
   }
 }
 
-void SolverInterfaceImpl:: setMeshQuad
-(
-  int meshID,
-  int firstEdgeID,
-  int secondEdgeID,
-  int thirdEdgeID,
-  int fourthEdgeID )
+void SolverInterfaceImpl::setMeshQuad(
+    int meshID,
+    int firstEdgeID,
+    int secondEdgeID,
+    int thirdEdgeID,
+    int fourthEdgeID)
 {
   PRECICE_TRACE(meshID, firstEdgeID, secondEdgeID, thirdEdgeID,
                 fourthEdgeID);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestSetMeshQuad(meshID, firstEdgeID, secondEdgeID,
                                         thirdEdgeID, fourthEdgeID);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_MESH_MODIFY(meshID);
-    MeshContext& context = _accessor->meshContext(meshID);
-    if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
-      mesh::PtrMesh& mesh = context.mesh;
-      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID),  "Given EdgeID is invalid!");
+    MeshContext &context = _accessor->meshContext(meshID);
+    if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+      mesh::PtrMesh &mesh = context.mesh;
+      PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID), "Given EdgeID is invalid!");
       PRECICE_CHECK(mesh->isValidEdgeID(secondEdgeID), "Given EdgeID is invalid!");
-      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID),  "Given EdgeID is invalid!");
+      PRECICE_CHECK(mesh->isValidEdgeID(thirdEdgeID), "Given EdgeID is invalid!");
       PRECICE_CHECK(mesh->isValidEdgeID(fourthEdgeID), "Given EdgeID is invalid!");
-      mesh::Edge& e0 = mesh->edges()[firstEdgeID];
-      mesh::Edge& e1 = mesh->edges()[secondEdgeID];
-      mesh::Edge& e2 = mesh->edges()[thirdEdgeID];
-      mesh::Edge& e3 = mesh->edges()[fourthEdgeID];
+      mesh::Edge &e0 = mesh->edges()[firstEdgeID];
+      mesh::Edge &e1 = mesh->edges()[secondEdgeID];
+      mesh::Edge &e2 = mesh->edges()[thirdEdgeID];
+      mesh::Edge &e3 = mesh->edges()[fourthEdgeID];
       mesh->createQuad(e0, e1, e2, e3);
     }
   }
 }
 
-void SolverInterfaceImpl:: setMeshQuadWithEdges
-(
-  int meshID,
-  int firstVertexID,
-  int secondVertexID,
-  int thirdVertexID,
-  int fourthVertexID )
+void SolverInterfaceImpl::setMeshQuadWithEdges(
+    int meshID,
+    int firstVertexID,
+    int secondVertexID,
+    int thirdVertexID,
+    int fourthVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID,
                 secondVertexID, thirdVertexID, fourthVertexID);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestSetMeshQuadWithEdges(
         meshID, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
     return;
   }
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
-  MeshContext& context = _accessor->meshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL){
-    mesh::PtrMesh& mesh = context.mesh;
-    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID),  "Given VertexID is invalid!");
+  MeshContext &context = _accessor->meshContext(meshID);
+  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+    mesh::PtrMesh &mesh = context.mesh;
+    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), "Given VertexID is invalid!");
     PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), "Given VertexID is invalid!");
-    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID),  "Given VertexID is invalid!");
+    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID), "Given VertexID is invalid!");
     PRECICE_CHECK(mesh->isValidVertexID(fourthVertexID), "Given VertexID is invalid!");
-    mesh::Vertex* vertices[4];
+    mesh::Vertex *vertices[4];
     vertices[0] = &mesh->vertices()[firstVertexID];
     vertices[1] = &mesh->vertices()[secondVertexID];
     vertices[2] = &mesh->vertices()[thirdVertexID];
     vertices[3] = &mesh->vertices()[fourthVertexID];
-    mesh::Edge* edges[4];
-    edges[0] = & mesh->createUniqueEdge(*vertices[0], *vertices[1]);
-    edges[1] = & mesh->createUniqueEdge(*vertices[1], *vertices[2]);
-    edges[2] = & mesh->createUniqueEdge(*vertices[2], *vertices[3]);
-    edges[3] = & mesh->createUniqueEdge(*vertices[3], *vertices[0]);
+    mesh::Edge *edges[4];
+    edges[0] = &mesh->createUniqueEdge(*vertices[0], *vertices[1]);
+    edges[1] = &mesh->createUniqueEdge(*vertices[1], *vertices[2]);
+    edges[2] = &mesh->createUniqueEdge(*vertices[2], *vertices[3]);
+    edges[3] = &mesh->createUniqueEdge(*vertices[3], *vertices[0]);
 
     mesh->createQuad(*edges[0], *edges[1], *edges[2], *edges[3]);
   }
 }
 
-void SolverInterfaceImpl:: mapWriteDataFrom
-(
-  int fromMeshID )
+void SolverInterfaceImpl::mapWriteDataFrom(
+    int fromMeshID)
 {
   PRECICE_TRACE(fromMeshID);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestMapWriteDataFrom(fromMeshID);
     return;
   }
   PRECICE_VALIDATE_MESH_ID(fromMeshID);
-  impl::MeshContext& context = _accessor->meshContext(fromMeshID);
-  impl::MappingContext& mappingContext = context.fromMappingContext;
-  if (mappingContext.mapping.use_count() == 0){
+  impl::MeshContext &   context        = _accessor->meshContext(fromMeshID);
+  impl::MappingContext &mappingContext = context.fromMappingContext;
+  if (mappingContext.mapping.use_count() == 0) {
     PRECICE_ERROR("From mesh \"" << context.mesh->getName()
-                   << "\", there is no mapping defined");
+                                 << "\", there is no mapping defined");
     return;
   }
-  if (not mappingContext.mapping->hasComputedMapping()){
+  if (not mappingContext.mapping->hasComputedMapping()) {
     PRECICE_DEBUG("Compute mapping from mesh \"" << context.mesh->getName() << "\"");
     mappingContext.mapping->computeMapping();
   }
-  for (impl::DataContext& context : _accessor->writeDataContexts()) {
-    if (context.mesh->getID() == fromMeshID){
-      int inDataID = context.fromData->getID();
-      int outDataID = context.toData->getID();
+  for (impl::DataContext &context : _accessor->writeDataContexts()) {
+    if (context.mesh->getID() == fromMeshID) {
+      int inDataID             = context.fromData->getID();
+      int outDataID            = context.toData->getID();
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
-                   << "\" from mesh \"" << context.mesh->getName() << "\"");
-      PRECICE_ASSERT(mappingContext.mapping==context.mappingContext.mapping);
+                                  << "\" from mesh \"" << context.mesh->getName() << "\"");
+      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
       mappingContext.mapping->map(inDataID, outDataID);
     }
   }
   mappingContext.hasMappedData = true;
 }
 
-
-void SolverInterfaceImpl:: mapReadDataTo
-(
-  int toMeshID )
+void SolverInterfaceImpl::mapReadDataTo(
+    int toMeshID)
 {
   PRECICE_TRACE(toMeshID);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestMapReadDataTo(toMeshID);
     return;
   }
   PRECICE_VALIDATE_MESH_ID(toMeshID);
-  impl::MeshContext& context = _accessor->meshContext(toMeshID);
-  impl::MappingContext& mappingContext = context.toMappingContext;
-  if (mappingContext.mapping.use_count() == 0){
+  impl::MeshContext &   context        = _accessor->meshContext(toMeshID);
+  impl::MappingContext &mappingContext = context.toMappingContext;
+  if (mappingContext.mapping.use_count() == 0) {
     PRECICE_ERROR("From mesh \"" << context.mesh->getName()
-                   << "\", there is no mapping defined!");
+                                 << "\", there is no mapping defined!");
     return;
   }
-  if (not mappingContext.mapping->hasComputedMapping()){
+  if (not mappingContext.mapping->hasComputedMapping()) {
     PRECICE_DEBUG("Compute mapping from mesh \"" << context.mesh->getName() << "\"");
     mappingContext.mapping->computeMapping();
   }
-  for (impl::DataContext& context : _accessor->readDataContexts()) {
-    if (context.mesh->getID() == toMeshID){
-      int inDataID = context.fromData->getID();
-      int outDataID = context.toData->getID();
+  for (impl::DataContext &context : _accessor->readDataContexts()) {
+    if (context.mesh->getID() == toMeshID) {
+      int inDataID             = context.fromData->getID();
+      int outDataID            = context.toData->getID();
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
-                   << "\" to mesh \"" << context.mesh->getName() << "\"");
-      PRECICE_ASSERT(mappingContext.mapping==context.mappingContext.mapping);
+                                  << "\" to mesh \"" << context.mesh->getName() << "\"");
+      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
       mappingContext.mapping->map(inDataID, outDataID);
       PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
     }
@@ -1001,12 +953,11 @@ void SolverInterfaceImpl:: mapReadDataTo
   mappingContext.hasMappedData = true;
 }
 
-void SolverInterfaceImpl:: writeBlockVectorData
-(
-  int           fromDataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values )
+void SolverInterfaceImpl::writeBlockVectorData(
+    int           fromDataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   PRECICE_TRACE(fromDataID, size);
   PRECICE_VALIDATE_DATA_ID(fromDataID);
@@ -1014,64 +965,59 @@ void SolverInterfaceImpl:: writeBlockVectorData
     return;
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestWriteBlockVectorData(fromDataID, size, valueIndices, values);
-  }
-  else { //couplingMode
+  } else { //couplingMode
     PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-    DataContext& context = _accessor->dataContext(fromDataID);
-    PRECICE_CHECK(context.fromData->getDimensions()==_dimensions,
-        "You cannot call writeBlockVectorData on the scalar data type " << context.fromData->getName());
+    DataContext &context = _accessor->dataContext(fromDataID);
+    PRECICE_CHECK(context.fromData->getDimensions() == _dimensions,
+                  "You cannot call writeBlockVectorData on the scalar data type " << context.fromData->getName());
     PRECICE_ASSERT(context.toData.get() != nullptr);
-    auto& valuesInternal = context.fromData->values();
-    for (int i=0; i < size; i++){
+    auto &valuesInternal = context.fromData->values();
+    for (int i = 0; i < size; i++) {
       const auto valueIndex = valueIndices[i];
-      PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size()/context.fromData->getDimensions(), "Value index out of range");
-      int offsetInternal = valueIndex*_dimensions;
-      int offset = i*_dimensions;
-      for (int dim=0; dim < _dimensions; dim++){
-        PRECICE_ASSERT(offset+dim < valuesInternal.size(),
-                   offset+dim, valuesInternal.size());
+      PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / context.fromData->getDimensions(), "Value index out of range");
+      int offsetInternal = valueIndex * _dimensions;
+      int offset         = i * _dimensions;
+      for (int dim = 0; dim < _dimensions; dim++) {
+        PRECICE_ASSERT(offset + dim < valuesInternal.size(),
+                       offset + dim, valuesInternal.size());
         valuesInternal[offsetInternal + dim] = values[offset + dim];
       }
     }
   }
 }
 
-void SolverInterfaceImpl:: writeVectorData
-(
-  int           fromDataID,
-  int           valueIndex,
-  const double* value )
+void SolverInterfaceImpl::writeVectorData(
+    int           fromDataID,
+    int           valueIndex,
+    const double *value)
 {
-  PRECICE_TRACE(fromDataID, valueIndex );
+  PRECICE_TRACE(fromDataID, valueIndex);
   PRECICE_VALIDATE_DATA_ID(fromDataID);
   PRECICE_DEBUG("value = " << Eigen::Map<const Eigen::VectorXd>(value, _dimensions));
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestWriteVectorData(fromDataID, valueIndex, value);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-    DataContext& context = _accessor->dataContext(fromDataID);
-    PRECICE_CHECK(context.fromData->getDimensions()==_dimensions,
-        "You cannot call writeVectorData on the scalar data type " << context.fromData->getName());
+    DataContext &context = _accessor->dataContext(fromDataID);
+    PRECICE_CHECK(context.fromData->getDimensions() == _dimensions,
+                  "You cannot call writeVectorData on the scalar data type " << context.fromData->getName());
     PRECICE_ASSERT(context.toData.get() != nullptr);
-    auto& values = context.fromData->values();
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size()/context.fromData->getDimensions(), "Value index out of range");
+    auto &values = context.fromData->values();
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / context.fromData->getDimensions(), "Value index out of range");
     int offset = valueIndex * _dimensions;
-    for (int dim=0; dim < _dimensions; dim++){
-      values[offset+dim] = value[dim];
+    for (int dim = 0; dim < _dimensions; dim++) {
+      values[offset + dim] = value[dim];
     }
-
   }
 }
 
-void SolverInterfaceImpl:: writeBlockScalarData
-(
-  int           fromDataID,
-  int           size,
-  const int*    valueIndices,
-  const double* values )
+void SolverInterfaceImpl::writeBlockScalarData(
+    int           fromDataID,
+    int           size,
+    const int *   valueIndices,
+    const double *values)
 {
   PRECICE_TRACE(fromDataID, size);
   PRECICE_VALIDATE_DATA_ID(fromDataID);
@@ -1079,55 +1025,51 @@ void SolverInterfaceImpl:: writeBlockScalarData
     return;
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestWriteBlockScalarData(fromDataID, size, valueIndices, values);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-    DataContext& context = _accessor->dataContext(fromDataID);
-    PRECICE_CHECK(context.fromData->getDimensions()==1,
-        "You cannot call writeBlockScalarData on the vector data type " << context.fromData->getName());
+    DataContext &context = _accessor->dataContext(fromDataID);
+    PRECICE_CHECK(context.fromData->getDimensions() == 1,
+                  "You cannot call writeBlockScalarData on the vector data type " << context.fromData->getName());
     PRECICE_ASSERT(context.toData.get() != nullptr);
-    auto& valuesInternal = context.fromData->values();
-    for (int i=0; i < size; i++){
+    auto &valuesInternal = context.fromData->values();
+    for (int i = 0; i < size; i++) {
       const auto valueIndex = valueIndices[i];
-      PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size()/context.fromData->getDimensions(), "Value index out of range");
+      PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / context.fromData->getDimensions(), "Value index out of range");
       PRECICE_ASSERT(i < valuesInternal.size(), i, valuesInternal.size());
       valuesInternal[valueIndex] = values[i];
     }
   }
 }
 
-void SolverInterfaceImpl:: writeScalarData
-(
-  int    fromDataID,
-  int    valueIndex,
-  double value)
+void SolverInterfaceImpl::writeScalarData(
+    int    fromDataID,
+    int    valueIndex,
+    double value)
 {
-  PRECICE_TRACE(fromDataID, valueIndex, value );
+  PRECICE_TRACE(fromDataID, valueIndex, value);
   PRECICE_VALIDATE_DATA_ID(fromDataID);
   PRECICE_CHECK(valueIndex >= -1, "Invalid value index (" << valueIndex << ") when writing scalar data!");
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestWriteScalarData(fromDataID, valueIndex, value);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-    DataContext& context = _accessor->dataContext(fromDataID);
-    PRECICE_CHECK(context.fromData->getDimensions()==1,
-        "You cannot call writeScalarData on the vector data type " << context.fromData->getName());
+    DataContext &context = _accessor->dataContext(fromDataID);
+    PRECICE_CHECK(context.fromData->getDimensions() == 1,
+                  "You cannot call writeScalarData on the vector data type " << context.fromData->getName());
     PRECICE_ASSERT(context.toData);
-    auto& values = context.fromData->values();
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size()/context.fromData->getDimensions(), "Value index out of range");
+    auto &values = context.fromData->values();
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / context.fromData->getDimensions(), "Value index out of range");
     values[valueIndex] = value;
   }
 }
 
-void SolverInterfaceImpl:: readBlockVectorData
-(
-  int        toDataID,
-  int        size,
-  const int* valueIndices,
-  double*    values ) const
+void SolverInterfaceImpl::readBlockVectorData(
+    int        toDataID,
+    int        size,
+    const int *valueIndices,
+    double *   values) const
 {
   PRECICE_TRACE(toDataID, size);
   PRECICE_VALIDATE_DATA_ID(toDataID);
@@ -1135,65 +1077,60 @@ void SolverInterfaceImpl:: readBlockVectorData
     return;
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestReadBlockVectorData(toDataID, size, valueIndices, values);
-  }
-  else { //couplingMode
+  } else { //couplingMode
     PRECICE_REQUIRE_DATA_READ(toDataID);
-    DataContext& context = _accessor->dataContext(toDataID);
-    PRECICE_CHECK(context.toData->getDimensions()==_dimensions,
-        "You cannot call readBlockVectorData on the scalar data type " << context.toData->getName());
+    DataContext &context = _accessor->dataContext(toDataID);
+    PRECICE_CHECK(context.toData->getDimensions() == _dimensions,
+                  "You cannot call readBlockVectorData on the scalar data type " << context.toData->getName());
     PRECICE_ASSERT(context.fromData.get() != nullptr);
-    auto& valuesInternal = context.toData->values();
-    for (int i=0; i < size; i++){
+    auto &valuesInternal = context.toData->values();
+    for (int i = 0; i < size; i++) {
       const auto valueIndex = valueIndices[i];
-      PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size()/context.fromData->getDimensions(), "Value index out of range");
+      PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / context.fromData->getDimensions(), "Value index out of range");
       int offsetInternal = valueIndex * _dimensions;
-      int offset = i * _dimensions;
-      for (int dim=0; dim < _dimensions; dim++){
-        PRECICE_ASSERT(offsetInternal+dim < valuesInternal.size(),
-                   offsetInternal+dim, valuesInternal.size());
+      int offset         = i * _dimensions;
+      for (int dim = 0; dim < _dimensions; dim++) {
+        PRECICE_ASSERT(offsetInternal + dim < valuesInternal.size(),
+                       offsetInternal + dim, valuesInternal.size());
         values[offset + dim] = valuesInternal[offsetInternal + dim];
       }
     }
   }
 }
 
-void SolverInterfaceImpl:: readVectorData
-(
-  int     toDataID,
-  int     valueIndex,
-  double* value ) const
+void SolverInterfaceImpl::readVectorData(
+    int     toDataID,
+    int     valueIndex,
+    double *value) const
 {
   PRECICE_TRACE(toDataID, valueIndex);
   PRECICE_VALIDATE_DATA_ID(toDataID);
   PRECICE_CHECK(valueIndex >= -1, "Invalid value index ( " << valueIndex << " )when reading vector data!");
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestReadVectorData(toDataID, valueIndex, value);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_DATA_READ(toDataID);
-    DataContext& context = _accessor->dataContext(toDataID);
-    PRECICE_CHECK(context.toData->getDimensions()==_dimensions,
-        "You cannot call readVectorData on the scalar data type " << context.toData->getName());
+    DataContext &context = _accessor->dataContext(toDataID);
+    PRECICE_CHECK(context.toData->getDimensions() == _dimensions,
+                  "You cannot call readVectorData on the scalar data type " << context.toData->getName());
     PRECICE_ASSERT(context.fromData);
-    auto& values = context.toData->values();
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size()/context.fromData->getDimensions(), "Value index out of range");
+    auto &values = context.toData->values();
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / context.fromData->getDimensions(), "Value index out of range");
     int offset = valueIndex * _dimensions;
-    for (int dim=0; dim < _dimensions; dim++){
+    for (int dim = 0; dim < _dimensions; dim++) {
       value[dim] = values[offset + dim];
     }
-
   }
   PRECICE_DEBUG("read value = " << Eigen::Map<const Eigen::VectorXd>(value, _dimensions));
 }
 
-void SolverInterfaceImpl:: readBlockScalarData
-(
-  int        toDataID,
-  int        size,
-  const int* valueIndices,
-  double*    values ) const
+void SolverInterfaceImpl::readBlockScalarData(
+    int        toDataID,
+    int        size,
+    const int *valueIndices,
+    double *   values) const
 {
   PRECICE_TRACE(toDataID, size);
   PRECICE_VALIDATE_DATA_ID(toDataID);
@@ -1202,127 +1139,118 @@ void SolverInterfaceImpl:: readBlockScalarData
   PRECICE_DEBUG("size = " << size);
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestReadBlockScalarData(toDataID, size, valueIndices, values);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_DATA_READ(toDataID);
-    DataContext& context = _accessor->dataContext(toDataID);
-    PRECICE_CHECK(context.toData->getDimensions()==1,
-        "You cannot call readBlockScalarData on the vector data type " << context.toData->getName());
+    DataContext &context = _accessor->dataContext(toDataID);
+    PRECICE_CHECK(context.toData->getDimensions() == 1,
+                  "You cannot call readBlockScalarData on the vector data type " << context.toData->getName());
     PRECICE_ASSERT(context.fromData.get() != nullptr);
-    auto& valuesInternal = context.toData->values();
-    for (int i=0; i < size; i++){
-        const auto valueIndex = valueIndices[i];
-        PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size(), "Value index out of range");
-        values[i] = valuesInternal[valueIndex];
+    auto &valuesInternal = context.toData->values();
+    for (int i = 0; i < size; i++) {
+      const auto valueIndex = valueIndices[i];
+      PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size(), "Value index out of range");
+      values[i] = valuesInternal[valueIndex];
     }
   }
 }
 
-void SolverInterfaceImpl:: readScalarData
-(
-  int     toDataID,
-  int     valueIndex,
-  double& value ) const
+void SolverInterfaceImpl::readScalarData(
+    int     toDataID,
+    int     valueIndex,
+    double &value) const
 {
   PRECICE_TRACE(toDataID, valueIndex, value);
   PRECICE_VALIDATE_DATA_ID(toDataID);
   PRECICE_CHECK(valueIndex >= -1, "Invalid value index ( " << valueIndex << " )when reading vector data!");
-  if (_clientMode){
+  if (_clientMode) {
     _requestManager->requestReadScalarData(toDataID, valueIndex, value);
-  }
-  else {
+  } else {
     PRECICE_REQUIRE_DATA_READ(toDataID);
-    DataContext& context = _accessor->dataContext(toDataID);
-    PRECICE_CHECK(context.toData->getDimensions()==1,
-        "You cannot call readScalarData on the vector data type " << context.toData->getName());
+    DataContext &context = _accessor->dataContext(toDataID);
+    PRECICE_CHECK(context.toData->getDimensions() == 1,
+                  "You cannot call readScalarData on the vector data type " << context.toData->getName());
     PRECICE_ASSERT(context.fromData);
-    auto& values = context.toData->values();
+    auto &values = context.toData->values();
     PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size(), "Value index out of range");
     value = values[valueIndex];
-
   }
   PRECICE_DEBUG("Read value = " << value);
 }
 
-void SolverInterfaceImpl:: exportMesh
-(
-  const std::string& filenameSuffix,
-  int                exportType ) const
+void SolverInterfaceImpl::exportMesh(
+    const std::string &filenameSuffix,
+    int                exportType) const
 {
-  PRECICE_TRACE(filenameSuffix, exportType );
+  PRECICE_TRACE(filenameSuffix, exportType);
   // Export meshes
   //const ExportContext& context = _accessor->exportContext();
-  for (const io::ExportContext& context : _accessor->exportContexts()) {
-    PRECICE_DEBUG( "Export type = " << exportType );
-    bool exportAll = exportType == io::constants::exportAll();
+  for (const io::ExportContext &context : _accessor->exportContexts()) {
+    PRECICE_DEBUG("Export type = " << exportType);
+    bool exportAll  = exportType == io::constants::exportAll();
     bool exportThis = context.exporter->getType() == exportType;
-    if ( exportAll || exportThis ){
-      for (const MeshContext* meshContext : _accessor->usedMeshContexts()) {
+    if (exportAll || exportThis) {
+      for (const MeshContext *meshContext : _accessor->usedMeshContexts()) {
         std::string name = meshContext->mesh->getName() + "-" + filenameSuffix;
-        PRECICE_DEBUG( "Exporting mesh to file \"" << name << "\" at location \"" << context.location << "\"" );
-        context.exporter->doExport ( name, context.location, *(meshContext->mesh) );
+        PRECICE_DEBUG("Exporting mesh to file \"" << name << "\" at location \"" << context.location << "\"");
+        context.exporter->doExport(name, context.location, *(meshContext->mesh));
       }
     }
   }
 }
 
-
-MeshHandle SolverInterfaceImpl:: getMeshHandle
-(
-  const std::string& meshName )
+MeshHandle SolverInterfaceImpl::getMeshHandle(
+    const std::string &meshName)
 {
   PRECICE_TRACE(meshName);
   PRECICE_ASSERT(not _clientMode);
-  for (MeshContext* context : _accessor->usedMeshContexts()){
-    if (context->mesh->getName() == meshName){
+  for (MeshContext *context : _accessor->usedMeshContexts()) {
+    if (context->mesh->getName() == meshName) {
       return {*context->mesh};
     }
   }
   PRECICE_ERROR("Participant \"" << _accessorName
-               << "\" does not use mesh \"" << meshName << "\"!");
+                                 << "\" does not use mesh \"" << meshName << "\"!");
 }
 
-void SolverInterfaceImpl:: runServer()
+void SolverInterfaceImpl::runServer()
 {
   PRECICE_ASSERT(_serverMode);
   initializeClientServerCommunication();
   _requestManager->handleRequests();
 }
 
-void SolverInterfaceImpl:: configureM2Ns
-(
-  const m2n::M2NConfiguration::SharedPointer& config )
+void SolverInterfaceImpl::configureM2Ns(
+    const m2n::M2NConfiguration::SharedPointer &config)
 {
   PRECICE_TRACE();
-  for (const auto& m2nTuple : config->m2ns()) {
+  for (const auto &m2nTuple : config->m2ns()) {
     std::string comPartner("");
-    bool isRequesting = false;
-    if (std::get<1>(m2nTuple) == _accessorName){
-      comPartner = std::get<2>(m2nTuple);
+    bool        isRequesting = false;
+    if (std::get<1>(m2nTuple) == _accessorName) {
+      comPartner   = std::get<2>(m2nTuple);
       isRequesting = true;
-    }
-    else if (std::get<2>(m2nTuple) == _accessorName){
+    } else if (std::get<2>(m2nTuple) == _accessorName) {
       comPartner = std::get<1>(m2nTuple);
     }
-    if (not comPartner.empty()){
-      for (const impl::PtrParticipant& participant : _participants) {
-        if (participant->getName() == comPartner){
-          if (participant->useServer()){
+    if (not comPartner.empty()) {
+      for (const impl::PtrParticipant &participant : _participants) {
+        if (participant->getName() == comPartner) {
+          if (participant->useServer()) {
             comPartner += "Server";
           }
           PRECICE_ASSERT(not utils::contained(comPartner, _m2ns), comPartner);
           PRECICE_ASSERT(std::get<0>(m2nTuple));
 
-          _m2ns[comPartner] = [&]{
-              m2n::BoundM2N bound;
-              bound.m2n = std::get<0>(m2nTuple);
-              bound.localName = _accessorName;
-              bound.remoteName = comPartner;
-              bound.isRequesting = isRequesting;
-              bound.localServer = _serverMode;
-              return bound;
+          _m2ns[comPartner] = [&] {
+            m2n::BoundM2N bound;
+            bound.m2n          = std::get<0>(m2nTuple);
+            bound.localName    = _accessorName;
+            bound.remoteName   = comPartner;
+            bound.isRequesting = isRequesting;
+            bound.localServer  = _serverMode;
+            return bound;
           }();
         }
       }
@@ -1330,30 +1258,29 @@ void SolverInterfaceImpl:: configureM2Ns
   }
 }
 
-void SolverInterfaceImpl:: configurePartitions
-(
-  const m2n::M2NConfiguration::SharedPointer& m2nConfig )
+void SolverInterfaceImpl::configurePartitions(
+    const m2n::M2NConfiguration::SharedPointer &m2nConfig)
 {
   PRECICE_TRACE();
-  for (MeshContext* context : _accessor->usedMeshContexts()) {
-    if ( context->provideMesh ) { // Accessor provides mesh
-      PRECICE_CHECK( context->receiveMeshFrom.empty(),
-              "Participant \"" << _accessorName << "\" cannot provide "
-              << "and receive mesh " << context->mesh->getName() << "!" );
+  for (MeshContext *context : _accessor->usedMeshContexts()) {
+    if (context->provideMesh) { // Accessor provides mesh
+      PRECICE_CHECK(context->receiveMeshFrom.empty(),
+                    "Participant \"" << _accessorName << "\" cannot provide "
+                                     << "and receive mesh " << context->mesh->getName() << "!");
 
       context->partition = partition::PtrPartition(new partition::ProvidedPartition(context->mesh));
 
-      for (auto& receiver : _participants ) {
-        for (auto& receiverContext : receiver->usedMeshContexts()) {
-          if(receiverContext->receiveMeshFrom == _accessorName && receiverContext->mesh->getName() == context->mesh->getName()){
+      for (auto &receiver : _participants) {
+        for (auto &receiverContext : receiver->usedMeshContexts()) {
+          if (receiverContext->receiveMeshFrom == _accessorName && receiverContext->mesh->getName() == context->mesh->getName()) {
             //PRECICE_CHECK( not hasToSend, "Mesh " << context->mesh->getName() << " can currently only be received once.")
 
             // meshRequirement has to be copied from "from" to provide", since
             // mapping are only defined at "provide"
-            if(receiverContext->meshRequirement > context->meshRequirement){
+            if (receiverContext->meshRequirement > context->meshRequirement) {
               context->meshRequirement = receiverContext->meshRequirement;
             }
-            m2n::PtrM2N m2n = m2nConfig->getM2N( receiver->getName(), _accessorName );
+            m2n::PtrM2N m2n = m2nConfig->getM2N(receiver->getName(), _accessorName);
             m2n->createDistributedCommunication(context->mesh);
             context->partition->addM2N(m2n);
           }
@@ -1361,19 +1288,18 @@ void SolverInterfaceImpl:: configurePartitions
       }
       /// @todo support offset??
 
-    }
-    else { // Accessor receives mesh
+    } else { // Accessor receives mesh
       PRECICE_CHECK(not context->receiveMeshFrom.empty(),
-            "Participant \"" << _accessorName << "\" must either provide or receive the mesh " << context->mesh->getName() << "!")
+                    "Participant \"" << _accessorName << "\" must either provide or receive the mesh " << context->mesh->getName() << "!")
       PRECICE_CHECK(not context->provideMesh,
-            "Participant \"" << _accessorName << "\" cannot provide and receive mesh " << context->mesh->getName() << "!" );
-      std::string receiver ( _accessorName );
-      std::string provider ( context->receiveMeshFrom );
-      PRECICE_DEBUG( "Receiving mesh from " << provider );
+                    "Participant \"" << _accessorName << "\" cannot provide and receive mesh " << context->mesh->getName() << "!");
+      std::string receiver(_accessorName);
+      std::string provider(context->receiveMeshFrom);
+      PRECICE_DEBUG("Receiving mesh from " << provider);
 
       context->partition = partition::PtrPartition(new partition::ReceivedPartition(context->mesh, context->geoFilter, context->safetyFactor));
 
-      m2n::PtrM2N m2n = m2nConfig->getM2N ( receiver, provider );
+      m2n::PtrM2N m2n = m2nConfig->getM2N(receiver, provider);
       m2n->createDistributedCommunication(context->mesh);
       context->partition->addM2N(m2n);
       context->partition->setFromMapping(context->fromMappingContext.mapping);
@@ -1382,7 +1308,7 @@ void SolverInterfaceImpl:: configurePartitions
   }
 }
 
-void SolverInterfaceImpl:: computePartitions()
+void SolverInterfaceImpl::computePartitions()
 {
   //We need to do this in two loops: First, communicate the mesh and later compute the partition.
   //Originally, this was done in one loop. This however gave deadlock if two meshes needed to be communicated cross-wise.
@@ -1412,41 +1338,40 @@ void SolverInterfaceImpl:: computePartitions()
   }
 }
 
-
-void SolverInterfaceImpl:: mapWrittenData()
+void SolverInterfaceImpl::mapWrittenData()
 {
   PRECICE_TRACE();
   using namespace mapping;
   MappingConfiguration::Timing timing;
   // Compute mappings
-  for (impl::MappingContext& context : _accessor->writeMappingContexts()) {
-    timing = context.timing;
+  for (impl::MappingContext &context : _accessor->writeMappingContexts()) {
+    timing         = context.timing;
     bool rightTime = timing == MappingConfiguration::ON_ADVANCE;
     rightTime |= timing == MappingConfiguration::INITIAL;
     bool hasComputed = context.mapping->hasComputedMapping();
-    if (rightTime && not hasComputed){
+    if (rightTime && not hasComputed) {
       PRECICE_INFO("Compute write mapping from mesh \""
-          << _accessor->meshContext(context.fromMeshID).mesh->getName()
-          << "\" to mesh \""
-          << _accessor->meshContext(context.toMeshID).mesh->getName()
-          << "\".");
+                   << _accessor->meshContext(context.fromMeshID).mesh->getName()
+                   << "\" to mesh \""
+                   << _accessor->meshContext(context.toMeshID).mesh->getName()
+                   << "\".");
 
       context.mapping->computeMapping();
     }
   }
 
   // Map data
-  for (impl::DataContext& context : _accessor->writeDataContexts()) {
-    timing = context.mappingContext.timing;
+  for (impl::DataContext &context : _accessor->writeDataContexts()) {
+    timing          = context.mappingContext.timing;
     bool hasMapping = context.mappingContext.mapping.get() != nullptr;
-    bool rightTime = timing == MappingConfiguration::ON_ADVANCE;
+    bool rightTime  = timing == MappingConfiguration::ON_ADVANCE;
     rightTime |= timing == MappingConfiguration::INITIAL;
     bool hasMapped = context.mappingContext.hasMappedData;
-    if (hasMapping && rightTime && (not hasMapped)){
-      int inDataID = context.fromData->getID();
+    if (hasMapping && rightTime && (not hasMapped)) {
+      int inDataID  = context.fromData->getID();
       int outDataID = context.toData->getID();
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
-                   << "\" from mesh \"" << context.mesh->getName() << "\"");
+                                  << "\" from mesh \"" << context.mesh->getName() << "\"");
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map from dataID " << inDataID << " to dataID: " << outDataID);
       context.mappingContext.mapping->map(inDataID, outDataID);
@@ -1455,160 +1380,154 @@ void SolverInterfaceImpl:: mapWrittenData()
   }
 
   // Clear non-stationary, non-incremental mappings
-  for (impl::MappingContext& context : _accessor->writeMappingContexts()) {
-    bool isStationary = context.timing
-                        == MappingConfiguration::INITIAL;
-    if (not isStationary){
-        context.mapping->clear();
-    }
-    context.hasMappedData = false;
-  }
-}
-
-void SolverInterfaceImpl:: mapReadData()
-{
-  PRECICE_TRACE();
-  mapping::MappingConfiguration::Timing timing;
-  // Compute mappings
-  for (impl::MappingContext& context : _accessor->readMappingContexts()) {
-    timing = context.timing;
-    bool mapNow = timing == mapping::MappingConfiguration::ON_ADVANCE;
-    mapNow |= timing == mapping::MappingConfiguration::INITIAL;
-    bool hasComputed = context.mapping->hasComputedMapping();
-    if (mapNow && not hasComputed){
-      PRECICE_INFO("Compute read mapping from mesh \""
-              << _accessor->meshContext(context.fromMeshID).mesh->getName()
-              << "\" to mesh \""
-              << _accessor->meshContext(context.toMeshID).mesh->getName()
-              << "\".");
-
-      context.mapping->computeMapping();
-    }
-  }
-
-  // Map data
-  for (impl::DataContext& context : _accessor->readDataContexts()) {
-    timing = context.mappingContext.timing;
-    bool mapNow = timing == mapping::MappingConfiguration::ON_ADVANCE;
-    mapNow |= timing == mapping::MappingConfiguration::INITIAL;
-    bool hasMapping = context.mappingContext.mapping.get() != nullptr;
-    bool hasMapped = context.mappingContext.hasMappedData;
-    if (mapNow && hasMapping && (not hasMapped)){
-      int inDataID = context.fromData->getID();
-      int outDataID = context.toData->getID();
-      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-      PRECICE_DEBUG("Map read data \"" << context.fromData->getName()
-                   << "\" to mesh \"" << context.mesh->getName() << "\"");
-      context.mappingContext.mapping->map(inDataID, outDataID);
-      PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
-    }
-  }
-
-  // Clear non-initial, non-incremental mappings
-  for (impl::MappingContext& context : _accessor->readMappingContexts()) {
-    bool isStationary = context.timing
-              == mapping::MappingConfiguration::INITIAL;
-    if (not isStationary){
+  for (impl::MappingContext &context : _accessor->writeMappingContexts()) {
+    bool isStationary = context.timing == MappingConfiguration::INITIAL;
+    if (not isStationary) {
       context.mapping->clear();
     }
     context.hasMappedData = false;
   }
 }
 
-void SolverInterfaceImpl:: performDataActions
-(
-  const std::set<action::Action::Timing>& timings,
-  double                 time,
-  double                 dt,
-  double                 partFullDt,
-  double                 fullDt )
+void SolverInterfaceImpl::mapReadData()
+{
+  PRECICE_TRACE();
+  mapping::MappingConfiguration::Timing timing;
+  // Compute mappings
+  for (impl::MappingContext &context : _accessor->readMappingContexts()) {
+    timing      = context.timing;
+    bool mapNow = timing == mapping::MappingConfiguration::ON_ADVANCE;
+    mapNow |= timing == mapping::MappingConfiguration::INITIAL;
+    bool hasComputed = context.mapping->hasComputedMapping();
+    if (mapNow && not hasComputed) {
+      PRECICE_INFO("Compute read mapping from mesh \""
+                   << _accessor->meshContext(context.fromMeshID).mesh->getName()
+                   << "\" to mesh \""
+                   << _accessor->meshContext(context.toMeshID).mesh->getName()
+                   << "\".");
+
+      context.mapping->computeMapping();
+    }
+  }
+
+  // Map data
+  for (impl::DataContext &context : _accessor->readDataContexts()) {
+    timing      = context.mappingContext.timing;
+    bool mapNow = timing == mapping::MappingConfiguration::ON_ADVANCE;
+    mapNow |= timing == mapping::MappingConfiguration::INITIAL;
+    bool hasMapping = context.mappingContext.mapping.get() != nullptr;
+    bool hasMapped  = context.mappingContext.hasMappedData;
+    if (mapNow && hasMapping && (not hasMapped)) {
+      int inDataID             = context.fromData->getID();
+      int outDataID            = context.toData->getID();
+      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
+      PRECICE_DEBUG("Map read data \"" << context.fromData->getName()
+                                       << "\" to mesh \"" << context.mesh->getName() << "\"");
+      context.mappingContext.mapping->map(inDataID, outDataID);
+      PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
+    }
+  }
+
+  // Clear non-initial, non-incremental mappings
+  for (impl::MappingContext &context : _accessor->readMappingContexts()) {
+    bool isStationary = context.timing == mapping::MappingConfiguration::INITIAL;
+    if (not isStationary) {
+      context.mapping->clear();
+    }
+    context.hasMappedData = false;
+  }
+}
+
+void SolverInterfaceImpl::performDataActions(
+    const std::set<action::Action::Timing> &timings,
+    double                                  time,
+    double                                  dt,
+    double                                  partFullDt,
+    double                                  fullDt)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(not _clientMode);
-  for (action::PtrAction& action : _accessor->actions()) {
-    if (timings.find(action->getTiming()) != timings.end()){
+  for (action::PtrAction &action : _accessor->actions()) {
+    if (timings.find(action->getTiming()) != timings.end()) {
       action->performAction(time, dt, partFullDt, fullDt);
     }
   }
 }
 
-void SolverInterfaceImpl:: handleExports()
+void SolverInterfaceImpl::handleExports()
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(not _clientMode);
   //timesteps was already incremented before
-  int timesteps = _couplingScheme->getTimesteps()-1;
+  int timesteps = _couplingScheme->getTimesteps() - 1;
 
-  for (const io::ExportContext& context : _accessor->exportContexts()) {
-    if (_couplingScheme->isCouplingTimestepComplete() || context.everyIteration){
-      if (context.timestepInterval != -1){
-        if (timesteps % context.timestepInterval == 0){
-          if (context.everyIteration){
+  for (const io::ExportContext &context : _accessor->exportContexts()) {
+    if (_couplingScheme->isCouplingTimestepComplete() || context.everyIteration) {
+      if (context.timestepInterval != -1) {
+        if (timesteps % context.timestepInterval == 0) {
+          if (context.everyIteration) {
             std::ostringstream everySuffix;
             everySuffix << _accessorName << ".it" << _numberAdvanceCalls;
             exportMesh(everySuffix.str());
           }
           std::ostringstream suffix;
-          suffix << _accessorName << ".dt" << _couplingScheme->getTimesteps()-1;
+          suffix << _accessorName << ".dt" << _couplingScheme->getTimesteps() - 1;
           exportMesh(suffix.str());
-          if (context.triggerSolverPlot){
-            _couplingScheme->requireAction( std::string ("plot-output") );
+          if (context.triggerSolverPlot) {
+            _couplingScheme->requireAction(std::string("plot-output"));
           }
         }
       }
     }
   }
 
-  if (_couplingScheme->isCouplingTimestepComplete()){
+  if (_couplingScheme->isCouplingTimestepComplete()) {
     // Export watch point data
-    for (const PtrWatchPoint& watchPoint : _accessor->watchPoints()) {
+    for (const PtrWatchPoint &watchPoint : _accessor->watchPoints()) {
       watchPoint->exportPointData(_couplingScheme->getTime());
     }
   }
 }
 
-void SolverInterfaceImpl:: resetWrittenData()
+void SolverInterfaceImpl::resetWrittenData()
 {
   PRECICE_TRACE();
-  for (DataContext& context : _accessor->writeDataContexts()) {
+  for (DataContext &context : _accessor->writeDataContexts()) {
     context.fromData->values() = Eigen::VectorXd::Zero(context.fromData->values().size());
-    if (context.toData != context.fromData){
+    if (context.toData != context.fromData) {
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
     }
   }
 }
 
-PtrParticipant SolverInterfaceImpl:: determineAccessingParticipant
-(
-   const config::SolverInterfaceConfiguration& config )
+PtrParticipant SolverInterfaceImpl::determineAccessingParticipant(
+    const config::SolverInterfaceConfiguration &config)
 {
-  const auto& partConfig = config.getParticipantConfiguration();
-  for (const PtrParticipant& participant : partConfig->getParticipants()) {
-    if ( participant->getName() == _accessorName ) {
+  const auto &partConfig = config.getParticipantConfiguration();
+  for (const PtrParticipant &participant : partConfig->getParticipants()) {
+    if (participant->getName() == _accessorName) {
       return participant;
     }
   }
   PRECICE_ERROR("Accessing participant \"" << _accessorName << "\" is not defined in configuration!");
 }
 
-
-void SolverInterfaceImpl:: initializeClientServerCommunication()
+void SolverInterfaceImpl::initializeClientServerCommunication()
 {
   PRECICE_TRACE();
   com::PtrCommunication com = _accessor->getClientServerCommunication();
   PRECICE_ASSERT(com.get() != nullptr);
-  if ( _serverMode ){
-    PRECICE_INFO("Setting up communication to client" );
-    com->acceptConnection ( _accessorName + "Server", _accessorName, 0);
-  }
-  else {
-    PRECICE_INFO("Setting up communication to server" );
-    com->requestConnection( _accessorName + "Server", _accessorName,
-                            _accessorProcessRank, _accessorCommunicatorSize );
+  if (_serverMode) {
+    PRECICE_INFO("Setting up communication to client");
+    com->acceptConnection(_accessorName + "Server", _accessorName, 0);
+  } else {
+    PRECICE_INFO("Setting up communication to server");
+    com->requestConnection(_accessorName + "Server", _accessorName,
+                           _accessorProcessRank, _accessorCommunicatorSize);
   }
 }
 
-void SolverInterfaceImpl:: initializeMasterSlaveCommunication()
+void SolverInterfaceImpl::initializeMasterSlaveCommunication()
 {
   PRECICE_TRACE();
 
@@ -1617,32 +1536,31 @@ void SolverInterfaceImpl:: initializeMasterSlaveCommunication()
   //therefore, the master uses a rankOffset and the slaves have to call request
   // with that offset
   int rankOffset = 1;
-  if ( utils::MasterSlave::isMaster() ){
-    PRECICE_INFO("Setting up communication to slaves" );
-    utils::MasterSlave::_communication->acceptConnection ( _accessorName + "Master", _accessorName, utils::MasterSlave::getRank());
+  if (utils::MasterSlave::isMaster()) {
+    PRECICE_INFO("Setting up communication to slaves");
+    utils::MasterSlave::_communication->acceptConnection(_accessorName + "Master", _accessorName, utils::MasterSlave::getRank());
     utils::MasterSlave::_communication->setRankOffset(rankOffset);
-  }
-  else {
+  } else {
     PRECICE_ASSERT(utils::MasterSlave::isSlave());
-    utils::MasterSlave::_communication->requestConnection( _accessorName + "Master", _accessorName,
-                            _accessorProcessRank-rankOffset, _accessorCommunicatorSize-rankOffset );
+    utils::MasterSlave::_communication->requestConnection(_accessorName + "Master", _accessorName,
+                                                          _accessorProcessRank - rankOffset, _accessorCommunicatorSize - rankOffset);
   }
 }
 
-void SolverInterfaceImpl:: syncTimestep(double computedTimestepLength)
+void SolverInterfaceImpl::syncTimestep(double computedTimestepLength)
 {
   PRECICE_ASSERT(utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave());
-  if(utils::MasterSlave::isSlave()){
+  if (utils::MasterSlave::isSlave()) {
     utils::MasterSlave::_communication->send(computedTimestepLength, 0);
-  }
-  else if(utils::MasterSlave::isMaster()){
-    for(int rankSlave = 1; rankSlave < _accessorCommunicatorSize; rankSlave++){
+  } else if (utils::MasterSlave::isMaster()) {
+    for (int rankSlave = 1; rankSlave < _accessorCommunicatorSize; rankSlave++) {
       double dt;
       utils::MasterSlave::_communication->receive(dt, rankSlave);
       PRECICE_CHECK(math::equals(dt, computedTimestepLength),
-            "Ambiguous timestep length when calling request advance from several processes!");
+                    "Ambiguous timestep length when calling request advance from several processes!");
     }
   }
 }
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -1,45 +1,43 @@
 #pragma once
 
-#include "precice/MeshHandle.hpp"
-#include "precice/SolverInterface.hpp"
-#include "precice/impl/SharedPointer.hpp"
-#include "precice/impl/DataContext.hpp"
-#include "action/Action.hpp"
-#include "boost/noncopyable.hpp"
-#include "io/Constants.hpp"
-#include "cplscheme/SharedPointer.hpp"
-#include "com/Communication.hpp"
-#include "m2n/config/M2NConfiguration.hpp"
-#include "m2n/BoundM2N.hpp"
-#include "utils/MultiLock.hpp"
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
+#include "action/Action.hpp"
+#include "boost/noncopyable.hpp"
+#include "com/Communication.hpp"
+#include "cplscheme/SharedPointer.hpp"
+#include "io/Constants.hpp"
+#include "m2n/BoundM2N.hpp"
+#include "m2n/config/M2NConfiguration.hpp"
+#include "precice/MeshHandle.hpp"
+#include "precice/SolverInterface.hpp"
+#include "precice/impl/DataContext.hpp"
+#include "precice/impl/SharedPointer.hpp"
+#include "utils/MultiLock.hpp"
 
 namespace precice {
-  namespace impl {
-    class RequestManager;
-  }
-  namespace config {
-    class SolverInterfaceConfiguration;
-  }
+namespace impl {
+class RequestManager;
 }
+namespace config {
+class SolverInterfaceConfiguration;
+}
+} // namespace precice
 
 // Forward declaration to friend the boost test struct
 namespace PreciceTests {
-  namespace Serial {
-    struct TestConfiguration;
-  }
+namespace Serial {
+struct TestConfiguration;
 }
+} // namespace PreciceTests
 
 namespace precice {
 namespace impl {
 
 /// Implementation of solver interface.
-class SolverInterfaceImpl
-{
+class SolverInterfaceImpl {
 public:
-
   /**
    * @brief Constructor.
    *
@@ -51,23 +49,23 @@ public:
    *                            match the name given for a participant in the
    *                            xml configuration file.
    */
-  SolverInterfaceImpl (
-    std::string participantName,
-    int         accessorProcessRank,
-    int         accessorCommunicatorSize,
-    bool        serverMode );
+  SolverInterfaceImpl(
+      std::string participantName,
+      int         accessorProcessRank,
+      int         accessorCommunicatorSize,
+      bool        serverMode);
 
   /// Deleted copy constructor
   SolverInterfaceImpl(SolverInterfaceImpl const &) = delete;
 
   /// Deleted copy assignment
-  SolverInterfaceImpl& operator=(SolverInterfaceImpl const &) = delete;
+  SolverInterfaceImpl &operator=(SolverInterfaceImpl const &) = delete;
 
   /// Deleted move constructor
   SolverInterfaceImpl(SolverInterfaceImpl &&) = delete;
 
   /// Deleted move assignment
-  SolverInterfaceImpl& operator=(SolverInterfaceImpl &&) = delete;
+  SolverInterfaceImpl &operator=(SolverInterfaceImpl &&) = delete;
 
   /**
    * @brief Constructor with support for custom MPI_COMM_WORLD.
@@ -84,12 +82,12 @@ public:
    *                            xml configuration file.
    * @param[in] communicator    A pointer to the MPI_Comm to use.
    */
-  SolverInterfaceImpl (
-    std::string participantName,
-    int         accessorProcessRank,
-    int         accessorCommunicatorSize,
-    bool        serverMode,
-    void*       communicator);
+  SolverInterfaceImpl(
+      std::string participantName,
+      int         accessorProcessRank,
+      int         accessorCommunicatorSize,
+      bool        serverMode,
+      void *      communicator);
 
   /**
    * @brief Configures the coupling interface from the given xml file.
@@ -99,7 +97,7 @@ public:
    *
    * @param configurationFileName [IN] Name (with path) of the xml config. file.
    */
-  void configure ( const std::string& configurationFileName );
+  void configure(const std::string &configurationFileName);
 
   /**
    * @brief Configures the coupling interface with a prepared configuration.
@@ -107,7 +105,7 @@ public:
    * Can be used to configure the SolverInterfaceImpl without xml file. Requires
    * to manually setup the configuration object.
    */
-  void configure ( const config::SolverInterfaceConfiguration& configuration );
+  void configure(const config::SolverInterfaceConfiguration &configuration);
 
   /**
    * @brief Initializes all coupling data and starts (coupled) simulation.
@@ -143,7 +141,7 @@ public:
    * @param[in] computedTimestepLength Length of timestep computed by solver.
    * @return Maximum length of next timestep to be computed by solver.
    */
-  double advance ( double computedTimestepLength );
+  double advance(double computedTimestepLength);
 
   /**
    * @brief Finalizes the coupled simulation.
@@ -177,7 +175,7 @@ public:
   /**
    * @brief Returns true, if new data has to be written.
    */
-  bool isWriteDataRequired ( double computedTimestepLength ) const;
+  bool isWriteDataRequired(double computedTimestepLength) const;
 
   /**
    * @brief Returns true, if a global timestep is completed.
@@ -207,36 +205,36 @@ public:
    * performing them on demand, and calling fulfilledAction() to signalize
    * preCICE the correct behavior of the solver.
    */
-  bool isActionRequired (	const std::string& action ) const;
+  bool isActionRequired(const std::string &action) const;
 
   /**
    * @brief Tells preCICE that a required action has been fulfilled by a solver.
    *
    * For more details see method requireAction().
    */
-  void fulfilledAction ( const std::string& action );
+  void fulfilledAction(const std::string &action);
 
   /// Returns true, if the mesh with given name is used.
-  bool hasMesh ( const std::string& meshName ) const;
+  bool hasMesh(const std::string &meshName) const;
 
   /**
    * @brief Returns the ID belonging to the mesh with given name.
    *
    * The existing names are determined from the configuration.
    */
-  int getMeshID (	const std::string& meshName ) const;
+  int getMeshID(const std::string &meshName) const;
 
   /// Returns all mesh IDs (besides sub-ids).
   std::set<int> getMeshIDs() const;
 
   /// Returns true, if the data with given name is used in the given mesh.
-  bool hasData ( const std::string& dataName, int meshID ) const;
+  bool hasData(const std::string &dataName, int meshID) const;
 
   /// Returns data id corresponding to the given name (from configuration) and mesh.
-  int getDataID ( const std::string& dataName, int meshID ) const;
+  int getDataID(const std::string &dataName, int meshID) const;
 
   /// Returns the number of nodes of a mesh.
-  int getMeshVertexSize ( int meshID ) const;
+  int getMeshVertexSize(int meshID) const;
 
   /**
    * @brief Resets mesh with given ID.
@@ -245,27 +243,27 @@ public:
    * changes. Only has an effect, if the mapping used is non-stationary and
    * non-incremental.
    */
-  void resetMesh ( int meshID );
+  void resetMesh(int meshID);
 
   /**
    * @brief Set the position of a solver mesh vertex.
    *
    * @return Vertex ID to be used when setting an edge.
    */
-  int setMeshVertex (
-    int           meshID,
-    const double* position );
+  int setMeshVertex(
+      int           meshID,
+      const double *position);
 
   /**
    * @brief Sets several spatial positions for a mesh.
    *
    * @param[out] ids IDs for data from given positions.
    */
-  void setMeshVertices (
-    int           meshID,
-    int           size,
-    const double* positions,
-    int*          ids );
+  void setMeshVertices(
+      int           meshID,
+      int           size,
+      const double *positions,
+      int *         ids);
 
   /**
    * @brief Gets spatial positions of vertices for given IDs.
@@ -273,11 +271,11 @@ public:
    * @param[in] ids IDs obtained when setting write positions.
    * @param[out] positions Positions corresponding to IDs.
    */
-  void getMeshVertices (
-    int        meshID,
-    size_t     size,
-    const int* ids,
-    double*    positions ) const;
+  void getMeshVertices(
+      int        meshID,
+      size_t     size,
+      const int *ids,
+      double *   positions) const;
 
   /**
    * @brief Gets vertex data ids from positions.
@@ -286,51 +284,51 @@ public:
    * @param[in] positions Positions (x,y,z,x,y,z,...) to find ids for.
    * @param[out] ids IDs corresponding to positions.
    */
-  void getMeshVertexIDsFromPositions (
-    int           meshID,
-    size_t        size,
-    const double* positions,
-    int*          ids ) const;
+  void getMeshVertexIDsFromPositions(
+      int           meshID,
+      size_t        size,
+      const double *positions,
+      int *         ids) const;
 
   /**
    * @brief Set an edge of a solver mesh.
    *
    * @return Index of the edge to be used when setting a triangle.
    */
-  int setMeshEdge (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID );
+  int setMeshEdge(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID);
 
   /// Set a triangle of a solver mesh.
-  void setMeshTriangle (
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID );
+  void setMeshTriangle(
+      int meshID,
+      int firstEdgeID,
+      int secondEdgeID,
+      int thirdEdgeID);
 
   /// Sets a triangle and creates/sets edges automatically of a solver mesh.
-  void setMeshTriangleWithEdges (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID );
+  void setMeshTriangleWithEdges(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID,
+      int thirdVertexID);
 
   /// Set a quadrangle of a solver mesh.
-  void setMeshQuad (
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID,
-    int fourthEdgeID );
+  void setMeshQuad(
+      int meshID,
+      int firstEdgeID,
+      int secondEdgeID,
+      int thirdEdgeID,
+      int fourthEdgeID);
 
   /// Sets a quadrangle and creates/sets edges automatically of a solver mesh.
-  void setMeshQuadWithEdges (
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID,
-    int fourthVertexID );
+  void setMeshQuadWithEdges(
+      int meshID,
+      int firstVertexID,
+      int secondVertexID,
+      int thirdVertexID,
+      int fourthVertexID);
 
   /**
    * @brief Computes and maps all write data mapped from mesh with given ID.
@@ -353,12 +351,11 @@ public:
    * @param[in] size Number of valueIndices, and number of values * dimensions.
    * @param[in] values Values of the data to be written.
    */
-  void writeBlockVectorData (
-    int           fromDataID,
-    int           size,
-    const int*    valueIndices,
-    const double* values );
-
+  void writeBlockVectorData(
+      int           fromDataID,
+      int           size,
+      const int *   valueIndices,
+      const double *values);
 
   /**
    * @brief Write vectorial data to the interface mesh
@@ -369,10 +366,10 @@ public:
    * @param[in] dataPosition Position (coordinate, e.g.) of data to be written
    * @param[in] dataValue Value of the data to be written
    */
-  void writeVectorData (
-    int           fromDataID,
-    int           valueIndex,
-    const double* value );
+  void writeVectorData(
+      int           fromDataID,
+      int           valueIndex,
+      const double *value);
 
   /**
    * @brief Writes scalar data values given as block.
@@ -381,11 +378,11 @@ public:
    * @param size [IN] Number of valueIndices, and number of values.
    * @param values [IN] Values of the data to be written.
    */
-  void writeBlockScalarData (
-    int           fromDataID,
-    int           size,
-    const int*    valueIndices,
-    const double* values );
+  void writeBlockScalarData(
+      int           fromDataID,
+      int           size,
+      const int *   valueIndices,
+      const double *values);
 
   /**
    * @brief Write scalar data to the interface mesh
@@ -397,9 +394,9 @@ public:
    * @param dataValue    [IN] Value of the data to be written
    */
   void writeScalarData(
-    int    fromDataID,
-    int    valueIndex,
-    double value);
+      int    fromDataID,
+      int    valueIndex,
+      double value);
 
   /**
    * @brief Reads vector data values given as block.
@@ -413,11 +410,11 @@ public:
    * @param valueIndices [IN] Indices (from setReadPosition()) of data values.
    * @param values [IN] Values of the data to be read.
    */
-  void readBlockVectorData (
-    int        toDataID,
-    int        size,
-    const int* valueIndices,
-    double*    values ) const;
+  void readBlockVectorData(
+      int        toDataID,
+      int        size,
+      const int *valueIndices,
+      double *   values) const;
 
   /**
    * @brief Reads vector data from the coupling mesh.
@@ -426,10 +423,10 @@ public:
    * @param[in] dataPosition Position (coordinate, e.g.) of data to be read
    * @param[out] dataValue Read data value
    */
-  void readVectorData (
-    int     toDataID,
-    int     valueIndex,
-    double* value ) const;
+  void readVectorData(
+      int     toDataID,
+      int     valueIndex,
+      double *value) const;
 
   /**
    * @brief Reads scalar data values given as block.
@@ -438,11 +435,11 @@ public:
    * @param[in] size Number of valueIndices, and number of values.
    * @param[in] values Values of the data to be written.
    */
-  void readBlockScalarData (
-    int        toDataID,
-    int        size,
-    const int* valueIndices,
-    double*    values ) const;
+  void readBlockScalarData(
+      int        toDataID,
+      int        size,
+      const int *valueIndices,
+      double *   values) const;
 
   /**
    * @brief Read scalar data from the interface mesh.
@@ -453,10 +450,10 @@ public:
    * @param[in] dataPosition Position (coordinate, e.g.) of data to be read
    * @param[in] dataValue    Read data value
    */
-  void readScalarData (
-    int     toDataID,
-    int     valueIndex,
-    double& value ) const;
+  void readScalarData(
+      int     toDataID,
+      int     valueIndex,
+      double &value) const;
 
   /**
    * @brief Sets the location for all output of preCICE.
@@ -464,9 +461,9 @@ public:
    * If done after configuration, this overwrites the output location specified
    * in the configuration.
    */
-//  void setExportLocation (
-//    const std::string& location,
-//    int                exportType = io::constants::exportAll() );
+  //  void setExportLocation (
+  //    const std::string& location,
+  //    int                exportType = io::constants::exportAll() );
 
   /**
    * @brief Writes a mesh to vtk file.
@@ -476,9 +473,9 @@ public:
    *
    * @param[in] filenameSuffix Suffix of all plotted files
    */
-  void exportMesh (
-    const std::string& filenameSuffix,
-    int                exportType = io::constants::exportAll() ) const;
+  void exportMesh(
+      const std::string &filenameSuffix,
+      int                exportType = io::constants::exportAll()) const;
 
   /**
    * @brief Scales data values according to configuration.
@@ -487,25 +484,33 @@ public:
    * through the surface area belonging to its "support". This allows to come
    * from forces to stresses, e.g..
    */
-//  void scaleReadData ()
+  //  void scaleReadData ()
 
   /// Returns a handle to a created mesh.
-  MeshHandle getMeshHandle ( const std::string& meshName );
+  MeshHandle getMeshHandle(const std::string &meshName);
 
   /// Runs the solver interface in server mode.
   void runServer();
 
   /// Returns the name of the accessor
-  std::string getAccessorName() const { return _accessorName; }
+  std::string getAccessorName() const
+  {
+    return _accessorName;
+  }
 
   /// Returns the rank of the accessor
-  int getAccessorProcessRank() const { return _accessorProcessRank; }
+  int getAccessorProcessRank() const
+  {
+    return _accessorProcessRank;
+  }
 
   /// Returns the size of the accessors communicator
-  int getAccessorCommunicatorSize() const { return _accessorCommunicatorSize; }
+  int getAccessorCommunicatorSize() const
+  {
+    return _accessorCommunicatorSize;
+  }
 
 private:
-
   mutable logging::Logger _log{"impl::SolverInterfaceImpl"};
 
   std::string _accessorName;
@@ -531,12 +536,12 @@ private:
   //com::Communication::SharedPointer _clientServerCommunication;
 
   /// mesh name to mesh ID mapping.
-  std::map<std::string,int> _meshIDs;
+  std::map<std::string, int> _meshIDs;
 
   /// dataIDs referenced by meshID and data name
-  std::map<int,std::map<std::string,int> > _dataIDs;
+  std::map<int, std::map<std::string, int>> _dataIDs;
 
-  std::map<std::string,m2n::BoundM2N> _m2ns;
+  std::map<std::string, m2n::BoundM2N> _m2ns;
 
   /// Holds information about solvers participating in the coupled simulation.
   std::vector<impl::PtrParticipant> _participants;
@@ -546,8 +551,8 @@ private:
   /// Counts calls to advance for plotting.
   long int _numberAdvanceCalls = 0;
 
-//  // @brief Locks the next receive operation of the server to a specific client.
-//  int _lockServerToClient;
+  //  // @brief Locks the next receive operation of the server to a specific client.
+  //  int _lockServerToClient;
 
   /// Manages client-server requests, when a server is used.
   std::shared_ptr<RequestManager> _requestManager;
@@ -556,7 +561,7 @@ private:
   //        is expected.
   //int _expectRequest;
 
-  void configureM2Ns ( const m2n::M2NConfiguration::SharedPointer& config );
+  void configureM2Ns(const m2n::M2NConfiguration::SharedPointer &config);
 
   /// Exports meshes with data and watch point data.
   void handleExports();
@@ -574,8 +579,8 @@ private:
    * - _accessor is valid
    * - _couplingScheme is valid
    */
-  void addDataToCouplingScheme (
-    const cplscheme::CouplingSchemeConfiguration& config );
+  void addDataToCouplingScheme(
+      const cplscheme::CouplingSchemeConfiguration &config);
 
   /**
    * @brief Configures _couplingScheme to be ready to use.
@@ -588,11 +593,11 @@ private:
   void addMeshesToCouplingScheme();
 
   /// Returns true, if the accessor uses the mesh with given name.
-  bool isUsingMesh ( const std::string& meshName ) const;
+  bool isUsingMesh(const std::string &meshName) const;
 
   /// Determines participants providing meshes to other participants.
-  void configurePartitions (
-    const m2n::M2NConfiguration::SharedPointer& m2nConfig );
+  void configurePartitions(
+      const m2n::M2NConfiguration::SharedPointer &m2nConfig);
 
   /// Communicate meshes and create partition
   void computePartitions();
@@ -610,22 +615,28 @@ private:
    * @param[in] partFullDt Part of current full timestep computed by solver.
    * @param[out] fullDt Length of current full timestep.
    */
-  void performDataActions (
-    const std::set<action::Action::Timing>& timings,
-    double                 time,
-    double                 dt,
-    double                 partFullDt,
-    double                 fullDt );
+  void performDataActions(
+      const std::set<action::Action::Timing> &timings,
+      double                                  time,
+      double                                  dt,
+      double                                  partFullDt,
+      double                                  fullDt);
 
   /// Resets written data, displacements and mesh neighbors to export.
   void resetWrittenData();
 
   /// Determines participant accessing this interface from the configuration.
-  impl::PtrParticipant determineAccessingParticipant (
-    const config::SolverInterfaceConfiguration& config );
+  impl::PtrParticipant determineAccessingParticipant(
+      const config::SolverInterfaceConfiguration &config);
 
-  int markedSkip() const { return 0; }
-  int markedQueryDirectly() const { return 1; }
+  int markedSkip() const
+  {
+    return 0;
+  }
+  int markedQueryDirectly() const
+  {
+    return 1;
+  }
 
   /// Initializes communication between data server and client.
   void initializeClientServerCommunication();
@@ -638,7 +649,7 @@ private:
 
   /// To allow white box tests.
   friend struct PreciceTests::Serial::TestConfiguration;
-
 };
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -7,7 +7,7 @@
  */
 
 //
-// MESH VALIDATION 
+// MESH VALIDATION
 //
 
 /** Implementation of PRECICE_VALIDATE_MESH_ID()
@@ -15,112 +15,112 @@
  * @attention Do not use this macro directly!
  */
 #define PRECICE_VALIDATE_MESH_ID_IMPL(id) \
-    PRECICE_CHECK(_dataIDs.find(id) != _dataIDs.end(), "There is no Mesh with ID:" << id);
+  PRECICE_CHECK(_dataIDs.find(id) != _dataIDs.end(), "There is no Mesh with ID:" << id);
 
 /** Implementation of PRECICE_REQUIRE_MESH_USE()
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_REQUIRE_MESH_USE_IMPL(id) \
-    PRECICE_VALIDATE_MESH_ID_IMPL(id) \
-    MeshContext& context = _accessor->meshContext(id); \
-    PRECICE_CHECK(_accessor->isMeshUsed(id), "This participant is required to use Mesh \"" << context.mesh->getName() << "\"!");
+#define PRECICE_REQUIRE_MESH_USE_IMPL(id)            \
+  PRECICE_VALIDATE_MESH_ID_IMPL(id)                  \
+  MeshContext &context = _accessor->meshContext(id); \
+  PRECICE_CHECK(_accessor->isMeshUsed(id), "This participant is required to use Mesh \"" << context.mesh->getName() << "\"!");
 
 /** Implementation of PRECICE_REQUIRE_MESH_PROVIDE()
  *
  * @attention Do not use this macro directly!
  */
 #define PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id) \
-    PRECICE_REQUIRE_MESH_USE_IMPL(id) \
-    PRECICE_CHECK(context.provideMesh, "This participant is required to provide Mesh \"" << context.mesh->getName() << "\"!");
+  PRECICE_REQUIRE_MESH_USE_IMPL(id)           \
+  PRECICE_CHECK(context.provideMesh, "This participant is required to provide Mesh \"" << context.mesh->getName() << "\"!");
 
 /** Implementation of PRECICE_REQUIRE_MESH_MODIFY()
  *
  * @attention Do not use this macro directly!
  */
 #define PRECICE_REQUIRE_MESH_MODIFY_IMPL(id) \
-    PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id) \
-    PRECICE_CHECK(!_meshLock.check(meshID), "This participant attempted to modify the locked Mesh \"" << context.mesh->getName() << "\"!");
+  PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id)      \
+  PRECICE_CHECK(!_meshLock.check(meshID), "This participant attempted to modify the locked Mesh \"" << context.mesh->getName() << "\"!");
 
 /// Validates a given meshID
 #define PRECICE_VALIDATE_MESH_ID(meshID) \
-    do { \
-        const auto id = (meshID); \
-        PRECICE_VALIDATE_MESH_ID_IMPL(id) \
-    } while(false)
+  do {                                   \
+    const auto id = (meshID);            \
+    PRECICE_VALIDATE_MESH_ID_IMPL(id)    \
+  } while (false)
 
 /// Validates a given meshID and checks if the mesh is used by the current participant
 #define PRECICE_REQUIRE_MESH_USE(meshID) \
-    do { \
-        const auto id = (meshID); \
-        PRECICE_REQUIRE_MESH_USE_IMPL(id) \
-    } while(false)
+  do {                                   \
+    const auto id = (meshID);            \
+    PRECICE_REQUIRE_MESH_USE_IMPL(id)    \
+  } while (false)
 
 /// Validates a given meshID and checks if the mesh is provided by the current participant
 #define PRECICE_REQUIRE_MESH_PROVIDE(meshID) \
-    do { \
-        const auto id = (meshID); \
-        PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id) \
-    } while(false)
+  do {                                       \
+    const auto id = (meshID);                \
+    PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id)    \
+  } while (false)
 
 /// Validates a given meshID and checks if the mesh is provided by the current participant and unlocked
 #define PRECICE_REQUIRE_MESH_MODIFY(meshID) \
-    do { \
-        const auto id = (meshID); \
-        PRECICE_REQUIRE_MESH_MODIFY_IMPL(id) \
-    } while(false)
+  do {                                      \
+    const auto id = (meshID);               \
+    PRECICE_REQUIRE_MESH_MODIFY_IMPL(id)    \
+  } while (false)
 
 //
-// DATA VALIDATION 
+// DATA VALIDATION
 //
 
 /** Implementation of PRECICE_VALIDATE_DATA_ID()
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_VALIDATE_DATA_ID_IMPL(id) \
-    PRECICE_CHECK(std::any_of(_dataIDs.begin(), _dataIDs.end(), [id](const typename decltype(_dataIDs)::value_type & meshkv){ \
-                return std::any_of(meshkv.second.begin(), meshkv.second.end(), [id](const typename decltype(meshkv.second)::value_type& datakv){ \
-                        return datakv.second == id; \
-                        }); \
-                }), \
-            "There is no Data with ID " << id); \
+#define PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                                           \
+  PRECICE_CHECK(std::any_of(_dataIDs.begin(), _dataIDs.end(), [id](const typename decltype(_dataIDs)::value_type &meshkv) {                         \
+                  return std::any_of(meshkv.second.begin(), meshkv.second.end(), [id](const typename decltype(meshkv.second)::value_type &datakv) { \
+                    return datakv.second == id;                                                                                                     \
+                  });                                                                                                                               \
+                }),                                                                                                                                 \
+                "There is no Data with ID " << id);
 
 /** Implementation of PRECICE_REQUIRE_DATA_READ()
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_REQUIRE_DATA_READ_IMPL(id) \
-    PRECICE_VALIDATE_DATA_ID_IMPL(id) \
-    PRECICE_CHECK(_accessor->isDataUsed(id), "Data is not used by this participant! " << id); \
-    PRECICE_CHECK(_accessor->isDataRead(id), "Data is not marked as read! " << id); \
+#define PRECICE_REQUIRE_DATA_READ_IMPL(id)                                                  \
+  PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                         \
+  PRECICE_CHECK(_accessor->isDataUsed(id), "Data is not used by this participant! " << id); \
+  PRECICE_CHECK(_accessor->isDataRead(id), "Data is not marked as read! " << id);
 
 /** Implementation of PRECICE_REQUIRE_DATA_WRITE()
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_REQUIRE_DATA_WRITE_IMPL(id) \
-    PRECICE_VALIDATE_DATA_ID_IMPL(id) \
-    PRECICE_CHECK(_accessor->isDataUsed(id), "Data is not used by this participant! " << id); \
-    PRECICE_CHECK(_accessor->isDataWrite(id), "Data is not marked as write! " << id); \
+#define PRECICE_REQUIRE_DATA_WRITE_IMPL(id)                                                 \
+  PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                         \
+  PRECICE_CHECK(_accessor->isDataUsed(id), "Data is not used by this participant! " << id); \
+  PRECICE_CHECK(_accessor->isDataWrite(id), "Data is not marked as write! " << id);
 
 /// Validates a given dataID
 #define PRECICE_VALIDATE_DATA_ID(dataID) \
-    do { \
-        const auto id = (dataID); \
-        PRECICE_VALIDATE_DATA_ID_IMPL(id) \
-    } while(false)
+  do {                                   \
+    const auto id = (dataID);            \
+    PRECICE_VALIDATE_DATA_ID_IMPL(id)    \
+  } while (false)
 
 /// Validates a dataID and checks for read access
 #define PRECICE_REQUIRE_DATA_READ(dataID) \
-    do { \
-        const auto id = (dataID); \
-        PRECICE_REQUIRE_DATA_READ_IMPL(id) \
-    } while(false)
+  do {                                    \
+    const auto id = (dataID);             \
+    PRECICE_REQUIRE_DATA_READ_IMPL(id)    \
+  } while (false)
 
 /// Validates a dataID and checks for write access
 #define PRECICE_REQUIRE_DATA_WRITE(dataID) \
-    do { \
-        const auto id = (dataID); \
-        PRECICE_REQUIRE_DATA_WRITE_IMPL(id) \
-    } while(false)
+  do {                                     \
+    const auto id = (dataID);              \
+    PRECICE_REQUIRE_DATA_WRITE_IMPL(id)    \
+  } while (false)

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -1,120 +1,117 @@
 #include "WatchPoint.hpp"
-#include "query/FindClosestVertex.hpp"
+#include <limits>
+#include "com/Communication.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
 #include "query/FindClosestEdge.hpp"
 #include "query/FindClosestTriangle.hpp"
-#include "mesh/Mesh.hpp"
-#include "mesh/Vertex.hpp"
-#include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
-#include "mesh/Data.hpp"
+#include "query/FindClosestVertex.hpp"
 #include "utils/MasterSlave.hpp"
-#include "com/Communication.hpp"
-#include <limits>
 
 namespace precice {
 namespace impl {
 
-WatchPoint:: WatchPoint
-(
-  Eigen::VectorXd    pointCoords,
-  mesh::PtrMesh      meshToWatch,
-  const std::string& exportFilename )
-:
-  _point(std::move(pointCoords)),
-  _mesh(std::move(meshToWatch)),
-  _txtWriter ( exportFilename )
+WatchPoint::WatchPoint(
+    Eigen::VectorXd    pointCoords,
+    mesh::PtrMesh      meshToWatch,
+    const std::string &exportFilename)
+    : _point(std::move(pointCoords)),
+      _mesh(std::move(meshToWatch)),
+      _txtWriter(exportFilename)
 {
-  PRECICE_ASSERT( _mesh );
-  PRECICE_ASSERT( _point.size() == _mesh->getDimensions(), _point.size(),
-               _mesh->getDimensions() );
+  PRECICE_ASSERT(_mesh);
+  PRECICE_ASSERT(_point.size() == _mesh->getDimensions(), _point.size(),
+                 _mesh->getDimensions());
 }
 
-const mesh::PtrMesh& WatchPoint:: mesh() const
+const mesh::PtrMesh &WatchPoint::mesh() const
 {
   return _mesh;
 }
 
-void WatchPoint:: initialize()
+void WatchPoint::initialize()
 {
   PRECICE_TRACE();
   // Find closest vertex
-  if(_mesh->vertices().size()>0){
-    query::FindClosestVertex findVertex ( _point );
-    findVertex ( *_mesh );
-    _vertices.push_back ( & findVertex.getClosestVertex() );
-    _shortestDistance = findVertex.getEuclidianDistance ();
-    _weights.push_back ( 1.0 );
+  if (_mesh->vertices().size() > 0) {
+    query::FindClosestVertex findVertex(_point);
+    findVertex(*_mesh);
+    _vertices.push_back(&findVertex.getClosestVertex());
+    _shortestDistance = findVertex.getEuclidianDistance();
+    _weights.push_back(1.0);
   }
 
-  if(utils::MasterSlave::isSlave()){
+  if (utils::MasterSlave::isSlave()) {
     utils::MasterSlave::_communication->send(_shortestDistance, 0);
     utils::MasterSlave::_communication->receive(_isClosest, 0);
   }
 
-  if(utils::MasterSlave::isMaster()){
-    int closestRank = 0;
+  if (utils::MasterSlave::isMaster()) {
+    int    closestRank           = 0;
     double closestDistanceGlobal = _shortestDistance;
-    double closestDistanceLocal = std::numeric_limits<double>::max();
-    for(int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++){
+    double closestDistanceLocal  = std::numeric_limits<double>::max();
+    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
       utils::MasterSlave::_communication->receive(closestDistanceLocal, rankSlave);
-      if(closestDistanceLocal < closestDistanceGlobal){
+      if (closestDistanceLocal < closestDistanceGlobal) {
         closestDistanceGlobal = closestDistanceLocal;
-        closestRank = rankSlave;
+        closestRank           = rankSlave;
       }
     }
     _isClosest = closestRank == 0;
-    for(int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++){
-      utils::MasterSlave::_communication->send(closestRank==rankSlave, rankSlave);
+    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+      utils::MasterSlave::_communication->send(closestRank == rankSlave, rankSlave);
     }
   }
 
   PRECICE_DEBUG("Rank: " << utils::MasterSlave::getRank() << ", isClosest: " << _isClosest);
 
-  if(_isClosest){
+  if (_isClosest) {
 
     // Find closest edge
-    query::FindClosestEdge findEdge ( _point );
-    if ( findEdge(*_mesh) ) {
-      if ( findEdge.getEuclidianDistance() < _shortestDistance ) {
+    query::FindClosestEdge findEdge(_point);
+    if (findEdge(*_mesh)) {
+      if (findEdge.getEuclidianDistance() < _shortestDistance) {
         //         _closestEdge = & findEdge.getClosestEdge ();
-        _vertices.clear ();
-        _vertices.push_back ( & findEdge.getClosestEdge().vertex(0) );
-        _vertices.push_back ( & findEdge.getClosestEdge().vertex(1) );
-        _shortestDistance = findEdge.getEuclidianDistance ();
-        _weights.clear ();
-        _weights.push_back ( findEdge.getProjectionPointParameter(0) );
-        _weights.push_back ( findEdge.getProjectionPointParameter(1) );
+        _vertices.clear();
+        _vertices.push_back(&findEdge.getClosestEdge().vertex(0));
+        _vertices.push_back(&findEdge.getClosestEdge().vertex(1));
+        _shortestDistance = findEdge.getEuclidianDistance();
+        _weights.clear();
+        _weights.push_back(findEdge.getProjectionPointParameter(0));
+        _weights.push_back(findEdge.getProjectionPointParameter(1));
       }
     }
-    if ( _mesh->getDimensions() == 3 ) {
+    if (_mesh->getDimensions() == 3) {
       // Find closest triangle
-      query::FindClosestTriangle findTriangle ( _point );
-      if ( findTriangle(*_mesh) ) {
-        if ( findTriangle.getEuclidianDistance() < _shortestDistance ) {
-          _vertices.clear ();
-          _vertices.push_back ( & findTriangle.getClosestTriangle().vertex(0) );
-          _vertices.push_back ( & findTriangle.getClosestTriangle().vertex(1) );
-          _vertices.push_back ( & findTriangle.getClosestTriangle().vertex(2) );
-          _shortestDistance = findTriangle.getEuclidianDistance ();
-          _weights.clear ();
-          _weights.push_back ( findTriangle.getProjectionPointParameter(0) );
-          _weights.push_back ( findTriangle.getProjectionPointParameter(1) );
-          _weights.push_back ( findTriangle.getProjectionPointParameter(2) );
+      query::FindClosestTriangle findTriangle(_point);
+      if (findTriangle(*_mesh)) {
+        if (findTriangle.getEuclidianDistance() < _shortestDistance) {
+          _vertices.clear();
+          _vertices.push_back(&findTriangle.getClosestTriangle().vertex(0));
+          _vertices.push_back(&findTriangle.getClosestTriangle().vertex(1));
+          _vertices.push_back(&findTriangle.getClosestTriangle().vertex(2));
+          _shortestDistance = findTriangle.getEuclidianDistance();
+          _weights.clear();
+          _weights.push_back(findTriangle.getProjectionPointParameter(0));
+          _weights.push_back(findTriangle.getProjectionPointParameter(1));
+          _weights.push_back(findTriangle.getProjectionPointParameter(2));
         }
       }
     }
 
     io::TXTTableWriter::DataType vectorType = _mesh->getDimensions() == 2
-        ? io::TXTTableWriter::VECTOR2D
-        : io::TXTTableWriter::VECTOR3D;
+                                                  ? io::TXTTableWriter::VECTOR2D
+                                                  : io::TXTTableWriter::VECTOR3D;
     _txtWriter.addData("Time", io::TXTTableWriter::DOUBLE);
     _txtWriter.addData("Coordinate", vectorType);
-    for (size_t i=0; i < _mesh->data().size(); i++){
+    for (size_t i = 0; i < _mesh->data().size(); i++) {
       _dataToExport.push_back(_mesh->data()[i]);
-      if (_dataToExport[i]->getDimensions() > 1){
+      if (_dataToExport[i]->getDimensions() > 1) {
         _txtWriter.addData(_dataToExport[i]->getName(), vectorType);
-      }
-      else {
+      } else {
         _txtWriter.addData(_dataToExport[i]->getName(), io::TXTTableWriter::DOUBLE);
       }
     }
@@ -122,78 +119,72 @@ void WatchPoint:: initialize()
   } //isClosest
 }
 
-void WatchPoint:: exportPointData
-(
-  double time )
+void WatchPoint::exportPointData(
+    double time)
 {
-  if(_isClosest){
+  if (_isClosest) {
     PRECICE_ASSERT(_vertices.size() == _weights.size());
     _txtWriter.writeData("Time", time);
     // Export watch point coordinates
     Eigen::VectorXd coords = Eigen::VectorXd::Constant(_mesh->getDimensions(), 0.0);
-    for (size_t i=0; i < _vertices.size(); i++){
+    for (size_t i = 0; i < _vertices.size(); i++) {
       coords += _weights[i] * _vertices[i]->getCoords();
     }
-    if (coords.size() == 2){
+    if (coords.size() == 2) {
       _txtWriter.writeData("Coordinate", Eigen::Vector2d(coords));
-    }
-    else {
+    } else {
       _txtWriter.writeData("Coordinate", Eigen::Vector3d(coords));
     }
     // Export watch point data
-    for (auto & elem : _dataToExport){
-      if (elem->getDimensions() > 1){
+    for (auto &elem : _dataToExport) {
+      if (elem->getDimensions() > 1) {
         Eigen::VectorXd toExport = Eigen::VectorXd::Zero(_mesh->getDimensions());
         getValue(toExport, elem);
-        if (coords.size() == 2){
+        if (coords.size() == 2) {
           _txtWriter.writeData(elem->getName(), Eigen::Vector2d(toExport));
-        }
-        else {
+        } else {
           _txtWriter.writeData(elem->getName(), Eigen::Vector3d(toExport));
         }
 
-      }
-      else {
+      } else {
         double valueToExport = 0.0;
-        getValue ( valueToExport, elem );
-        _txtWriter.writeData ( elem->getName(), valueToExport );
+        getValue(valueToExport, elem);
+        _txtWriter.writeData(elem->getName(), valueToExport);
       }
     }
   }
 }
 
-void WatchPoint:: getValue
-(
-  Eigen::VectorXd&  value,
-  mesh::PtrData&    data )
+void WatchPoint::getValue(
+    Eigen::VectorXd &value,
+    mesh::PtrData &  data)
 {
-  int dim = _mesh->getDimensions();
-  Eigen::VectorXd temp(dim);
-  size_t index = 0;
-  const Eigen::VectorXd& values = data->values();
-  for (mesh::Vertex* vertex : _vertices ) {
-    int offset = vertex->getID()*dim;
-    for ( int i=0; i < dim; i++ ){
+  int                    dim = _mesh->getDimensions();
+  Eigen::VectorXd        temp(dim);
+  size_t                 index  = 0;
+  const Eigen::VectorXd &values = data->values();
+  for (mesh::Vertex *vertex : _vertices) {
+    int offset = vertex->getID() * dim;
+    for (int i = 0; i < dim; i++) {
       temp[i] = values[offset + i];
     }
     temp *= _weights[index];
     value += temp;
-    index ++;
+    index++;
   }
 }
 
-void WatchPoint:: getValue
-(
-  double&        value,
-  mesh::PtrData& data  )
+void WatchPoint::getValue(
+    double &       value,
+    mesh::PtrData &data)
 {
-  size_t index = 0;
-  const Eigen::VectorXd& values = data->values();
-  for (mesh::Vertex* vertex : _vertices ) {
+  size_t                 index  = 0;
+  const Eigen::VectorXd &values = data->values();
+  for (mesh::Vertex *vertex : _vertices) {
     value += _weights[index] * values[vertex->getID()];
-    index ++;
+    index++;
   }
 }
 
-}} // namespace precice, impl
-
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/WatchPoint.hpp
+++ b/src/precice/impl/WatchPoint.hpp
@@ -1,39 +1,37 @@
 #pragma once
 
-#include "SharedPointer.hpp"
-#include "io/TXTTableWriter.hpp"
-#include "mesh/SharedPointer.hpp"
-#include "logging/Logger.hpp"
 #include <string>
 #include <vector>
+#include "SharedPointer.hpp"
+#include "io/TXTTableWriter.hpp"
+#include "logging/Logger.hpp"
+#include "mesh/SharedPointer.hpp"
 
 namespace precice {
 namespace mesh {
 class Vertex;
 }
-}
+} // namespace precice
 
 namespace precice {
 namespace impl {
 
 /// Observes and exports coordinates of a point on the geometry.
-class WatchPoint
-{
+class WatchPoint {
 public:
-
   /**
    * @brief Constructor.
    *
    * @param[in] meshToWatch Mesh to be watched, can be empty on construction.
    */
-  WatchPoint (
-    Eigen::VectorXd    pointCoords,
-    mesh::PtrMesh      meshToWatch,
-    const std::string& exportFilename );
+  WatchPoint(
+      Eigen::VectorXd    pointCoords,
+      mesh::PtrMesh      meshToWatch,
+      const std::string &exportFilename);
 
-  const mesh::PtrMesh& mesh() const;
-  
-  const std::string& filename() const;
+  const mesh::PtrMesh &mesh() const;
+
+  const std::string &filename() const;
 
   /// Initializes the watch point for exporting point data.
   void initialize();
@@ -42,7 +40,6 @@ public:
   void exportPointData(double time);
 
 private:
-
   logging::Logger _log{"impl::WatchPoint"};
 
   Eigen::VectorXd _point;
@@ -55,20 +52,21 @@ private:
 
   std::vector<double> _weights;
 
-  std::vector<mesh::Vertex*> _vertices;
+  std::vector<mesh::Vertex *> _vertices;
 
   std::vector<mesh::PtrData> _dataToExport;
 
   /// Holds the information if this processor is the closest
   bool _isClosest = true;
 
-  void getValue (
-    Eigen::VectorXd&  value,
-    mesh::PtrData&    data );
+  void getValue(
+      Eigen::VectorXd &value,
+      mesh::PtrData &  data);
 
-  void getValue (
-    double&        value,
-    mesh::PtrData& data );
+  void getValue(
+      double &       value,
+      mesh::PtrData &data);
 };
 
-}} // namespace precice, impl
+} // namespace impl
+} // namespace precice

--- a/src/precice/tests/MeshHandleTest.cpp
+++ b/src/precice/tests/MeshHandleTest.cpp
@@ -1,86 +1,87 @@
+#include <Eigen/Core>
+#include <algorithm>
+#include <vector>
+#include "mesh/Mesh.hpp"
 #include "precice/MeshHandle.hpp"
 #include "testing/Testing.hpp"
-#include "mesh/Mesh.hpp"
-#include <Eigen/Core>
-#include <vector>
-#include <algorithm>
 
 using namespace precice;
 
 struct MeshFixture {
-    MeshFixture() : mesh("MyMesh", 3, false, testing::nextMeshID()), handle(mesh) {
-        auto & v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
-        auto & v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
-        auto & v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
-        auto & v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
-        // Quad Borders
-        auto & e1 = mesh.createEdge(v1, v2);
-        auto & e2 = mesh.createEdge(v2, v3);
-        auto & e3 = mesh.createEdge(v3, v4);
-        auto & e4 = mesh.createEdge(v4, v1);
-        // Diagonal
-        auto & e5 = mesh.createEdge(v2, v4);
-        // Triangles
-        mesh.createTriangle(e1, e5, e4);
-        mesh.createTriangle(e2, e3, e5);
-        // Quad
-        mesh.createQuad(e1, e2, e3, e4);
-        // Check the Mesh
-        BOOST_TEST(mesh.vertices().size() == 4);
-        BOOST_TEST(mesh.edges().size() == 5);
-        BOOST_TEST(mesh.triangles().size() == 2);
-        BOOST_TEST(mesh.quads().size() == 1);
-    }
+  MeshFixture()
+      : mesh("MyMesh", 3, false, testing::nextMeshID()), handle(mesh)
+  {
+    auto &v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
+    auto &v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
+    auto &v3 = mesh.createVertex(Eigen::Vector3d(3, 0, 0));
+    auto &v4 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
+    // Quad Borders
+    auto &e1 = mesh.createEdge(v1, v2);
+    auto &e2 = mesh.createEdge(v2, v3);
+    auto &e3 = mesh.createEdge(v3, v4);
+    auto &e4 = mesh.createEdge(v4, v1);
+    // Diagonal
+    auto &e5 = mesh.createEdge(v2, v4);
+    // Triangles
+    mesh.createTriangle(e1, e5, e4);
+    mesh.createTriangle(e2, e3, e5);
+    // Quad
+    mesh.createQuad(e1, e2, e3, e4);
+    // Check the Mesh
+    BOOST_TEST(mesh.vertices().size() == 4);
+    BOOST_TEST(mesh.edges().size() == 5);
+    BOOST_TEST(mesh.triangles().size() == 2);
+    BOOST_TEST(mesh.quads().size() == 1);
+  }
 
-    mesh::Mesh mesh;
-    MeshHandle handle;
-    const int vertex_cnt = 4;
-    const int edge_cnt = 5;
-    const int triangle_cnt = 2;
-    const int quad_cnt = 1;
-    const int primitive_cnt = 4+5+2+1;
+  mesh::Mesh mesh;
+  MeshHandle handle;
+  const int  vertex_cnt    = 4;
+  const int  edge_cnt      = 5;
+  const int  triangle_cnt  = 2;
+  const int  quad_cnt      = 1;
+  const int  primitive_cnt = 4 + 5 + 2 + 1;
 };
-
 
 BOOST_FIXTURE_TEST_SUITE(PreciceTests, MeshFixture)
 
 BOOST_AUTO_TEST_CASE(VertexHandle)
 {
-    const auto& vertices = handle.vertices();
-    BOOST_TEST(std::distance(vertices.begin(), vertices.end()) == vertex_cnt);
-    BOOST_TEST(vertices.size() == vertex_cnt);
-    std::set<int> vs;
-    for(const auto & v : vertices) {
-        vs.insert(v.vertexID());
-    }
-    BOOST_TEST(vs.size() == vertex_cnt);
+  const auto &vertices = handle.vertices();
+  BOOST_TEST(std::distance(vertices.begin(), vertices.end()) == vertex_cnt);
+  BOOST_TEST(vertices.size() == vertex_cnt);
+  std::set<int> vs;
+  for (const auto &v : vertices) {
+    vs.insert(v.vertexID());
+  }
+  BOOST_TEST(vs.size() == vertex_cnt);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeHandle)
 {
-    const auto& edges = handle.edges();
-    BOOST_TEST(std::distance(edges.begin(), edges.end()) == edge_cnt);
-    BOOST_TEST(edges.size() == edge_cnt);
-    std::set<int> vs;
-    for(const auto & e : handle.edges()) {
-        vs.insert(e.vertexID(0));
-        vs.insert(e.vertexID(1));
-    }
-    BOOST_TEST(vs.size() == vertex_cnt);
+  const auto &edges = handle.edges();
+  BOOST_TEST(std::distance(edges.begin(), edges.end()) == edge_cnt);
+  BOOST_TEST(edges.size() == edge_cnt);
+  std::set<int> vs;
+  for (const auto &e : handle.edges()) {
+    vs.insert(e.vertexID(0));
+    vs.insert(e.vertexID(1));
+  }
+  BOOST_TEST(vs.size() == vertex_cnt);
 }
 
 BOOST_AUTO_TEST_CASE(TriangleHandle)
 {
-    const auto& triangles = handle.triangles();
-    BOOST_TEST(std::distance(triangles.begin(), triangles.end()) == triangle_cnt);
-    BOOST_TEST(triangles.size() == triangle_cnt);
-    std::set<int> vs;
-    for(const auto & t : handle.triangles()) {
-        vs.insert(t.vertexID(0));
-        vs.insert(t.vertexID(1));
-        vs.insert(t.vertexID(2));
-    }
-    BOOST_TEST(vs.size() == vertex_cnt);
+  const auto &triangles = handle.triangles();
+  BOOST_TEST(std::distance(triangles.begin(), triangles.end()) == triangle_cnt);
+  BOOST_TEST(triangles.size() == triangle_cnt);
+  std::set<int> vs;
+  for (const auto &t : handle.triangles()) {
+    vs.insert(t.vertexID(0));
+    vs.insert(t.vertexID(1));
+    vs.insert(t.vertexID(2));
+  }
+  BOOST_TEST(vs.size() == vertex_cnt);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -1,21 +1,19 @@
 #ifndef PRECICE_NO_MPI
-#include "testing/Testing.hpp"
 #include "testing/Fixtures.hpp"
+#include "testing/Testing.hpp"
 
-#include "utils/Parallel.hpp"
-#include "precice/impl/SolverInterfaceImpl.hpp"
 #include "precice/SolverInterface.hpp"
-#include "precice/impl/Participant.hpp"
 #include "precice/config/Configuration.hpp"
+#include "precice/impl/Participant.hpp"
+#include "precice/impl/SolverInterfaceImpl.hpp"
+#include "utils/Event.hpp"
+#include "utils/MasterSlave.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/Petsc.hpp"
-#include "utils/MasterSlave.hpp"
-#include "utils/Event.hpp"
 
 using namespace precice;
 
-
-void reset ()
+void reset()
 {
   mesh::Data::resetDataCount();
   impl::Participant::resetParticipantCount();
@@ -30,7 +28,7 @@ struct ParallelTestFixture : testing::SlimConfigurator {
   {
     reset();
     _pathToTests = testing::getPathToSources() + "/precice/tests/";
-    utils::Parallel::restrictGlobalCommunicator({0,1,2,3});
+    utils::Parallel::restrictGlobalCommunicator({0, 1, 2, 3});
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
   }
 
@@ -41,153 +39,145 @@ struct ParallelTestFixture : testing::SlimConfigurator {
   }
 };
 
-
-
 BOOST_AUTO_TEST_SUITE(PreciceTests)
 BOOST_FIXTURE_TEST_SUITE(Parallel, ParallelTestFixture)
 
-
-BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup, *testing::OnSize(4))
 {
-  SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 4 );
-  std::string configFilename = _pathToTests + "config1.xml";
+  SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 4);
+  std::string     configFilename = _pathToTests + "config1.xml";
   slimConfigure(interface, configFilename);
-  BOOST_TEST ( interface.getDimensions() == 3 );
+  BOOST_TEST(interface.getDimensions() == 3);
 
-  if(utils::Parallel::getProcessRank()==0){
+  if (utils::Parallel::getProcessRank() == 0) {
     BOOST_TEST(utils::MasterSlave::isMaster() == true);
     BOOST_TEST(utils::MasterSlave::isSlave() == false);
-  }
-  else {
+  } else {
     BOOST_TEST(utils::MasterSlave::isMaster() == false);
     BOOST_TEST(utils::MasterSlave::isSlave() == true);
   }
 
   BOOST_TEST(utils::MasterSlave::getRank() == utils::Parallel::getProcessRank());
   BOOST_TEST(utils::MasterSlave::getSize() == 4);
-  BOOST_TEST(utils::MasterSlave::_communication.use_count()>0);
+  BOOST_TEST(utils::MasterSlave::_communication.use_count() > 0);
   BOOST_TEST(utils::MasterSlave::_communication->isConnected());
-
 
   //necessary as this test does not call finalize
   utils::MasterSlave::_communication = nullptr;
   utils::Parallel::clearGroups();
 }
 
-BOOST_AUTO_TEST_CASE(TestFinalize, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestFinalize, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "config1.xml";
-  if(utils::Parallel::getProcessRank()<=1){
-    SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 2 );
+  if (utils::Parallel::getProcessRank() <= 1) {
+    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 2);
     slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshOne");
+    int    meshID = interface.getMeshID("MeshOne");
     double xCoord = 0.0 + utils::Parallel::getProcessRank();
-    interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord, 0.0, 0.0).data());
     interface.initialize();
-    BOOST_TEST(interface.getMeshHandle("MeshOne").vertices().size()==1);
-    BOOST_TEST(interface.getMeshHandle("MeshTwo").vertices().size()==1);
+    BOOST_TEST(interface.getMeshHandle("MeshOne").vertices().size() == 1);
+    BOOST_TEST(interface.getMeshHandle("MeshTwo").vertices().size() == 1);
     interface.finalize();
-  }
-  else {
-    SolverInterface interface ( "SolverTwo", utils::Parallel::getProcessRank()-2, 2 );
+  } else {
+    SolverInterface interface("SolverTwo", utils::Parallel::getProcessRank() - 2, 2);
     slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshTwo");
+    int    meshID = interface.getMeshID("MeshTwo");
     double xCoord = -2.0 + utils::Parallel::getProcessRank();
-    interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord,0.0,0.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord, 0.0, 0.0).data());
     interface.initialize();
-    BOOST_TEST(interface.getMeshHandle("MeshTwo").vertices().size()==1);
+    BOOST_TEST(interface.getMeshHandle("MeshTwo").vertices().size() == 1);
     interface.finalize();
   }
 }
 
 #ifndef PRECICE_NO_PETSC
-BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "globalRBFPartitioning.xml";
 
-  if(utils::Parallel::getProcessRank()<=2){
-    utils::Parallel::splitCommunicator( "SolverOne" );
+  if (utils::Parallel::getProcessRank() <= 2) {
+    utils::Parallel::splitCommunicator("SolverOne");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator()); //needed since this test uses PETSc
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
+    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3);
     slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
-    int vertexIDs[2];
-    double xCoord = utils::Parallel::getProcessRank() * 0.4;
-    double positions[4] = {xCoord,0.0,xCoord+0.2,0.0};
+    int    vertexIDs[2];
+    double xCoord       = utils::Parallel::getProcessRank() * 0.4;
+    double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
     interface.initialize();
     double values[2];
     interface.advance(1.0);
     interface.readBlockScalarData(dataID, 2, vertexIDs, values);
-//    std::cout << utils::Parallel::getProcessRank() <<": " << values << '\n';
+    //    std::cout << utils::Parallel::getProcessRank() <<": " << values << '\n';
     interface.finalize();
-  }
-  else {
-    utils::Parallel::splitCommunicator( "SolverTwo" );
+  } else {
+    utils::Parallel::splitCommunicator("SolverTwo");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverTwo", 0, 1 );
+    SolverInterface interface("SolverTwo", 0, 1);
     slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshTwo");
-    int vertexIDs[6];
-    double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
+    int    meshID = interface.getMeshID("MeshTwo");
+    int    vertexIDs[6];
+    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
-    int dataID = interface.getDataID("Data2", meshID);
-    double values[6] = {1.0,2.0,3.0,4.0,5.0,6.0};
+    int    dataID    = interface.getDataID("Data2", meshID);
+    double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
     interface.writeBlockScalarData(dataID, 6, vertexIDs, values);
     interface.advance(1.0);
     interface.finalize();
   }
 }
 
-BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "localRBFPartitioning.xml";
 
-  if(utils::Parallel::getProcessRank()<=2){
-    utils::Parallel::splitCommunicator( "SolverOne" );
+  if (utils::Parallel::getProcessRank() <= 2) {
+    utils::Parallel::splitCommunicator("SolverOne");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3 );
+    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3);
     slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
     int dataID = interface.getDataID("Data2", meshID);
 
-    int vertexIDs[2];
-    double xCoord = utils::Parallel::getProcessRank() * 0.4;
-    double positions[4] = {xCoord,0.0,xCoord+0.2,0.0};
+    int    vertexIDs[2];
+    double xCoord       = utils::Parallel::getProcessRank() * 0.4;
+    double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
     interface.initialize();
     double values[2];
     interface.advance(1.0);
     interface.readBlockScalarData(dataID, 2, vertexIDs, values);
     interface.finalize();
-  }
-  else {
-    utils::Parallel::splitCommunicator( "SolverTwo" );
+  } else {
+    utils::Parallel::splitCommunicator("SolverTwo");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverTwo", 0, 1 );
+    SolverInterface interface("SolverTwo", 0, 1);
     slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshTwo");
-    int vertexIDs[6];
-    double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
+    int    meshID = interface.getMeshID("MeshTwo");
+    int    vertexIDs[6];
+    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
-    int dataID = interface.getDataID("Data2", meshID);
-    double values[6] = {1.0,2.0,3.0,4.0,5.0,6.0};
+    int    dataID    = interface.getDataID("Data2", meshID);
+    double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
     interface.writeBlockScalarData(dataID, 6, vertexIDs, values);
     interface.advance(1.0);
     interface.finalize();
@@ -197,23 +187,23 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, * testing::OnSize(4))
 #endif // PRECICE_NO_PETSC
 
 /// This testcase is based on a bug reported by Thorsten for acoustic FASTEST-Ateles coupling
-BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(CouplingOnLine, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "line-coupling.xml";
 
-  if(utils::Parallel::getProcessRank()<=2){
-    utils::Parallel::splitCommunicator( "Ateles" );
+  if (utils::Parallel::getProcessRank() <= 2) {
+    utils::Parallel::splitCommunicator("Ateles");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    SolverInterface interface ( "Ateles", utils::Parallel::getProcessRank(), 3 );
+    SolverInterface interface("Ateles", utils::Parallel::getProcessRank(), 3);
     slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("Ateles_Mesh");
 
-    int vertexIDs[4];
-    double offset = utils::Parallel::getProcessRank() * 0.4;
-    double xCoord = 0.0;
-    double yCoord = 1.0;
+    int    vertexIDs[4];
+    double offset        = utils::Parallel::getProcessRank() * 0.4;
+    double xCoord        = 0.0;
+    double yCoord        = 1.0;
     double positions[12] = {xCoord, yCoord, 0.1 + offset,
                             xCoord, yCoord, 0.2 + offset,
                             xCoord, yCoord, 0.3 + offset,
@@ -222,18 +212,17 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
     interface.initialize();
     interface.advance(1.0);
     interface.finalize();
-  }
-  else {
-    utils::Parallel::splitCommunicator( "FASTEST" );
+  } else {
+    utils::Parallel::splitCommunicator("FASTEST");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    SolverInterface interface ( "FASTEST", 0, 1 );
+    SolverInterface interface("FASTEST", 0, 1);
     slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("FASTEST_Mesh");
-    int vertexIDs[10];
-    double xCoord = -0.0001;
-    double yCoord = 1.00001;
+    int    meshID = interface.getMeshID("FASTEST_Mesh");
+    int    vertexIDs[10];
+    double xCoord        = -0.0001;
+    double yCoord        = 1.00001;
     double positions[30] = {xCoord, yCoord, 0.12,
                             xCoord, yCoord, 0.24,
                             xCoord, yCoord, 0.36,
@@ -251,11 +240,10 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, * testing::OnSize(4))
   }
 }
 
-
 /// tests for various QN settings if correct number of iterations is returned
-BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(TestQN, *testing::OnSize(4))
 {
-  int numberOfTests = 3;
+  int                      numberOfTests = 3;
   std::vector<std::string> configs;
   configs.resize(numberOfTests);
   configs[0] = _pathToTests + "QN1.xml";
@@ -265,77 +253,72 @@ BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
   int correctIterations[3] = {29, 17, 15};
 
   std::string solverName, meshName, writeDataName, readDataName;
-  int rank, size;
+  int         rank, size;
 
-  if(utils::Parallel::getProcessRank()==0){
-    solverName = "SolverOne";
-    meshName = "MeshOne";
+  if (utils::Parallel::getProcessRank() == 0) {
+    solverName    = "SolverOne";
+    meshName      = "MeshOne";
     writeDataName = "Data1";
-    readDataName = "Data2";
-    rank = 0;
-    size = 1;
-  }
-  else {
-    solverName = "SolverTwo";
-    meshName = "MeshTwo";
+    readDataName  = "Data2";
+    rank          = 0;
+    size          = 1;
+  } else {
+    solverName    = "SolverTwo";
+    meshName      = "MeshTwo";
     writeDataName = "Data2";
-    readDataName = "Data1";
-    rank = utils::Parallel::getProcessRank() - 1;
-    size = 3;
+    readDataName  = "Data1";
+    rank          = utils::Parallel::getProcessRank() - 1;
+    size          = 3;
   }
 
-  utils::Parallel::splitCommunicator( solverName );
+  utils::Parallel::splitCommunicator(solverName);
   utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == size);
   utils::Parallel::clearGroups();
 
-  for(int k=0; k<numberOfTests; k++){
+  for (int k = 0; k < numberOfTests; k++) {
     reset();
 
-    SolverInterface interface ( solverName, rank, size );
+    SolverInterface interface(solverName, rank, size);
     slimConfigure(interface, configs[k]);
-    int meshID = interface.getMeshID(meshName);
+    int meshID      = interface.getMeshID(meshName);
     int writeDataID = interface.getDataID(writeDataName, meshID);
-    int readDataID = interface.getDataID(readDataName, meshID);
+    int readDataID  = interface.getDataID(readDataName, meshID);
 
     int vertexIDs[4];
 
-    if(utils::Parallel::getProcessRank()==0){
+    if (utils::Parallel::getProcessRank() == 0) {
       double positions[8] = {2.0, 0.0, 2.0, 0.5, 2.0, 1.0, 2.5, 1.0};
       interface.setMeshVertices(meshID, 4, positions, vertexIDs);
-    }
-    else if(utils::Parallel::getProcessRank()==1){
+    } else if (utils::Parallel::getProcessRank() == 1) {
       double positions[8] = {2.0, 0.1, 2.0, 0.25, 2.0, 0.4, 2.0, 0.5};
       interface.setMeshVertices(meshID, 4, positions, vertexIDs);
-    }
-    else if(utils::Parallel::getProcessRank()==2){
+    } else if (utils::Parallel::getProcessRank() == 2) {
       double positions[8] = {2.0, 0.6, 2.0, 0.75, 2.0, 0.9, 2.0, 1.0};
       interface.setMeshVertices(meshID, 4, positions, vertexIDs);
-    }
-    else if(utils::Parallel::getProcessRank()==3){
+    } else if (utils::Parallel::getProcessRank() == 3) {
       double positions[8] = {2.1, 1.0, 2.25, 1.0, 2.4, 1.0, 2.5, 1.0};
       interface.setMeshVertices(meshID, 4, positions, vertexIDs);
     }
 
     interface.initialize();
-    double inValues[4] = {0.0, 0.0, 0.0, 0.0};
+    double inValues[4]  = {0.0, 0.0, 0.0, 0.0};
     double outValues[4] = {0.0, 0.0, 0.0, 0.0};
 
     int iterations = 0;
 
-    while(interface.isCouplingOngoing()){
-      if(interface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())){
+    while (interface.isCouplingOngoing()) {
+      if (interface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
         interface.fulfilledAction(precice::constants::actionWriteIterationCheckpoint());
       }
 
-      if(utils::Parallel::getProcessRank()==0){
-        for(int i=0; i<4; i++){
-          outValues[i] = inValues[i]*inValues[i] - 30.0;
+      if (utils::Parallel::getProcessRank() == 0) {
+        for (int i = 0; i < 4; i++) {
+          outValues[i] = inValues[i] * inValues[i] - 30.0;
         }
-      }
-      else {
-        for(int i=0; i<4; i++){
-          outValues[i] = inValues[(i+1)%4]*inValues[(i+2)%4] - 2.0;
+      } else {
+        for (int i = 0; i < 4; i++) {
+          outValues[i] = inValues[(i + 1) % 4] * inValues[(i + 2) % 4] - 2.0;
         }
       }
 
@@ -343,7 +326,7 @@ BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
       interface.advance(1.0);
       interface.readBlockScalarData(readDataID, 4, vertexIDs, inValues);
 
-      if(interface.isActionRequired(precice::constants::actionReadIterationCheckpoint())){
+      if (interface.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
         interface.fulfilledAction(precice::constants::actionReadIterationCheckpoint());
         iterations++;
       }
@@ -357,20 +340,19 @@ BOOST_AUTO_TEST_CASE(TestQN, * testing::OnSize(4))
 
 // This test does not restrict the communicator per participant, since otherwise MPI ports do not work for Open-MPI
 /// Tests various distributed communication schemes.
-BOOST_AUTO_TEST_CASE(testDistributedCommunications, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(testDistributedCommunications, *testing::OnSize(4))
 {
-  std::vector<std::string> fileNames({
-      "point-to-point-sockets.xml",
-      "point-to-point-mpi.xml",
-      "gather-scatter-mpi.xml"});
+  std::vector<std::string> fileNames({"point-to-point-sockets.xml",
+                                      "point-to-point-mpi.xml",
+                                      "gather-scatter-mpi.xml"});
 
   for (auto fileName : fileNames) {
     reset();
 
     std::string solverName;
-    int rank = -1, size = -1;
+    int         rank = -1, size = -1;
     std::string meshName;
-    int i1 = -1 ,i2 = -1; //indices for data and positions
+    int         i1 = -1, i2 = -1; //indices for data and positions
 
     std::vector<Eigen::VectorXd> positions;
     std::vector<Eigen::VectorXd> data;
@@ -379,88 +361,84 @@ BOOST_AUTO_TEST_CASE(testDistributedCommunications, * testing::OnSize(4))
     Eigen::Vector3d position;
     Eigen::Vector3d datum;
 
-    for( int i=0; i<4; i++){
-      position[0] = i*1.0;
+    for (int i = 0; i < 4; i++) {
+      position[0] = i * 1.0;
       position[1] = 0.0;
       position[2] = 0.0;
       positions.push_back(position);
-      datum[0] = i*1.0;
-      datum[1] = i*1.0;
+      datum[0] = i * 1.0;
+      datum[1] = i * 1.0;
       datum[2] = 0.0;
       data.push_back(datum);
-      datum[0] = i*2.0+1.0;
-      datum[1] = i*2.0+1.0;
+      datum[0] = i * 2.0 + 1.0;
+      datum[1] = i * 2.0 + 1.0;
       datum[2] = 1.0;
       expectedData.push_back(datum);
     }
 
-    if (utils::Parallel::getProcessRank() == 0){
+    if (utils::Parallel::getProcessRank() == 0) {
       solverName = "Fluid";
-      rank = 0;
-      size = 2;
-      meshName = "FluidMesh";
-      i1 = 0;
-      i2 = 2;
-    }
-    else if(utils::Parallel::getProcessRank() == 1){
+      rank       = 0;
+      size       = 2;
+      meshName   = "FluidMesh";
+      i1         = 0;
+      i2         = 2;
+    } else if (utils::Parallel::getProcessRank() == 1) {
       solverName = "Fluid";
-      rank = 1;
-      size = 2;
-      meshName = "FluidMesh";
-      i1 = 2;
-      i2 = 4;
-    }
-    else if(utils::Parallel::getProcessRank() == 2){
+      rank       = 1;
+      size       = 2;
+      meshName   = "FluidMesh";
+      i1         = 2;
+      i2         = 4;
+    } else if (utils::Parallel::getProcessRank() == 2) {
       solverName = "Structure";
-      rank = 0;
-      size = 2;
-      meshName = "StructureMesh";
-      i1 = 0;
-      i2 = 1;
-    }
-    else if(utils::Parallel::getProcessRank() == 3){
+      rank       = 0;
+      size       = 2;
+      meshName   = "StructureMesh";
+      i1         = 0;
+      i2         = 1;
+    } else if (utils::Parallel::getProcessRank() == 3) {
       solverName = "Structure";
-      rank = 1;
-      size = 2;
-      meshName = "StructureMesh";
-      i1 = 1;
-      i2 = 4;
+      rank       = 1;
+      size       = 2;
+      meshName   = "StructureMesh";
+      i1         = 1;
+      i2         = 4;
     }
 
     SolverInterface precice(solverName, rank, size);
     slimConfigure(precice, _pathToTests + fileName);
-    int meshID = precice.getMeshID(meshName);
+    int meshID   = precice.getMeshID(meshName);
     int forcesID = precice.getDataID("Forces", meshID);
-    int velocID = precice.getDataID("Velocities", meshID);
+    int velocID  = precice.getDataID("Velocities", meshID);
 
     std::vector<int> vertexIDs;
-    for(int i=i1; i<i2; i++){
+    for (int i = i1; i < i2; i++) {
       int vertexID = precice.setMeshVertex(meshID, positions[i].data());
       vertexIDs.push_back(vertexID);
     }
 
     precice.initialize();
 
-    if (utils::Parallel::getProcessRank() <= 1){ //Fluid
-      for( size_t i=0; i<vertexIDs.size(); i++){
-        precice.writeVectorData(forcesID, vertexIDs[i], data[i+i1].data());
+    if (utils::Parallel::getProcessRank() <= 1) { //Fluid
+      for (size_t i = 0; i < vertexIDs.size(); i++) {
+        precice.writeVectorData(forcesID, vertexIDs[i], data[i + i1].data());
       }
-    }
-    else if (utils::Parallel::getProcessRank() >= 2){ //Structure
-      for( size_t i=0; i<vertexIDs.size(); i++){
+    } else if (utils::Parallel::getProcessRank() >= 2) { //Structure
+      for (size_t i = 0; i < vertexIDs.size(); i++) {
         precice.readVectorData(forcesID, vertexIDs[i], data[i].data());
-        data[i] = (data[i]*2).array() + 1.0;
+        data[i] = (data[i] * 2).array() + 1.0;
         precice.writeVectorData(velocID, vertexIDs[i], data[i].data());
       }
     }
 
     precice.advance(1.0);
 
-    if (utils::Parallel::getProcessRank() <= 1){ //Fluid
-      for( size_t i=0; i<vertexIDs.size(); i++){
-        precice.readVectorData(velocID, vertexIDs[i], data[i+i1].data());
-        for (size_t d=0; d<3; d++){
-          BOOST_TEST(expectedData[i+i1][d] == data[i+i1][d]);
+    if (utils::Parallel::getProcessRank() <= 1) { //Fluid
+      for (size_t i = 0; i < vertexIDs.size(); i++) {
+        precice.readVectorData(velocID, vertexIDs[i], data[i + i1].data());
+        for (size_t d = 0; d < 3; d++) {
+          BOOST_TEST(expectedData[i + i1][d] == data[i + i1][d]);
         }
       }
     }
@@ -470,174 +448,173 @@ BOOST_AUTO_TEST_CASE(testDistributedCommunications, * testing::OnSize(4))
 }
 
 /// This testcase is based on a bug documented in issue #371
-BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "np-repartitioning.xml";
 
-  if(utils::Parallel::getProcessRank()<=2){
-    utils::Parallel::splitCommunicator( "FluidSolver" );
+  if (utils::Parallel::getProcessRank() <= 2) {
+    utils::Parallel::splitCommunicator("FluidSolver");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    SolverInterface interface ( "FluidSolver", utils::Parallel::getProcessRank(), 3 );
+    SolverInterface interface("FluidSolver", utils::Parallel::getProcessRank(), 3);
     slimConfigure(interface, configFilename);
 
-    if(utils::Parallel::getProcessRank()==1) {
+    if (utils::Parallel::getProcessRank() == 1) {
 
-      const int meshID = interface.getMeshID("CellCenters");
+      const int meshID     = interface.getMeshID("CellCenters");
       const int dimensions = 3;
-      BOOST_TEST(interface.getDimensions()==dimensions);
+      BOOST_TEST(interface.getDimensions() == dimensions);
 
-      const int numberOfVertices = 65;
-      const double yCoord = 0.0;
-      const double zCoord = 0.005;
+      const int                 numberOfVertices = 65;
+      const double              yCoord           = 0.0;
+      const double              zCoord           = 0.005;
       const std::vector<double> positions{
-                                         0.00124795, yCoord, zCoord,
-                                         0.00375646, yCoord, zCoord,
-                                         0.00629033, yCoord, zCoord,
-                                         0.00884982, yCoord, zCoord,
-                                         0.0114352, yCoord, zCoord,
-                                         0.0140467, yCoord, zCoord,
-                                         0.0166846, yCoord, zCoord,
-                                         0.0193492, yCoord, zCoord,
-                                         0.0220407, yCoord, zCoord,
-                                         0.0247594, yCoord, zCoord,
-                                         0.0275056, yCoord, zCoord,
-                                         0.0302796, yCoord, zCoord,
-                                         0.0330816, yCoord, zCoord,
-                                         0.0359119, yCoord, zCoord,
-                                         0.0387709, yCoord, zCoord,
-                                         0.0416588, yCoord, zCoord,
-                                         0.0445758, yCoord, zCoord,
-                                         0.0475224, yCoord, zCoord,
-                                         0.0504987, yCoord, zCoord,
-                                         0.0535051, yCoord, zCoord,
-                                         0.0565419, yCoord, zCoord,
-                                         0.0596095, yCoord, zCoord,
-                                         0.062708, yCoord, zCoord,
-                                         0.0658378, yCoord, zCoord,
-                                         0.0689993, yCoord, zCoord,
-                                         0.0721928, yCoord, zCoord,
-                                         0.0754186, yCoord, zCoord,
-                                         0.0786769, yCoord, zCoord,
-                                         0.0819682, yCoord, zCoord,
-                                         0.0852928, yCoord, zCoord,
-                                         0.088651, yCoord, zCoord,
-                                         0.0920431, yCoord, zCoord,
-                                         0.0954695, yCoord, zCoord,
-                                         0.0989306, yCoord, zCoord,
-                                         0.102427, yCoord, zCoord,
-                                         0.105958, yCoord, zCoord,
-                                         0.109525, yCoord, zCoord,
-                                         0.113128, yCoord, zCoord,
-                                         0.116768, yCoord, zCoord,
-                                         0.120444, yCoord, zCoord,
-                                         0.124158, yCoord, zCoord,
-                                         0.127909, yCoord, zCoord,
-                                         0.131698, yCoord, zCoord,
-                                         0.135525, yCoord, zCoord,
-                                         0.139391, yCoord, zCoord,
-                                         0.143296, yCoord, zCoord,
-                                         0.147241, yCoord, zCoord,
-                                         0.151226, yCoord, zCoord,
-                                         0.15525, yCoord, zCoord,
-                                         0.159316, yCoord, zCoord,
-                                         0.163422, yCoord, zCoord,
-                                         0.16757, yCoord, zCoord,
-                                         0.17176, yCoord, zCoord,
-                                         0.175993, yCoord, zCoord,
-                                         0.180268, yCoord, zCoord,
-                                         0.184586, yCoord, zCoord,
-                                         0.188948, yCoord, zCoord,
-                                         0.193354, yCoord, zCoord,
-                                         0.197805, yCoord, zCoord,
-                                         0.202301, yCoord, zCoord,
-                                         0.206842, yCoord, zCoord,
-                                         0.211429, yCoord, zCoord,
-                                         0.216062, yCoord, zCoord,
-                                         0.220742, yCoord, zCoord,
-                                         0.22547, yCoord, zCoord};
-      BOOST_TEST(numberOfVertices*dimensions == positions.size());
+          0.00124795, yCoord, zCoord,
+          0.00375646, yCoord, zCoord,
+          0.00629033, yCoord, zCoord,
+          0.00884982, yCoord, zCoord,
+          0.0114352, yCoord, zCoord,
+          0.0140467, yCoord, zCoord,
+          0.0166846, yCoord, zCoord,
+          0.0193492, yCoord, zCoord,
+          0.0220407, yCoord, zCoord,
+          0.0247594, yCoord, zCoord,
+          0.0275056, yCoord, zCoord,
+          0.0302796, yCoord, zCoord,
+          0.0330816, yCoord, zCoord,
+          0.0359119, yCoord, zCoord,
+          0.0387709, yCoord, zCoord,
+          0.0416588, yCoord, zCoord,
+          0.0445758, yCoord, zCoord,
+          0.0475224, yCoord, zCoord,
+          0.0504987, yCoord, zCoord,
+          0.0535051, yCoord, zCoord,
+          0.0565419, yCoord, zCoord,
+          0.0596095, yCoord, zCoord,
+          0.062708, yCoord, zCoord,
+          0.0658378, yCoord, zCoord,
+          0.0689993, yCoord, zCoord,
+          0.0721928, yCoord, zCoord,
+          0.0754186, yCoord, zCoord,
+          0.0786769, yCoord, zCoord,
+          0.0819682, yCoord, zCoord,
+          0.0852928, yCoord, zCoord,
+          0.088651, yCoord, zCoord,
+          0.0920431, yCoord, zCoord,
+          0.0954695, yCoord, zCoord,
+          0.0989306, yCoord, zCoord,
+          0.102427, yCoord, zCoord,
+          0.105958, yCoord, zCoord,
+          0.109525, yCoord, zCoord,
+          0.113128, yCoord, zCoord,
+          0.116768, yCoord, zCoord,
+          0.120444, yCoord, zCoord,
+          0.124158, yCoord, zCoord,
+          0.127909, yCoord, zCoord,
+          0.131698, yCoord, zCoord,
+          0.135525, yCoord, zCoord,
+          0.139391, yCoord, zCoord,
+          0.143296, yCoord, zCoord,
+          0.147241, yCoord, zCoord,
+          0.151226, yCoord, zCoord,
+          0.15525, yCoord, zCoord,
+          0.159316, yCoord, zCoord,
+          0.163422, yCoord, zCoord,
+          0.16757, yCoord, zCoord,
+          0.17176, yCoord, zCoord,
+          0.175993, yCoord, zCoord,
+          0.180268, yCoord, zCoord,
+          0.184586, yCoord, zCoord,
+          0.188948, yCoord, zCoord,
+          0.193354, yCoord, zCoord,
+          0.197805, yCoord, zCoord,
+          0.202301, yCoord, zCoord,
+          0.206842, yCoord, zCoord,
+          0.211429, yCoord, zCoord,
+          0.216062, yCoord, zCoord,
+          0.220742, yCoord, zCoord,
+          0.22547, yCoord, zCoord};
+      BOOST_TEST(numberOfVertices * dimensions == positions.size());
       std::vector<int> vertexIDs(numberOfVertices);
       interface.setMeshVertices(meshID, numberOfVertices, positions.data(), vertexIDs.data());
       interface.initialize();
-      BOOST_TEST(impl(interface).getMeshHandle("Nodes").triangles().size()==15);
+      BOOST_TEST(impl(interface).getMeshHandle("Nodes").triangles().size() == 15);
       interface.advance(1.0);
       interface.finalize();
     } else {
-        interface.initialize();
-        interface.advance(1.0);
-        interface.finalize();
+      interface.initialize();
+      interface.advance(1.0);
+      interface.finalize();
     }
-  }
-  else {
-    utils::Parallel::splitCommunicator( "SolidSolver" );
+  } else {
+    utils::Parallel::splitCommunicator("SolidSolver");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    SolverInterface interface ( "SolidSolver", 0, 1 );
+    SolverInterface interface("SolidSolver", 0, 1);
     slimConfigure(interface, configFilename);
-    const int meshID = interface.getMeshID("Nodes");
+    const int meshID     = interface.getMeshID("Nodes");
     const int dimensions = 3;
-    BOOST_TEST(interface.getDimensions()==dimensions);
-    const int numberOfVertices = 34;
-    const double yCoord = 0.0;
-    const double zCoord1 = 0.0;
-    const double zCoord2 = 0.01;
+    BOOST_TEST(interface.getDimensions() == dimensions);
+    const int                 numberOfVertices = 34;
+    const double              yCoord           = 0.0;
+    const double              zCoord1          = 0.0;
+    const double              zCoord2          = 0.01;
     const std::vector<double> positions{
-                                      0.0, yCoord, zCoord2,
-                                      0.0, yCoord, zCoord1,
-                                      0.03125, yCoord, zCoord2,
-                                      0.03125, yCoord, zCoord1,
-                                      0.0625, yCoord, zCoord2,
-                                      0.0625, yCoord, zCoord1,
-                                      0.09375, yCoord, zCoord2,
-                                      0.09375, yCoord, zCoord1,
-                                      0.125, yCoord, zCoord2,
-                                      0.125, yCoord, zCoord1,
-                                      0.15625, yCoord, zCoord2,
-                                      0.15625, yCoord, zCoord1,
-                                      0.1875, yCoord, zCoord2,
-                                      0.1875, yCoord, zCoord1,
-                                      0.21875, yCoord, zCoord2,
-                                      0.21875, yCoord, zCoord1,
-                                      0.25, yCoord, zCoord2,
-                                      0.25, yCoord, zCoord1,
-                                      0.28125, yCoord, zCoord2,
-                                      0.28125, yCoord, zCoord1,
-                                      0.3125, yCoord, zCoord2,
-                                      0.3125, yCoord, zCoord1,
-                                      0.34375, yCoord, zCoord2,
-                                      0.34375, yCoord, zCoord1,
-                                      0.375, yCoord, zCoord2,
-                                      0.375, yCoord, zCoord1,
-                                      0.40625, yCoord, zCoord2,
-                                      0.40625, yCoord, zCoord1,
-                                      0.4375, yCoord, zCoord2,
-                                      0.4375, yCoord, zCoord1,
-                                      0.46875, yCoord, zCoord2,
-                                      0.46875, yCoord, zCoord1,
-                                      0.5, yCoord, zCoord2,
-                                      0.5, yCoord, zCoord1};
-    BOOST_TEST(numberOfVertices*dimensions == positions.size());
+        0.0, yCoord, zCoord2,
+        0.0, yCoord, zCoord1,
+        0.03125, yCoord, zCoord2,
+        0.03125, yCoord, zCoord1,
+        0.0625, yCoord, zCoord2,
+        0.0625, yCoord, zCoord1,
+        0.09375, yCoord, zCoord2,
+        0.09375, yCoord, zCoord1,
+        0.125, yCoord, zCoord2,
+        0.125, yCoord, zCoord1,
+        0.15625, yCoord, zCoord2,
+        0.15625, yCoord, zCoord1,
+        0.1875, yCoord, zCoord2,
+        0.1875, yCoord, zCoord1,
+        0.21875, yCoord, zCoord2,
+        0.21875, yCoord, zCoord1,
+        0.25, yCoord, zCoord2,
+        0.25, yCoord, zCoord1,
+        0.28125, yCoord, zCoord2,
+        0.28125, yCoord, zCoord1,
+        0.3125, yCoord, zCoord2,
+        0.3125, yCoord, zCoord1,
+        0.34375, yCoord, zCoord2,
+        0.34375, yCoord, zCoord1,
+        0.375, yCoord, zCoord2,
+        0.375, yCoord, zCoord1,
+        0.40625, yCoord, zCoord2,
+        0.40625, yCoord, zCoord1,
+        0.4375, yCoord, zCoord2,
+        0.4375, yCoord, zCoord1,
+        0.46875, yCoord, zCoord2,
+        0.46875, yCoord, zCoord1,
+        0.5, yCoord, zCoord2,
+        0.5, yCoord, zCoord1};
+    BOOST_TEST(numberOfVertices * dimensions == positions.size());
     std::vector<int> vertexIDs(numberOfVertices);
     interface.setMeshVertices(meshID, numberOfVertices, positions.data(), vertexIDs.data());
 
-    const int numberOfCells = numberOfVertices / 2 - 1;
-    const int numberOfEdges = numberOfCells * 4 + 1;
+    const int        numberOfCells = numberOfVertices / 2 - 1;
+    const int        numberOfEdges = numberOfCells * 4 + 1;
     std::vector<int> edgeIDs(numberOfEdges);
 
-    for( int i = 0; i < numberOfCells; i++){
-      edgeIDs.at(4*i)   = interface.setMeshEdge(meshID, vertexIDs.at(i*2),   vertexIDs.at(i*2+1)); //left
-      edgeIDs.at(4*i+1) = interface.setMeshEdge(meshID, vertexIDs.at(i*2),   vertexIDs.at(i*2+2)); //top
-      edgeIDs.at(4*i+2) = interface.setMeshEdge(meshID, vertexIDs.at(i*2+1), vertexIDs.at(i*2+3)); //bottom
-      edgeIDs.at(4*i+3) = interface.setMeshEdge(meshID, vertexIDs.at(i*2),   vertexIDs.at(i*2+3)); //diagonal
+    for (int i = 0; i < numberOfCells; i++) {
+      edgeIDs.at(4 * i)     = interface.setMeshEdge(meshID, vertexIDs.at(i * 2), vertexIDs.at(i * 2 + 1));     //left
+      edgeIDs.at(4 * i + 1) = interface.setMeshEdge(meshID, vertexIDs.at(i * 2), vertexIDs.at(i * 2 + 2));     //top
+      edgeIDs.at(4 * i + 2) = interface.setMeshEdge(meshID, vertexIDs.at(i * 2 + 1), vertexIDs.at(i * 2 + 3)); //bottom
+      edgeIDs.at(4 * i + 3) = interface.setMeshEdge(meshID, vertexIDs.at(i * 2), vertexIDs.at(i * 2 + 3));     //diagonal
     }
-    edgeIDs.at(numberOfEdges-1) = interface.setMeshEdge(meshID, vertexIDs.at(numberOfVertices-2), vertexIDs.at(numberOfVertices-1)); //very right
+    edgeIDs.at(numberOfEdges - 1) = interface.setMeshEdge(meshID, vertexIDs.at(numberOfVertices - 2), vertexIDs.at(numberOfVertices - 1)); //very right
 
-    for( int i = 0; i < numberOfCells; i++){
-      interface.setMeshTriangle(meshID, edgeIDs.at(4*i),   edgeIDs.at(4*i+3), edgeIDs.at(4*i+2)); //left-diag-bottom
-      interface.setMeshTriangle(meshID, edgeIDs.at(4*i+1), edgeIDs.at(4*i+3), edgeIDs.at(4*i+4)); //top-diag-right
+    for (int i = 0; i < numberOfCells; i++) {
+      interface.setMeshTriangle(meshID, edgeIDs.at(4 * i), edgeIDs.at(4 * i + 3), edgeIDs.at(4 * i + 2));     //left-diag-bottom
+      interface.setMeshTriangle(meshID, edgeIDs.at(4 * i + 1), edgeIDs.at(4 * i + 3), edgeIDs.at(4 * i + 4)); //top-diag-right
     }
 
     interface.initialize();
@@ -646,26 +623,25 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, * testing::OnSize(4))
   }
 }
 
-BOOST_AUTO_TEST_CASE(MasterSockets, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(MasterSockets, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "master-sockets.xml";
   std::string myName, myMeshName;
-  int myRank, mySize;
-  if(utils::Parallel::getProcessRank()<=2){
-    myName = "ParallelSolver";
-    myRank = utils::Parallel::getProcessRank();
-    mySize = 3;
+  int         myRank, mySize;
+  if (utils::Parallel::getProcessRank() <= 2) {
+    myName     = "ParallelSolver";
+    myRank     = utils::Parallel::getProcessRank();
+    mySize     = 3;
     myMeshName = "ParallelMesh";
-  }
-  else{
-    myName = "SerialSolver";
-    myRank = 0;
-    mySize = 1;
+  } else {
+    myName     = "SerialSolver";
+    myRank     = 0;
+    mySize     = 1;
     myMeshName = "SerialMesh";
   }
   SolverInterface interface(myName, myRank, mySize);
   slimConfigure(interface, configFilename);
-  int meshID = interface.getMeshID(myMeshName);
+  int    meshID      = interface.getMeshID(myMeshName);
   double position[2] = {0, 0};
   interface.setMeshVertex(meshID, position);
   interface.initialize();
@@ -674,40 +650,39 @@ BOOST_AUTO_TEST_CASE(MasterSockets, * testing::OnSize(4))
 }
 
 // Tests SolverInterface() with a user-defined MPI communicator.
-BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "userDefinedMPICommunicator.xml";
-  
-  if(utils::Parallel::getProcessRank()<=2){
-    utils::Parallel::splitCommunicator( "SolverOne" );
+
+  if (utils::Parallel::getProcessRank() <= 2) {
+    utils::Parallel::splitCommunicator("SolverOne");
     MPI_Comm myComm = utils::Parallel::getLocalCommunicator();
-    int myCommSize;
+    int      myCommSize;
     MPI_Comm_size(myComm, &myCommSize);
     BOOST_TEST(myCommSize == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3, &myComm );
+    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3, &myComm);
     slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
 
-    int vertexIDs[2];
-    double xCoord = utils::Parallel::getProcessRank() * 0.4;
-    double positions[4] = {xCoord,0.0,xCoord+0.2,0.0};
+    int    vertexIDs[2];
+    double xCoord       = utils::Parallel::getProcessRank() * 0.4;
+    double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
-  }
-  else {
-    utils::Parallel::splitCommunicator( "SolverTwo" );
+  } else {
+    utils::Parallel::splitCommunicator("SolverTwo");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverTwo", 0, 1 );
+    SolverInterface interface("SolverTwo", 0, 1);
     slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshTwo");
-    int vertexIDs[6];
-    double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
+    int    meshID = interface.getMeshID("MeshTwo");
+    int    vertexIDs[6];
+    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
@@ -717,41 +692,40 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, * testing::OnSize(4))
 #ifndef PRECICE_NO_PETSC
 // Tests SolverInterface() with a user-defined MPI communicator.
 // Since PETSc also uses MPI, we use petrbf mapping here.
-BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, *testing::OnSize(4))
 {
-  std::string configFilename = _pathToTests + "userDefinedMPICommunicatorPetRBF.xml";
+  std::string           configFilename = _pathToTests + "userDefinedMPICommunicatorPetRBF.xml";
   config::Configuration config;
-  
-  if(utils::Parallel::getProcessRank()<=2){
-    utils::Parallel::splitCommunicator( "SolverOne" );
+
+  if (utils::Parallel::getProcessRank() <= 2) {
+    utils::Parallel::splitCommunicator("SolverOne");
     MPI_Comm myComm = utils::Parallel::getLocalCommunicator();
-    int myCommSize;
+    int      myCommSize;
     MPI_Comm_size(myComm, &myCommSize);
     BOOST_TEST(myCommSize == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverOne", utils::Parallel::getProcessRank(), 3, &myComm );
+    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3, &myComm);
     slimConfigure(interface, configFilename);
     int meshID = interface.getMeshID("MeshOne");
 
-    int vertexIDs[2];
-    double xCoord = utils::Parallel::getProcessRank() * 0.4;
-    double positions[4] = {xCoord,0.0,xCoord+0.2,0.0};
+    int    vertexIDs[2];
+    double xCoord       = utils::Parallel::getProcessRank() * 0.4;
+    double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
-  }
-  else {
-    utils::Parallel::splitCommunicator( "SolverTwo" );
+  } else {
+    utils::Parallel::splitCommunicator("SolverTwo");
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface ( "SolverTwo", 0, 1 );
+    SolverInterface interface("SolverTwo", 0, 1);
     slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshTwo");
-    int vertexIDs[6];
-    double positions[12] = {0.0,0.0,0.2,0.0,0.4,0.0,0.6,0.0,0.8,0.0,1.0,0.0};
+    int    meshID = interface.getMeshID("MeshTwo");
+    int    vertexIDs[6];
+    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
     interface.finalize();

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -1,28 +1,27 @@
 #ifndef PRECICE_NO_MPI
 #include "testing/Testing.hpp"
 
-#include "precice/impl/SolverInterfaceImpl.hpp"
-#include "precice/impl/Participant.hpp"
-#include "precice/impl/MeshContext.hpp"
-#include "precice/impl/DataContext.hpp"
 #include "precice/SolverInterface.hpp"
-#include "utils/Parallel.hpp"
-#include "precice/impl/Participant.hpp"
 #include "precice/config/Configuration.hpp"
+#include "precice/impl/DataContext.hpp"
+#include "precice/impl/MeshContext.hpp"
+#include "precice/impl/Participant.hpp"
+#include "precice/impl/SolverInterfaceImpl.hpp"
 #include "utils/MasterSlave.hpp"
+#include "utils/Parallel.hpp"
 
 using namespace precice;
-
 
 struct SerialTestFixture : testing::SlimConfigurator {
 
   std::string _pathToTests;
 
-  void reset(){
-     mesh::Data::resetDataCount();
-     impl::Participant::resetParticipantCount();
-     utils::MasterSlave::reset();
-   }
+  void reset()
+  {
+    mesh::Data::resetDataCount();
+    impl::Participant::resetParticipantCount();
+    utils::MasterSlave::reset();
+  }
 
   SerialTestFixture()
   {
@@ -30,7 +29,6 @@ struct SerialTestFixture : testing::SlimConfigurator {
     reset();
   }
 };
-
 
 BOOST_AUTO_TEST_SUITE(PreciceTests)
 BOOST_FIXTURE_TEST_SUITE(Serial, SerialTestFixture)
@@ -40,7 +38,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
 {
   std::string filename = _pathToTests + "/configuration.xml";
   // Test configuration for accessor "Peano"
-  SolverInterface interfacePeano ("Peano", 0, 1);
+  SolverInterface interfacePeano("Peano", 0, 1);
   slimConfigure(interfacePeano, filename);
 
   BOOST_TEST(impl(interfacePeano)._participants.size() == 2);
@@ -51,7 +49,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   BOOST_TEST(peano->getName() == "Peano");
   BOOST_TEST(peano->getID() == 0);
 
-  std::vector<impl::MeshContext*> meshContexts = peano->_meshContexts;
+  std::vector<impl::MeshContext *> meshContexts = peano->_meshContexts;
   BOOST_TEST(meshContexts.size() == 2);
   BOOST_TEST(peano->_usedMeshContexts.size() == 2);
 
@@ -59,7 +57,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   BOOST_TEST(meshContexts[1]->mesh->getName() == std::string("ComsolNodes"));
 
   // Test configuration for accessor "Comsol"
-  SolverInterface interfaceComsol ("Comsol", 0, 1);
+  SolverInterface interfaceComsol("Comsol", 0, 1);
   slimConfigure(interfaceComsol, filename);
   BOOST_TEST(impl(interfaceComsol)._participants.size() == 2);
   BOOST_TEST(interfaceComsol.getDimensions() == 2);
@@ -67,19 +65,18 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   impl::PtrParticipant comsol = impl(interfaceComsol)._participants[1];
   BOOST_TEST(comsol);
   BOOST_TEST(comsol->getName() == "Comsol");
-  BOOST_TEST(comsol->getID()== 1);
+  BOOST_TEST(comsol->getID() == 1);
 
   meshContexts = comsol->_meshContexts;
   BOOST_TEST(meshContexts.size() == 2);
-  BOOST_TEST(meshContexts[0] == static_cast<void*>(nullptr));
+  BOOST_TEST(meshContexts[0] == static_cast<void *>(nullptr));
   BOOST_TEST(meshContexts[1]->mesh->getName() == std::string("ComsolNodes"));
   BOOST_TEST(comsol->_usedMeshContexts.size() == 1);
 }
 
 /// Test to run simple "do nothing" coupling between two solvers.
 BOOST_AUTO_TEST_CASE(TestExplicit,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
@@ -90,19 +87,18 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
   configs[1] = _pathToTests + "explicit-mpi.xml";
   configs[2] = _pathToTests + "explicit-sockets.xml";
 
-  for(std::string configurationFileName : configs){
+  for (std::string configurationFileName : configs) {
 
     reset();
 
     BOOST_TEST_MESSAGE("Config: " << configurationFileName);
 
     std::string solverName;
-    int timesteps = 0;
-    double time = 0.0;
-    if (utils::Parallel::getProcessRank() == 0){
+    int         timesteps = 0;
+    double      time      = 0.0;
+    if (utils::Parallel::getProcessRank() == 0) {
       solverName = "SolverOne";
-    }
-    else {
+    } else {
       BOOST_TEST(utils::Parallel::getProcessRank() == 1);
       solverName = "SolverTwo";
     }
@@ -111,23 +107,23 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
     slimConfigure(couplingInterface, configurationFileName);
 
     //was necessary to replace pre-defined geometries
-    if(solverName=="SolverOne" && couplingInterface.hasMesh("MeshOne")){
-     int meshID = couplingInterface.getMeshID("MeshOne");
-     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
-     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
+    if (solverName == "SolverOne" && couplingInterface.hasMesh("MeshOne")) {
+      int meshID = couplingInterface.getMeshID("MeshOne");
+      couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+      couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     }
-    if(solverName=="SolverTwo" && couplingInterface.hasMesh("Test-Square")){
-     int meshID = couplingInterface.getMeshID("Test-Square");
-     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
-     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
+    if (solverName == "SolverTwo" && couplingInterface.hasMesh("Test-Square")) {
+      int meshID = couplingInterface.getMeshID("Test-Square");
+      couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+      couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     }
 
     BOOST_TEST(couplingInterface.getDimensions() == 3);
     double dt = couplingInterface.initialize();
-    while (couplingInterface.isCouplingOngoing()){
-     time += dt;
-     dt = couplingInterface.advance(dt);
-     timesteps++;
+    while (couplingInterface.isCouplingOngoing()) {
+      time += dt;
+      dt = couplingInterface.advance(dt);
+      timesteps++;
     }
     couplingInterface.finalize();
 
@@ -138,52 +134,49 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
 
 /// Test to run a simple "do nothing" coupling with subcycling solvers.
 BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     SolverInterface precice("SolverOne", 0, 1);
     slimConfigure(precice, _pathToTests + "explicit-mpi-single.xml");
 
-    double maxDt = precice.initialize();
-    int timestep = 0;
-    double dt = maxDt / 2.0; // Timestep length desired by solver
-    double currentDt = dt;   // Timestep length used by solver
-    while (precice.isCouplingOngoing()){
-      maxDt = precice.advance(currentDt);
+    double maxDt     = precice.initialize();
+    int    timestep  = 0;
+    double dt        = maxDt / 2.0; // Timestep length desired by solver
+    double currentDt = dt;          // Timestep length used by solver
+    while (precice.isCouplingOngoing()) {
+      maxDt     = precice.advance(currentDt);
       currentDt = dt > maxDt ? maxDt : dt;
       timestep++;
     }
     precice.finalize();
     BOOST_TEST(timestep == 20);
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+  } else if (utils::Parallel::getProcessRank() == 1) {
     SolverInterface precice("SolverTwo", 0, 1);
     slimConfigure(precice, _pathToTests + "explicit-mpi-single.xml");
     int meshID = precice.getMeshID("Test-Square");
-    precice.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
-    precice.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
-    double maxDt = precice.initialize ();
-    int timestep = 0;
-    double dt = maxDt / 3.0; // Timestep length desired by solver
-    double currentDt = dt;   // Timestep length used by solver
-    while ( precice.isCouplingOngoing() ){
-      maxDt = precice.advance ( currentDt );
+    precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+    precice.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    double maxDt     = precice.initialize();
+    int    timestep  = 0;
+    double dt        = maxDt / 3.0; // Timestep length desired by solver
+    double currentDt = dt;          // Timestep length used by solver
+    while (precice.isCouplingOngoing()) {
+      maxDt     = precice.advance(currentDt);
       currentDt = dt > maxDt ? maxDt : dt;
       timestep++;
     }
     precice.finalize();
-    BOOST_TEST ( timestep == 30 );
+    BOOST_TEST(timestep == 30);
   }
 }
 
 /// One solver uses incremental position set, read/write methods.
 BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
@@ -191,13 +184,13 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
   double counter = 0.0;
   using Eigen::Vector3d;
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     SolverInterface cplInterface("SolverOne", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single.xml");
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     /* int squareID = */ cplInterface.getMeshID("Test-Square");
-    int forcesID = cplInterface.getDataID("Forces", meshOneID);
+    int forcesID     = cplInterface.getDataID("Forces", meshOneID);
     int velocitiesID = cplInterface.getDataID("Velocities", meshOneID);
     int indices[8];
     int i = 0;
@@ -208,25 +201,25 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
     double maxDt = cplInterface.initialize();
 
     VertexHandle vertices = cplInterface.getMeshHandle("Test-Square").vertices();
-    while (cplInterface.isCouplingOngoing()){
+    while (cplInterface.isCouplingOngoing()) {
       impl(cplInterface).resetMesh(meshOneID);
       i = 0;
-      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
+      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
         int index = cplInterface.setMeshVertex(meshOneID, it.vertexCoords());
         BOOST_TEST(index == it.vertexID());
         indices[i] = index;
         i++;
       }
-      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
+      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
         Vector3d force(Vector3d::Constant(counter) + Eigen::Map<const Vector3d>(it.vertexCoords()));
         cplInterface.writeVectorData(forcesID, it.vertexID(), force.data());
       }
       maxDt = cplInterface.advance(maxDt);
-      if (cplInterface.isCouplingOngoing()){
-        i=0;
-        for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
-          Vector3d vel = Vector3d::Zero();
-          int index = indices[i];
+      if (cplInterface.isCouplingOngoing()) {
+        i = 0;
+        for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
+          Vector3d vel   = Vector3d::Zero();
+          int      index = indices[i];
           i++;
           cplInterface.readVectorData(velocitiesID, index, vel.data());
           BOOST_TEST(vel == Vector3d::Constant(counter) + Eigen::Map<const Vector3d>(it.vertexCoords()));
@@ -235,37 +228,36 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
       }
     }
     cplInterface.finalize();
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+  } else if (utils::Parallel::getProcessRank() == 1) {
     SolverInterface cplInterface("SolverTwo", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single.xml");
 
     int meshID = cplInterface.getMeshID("Test-Square");
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,1.0,0.0).data());
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,1.0,0.0).data());
-    int forcesID = cplInterface.getDataID("Forces", meshID);
-    int velocitiesID = cplInterface.getDataID("Velocities", meshID);
-    double maxDt = cplInterface.initialize();
-    VertexHandle vertices = cplInterface.getMeshHandle("Test-Square").vertices();
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 1.0, 0.0).data());
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 1.0, 0.0).data());
+    int          forcesID     = cplInterface.getDataID("Forces", meshID);
+    int          velocitiesID = cplInterface.getDataID("Velocities", meshID);
+    double       maxDt        = cplInterface.initialize();
+    VertexHandle vertices     = cplInterface.getMeshHandle("Test-Square").vertices();
     // SolverTwo does not start the coupled simulation and has, hence,
     // already received the first data to be validated.
-    for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
+    for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
       Vector3d force = Vector3d::Zero();
       cplInterface.readVectorData(forcesID, it.vertexID(), force.data());
       BOOST_TEST(force == Vector3d::Constant(counter) + Eigen::Map<const Vector3d>(it.vertexCoords()));
     }
     counter += 1.0;
 
-    while (cplInterface.isCouplingOngoing()){
-      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
+    while (cplInterface.isCouplingOngoing()) {
+      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
         Vector3d vel(Vector3d::Constant(counter - 1.0) + Eigen::Map<const Vector3d>(it.vertexCoords()));
         cplInterface.writeVectorData(velocitiesID, it.vertexID(), vel.data());
       }
       maxDt = cplInterface.advance(maxDt);
-      if (cplInterface.isCouplingOngoing()){
-        for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
+      if (cplInterface.isCouplingOngoing()) {
+        for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
           Vector3d force = Vector3d::Zero();
           cplInterface.readVectorData(forcesID, it.vertexID(), force.data());
           BOOST_TEST(force == Vector3d::Constant(counter) + Eigen::Map<const Vector3d>(it.vertexCoords()));
@@ -284,28 +276,27 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
  * initializeData(), the mapping needs to be invoked.
  */
 BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
   using Eigen::Vector3d;
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     SolverInterface cplInterface("SolverOne", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-data-init.xml");
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
-    cplInterface.setMeshVertex(meshOneID, Vector3d(1.0,2.0,3.0).data());
-    double maxDt = cplInterface.initialize();
-    int dataAID = cplInterface.getDataID("DataOne",meshOneID);
-    int dataBID = cplInterface.getDataID("DataTwo",meshOneID);
+    cplInterface.setMeshVertex(meshOneID, Vector3d(1.0, 2.0, 3.0).data());
+    double maxDt      = cplInterface.initialize();
+    int    dataAID    = cplInterface.getDataID("DataOne", meshOneID);
+    int    dataBID    = cplInterface.getDataID("DataTwo", meshOneID);
     double valueDataB = 0.0;
     cplInterface.initializeData();
     cplInterface.readScalarData(dataBID, 0, valueDataB);
     BOOST_TEST(2.0 == valueDataB);
-    while (cplInterface.isCouplingOngoing()){
+    while (cplInterface.isCouplingOngoing()) {
       Vector3d valueDataA(1.0, 1.0, 1.0);
       cplInterface.writeVectorData(dataAID, 0, valueDataA.data());
       maxDt = cplInterface.advance(maxDt);
@@ -313,17 +304,16 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
       BOOST_TEST(2.5 == valueDataB);
     }
     cplInterface.finalize();
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+  } else if (utils::Parallel::getProcessRank() == 1) {
     SolverInterface cplInterface("SolverTwo", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-data-init.xml");
 
-    int meshTwoID = cplInterface.getMeshID("MeshTwo");
-    Vector3d pos = Vector3d::Zero();
+    int      meshTwoID = cplInterface.getMeshID("MeshTwo");
+    Vector3d pos       = Vector3d::Zero();
     cplInterface.setMeshVertex(meshTwoID, pos.data());
-    double maxDt = cplInterface.initialize();
-    int dataAID = cplInterface.getDataID("DataOne",meshTwoID);
-    int dataBID = cplInterface.getDataID("DataTwo",meshTwoID);
+    double maxDt   = cplInterface.initialize();
+    int    dataAID = cplInterface.getDataID("DataOne", meshTwoID);
+    int    dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
     cplInterface.writeScalarData(dataBID, 0, 2.0);
     //sagen dass daten jetzt geschrieben
     cplInterface.fulfilledAction(precice::constants::actionWriteInitialData());
@@ -332,7 +322,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
     cplInterface.readVectorData(dataAID, 0, valueDataA.data());
     Vector3d expected(1.0, 1.0, 1.0);
     BOOST_TEST(valueDataA == expected);
-    while (cplInterface.isCouplingOngoing()){
+    while (cplInterface.isCouplingOngoing()) {
       cplInterface.writeScalarData(dataBID, 0, 2.5);
       maxDt = cplInterface.advance(maxDt);
       cplInterface.readVectorData(dataAID, 0, valueDataA.data());
@@ -344,8 +334,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
 
 /// One solver uses block set/get/read/write methods.
 BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
@@ -353,47 +342,48 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
   double counter = 0.0;
   using Eigen::Vector3d;
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     SolverInterface cplInterface("SolverOne", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
 
-    int meshOneID = cplInterface.getMeshID("MeshOne");
-    double maxDt = cplInterface.initialize();
-    int forcesID = cplInterface.getDataID("Forces", meshOneID);
-    int pressuresID = cplInterface.getDataID("Pressures", meshOneID);
-    int velocitiesID = cplInterface.getDataID("Velocities", meshOneID);
-    int temperaturesID = cplInterface.getDataID("Temperatures", meshOneID);
-    VertexHandle vertices = cplInterface.getMeshHandle("Test-Square").vertices();
-    int size = vertices.size();
-    Eigen::VectorXd writePositions(size*3);
-    Eigen::VectorXd getWritePositions(size*3);
-    Eigen::VectorXd forces(size*3);
+    int             meshOneID      = cplInterface.getMeshID("MeshOne");
+    double          maxDt          = cplInterface.initialize();
+    int             forcesID       = cplInterface.getDataID("Forces", meshOneID);
+    int             pressuresID    = cplInterface.getDataID("Pressures", meshOneID);
+    int             velocitiesID   = cplInterface.getDataID("Velocities", meshOneID);
+    int             temperaturesID = cplInterface.getDataID("Temperatures", meshOneID);
+    VertexHandle    vertices       = cplInterface.getMeshHandle("Test-Square").vertices();
+    int             size           = vertices.size();
+    Eigen::VectorXd writePositions(size * 3);
+    Eigen::VectorXd getWritePositions(size * 3);
+    Eigen::VectorXd forces(size * 3);
     Eigen::VectorXd pressures(size);
     Eigen::VectorXi writeIDs(size);
     Eigen::VectorXi getWriteIDs(size);
-    Eigen::VectorXd readPositions(size*3);
-    Eigen::VectorXd getReadPositions(size*3);
-    Eigen::VectorXd velocities(size*3);
+    Eigen::VectorXd readPositions(size * 3);
+    Eigen::VectorXd getReadPositions(size * 3);
+    Eigen::VectorXd velocities(size * 3);
     Eigen::VectorXd temperatures(size);
-    Eigen::VectorXd expectedVelocities(size*3);
+    Eigen::VectorXd expectedVelocities(size * 3);
     Eigen::VectorXd expectedTemperatures(size);
     Eigen::VectorXi readIDs(size);
     Eigen::VectorXi getReadIDs(size);
 
-    while (cplInterface.isCouplingOngoing()){
+    while (cplInterface.isCouplingOngoing()) {
       impl(cplInterface).resetMesh(meshOneID);
-      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
-        for (int dim=0; dim < 3; dim++){
-          writePositions[it.vertexID()*3 + dim] = it.vertexCoords()[dim];
+      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
+        for (int dim = 0; dim < 3; dim++) {
+          writePositions[it.vertexID() * 3 + dim] = it.vertexCoords()[dim];
         }
       }
       cplInterface.setMeshVertices(meshOneID, size, writePositions.data(),
                                    writeIDs.data());
-      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
+      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
         // Vector3d force ( Vector3D(counter) + wrap<3,double>(it.vertexCoords()) );
-        Vector3d force ( Vector3d::Constant(counter) +
-                         Eigen::Map<const Vector3d>(it.vertexCoords()) );
-        for (int dim=0; dim<3; dim++) forces[it.vertexID()*3+dim] = force[dim];
+        Vector3d force(Vector3d::Constant(counter) +
+                       Eigen::Map<const Vector3d>(it.vertexCoords()));
+        for (int dim = 0; dim < 3; dim++)
+          forces[it.vertexID() * 3 + dim] = force[dim];
         pressures[it.vertexID()] = counter + it.vertexCoords()[0];
       }
       cplInterface.writeBlockVectorData(forcesID, size, writeIDs.data(), forces.data());
@@ -408,11 +398,11 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
       BOOST_TEST(writeIDs == getWriteIDs);
       //cplInterface.mapWrittenData(meshID);
       maxDt = cplInterface.advance(maxDt);
-      if (cplInterface.isCouplingOngoing()){
-        for (VertexIterator it = vertices.begin(); it != vertices.end(); it++){
-          for (int dim=0; dim < 3; dim++){
-            int index = it.vertexID()*3+dim;
-            readPositions[index] = it.vertexCoords()[dim];
+      if (cplInterface.isCouplingOngoing()) {
+        for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
+          for (int dim = 0; dim < 3; dim++) {
+            int index                 = it.vertexID() * 3 + dim;
+            readPositions[index]      = it.vertexCoords()[dim];
             expectedVelocities[index] = counter + it.vertexCoords()[dim];
           }
           expectedTemperatures[it.vertexID()] = counter + it.vertexCoords()[0];
@@ -430,48 +420,47 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
         counter += 1.0;
       }
     }
-    cplInterface.finalize ();
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ) {
-    SolverInterface cplInterface ( "SolverTwo", 0, 1 );
+    cplInterface.finalize();
+  } else if (utils::Parallel::getProcessRank() == 1) {
+    SolverInterface cplInterface("SolverTwo", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
 
-    int squareID = cplInterface.getMeshID("Test-Square");
-    int forcesID = cplInterface.getDataID ( "Forces", squareID );
-    int pressuresID = cplInterface.getDataID("Pressures", squareID );
-    int velocitiesID = cplInterface.getDataID ( "Velocities", squareID );
-    int temperaturesID = cplInterface.getDataID("Temperatures", squareID );
-    int meshID = cplInterface.getMeshID("Test-Square");
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,1.0,0.0).data());
-    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,1.0,0.0).data());
-    double maxDt = cplInterface.initialize ();
+    int squareID       = cplInterface.getMeshID("Test-Square");
+    int forcesID       = cplInterface.getDataID("Forces", squareID);
+    int pressuresID    = cplInterface.getDataID("Pressures", squareID);
+    int velocitiesID   = cplInterface.getDataID("Velocities", squareID);
+    int temperaturesID = cplInterface.getDataID("Temperatures", squareID);
+    int meshID         = cplInterface.getMeshID("Test-Square");
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 1.0, 0.0).data());
+    cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 1.0, 0.0).data());
+    double       maxDt    = cplInterface.initialize();
     VertexHandle vertices = cplInterface.getMeshHandle("Test-Square").vertices();
     // SolverTwo does not start the coupled simulation and has, hence,
     // already received the first data to be validated.
-    for ( VertexIterator it = vertices.begin(); it != vertices.end(); it++ ){
-      Vector3d force = Vector3d::Zero();
-      double pressure = 0.0;
+    for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
+      Vector3d force    = Vector3d::Zero();
+      double   pressure = 0.0;
       cplInterface.readVectorData(forcesID, it.vertexID(), force.data());
       cplInterface.readScalarData(pressuresID, it.vertexID(), pressure);
-      BOOST_TEST(force == Vector3d::Constant(counter) + Eigen::Map<const Vector3d>(it.vertexCoords()) );
+      BOOST_TEST(force == Vector3d::Constant(counter) + Eigen::Map<const Vector3d>(it.vertexCoords()));
       BOOST_TEST(pressure == counter + it.vertexCoords()[0]);
     }
     counter += 1.0;
 
-    while ( cplInterface.isCouplingOngoing() ) {
-      for ( VertexIterator it = vertices.begin(); it != vertices.end(); it++ ){
-        Vector3d vel ( Vector3d::Constant(counter - 1.0) + Eigen::Map<const Vector3d>(it.vertexCoords()) );
-        cplInterface.writeVectorData ( velocitiesID, it.vertexID(), vel.data() );
+    while (cplInterface.isCouplingOngoing()) {
+      for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
+        Vector3d vel(Vector3d::Constant(counter - 1.0) + Eigen::Map<const Vector3d>(it.vertexCoords()));
+        cplInterface.writeVectorData(velocitiesID, it.vertexID(), vel.data());
         double temperature = counter - 1.0 + it.vertexCoords()[0];
         cplInterface.writeScalarData(temperaturesID, it.vertexID(), temperature);
       }
-      maxDt = cplInterface.advance ( maxDt );
-      if ( cplInterface.isCouplingOngoing() ) {
-        for ( VertexIterator it = vertices.begin(); it != vertices.end(); it++ ){
-          Vector3d force = Vector3d::Zero();
-          double pressure = 0.0;
+      maxDt = cplInterface.advance(maxDt);
+      if (cplInterface.isCouplingOngoing()) {
+        for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
+          Vector3d force    = Vector3d::Zero();
+          double   pressure = 0.0;
           cplInterface.readVectorData(forcesID, it.vertexID(), force.data());
           cplInterface.readScalarData(pressuresID, it.vertexID(), pressure);
           BOOST_TEST(force == Vector3d::Constant(counter) + Eigen::Map<const Vector3d>(it.vertexCoords()));
@@ -492,53 +481,51 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
   * displaces the coordinates.
   */
 BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
-  int timesteps = 0;
-  double time = 0;
+  int    timesteps = 0;
+  double time      = 0;
 
-  if ( utils::Parallel::getProcessRank() == 0 ){
+  if (utils::Parallel::getProcessRank() == 0) {
 
     SolverInterface couplingInterface("SolverOne", 0, 1);
     slimConfigure(couplingInterface, _pathToTests + "explicit-solvergeometry.xml");
 
     //was necessary to replace pre-defined geometries
     int meshID = couplingInterface.getMeshID("MeshOne");
-    couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
-    couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
+    couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+    couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
 
     BOOST_TEST(couplingInterface.getDimensions() == 3);
     double dt = couplingInterface.initialize();
-    while (couplingInterface.isCouplingOngoing()){
-     time += dt;
-     dt = couplingInterface.advance(dt);
-     timesteps++;
+    while (couplingInterface.isCouplingOngoing()) {
+      time += dt;
+      dt = couplingInterface.advance(dt);
+      timesteps++;
     }
     couplingInterface.finalize();
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ){
-    SolverInterface cplInterface ( "SolverTwo", 0, 1 );
+  } else if (utils::Parallel::getProcessRank() == 1) {
+    SolverInterface cplInterface("SolverTwo", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
 
     BOOST_TEST(cplInterface.getDimensions() == 3);
-    int meshID = cplInterface.getMeshID ( "SolverGeometry" );
-    int i0 = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,0.0,0.0).data());
-    int i1 = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0,0.0,0.0).data());
-    int i2 = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0,1.0,0.0).data());
-    int e0 = cplInterface.setMeshEdge(meshID, i0, i1);
-    int e1 = cplInterface.setMeshEdge(meshID, i1, i2);
-    int e2 = cplInterface.setMeshEdge(meshID, i2, i0);
+    int meshID = cplInterface.getMeshID("SolverGeometry");
+    int i0     = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+    int i1     = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    int i2     = cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 1.0, 0.0).data());
+    int e0     = cplInterface.setMeshEdge(meshID, i0, i1);
+    int e1     = cplInterface.setMeshEdge(meshID, i1, i2);
+    int e2     = cplInterface.setMeshEdge(meshID, i2, i0);
     cplInterface.setMeshTriangle(meshID, e0, e1, e2);
     double dt = cplInterface.initialize();
 
     int size = cplInterface.getMeshVertexSize(meshID);
     BOOST_TEST(size == 3);
 
-    while ( cplInterface.isCouplingOngoing() ){
+    while (cplInterface.isCouplingOngoing()) {
       time += dt;
       dt = cplInterface.advance(dt);
       timesteps++;
@@ -555,57 +542,55 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
  * values activated and reads the scaled values.
  */
 BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
-                     * testing::Deleted()
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::Deleted() * testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
   double dt;
-  if ( utils::Parallel::getProcessRank() == 0 ) { // SolverOne part
-    SolverInterface cplInterface ( "SolverOne", 0, 1 );
+  if (utils::Parallel::getProcessRank() == 0) { // SolverOne part
+    SolverInterface cplInterface("SolverOne", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-datascaling.xml");
 
-    BOOST_TEST ( cplInterface.getDimensions() == 2 );
+    BOOST_TEST(cplInterface.getDimensions() == 2);
 
-    int meshID = cplInterface.getMeshID("Test-Square");
-    std::vector<double> positions = {0.0,0.0,0.1,0.0,0.2,0.0,0.3,0.0,0.4,0.0};
-    std::vector<int> ids = {0,0,0,0,0};
-    cplInterface.setMeshVertices(meshID,5,positions.data(), ids.data());
-    for(int i=0;i<4;i++) cplInterface.setMeshEdge(meshID,ids[i],ids[i+1]);
+    int                 meshID    = cplInterface.getMeshID("Test-Square");
+    std::vector<double> positions = {0.0, 0.0, 0.1, 0.0, 0.2, 0.0, 0.3, 0.0, 0.4, 0.0};
+    std::vector<int>    ids       = {0, 0, 0, 0, 0};
+    cplInterface.setMeshVertices(meshID, 5, positions.data(), ids.data());
+    for (int i = 0; i < 4; i++)
+      cplInterface.setMeshEdge(meshID, ids[i], ids[i + 1]);
 
     dt = cplInterface.initialize();
 
-    int velocitiesID = cplInterface.getDataID ( "Velocities", meshID );
-    while ( cplInterface.isCouplingOngoing() ){
-      MeshHandle handle = cplInterface.getMeshHandle ( "Test-Square" );
-      VertexIterator iter = handle.vertices().begin();
-      for ( size_t i=0; iter != handle.vertices().end(); i++, iter++ ) {
+    int velocitiesID = cplInterface.getDataID("Velocities", meshID);
+    while (cplInterface.isCouplingOngoing()) {
+      MeshHandle     handle = cplInterface.getMeshHandle("Test-Square");
+      VertexIterator iter   = handle.vertices().begin();
+      for (size_t i = 0; iter != handle.vertices().end(); i++, iter++) {
         Eigen::Vector2d data = Eigen::Vector2d::Constant(i);
-        cplInterface.writeVectorData ( velocitiesID, i, data.data() );
+        cplInterface.writeVectorData(velocitiesID, i, data.data());
       }
       dt = cplInterface.advance(dt);
     }
     cplInterface.finalize();
 
-  }
-  else if ( utils::Parallel::getProcessRank() == 1 ){
-    SolverInterface cplInterface ( "SolverTwo", 0, 1 );
+  } else if (utils::Parallel::getProcessRank() == 1) {
+    SolverInterface cplInterface("SolverTwo", 0, 1);
     slimConfigure(cplInterface, _pathToTests + "explicit-datascaling.xml");
 
-    BOOST_TEST ( cplInterface.getDimensions() == 2 );
-    dt = cplInterface.initialize();
-    int meshID = cplInterface.getMeshID("Test-Square");
-    int velocitiesID = cplInterface.getDataID ( "Velocities", meshID );
-    while ( cplInterface.isCouplingOngoing() ){
-      MeshHandle handle = cplInterface.getMeshHandle ( "Test-Square" );
-      VertexIterator iter = handle.vertices().begin();
-      for ( size_t i=0; iter != handle.vertices().end(); iter++, i++ ){
+    BOOST_TEST(cplInterface.getDimensions() == 2);
+    dt               = cplInterface.initialize();
+    int meshID       = cplInterface.getMeshID("Test-Square");
+    int velocitiesID = cplInterface.getDataID("Velocities", meshID);
+    while (cplInterface.isCouplingOngoing()) {
+      MeshHandle     handle = cplInterface.getMeshHandle("Test-Square");
+      VertexIterator iter   = handle.vertices().begin();
+      for (size_t i = 0; iter != handle.vertices().end(); iter++, i++) {
         Eigen::Vector2d readData;
-        cplInterface.readVectorData ( velocitiesID, i, readData.data() );
+        cplInterface.readVectorData(velocitiesID, i, readData.data());
         Eigen::Vector2d expectedData = Eigen::Vector2d::Constant(i * 10.0);
-        BOOST_TEST (readData == expectedData, boost::test_tools::tolerance(5e-13) );
+        BOOST_TEST(readData == expectedData, boost::test_tools::tolerance(5e-13));
       }
       dt = cplInterface.advance(dt);
     }
@@ -615,78 +600,84 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
 
 /// Test simple coupled simulation with coupling iterations.
 BOOST_AUTO_TEST_CASE(testImplicit,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
-  double state = 0.0;
-  double checkpoint = 0.0;
-  int iterationCount = 0;
+  double state              = 0.0;
+  double checkpoint         = 0.0;
+  int    iterationCount     = 0;
   double initialStateChange = 5.0;
-  double stateChange = initialStateChange;
-  int computedTimesteps = 0;
+  double stateChange        = initialStateChange;
+  int    computedTimesteps  = 0;
   using namespace precice::constants;
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     SolverInterface couplingInterface("SolverOne", 0, 1);
     slimConfigure(couplingInterface, _pathToTests + "implicit.xml");
 
-    int meshID = couplingInterface.getMeshID("Square");
+    int    meshID = couplingInterface.getMeshID("Square");
     double pos[3];
     // Set mesh positions
-    pos[0] = 0.0; pos[1] = 0.0; pos[2] = 0.0;
+    pos[0] = 0.0;
+    pos[1] = 0.0;
+    pos[2] = 0.0;
     couplingInterface.setMeshVertex(meshID, pos);
-    pos[0] = 1.0; pos[1] = 0.0; pos[2] = 0.0;
+    pos[0] = 1.0;
+    pos[1] = 0.0;
+    pos[2] = 0.0;
     couplingInterface.setMeshVertex(meshID, pos);
-    pos[0] = 1.0; pos[1] = 1.0; pos[2] = 0.0;
+    pos[0] = 1.0;
+    pos[1] = 1.0;
+    pos[2] = 0.0;
     couplingInterface.setMeshVertex(meshID, pos);
-    pos[0] = 0.0; pos[1] = 1.0; pos[2] = 0.0;
+    pos[0] = 0.0;
+    pos[1] = 1.0;
+    pos[2] = 0.0;
     couplingInterface.setMeshVertex(meshID, pos);
 
     double maxDt = couplingInterface.initialize();
-    while (couplingInterface.isCouplingOngoing()){
-      if (couplingInterface.isActionRequired(actionWriteIterationCheckpoint())){
+    while (couplingInterface.isCouplingOngoing()) {
+      if (couplingInterface.isActionRequired(actionWriteIterationCheckpoint())) {
         couplingInterface.fulfilledAction(actionWriteIterationCheckpoint());
-        checkpoint = state;
+        checkpoint     = state;
         iterationCount = 1;
       }
-      if (couplingInterface.isActionRequired(actionReadIterationCheckpoint())){
+      if (couplingInterface.isActionRequired(actionReadIterationCheckpoint())) {
         couplingInterface.fulfilledAction(actionReadIterationCheckpoint());
         state = checkpoint;
       }
       iterationCount++;
-      stateChange = initialStateChange / (double)iterationCount;
+      stateChange = initialStateChange / (double) iterationCount;
       state += stateChange;
       maxDt = couplingInterface.advance(maxDt);
-      if (couplingInterface.isTimestepComplete()){
-        computedTimesteps ++;
+      if (couplingInterface.isTimestepComplete()) {
+        computedTimesteps++;
       }
     }
     couplingInterface.finalize();
     BOOST_TEST(computedTimesteps == 4);
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+  } else if (utils::Parallel::getProcessRank() == 1) {
     SolverInterface couplingInterface("SolverTwo", 0, 1);
     slimConfigure(couplingInterface, _pathToTests + "implicit.xml");
 
     double maxDt = couplingInterface.initialize();
-    while (couplingInterface.isCouplingOngoing()){
-      if (couplingInterface.isActionRequired(actionWriteIterationCheckpoint())){
+    while (couplingInterface.isCouplingOngoing()) {
+      if (couplingInterface.isActionRequired(actionWriteIterationCheckpoint())) {
         couplingInterface.fulfilledAction(actionWriteIterationCheckpoint());
-        checkpoint = state;
+        checkpoint     = state;
         iterationCount = 1;
       }
-      if (couplingInterface.isActionRequired(actionReadIterationCheckpoint())){
+      if (couplingInterface.isActionRequired(actionReadIterationCheckpoint())) {
         couplingInterface.fulfilledAction(actionReadIterationCheckpoint());
         state = checkpoint;
         iterationCount++;
       }
-      stateChange = initialStateChange / (double)iterationCount;
+      stateChange = initialStateChange / (double) iterationCount;
       state += stateChange;
       maxDt = couplingInterface.advance(maxDt);
-      if (couplingInterface.isTimestepComplete()){
+      if (couplingInterface.isTimestepComplete()) {
         computedTimesteps++;
       }
     }
@@ -695,29 +686,27 @@ BOOST_AUTO_TEST_CASE(testImplicit,
   }
 }
 
-
 /// Tests stationary mapping with solver provided meshes.
 BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
   std::string config2D = _pathToTests + "mapping-without-geo-2D.xml";
   std::string config3D = _pathToTests + "mapping-without-geo-3D.xml";
-  int rank = utils::Parallel::getProcessRank();
+  int         rank     = utils::Parallel::getProcessRank();
   BOOST_TEST(((rank == 0) || (rank == 1)), rank);
-  std::string solverName = rank == 0 ? "SolverA" : "SolverB";
+  std::string solverName  = rank == 0 ? "SolverA" : "SolverB";
   std::string meshForcesA = "MeshForcesA";
-  std::string meshDisplA = "MeshDisplacementsA";
+  std::string meshDisplA  = "MeshDisplacementsA";
   std::string meshForcesB = "MeshForcesB";
-  std::string meshDisplB = "MeshDisplacementsB";
-  std::string dataForces = "Forces";
-  std::string dataDispl = "Displacements";
+  std::string meshDisplB  = "MeshDisplacementsB";
+  std::string dataForces  = "Forces";
+  std::string dataDispl   = "Displacements";
   using testing::equals;
 
-  for (int dim: {2, 3}){
+  for (int dim : {2, 3}) {
     // @todo this should normally happen in finalize and should not be necessary
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
@@ -726,8 +715,8 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
     BOOST_TEST(interface.getDimensions() == dim);
 
     std::vector<Eigen::VectorXd> positions;
-    Eigen::VectorXd position(dim);
-    if (dim == 2){
+    Eigen::VectorXd              position(dim);
+    if (dim == 2) {
       position << 0.0, 0.0;
       positions.push_back(position);
       position << 1.0, 0.0;
@@ -736,8 +725,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
       positions.push_back(position);
       position << 0.0, 1.0;
       positions.push_back(position);
-    }
-    else {
+    } else {
       position << 0.0, 0.0, 0.0;
       positions.push_back(position);
       position << 1.0, 0.0, 0.0;
@@ -751,14 +739,14 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
     }
     size_t size = positions.size();
 
-    if (rank == 0){
+    if (rank == 0) {
       int meshForcesID = interface.getMeshID(meshForcesA);
-      int meshDisplID = interface.getMeshID(meshDisplA);
+      int meshDisplID  = interface.getMeshID(meshDisplA);
       int dataForcesID = interface.getDataID(dataForces, meshForcesID);
-      int dataDisplID = interface.getDataID(dataDispl, meshDisplID);
+      int dataDisplID  = interface.getDataID(dataDispl, meshDisplID);
 
       // Set solver mesh positions for reading and writing data with mappings
-      for (size_t i=0; i < size; i++){
+      for (size_t i = 0; i < size; i++) {
         position = positions[i].array() + 0.1;
         interface.setMeshVertex(meshForcesID, position.data());
         position = positions[i].array() + 0.6;
@@ -770,7 +758,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
       BOOST_TEST(not interface.isReadDataAvailable());
       Eigen::VectorXd force = Eigen::VectorXd::Constant(dim, 1);
       Eigen::VectorXd displ = Eigen::VectorXd::Constant(dim, 0);
-      for (size_t i=0; i < size; i++){
+      for (size_t i = 0; i < size; i++) {
         interface.writeVectorData(dataForcesID, i, force.data());
       }
       interface.mapWriteDataFrom(meshForcesID);
@@ -780,7 +768,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
       BOOST_TEST(interface.isWriteDataRequired(maxDt));
       BOOST_TEST(interface.isReadDataAvailable());
       force.array() += 1.0;
-      for (size_t i=0; i < size; i++){
+      for (size_t i = 0; i < size; i++) {
         interface.readVectorData(dataDisplID, i, displ.data());
         BOOST_TEST(displ[0] == positions[i][0] + 0.1);
         interface.writeVectorData(dataForcesID, i, force.data());
@@ -791,21 +779,20 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
 
       BOOST_TEST(interface.isWriteDataRequired(maxDt));
       BOOST_TEST(interface.isReadDataAvailable());
-      for (size_t i=0; i < size; i++){
+      for (size_t i = 0; i < size; i++) {
         interface.readVectorData(dataDisplID, i, displ.data());
-        BOOST_TEST(displ[0] == 2.0*(positions[i][0] + 0.1));
+        BOOST_TEST(displ[0] == 2.0 * (positions[i][0] + 0.1));
       }
       interface.finalize();
-    }
-    else {
+    } else {
       BOOST_TEST(rank == 1, rank);
       int meshForcesID = interface.getMeshID(meshForcesB);
-      int meshDisplID = interface.getMeshID(meshDisplB);
+      int meshDisplID  = interface.getMeshID(meshDisplB);
       int dataForcesID = interface.getDataID(dataForces, meshForcesID);
-      int dataDisplID = interface.getDataID(dataDispl, meshDisplID);
+      int dataDisplID  = interface.getDataID(dataDispl, meshDisplID);
 
       // Set solver mesh positions provided to SolverA for data mapping
-      for (size_t i=0; i < size; i++){
+      for (size_t i = 0; i < size; i++) {
         interface.setMeshVertex(meshForcesID, positions[i].data());
         position = positions[i].array() + 0.5;
         interface.setMeshVertex(meshDisplID, position.data());
@@ -814,10 +801,10 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
 
       BOOST_TEST(interface.isWriteDataRequired(maxDt));
       BOOST_TEST(interface.isReadDataAvailable());
-      Eigen::VectorXd force = Eigen::VectorXd::Zero(dim);
+      Eigen::VectorXd force      = Eigen::VectorXd::Zero(dim);
       Eigen::VectorXd totalForce = Eigen::VectorXd::Zero(dim);
-      Eigen::VectorXd displ = Eigen::VectorXd::Zero(dim);
-      for (size_t i=0; i < size; i++){
+      Eigen::VectorXd displ      = Eigen::VectorXd::Zero(dim);
+      for (size_t i = 0; i < size; i++) {
         interface.readVectorData(dataForcesID, i, force.data());
         totalForce += force;
         displ.setConstant(positions[i][0]);
@@ -830,19 +817,19 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
       BOOST_TEST(interface.isWriteDataRequired(maxDt));
       BOOST_TEST(interface.isReadDataAvailable());
       totalForce.setConstant(0);
-      for (size_t i=0; i < positions.size(); i++){
+      for (size_t i = 0; i < positions.size(); i++) {
         interface.readVectorData(dataForcesID, i, force.data());
         totalForce += force;
         displ.setConstant(2.0 * positions[i][0]);
         interface.writeVectorData(dataDisplID, i, displ.data());
       }
-      expected.setConstant(2.0 * (double)size);
+      expected.setConstant(2.0 * (double) size);
       BOOST_TEST(equals(totalForce, expected));
       maxDt = interface.advance(maxDt);
 
       BOOST_TEST(interface.isWriteDataRequired(maxDt));
       BOOST_TEST(not interface.isReadDataAvailable()); //second participant has no new data after last advance
-      for (size_t i=0; i < size; i++){
+      for (size_t i = 0; i < size; i++) {
         interface.readVectorData(dataForcesID, i, force.data());
       }
       interface.finalize();
@@ -861,8 +848,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
  * - Mapping is done on Flite side with RBF
  */
 BOOST_AUTO_TEST_CASE(testBug,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
@@ -870,42 +856,42 @@ BOOST_AUTO_TEST_CASE(testBug,
   using Eigen::Vector3d;
   std::string configName = _pathToTests + "bug.xml";
 
-  int slices = 5;
+  int                   slices = 5;
   std::vector<Vector3d> coords;
-  for (int i=0; i < slices; i++){
-    double z = (double)i * 1.0;
-    coords.push_back( Vector3d( 1.0,  0.0, z) );
-    coords.push_back( Vector3d( 0.0,  1.0, z) );
-    coords.push_back( Vector3d(-1.0,  0.0, z) );
-    coords.push_back( Vector3d( 0.0, -1.0, z) );
+  for (int i = 0; i < slices; i++) {
+    double z = (double) i * 1.0;
+    coords.push_back(Vector3d(1.0, 0.0, z));
+    coords.push_back(Vector3d(0.0, 1.0, z));
+    coords.push_back(Vector3d(-1.0, 0.0, z));
+    coords.push_back(Vector3d(0.0, -1.0, z));
   }
 
   int rank = utils::Parallel::getProcessRank();
   BOOST_TEST(((rank == 0) || (rank == 1)), rank);
   std::string solverName = rank == 0 ? "Flite" : "Calculix";
-  if (solverName == std::string("Flite")){
+  if (solverName == std::string("Flite")) {
     SolverInterface precice("Flite", 0, 1);
     slimConfigure(precice, configName);
 
-    int meshID = precice.getMeshID("FliteNodes");
-    int forcesID = precice.getDataID("Forces", meshID);
-    int displacementsID = precice.getDataID("Displacements", meshID);
+    int meshID             = precice.getMeshID("FliteNodes");
+    int forcesID           = precice.getDataID("Forces", meshID);
+    int displacementsID    = precice.getDataID("Displacements", meshID);
     int oldDisplacementsID = precice.getDataID("OldDisplacements", meshID);
     BOOST_TEST(precice.getDimensions() == 3);
-    for (Vector3d& coord : coords){
+    for (Vector3d &coord : coords) {
       precice.setMeshVertex(meshID, coord.data());
     }
     double maxDt = precice.initialize();
-    double dt = 1.0e-5 / 15.0; // Flite took 15 subcycling steps
-    while (precice.isCouplingOngoing()){
+    double dt    = 1.0e-5 / 15.0; // Flite took 15 subcycling steps
+    while (precice.isCouplingOngoing()) {
       dt = dt < maxDt ? dt : maxDt;
-      for(int i=0; i < (int)coords.size(); i++){
-        double force[3] = { 1.0, 2.0, 3.0 };
+      for (int i = 0; i < (int) coords.size(); i++) {
+        double force[3] = {1.0, 2.0, 3.0};
         precice.writeVectorData(forcesID, i, force);
       }
       maxDt = precice.advance(dt);
       precice.mapReadDataTo(meshID);
-      for(int i=0; i < (int)coords.size(); i++){
+      for (int i = 0; i < (int) coords.size(); i++) {
         double displacement[3];
         double oldDisplacement[3];
         precice.readVectorData(displacementsID, i, displacement);
@@ -913,29 +899,28 @@ BOOST_AUTO_TEST_CASE(testBug,
       }
     }
     precice.finalize();
-  }
-  else {
+  } else {
     BOOST_TEST(solverName == std::string("Calculix"), solverName);
     SolverInterface precice("Calculix", 0, 1);
     slimConfigure(precice, configName);
 
     int meshID = precice.getMeshID("CalculixNodes");
-    for (Vector3d& coord : coords){
+    for (Vector3d &coord : coords) {
       precice.setMeshVertex(meshID, coord.data());
     }
-    for(int i=0; i < slices-1; i++){
+    for (int i = 0; i < slices - 1; i++) {
       // Build cylinder/channel geometry
-      precice.setMeshTriangleWithEdges(meshID, i*4, (i*4)+1, (i+1)*4);
-      precice.setMeshTriangleWithEdges(meshID, (i+1)*4, (i*4)+1, ((i+1)*4)+1);
-      precice.setMeshTriangleWithEdges(meshID, i*4+1, (i*4)+2, (i+1)*4+1);
-      precice.setMeshTriangleWithEdges(meshID, (i+1)*4+1, (i*4)+2, ((i+1)*4)+2);
-      precice.setMeshTriangleWithEdges(meshID, i*4+2, (i*4)+3, (i+1)*4+2);
-      precice.setMeshTriangleWithEdges(meshID, (i+1)*4+2, (i*4)+3, ((i+1)*4)+3);
-      precice.setMeshTriangleWithEdges(meshID, i*4+3, (i*4), (i+1)*4+3);
-      precice.setMeshTriangleWithEdges(meshID, (i+1)*4+3, i*4, (i+1)*4);
+      precice.setMeshTriangleWithEdges(meshID, i * 4, (i * 4) + 1, (i + 1) * 4);
+      precice.setMeshTriangleWithEdges(meshID, (i + 1) * 4, (i * 4) + 1, ((i + 1) * 4) + 1);
+      precice.setMeshTriangleWithEdges(meshID, i * 4 + 1, (i * 4) + 2, (i + 1) * 4 + 1);
+      precice.setMeshTriangleWithEdges(meshID, (i + 1) * 4 + 1, (i * 4) + 2, ((i + 1) * 4) + 2);
+      precice.setMeshTriangleWithEdges(meshID, i * 4 + 2, (i * 4) + 3, (i + 1) * 4 + 2);
+      precice.setMeshTriangleWithEdges(meshID, (i + 1) * 4 + 2, (i * 4) + 3, ((i + 1) * 4) + 3);
+      precice.setMeshTriangleWithEdges(meshID, i * 4 + 3, (i * 4), (i + 1) * 4 + 3);
+      precice.setMeshTriangleWithEdges(meshID, (i + 1) * 4 + 3, i * 4, (i + 1) * 4);
     }
     double dt = precice.initialize();
-    while(precice.isCouplingOngoing()){
+    while (precice.isCouplingOngoing()) {
       precice.advance(dt);
     }
     precice.finalize();
@@ -949,13 +934,12 @@ BOOST_AUTO_TEST_CASE(testBug,
  * solvers.
  */
 BOOST_AUTO_TEST_CASE(testThreeSolvers,
-                     * testing::MinRanks(3)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
+                     *testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
 {
   if (utils::Parallel::getCommunicatorSize() != 3)
     return;
 
-  int numberOfTests = 5;
+  int                      numberOfTests = 5;
   std::vector<std::string> configs;
   configs.resize(5);
   configs[0] = _pathToTests + "three-solver-explicit-explicit.xml";
@@ -964,7 +948,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
   configs[3] = _pathToTests + "three-solver-explicit-implicit.xml";
   configs[4] = _pathToTests + "three-solver-parallel.xml";
 
-  std::vector<std::vector<int> > expectedCallsOfAdvance;
+  std::vector<std::vector<int>> expectedCallsOfAdvance;
   expectedCallsOfAdvance.resize(5);
   expectedCallsOfAdvance[0] = {10, 10, 10};
   expectedCallsOfAdvance[1] = {30, 30, 20};
@@ -972,7 +956,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
   expectedCallsOfAdvance[3] = {30, 10, 30};
   expectedCallsOfAdvance[4] = {30, 30, 10};
 
-  for(int k=0; k< numberOfTests; k++){
+  for (int k = 0; k < numberOfTests; k++) {
     reset();
 
     int rank = utils::Parallel::getProcessRank();
@@ -983,12 +967,15 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     std::string writeInitData(constants::actionWriteInitialData());
 
     std::string solverName;
-    if (rank == 0) solverName = std::string("SolverOne");
-    else if (rank == 1) solverName = std::string("SolverTwo");
-    else solverName = std::string("SolverThree");
+    if (rank == 0)
+      solverName = std::string("SolverOne");
+    else if (rank == 1)
+      solverName = std::string("SolverTwo");
+    else
+      solverName = std::string("SolverThree");
     int callsOfAdvance = 0;
 
-    if (solverName == std::string("SolverOne")){
+    if (solverName == std::string("SolverOne")) {
       SolverInterface precice(solverName, 0, 1);
       slimConfigure(precice, configs[k]);
 
@@ -998,25 +985,24 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       precice.setMeshVertex(meshBID, Eigen::Vector2d(1, 1).data());
       double dt = precice.initialize();
 
-      if (precice.isActionRequired(writeInitData)){
+      if (precice.isActionRequired(writeInitData)) {
         precice.fulfilledAction(writeInitData);
       }
       precice.initializeData();
 
-      while (precice.isCouplingOngoing()){
-        if (precice.isActionRequired(writeIterCheckpoint)){
+      while (precice.isCouplingOngoing()) {
+        if (precice.isActionRequired(writeIterCheckpoint)) {
           precice.fulfilledAction(writeIterCheckpoint);
         }
         dt = precice.advance(dt);
-        if (precice.isActionRequired(readIterCheckpoint)){
+        if (precice.isActionRequired(readIterCheckpoint)) {
           precice.fulfilledAction(readIterCheckpoint);
         }
         callsOfAdvance++;
       }
       precice.finalize();
       BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[k][0]);
-    }
-    else if (solverName == std::string("SolverTwo")){
+    } else if (solverName == std::string("SolverTwo")) {
       SolverInterface precice(solverName, 0, 1);
       slimConfigure(precice, configs[k]);
 
@@ -1024,25 +1010,24 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
 
-      if (precice.isActionRequired(writeInitData)){
+      if (precice.isActionRequired(writeInitData)) {
         precice.fulfilledAction(writeInitData);
       }
       precice.initializeData();
 
-      while (precice.isCouplingOngoing()){
-        if (precice.isActionRequired(writeIterCheckpoint)){
+      while (precice.isCouplingOngoing()) {
+        if (precice.isActionRequired(writeIterCheckpoint)) {
           precice.fulfilledAction(writeIterCheckpoint);
         }
         dt = precice.advance(dt);
-        if (precice.isActionRequired(readIterCheckpoint)){
+        if (precice.isActionRequired(readIterCheckpoint)) {
           precice.fulfilledAction(readIterCheckpoint);
         }
         callsOfAdvance++;
       }
       precice.finalize();
       BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[k][1]);
-    }
-    else {
+    } else {
       BOOST_TEST(solverName == std::string("SolverThree"), solverName);
       SolverInterface precice(solverName, 0, 1);
       slimConfigure(precice, configs[k]);
@@ -1051,17 +1036,17 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
       double dt = precice.initialize();
 
-      if (precice.isActionRequired(writeInitData)){
+      if (precice.isActionRequired(writeInitData)) {
         precice.fulfilledAction(writeInitData);
       }
       precice.initializeData();
 
-      while (precice.isCouplingOngoing()){
-        if (precice.isActionRequired(writeIterCheckpoint)){
+      while (precice.isCouplingOngoing()) {
+        if (precice.isActionRequired(writeIterCheckpoint)) {
           precice.fulfilledAction(writeIterCheckpoint);
         }
         dt = precice.advance(dt);
-        if (precice.isActionRequired(readIterCheckpoint)){
+        if (precice.isActionRequired(readIterCheckpoint)) {
           precice.fulfilledAction(readIterCheckpoint);
         }
         callsOfAdvance++;
@@ -1073,10 +1058,10 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
 }
 
 /// Four solvers are multi-coupled.
-BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
+BOOST_AUTO_TEST_CASE(testMultiCoupling, *testing::OnSize(4))
 {
   std::vector<Eigen::Vector2d> positions;
-  Eigen::Vector2d position;
+  Eigen::Vector2d              position;
   position << 0.0, 0.0;
   positions.push_back(position);
   position << 1.0, 0.0;
@@ -1087,7 +1072,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
   positions.push_back(position);
 
   std::vector<Eigen::Vector2d> datas;
-  Eigen::Vector2d data;
+  Eigen::Vector2d              data;
   data << 1.0, 1.0;
   datas.push_back(data);
   data << 2.0, 2.0;
@@ -1100,20 +1085,18 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
   std::string writeIterCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterCheckpoint(constants::actionReadIterationCheckpoint());
 
-  if (utils::Parallel::getProcessRank() < 3){
-    int meshID = -1;
+  if (utils::Parallel::getProcessRank() < 3) {
+    int meshID      = -1;
     int dataWriteID = -1;
-    int dataReadID = -1;
+    int dataReadID  = -1;
 
     std::string participant = "";
 
-    if (utils::Parallel::getProcessRank() == 0){
+    if (utils::Parallel::getProcessRank() == 0) {
       participant = "SOLIDZ1";
-    }
-    else if (utils::Parallel::getProcessRank() == 1){
+    } else if (utils::Parallel::getProcessRank() == 1) {
       participant = "SOLIDZ2";
-    }
-    else if (utils::Parallel::getProcessRank() == 2){
+    } else if (utils::Parallel::getProcessRank() == 2) {
       participant = "SOLIDZ3";
     }
 
@@ -1121,44 +1104,42 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
     slimConfigure(precice, _pathToTests + "/multi.xml");
     BOOST_TEST(precice.getDimensions() == 2);
 
-    if (utils::Parallel::getProcessRank() == 0){
-      meshID = precice.getMeshID("SOLIDZ_Mesh1");
+    if (utils::Parallel::getProcessRank() == 0) {
+      meshID      = precice.getMeshID("SOLIDZ_Mesh1");
       dataWriteID = precice.getDataID("Displacements1", meshID);
-      dataReadID = precice.getDataID("Forces1", meshID);
-    }
-    else if (utils::Parallel::getProcessRank() == 1){
-      meshID = precice.getMeshID("SOLIDZ_Mesh2");
+      dataReadID  = precice.getDataID("Forces1", meshID);
+    } else if (utils::Parallel::getProcessRank() == 1) {
+      meshID      = precice.getMeshID("SOLIDZ_Mesh2");
       dataWriteID = precice.getDataID("Displacements2", meshID);
-      dataReadID = precice.getDataID("Forces2", meshID);
-    }
-    else if (utils::Parallel::getProcessRank() == 2){
-      meshID = precice.getMeshID("SOLIDZ_Mesh3");
+      dataReadID  = precice.getDataID("Forces2", meshID);
+    } else if (utils::Parallel::getProcessRank() == 2) {
+      meshID      = precice.getMeshID("SOLIDZ_Mesh3");
       dataWriteID = precice.getDataID("Displacements3", meshID);
-      dataReadID = precice.getDataID("Forces3", meshID);
+      dataReadID  = precice.getDataID("Forces3", meshID);
     }
 
     std::vector<int> vertexIDs;
-    int vertexID = -1;
-    for (size_t i=0; i < 4; i++){
+    int              vertexID = -1;
+    for (size_t i = 0; i < 4; i++) {
       vertexID = precice.setMeshVertex(meshID, positions[i].data());
       vertexIDs.push_back(vertexID);
     }
 
     precice.initialize();
 
-    for (size_t i=0; i < 4; i++){
+    for (size_t i = 0; i < 4; i++) {
       precice.writeVectorData(dataWriteID, vertexIDs[i], datas[i].data());
     }
 
-    if (precice.isActionRequired(writeIterCheckpoint)){
+    if (precice.isActionRequired(writeIterCheckpoint)) {
       precice.fulfilledAction(writeIterCheckpoint);
     }
     precice.advance(0.0001);
-    if (precice.isActionRequired(readIterCheckpoint)){
+    if (precice.isActionRequired(readIterCheckpoint)) {
       precice.fulfilledAction(readIterCheckpoint);
     }
 
-    for (size_t i=0; i < 4; i++){
+    for (size_t i = 0; i < 4; i++) {
       precice.readVectorData(dataReadID, vertexIDs[i], datas[i].data());
     }
 
@@ -1173,56 +1154,53 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, * testing::OnSize(4))
 
     precice.finalize();
 
-  }
-  else {
+  } else {
     BOOST_TEST(utils::Parallel::getProcessRank() == 3);
     SolverInterface precice("NASTIN", 0, 1);
     slimConfigure(precice, _pathToTests + "/multi.xml");
     BOOST_TEST(precice.getDimensions() == 2);
-    int meshID1 = precice.getMeshID("NASTIN_Mesh1");
-    int meshID2 = precice.getMeshID("NASTIN_Mesh2");
-    int meshID3 = precice.getMeshID("NASTIN_Mesh3");
+    int meshID1      = precice.getMeshID("NASTIN_Mesh1");
+    int meshID2      = precice.getMeshID("NASTIN_Mesh2");
+    int meshID3      = precice.getMeshID("NASTIN_Mesh3");
     int dataWriteID1 = precice.getDataID("Forces1", meshID1);
     int dataWriteID2 = precice.getDataID("Forces2", meshID2);
     int dataWriteID3 = precice.getDataID("Forces3", meshID3);
 
     std::vector<int> vertexIDs1;
-    int vertexID = -1;
-    for (size_t i=0; i < 4; i++){
+    int              vertexID = -1;
+    for (size_t i = 0; i < 4; i++) {
       vertexID = precice.setMeshVertex(meshID1, positions[i].data());
       vertexIDs1.push_back(vertexID);
     }
     std::vector<int> vertexIDs2;
-    for (size_t i=0; i < 4; i++){
+    for (size_t i = 0; i < 4; i++) {
       vertexID = precice.setMeshVertex(meshID2, positions[i].data());
       vertexIDs2.push_back(vertexID);
     }
     std::vector<int> vertexIDs3;
-    for (size_t i=0; i < 4; i++){
+    for (size_t i = 0; i < 4; i++) {
       vertexID = precice.setMeshVertex(meshID3, positions[i].data());
       vertexIDs3.push_back(vertexID);
     }
 
     precice.initialize();
 
-    for (size_t i=0; i < 4; i++){
+    for (size_t i = 0; i < 4; i++) {
       precice.writeVectorData(dataWriteID1, vertexIDs1[i], datas[i].data());
       precice.writeVectorData(dataWriteID2, vertexIDs2[i], datas[i].data());
       precice.writeVectorData(dataWriteID3, vertexIDs3[i], datas[i].data());
     }
 
-    if (precice.isActionRequired(writeIterCheckpoint)){
+    if (precice.isActionRequired(writeIterCheckpoint)) {
       precice.fulfilledAction(writeIterCheckpoint);
     }
     precice.advance(0.0001);
-    if (precice.isActionRequired(readIterCheckpoint)){
+    if (precice.isActionRequired(readIterCheckpoint)) {
       precice.fulfilledAction(readIterCheckpoint);
     }
 
     precice.finalize();
-
   }
-
 }
 
 void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string configFile)
@@ -1236,22 +1214,22 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
   Vector3d coordOneB{1.0, 0.0, z};
   Vector3d coordOneC{1.0, 1.0, z};
   Vector3d coordOneD{0.0, 1.0, z};
-  double valOneA = 1.0;
-  double valOneB = 3.0;
-  double valOneC = 5.0;
-  double valOneD = 7.0;
+  double   valOneA = 1.0;
+  double   valOneB = 3.0;
+  double   valOneC = 5.0;
+  double   valOneD = 7.0;
 
   // MeshTwo
-  Vector3d coordTwoA{0.0, 0.0, z+0.1}; // Maps to vertex A
-  Vector3d coordTwoB{0.0, 0.5, z-0.01}; // Maps to edge AD
-  Vector3d coordTwoC{2.0/3.0, 1.0/3.0, z+0.001}; // Maps to triangle ABC
+  Vector3d coordTwoA{0.0, 0.0, z + 0.1};               // Maps to vertex A
+  Vector3d coordTwoB{0.0, 0.5, z - 0.01};              // Maps to edge AD
+  Vector3d coordTwoC{2.0 / 3.0, 1.0 / 3.0, z + 0.001}; // Maps to triangle ABC
   // This corresponds to the point C from mesh two on the triangle ABC on mesh one.
   Vector3d barycenterABC{0.3798734633239789, 0.24025307335204216, 0.3798734633239789};
-  double expectedValTwoA = 1.0;
-  double expectedValTwoB = 4.0;
-  double expectedValTwoC = Vector3d{valOneA, valOneB, valOneC}.dot(barycenterABC);
+  double   expectedValTwoA = 1.0;
+  double   expectedValTwoB = 4.0;
+  double   expectedValTwoC = Vector3d{valOneA, valOneB, valOneC}.dot(barycenterABC);
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     SolverInterface cplInterface("SolverOne", 0, 1);
     // namespace is required because we are outside the fixture
     testing::SlimConfigurator::slimConfigure(cplInterface, configFile);
@@ -1263,7 +1241,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
     int idC = cplInterface.setMeshVertex(meshOneID, coordOneC.data());
     int idD = cplInterface.setMeshVertex(meshOneID, coordOneD.data());
 
-    if (defineEdgesExplicitly){
+    if (defineEdgesExplicitly) {
 
       int idAB = cplInterface.setMeshEdge(meshOneID, idA, idB);
       int idBC = cplInterface.setMeshEdge(meshOneID, idB, idC);
@@ -1284,7 +1262,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
     BOOST_TEST(cplInterface.isCouplingOngoing(), "Sending participant should have to advance once!");
 
     // Write the data to be send.
-    int dataAID = cplInterface.getDataID("DataOne",meshOneID);
+    int dataAID = cplInterface.getDataID("DataOne", meshOneID);
     cplInterface.writeScalarData(dataAID, idA, valOneA);
     cplInterface.writeScalarData(dataAID, idB, valOneB);
     cplInterface.writeScalarData(dataAID, idC, valOneC);
@@ -1294,8 +1272,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
     cplInterface.advance(maxDt);
     BOOST_TEST(!cplInterface.isCouplingOngoing(), "Sending participant should have to advance once!");
     cplInterface.finalize();
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+  } else if (utils::Parallel::getProcessRank() == 1) {
     SolverInterface cplInterface("SolverTwo", 0, 1);
     // namespace is required because we are outside the fixture
     testing::SlimConfigurator::slimConfigure(cplInterface, configFile);
@@ -1311,7 +1288,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
     BOOST_TEST(cplInterface.isCouplingOngoing(), "Receiving participant should have to advance once!");
 
     // Read the mapped data from the mesh.
-    int dataAID = cplInterface.getDataID("DataOne",meshTwoID);
+    int    dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     double valueA, valueB, valueC;
     cplInterface.readScalarData(dataAID, idA, valueA);
     cplInterface.readScalarData(dataAID, idB, valueB);
@@ -1328,19 +1305,17 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
   }
 }
 
-
 /**
  * @brief Tests the Nearest Projection Mapping between two participants with explicit definition of edges
  *
  */
 BOOST_AUTO_TEST_CASE(testMappingNearestProjectionExplicitEdges,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
-  bool defineEdgesExplicitly = true;
-  const std::string configFile = _pathToTests + "mapping-nearest-projection.xml";
+  bool              defineEdgesExplicitly = true;
+  const std::string configFile            = _pathToTests + "mapping-nearest-projection.xml";
   testMappingNearestProjection(defineEdgesExplicitly, configFile);
 }
 
@@ -1349,13 +1324,12 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjectionExplicitEdges,
  *
  */
 BOOST_AUTO_TEST_CASE(testMappingNearestProjectionImplicitEdges,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
-  bool defineEdgesExplicitly = false;
-  const std::string configFile = _pathToTests + "mapping-nearest-projection.xml";
+  bool              defineEdgesExplicitly = false;
+  const std::string configFile            = _pathToTests + "mapping-nearest-projection.xml";
   testMappingNearestProjection(defineEdgesExplicitly, configFile);
 }
 
@@ -1364,31 +1338,28 @@ BOOST_AUTO_TEST_CASE(testMappingNearestProjectionImplicitEdges,
  *
  */
 BOOST_AUTO_TEST_CASE(testSendMeshToMultipleParticipants,
-                     * testing::MinRanks(3)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
+                     *testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
 {
   if (utils::Parallel::getCommunicatorSize() != 3)
     return;
 
   const std::string configFile = _pathToTests + "send-mesh-to-multiple-participants.xml";
-  std::string solverName;
-  std::string meshName;
+  std::string       solverName;
+  std::string       meshName;
 
   Eigen::Vector2d vertex{0.0, 0.0};
 
   double value = 1.0;
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     solverName = "SolverOne";
-    meshName = "MeshA";
-  }
-  else if (utils::Parallel::getProcessRank() == 1){
+    meshName   = "MeshA";
+  } else if (utils::Parallel::getProcessRank() == 1) {
     solverName = "SolverTwo";
-    meshName = "MeshB";
-  }
-  else if (utils::Parallel::getProcessRank() == 2){
+    meshName   = "MeshB";
+  } else if (utils::Parallel::getProcessRank() == 2) {
     solverName = "SolverThree";
-    meshName = "MeshC";
+    meshName   = "MeshC";
   }
 
   SolverInterface cplInterface(solverName, 0, 1);
@@ -1402,10 +1373,9 @@ BOOST_AUTO_TEST_CASE(testSendMeshToMultipleParticipants,
 
   int dataID = cplInterface.getDataID("Data", meshID);
 
-  if (utils::Parallel::getProcessRank() == 0){
+  if (utils::Parallel::getProcessRank() == 0) {
     cplInterface.writeScalarData(dataID, vertexID, value);
-  }
-  else{
+  } else {
     double valueReceived = -1.0;
     cplInterface.readScalarData(dataID, vertexID, valueReceived);
     BOOST_TEST(valueReceived == value);
@@ -1420,8 +1390,7 @@ BOOST_AUTO_TEST_CASE(testSendMeshToMultipleParticipants,
  *
  */
 BOOST_AUTO_TEST_CASE(testPreconditionerBug,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
@@ -1432,7 +1401,7 @@ BOOST_AUTO_TEST_CASE(testPreconditionerBug,
   const std::string configFile = _pathToTests + "preconditioner-bug.xml";
 
   std::string participantName = utils::Parallel::getProcessRank() == 0 ? "SolverOne" : "SolverTwo";
-  std::string meshName = utils::Parallel::getProcessRank() == 0 ? "MeshOne" : "MeshTwo";
+  std::string meshName        = utils::Parallel::getProcessRank() == 0 ? "MeshOne" : "MeshTwo";
 
   SolverInterface cplInterface(participantName, 0, 1);
   slimConfigure(cplInterface, configFile);
@@ -1451,7 +1420,7 @@ BOOST_AUTO_TEST_CASE(testPreconditionerBug,
     if (cplInterface.isActionRequired(actionReadIterationCheckpoint()))
       cplInterface.fulfilledAction(actionReadIterationCheckpoint());
 
-    if (utils::Parallel::getProcessRank() == 1){
+    if (utils::Parallel::getProcessRank() == 1) {
       int dataID = cplInterface.getDataID("DataOne", meshID);
       // to get convergence in first timestep (everything 0), but not in second timestep
       Vector2d value{0.0, 0.0 + numberOfAdvanceCalls};
@@ -1462,7 +1431,6 @@ BOOST_AUTO_TEST_CASE(testPreconditionerBug,
   }
   cplInterface.finalize();
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/ServerTests.cpp
+++ b/src/precice/tests/ServerTests.cpp
@@ -1,11 +1,11 @@
 #ifndef PRECICE_NO_MPI
 #include "testing/Testing.hpp"
 
-#include "precice/impl/SolverInterfaceImpl.hpp"
 #include "precice/SolverInterface.hpp"
 #include "precice/config/Configuration.hpp"
-#include "utils/MasterSlave.hpp"
+#include "precice/impl/SolverInterfaceImpl.hpp"
 #include "utils/Event.hpp"
+#include "utils/MasterSlave.hpp"
 
 using namespace precice;
 
@@ -13,15 +13,15 @@ namespace precice {
 extern bool testMode;
 }
 
-
 struct ServerTestFixture : testing::WhiteboxAccessor {
   std::string _pathToTests;
 
-  void reset(){
-     mesh::Data::resetDataCount();
-     impl::Participant::resetParticipantCount();
-     utils::MasterSlave::reset();
-   }
+  void reset()
+  {
+    mesh::Data::resetDataCount();
+    impl::Participant::resetParticipantCount();
+    utils::MasterSlave::reset();
+  }
 
   ServerTestFixture()
   {
@@ -30,36 +30,33 @@ struct ServerTestFixture : testing::WhiteboxAccessor {
   }
 };
 
-
-
 BOOST_AUTO_TEST_SUITE(PreciceTests)
 BOOST_FIXTURE_TEST_SUITE(Server, ServerTestFixture)
 
 /// Runs two solver interfaces in coupling mode, one using a server
 BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
-                     * testing::MinRanks(3)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
+                     *testing::MinRanks(3) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1, 2})))
 {
   if (utils::Parallel::getCommunicatorSize() != 3)
     return;
 
-  int rank = utils::Parallel::getProcessRank();
+  int         rank       = utils::Parallel::getProcessRank();
   std::string configFile = _pathToTests + "cplmode-1.xml";
-  if ( rank == 0 ){
-    SolverInterface interface("ParticipantA", 0, 1);
+  if (rank == 0) {
+    SolverInterface           interface("ParticipantA", 0, 1);
     xml::ConfigurationContext context{"ParticipantA", 0, 1};
-    config::Configuration config;
+    config::Configuration     config;
     xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
-    double time = 0.0;
-    int timesteps = 0;
+    double time      = 0.0;
+    int    timesteps = 0;
 
     int meshID = interface.getMeshID("Mesh");
-    interface.setMeshVertex(meshID, Eigen::Vector2d(0.0,0.0).data());
-    interface.setMeshVertex(meshID, Eigen::Vector2d(1.0,0.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector2d(0.0, 0.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector2d(1.0, 0.0).data());
 
     double dt = interface.initialize();
-    while ( interface.isCouplingOngoing() ){
+    while (interface.isCouplingOngoing()) {
       time += dt;
       timesteps++;
       dt = interface.advance(dt);
@@ -67,17 +64,16 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     interface.finalize();
     BOOST_TEST(time == 5.0);
     BOOST_TEST(timesteps == 5);
-  }
-  else if ( rank == 1 ){
-    SolverInterface interface("ParticipantB", 0, 1);
+  } else if (rank == 1) {
+    SolverInterface           interface("ParticipantB", 0, 1);
     xml::ConfigurationContext context{"ParticipantB", 0, 1};
-    config::Configuration config;
+    config::Configuration     config;
     xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
-    double time = 0.0;
-    int timesteps = 0;
-    double dt = interface.initialize();
-    while ( interface.isCouplingOngoing() ){
+    double time      = 0.0;
+    int    timesteps = 0;
+    double dt        = interface.initialize();
+    while (interface.isCouplingOngoing()) {
       time += dt;
       timesteps++;
       dt = interface.advance(dt);
@@ -85,10 +81,9 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     interface.finalize();
     BOOST_TEST(time == 5.0);
     BOOST_TEST(timesteps == 5);
-  }
-  else {
-    BOOST_TEST (rank == 2, rank);
-    bool isServer = true;
+  } else {
+    BOOST_TEST(rank == 2, rank);
+    bool                      isServer = true;
     impl::SolverInterfaceImpl server("ParticipantB", 0, 1, isServer);
     xml::ConfigurationContext context{"ParticipantB", 0, 1};
 
@@ -96,8 +91,8 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
     config::Configuration config;
-    xml::configure ( config.getXMLTag(), context, configFile );
-    server.configure ( config.getSolverInterfaceConfiguration() );
+    xml::configure(config.getXMLTag(), context, configFile);
+    server.configure(config.getSolverInterfaceConfiguration());
 
     server.runServer();
   }
@@ -105,37 +100,36 @@ BOOST_AUTO_TEST_CASE(testCouplingModeWithOneServer,
 
 // deleted as parallel solvers in server mode are no longer supported
 /// Two solvers in coupling mode, one in parallel using a server
-BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
-                                                            * testing::Deleted())
+BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, *testing::OnSize(4) * testing::Deleted())
 {
-  int rank = utils::Parallel::getProcessRank();
+  int         rank       = utils::Parallel::getProcessRank();
   std::string configFile = _pathToTests + "cplmode-1.xml";
-  if (rank == 0){
-    SolverInterface interface("ParticipantA", 0, 1);
+  if (rank == 0) {
+    SolverInterface           interface("ParticipantA", 0, 1);
     xml::ConfigurationContext context{"ParticipantA", 0, 1};
-    config::Configuration config;
+    config::Configuration     config;
     xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
-    double time = 0.0;
-    int timesteps = 0;
+    double time      = 0.0;
+    int    timesteps = 0;
 
-    int meshID = interface.getMeshID("Mesh");
+    int meshID       = interface.getMeshID("Mesh");
     int scalarDataID = interface.getDataID("ScalarData", meshID);
     int vectorDataID = interface.getDataID("VectorData", meshID);
-    interface.setMeshVertex(meshID, Eigen::Vector2d(1.0,0.0).data());
-    interface.setMeshVertex(meshID, Eigen::Vector2d(0.0,-1.0).data());
-    interface.setMeshVertex(meshID, Eigen::Vector2d(-1.0,0.0).data());
-    interface.setMeshVertex(meshID, Eigen::Vector2d(0.0,1.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector2d(1.0, 0.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector2d(0.0, -1.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector2d(-1.0, 0.0).data());
+    interface.setMeshVertex(meshID, Eigen::Vector2d(0.0, 1.0).data());
 
-    double dt = interface.initialize();
-    MeshHandle handle = interface.getMeshHandle("Mesh");
-    VertexHandle vertices = handle.vertices();
-    int dataSize = 4;
-    int indices[] = {0, 1, 2, 3};
-    double vectorValues[] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    double                      dt             = interface.initialize();
+    MeshHandle                  handle         = interface.getMeshHandle("Mesh");
+    VertexHandle                vertices       = handle.vertices();
+    int                         dataSize       = 4;
+    int                         indices[]      = {0, 1, 2, 3};
+    double                      vectorValues[] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     Eigen::Matrix<double, 8, 1> expect;
     expect << 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0;
-    while (interface.isCouplingOngoing()){
+    while (interface.isCouplingOngoing()) {
       time += dt;
       timesteps++;
       for (VertexIterator vertex : vertices) {
@@ -149,23 +143,22 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     interface.finalize();
     BOOST_TEST(time == 5.0);
     BOOST_TEST(timesteps == 5);
-  }
-  else if ((rank == 1) || (rank == 2)){
-    SolverInterface interface("ParticipantB", rank-1, 2);
-    xml::ConfigurationContext context{"ParticipantB", rank-1, 2};
-    config::Configuration config;
+  } else if ((rank == 1) || (rank == 2)) {
+    SolverInterface           interface("ParticipantB", rank - 1, 2);
+    xml::ConfigurationContext context{"ParticipantB", rank - 1, 2};
+    config::Configuration     config;
     xml::configure(config.getXMLTag(), context, configFile);
     impl(interface).configure(config.getSolverInterfaceConfiguration());
-    double time = 0.0;
-    int timesteps = 0;
-    double dt = interface.initialize();
-    int meshID = interface.getMeshID("Mesh");
-    int scalarDataID = interface.getDataID("ScalarData", meshID);
-    int vectorDataID = interface.getDataID("VectorData", meshID);
-    int dataSize = 4;
-    int indices[] = {0, 1, 2, 3};
+    double time           = 0.0;
+    int    timesteps      = 0;
+    double dt             = interface.initialize();
+    int    meshID         = interface.getMeshID("Mesh");
+    int    scalarDataID   = interface.getDataID("ScalarData", meshID);
+    int    vectorDataID   = interface.getDataID("VectorData", meshID);
+    int    dataSize       = 4;
+    int    indices[]      = {0, 1, 2, 3};
     double vectorValues[] = {1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0};
-    while (interface.isCouplingOngoing()){
+    while (interface.isCouplingOngoing()) {
       double value = 0.0;
       interface.readScalarData(scalarDataID, 0, value);
       BOOST_TEST(value == 1.0);
@@ -177,10 +170,9 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     interface.finalize();
     BOOST_TEST(time == 5.0);
     BOOST_TEST(timesteps == 5);
-  }
-  else {
+  } else {
     BOOST_TEST(rank == 3, rank);
-    bool isServer = true;
+    bool                      isServer = true;
     impl::SolverInterfaceImpl server("ParticipantB", 0, 1, isServer);
     xml::ConfigurationContext context{"ParticipantB", 0, 1};
 
@@ -193,7 +185,6 @@ BOOST_AUTO_TEST_CASE(testCouplingModeParallelWithOneServer, * testing::OnSize(4)
     server.runServer();
   }
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/VersioningTests.cpp
+++ b/src/precice/tests/VersioningTests.cpp
@@ -1,7 +1,7 @@
 #include "testing/Testing.hpp"
 
-#include <string>
 #include <algorithm>
+#include <string>
 #include "precice/SolverInterface.hpp"
 #include "precice/impl/versions.hpp"
 
@@ -10,23 +10,24 @@ BOOST_AUTO_TEST_SUITE(Versioning)
 
 BOOST_AUTO_TEST_CASE(VersionInformation)
 {
-    const std::string info{::precice::getVersionInformation()};
-    BOOST_TEST_CONTEXT("Info is \"" << info << "\"") {
-        BOOST_TEST(!info.empty(), "The info contains at least the version.");
+  const std::string info{::precice::getVersionInformation()};
+  BOOST_TEST_CONTEXT("Info is \"" << info << "\"")
+  {
+    BOOST_TEST(!info.empty(), "The info contains at least the version.");
 
-        auto semis = std::count(info.begin(), info.end(), ';');
-        BOOST_TEST(semis >= 2, "The info contains " << semis << " of at least 3 sections ");
+    auto semis = std::count(info.begin(), info.end(), ';');
+    BOOST_TEST(semis >= 2, "The info contains " << semis << " of at least 3 sections ");
 
-        auto firstSemi = info.find(';');
-        auto version = info.substr(0, firstSemi);
-        BOOST_TEST_INFO("Section: " << version);
-        BOOST_TEST(!version.empty(), "The info contains the version section");
+    auto firstSemi = info.find(';');
+    auto version   = info.substr(0, firstSemi);
+    BOOST_TEST_INFO("Section: " << version);
+    BOOST_TEST(!version.empty(), "The info contains the version section");
 
-        auto secondSemi = info.find(';', firstSemi+1);
-        auto revision = info.substr(firstSemi+1, secondSemi-firstSemi-1);
-        BOOST_TEST_INFO("Section: " << revision);
-        BOOST_TEST(!revision.empty(), "The info contains the revision section");
-    }
+    auto secondSemi = info.find(';', firstSemi + 1);
+    auto revision   = info.substr(firstSemi + 1, secondSemi - firstSemi - 1);
+    BOOST_TEST_INFO("Section: " << revision);
+    BOOST_TEST(!revision.empty(), "The info contains the revision section");
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -15,32 +15,31 @@ BOOST_AUTO_TEST_CASE(WatchPoint)
   using Eigen::VectorXd;
   // Setup geometry
   std::string name("rectangle");
-  bool flipNormals = false;
-  PtrMesh mesh(new Mesh(name, dim, flipNormals, testing::nextMeshID()));
+  bool        flipNormals = false;
+  PtrMesh     mesh(new Mesh(name, dim, flipNormals, testing::nextMeshID()));
 
-  mesh::Vertex& v1 = mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
-  mesh::Vertex& v2 = mesh->createVertex(Eigen::Vector2d(2.0, 1.0));
-  mesh::Vertex& v3 = mesh->createVertex(Eigen::Vector2d(1.0, 2.0));
-  mesh::Vertex& v4 = mesh->createVertex(Eigen::Vector2d(2.0, 2.0));
-  mesh->createEdge(v1,v2);
-  mesh->createEdge(v1,v3);
-  mesh->createEdge(v2,v4);
-  mesh->createEdge(v3,v4);
+  mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(2.0, 1.0));
+  mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector2d(1.0, 2.0));
+  mesh::Vertex &v4 = mesh->createVertex(Eigen::Vector2d(2.0, 2.0));
+  mesh->createEdge(v1, v2);
+  mesh->createEdge(v1, v3);
+  mesh->createEdge(v2, v4);
+  mesh->createEdge(v3, v4);
 
-  PtrData doubleData = mesh->createData("DoubleData", 1);
-  PtrData vectorData = mesh->createData("VectorData", dim);
-  auto &doubleValues = doubleData->values();
-  auto &vectorValues = vectorData->values();
+  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData vectorData   = mesh->createData("VectorData", dim);
+  auto &  doubleValues = doubleData->values();
+  auto &  vectorValues = vectorData->values();
   mesh->computeState();
   mesh->allocateDataValues();
 
-
   // Create watchpoints
-  Eigen::Vector2d pointToWatch0(1.0, 1.0);
-  std::string filename0("precice-WatchPointTest-output0.log");
+  Eigen::Vector2d  pointToWatch0(1.0, 1.0);
+  std::string      filename0("precice-WatchPointTest-output0.log");
   impl::WatchPoint watchpoint0(pointToWatch0, mesh, filename0);
-  Eigen::Vector2d pointToWatch1(1.0, 1.5);
-  std::string filename1("precice-WatchPointTest-output1.log");
+  Eigen::Vector2d  pointToWatch1(1.0, 1.5);
+  std::string      filename1("precice-WatchPointTest-output1.log");
   impl::WatchPoint watchpoint1(pointToWatch1, mesh, filename1);
 
   // Initialize

--- a/src/query/FindClosest.cpp
+++ b/src/query/FindClosest.cpp
@@ -1,41 +1,42 @@
 #include "FindClosest.hpp"
-#include "mesh/Vertex.hpp"
-#include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
-#include "mesh/Quad.hpp"
-#include "math/barycenter.hpp"
-#include "math/math.hpp"
 #include <limits>
 #include <utility>
+#include "math/barycenter.hpp"
+#include "math/math.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Quad.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
 
 namespace precice {
 namespace query {
 
-std::ostream& operator<<(std::ostream& out, const InterpolationElement& val)
+std::ostream &operator<<(std::ostream &out, const InterpolationElement &val)
 {
-    out << '(' << *val.element << ", w:" << val.weight << ')';
-    return out;
+  out << '(' << *val.element << ", w:" << val.weight << ')';
+  return out;
 }
 
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex& /*location*/,
-    const mesh::Vertex& element)
+    const mesh::Vertex & /*location*/,
+    const mesh::Vertex &element)
 {
   return {{element, 1.0}};
 }
 
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex& location,
-    const mesh::Edge&   element)
+    const mesh::Vertex &location,
+    const mesh::Edge &  element)
 {
   auto &A = element.vertex(0);
   auto &B = element.vertex(1);
 
   const auto bcoords = math::barycenter::calcBarycentricCoordsForEdge(
-      A.getCoords(),
-      B.getCoords(),
-      element.getNormal(),
-      location.getCoords()).barycentricCoords;
+                           A.getCoords(),
+                           B.getCoords(),
+                           element.getNormal(),
+                           location.getCoords())
+                           .barycentricCoords;
 
   InterpolationElements elems;
   elems.emplace_back(A, bcoords(0));
@@ -44,19 +45,20 @@ InterpolationElements generateInterpolationElements(
 }
 
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex&   location,
-    const mesh::Triangle& element)
+    const mesh::Vertex &  location,
+    const mesh::Triangle &element)
 {
   auto &A = element.vertex(0);
   auto &B = element.vertex(1);
   auto &C = element.vertex(2);
 
   const auto bcoords = math::barycenter::calcBarycentricCoordsForTriangle(
-      A.getCoords(),
-      B.getCoords(),
-      C.getCoords(),
-      element.getNormal(),
-      location.getCoords()).barycentricCoords;
+                           A.getCoords(),
+                           B.getCoords(),
+                           C.getCoords(),
+                           element.getNormal(),
+                           location.getCoords())
+                           .barycentricCoords;
 
   InterpolationElements elems;
   elems.emplace_back(A, bcoords(0));
@@ -66,8 +68,8 @@ InterpolationElements generateInterpolationElements(
 }
 
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex& location,
-    const mesh::Quad&   element)
+    const mesh::Vertex &location,
+    const mesh::Quad &  element)
 {
   auto &A = element.vertex(0);
   auto &B = element.vertex(1);
@@ -75,12 +77,13 @@ InterpolationElements generateInterpolationElements(
   auto &D = element.vertex(3);
 
   const auto bcoords = math::barycenter::calcBarycentricCoordsForQuad(
-      A.getCoords(),
-      B.getCoords(),
-      C.getCoords(),
-      D.getCoords(),
-      element.getNormal(),
-      location.getCoords()).barycentricCoords;
+                           A.getCoords(),
+                           B.getCoords(),
+                           C.getCoords(),
+                           D.getCoords(),
+                           element.getNormal(),
+                           location.getCoords())
+                           .barycentricCoords;
 
   InterpolationElements elems;
   elems.emplace_back(A, bcoords(0));
@@ -90,121 +93,118 @@ InterpolationElements generateInterpolationElements(
   return elems;
 }
 
-bool FindClosest:: hasFound() const
+bool FindClosest::hasFound() const
 {
   return not _closest.meshIDs.empty();
 }
 
-const ClosestElement& FindClosest:: getClosest()
+const ClosestElement &FindClosest::getClosest()
 {
   return _closest;
 }
 
-double FindClosest:: getEuclidianDistance()
+double FindClosest::getEuclidianDistance()
 {
   return std::abs(_closest.distance);
 }
 
-const Eigen::VectorXd& FindClosest:: getSearchPoint() const
+const Eigen::VectorXd &FindClosest::getSearchPoint() const
 {
   return _searchpoint;
 }
 
-bool FindClosest:: determineClosest()
+bool FindClosest::determineClosest()
 {
   PRECICE_TRACE(_searchpoint);
   using math::greater;
-  _closest = ClosestElement(_searchpoint.size());
+  _closest          = ClosestElement(_searchpoint.size());
   _closest.distance = std::numeric_limits<double>::max();
-  int closestType = -1;
-  if ( greater(_closest.distance, _findClosestVertex.getEuclidianDistance()) ) {
+  int closestType   = -1;
+  if (greater(_closest.distance, _findClosestVertex.getEuclidianDistance())) {
     _closest.distance = _findClosestVertex.getEuclidianDistance();
-    closestType = 0;
+    closestType       = 0;
   }
-  if ( greater(_closest.distance, _findClosestEdge.getEuclidianDistance()) ) {
+  if (greater(_closest.distance, _findClosestEdge.getEuclidianDistance())) {
     _closest.distance = _findClosestEdge.getEuclidianDistance();
-    closestType = 1;
+    closestType       = 1;
   }
-  if ( greater(_closest.distance, _findClosestTriangle.getEuclidianDistance()) ) {
+  if (greater(_closest.distance, _findClosestTriangle.getEuclidianDistance())) {
     _closest.distance = _findClosestTriangle.getEuclidianDistance();
-    closestType = 2;
+    closestType       = 2;
   }
-  if ( greater(_closest.distance, _findClosestQuad.getEuclidianDistance()) ) {
+  if (greater(_closest.distance, _findClosestQuad.getEuclidianDistance())) {
     _closest.distance = _findClosestQuad.getEuclidianDistance();
-    closestType = 3;
+    closestType       = 3;
   }
   // Assign all properties to _closest
   Eigen::VectorXd normal = Eigen::VectorXd::Zero(_searchpoint.size());
-  if ( closestType == 0 ) { // Vertex
-    mesh::Vertex& vertex = _findClosestVertex.getClosestVertex ();
+  if (closestType == 0) { // Vertex
+    mesh::Vertex &vertex     = _findClosestVertex.getClosestVertex();
     _closest.vectorToElement = vertex.getCoords() - _searchpoint;
-    normal = vertex.getNormal();
+    normal                   = vertex.getNormal();
     InterpolationElement element;
-    element.element = & vertex;
-    element.weight = 1.0;
-    _closest.interpolationElements.push_back ( element );
-  }
-  else if ( closestType == 1 ) { // Edge
-    mesh::Edge& edge = _findClosestEdge.getClosestEdge();
+    element.element = &vertex;
+    element.weight  = 1.0;
+    _closest.interpolationElements.push_back(element);
+  } else if (closestType == 1) { // Edge
+    mesh::Edge &edge         = _findClosestEdge.getClosestEdge();
     _closest.vectorToElement = _findClosestEdge.getVectorToProjectionPoint();
-    normal = edge.getNormal();
+    normal                   = edge.getNormal();
     InterpolationElement element0, element1;
-    element0.element = & edge.vertex (0);
-    element1.element = & edge.vertex (1);
-    element0.weight = _findClosestEdge.getProjectionPointParameter(0);
-    element1.weight = _findClosestEdge.getProjectionPointParameter(1);
-    _closest.interpolationElements.push_back ( element0 );
-    _closest.interpolationElements.push_back ( element1 );
-  }
-  else if ( closestType == 2 ) { // Triangle
-    mesh::Triangle& triangle = _findClosestTriangle.getClosestTriangle ();
+    element0.element = &edge.vertex(0);
+    element1.element = &edge.vertex(1);
+    element0.weight  = _findClosestEdge.getProjectionPointParameter(0);
+    element1.weight  = _findClosestEdge.getProjectionPointParameter(1);
+    _closest.interpolationElements.push_back(element0);
+    _closest.interpolationElements.push_back(element1);
+  } else if (closestType == 2) { // Triangle
+    mesh::Triangle &triangle = _findClosestTriangle.getClosestTriangle();
     _closest.vectorToElement = _findClosestTriangle.getVectorToProjectionPoint();
-    normal = triangle.getNormal();
+    normal                   = triangle.getNormal();
     InterpolationElement element0, element1, element2;
-    element0.element = & triangle.vertex (0);
-    element1.element = & triangle.vertex (1);
-    element2.element = & triangle.vertex (2);
-    element0.weight = _findClosestTriangle.getProjectionPointParameter(0);
-    element1.weight = _findClosestTriangle.getProjectionPointParameter(1);
-    element2.weight = _findClosestTriangle.getProjectionPointParameter(2);
-    _closest.interpolationElements.push_back ( element0 );
-    _closest.interpolationElements.push_back ( element1 );
-    _closest.interpolationElements.push_back ( element2 );
-  }
-  else if ( closestType == 3 ) { // Quad
-    mesh::Quad& quad = _findClosestQuad.getClosestQuad();
+    element0.element = &triangle.vertex(0);
+    element1.element = &triangle.vertex(1);
+    element2.element = &triangle.vertex(2);
+    element0.weight  = _findClosestTriangle.getProjectionPointParameter(0);
+    element1.weight  = _findClosestTriangle.getProjectionPointParameter(1);
+    element2.weight  = _findClosestTriangle.getProjectionPointParameter(2);
+    _closest.interpolationElements.push_back(element0);
+    _closest.interpolationElements.push_back(element1);
+    _closest.interpolationElements.push_back(element2);
+  } else if (closestType == 3) { // Quad
+    mesh::Quad &quad         = _findClosestQuad.getClosestQuad();
     _closest.vectorToElement = _findClosestQuad.getVectorToProjectionPoint();
-    normal = quad.getNormal();
+    normal                   = quad.getNormal();
     InterpolationElement element0, element1, element2, element3;
     element0.element = &quad.vertex(0);
     element1.element = &quad.vertex(1);
     element2.element = &quad.vertex(2);
     element3.element = &quad.vertex(3);
-    element0.weight = _findClosestQuad.getProjectionPointParameter(0);
-    element1.weight = _findClosestQuad.getProjectionPointParameter(1);
-    element2.weight = _findClosestQuad.getProjectionPointParameter(2);
-    element3.weight = _findClosestQuad.getProjectionPointParameter(3);
+    element0.weight  = _findClosestQuad.getProjectionPointParameter(0);
+    element1.weight  = _findClosestQuad.getProjectionPointParameter(1);
+    element2.weight  = _findClosestQuad.getProjectionPointParameter(2);
+    element3.weight  = _findClosestQuad.getProjectionPointParameter(3);
     _closest.interpolationElements.push_back(element0);
     _closest.interpolationElements.push_back(element1);
     _closest.interpolationElements.push_back(element2);
     _closest.interpolationElements.push_back(element3);
-  }
-  else {
+  } else {
     return false;
   }
-// Flip sign of distance, depending on normal of closest element
-if (_closest.vectorToElement.dot(normal) > 0.0) {
+  // Flip sign of distance, depending on normal of closest element
+  if (_closest.vectorToElement.dot(normal) > 0.0) {
     _closest.distance *= -1.0;
   }
   return true;
 }
 
-void FindClosest:: reset()
+void FindClosest::reset()
 {
-  _findClosestVertex = FindClosestVertex(_searchpoint);
-  _findClosestEdge = FindClosestEdge(_searchpoint);
+  _findClosestVertex   = FindClosestVertex(_searchpoint);
+  _findClosestEdge     = FindClosestEdge(_searchpoint);
   _findClosestTriangle = FindClosestTriangle(_searchpoint);
-  _findClosestQuad = FindClosestQuad(_searchpoint);
+  _findClosestQuad     = FindClosestQuad(_searchpoint);
 }
 
-}} // namespace precice, query
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosest.hpp
+++ b/src/query/FindClosest.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "FindClosestVertex.hpp"
-#include "FindClosestEdge.hpp"
-#include "FindClosestTriangle.hpp"
-#include "FindClosestQuad.hpp"
 #include <vector>
+#include "FindClosestEdge.hpp"
+#include "FindClosestQuad.hpp"
+#include "FindClosestTriangle.hpp"
+#include "FindClosestVertex.hpp"
 
 namespace precice {
-   namespace mesh {
-      class Mesh;
-   }
+namespace mesh {
+class Mesh;
 }
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
@@ -20,17 +20,18 @@ namespace query {
 /**
  * @brief Weighting and reference to target element for a value to interpolate
  */
-struct InterpolationElement
-{
-  const mesh::Vertex* element = nullptr;
-  double weight = 0.0;
+struct InterpolationElement {
+  const mesh::Vertex *element = nullptr;
+  double              weight  = 0.0;
 
   InterpolationElement() = default;
-  InterpolationElement(const mesh::Vertex* element_, double weight_): element(element_), weight(weight_) {}
-  InterpolationElement(const mesh::Vertex& element_, double weight_): element(&element_), weight(weight_) {}
+  InterpolationElement(const mesh::Vertex *element_, double weight_)
+      : element(element_), weight(weight_) {}
+  InterpolationElement(const mesh::Vertex &element_, double weight_)
+      : element(&element_), weight(weight_) {}
 };
 
-std::ostream& operator<<(std::ostream& out, const InterpolationElement& val);
+std::ostream &operator<<(std::ostream &out, const InterpolationElement &val);
 
 /// A vector of InterpolationElement
 using InterpolationElements = std::vector<InterpolationElement>;
@@ -38,37 +39,37 @@ using InterpolationElements = std::vector<InterpolationElement>;
 /**
  * @brief Closest element to all objects with given mesh ID
  */
-struct ClosestElement
-{
-  std::vector<int> meshIDs;
-  double distance = 0;
-  Eigen::VectorXd vectorToElement;
+struct ClosestElement {
+  std::vector<int>      meshIDs;
+  double                distance = 0;
+  Eigen::VectorXd       vectorToElement;
   InterpolationElements interpolationElements;
 
-  ClosestElement (int dim)
-    : vectorToElement(Eigen::VectorXd::Zero(dim))
-  {}
+  ClosestElement(int dim)
+      : vectorToElement(Eigen::VectorXd::Zero(dim))
+  {
+  }
 };
 
 /// Generates the InterpolationElements for directly projecting a Vertex on another Vertex
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex& location,
-    const mesh::Vertex& element);
+    const mesh::Vertex &location,
+    const mesh::Vertex &element);
 
 /// Generates the InterpolationElements for projecting a Vertex on an Edge
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex& location,
-    const mesh::Edge&   element);
+    const mesh::Vertex &location,
+    const mesh::Edge &  element);
 
 /// Generates the InterpolationElements for projecting a Vertex on a Triangle
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex&   location,
-    const mesh::Triangle& element);
+    const mesh::Vertex &  location,
+    const mesh::Triangle &element);
 
 /// Generates the InterpolationElements for projecting a Vertex on a Quad
 InterpolationElements generateInterpolationElements(
-    const mesh::Vertex& location,
-    const mesh::Quad&   element);
+    const mesh::Vertex &location,
+    const mesh::Quad &  element);
 
 /**
  * @brief Determines closest Triangle, Edge, or Vertex object to a given point.
@@ -86,39 +87,36 @@ InterpolationElements generateInterpolationElements(
  * all smaller or equal to one. The interpolation weigths for the points of the
  * triangle are equal to the barycentric coordinates.
  */
-class FindClosest
-{
+class FindClosest {
 public:
-
   /**
    * @brief Constructor, searchpoint can be specified only there
    *
    * @param[in] searchpoint Point from where distances to objects are measured
    */
-  template<typename VECTOR_T>
-  FindClosest ( const VECTOR_T& searchpoint );
+  template <typename VECTOR_T>
+  FindClosest(const VECTOR_T &searchpoint);
 
   /// Finds closest distance to all mesh elements in the given container.
-  template<typename CONTAINER_T>
-  bool operator() ( CONTAINER_T& container );
+  template <typename CONTAINER_T>
+  bool operator()(CONTAINER_T &container);
 
   /// Returns true, if a closest element was found.
   bool hasFound() const;
 
   /// Returns ClosestElement found, error when no visitable has been found
-  const ClosestElement& getClosest();
+  const ClosestElement &getClosest();
 
   /// Returns the euclidian distance to the closest element.
   double getEuclidianDistance();
 
   /// Returns search point
-  const Eigen::VectorXd& getSearchPoint() const;
+  const Eigen::VectorXd &getSearchPoint() const;
 
   /// Resets the found visitables, not done automatically
   void reset();
 
 private:
-
   logging::Logger _log{"query::FindClosest"};
 
   /// Finds closest distance to Vertex objects.
@@ -149,23 +147,21 @@ private:
 
 // --------------------------------------------------------- HEADER DEFINITIONS
 
-template<typename VECTOR_T>
-FindClosest:: FindClosest
-(
-  const VECTOR_T& searchpoint )
-:
-  _findClosestVertex(searchpoint),
-  _findClosestEdge(searchpoint),
-  _findClosestTriangle(searchpoint),
-  _findClosestQuad(searchpoint),
-  _closest(searchpoint.size()),
-  _searchpoint(searchpoint)
-{}
+template <typename VECTOR_T>
+FindClosest::FindClosest(
+    const VECTOR_T &searchpoint)
+    : _findClosestVertex(searchpoint),
+      _findClosestEdge(searchpoint),
+      _findClosestTriangle(searchpoint),
+      _findClosestQuad(searchpoint),
+      _closest(searchpoint.size()),
+      _searchpoint(searchpoint)
+{
+}
 
-template<typename CONTAINER_T>
-bool FindClosest:: operator()
-(
-  CONTAINER_T& container )
+template <typename CONTAINER_T>
+bool FindClosest::operator()(
+    CONTAINER_T &container)
 {
   // It is not valid here, to stop the search for vertices (e.g.) if a closest
   // edge has been found already, since the edge might be oriented wrongly.
@@ -176,4 +172,5 @@ bool FindClosest:: operator()
   return determineClosest();
 }
 
-}} // namespace precice, query
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestEdge.cpp
+++ b/src/query/FindClosestEdge.cpp
@@ -1,57 +1,54 @@
 #include "FindClosestEdge.hpp"
 #include <Eigen/Dense>
-#include "mesh/Vertex.hpp"
+#include <array>
+#include <utility>
+#include "math/barycenter.hpp"
+#include "math/geometry.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Mesh.hpp"
-#include "math/geometry.hpp"
-#include "math/barycenter.hpp"
-#include <utility>
-#include <array>
+#include "mesh/Vertex.hpp"
 
 namespace precice {
 namespace query {
 
-FindClosestEdge:: FindClosestEdge
-(
-  const Eigen::VectorXd& searchPoint )
-:
-  _searchPoint ( searchPoint ),
-  _vectorToProjectionPoint ( Eigen::VectorXd::Constant(searchPoint.size(), std::numeric_limits<double>::max()) ),
-  _parametersProjectionPoint( {_shortestDistance , _shortestDistance} )
+FindClosestEdge::FindClosestEdge(
+    const Eigen::VectorXd &searchPoint)
+    : _searchPoint(searchPoint),
+      _vectorToProjectionPoint(Eigen::VectorXd::Constant(searchPoint.size(), std::numeric_limits<double>::max())),
+      _parametersProjectionPoint({_shortestDistance, _shortestDistance})
 {
-  PRECICE_ASSERT( (_searchPoint.size() == 2) || (_searchPoint.size() == 3),
-               _searchPoint.size() );
+  PRECICE_ASSERT((_searchPoint.size() == 2) || (_searchPoint.size() == 3),
+                 _searchPoint.size());
 }
 
-const Eigen::VectorXd& FindClosestEdge:: getSearchPoint() const
+const Eigen::VectorXd &FindClosestEdge::getSearchPoint() const
 {
   return _searchPoint;
 }
 
-bool FindClosestEdge:: hasFound() const
+bool FindClosestEdge::hasFound() const
 {
   return _closestEdge != nullptr;
 }
 
-double FindClosestEdge:: getEuclidianDistance()
+double FindClosestEdge::getEuclidianDistance()
 {
   return _shortestDistance;
 }
 
-mesh::Edge& FindClosestEdge:: getClosestEdge()
+mesh::Edge &FindClosestEdge::getClosestEdge()
 {
-  PRECICE_ASSERT( _closestEdge != nullptr );
+  PRECICE_ASSERT(_closestEdge != nullptr);
   return *_closestEdge;
 }
 
-const Eigen::VectorXd& FindClosestEdge:: getVectorToProjectionPoint() const
+const Eigen::VectorXd &FindClosestEdge::getVectorToProjectionPoint() const
 {
   return _vectorToProjectionPoint;
 }
 
-double FindClosestEdge:: getProjectionPointParameter
-(
-  int index ) const
+double FindClosestEdge::getProjectionPointParameter(
+    int index) const
 {
   return _parametersProjectionPoint[index];
 }
@@ -66,33 +63,34 @@ double FindClosestEdge:: getProjectionPointParameter
 //  return _parametersProjectionPoint[1];
 //}
 
-void FindClosestEdge:: find ( mesh::Edge& edge )
+void FindClosestEdge::find(mesh::Edge &edge)
 {
-  PRECICE_TRACE(edge.vertex(0).getCoords(), edge.vertex(1).getCoords() );
+  PRECICE_TRACE(edge.vertex(0).getCoords(), edge.vertex(1).getCoords());
 
   // Methodology of book "Computational Geometry", Joseph O' Rourke, Chapter 7.2
-  auto& a = edge.vertex(0).getCoords();
-  auto& b = edge.vertex(1).getCoords();
-  auto& norm = edge.getNormal();
+  auto &a    = edge.vertex(0).getCoords();
+  auto &b    = edge.vertex(1).getCoords();
+  auto &norm = edge.getNormal();
 
   auto ret = math::barycenter::calcBarycentricCoordsForEdge(a, b, norm, _searchPoint);
   PRECICE_ASSERT(ret.barycentricCoords.size() == 2);
 
-  bool inside = not (ret.barycentricCoords.array() < - math::NUMERICAL_ZERO_DIFFERENCE).any();
+  bool inside = not(ret.barycentricCoords.array() < -math::NUMERICAL_ZERO_DIFFERENCE).any();
 
   // if valid, compute distance to triangle and evtl. store distance
   if (inside) {
     Eigen::VectorXd distanceVector = ret.projected;
     distanceVector -= _searchPoint;
     double distance = distanceVector.norm();
-    if ( _shortestDistance > distance ) {
-      _shortestDistance = distance;
-      _vectorToProjectionPoint = distanceVector;
+    if (_shortestDistance > distance) {
+      _shortestDistance             = distance;
+      _vectorToProjectionPoint      = distanceVector;
       _parametersProjectionPoint[0] = ret.barycentricCoords[0];
       _parametersProjectionPoint[1] = ret.barycentricCoords[1];
-      _closestEdge = &edge;
+      _closestEdge                  = &edge;
     }
   }
 }
 
-}} // namespace precice, query
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestEdge.hpp
+++ b/src/query/FindClosestEdge.hpp
@@ -1,49 +1,46 @@
 #pragma once
 
-#include <array>
 #include <Eigen/Core>
+#include <array>
 #include "logging/Logger.hpp"
 
 namespace precice {
-  namespace mesh {
-    class Edge;
-    class Mesh;
-  }
-}
+namespace mesh {
+class Edge;
+class Mesh;
+} // namespace mesh
+} // namespace precice
 
 namespace precice {
 namespace query {
 
 /// Finds the closest Edge object contained in Mesh objects.
-class FindClosestEdge
-{
+class FindClosestEdge {
 public:
-
-  explicit FindClosestEdge ( const Eigen::VectorXd& searchPoint );
+  explicit FindClosestEdge(const Eigen::VectorXd &searchPoint);
 
   /**
    * @brief Finds the closest Edge object contained in the given Mesh object.
    *
    * @return True, if a closest Edge object could be found.
    */
-  template<typename CONTAINER_T>
-  bool operator() ( CONTAINER_T& container );
+  template <typename CONTAINER_T>
+  bool operator()(CONTAINER_T &container);
 
-  const Eigen::VectorXd& getSearchPoint() const;
+  const Eigen::VectorXd &getSearchPoint() const;
 
   bool hasFound() const;
 
   double getEuclidianDistance();
 
-  mesh::Edge& getClosestEdge();
+  mesh::Edge &getClosestEdge();
 
-  const Eigen::VectorXd& getVectorToProjectionPoint() const;
+  const Eigen::VectorXd &getVectorToProjectionPoint() const;
 
   /// Returns parametric description value (index 0,1) of projected point.
-  double getProjectionPointParameter ( int index ) const;
+  double getProjectionPointParameter(int index) const;
 
 private:
-
   logging::Logger _log{"query::FindClosestEdge"};
 
   Eigen::VectorXd _searchPoint;
@@ -52,30 +49,26 @@ private:
 
   Eigen::VectorXd _vectorToProjectionPoint;
 
-  std::array<double,2> _parametersProjectionPoint;
+  std::array<double, 2> _parametersProjectionPoint;
 
-  mesh::Edge* _closestEdge = nullptr;
+  mesh::Edge *_closestEdge = nullptr;
 
-  void find ( mesh::Edge& edge );
+  void find(mesh::Edge &edge);
 };
-
-
 
 // --------------------------------------------------------- HEADER DEFINITIONS
 
-template<typename CONTAINER_T>
-bool FindClosestEdge:: operator()
-(
-  CONTAINER_T& container )
+template <typename CONTAINER_T>
+bool FindClosestEdge::operator()(
+    CONTAINER_T &container)
 {
   size_t index = 0;
-  for ( mesh::Edge& edge : container.edges() ) {
-    find ( edge );
-    index ++;
+  for (mesh::Edge &edge : container.edges()) {
+    find(edge);
+    index++;
   }
   return _closestEdge != nullptr;
 }
 
-}} // namespace precice, query
-
-
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestQuad.cpp
+++ b/src/query/FindClosestQuad.cpp
@@ -1,88 +1,86 @@
 #include "FindClosestQuad.hpp"
-#include "mesh/Quad.hpp"
-#include "mesh/Vertex.hpp"
-#include "mesh/Mesh.hpp"
 #include <Eigen/Dense>
 #include "math/barycenter.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/Quad.hpp"
+#include "mesh/Vertex.hpp"
 
 namespace precice {
 namespace query {
 
-FindClosestQuad:: FindClosestQuad
-(
-  const Eigen::VectorXd& searchPoint )
-:
-  _searchPoint ( searchPoint ),
-  _vectorToProjectionPoint ( Eigen::VectorXd::Constant(_searchPoint.size(), std::numeric_limits<double>::max()) ),
-  _parametersProjectionPoint( {_shortestDistance ,_shortestDistance, _shortestDistance, _shortestDistance} )
-{}
+FindClosestQuad::FindClosestQuad(
+    const Eigen::VectorXd &searchPoint)
+    : _searchPoint(searchPoint),
+      _vectorToProjectionPoint(Eigen::VectorXd::Constant(_searchPoint.size(), std::numeric_limits<double>::max())),
+      _parametersProjectionPoint({_shortestDistance, _shortestDistance, _shortestDistance, _shortestDistance})
+{
+}
 
-const Eigen::VectorXd& FindClosestQuad:: getSearchPoint() const
+const Eigen::VectorXd &FindClosestQuad::getSearchPoint() const
 {
   return _searchPoint;
 }
 
-bool FindClosestQuad:: hasFound() const
+bool FindClosestQuad::hasFound() const
 {
   return _closestQuad != nullptr;
 }
 
-double FindClosestQuad:: getEuclidianDistance()
+double FindClosestQuad::getEuclidianDistance()
 {
   return _shortestDistance;
 }
 
-mesh::Quad & FindClosestQuad:: getClosestQuad()
+mesh::Quad &FindClosestQuad::getClosestQuad()
 {
   PRECICE_ASSERT(_closestQuad != nullptr);
   return *_closestQuad;
 }
 
-const Eigen::VectorXd& FindClosestQuad:: getVectorToProjectionPoint() const
+const Eigen::VectorXd &FindClosestQuad::getVectorToProjectionPoint() const
 {
   return _vectorToProjectionPoint;
 }
 
-double FindClosestQuad:: getProjectionPointParameter
-(
-  int index ) const
+double FindClosestQuad::getProjectionPointParameter(
+    int index) const
 {
   return _parametersProjectionPoint[index];
 }
 
-void FindClosestQuad:: find
-(
-  mesh::Quad& quad )
+void FindClosestQuad::find(
+    mesh::Quad &quad)
 {
-  PRECICE_TRACE(quad.vertex(0).getCoords(), quad.vertex(1).getCoords(), quad.vertex(2).getCoords() , quad.vertex(3).getCoords());
+  PRECICE_TRACE(quad.vertex(0).getCoords(), quad.vertex(1).getCoords(), quad.vertex(2).getCoords(), quad.vertex(3).getCoords());
 
   // Methodology of book "Computational Geometry", Joseph O' Rourke, Chapter 7.2
-  auto& a = quad.vertex(0).getCoords();
-  auto& b = quad.vertex(1).getCoords();
-  auto& c = quad.vertex(2).getCoords();
-  auto& d = quad.vertex(3).getCoords();
-  auto& norm = quad.getNormal();
+  auto &a    = quad.vertex(0).getCoords();
+  auto &b    = quad.vertex(1).getCoords();
+  auto &c    = quad.vertex(2).getCoords();
+  auto &d    = quad.vertex(3).getCoords();
+  auto &norm = quad.getNormal();
 
   auto ret = math::barycenter::calcBarycentricCoordsForQuad(a, b, c, d, norm, _searchPoint);
   PRECICE_ASSERT(ret.barycentricCoords.size() == 4);
 
-  const bool inside = not (ret.barycentricCoords.array() < - math::NUMERICAL_ZERO_DIFFERENCE).any();
+  const bool inside = not(ret.barycentricCoords.array() < -math::NUMERICAL_ZERO_DIFFERENCE).any();
 
   // if valid, compute distance to triangle and evtl. store distance
   if (inside) {
     Eigen::VectorXd distanceVector = ret.projected;
     distanceVector -= _searchPoint;
     double distance = distanceVector.norm();
-    if ( _shortestDistance > distance ) {
-      _shortestDistance = distance;
-      _vectorToProjectionPoint = distanceVector;
+    if (_shortestDistance > distance) {
+      _shortestDistance             = distance;
+      _vectorToProjectionPoint      = distanceVector;
       _parametersProjectionPoint[0] = ret.barycentricCoords[0];
       _parametersProjectionPoint[1] = ret.barycentricCoords[1];
       _parametersProjectionPoint[2] = ret.barycentricCoords[2];
       _parametersProjectionPoint[3] = ret.barycentricCoords[3];
-      _closestQuad = &quad;
+      _closestQuad                  = &quad;
     }
   }
 }
 
-}} // namespace precice, query
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestQuad.hpp
+++ b/src/query/FindClosestQuad.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <array>
 #include <Eigen/Core>
+#include <array>
 #include "logging/Logger.hpp"
 
 namespace precice {
-  namespace mesh {
-    class Mesh;
-    class Quad;
-  }
-}
+namespace mesh {
+class Mesh;
+class Quad;
+} // namespace mesh
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
@@ -19,27 +19,25 @@ namespace query {
 /**
  * @brief Finds the closest Quad object contained in a Mesh object.
  */
-class FindClosestQuad
-{
+class FindClosestQuad {
 public:
-
   /**
    * @brief Constructor.
    *
    * @param[in] searchPoint Origin from which the closest Quad object should be found.
    */
-  explicit FindClosestQuad ( const Eigen::VectorXd& searchPoint );
+  explicit FindClosestQuad(const Eigen::VectorXd &searchPoint);
 
   /**
    * @brief Searches for the closest quad on the given mesh object.
    *
    * @return True, if a closest quad could be found.
    */
-  template<typename CONTAINER_T>
-  bool operator() ( CONTAINER_T & container );
+  template <typename CONTAINER_T>
+  bool operator()(CONTAINER_T &container);
 
   /// Returns the coordinates of the search point.
-  const Eigen::VectorXd& getSearchPoint() const;
+  const Eigen::VectorXd &getSearchPoint() const;
 
   /// Returns true, if a closest quad has been found.
   bool hasFound() const;
@@ -56,20 +54,19 @@ public:
    *
    * @pre Find has been called and returned true.
    */
-  mesh::Quad& getClosestQuad();
+  mesh::Quad &getClosestQuad();
 
   /**
    * @brief Returns the vector from the search point to the projection point.
    *
    * @pre Find has been called and returned true.
    */
-  const Eigen::VectorXd& getVectorToProjectionPoint() const;
+  const Eigen::VectorXd &getVectorToProjectionPoint() const;
 
   /// Returns parametric description value (index 0, 1, 2) of proj. point.
-  double getProjectionPointParameter ( int index ) const;
+  double getProjectionPointParameter(int index) const;
 
 private:
-
   logging::Logger _log{"query::FindClosestQuad"};
 
   /// Search point coordinates.
@@ -82,25 +79,24 @@ private:
   Eigen::VectorXd _vectorToProjectionPoint;
 
   /// Quad coordinates of the projection point.
-  std::array<double,4> _parametersProjectionPoint; // Does this make sense?
+  std::array<double, 4> _parametersProjectionPoint; // Does this make sense?
 
   /// Pointer to found Quad object.
-  mesh::Quad* _closestQuad = nullptr;
+  mesh::Quad *_closestQuad = nullptr;
 
-  void find ( mesh::Quad& quad );
+  void find(mesh::Quad &quad);
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS
 
-template<typename CONTAINER_T>
-bool FindClosestQuad:: operator() ( CONTAINER_T& container )
+template <typename CONTAINER_T>
+bool FindClosestQuad::operator()(CONTAINER_T &container)
 {
-  for ( mesh::Quad& quad : container.quads() ) {
-    find ( quad );
+  for (mesh::Quad &quad : container.quads()) {
+    find(quad);
   }
   return _closestQuad != NULL;
 }
 
-}} // namespace precice, query
-
-
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestTriangle.cpp
+++ b/src/query/FindClosestTriangle.cpp
@@ -1,85 +1,84 @@
 #include "FindClosestTriangle.hpp"
 #include <Eigen/Dense>
+#include "math/barycenter.hpp"
+#include "math/math.hpp"
+#include "mesh/Mesh.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
-#include "mesh/Mesh.hpp"
-#include "math/math.hpp"
-#include "math/barycenter.hpp"
 
 namespace precice {
 namespace query {
 
-FindClosestTriangle:: FindClosestTriangle
-(
-  const Eigen::VectorXd& searchPoint )
-:
-  _searchPoint ( searchPoint ),
-  _vectorToProjectionPoint ( Eigen::VectorXd::Constant(_searchPoint.size(), std::numeric_limits<double>::max()) ),
-  _parametersProjectionPoint( {_shortestDistance, _shortestDistance, _shortestDistance } )
-{}
+FindClosestTriangle::FindClosestTriangle(
+    const Eigen::VectorXd &searchPoint)
+    : _searchPoint(searchPoint),
+      _vectorToProjectionPoint(Eigen::VectorXd::Constant(_searchPoint.size(), std::numeric_limits<double>::max())),
+      _parametersProjectionPoint({_shortestDistance, _shortestDistance, _shortestDistance})
+{
+}
 
-const Eigen::VectorXd& FindClosestTriangle:: getSearchPoint() const
+const Eigen::VectorXd &FindClosestTriangle::getSearchPoint() const
 {
   return _searchPoint;
 }
 
-bool FindClosestTriangle:: hasFound() const
+bool FindClosestTriangle::hasFound() const
 {
   return _closestTriangle != nullptr;
 }
 
-double FindClosestTriangle:: getEuclidianDistance() const
+double FindClosestTriangle::getEuclidianDistance() const
 {
   return _shortestDistance;
 }
 
-mesh::Triangle & FindClosestTriangle:: getClosestTriangle()
+mesh::Triangle &FindClosestTriangle::getClosestTriangle()
 {
   PRECICE_ASSERT(_closestTriangle != nullptr);
   return *_closestTriangle;
 }
 
-const Eigen::VectorXd& FindClosestTriangle:: getVectorToProjectionPoint() const
+const Eigen::VectorXd &FindClosestTriangle::getVectorToProjectionPoint() const
 {
   return _vectorToProjectionPoint;
 }
 
-double FindClosestTriangle:: getProjectionPointParameter(int index ) const
+double FindClosestTriangle::getProjectionPointParameter(int index) const
 {
   return _parametersProjectionPoint[index];
 }
 
-void FindClosestTriangle:: find
-(
-  mesh::Triangle& triangle )
+void FindClosestTriangle::find(
+    mesh::Triangle &triangle)
 {
-  using Eigen::Vector2d; using Eigen::Vector3d;
-  
+  using Eigen::Vector2d;
+  using Eigen::Vector3d;
+
   auto ret = math::barycenter::calcBarycentricCoordsForTriangle(
-          triangle.vertex(0).getCoords(),
-          triangle.vertex(1).getCoords(),
-          triangle.vertex(2).getCoords(),
-          triangle.getNormal(),
-          _searchPoint
-          );
+      triangle.vertex(0).getCoords(),
+      triangle.vertex(1).getCoords(),
+      triangle.vertex(2).getCoords(),
+      triangle.getNormal(),
+      _searchPoint);
   PRECICE_ASSERT(ret.barycentricCoords.size() == 3);
 
   // Determine from barycentric coordinates, if point is inside triangle
-  const bool inside = not (ret.barycentricCoords.array() < - math::NUMERICAL_ZERO_DIFFERENCE).any();
+  const bool inside = not(ret.barycentricCoords.array() < -math::NUMERICAL_ZERO_DIFFERENCE).any();
 
   // If inside, compute distance to triangle and evtl. store distance
   if (inside) {
     Vector3d distanceVector = ret.projected - _searchPoint;
-    double distance = distanceVector.norm();
-    if (_shortestDistance > distance){
-      _shortestDistance = distance;
-      _vectorToProjectionPoint = distanceVector;
+    double   distance       = distanceVector.norm();
+    if (_shortestDistance > distance) {
+      _shortestDistance             = distance;
+      _vectorToProjectionPoint      = distanceVector;
       _parametersProjectionPoint[0] = ret.barycentricCoords(0);
       _parametersProjectionPoint[1] = ret.barycentricCoords(1);
       _parametersProjectionPoint[2] = ret.barycentricCoords(2);
-      _closestTriangle = &triangle;
+      _closestTriangle              = &triangle;
     }
   }
 }
 
-}} // namespace precice, query
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestTriangle.hpp
+++ b/src/query/FindClosestTriangle.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <array>
 #include <Eigen/Core>
+#include <array>
 #include "logging/Logger.hpp"
 
 namespace precice {
-  namespace mesh {
-    class Mesh;
-    class Triangle;
-  }
-}
+namespace mesh {
+class Mesh;
+class Triangle;
+} // namespace mesh
+} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
@@ -17,27 +17,25 @@ namespace precice {
 namespace query {
 
 /// Finds the closest Triangle object contained in a Mesh object.
-class FindClosestTriangle
-{
+class FindClosestTriangle {
 public:
-
   /**
    * @brief Constructor.
    *
    * @param[in] searchPoint Origin from which the closest Triangle object should be found.
    */
-  explicit FindClosestTriangle ( const Eigen::VectorXd& searchPoint );
+  explicit FindClosestTriangle(const Eigen::VectorXd &searchPoint);
 
   /**
    * @brief Searches for the closest triangle on the given mesh object.
    *
    * @return True, if a closest triangle could be found.
    */
-  template<typename CONTAINER_T>
-  bool operator() ( CONTAINER_T & container );
+  template <typename CONTAINER_T>
+  bool operator()(CONTAINER_T &container);
 
   /// Returns the coordinates of the search point.
-  const Eigen::VectorXd& getSearchPoint() const;
+  const Eigen::VectorXd &getSearchPoint() const;
 
   /// Returns true, if a closest triangle has been found.
   bool hasFound() const;
@@ -48,26 +46,25 @@ public:
    * @pre Find has been called and returned true.
    */
   double getEuclidianDistance() const;
-  
+
   /**
    * @brief Returns the found triangle.
    *
    * @pre Find has been called and returned true.
    */
-  mesh::Triangle& getClosestTriangle();
+  mesh::Triangle &getClosestTriangle();
 
   /**
    * @brief Returns the vector from the search point to the projection point.
    *
    * @pre Find has been called and returned true.
    */
-  const Eigen::VectorXd& getVectorToProjectionPoint() const;
+  const Eigen::VectorXd &getVectorToProjectionPoint() const;
 
   /// Returns parametric description value (index 0, 1, 2) of proj. point.
-  double getProjectionPointParameter ( int index ) const;
+  double getProjectionPointParameter(int index) const;
 
 private:
-
   logging::Logger _log{"query::FindClosestTriangle"};
 
   /// Search point coordinates.
@@ -80,24 +77,24 @@ private:
   Eigen::VectorXd _vectorToProjectionPoint;
 
   /// Barycentric coordinates of the projection point.
-  std::array<double,3> _parametersProjectionPoint;
+  std::array<double, 3> _parametersProjectionPoint;
 
   /// Pointer to found Triangle object.
-  mesh::Triangle* _closestTriangle = nullptr;
+  mesh::Triangle *_closestTriangle = nullptr;
 
-  void find ( mesh::Triangle& triangle );
+  void find(mesh::Triangle &triangle);
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS
 
-template<typename CONTAINER_T>
-bool FindClosestTriangle:: operator() ( CONTAINER_T& container )
+template <typename CONTAINER_T>
+bool FindClosestTriangle::operator()(CONTAINER_T &container)
 {
-  for ( mesh::Triangle& triangle : container.triangles() ) {
-    find ( triangle );
+  for (mesh::Triangle &triangle : container.triangles()) {
+    find(triangle);
   }
   return _closestTriangle != NULL;
 }
 
-}} // namespace precice, query
-
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestVertex.cpp
+++ b/src/query/FindClosestVertex.cpp
@@ -1,36 +1,36 @@
 #include "FindClosestVertex.hpp"
-#include "mesh/Vertex.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/Vertex.hpp"
 
 namespace precice {
 namespace query {
 
-FindClosestVertex:: FindClosestVertex
-(
-  const Eigen::VectorXd& searchPoint )
-:
-  _searchPoint (searchPoint)
-{}
+FindClosestVertex::FindClosestVertex(
+    const Eigen::VectorXd &searchPoint)
+    : _searchPoint(searchPoint)
+{
+}
 
-const Eigen::VectorXd& FindClosestVertex:: getSearchPoint() const
+const Eigen::VectorXd &FindClosestVertex::getSearchPoint() const
 {
   return _searchPoint;
 }
 
-bool FindClosestVertex:: hasFound() const
+bool FindClosestVertex::hasFound() const
 {
   return _closestVertex != nullptr;
 }
 
-double FindClosestVertex:: getEuclidianDistance()
+double FindClosestVertex::getEuclidianDistance()
 {
-   return _shortestDistance;
+  return _shortestDistance;
 }
 
-mesh::Vertex& FindClosestVertex:: getClosestVertex()
+mesh::Vertex &FindClosestVertex::getClosestVertex()
 {
-  PRECICE_ASSERT( _closestVertex != nullptr );
+  PRECICE_ASSERT(_closestVertex != nullptr);
   return *_closestVertex;
 }
 
-}} // namespace precice, query
+} // namespace query
+} // namespace precice

--- a/src/query/FindClosestVertex.hpp
+++ b/src/query/FindClosestVertex.hpp
@@ -8,16 +8,14 @@ namespace precice {
 namespace query {
 
 /// Finds the closest Vertex object hold by Mesh objects.
-class FindClosestVertex
-{
+class FindClosestVertex {
 public:
-
   /**
    * @brief Constructor.
    *
    * @param[in] searchPoint Coordinates of origin of search for closest point.
    */
-  explicit FindClosestVertex ( const Eigen::VectorXd& searchPoint );
+  explicit FindClosestVertex(const Eigen::VectorXd &searchPoint);
 
   /**
    * @brief Searches among all Vertex objects hold by the given Mesh object.
@@ -25,11 +23,11 @@ public:
    * When called for different meshes, the closest Vertex object in among all
    * the meshes is found.
    */
-  template<typename CONTAINER_T>
-  bool operator() ( CONTAINER_T& container );
+  template <typename CONTAINER_T>
+  bool operator()(CONTAINER_T &container);
 
   /// Returns the coordinates of the search point.
-  const Eigen::VectorXd& getSearchPoint() const;
+  const Eigen::VectorXd &getSearchPoint() const;
 
   bool hasFound() const;
 
@@ -45,10 +43,9 @@ public:
    *
    * @pre find() has been called and returned true.
    */
-  mesh::Vertex& getClosestVertex();
+  mesh::Vertex &getClosestVertex();
 
 private:
-
   /// Origin of search for closest vertex.
   Eigen::VectorXd _searchPoint;
 
@@ -56,31 +53,29 @@ private:
   double _shortestDistance = std::numeric_limits<double>::max();
 
   /// Pointer to closest Vertex object found.
-  mesh::Vertex* _closestVertex = nullptr;
+  mesh::Vertex *_closestVertex = nullptr;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS
 
-template<typename CONTAINER_T>
-bool FindClosestVertex:: operator()
-(
-  CONTAINER_T& container )
+template <typename CONTAINER_T>
+bool FindClosestVertex::operator()(
+    CONTAINER_T &container)
 {
   Eigen::VectorXd vectorDistance = Eigen::VectorXd::Zero(_searchPoint.size());
-  for ( mesh::Vertex& vertex : container.vertices() ) {
-    PRECICE_ASSERT( vertex.getDimensions() == _searchPoint.size(),
-                vertex.getDimensions(), _searchPoint.size() );
+  for (mesh::Vertex &vertex : container.vertices()) {
+    PRECICE_ASSERT(vertex.getDimensions() == _searchPoint.size(),
+                   vertex.getDimensions(), _searchPoint.size());
     vectorDistance = vertex.getCoords();
     vectorDistance -= _searchPoint;
     double distance = vectorDistance.norm();
-    if ( distance < _shortestDistance) {
+    if (distance < _shortestDistance) {
       _shortestDistance = distance;
-      _closestVertex = &vertex;
+      _closestVertex    = &vertex;
     }
   }
   return _closestVertex != NULL;
 }
 
-}} // namespace precice, query
-
-
+} // namespace query
+} // namespace precice

--- a/src/query/tests/FindClosestTest.cpp
+++ b/src/query/tests/FindClosestTest.cpp
@@ -184,7 +184,6 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges3D)
     BOOST_TEST((*finds[i])(mesh));
   }
 
-
   // Evaluate query results
   BOOST_TEST(finds[0]->getClosest().distance == std::sqrt(1.0 / 8.0));
   BOOST_TEST(finds[1]->getClosest().distance == std::sqrt(1.0 / 8.0));
@@ -297,7 +296,7 @@ BOOST_AUTO_TEST_CASE(WeigthsOfVertices)
   int dim = 2;
 
   // Create mesh
-  mesh::Mesh mesh("Mesh", dim, true, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, true, testing::nextMeshID());
   mesh::Vertex &vertex1 = mesh.createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &vertex2 = mesh.createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh.createEdge(vertex1, vertex2);
@@ -318,28 +317,28 @@ BOOST_AUTO_TEST_CASE(WeigthsOfVertices)
   BOOST_TEST(closest.interpolationElements[1].weight == 0.3);
 }
 
-
 struct MeshFixture {
-    int dimension = 3;
-    double z = 0.0;
-    mesh::Mesh mesh;
-    mesh::Vertex *v1, *v2, *v3, *vinside, *voutside;
-    mesh::Edge *e12, *e23, *e31;
-    mesh::Triangle* t;
-    MeshFixture() : mesh("Mesh", dimension, true, testing::nextMeshID())
-    {
-        v1 = &mesh.createVertex(Eigen::Vector3d(0.0, 0.0, z));
-        v2 = &mesh.createVertex(Eigen::Vector3d(1.0, 0.0, z));
-        v3 = &mesh.createVertex(Eigen::Vector3d(0.5, 0.5, z));
-        vinside = &mesh.createVertex(Eigen::Vector3d(0.1, 0.1, z));
-        voutside = &mesh.createVertex(Eigen::Vector3d(1.0, 1.0, z));
-        e12 = &mesh.createEdge(*v1, *v2);
-        e23= &mesh.createEdge(*v2, *v3);
-        e31= &mesh.createEdge(*v3, *v1);
-        t=&mesh.createTriangle(*e12, *e23, *e31);
-        mesh.computeState();
-    }
-    ~MeshFixture(){}
+  int             dimension = 3;
+  double          z         = 0.0;
+  mesh::Mesh      mesh;
+  mesh::Vertex *  v1, *v2, *v3, *vinside, *voutside;
+  mesh::Edge *    e12, *e23, *e31;
+  mesh::Triangle *t;
+  MeshFixture()
+      : mesh("Mesh", dimension, true, testing::nextMeshID())
+  {
+    v1       = &mesh.createVertex(Eigen::Vector3d(0.0, 0.0, z));
+    v2       = &mesh.createVertex(Eigen::Vector3d(1.0, 0.0, z));
+    v3       = &mesh.createVertex(Eigen::Vector3d(0.5, 0.5, z));
+    vinside  = &mesh.createVertex(Eigen::Vector3d(0.1, 0.1, z));
+    voutside = &mesh.createVertex(Eigen::Vector3d(1.0, 1.0, z));
+    e12      = &mesh.createEdge(*v1, *v2);
+    e23      = &mesh.createEdge(*v2, *v3);
+    e31      = &mesh.createEdge(*v3, *v1);
+    t        = &mesh.createTriangle(*e12, *e23, *e31);
+    mesh.computeState();
+  }
+  ~MeshFixture() {}
 };
 
 BOOST_FIXTURE_TEST_SUITE(InterpolationElements, MeshFixture)
@@ -367,8 +366,8 @@ BOOST_AUTO_TEST_CASE(TriangleInside)
   auto elems = query::generateInterpolationElements(*vinside, *t);
   BOOST_TEST(elems.size() == 3);
   std::map<mesh::Vertex const *, double> weights;
-  for(const auto& elem : elems) {
-      weights[elem.element] = elem.weight;
+  for (const auto &elem : elems) {
+    weights[elem.element] = elem.weight;
   }
   BOOST_TEST(weights.at(v1) == 0.8);
   BOOST_TEST(weights.at(v2) == 0.0);
@@ -380,8 +379,8 @@ BOOST_AUTO_TEST_CASE(TriangleOutside)
   auto elems = query::generateInterpolationElements(*voutside, *t);
   BOOST_TEST(elems.size() == 3);
   std::map<mesh::Vertex const *, double> weights;
-  for(const auto& elem : elems) {
-      weights[elem.element] = elem.weight;
+  for (const auto &elem : elems) {
+    weights[elem.element] = elem.weight;
   }
   // Extrapolating
   BOOST_TEST(weights.at(v1) == -1.0);
@@ -390,7 +389,6 @@ BOOST_AUTO_TEST_CASE(TriangleOutside)
 }
 
 BOOST_AUTO_TEST_SUITE_END() // InterpolationElements
-
 
 BOOST_AUTO_TEST_SUITE_END() // FindClosestTests
 BOOST_AUTO_TEST_SUITE_END() // QueryTests

--- a/src/testing/Fixtures.hpp
+++ b/src/testing/Fixtures.hpp
@@ -1,18 +1,16 @@
 #pragma once
 
 #include "Testing.hpp"
-#include "utils/Parallel.hpp"
-#include "utils/MasterSlave.hpp"
 #include "com/Communication.hpp"
 #include "com/MPIDirectCommunication.hpp"
-#include "m2n/M2N.hpp"
 #include "m2n/GatherScatterComFactory.hpp"
+#include "m2n/M2N.hpp"
 #include "m2n/SharedPointer.hpp"
+#include "utils/MasterSlave.hpp"
+#include "utils/Parallel.hpp"
 
-namespace precice
-{
-namespace testing
-{
+namespace precice {
+namespace testing {
 
 #ifndef PRECICE_NO_MPI
 
@@ -24,19 +22,18 @@ struct MasterComFixture {
   MasterComFixture()
   {
     utils::MasterSlave::_communication = com::PtrCommunication(new com::MPIDirectCommunication());
-    int size = Par::getCommunicatorSize();
+    int size                           = Par::getCommunicatorSize();
 
-    if (utils::Parallel::getProcessRank() == 0){ //Master
-      utils::Parallel::splitCommunicator( "Master" );
+    if (utils::Parallel::getProcessRank() == 0) { //Master
+      utils::Parallel::splitCommunicator("Master");
       utils::MasterSlave::configure(0, size);
-      utils::MasterSlave::_communication->acceptConnection ( "Master", "Slaves", utils::Parallel::getProcessRank() );
+      utils::MasterSlave::_communication->acceptConnection("Master", "Slaves", utils::Parallel::getProcessRank());
       utils::MasterSlave::_communication->setRankOffset(1);
-    }
-    else {//Slaves
+    } else { //Slaves
       PRECICE_ASSERT(utils::Parallel::getProcessRank() > 0 && utils::Parallel::getProcessRank() < size);
-      utils::Parallel::splitCommunicator( "Slaves" );
+      utils::Parallel::splitCommunicator("Slaves");
       utils::MasterSlave::configure(utils::Parallel::getProcessRank(), size);
-      utils::MasterSlave::_communication->requestConnection( "Master", "Slaves", utils::Parallel::getProcessRank()-1 , size-1 );
+      utils::MasterSlave::_communication->requestConnection("Master", "Slaves", utils::Parallel::getProcessRank() - 1, size - 1);
     }
   }
 
@@ -55,18 +52,17 @@ struct M2NFixture {
   M2NFixture()
   {
     utils::MasterSlave::reset();
-    auto participantCom = com::PtrCommunication(new com::MPIDirectCommunication());
-    auto distrFactory = m2n::DistributedComFactory::SharedPointer(new m2n::GatherScatterComFactory(participantCom));
+    auto participantCom   = com::PtrCommunication(new com::MPIDirectCommunication());
+    auto distrFactory     = m2n::DistributedComFactory::SharedPointer(new m2n::GatherScatterComFactory(participantCom));
     bool useOnlyMasterCom = true;
-    m2n = m2n::PtrM2N(new m2n::M2N(participantCom, distrFactory, useOnlyMasterCom));
+    m2n                   = m2n::PtrM2N(new m2n::M2N(participantCom, distrFactory, useOnlyMasterCom));
 
-    if (utils::Parallel::getProcessRank() == 0){
-      utils::Parallel::splitCommunicator( "ParticipantOne" );
-      m2n->acceptMasterConnection ( "ParticipantOne", "ParticipantTwo");
-    }
-    else if(utils::Parallel::getProcessRank() == 1){//Master
-      utils::Parallel::splitCommunicator( "ParticipantTwo" );
-      m2n->requestMasterConnection ( "ParticipantOne", "ParticipantTwo" );
+    if (utils::Parallel::getProcessRank() == 0) {
+      utils::Parallel::splitCommunicator("ParticipantOne");
+      m2n->acceptMasterConnection("ParticipantOne", "ParticipantTwo");
+    } else if (utils::Parallel::getProcessRank() == 1) { //Master
+      utils::Parallel::splitCommunicator("ParticipantTwo");
+      m2n->requestMasterConnection("ParticipantOne", "ParticipantTwo");
     }
   }
 
@@ -84,15 +80,14 @@ struct SplitParticipantsFixture {
 
   SplitParticipantsFixture()
   {
-    if(utils::Parallel::getProcessRank()<=1){
-      utils::Parallel::splitCommunicator( "ParticipantOne" );
+    if (utils::Parallel::getProcessRank() <= 1) {
+      utils::Parallel::splitCommunicator("ParticipantOne");
       utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
       utils::Parallel::clearGroups(); //This is important, if the testcase uses MPI communication again
       participantID = 1;
-    }
-    else {
+    } else {
       PRECICE_ASSERT(utils::Parallel::getProcessRank() > 1 && utils::Parallel::getProcessRank() < 4);
-      utils::Parallel::splitCommunicator( "ParticipantTwo" );
+      utils::Parallel::splitCommunicator("ParticipantTwo");
       utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
       utils::Parallel::clearGroups();
       participantID = 2;
@@ -103,7 +98,7 @@ struct SplitParticipantsFixture {
   {
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getCommunicatorWorld());
   }
-
 };
 
-}}
+} // namespace testing
+} // namespace precice

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -1,6 +1,6 @@
 #include "Testing.hpp"
-#include "logging/LogMacros.hpp"
 #include <cstdlib>
+#include "logging/LogMacros.hpp"
 
 namespace precice {
 namespace testing {
@@ -8,12 +8,11 @@ namespace testing {
 std::string getPathToSources()
 {
   precice::logging::Logger _log("testing");
-  char* preciceRoot = std::getenv("PRECICE_ROOT");
+  char *                   preciceRoot = std::getenv("PRECICE_ROOT");
   PRECICE_CHECK(preciceRoot != nullptr,
-        "Environment variable PRECICE_ROOT has not been set. Please set it to the precice directory.");
+                "Environment variable PRECICE_ROOT has not been set. Please set it to the precice directory.");
   return std::string(preciceRoot) + "/src";
 }
 
-
-}
-}
+} // namespace testing
+} // namespace precice

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -1,19 +1,17 @@
 #pragma once
 
-#include "math/math.hpp"
-#include "utils/Parallel.hpp"
 #include <boost/test/unit_test.hpp>
+#include "math/math.hpp"
 #include "precice/config/Configuration.hpp"
-#include "xml/XMLTag.hpp"
 #include "utils/ManageUniqueIDs.hpp"
+#include "utils/Parallel.hpp"
+#include "xml/XMLTag.hpp"
 
-namespace precice
-{
-namespace testing
-{
+namespace precice {
+namespace testing {
 
 namespace bt = boost::unit_test;
-using Par = precice::utils::Parallel;
+using Par    = precice::utils::Parallel;
 
 /// Fixture to set and reset MPI communicator
 struct MPICommRestrictFixture {
@@ -51,7 +49,6 @@ struct SingleRankFixture {
   }
 };
 
-
 /// Fixture to sync procceses before and after test
 struct SyncProcessesFixture {
   SyncProcessesFixture()
@@ -65,13 +62,11 @@ struct SyncProcessesFixture {
   }
 };
 
-
 /// Boost.Test decorator that makes the test run only on specfic ranks.
 /*
  * This does not restrict the communicator, which must be done by installing the MPICommrestrictFixture.
  */
-class OnRanks : public bt::decorator::base
-{
+class OnRanks : public bt::decorator::base {
 public:
   explicit OnRanks(const std::vector<int> &ranks)
       : _ranks(ranks)
@@ -82,7 +77,7 @@ private:
   virtual void apply(bt::test_unit &tu)
   {
     size_t myRank = Par::getProcessRank();
-    size_t size = Par::getCommunicatorSize();
+    size_t size   = Par::getCommunicatorSize();
 
     // If current rank is not in requested ranks
     if (std::find(_ranks.begin(), _ranks.end(), myRank) == _ranks.end()) {
@@ -113,8 +108,7 @@ private:
 };
 
 /// Boost.Test decorator that makes the test run only on the master aka rank 0
-class OnMaster : public OnRanks
-{
+class OnMaster : public OnRanks {
 public:
   explicit OnMaster()
       : OnRanks({0})
@@ -123,8 +117,7 @@ public:
 };
 
 /// Boost.Test decorator that makes the test run only on a specific MPI size
-class OnSize : public bt::decorator::base
-{
+class OnSize : public bt::decorator::base {
 public:
   explicit OnSize(const int size)
       : givenSize(size)
@@ -151,8 +144,7 @@ public:
 /*
  * This does not restrict the communicator, which must be done by installing the MPICommrestrictFixture.
  */
-class MinRanks : public bt::decorator::base
-{
+class MinRanks : public bt::decorator::base {
 public:
   explicit MinRanks(const int minimumSize)
       : minSize(minimumSize)
@@ -176,10 +168,8 @@ private:
   const int minSize;
 };
 
-
 /// Boost.Test decorator that unconditionally deletes the test.
-class Deleted : public bt::decorator::base
-{
+class Deleted : public bt::decorator::base {
 private:
   virtual void apply(bt::test_unit &tu)
   {
@@ -192,10 +182,9 @@ private:
   }
 };
 
-
 /// struct giving access to the impl of a befriended class or struct
 struct WhiteboxAccessor {
-    /** Returns the impl of the obj by reference.
+  /** Returns the impl of the obj by reference.
      *
      * Returns a reference to the object pointed to by the _impl of a class.
      * This class needs to be friend of T.
@@ -203,15 +192,16 @@ struct WhiteboxAccessor {
      * @param[in] obj The object to fetch the impl from.
      * @returns a lvalue reference to the impl object.
      */
-    template<typename T>
-    static auto impl(T& obj) -> typename std::add_lvalue_reference<decltype(*(obj._impl))>::type {
-        return *obj._impl;
-    }
+  template <typename T>
+  static auto impl(T &obj) -> typename std::add_lvalue_reference<decltype(*(obj._impl))>::type
+  {
+    return *obj._impl;
+  }
 };
 
 /// struct extending WhiteboxAccessor by a slim configuration call.
 struct SlimConfigurator : WhiteboxAccessor {
-    /** Configures the interface given a fileName in a slim and quiet manner.
+  /** Configures the interface given a fileName in a slim and quiet manner.
      *
      * This first generates a ConfigurationContext from the SolverInterface.
      * It then configures a config::Configuration using the context and the given file.
@@ -220,32 +210,32 @@ struct SlimConfigurator : WhiteboxAccessor {
      * @param[in] interface The SolverInterface to configure.
      * @param[in] configFilename The filename of the configuration file.
      */
-    template<typename T>
-    static void slimConfigure(T& interface, const std::string& configFilename) {
-        auto & interfaceImpl = impl(interface);
-        precice::xml::ConfigurationContext context{
-            interfaceImpl.getAccessorName(),
-            interfaceImpl.getAccessorProcessRank(),
-            interfaceImpl.getAccessorCommunicatorSize()
-        };
-        precice::config::Configuration config;
-        precice::xml::configure(config.getXMLTag(), context, configFilename);
-        interfaceImpl.configure(config.getSolverInterfaceConfiguration());
-    }
+  template <typename T>
+  static void slimConfigure(T &interface, const std::string &configFilename)
+  {
+    auto &                             interfaceImpl = impl(interface);
+    precice::xml::ConfigurationContext context{
+        interfaceImpl.getAccessorName(),
+        interfaceImpl.getAccessorProcessRank(),
+        interfaceImpl.getAccessorCommunicatorSize()};
+    precice::config::Configuration config;
+    precice::xml::configure(config.getXMLTag(), context, configFilename);
+    interfaceImpl.configure(config.getSolverInterfaceConfiguration());
+  }
 };
 
 /// equals to be used in tests. Prints both operatorans on failure
 template <class DerivedA, class DerivedB>
 boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,
                                            const Eigen::MatrixBase<DerivedB> &B,
-                                           double tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
+                                           double                             tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
   if (not math::equals(A, B, tolerance)) {
     boost::test_tools::predicate_result res(false);
-    Eigen::IOFormat format;
+    Eigen::IOFormat                     format;
     if (A.cols() == 1) {
       format.rowSeparator = ", ";
-      format.rowPrefix = "  ";
+      format.rowPrefix    = "  ";
     }
     res.message() << "\n"
                   << A.format(format) << " != \n"
@@ -276,10 +266,9 @@ std::string getPathToSources();
  */
 inline int nextMeshID()
 {
-    static utils::ManageUniqueIDs manager;
-    return manager.getFreeID();
+  static utils::ManageUniqueIDs manager;
+  return manager.getFreeID();
 }
 
 } // namespace testing
 } // namespace precice
-

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -1,22 +1,20 @@
+#include <boost/filesystem.hpp>
+#include <boost/test/tree/test_case_counter.hpp>
+#include <boost/test/tree/traverse.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_parameters.hpp>
-#include <boost/test/tree/traverse.hpp>                                          
-#include <boost/test/tree/test_case_counter.hpp> 
-#include <boost/filesystem.hpp>
-#include "utils/Parallel.hpp"
-#include "utils/Petsc.hpp"
+#include <iostream>
+#include "logging/LogConfiguration.hpp"
 #include "utils/EventUtils.hpp"
 #include "utils/MasterSlave.hpp"
-#include "logging/LogConfiguration.hpp"
-#include <iostream>
+#include "utils/Parallel.hpp"
+#include "utils/Petsc.hpp"
 
 namespace precice {
 extern bool testMode;
 extern bool syncMode;
-static int testCount{0};
-}
-
-
+static int  testCount{0};
+} // namespace precice
 
 /// Boost test Initialization function
 /**
@@ -43,24 +41,24 @@ bool init_unit_test()
   using namespace boost::unit_test;
   using namespace precice;
 
-  auto & master_suite = framework::master_test_suite();
+  auto &master_suite        = framework::master_test_suite();
   master_suite.p_name.value = "preCICE Tests";
 
   {
-      test_case_counter tcc;                                                       
-      traverse_test_tree( master_suite.p_id, tcc );
-      precice::testCount = tcc.p_count;
+    test_case_counter tcc;
+    traverse_test_tree(master_suite.p_id, tcc);
+    precice::testCount = tcc.p_count;
   }
 
   auto logConfigs = logging::readLogConfFile("log.conf");
 
   if (logConfigs.empty()) { // nothing has been read from log.conf
-    #if BOOST_VERSION == 106900
+#if BOOST_VERSION == 106900
     std::cerr << "Boost 1.69 get log_level is broken, preCICE log level set to debug.\n";
     auto logLevel = log_successful_tests;
-    #else
+#else
     auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);
-    #endif
+#endif
 
     logging::BackendConfiguration config;
     if (logLevel == log_successful_tests or logLevel == log_test_units)
@@ -80,22 +78,21 @@ bool init_unit_test()
   logging::setupLogging(logConfigs);
   logging::lockConf();
 
-
   // Sets the default tolerance for floating point comparisions
   // Can be overwritten on a per-test or per-suite basis using decators
   // boost::unit_test::decorator::collector::instance() * boost::unit_test::tolerance(0.001);
-  * tolerance(1e-9); // Stores the decorator in the collector singleton
-  #if BOOST_VERSION < 106900
+  *tolerance(1e-9); // Stores the decorator in the collector singleton
+#if BOOST_VERSION < 106900
   decorator::collector::instance().store_in(master_suite);
-  #else
+#else
   decorator::collector_t::instance().store_in(master_suite);
-  #endif
+#endif
 
   return true;
 }
 
 /// Entry point for the boost test executable
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   using namespace precice;
 
@@ -117,10 +114,10 @@ int main(int argc, char* argv[])
     std::exit(-1);
   }
 
-  int retCode = boost::unit_test::unit_test_main( &init_unit_test, argc, argv );
+  int retCode = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
   // Override the return code if the slaves have nothing to test
   if ((precice::testCount == 0) && (utils::Parallel::getProcessRank() != 0)) {
-     retCode = EXIT_SUCCESS;
+    retCode = EXIT_SUCCESS;
   }
 
   utils::EventRegistry::instance().finalize();

--- a/src/testing/tests/ExampleTests.cpp
+++ b/src/testing/tests/ExampleTests.cpp
@@ -1,7 +1,6 @@
-#include "testing/Testing.hpp"
 #include "testing/Fixtures.hpp" // include that for the more advanced fixtures, e.g. to build up m2n com
+#include "testing/Testing.hpp"
 #include "utils/Parallel.hpp" // only required when using something from utils::Parallel
-
 
 using namespace precice;
 
@@ -34,7 +33,7 @@ BOOST_AUTO_TEST_CASE(SingleProcessor)
 
 /// Test with a modified numerical tolerance
 BOOST_AUTO_TEST_CASE(NumericalTolerance,
-                     * boost::unit_test::tolerance(1e-4))
+                     *boost::unit_test::tolerance(1e-4))
 {
   // Default tolerance is 1e-9, it can be changed for the entire case or even suite
   // using the decorator above
@@ -46,18 +45,17 @@ BOOST_AUTO_TEST_CASE(NumericalTolerance,
 
 /// Use testing::Deleted to unconditionally delete the test
 BOOST_AUTO_TEST_CASE(Deleted,
-                     * testing::Deleted())
+                     *testing::Deleted())
 {
   BOOST_TEST(false);
 }
-
 
 /// Test that requires 4 processors.
 /*
  * If less than 4 procs are available, the test is deleted, if more are available, procs > 4 are deleted
  */
 BOOST_AUTO_TEST_CASE(FourProcTests,
-                     * testing::OnSize(4))
+                     *testing::OnSize(4))
 {
   // Don't copy over that line, it's for testing the example
   BOOST_TEST(utils::Parallel::getCommunicatorSize() == 4);
@@ -69,14 +67,12 @@ BOOST_AUTO_TEST_CASE(FourProcTests,
  * ranks first, and then test if we execute at the correct ranks.
  */
 BOOST_AUTO_TEST_CASE(TwoProcTests,
-                     * testing::MinRanks(2)
-                     * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                     *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
   // Put your test code here
-
 }
 
 #ifndef PRECICE_NO_MPI
@@ -86,8 +82,7 @@ BOOST_AUTO_TEST_CASE(TwoProcTests,
  * Please note: Such tests always need to be excluded for compilation without MPI (PRECICE_NO_MPI).
  */
 BOOST_AUTO_TEST_CASE(FourProcTestsWithMasterCommmunication,
-                     * testing::OnSize(4)
-                     * boost::unit_test::fixture<testing::MasterComFixture>())
+                     *testing::OnSize(4) * boost::unit_test::fixture<testing::MasterComFixture>())
 {
   // In this test you can use a master communication, here is an example how:
   BOOST_TEST(utils::MasterSlave::_communication->isConnected());
@@ -101,19 +96,16 @@ BOOST_AUTO_TEST_CASE(FourProcTestsWithMasterCommmunication,
  * Please note: Such tests always need to be excluded for compilation without MPI (PRECICE_NO_MPI).
  */
 BOOST_FIXTURE_TEST_CASE(TwoProcTestsWithM2NCommunication, testing::M2NFixture,
-                       * testing::MinRanks(2)
-                       * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
+                        *testing::MinRanks(2) * boost::unit_test::fixture<testing::MPICommRestrictFixture>(std::vector<int>({0, 1})))
 {
   if (utils::Parallel::getCommunicatorSize() != 2)
     return;
 
   //This is how you can access the m2n communication
   BOOST_TEST(m2n->getMasterCommunication()->isConnected());
-
 }
 
 #endif // PRECICE_NO_MPI
-
 
 /// Integration tests with two participants.
 /*
@@ -127,17 +119,16 @@ BOOST_FIXTURE_TEST_CASE(TwoProcTestsWithM2NCommunication, testing::M2NFixture,
  * fixture as a decorator, but only the following way:
  */
 BOOST_FIXTURE_TEST_CASE(IntegrationTestsWithTwoParticipants, testing::SplitParticipantsFixture,
-                     * testing::OnSize(4))
+                        *testing::OnSize(4))
 {
-  if(participantID==1){
+  if (participantID == 1) {
 
     // Put here your preCICE API code for the first participant
 
     // Don't copy over that line, it's for testing the example
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 2);
-  }
-  else {
-    BOOST_TEST(participantID==2);
+  } else {
+    BOOST_TEST(participantID == 2);
 
     // Put here your preCICE API code for the second participant
 
@@ -145,9 +136,6 @@ BOOST_FIXTURE_TEST_CASE(IntegrationTestsWithTwoParticipants, testing::SplitParti
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 2);
   }
 }
-
-
-
 
 BOOST_AUTO_TEST_SUITE_END() // Examples
 BOOST_AUTO_TEST_SUITE_END() // TestingTests

--- a/src/utils/Dimensions.cpp
+++ b/src/utils/Dimensions.cpp
@@ -5,84 +5,77 @@ namespace precice {
 namespace utils {
 
 const Eigen::VectorXd DELINEARIZE_2D[8] =
-{
- Eigen::VectorXd(Eigen::Vector2d(-1.0, -1.0)),
- Eigen::VectorXd(Eigen::Vector2d( 1.0, -1.0)),
- Eigen::VectorXd(Eigen::Vector2d(-1.0,  1.0)),
- Eigen::VectorXd(Eigen::Vector2d( 1.0,  1.0))
-};
+    {
+        Eigen::VectorXd(Eigen::Vector2d(-1.0, -1.0)),
+        Eigen::VectorXd(Eigen::Vector2d(1.0, -1.0)),
+        Eigen::VectorXd(Eigen::Vector2d(-1.0, 1.0)),
+        Eigen::VectorXd(Eigen::Vector2d(1.0, 1.0))};
 
 const Eigen::VectorXd DELINEARIZE_3D[8] =
-{
- Eigen::VectorXd(Eigen::Vector3d(-1.0, -1.0, -1.0)),
- Eigen::VectorXd(Eigen::Vector3d( 1.0, -1.0, -1.0)),
- Eigen::VectorXd(Eigen::Vector3d(-1.0,  1.0, -1.0)),
- Eigen::VectorXd(Eigen::Vector3d( 1.0,  1.0, -1.0)),
- Eigen::VectorXd(Eigen::Vector3d(-1.0, -1.0,  1.0)),
- Eigen::VectorXd(Eigen::Vector3d( 1.0, -1.0,  1.0)),
- Eigen::VectorXd(Eigen::Vector3d(-1.0,  1.0,  1.0)),
- Eigen::VectorXd(Eigen::Vector3d( 1.0,  1.0,  1.0))
-};
+    {
+        Eigen::VectorXd(Eigen::Vector3d(-1.0, -1.0, -1.0)),
+        Eigen::VectorXd(Eigen::Vector3d(1.0, -1.0, -1.0)),
+        Eigen::VectorXd(Eigen::Vector3d(-1.0, 1.0, -1.0)),
+        Eigen::VectorXd(Eigen::Vector3d(1.0, 1.0, -1.0)),
+        Eigen::VectorXd(Eigen::Vector3d(-1.0, -1.0, 1.0)),
+        Eigen::VectorXd(Eigen::Vector3d(1.0, -1.0, 1.0)),
+        Eigen::VectorXd(Eigen::Vector3d(-1.0, 1.0, 1.0)),
+        Eigen::VectorXd(Eigen::Vector3d(1.0, 1.0, 1.0))};
 
-const Eigen::VectorXd& delinearize
-(
-  int toDelinearize,
-  int dimensions )
+const Eigen::VectorXd &delinearize(
+    int toDelinearize,
+    int dimensions)
 {
-  if ( dimensions == 2 ){
-    PRECICE_ASSERT( (toDelinearize >= 0) && (toDelinearize < 4), toDelinearize );
+  if (dimensions == 2) {
+    PRECICE_ASSERT((toDelinearize >= 0) && (toDelinearize < 4), toDelinearize);
     return DELINEARIZE_2D[toDelinearize];
-  }
-  else {
-    PRECICE_ASSERT( dimensions == 3, dimensions );
-    PRECICE_ASSERT( (toDelinearize >= 0) && (toDelinearize < 8), toDelinearize );
+  } else {
+    PRECICE_ASSERT(dimensions == 3, dimensions);
+    PRECICE_ASSERT((toDelinearize >= 0) && (toDelinearize < 8), toDelinearize);
     return DELINEARIZE_3D[toDelinearize];
   }
 }
 
-
-const int IndexMaps<2>:: CUBOID_EDGE_VERTICES[4][2] =
-{
-   {0, 2}, // edge 0
-   {1, 3}, // edge 1
-   {0, 1}, // edge 2
-   {2, 3}  // edge 3
+const int IndexMaps<2>::CUBOID_EDGE_VERTICES[4][2] =
+    {
+        {0, 2}, // edge 0
+        {1, 3}, // edge 1
+        {0, 1}, // edge 2
+        {2, 3}  // edge 3
 };
 
-const int IndexMaps<3>:: CUBOID_FACE_VERTICES[6][4] =
-{
-   {0, 2, 4, 6},
-   {1, 3, 5, 7},
-   {0, 1, 4, 5},
-   {2, 3, 6, 7},
-   {0, 1, 2, 3},
-   {4, 5, 6 ,7}
-};
+const int IndexMaps<3>::CUBOID_FACE_VERTICES[6][4] =
+    {
+        {0, 2, 4, 6},
+        {1, 3, 5, 7},
+        {0, 1, 4, 5},
+        {2, 3, 6, 7},
+        {0, 1, 2, 3},
+        {4, 5, 6, 7}};
 
-const int IndexMaps<3>:: CUBOID_FACE_EDGES[6][4] =
-{
-   {4,  6,  8, 10},
-   {5,  7,  9, 11},
-   {0,  2,  8,  9},
-   {1,  3, 10, 11},
-   {0,  1,  4,  5},
-   {2,  3,  6,  7}
-};
+const int IndexMaps<3>::CUBOID_FACE_EDGES[6][4] =
+    {
+        {4, 6, 8, 10},
+        {5, 7, 9, 11},
+        {0, 2, 8, 9},
+        {1, 3, 10, 11},
+        {0, 1, 4, 5},
+        {2, 3, 6, 7}};
 
-const int IndexMaps<3>:: CUBOID_EDGE_VERTICES[12][2] =
-{
-   /*  0 */ {0, 1},
-   /*  1 */ {2, 3},
-   /*  2 */ {4, 5},
-   /*  3 */ {6, 7},
-   /*  4 */ {0, 2},
-   /*  5 */ {1, 3},
-   /*  6 */ {4, 6},
-   /*  7 */ {5, 7},
-   /*  8 */ {0, 4},
-   /*  9 */ {1, 5},
-   /* 10 */ {2, 6},
-   /* 11 */ {3, 7}
-};
+const int IndexMaps<3>::CUBOID_EDGE_VERTICES[12][2] =
+    {
+        /*  0 */ {0, 1},
+        /*  1 */ {2, 3},
+        /*  2 */ {4, 5},
+        /*  3 */ {6, 7},
+        /*  4 */ {0, 2},
+        /*  5 */ {1, 3},
+        /*  6 */ {4, 6},
+        /*  7 */ {5, 7},
+        /*  8 */ {0, 4},
+        /*  9 */ {1, 5},
+        /* 10 */ {2, 6},
+        /* 11 */ {3, 7}};
 
-}} // namespace precice, utils
+} // namespace utils
+} // namespace precice

--- a/src/utils/Dimensions.hpp
+++ b/src/utils/Dimensions.hpp
@@ -5,17 +5,16 @@
 namespace precice {
 namespace utils {
 
-const Eigen::VectorXd& delinearize (
-  int toDelinearize,
-  int dimensions );
+const Eigen::VectorXd &delinearize(
+    int toDelinearize,
+    int dimensions);
 
-template<typename VECTOR_T>
-int linearize
-(
-  const VECTOR_T& toLinearize )
+template <typename VECTOR_T>
+int linearize(
+    const VECTOR_T &toLinearize)
 {
   int index = 0;
-  for (int dim=0; dim < toLinearize.size(); dim++) {
+  for (int dim = 0; dim < toLinearize.size(); dim++) {
     if (toLinearize(dim) > 0.0) {
       index += (int) std::pow(2.0, dim);
     }
@@ -24,19 +23,21 @@ int linearize
 }
 
 /// Provides mappings of indices for dimensions 2 and 3.
-template< int dimension > struct IndexMaps {};
-
-template<> struct IndexMaps<2>
-{
-   static const int CUBOID_EDGE_VERTICES[4][2];
+template <int dimension>
+struct IndexMaps {
 };
 
-template<> struct IndexMaps<3>
-{
-   static const int CUBOID_FACE_VERTICES[6][4];
-   static const int CUBOID_FACE_EDGES[6][4];
-   static const int CUBOID_EDGE_VERTICES[12][2];
+template <>
+struct IndexMaps<2> {
+  static const int CUBOID_EDGE_VERTICES[4][2];
 };
 
-}} // namespace precice, utils
+template <>
+struct IndexMaps<3> {
+  static const int CUBOID_FACE_VERTICES[6][4];
+  static const int CUBOID_FACE_EDGES[6][4];
+  static const int CUBOID_EDGE_VERTICES[12][2];
+};
 
+} // namespace utils
+} // namespace precice

--- a/src/utils/EigenHelperFunctions.cpp
+++ b/src/utils/EigenHelperFunctions.cpp
@@ -5,28 +5,23 @@
  *      Author: scheufks
  */
 
-
 #include "EigenHelperFunctions.hpp"
 
 namespace precice {
 namespace utils {
 
-
-void shiftSetFirst
-(
-    Eigen::MatrixXd& A, Eigen::VectorXd& v)
+void shiftSetFirst(
+    Eigen::MatrixXd &A, Eigen::VectorXd &v)
 {
   PRECICE_ASSERT(v.size() == A.rows(), v.size(), A.rows());
   // A.bottomRightCorner(n, m - 1) = A.topLeftCorner(n, m - 1);
-  for(auto i = A.cols()-1; i > 0; i--)
-        A.col(i) = A.col(i-1);
+  for (auto i = A.cols() - 1; i > 0; i--)
+    A.col(i) = A.col(i - 1);
   A.col(0) = v;
 }
 
-
-void appendFront
-(
-    Eigen::MatrixXd& A, Eigen::VectorXd& v)
+void appendFront(
+    Eigen::MatrixXd &A, Eigen::VectorXd &v)
 {
   int n = A.rows(), m = A.cols();
   if (n <= 0 && m <= 0) {
@@ -35,15 +30,14 @@ void appendFront
     PRECICE_ASSERT(v.size() == n, v.size(), A.rows());
     A.conservativeResize(n, m + 1);
     //A.topRightCorner(n, m) = A.topLeftCorner(n, m); // bad error, reason unknown!
-    for(auto i = A.cols()-1; i > 0; i--)
-      A.col(i) = A.col(i-1);
+    for (auto i = A.cols() - 1; i > 0; i--)
+      A.col(i) = A.col(i - 1);
     A.col(0) = v;
   }
 }
 
-void removeColumnFromMatrix
-(
-    Eigen::MatrixXd& A, int col)
+void removeColumnFromMatrix(
+    Eigen::MatrixXd &A, int col)
 {
   PRECICE_ASSERT(col < A.cols() && col >= 0, col, A.cols());
   for (int j = col; j < A.cols() - 1; j++)
@@ -53,15 +47,13 @@ void removeColumnFromMatrix
 }
 
 void append(
-    Eigen::VectorXd& v,
-    double value)
+    Eigen::VectorXd &v,
+    double           value)
 {
   int n = v.size();
   v.conservativeResize(n + 1);
   v(n) = value;
 }
 
-}}
-
-
-
+} // namespace utils
+} // namespace precice

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -1,25 +1,24 @@
 #pragma once
 
 #include <Eigen/Core>
-#include "utils/assertion.hpp"
 #include "utils/algorithm.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace utils {
 
+void shiftSetFirst(Eigen::MatrixXd &A, Eigen::VectorXd &v);
 
-void shiftSetFirst(Eigen::MatrixXd& A, Eigen::VectorXd& v);
+void appendFront(Eigen::MatrixXd &A, Eigen::VectorXd &v);
 
-void appendFront(Eigen::MatrixXd& A, Eigen::VectorXd& v);
+void removeColumnFromMatrix(Eigen::MatrixXd &A, int col);
 
-void removeColumnFromMatrix(Eigen::MatrixXd& A, int col);
+void append(Eigen::VectorXd &v, double value);
 
-void append(Eigen::VectorXd& v, double value);
-
-template<typename Derived1>
+template <typename Derived1>
 void append(
-    Eigen::MatrixXd& A,
-    const Eigen::PlainObjectBase<Derived1>& B)
+    Eigen::MatrixXd &                       A,
+    const Eigen::PlainObjectBase<Derived1> &B)
 {
   int n = A.rows(), m = A.cols();
   if (n <= 0 && m <= 0) {
@@ -27,24 +26,24 @@ void append(
   } else {
     PRECICE_ASSERT(B.rows() == n, B.rows(), A.rows());
     A.conservativeResize(n, m + B.cols());
-    for(auto i = m; i < m + B.cols(); i++)
-      A.col(i) = B.col(i-m);
+    for (auto i = m; i < m + B.cols(); i++)
+      A.col(i) = B.col(i - m);
   }
 }
 
-template<typename Derived1>
+template <typename Derived1>
 void append(
-    Eigen::VectorXd& v,
-    const Eigen::PlainObjectBase<Derived1>& app)
+    Eigen::VectorXd &                       v,
+    const Eigen::PlainObjectBase<Derived1> &app)
 {
   int n = v.size();
-  if(n <= 0){
+  if (n <= 0) {
     v = app;
-  }else{
-    PRECICE_ASSERT(app.cols() == 1 , app.cols());
+  } else {
+    PRECICE_ASSERT(app.cols() == 1, app.cols());
     v.conservativeResize(n + app.size());
-    for(int i = 0; i < app.size(); i++)
-      v(n+i) = app(i);
+    for (int i = 0; i < app.size(); i++)
+      v(n + i) = app(i);
   }
 }
 
@@ -53,46 +52,47 @@ void append(
  * @param[in] val the Eigen object to map from
  * @returns the mapped const row vector
  */
-template<typename Derived>
-auto firstN(const Eigen::PlainObjectBase<Derived>& val, unsigned n) -> const Eigen::Map<const Eigen::Matrix<typename Derived::Scalar, 1, Eigen::Dynamic>> 
+template <typename Derived>
+auto firstN(const Eigen::PlainObjectBase<Derived> &val, unsigned n) -> const Eigen::Map<const Eigen::Matrix<typename Derived::Scalar, 1, Eigen::Dynamic>>
 {
-    return {val.data(), std::min<Eigen::Index>(n,val.size())};
+  return {val.data(), std::min<Eigen::Index>(n, val.size())};
 }
 
-template<typename Derived, typename Iter = const typename Derived::Scalar*, typename Size = typename std::iterator_traits<Iter>::difference_type>
-const RangePreview<Iter> previewRange(Size n, const Eigen::PlainObjectBase<Derived>& eigen) {
-    auto begin = eigen.data();
-    auto end = begin;
-    std::advance(end, eigen.size());
-    return {n, begin, end};
+template <typename Derived, typename Iter = const typename Derived::Scalar *, typename Size = typename std::iterator_traits<Iter>::difference_type>
+const RangePreview<Iter> previewRange(Size n, const Eigen::PlainObjectBase<Derived> &eigen)
+{
+  auto begin = eigen.data();
+  auto end   = begin;
+  std::advance(end, eigen.size());
+  return {n, begin, end};
 }
 
-
-template<typename DerivedLHS, typename DerivedRHS>
-bool componentWiseLess(const Eigen::PlainObjectBase<DerivedLHS>& lhs, const Eigen::PlainObjectBase<DerivedRHS>& rhs)
+template <typename DerivedLHS, typename DerivedRHS>
+bool componentWiseLess(const Eigen::PlainObjectBase<DerivedLHS> &lhs, const Eigen::PlainObjectBase<DerivedRHS> &rhs)
 {
-    const auto lhs_begin = lhs.data();
-    const auto lhs_end   = lhs.data()+lhs.size();
-    const auto rhs_begin = rhs.data();
-    const auto rhs_end   = rhs.data()+rhs.size();
-    
-    auto mismatch = utils::mismatch(lhs_begin, lhs_end, rhs_begin, rhs_end);
+  const auto lhs_begin = lhs.data();
+  const auto lhs_end   = lhs.data() + lhs.size();
+  const auto rhs_begin = rhs.data();
+  const auto rhs_end   = rhs.data() + rhs.size();
 
-    if (mismatch.first == lhs_end) {
-        return true;
-    }
-    if (mismatch.second == rhs_end) {
-        return false;
-    }
-    return *mismatch.first < *mismatch.second;
+  auto mismatch = utils::mismatch(lhs_begin, lhs_end, rhs_begin, rhs_end);
+
+  if (mismatch.first == lhs_end) {
+    return true;
+  }
+  if (mismatch.second == rhs_end) {
+    return false;
+  }
+  return *mismatch.first < *mismatch.second;
 }
 
 struct ComponentWiseLess {
-    template<typename DerivedLHS, typename DerivedRHS>
-    bool operator()(const Eigen::PlainObjectBase<DerivedLHS>& lhs, const Eigen::PlainObjectBase<DerivedRHS>& rhs) const
-    {
-        return componentWiseLess(lhs, rhs);
-    }
+  template <typename DerivedLHS, typename DerivedRHS>
+  bool operator()(const Eigen::PlainObjectBase<DerivedLHS> &lhs, const Eigen::PlainObjectBase<DerivedRHS> &rhs) const
+  {
+    return componentWiseLess(lhs, rhs);
+  }
 };
 
-}}
+} // namespace utils
+} // namespace precice

--- a/src/utils/Event.cpp
+++ b/src/utils/Event.cpp
@@ -5,15 +5,15 @@ namespace precice {
 namespace utils {
 
 Event::Event(std::string eventName, Clock::duration initialDuration)
-  : name(EventRegistry::instance().prefix + eventName),
-    duration(initialDuration)
+    : name(EventRegistry::instance().prefix + eventName),
+      duration(initialDuration)
 {
   EventRegistry::instance().put(*this);
 }
 
 Event::Event(std::string eventName, bool barrier, bool autostart)
-  : name(eventName),
-    _barrier(barrier)
+    : name(eventName),
+      _barrier(barrier)
 {
   // Set prefix here: workaround to omit data lock between instance() and Event ctor
   if (eventName != "_GLOBAL")
@@ -85,7 +85,7 @@ void Event::addData(std::string key, int value)
 
 // -----------------------------------------------------------------------
 
-ScopedEventPrefix::ScopedEventPrefix(std::string const & name)
+ScopedEventPrefix::ScopedEventPrefix(std::string const &name)
 {
   previousName = EventRegistry::instance().prefix;
   EventRegistry::instance().prefix += name;
@@ -96,4 +96,5 @@ ScopedEventPrefix::~ScopedEventPrefix()
   EventRegistry::instance().prefix = previousName;
 }
 
-}}
+} // namespace utils
+} // namespace precice

--- a/src/utils/Event.hpp
+++ b/src/utils/Event.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <chrono>
-#include <vector>
-#include <string>
 #include <map>
+#include <string>
+#include <vector>
 #include "logging/Logger.hpp"
 
 namespace precice {
@@ -13,10 +13,8 @@ namespace utils {
 /** Additionally to the duration there is a special property that can be set for a event.
 A property is a a key-value pair with a numerical value that can be used to trace certain events,
 like MPI calls in an event. It is intended to be set by the user. */
-class Event
-{
+class Event {
 public:
-
   enum class State : int {
     STOPPED = 0,
     STARTED = 1,
@@ -31,7 +29,7 @@ public:
   using Data = std::map<std::string, std::vector<int>>;
 
   /// An Event can't be copied.
-  Event(const Event & other) = delete;
+  Event(const Event &other) = delete;
 
   /// Name used to identify the timer. Events of the same name are accumulated to
   std::string name;
@@ -62,31 +60,28 @@ public:
   void addData(std::string key, int value);
 
   Data data;
-  
+
   StateChanges stateChanges;
 
 private:
   logging::Logger _log{"utils::Events"};
 
   Clock::time_point starttime;
-  Clock::duration duration = Clock::duration::zero();
-  State state = State::STOPPED;
-  bool _barrier = false;
+  Clock::duration   duration = Clock::duration::zero();
+  State             state    = State::STOPPED;
+  bool              _barrier = false;
 };
 
-
 /// Class that changes the prefix in its scope
-class ScopedEventPrefix
-{
+class ScopedEventPrefix {
 public:
-
-  ScopedEventPrefix(const std::string & name);
+  ScopedEventPrefix(const std::string &name);
 
   ~ScopedEventPrefix();
 
 private:
-
   std::string previousName = "";
 };
 
-}}
+} // namespace utils
+} // namespace precice

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -3,14 +3,14 @@
 #include <nlohmann/json.hpp>
 #include <prettyprint/prettyprint.hpp>
 
-#include <cassert>
 #include <algorithm>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <string>
-#include <sstream>
+#include <cassert>
 #include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
 #include <utility>
 #include "TableWriter.hpp"
 #include "utils/assertion.hpp"
@@ -22,36 +22,34 @@ extern bool testMode;
 namespace precice {
 namespace utils {
 
-using sys_clk = std::chrono::system_clock;
+using sys_clk  = std::chrono::system_clock;
 using stdy_clk = std::chrono::steady_clock;
-
 
 /// Converts the time_point into a string like "2019-01-10T18:30:46.834"
 std::string timepoint_to_string(sys_clk::time_point c)
 {
   using namespace std::chrono;
   std::time_t ts = sys_clk::to_time_t(c);
-  auto ms = duration_cast<milliseconds>(c.time_since_epoch()) % 1000;
+  auto        ms = duration_cast<milliseconds>(c.time_since_epoch()) % 1000;
 
   std::stringstream ss;
   ss << std::put_time(std::localtime(&ts), "%FT%T") << "." << std::setw(3) << std::setfill('0') << ms.count();
   return ss.str();
 }
 
-
 std::map<std::string, GlobalEventStats> getGlobalStats(std::vector<RankData> events)
 {
   std::map<std::string, GlobalEventStats> globalStats;
   for (size_t rank = 0; rank < events.size(); ++rank) {
-    for (auto & evData : events[rank].evData) {
-      auto const & event = evData.second;
-      GlobalEventStats & stats = globalStats[evData.first];
+    for (auto &evData : events[rank].evData) {
+      auto const &      event = evData.second;
+      GlobalEventStats &stats = globalStats[evData.first];
       if (event.max > stats.max) {
-        stats.max = event.max;
+        stats.max     = event.max;
         stats.maxRank = rank;
       }
       if (event.min < stats.min) {
-        stats.min = event.min;
+        stats.min     = event.min;
         stats.minRank = rank;
       }
     }
@@ -59,44 +57,42 @@ std::map<std::string, GlobalEventStats> getGlobalStats(std::vector<RankData> eve
   return globalStats;
 }
 
-
-struct MPI_EventData
-{
+struct MPI_EventData {
   char name[255] = {'\0'};
-  int count = 0;
+  int  count     = 0;
   long total = 0, max = 0, min = 0;
-  int dataSize = 0, stateChangesSize = 0;
+  int  dataSize = 0, stateChangesSize = 0;
 };
-
 
 // -----------------------------------------------------------------------
 
-EventData::EventData(std::string _name) :
-  name(_name)
-{}
+EventData::EventData(std::string _name)
+    : name(_name)
+{
+}
 
 EventData::EventData(std::string _name, long _count, long _total, long _max, long _min,
                      Event::Data data, Event::StateChanges _stateChanges)
-  :  max(std::chrono::milliseconds(_max)),
-     min(std::chrono::milliseconds(_min)),
-     total(std::chrono::milliseconds(_total)),
-     stateChanges(_stateChanges),
-     name(_name),
-     count(_count),
-     data(data)
-{}
+    : max(std::chrono::milliseconds(_max)),
+      min(std::chrono::milliseconds(_min)),
+      total(std::chrono::milliseconds(_total)),
+      stateChanges(_stateChanges),
+      name(_name),
+      count(_count),
+      data(data)
+{
+}
 
-
-void EventData::put(Event const & event)
+void EventData::put(Event const &event)
 {
   count++;
   stdy_clk::duration duration = event.getDuration();
   total += duration;
   min = std::min(duration, min);
   max = std::max(duration, max);
-  for (auto const & d : event.data) {
-    auto & source = std::get<1>(d);
-    auto & target = data[std::get<0>(d)];
+  for (auto const &d : event.data) {
+    auto &source = std::get<1>(d);
+    auto &target = data[std::get<0>(d)];
     target.insert(target.begin(), source.begin(), source.end());
   }
   stateChanges.insert(std::end(stateChanges), std::begin(event.stateChanges), std::end(event.stateChanges));
@@ -132,31 +128,28 @@ long EventData::getCount() const
   return count;
 }
 
-Event::Data const & EventData::getData() const
+Event::Data const &EventData::getData() const
 {
   return data;
 }
-
-
 
 // -----------------------------------------------------------------------
 
 void RankData::initialize()
 {
-  initializedAt = sys_clk::now();
+  initializedAt      = sys_clk::now();
   initializedAtTicks = stdy_clk::now();
-  isFinalized = false;
+  isFinalized        = false;
 }
 
 void RankData::finalize()
 {
-  finalizedAt = sys_clk::now();
+  finalizedAt      = sys_clk::now();
   finalizedAtTicks = stdy_clk::now();
-  isFinalized = true;
+  isFinalized      = true;
 }
 
-
-void RankData::put(Event const & event)
+void RankData::put(Event const &event)
 {
   /// Construct or return EventData object with name as key and name as arg to ctor.
   auto data = std::get<0>(evData.emplace(std::piecewise_construct,
@@ -165,22 +158,20 @@ void RankData::put(Event const & event)
   data->second.put(event);
 }
 
-
 void RankData::addEventData(EventData ed)
 {
   evData.emplace(ed.getName(), std::move(ed));
 }
 
-
 void RankData::normalizeTo(sys_clk::time_point t0)
 {
   auto const delta = initializedAt - t0; // duration that this rank initialized after the first rank
-  PRECICE_ASSERT(t0 <= initializedAt); // t0 should always be before or equal my init time
+  PRECICE_ASSERT(t0 <= initializedAt);   // t0 should always be before or equal my init time
 
-  for (auto & events : evData) {
-    for (auto & sc : events.second.stateChanges) {
-      auto & tp = sc.second;
-      tp = stdy_clk::time_point(tp - initializedAtTicks + delta);
+  for (auto &events : evData) {
+    for (auto &sc : events.second.stateChanges) {
+      auto &tp = sc.second;
+      tp       = stdy_clk::time_point(tp - initializedAtTicks + delta);
       // Deactivated, as it fails for the precice tests, likely because Events are used before initialize
       // assert(tp.time_since_epoch().count() >= 0); // Trying to do normalize twice?
     }
@@ -200,12 +191,9 @@ sys_clk::duration RankData::getDuration() const
     return sys_clk::now() - initializedAt;
 }
 
-
-
 // -----------------------------------------------------------------------
 
-
-EventRegistry & EventRegistry::instance()
+EventRegistry &EventRegistry::instance()
 {
   static EventRegistry instance;
   return instance;
@@ -214,35 +202,36 @@ EventRegistry & EventRegistry::instance()
 void EventRegistry::initialize(std::string applicationName, std::string runName, MPI_Comm comm)
 {
   this->applicationName = applicationName;
-  this->runName = runName;
-  this->comm = comm;
+  this->runName         = runName;
+  this->comm            = comm;
 
   localRankData.initialize();
 
   globalEvent.start(false);
   initialized = true;
-  finalized = false;
+  finalized   = false;
 }
 
 void EventRegistry::finalize()
 {
-  if (finalized) return;
+  if (finalized)
+    return;
 
   globalEvent.stop();
   localRankData.finalize();
 
-  for (auto & e : storedEvents)
+  for (auto &e : storedEvents)
     e.second.stop();
 
-  // @todo remove testMode flag once we have properly refactored the tests, cf. issue #597 
+  // @todo remove testMode flag once we have properly refactored the tests, cf. issue #597
   if (initialized && not precice::testMode) // this makes only sense when it was properly initialized
     normalize();
 
-  if(not precice::testMode)
+  if (not precice::testMode)
     collect();
 
   initialized = false;
-  finalized = true;
+  finalized   = true;
 }
 
 void EventRegistry::clear()
@@ -260,26 +249,25 @@ void EventRegistry::signal_handler(int signal)
   }
 }
 
-void EventRegistry::put(Event const & event)
+void EventRegistry::put(Event const &event)
 {
   localRankData.put(event);
 }
 
-Event & EventRegistry::getStoredEvent(std::string const & name)
+Event &EventRegistry::getStoredEvent(std::string const &name)
 {
   // Reset the prefix for creation of a stored event. Using prefixes with stored events is possible
   // but leads to unexpected results, such as not getting the event you want, because someone else up the
   // stack set a prefix.
   auto previousPrefix = prefix;
-  prefix = "";
-  auto insertion = storedEvents.emplace(std::piecewise_construct,
+  prefix              = "";
+  auto insertion      = storedEvents.emplace(std::piecewise_construct,
                                         std::forward_as_tuple(name),
                                         std::forward_as_tuple(name, false, false));
 
   prefix = previousPrefix;
   return std::get<0>(insertion)->second;
 }
-
 
 void EventRegistry::printAll()
 {
@@ -300,7 +288,6 @@ void EventRegistry::printAll()
   writeJSON(ofs);
 }
 
-
 void EventRegistry::writeSummary(std::ostream &out)
 {
   int rank, size;
@@ -310,7 +297,7 @@ void EventRegistry::writeSummary(std::ostream &out)
   if (rank == 0) {
     using std::endl;
     { // Print per event stats
-      std::time_t ts = sys_clk::to_time_t(localRankData.finalizedAt);
+      std::time_t  ts       = sys_clk::to_time_t(localRankData.finalizedAt);
       double const duration = std::chrono::duration_cast<std::chrono::milliseconds>(localRankData.getDuration()).count();
 
       out << "Run finished at " << std::asctime(std::localtime(&ts));
@@ -319,7 +306,8 @@ void EventRegistry::writeSummary(std::ostream &out)
           << duration << "ms / "
           << duration / 1000 << "s" << endl
           << "Number of processors = " << size << endl
-          << "# Rank: " << rank << endl << endl;
+          << "# Rank: " << rank << endl
+          << endl;
 
       Table table(out);
       table.addColumn("Event", getMaxNameWidth());
@@ -331,13 +319,14 @@ void EventRegistry::writeSummary(std::ostream &out)
       table.addColumn("Time Ratio", 6, 3);
       table.printHeader();
 
-      for (auto & e : localRankData.evData) {
-        auto & ev = e.second;
-        table.printRow(ev.getName(), ev.getCount(), ev.getTotal(), ev.getMax(),  ev.getMin(), ev.getAvg(),
+      for (auto &e : localRankData.evData) {
+        auto &ev = e.second;
+        table.printRow(ev.getName(), ev.getCount(), ev.getTotal(), ev.getMax(), ev.getMin(), ev.getAvg(),
                        ev.getTotal() / duration);
       }
     }
-    out << endl << endl;
+    out << endl
+        << endl;
     { // Print aggregated states
       Table t(out);
       t.addColumn("Name", getMaxNameWidth());
@@ -349,8 +338,8 @@ void EventRegistry::writeSummary(std::ostream &out)
       t.printHeader();
 
       auto stats = getGlobalStats(globalRankData);
-      for (auto & e : stats) {
-        auto & ev = e.second;
+      for (auto &e : stats) {
+        auto & ev  = e.second;
         double rel = 0;
         if (ev.max != stdy_clk::duration::zero()) // Guard against division by zero
           rel = static_cast<double>(ev.min.count()) / ev.max.count();
@@ -361,8 +350,7 @@ void EventRegistry::writeSummary(std::ostream &out)
   }
 }
 
-
-void EventRegistry::writeJSON(std::ostream & out)
+void EventRegistry::writeJSON(std::ostream &out)
 {
   using json = nlohmann::json;
   using namespace std::chrono;
@@ -371,59 +359,52 @@ void EventRegistry::writeJSON(std::ostream & out)
 
   sys_clk::time_point initT, finalT;
   std::tie(initT, finalT) = findFirstAndLastTime();
-  js["Name"] = runName;
-  js["Initialized"] = timepoint_to_string(initT);
-  js["Finalized"] = timepoint_to_string(finalT);
+  js["Name"]              = runName;
+  js["Initialized"]       = timepoint_to_string(initT);
+  js["Finalized"]         = timepoint_to_string(finalT);
 
-  for (auto const & rank : globalRankData) {
-    auto jTimings = json::object();
-    auto jStateChanges = json::array();
-    double const duration = duration_cast<milliseconds>(rank.getDuration()).count();
-    for (auto const & events : rank.evData) {
-      auto const & e = events.second;
+  for (auto const &rank : globalRankData) {
+    auto         jTimings      = json::object();
+    auto         jStateChanges = json::array();
+    double const duration      = duration_cast<milliseconds>(rank.getDuration()).count();
+    for (auto const &events : rank.evData) {
+      auto const &e                     = events.second;
       jTimings[events.second.getName()] = {
-        {"Count", e.getCount()},
-        {"Total", e.getTotal()},
-        {"Max", e.getMax()},
-        {"Min", e.getMin()},
-        {"TimeRatio", e.getTotal() / duration},
-        {"Data" , e.getData()}
-      };
-      for (auto const & sc : e.stateChanges) {
-        jStateChanges.push_back({
-            {"Name", events.second.getName()},
-            {"State", sc.first},
-            {"Timestamp", duration_cast<milliseconds>(sc.second.time_since_epoch()).count()}
-          });
+          {"Count", e.getCount()},
+          {"Total", e.getTotal()},
+          {"Max", e.getMax()},
+          {"Min", e.getMin()},
+          {"TimeRatio", e.getTotal() / duration},
+          {"Data", e.getData()}};
+      for (auto const &sc : e.stateChanges) {
+        jStateChanges.push_back({{"Name", events.second.getName()},
+                                 {"State", sc.first},
+                                 {"Timestamp", duration_cast<milliseconds>(sc.second.time_since_epoch()).count()}});
       }
     }
-    js["Ranks"].push_back({
-        {"Finalized", timepoint_to_string(rank.finalizedAt)},
-        {"Initialized", timepoint_to_string(rank.initializedAt)},
-        {"Timings", jTimings},
-        {"StateChanges", jStateChanges}
-      });
+    js["Ranks"].push_back({{"Finalized", timepoint_to_string(rank.finalizedAt)},
+                           {"Initialized", timepoint_to_string(rank.initializedAt)},
+                           {"Timings", jTimings},
+                           {"StateChanges", jStateChanges}});
   }
 
   out << std::setw(2) << js << std::endl;
 }
 
-
-MPI_Comm const & EventRegistry::getMPIComm() const
+MPI_Comm const &EventRegistry::getMPIComm() const
 {
   return comm;
 }
 
-
 void EventRegistry::collect()
 {
-  #ifndef PRECICE_NO_MPI
+#ifndef PRECICE_NO_MPI
   // Register MPI datatype
   MPI_Datatype MPI_EVENTDATA;
-  int blocklengths[] = {255, 1, 3, 2};
-  MPI_Aint displacements[] = {offsetof(MPI_EventData, name), offsetof(MPI_EventData, count),
+  int          blocklengths[]  = {255, 1, 3, 2};
+  MPI_Aint     displacements[] = {offsetof(MPI_EventData, name), offsetof(MPI_EventData, count),
                               offsetof(MPI_EventData, total), offsetof(MPI_EventData, dataSize)};
-  MPI_Datatype types[] = {MPI_CHAR, MPI_INT, MPI_LONG, MPI_INT};
+  MPI_Datatype types[]         = {MPI_CHAR, MPI_INT, MPI_LONG, MPI_INT};
   MPI_Type_create_struct(4, blocklengths, displacements, types, &MPI_EVENTDATA);
   MPI_Type_commit(&MPI_EVENTDATA);
 
@@ -432,55 +413,55 @@ void EventRegistry::collect()
   MPI_Comm_size(comm, &MPIsize);
 
   std::vector<MPI_Request> requests;
-  std::vector<int> eventsPerRank(MPIsize);
-  size_t eventsSize = localRankData.evData.size();
+  std::vector<int>         eventsPerRank(MPIsize);
+  size_t                   eventsSize = localRankData.evData.size();
   MPI_Gather(&eventsSize, 1, MPI_INT, eventsPerRank.data(), 1, MPI_INT, 0, comm);
 
-  std::vector<MPI_EventData> eventSendBuf(eventsSize);
+  std::vector<MPI_EventData>     eventSendBuf(eventsSize);
   std::vector<std::vector<long>> stateChangesBuf(eventsSize);
-  int i = 0;
+  int                            i = 0;
 
   MPI_Request req;
 
   // Send the times from the local RankData
-  std::array<long, 2> times= {localRankData.initializedAt.time_since_epoch().count(),
-                              localRankData.finalizedAt.time_since_epoch().count()};
+  std::array<long, 2> times = {localRankData.initializedAt.time_since_epoch().count(),
+                               localRankData.finalizedAt.time_since_epoch().count()};
   MPI_Isend(&times, times.size(), MPI_LONG, 0, 0, comm, &req);
   requests.push_back(req);
 
   // Send all events from all ranks, including rank 0, to rank 0
-  for (auto const & evData : localRankData.evData) {
-    const auto & ev = evData.second;
+  for (auto const &evData : localRankData.evData) {
+    const auto &  ev = evData.second;
     MPI_EventData eventdata;
 
     // Send aggregated EventData
     assert(evData.first.size() <= sizeof(eventdata.name));
     evData.first.copy(eventSendBuf[i].name, sizeof(eventdata.name));
-    eventSendBuf[i].count = ev.getCount();
-    eventSendBuf[i].total = ev.getTotal();
-    eventSendBuf[i].max = ev.getMax();
-    eventSendBuf[i].min = ev.getMin();
-    eventSendBuf[i].dataSize = ev.getData().size();
+    eventSendBuf[i].count            = ev.getCount();
+    eventSendBuf[i].total            = ev.getTotal();
+    eventSendBuf[i].max              = ev.getMax();
+    eventSendBuf[i].min              = ev.getMin();
+    eventSendBuf[i].dataSize         = ev.getData().size();
     eventSendBuf[i].stateChangesSize = ev.stateChanges.size();
     MPI_Isend(&eventSendBuf[i], 1, MPI_EVENTDATA, 0, 0, comm, &req);
     requests.push_back(req);
 
     // Send the state changes
-    for (auto const & sc : ev.stateChanges) {
+    for (auto const &sc : ev.stateChanges) {
       stateChangesBuf[i].push_back(static_cast<long>(sc.first)); // state
       stateChangesBuf[i].push_back(
-        std::chrono::duration_cast<std::chrono::milliseconds>(sc.second.time_since_epoch()).count());
+          std::chrono::duration_cast<std::chrono::milliseconds>(sc.second.time_since_epoch()).count());
     }
     MPI_Isend(stateChangesBuf[i].data(), ev.stateChanges.size() * 2, MPI_LONG, 0, 0, comm, &req);
     requests.push_back(req);
 
     // Send the map that stores the data associated with an event
-    for (auto const & md : ev.getData()) {
-      auto & key = std::get<0>(md);
-      auto & val = std::get<1>(md);
-      MPI_Isend(const_cast<char*>(key.c_str()), key.size(), MPI_CHAR, 0, 0, comm, &req);
+    for (auto const &md : ev.getData()) {
+      auto &key = std::get<0>(md);
+      auto &val = std::get<1>(md);
+      MPI_Isend(const_cast<char *>(key.c_str()), key.size(), MPI_CHAR, 0, 0, comm, &req);
       requests.push_back(req);
-      MPI_Isend(const_cast<int*>(val.data()), val.size(), MPI_INT, 0, 0, comm, &req);
+      MPI_Isend(const_cast<int *>(val.data()), val.size(), MPI_INT, 0, 0, comm, &req);
       requests.push_back(req);
     }
 
@@ -495,7 +476,7 @@ void EventRegistry::collect()
       std::array<long, 2> recvTimes;
       MPI_Recv(&recvTimes, 2, MPI_LONG, i, MPI_ANY_TAG, comm, MPI_STATUS_IGNORE);
       data.initializedAt = sys_clk::time_point(sys_clk::duration(recvTimes[0]));
-      data.finalizedAt = sys_clk::time_point(sys_clk::duration(recvTimes[1]));
+      data.finalizedAt   = sys_clk::time_point(sys_clk::duration(recvTimes[1]));
 
       // Receive all events from this rank
       for (int j = 0; j < eventsPerRank[i]; ++j) {
@@ -510,14 +491,14 @@ void EventRegistry::collect()
         Event::StateChanges stateChanges; // evtl. reserve
         for (size_t i = 0; i < recvStateChanges.size(); i += 2) {
           stateChanges.emplace_back(static_cast<Event::State>(recvStateChanges[i]),
-                                    stdy_clk::time_point(std::chrono::milliseconds(recvStateChanges[i+1])));
+                                    stdy_clk::time_point(std::chrono::milliseconds(recvStateChanges[i + 1])));
         }
 
         // Receive the map that stores the data associated with an event
         Event::Data dataMap;
         for (int j = 0; j < ev.dataSize; j++) {
           MPI_Status status;
-          int count = 0;
+          int        count = 0;
           MPI_Probe(i, MPI_ANY_TAG, comm, &status);
           MPI_Get_count(&status, MPI_CHAR, &count);
           std::string key(count, '\0');
@@ -538,11 +519,10 @@ void EventRegistry::collect()
   }
   MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
   MPI_Type_free(&MPI_EVENTDATA);
-  #else
+#else
   globalRankData.push_back(localRankData);
-  #endif
+#endif
 }
-
 
 void EventRegistry::normalize()
 {
@@ -570,13 +550,12 @@ EventRegistry::collectInitAndFinalize()
 
   return {sys_clk::time_point{sys_clk::duration{minTicks}},
           sys_clk::time_point{sys_clk::duration{maxTicks}}};
-
 }
 
 size_t EventRegistry::getMaxNameWidth()
 {
   size_t maxEventWidth = 0;
-  for (auto & ev : localRankData.evData)
+  for (auto &ev : localRankData.evData)
     if (ev.second.getName().size() > maxEventWidth)
       maxEventWidth = ev.second.getName().size();
 
@@ -585,16 +564,14 @@ size_t EventRegistry::getMaxNameWidth()
 
 std::pair<sys_clk::time_point, sys_clk::time_point> EventRegistry::findFirstAndLastTime()
 {
-  using T = decltype(globalRankData)::value_type const &;
+  using T    = decltype(globalRankData)::value_type const &;
   auto first = std::min_element(std::begin(globalRankData), std::end(globalRankData),
-                                [] (T a, T b)
-                                { return a.initializedAt < b.initializedAt; });
-  auto last = std::max_element(std::begin(globalRankData), std::end(globalRankData),
-                               [] (T a, T b)
-                               { return a.finalizedAt < b.finalizedAt; });
+                                [](T a, T b) { return a.initializedAt < b.initializedAt; });
+  auto last  = std::max_element(std::begin(globalRankData), std::end(globalRankData),
+                               [](T a, T b) { return a.finalizedAt < b.finalizedAt; });
 
   return std::make_pair(first->initializedAt, last->finalizedAt);
-
 }
 
-}}
+} // namespace utils
+} // namespace precice

--- a/src/utils/EventUtils.hpp
+++ b/src/utils/EventUtils.hpp
@@ -1,23 +1,22 @@
 #pragma once
 
-#include "Event.hpp"
 #include <chrono>
 #include <map>
-#include <vector>
 #include <string>
+#include <vector>
+#include "Event.hpp"
 
 #ifndef PRECICE_NO_MPI
-  #include <mpi.h>
+#include <mpi.h>
 #else
-  #include "utils/MPI_Mock.hpp"
+#include "utils/MPI_Mock.hpp"
 #endif
 
 namespace precice {
 namespace utils {
 
 /// Class that aggregates durations for a specific event.
-class EventData
-{
+class EventData {
 public:
   explicit EventData(std::string _name);
 
@@ -25,7 +24,7 @@ public:
             Event::Data data, Event::StateChanges stateChanges);
 
   /// Adds an Events data.
-  void put(Event const & event);
+  void put(Event const &event);
 
   std::string getName() const;
 
@@ -44,25 +43,23 @@ public:
   /// Get the number of all events so far
   long getCount() const;
 
-  Event::Data const & getData() const;
+  Event::Data const &getData() const;
 
-  Event::Clock::duration max = Event::Clock::duration::min();
-  Event::Clock::duration min = Event::Clock::duration::max();
+  Event::Clock::duration max   = Event::Clock::duration::min();
+  Event::Clock::duration min   = Event::Clock::duration::max();
   Event::Clock::duration total = Event::Clock::duration::zero();
 
   Event::StateChanges stateChanges;
 
 private:
-  std::string name;
-  long count = 0;
+  std::string                             name;
+  long                                    count = 0;
   std::map<std::string, std::vector<int>> data;
 };
 
 /// Holds all EventData of one particular rank
-class RankData
-{
+class RankData {
 public:
-
   /// Records the initialized timestamp
   void initialize();
 
@@ -70,7 +67,7 @@ public:
   void finalize();
 
   /// Adds a new event
-  void put(Event const & event);
+  void put(Event const &event);
 
   /// Adds aggregated data for a specific event
   void addEventData(EventData ed);
@@ -88,31 +85,27 @@ public:
 
   std::chrono::system_clock::time_point initializedAt;
   std::chrono::system_clock::time_point finalizedAt;
-  
+
 private:
   std::chrono::steady_clock::time_point initializedAtTicks;
   std::chrono::steady_clock::time_point finalizedAtTicks;
 
   bool isFinalized = true;
-  int rank = 0;
-
+  int  rank        = 0;
 };
 
 /// Holds data aggregated from all MPI ranks for one event
-struct GlobalEventStats
-{
-  int maxRank, minRank;
-  Event::Clock::duration max   = Event::Clock::duration::min();
-  Event::Clock::duration min   = Event::Clock::duration::max();
+struct GlobalEventStats {
+  int                    maxRank, minRank;
+  Event::Clock::duration max = Event::Clock::duration::min();
+  Event::Clock::duration min = Event::Clock::duration::max();
 };
-
 
 /// High level object that stores data of all events.
 /** Call EventRegistry::intialize at the beginning of your application and
 EventRegistry::finalize at the end. Event timings will be usuable without calling this
 function at all, but global timings as well as percentages do not work this way.  */
-class EventRegistry
-{
+class EventRegistry {
 public:
   /// Deleted copy operator for singleton pattern
   EventRegistry(EventRegistry const &) = delete;
@@ -121,7 +114,7 @@ public:
   void operator=(EventRegistry const &) = delete;
 
   /// Returns the only instance (singleton) of the EventRegistry class
-  static EventRegistry & instance();
+  static EventRegistry &instance();
 
   /// Sets the global start time
   /**
@@ -141,21 +134,21 @@ public:
   void signal_handler(int signal);
 
   /// Records the event.
-  void put(Event const & event);
+  void put(Event const &event);
 
   /// Returns or creates a stored event, i.e., an event with life beyond the current scope
-  Event & getStoredEvent(std::string const & name);
+  Event &getStoredEvent(std::string const &name);
 
   /// Prints a pretty report to stdout and a JSON report to appName-events.json
   void printAll();
 
   /// Prints the result table to an arbitrary stream, only prints at rank 0.
-  void writeSummary(std::ostream & out);
+  void writeSummary(std::ostream &out);
 
   /// Writes the aggregated timings and state changes at JSON, only at rank 0.
-  void writeJSON(std::ostream & out);
-  
-  MPI_Comm const & getMPIComm() const;
+  void writeJSON(std::ostream &out);
+
+  MPI_Comm const &getMPIComm() const;
 
   /// Currently active prefix. Changing that applies only to newly created events.
   std::string prefix;
@@ -166,8 +159,9 @@ public:
 private:
   /// Private, empty constructor for singleton pattern
   EventRegistry()
-    : globalEvent("_GLOBAL", true, false) // Unstarted, it's started in initialize
-  {}
+      : globalEvent("_GLOBAL", true, false) // Unstarted, it's started in initialize
+  {
+  }
 
   RankData localRankData;
 
@@ -205,4 +199,5 @@ private:
   MPI_Comm comm;
 };
 
-}}
+} // namespace utils
+} // namespace precice

--- a/src/utils/Helpers.cpp
+++ b/src/utils/Helpers.cpp
@@ -5,12 +5,13 @@ namespace utils {
 
 bool isMachineBigEndian()
 {
-   union {
-      uint32_t i;
-      char c[4];
-   } bint = {0x01020304};
+  union {
+    uint32_t i;
+    char     c[4];
+  } bint = {0x01020304};
 
-   return bint.c[0] == 1;
+  return bint.c[0] == 1;
 }
 
-}}
+} // namespace utils
+} // namespace precice

--- a/src/utils/Helpers.hpp
+++ b/src/utils/Helpers.hpp
@@ -1,25 +1,26 @@
 #pragma once
 
 #include <algorithm>
-#include <vector>
+#include <limits>
 #include <map>
 #include <set>
-#include <limits>
+#include <vector>
 
 namespace precice {
 namespace utils {
 
 /// Returns true, if numerical truncation happens in case of type conversion.
 template <class Out, class In>
-inline bool isTruncated(In in) {
-  return (                  in > std::numeric_limits<Out>::max()) ||
+inline bool isTruncated(In in)
+{
+  return (in > std::numeric_limits<Out>::max()) ||
          (In(-1) < In(0) && in < std::numeric_limits<Out>::min());
 }
 
 /// Exclusive "or" logical operation. Returns true, if either lhs or rhs are true.
-inline bool xOR ( bool lhs, bool rhs )
+inline bool xOR(bool lhs, bool rhs)
 {
-   return (lhs && (!rhs)) || ((!lhs) && rhs);
+  return (lhs && (!rhs)) || ((!lhs) && rhs);
 }
 
 /**
@@ -29,23 +30,23 @@ inline bool xOR ( bool lhs, bool rhs )
  * - ELEMENT_T must be comparable by ==
  */
 template <typename ELEMENT_T>
-bool contained(const ELEMENT_T& element, const std::vector<ELEMENT_T>& vec)
+bool contained(const ELEMENT_T &element, const std::vector<ELEMENT_T> &vec)
 {
   return std::find(vec.begin(), vec.end(), element) != vec.end();
 }
 
-template<typename KEY_T, typename ELEMENT_T>
-bool contained (
-  const KEY_T&                     key,
-  const std::map<KEY_T,ELEMENT_T>& map )
+template <typename KEY_T, typename ELEMENT_T>
+bool contained(
+    const KEY_T &                     key,
+    const std::map<KEY_T, ELEMENT_T> &map)
 {
   return map.find(key) != map.end();
 }
 
-template<typename KEY_T>
-bool contained (
-  const KEY_T&           key,
-  const std::set<KEY_T>& set )
+template <typename KEY_T>
+bool contained(
+    const KEY_T &          key,
+    const std::set<KEY_T> &set)
 {
   return set.find(key) != set.end();
 }
@@ -53,5 +54,5 @@ bool contained (
 /// Returns true if machine is big-endian needed for parallel vtk output
 bool isMachineBigEndian();
 
-}} // namespace precice, utils
-
+} // namespace utils
+} // namespace precice

--- a/src/utils/MPI_Mock.hpp
+++ b/src/utils/MPI_Mock.hpp
@@ -1,21 +1,20 @@
 #pragma once
 
-
 /**
  * MPI Mock
  *
  * Inlines because of getting multiple definitons from the compiler otherwise.
  */
 
-using MPI_Comm = std::nullptr_t;
-using MPI_Op = std::nullptr_t;
+using MPI_Comm     = std::nullptr_t;
+using MPI_Op       = std::nullptr_t;
 using MPI_Datatype = std::nullptr_t;
 
 static MPI_Comm MPI_COMM_WORLD = nullptr;
 
 const MPI_Datatype MPI_LONG = nullptr;
-const MPI_Op MPI_MIN = nullptr;
-const MPI_Op MPI_MAX = nullptr;
+const MPI_Op       MPI_MIN  = nullptr;
+const MPI_Op       MPI_MAX  = nullptr;
 
 inline int MPI_Barrier(MPI_Comm comm)
 {
@@ -34,18 +33,16 @@ inline int MPI_Comm_size(MPI_Comm comm, int *size)
   return 0;
 }
 
-template<class T>
+template <class T>
 inline int MPI_Allreduce(const T *sendbuf, T *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 {
   std::copy(sendbuf, sendbuf + count, recvbuf);
   return 0;
 }
 
-template<class T>
+template <class T>
 inline int MPI_Reduce(const T *sendbuf, T *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
-{  
+{
   std::copy(sendbuf, sendbuf + count, recvbuf);
   return 0;
 }
-
-

--- a/src/utils/ManageUniqueIDs.cpp
+++ b/src/utils/ManageUniqueIDs.cpp
@@ -1,9 +1,7 @@
 #include "utils/ManageUniqueIDs.hpp"
 
-namespace precice
-{
-namespace utils
-{
+namespace precice {
+namespace utils {
 
 int ManageUniqueIDs::getFreeID()
 {

--- a/src/utils/ManageUniqueIDs.hpp
+++ b/src/utils/ManageUniqueIDs.hpp
@@ -2,14 +2,11 @@
 
 #include <boost/container/flat_set.hpp>
 
-namespace precice
-{
-namespace utils
-{
+namespace precice {
+namespace utils {
 
 /// Manages a set of unique IDs.
-class ManageUniqueIDs
-{
+class ManageUniqueIDs {
 public:
   // Returns the next free, i.e. unique, ID.
   int getFreeID();

--- a/src/utils/MasterSlave.cpp
+++ b/src/utils/MasterSlave.cpp
@@ -2,30 +2,29 @@
 
 #include "MasterSlave.hpp"
 
-#include "utils/assertion.hpp"
 #include "com/Communication.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace utils {
 
-int MasterSlave::_rank = -1;
-int MasterSlave::_size = -1;
-bool MasterSlave::_isMaster = false;
-bool MasterSlave::_isSlave = false;
+int                   MasterSlave::_rank     = -1;
+int                   MasterSlave::_size     = -1;
+bool                  MasterSlave::_isMaster = false;
+bool                  MasterSlave::_isSlave  = false;
 com::PtrCommunication MasterSlave::_communication;
 
+logging::Logger MasterSlave::_log("utils::MasterSlave");
 
-logging::Logger MasterSlave:: _log("utils::MasterSlave" );
-
-void MasterSlave:: configure(int rank, int size)
+void MasterSlave::configure(int rank, int size)
 {
   PRECICE_TRACE(rank, size);
   _rank = rank;
   _size = size;
   PRECICE_ASSERT(_rank != -1 && _size != -1);
-  _isMaster = (rank==0) && _size != 1;
-  _isSlave = (rank!=0);
-  PRECICE_DEBUG("isSlave: " << _isSlave <<", isMaster: " << _isMaster);
+  _isMaster = (rank == 0) && _size != 1;
+  _isSlave  = (rank != 0);
+  PRECICE_DEBUG("isSlave: " << _isSlave << ", isMaster: " << _isMaster);
 }
 
 int MasterSlave::getRank()
@@ -48,27 +47,26 @@ bool MasterSlave::isSlave()
   return _isSlave;
 }
 
-
-double MasterSlave:: l2norm(const Eigen::VectorXd& vec)
+double MasterSlave::l2norm(const Eigen::VectorXd &vec)
 {
   PRECICE_TRACE();
 
-  if(not _isMaster && not _isSlave){ //old case
+  if (not _isMaster && not _isSlave) { //old case
     return vec.norm();
   }
 
   PRECICE_ASSERT(_communication.get() != nullptr);
   PRECICE_ASSERT(_communication->isConnected());
-  double localSum2 = 0.0;
+  double localSum2  = 0.0;
   double globalSum2 = 0.0;
 
-  for(int i=0; i<vec.size(); i++){
-    localSum2 += vec(i)*vec(i);
+  for (int i = 0; i < vec.size(); i++) {
+    localSum2 += vec(i) * vec(i);
   }
 
   // localSum is modified, do not use afterwards
   allreduceSum(localSum2, globalSum2, 1);
-   /* old loop over all slaves solution
+  /* old loop over all slaves solution
   if(_isSlave){
     _communication->send(localSum2, 0);
     _communication->receive(globalSum2, 0);
@@ -87,23 +85,22 @@ double MasterSlave:: l2norm(const Eigen::VectorXd& vec)
   return sqrt(globalSum2);
 }
 
-
-double MasterSlave:: dot(const Eigen::VectorXd& vec1, const Eigen::VectorXd& vec2)
+double MasterSlave::dot(const Eigen::VectorXd &vec1, const Eigen::VectorXd &vec2)
 {
   PRECICE_TRACE();
 
-  if(not _isMaster && not _isSlave){ //old case
+  if (not _isMaster && not _isSlave) { //old case
     return vec1.dot(vec2);
   }
 
   PRECICE_ASSERT(_communication.get() != nullptr);
   PRECICE_ASSERT(_communication->isConnected());
-  PRECICE_ASSERT(vec1.size()==vec2.size(), vec1.size(), vec2.size());
-  double localSum = 0.0;
+  PRECICE_ASSERT(vec1.size() == vec2.size(), vec1.size(), vec2.size());
+  double localSum  = 0.0;
   double globalSum = 0.0;
 
-  for(int i=0; i<vec1.size(); i++){
-    localSum += vec1(i)*vec2(i);
+  for (int i = 0; i < vec1.size(); i++) {
+    localSum += vec1(i) * vec2(i);
   }
 
   // localSum is modified, do not use afterwards
@@ -129,18 +126,17 @@ double MasterSlave:: dot(const Eigen::VectorXd& vec1, const Eigen::VectorXd& vec
   return globalSum;
 }
 
-void MasterSlave:: reset()
+void MasterSlave::reset()
 {
   PRECICE_TRACE();
   _isMaster = false;
-  _isSlave = false;
-  _rank = -1;
-  _size = -1;
+  _isSlave  = false;
+  _rank     = -1;
+  _size     = -1;
 }
 
-
-void
-MasterSlave::reduceSum(double* sendData, double* rcvData, int size) {
+void MasterSlave::reduceSum(double *sendData, double *rcvData, int size)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -161,8 +157,8 @@ MasterSlave::reduceSum(double* sendData, double* rcvData, int size) {
   }
 }
 
-void
-MasterSlave::reduceSum(int& sendData, int& rcvData, int size) {
+void MasterSlave::reduceSum(int &sendData, int &rcvData, int size)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -183,8 +179,8 @@ MasterSlave::reduceSum(int& sendData, int& rcvData, int size) {
   }
 }
 
-void
-MasterSlave::allreduceSum(double* sendData, double* rcvData, int size) {
+void MasterSlave::allreduceSum(double *sendData, double *rcvData, int size)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -205,8 +201,8 @@ MasterSlave::allreduceSum(double* sendData, double* rcvData, int size) {
   }
 }
 
-void
-MasterSlave::allreduceSum(double& sendData, double& rcvData, int size) {
+void MasterSlave::allreduceSum(double &sendData, double &rcvData, int size)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -227,8 +223,8 @@ MasterSlave::allreduceSum(double& sendData, double& rcvData, int size) {
   }
 }
 
-void
-MasterSlave::allreduceSum(int& sendData, int& rcvData, int size) {
+void MasterSlave::allreduceSum(int &sendData, int &rcvData, int size)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -249,8 +245,8 @@ MasterSlave::allreduceSum(int& sendData, int& rcvData, int size) {
   }
 }
 
-void
-MasterSlave::broadcast(bool& value) {
+void MasterSlave::broadcast(bool &value)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -271,9 +267,8 @@ MasterSlave::broadcast(bool& value) {
   }
 }
 
-
-void
-MasterSlave::broadcast(double& value) {
+void MasterSlave::broadcast(double &value)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -294,8 +289,8 @@ MasterSlave::broadcast(double& value) {
   }
 }
 
-void
-MasterSlave::broadcast(double* values, int size) {
+void MasterSlave::broadcast(double *values, int size)
+{
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
@@ -316,4 +311,5 @@ MasterSlave::broadcast(double* values, int size) {
   }
 }
 
-}} // precice, utils
+} // namespace utils
+} // namespace precice

--- a/src/utils/MasterSlave.hpp
+++ b/src/utils/MasterSlave.hpp
@@ -9,10 +9,8 @@ namespace precice {
 namespace utils {
 
 /// Utility class for managing Master-Slave operations.
-class MasterSlave
-{
+class MasterSlave {
 public:
-
   /// Communication between the master and all slaves.
   static com::PtrCommunication _communication;
 
@@ -24,7 +22,7 @@ public:
 
   /// Number of ranks. This includes ranks from both participants, e.g. minimal size is 2.
   static int getSize();
-  
+
   /// True if this process is running the master.
   static bool isMaster();
 
@@ -32,36 +30,35 @@ public:
   static bool isSlave();
 
   /// The l2 norm of a vector is calculated on distributed data.
-  static double l2norm(const Eigen::VectorXd& vec);
+  static double l2norm(const Eigen::VectorXd &vec);
 
   // The dot product of 2 vectors is calculated on distributed data.
-  static double dot(const Eigen::VectorXd& vec1, const Eigen::VectorXd& vec2);
+  static double dot(const Eigen::VectorXd &vec1, const Eigen::VectorXd &vec2);
 
   static void reset();
 
-  static void reduceSum(double* sendData, double* rcvData, int size);
+  static void reduceSum(double *sendData, double *rcvData, int size);
 
-  static void reduceSum(int& sendData, int& rcvData, int size);
+  static void reduceSum(int &sendData, int &rcvData, int size);
 
-  static void allreduceSum(double* sendData, double* rcvData, int size);
+  static void allreduceSum(double *sendData, double *rcvData, int size);
 
-  static void allreduceSum(double& sendData, double& rcvData, int size);
+  static void allreduceSum(double &sendData, double &rcvData, int size);
 
-  static void allreduceSum(int& sendData, int& rcvData, int size);
+  static void allreduceSum(int &sendData, int &rcvData, int size);
 
-  static void broadcast(bool& value);
+  static void broadcast(bool &value);
 
-  static void broadcast(double& value);
-  
-  static void broadcast(double* values, int size);
+  static void broadcast(double &value);
+
+  static void broadcast(double *values, int size);
 
 private:
-
   static logging::Logger _log;
 
   /// Current rank
   static int _rank;
-  
+
   /// Number of ranks. This includes ranks from both participants, e.g. minimal size is 2.
   static int _size;
 
@@ -70,8 +67,7 @@ private:
 
   /// True if this process is running a slave.
   static bool _isSlave;
-  
 };
 
-
-}} // namespace precice, utils
+} // namespace utils
+} // namespace precice

--- a/src/utils/MultiLock.hpp
+++ b/src/utils/MultiLock.hpp
@@ -4,19 +4,16 @@
 #include <exception>
 #include <map>
 
-namespace precice
-{
-namespace utils
-{
+namespace precice {
+namespace utils {
 
-class MultiLockException : public std::runtime_error
-{
+class MultiLockException : public std::runtime_error {
 public:
-  MultiLockException() : runtime_error("MultiLock") {}
+  MultiLockException()
+      : runtime_error("MultiLock") {}
 };
 
-class LockNotFoundException : public MultiLockException
-{
+class LockNotFoundException : public MultiLockException {
 public:
   LockNotFoundException() {}
   const char *what() const noexcept override
@@ -27,8 +24,7 @@ public:
 
 /// Class handling multiple locks allowing global lock and unlock operations.
 template <typename Key>
-class MultiLock
-{
+class MultiLock {
 public:
   /// The type of the key
   using key_type = Key;
@@ -92,7 +88,7 @@ public:
   /// Removes all known locks
   void clear() noexcept
   {
-      _locks.clear();
+    _locks.clear();
   }
 
   /** @brief Checks the status of a lock

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -3,10 +3,8 @@
 #include "assertion.hpp"
 #include "com/MPIDirectCommunication.hpp"
 
-namespace precice
-{
-namespace utils
-{
+namespace precice {
+namespace utils {
 
 logging::Logger Parallel::_log("utils::Parallel");
 
@@ -14,8 +12,8 @@ Parallel::Communicator Parallel::_globalCommunicator = Parallel::getCommunicator
 
 Parallel::Communicator Parallel::_localCommunicator = MPI_COMM_NULL;
 
-bool Parallel::_isInitialized = false;
-bool Parallel::_isSplit = false;
+bool Parallel::_isInitialized           = false;
+bool Parallel::_isSplit                 = false;
 bool Parallel::_mpiInitializedByPrecice = false;
 
 std::vector<Parallel::AccessorGroup> Parallel::_accessorGroups;
@@ -30,7 +28,7 @@ Parallel::Communicator Parallel::getCommunicatorWorld()
 }
 
 void Parallel::initializeMPI(
-    int *argc,
+    int *   argc,
     char ***argv)
 {
 #ifndef PRECICE_NO_MPI
@@ -56,8 +54,8 @@ void Parallel::splitCommunicator(const std::string &groupName)
     PRECICE_DEBUG("Exchange group information");
     //_accessorGroups.clear(); // Makes reinitialization possible
     std::map<std::string, int> groupMap; // map from names to group ID
-    MPI_Comm globalComm = getGlobalCommunicator();
-    int rank = -1;
+    MPI_Comm                   globalComm = getGlobalCommunicator();
+    int                        rank       = -1;
     MPI_Comm_rank(globalComm, &rank);
     int size = -1;
     MPI_Comm_size(globalComm, &size);
@@ -69,10 +67,10 @@ void Parallel::splitCommunicator(const std::string &groupName)
       if (rank == 0) {
         groupMap[groupName] = 0;
         AccessorGroup newGroup;
-        newGroup.id = 0;
-        newGroup.size = 1;
+        newGroup.id         = 0;
+        newGroup.size       = 1;
         newGroup.leaderRank = 0;
-        newGroup.name = groupName;
+        newGroup.name       = groupName;
         _accessorGroups.push_back(newGroup);
         for (int i = 1; i < size; i++) {
           std::string name;
@@ -80,10 +78,10 @@ void Parallel::splitCommunicator(const std::string &groupName)
           if (groupMap.find(name) == groupMap.end()) {
             groupMap[name] = _accessorGroups.size();
             AccessorGroup newGroup;
-            newGroup.id = _accessorGroups.size();
-            newGroup.size = 1;
+            newGroup.id         = _accessorGroups.size();
+            newGroup.size       = 1;
             newGroup.leaderRank = i;
-            newGroup.name = name;
+            newGroup.name       = name;
             _accessorGroups.push_back(newGroup);
           } else {
             _accessorGroups[groupMap[name]].size++;
@@ -135,8 +133,8 @@ void Parallel::splitCommunicator(const std::string &groupName)
       PRECICE_DEBUG("Detected " << _accessorGroups.size() << " groups");
       for (const AccessorGroup &group : _accessorGroups) {
         PRECICE_DEBUG("Group " << group.id << ": name = " << group.name
-                       << ", leaderRank = " << group.leaderRank
-                       << ", size = " << group.size);
+                               << ", leaderRank = " << group.leaderRank
+                               << ", size = " << group.size);
       }
 #endif // NDEBUG
     }
@@ -226,7 +224,7 @@ void Parallel::setGlobalCommunicator(
     MPI_Comm_free(&_globalCommunicator);
   }
   _globalCommunicator = defaultCommunicator;
-  _localCommunicator = _globalCommunicator;
+  _localCommunicator  = _globalCommunicator;
   _accessorGroups.clear();
 #endif // not PRECICE_NO_MPI
 }
@@ -304,7 +302,7 @@ const std::vector<Parallel::AccessorGroup> &Parallel::getAccessorGroups()
   PRECICE_ASSERT(_isInitialized);
   return _accessorGroups;
 }
-}
-} // precice, utils
+} // namespace utils
+} // namespace precice
 
 //#endif // not PRECICE_NO_MPI

--- a/src/utils/Parallel.hpp
+++ b/src/utils/Parallel.hpp
@@ -8,28 +8,25 @@
 #include <mpi.h>
 #endif // not PRECICE_NO_MPI
 
-namespace precice
-{
-namespace utils
-{
+namespace precice {
+namespace utils {
 
 /// Utility class for managing MPI operations.
-class Parallel
-{
+class Parallel {
 public:
 #ifndef PRECICE_NO_MPI
   using Communicator = MPI_Comm;
 #else
   using Communicator = std::nullptr_t;
-  #define MPI_COMM_NULL nullptr
+#define MPI_COMM_NULL nullptr
 #endif
 
   /// Used to sort and order all coupling participants.
   struct AccessorGroup {
     std::string name;
-    int id;
-    int leaderRank;
-    int size;
+    int         id;
+    int         leaderRank;
+    int         size;
   };
 
   static Communicator getCommunicatorWorld();
@@ -48,7 +45,7 @@ public:
    * @param[in] argv Parameter values, is passed to MPI_Init
    */
   static void initializeMPI(
-      int *argc,
+      int *   argc,
       char ***argv);
 
   /// Finalizes MPI environment.
@@ -144,5 +141,5 @@ private:
 
   static bool _mpiInitializedByPrecice;
 };
-}
-} // namespace precice, utils
+} // namespace utils
+} // namespace precice

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -1,6 +1,6 @@
 #include "Petsc.hpp"
-#include "utils/Parallel.hpp"
 #include <utility>
+#include "utils/Parallel.hpp"
 
 #ifndef PRECICE_NO_PETSC
 #include "petsc.h"
@@ -13,8 +13,8 @@ namespace utils {
 
 namespace {
 
-using new_signature = PetscErrorCode(PetscOptions, const char [], const char[]);
-using old_signature = PetscErrorCode(const char [], const char[]);
+using new_signature = PetscErrorCode(PetscOptions, const char[], const char[]);
+using old_signature = PetscErrorCode(const char[], const char[]);
 
 /**
  * @brief Fix for compatibility with PETSc < 3.7. 
@@ -23,10 +23,10 @@ using old_signature = PetscErrorCode(const char [], const char[]);
  * This instantiates only the template, that specifies correct function signature, whilst 
  * the other one is discarded ( https://en.cppreference.com/w/cpp/language/sfinae )
  */
-template< typename curr_signature = decltype(PetscOptionsSetValue) >
-PetscErrorCode PetscOptionsSetValueWrapper(const char name [], const char value[],
-    typename std::enable_if<std::is_same<curr_signature, new_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
-                           PetscOptionsSetValue)
+template <typename curr_signature = decltype(PetscOptionsSetValue)>
+PetscErrorCode PetscOptionsSetValueWrapper(const char name[], const char value[],
+                                           typename std::enable_if<std::is_same<curr_signature, new_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
+                                               PetscOptionsSetValue)
 {
   return PetscOptionsSetValueImpl(nullptr, name, value);
 };
@@ -40,23 +40,22 @@ PetscErrorCode PetscOptionsSetValueWrapper(const char name [], const char value[
  */
 template <typename curr_signature = decltype(PetscOptionsSetValue)>
 PetscErrorCode PetscOptionsSetValueWrapper(const char name[], const char value[],
-    typename std::enable_if<std::is_same<curr_signature, old_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
-                            PetscOptionsSetValue)
+                                           typename std::enable_if<std::is_same<curr_signature, old_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
+                                               PetscOptionsSetValue)
 {
   return PetscOptionsSetValueImpl(name, value);
 };
 
-}
+} // namespace
 #endif
 
 logging::Logger Petsc::_log("utils::Petsc");
 
 bool Petsc::weInitialized = false;
 
-void Petsc::initialize
-(
-  int*               argc,
-  char***            argv )
+void Petsc::initialize(
+    int *   argc,
+    char ***argv)
 {
   PRECICE_TRACE();
 #ifndef PRECICE_NO_PETSC
@@ -65,7 +64,8 @@ void Petsc::initialize
   if (not petscIsInitialized) {
     PETSC_COMM_WORLD = Parallel::getGlobalCommunicator();
     PetscErrorCode ierr;
-    ierr = PetscInitialize(argc, argv, "", nullptr); CHKERRV(ierr);
+    ierr = PetscInitialize(argc, argv, "", nullptr);
+    CHKERRV(ierr);
     weInitialized = true;
     PetscPushErrorHandler(&PetscMPIAbortErrorHandler, nullptr);
   }
@@ -78,34 +78,33 @@ void Petsc::finalize()
   PetscBool petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
   if (petscIsInitialized and weInitialized) {
-    PetscOptionsSetValueWrapper("-options_left", "no"); 
+    PetscOptionsSetValueWrapper("-options_left", "no");
     PetscFinalize();
   }
 #endif // not PRECICE_NO_PETSC
 }
-}} // namespace precice, utils
-
+} // namespace utils
+} // namespace precice
 
 #ifndef PRECICE_NO_PETSC
 
-#include <string>
 #include <limits>
 #include <random>
-#include "petscviewer.h"
+#include <string>
 #include "petscdraw.h"
+#include "petscviewer.h"
 
 namespace precice {
 namespace utils {
 namespace petsc {
 
-void openViewer(PetscViewer & viewer, std::string filename, VIEWERFORMAT format, MPI_Comm comm)
+void openViewer(PetscViewer &viewer, std::string filename, VIEWERFORMAT format, MPI_Comm comm)
 {
   PetscErrorCode ierr = 0;
   if (format == ASCII) {
     ierr = PetscViewerASCIIOpen(comm, filename.c_str(), &viewer);
     CHKERRV(ierr);
-  }
-  else if (format == BINARY) {
+  } else if (format == BINARY) {
     ierr = PetscViewerBinaryOpen(comm, filename.c_str(), FILE_MODE_WRITE, &viewer);
     CHKERRV(ierr);
     ierr = PetscViewerPushFormat(viewer, PETSC_VIEWER_NATIVE);
@@ -113,7 +112,7 @@ void openViewer(PetscViewer & viewer, std::string filename, VIEWERFORMAT format,
   }
 }
 
-template<class T>
+template <class T>
 MPI_Comm getCommunicator(T obj)
 {
   MPI_Comm comm;
@@ -121,14 +120,15 @@ MPI_Comm getCommunicator(T obj)
   return comm;
 }
 
-template<class T>
+template <class T>
 void setName(T obj, std::string name)
 {
   PetscErrorCode ierr = 0;
-  ierr = PetscObjectSetName(reinterpret_cast<PetscObject>(obj), name.c_str()); CHKERRV(ierr);
+  ierr                = PetscObjectSetName(reinterpret_cast<PetscObject>(obj), name.c_str());
+  CHKERRV(ierr);
 }
 
-template<class T>
+template <class T>
 std::string getName(T obj)
 {
   const char *cstr;
@@ -136,38 +136,42 @@ std::string getName(T obj)
   return cstr;
 }
 
-
 /////////////////////////////////////////////////////////////////////////
 
 Vector::Vector(const Vector &v)
 {
   PetscErrorCode ierr = 0;
-  ierr = VecDuplicate(v.vector, &vector); CHKERRV(ierr);
-  ierr = VecCopy(v.vector, vector); CHKERRV(ierr);
+  ierr                = VecDuplicate(v.vector, &vector);
+  CHKERRV(ierr);
+  ierr = VecCopy(v.vector, vector);
+  CHKERRV(ierr);
   setName(vector, getName(v.vector));
 }
 
-Vector& Vector::operator=(Vector other)
+Vector &Vector::operator=(Vector other)
 {
-    swap(other);
-    return *this;
+  swap(other);
+  return *this;
 }
 
-Vector::Vector(Vector&& other) {
-  vector = other.vector;
+Vector::Vector(Vector &&other)
+{
+  vector       = other.vector;
   other.vector = nullptr;
 }
 
-Vector::Vector(const std::string& name)
+Vector::Vector(const std::string &name)
 {
   int size;
   MPI_Comm_size(utils::Parallel::getGlobalCommunicator(), &size);
   PetscErrorCode ierr = 0;
-  ierr = VecCreate(utils::Parallel::getGlobalCommunicator(), &vector); CHKERRV(ierr);
+  ierr                = VecCreate(utils::Parallel::getGlobalCommunicator(), &vector);
+  CHKERRV(ierr);
   setName(vector, name);
 }
 
-Vector::Vector(Vec& v, const std::string& name) : vector(v)
+Vector::Vector(Vec &v, const std::string &name)
+    : vector(v)
 {
   setName(vector, name);
 }
@@ -175,58 +179,58 @@ Vector::Vector(Vec& v, const std::string& name) : vector(v)
 Vector::~Vector()
 {
   PetscErrorCode ierr = 0;
-  PetscBool petscIsInitialized;
+  PetscBool      petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
   if (petscIsInitialized) // If PetscFinalize is called before ~Vector
-    ierr = VecDestroy(&vector); CHKERRV(ierr);
+    ierr = VecDestroy(&vector);
+  CHKERRV(ierr);
 }
 
-
-Vector Vector::allocate(const std::string& name)
+Vector Vector::allocate(const std::string &name)
 {
-    return Vector{name};
+  return Vector{name};
 }
 
-Vector Vector::allocate(Vector& other, const std::string& name)
+Vector Vector::allocate(Vector &other, const std::string &name)
 {
   return allocate(other.vector, name);
 }
 
-Vector Vector::allocate(Vec& other, const std::string& name) 
+Vector Vector::allocate(Vec &other, const std::string &name)
 {
-  Vec newvector;
+  Vec            newvector;
   PetscErrorCode ierr = 0;
-  ierr = VecDuplicate(other, &newvector); [&]{CHKERRV(ierr);}();
+  ierr                = VecDuplicate(other, &newvector);
+  [&] { CHKERRV(ierr); }();
   return Vector{newvector, name};
 }
 
-Vector Vector::allocate(Matrix& m, const std::string& name, LEFTRIGHT type)
+Vector Vector::allocate(Matrix &m, const std::string &name, LEFTRIGHT type)
 {
   return allocate(m.matrix, name, type);
 }
 
-Vector Vector::allocate(Mat& m, const std::string& name, LEFTRIGHT type)
+Vector Vector::allocate(Mat &m, const std::string &name, LEFTRIGHT type)
 {
   Vec newvector;
   // MatGetVecs is deprecated, we keep it due to the old PETSc version at the SuperMUC.
   PetscErrorCode ierr = 0;
   if (type == LEFTRIGHT::LEFT) {
-    ierr = MatCreateVecs(m, nullptr, &newvector);// a vector with the same number of rows
-  }
-  else {
+    ierr = MatCreateVecs(m, nullptr, &newvector); // a vector with the same number of rows
+  } else {
     ierr = MatCreateVecs(m, &newvector, nullptr); // a vector with the same number of cols
   }
-  [&]{CHKERRV(ierr);}(); 
+  [&] { CHKERRV(ierr); }();
   return Vector{newvector, name};
 }
 
-void Vector::swap(Vector& other) noexcept
+void Vector::swap(Vector &other) noexcept
 {
-    using std::swap;
-    swap(vector, other.vector);
+  using std::swap;
+  swap(vector, other.vector);
 }
 
-Vector::operator Vec&()
+Vector::operator Vec &()
 {
   return vector;
 }
@@ -234,41 +238,47 @@ Vector::operator Vec&()
 void Vector::init(PetscInt rows)
 {
   PetscErrorCode ierr = 0;
-  ierr = VecSetSizes(vector, PETSC_DECIDE, rows); CHKERRV(ierr);
-  ierr = VecSetFromOptions(vector); CHKERRV(ierr);
+  ierr                = VecSetSizes(vector, PETSC_DECIDE, rows);
+  CHKERRV(ierr);
+  ierr = VecSetFromOptions(vector);
+  CHKERRV(ierr);
 }
 
 PetscInt Vector::getSize() const
 {
   PetscErrorCode ierr = 0;
-  PetscInt size;
-  ierr = VecGetSize(vector, &size); CHKERRQ(ierr);
+  PetscInt       size;
+  ierr = VecGetSize(vector, &size);
+  CHKERRQ(ierr);
   return size;
 }
 
 PetscInt Vector::getLocalSize() const
 {
   PetscErrorCode ierr = 0;
-  PetscInt size;
-  ierr = VecGetLocalSize(vector, &size); CHKERRQ(ierr);
+  PetscInt       size;
+  ierr = VecGetLocalSize(vector, &size);
+  CHKERRQ(ierr);
   return size;
 }
 
 void Vector::setValue(PetscInt row, PetscScalar value)
 {
   PetscErrorCode ierr = 0;
-  ierr = VecSetValue(vector, row, value, INSERT_VALUES); CHKERRV(ierr);
+  ierr                = VecSetValue(vector, row, value, INSERT_VALUES);
+  CHKERRV(ierr);
 }
 
 void Vector::arange(double start, double stop)
 {
   PetscErrorCode ierr = 0;
-  PetscScalar *a;
-  PetscInt range_start, range_end, size;
+  PetscScalar *  a;
+  PetscInt       range_start, range_end, size;
   VecGetSize(vector, &size);
   VecGetOwnershipRange(vector, &range_start, &range_end);
-  double step_size = (stop-start) / size;
-  ierr = VecGetArray(vector, &a); CHKERRV(ierr); 
+  double step_size = (stop - start) / size;
+  ierr             = VecGetArray(vector, &a);
+  CHKERRV(ierr);
   for (PetscInt i = range_start; i < range_end; i++) {
     a[i - range_start] = (i + start) * step_size;
   }
@@ -278,37 +288,42 @@ void Vector::arange(double start, double stop)
 void Vector::fillWithRandoms()
 {
   PetscErrorCode ierr = 0;
-  PetscRandom rctx;
+  PetscRandom    rctx;
 
-  std::random_device rd;
+  std::random_device                     rd;
   std::uniform_real_distribution<double> dist(0, 1);
 
   PetscRandomCreate(getCommunicator(vector), &rctx);
   PetscRandomSetType(rctx, PETSCRAND48);
   PetscRandomSetSeed(rctx, dist(rd));
-  PetscRandomSeed(rctx);     
-  ierr = VecSetRandom(vector, rctx); CHKERRV(ierr);
+  PetscRandomSeed(rctx);
+  ierr = VecSetRandom(vector, rctx);
+  CHKERRV(ierr);
   PetscRandomDestroy(&rctx);
 }
 
-void Vector::sort() 
+void Vector::sort()
 {
   PetscErrorCode ierr = 0;
-  PetscInt size;
-  PetscReal *a;
-  ierr = VecGetArray(vector, &a); CHKERRV(ierr);
+  PetscInt       size;
+  PetscReal *    a;
+  ierr = VecGetArray(vector, &a);
+  CHKERRV(ierr);
   ierr = VecGetSize(vector, &size);
-  ierr = PetscSortReal(size, a); CHKERRV(ierr);
-  ierr = VecRestoreArray(vector, &a); CHKERRV(ierr);
+  ierr = PetscSortReal(size, a);
+  CHKERRV(ierr);
+  ierr = VecRestoreArray(vector, &a);
+  CHKERRV(ierr);
 }
 
 void Vector::assemble()
 {
   PetscErrorCode ierr = 0;
-  ierr = VecAssemblyBegin(vector); CHKERRV(ierr); 
-  ierr = VecAssemblyEnd(vector); CHKERRV(ierr); 
+  ierr                = VecAssemblyBegin(vector);
+  CHKERRV(ierr);
+  ierr = VecAssemblyEnd(vector);
+  CHKERRV(ierr);
 }
-
 
 std::pair<PetscInt, PetscInt> Vector::ownerRange() const
 {
@@ -316,34 +331,38 @@ std::pair<PetscInt, PetscInt> Vector::ownerRange() const
   VecGetOwnershipRange(vector, &range_start, &range_end);
   return std::make_pair(range_start, range_end);
 }
-  
+
 void Vector::write(std::string filename, VIEWERFORMAT format) const
 {
   PetscErrorCode ierr = 0;
-  PetscViewer viewer;
+  PetscViewer    viewer;
   openViewer(viewer, filename, format, getCommunicator(vector));
-  VecView(vector, viewer); CHKERRV(ierr);
+  VecView(vector, viewer);
+  CHKERRV(ierr);
   PetscViewerDestroy(&viewer);
 }
 
 void Vector::read(std::string filename, VIEWERFORMAT format)
 {
-   PetscErrorCode ierr = 0;
-   PetscViewer viewer;
-   openViewer(viewer, filename, format, getCommunicator(vector));
-   VecLoad(vector, viewer); CHKERRV(ierr); CHKERRV(ierr);
-   PetscViewerDestroy(&viewer);
+  PetscErrorCode ierr = 0;
+  PetscViewer    viewer;
+  openViewer(viewer, filename, format, getCommunicator(vector));
+  VecLoad(vector, viewer);
+  CHKERRV(ierr);
+  CHKERRV(ierr);
+  PetscViewerDestroy(&viewer);
 }
 
 void Vector::view() const
 {
   PetscErrorCode ierr;
-  ierr = VecView(vector, PETSC_VIEWER_STDOUT_WORLD); CHKERRV(ierr);
+  ierr = VecView(vector, PETSC_VIEWER_STDOUT_WORLD);
+  CHKERRV(ierr);
 }
 
-void swap(Vector& lhs, Vector& rhs) noexcept
+void swap(Vector &lhs, Vector &rhs) noexcept
 {
-    lhs.swap(rhs);
+  lhs.swap(rhs);
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -351,21 +370,22 @@ void swap(Vector& lhs, Vector& rhs) noexcept
 Matrix::Matrix(std::string name)
 {
   PetscErrorCode ierr = 0;
-  ierr = MatCreate(utils::Parallel::getGlobalCommunicator(), &matrix); CHKERRV(ierr);
+  ierr                = MatCreate(utils::Parallel::getGlobalCommunicator(), &matrix);
+  CHKERRV(ierr);
   setName(matrix, name);
 }
-
 
 Matrix::~Matrix()
 {
   PetscErrorCode ierr = 0;
-  PetscBool petscIsInitialized;
+  PetscBool      petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
   if (petscIsInitialized) // If PetscFinalize is called before ~Matrix
-    ierr = MatDestroy(&matrix); CHKERRV(ierr);
+    ierr = MatDestroy(&matrix);
+  CHKERRV(ierr);
 }
 
-Matrix::operator Mat&()
+Matrix::operator Mat &()
 {
   return matrix;
 }
@@ -373,8 +393,10 @@ Matrix::operator Mat&()
 void Matrix::assemble(MatAssemblyType type)
 {
   PetscErrorCode ierr = 0;
-  ierr = MatAssemblyBegin(matrix, type); CHKERRV(ierr);
-  ierr = MatAssemblyEnd(matrix, type); CHKERRV(ierr);
+  ierr                = MatAssemblyBegin(matrix, type);
+  CHKERRV(ierr);
+  ierr = MatAssemblyEnd(matrix, type);
+  CHKERRV(ierr);
 }
 
 void Matrix::init(PetscInt localRows, PetscInt localCols, PetscInt globalRows, PetscInt globalCols,
@@ -382,20 +404,26 @@ void Matrix::init(PetscInt localRows, PetscInt localCols, PetscInt globalRows, P
 {
   PetscErrorCode ierr = 0;
   if (type != nullptr) {
-    ierr = MatSetType(matrix, type); CHKERRV(ierr);
+    ierr = MatSetType(matrix, type);
+    CHKERRV(ierr);
   }
-  ierr = MatSetSizes(matrix, localRows, localCols, globalRows, globalCols); CHKERRV(ierr);
-  ierr = MatSetFromOptions(matrix); CHKERRV(ierr);
+  ierr = MatSetSizes(matrix, localRows, localCols, globalRows, globalCols);
+  CHKERRV(ierr);
+  ierr = MatSetFromOptions(matrix);
+  CHKERRV(ierr);
   if (doSetup)
-    ierr = MatSetUp(matrix); CHKERRV(ierr);
+    ierr = MatSetUp(matrix);
+  CHKERRV(ierr);
 }
 
 void Matrix::reset()
 {
   PetscErrorCode ierr = 0;
-  std::string name = getName(matrix);
-  ierr = MatDestroy(&matrix); CHKERRV(ierr);
-  ierr = MatCreate(utils::Parallel::getGlobalCommunicator(), &matrix); CHKERRV(ierr);
+  std::string    name = getName(matrix);
+  ierr                = MatDestroy(&matrix);
+  CHKERRV(ierr);
+  ierr = MatCreate(utils::Parallel::getGlobalCommunicator(), &matrix);
+  CHKERRV(ierr);
   setName(matrix, name);
 }
 
@@ -409,39 +437,46 @@ MatInfo Matrix::getInfo(MatInfoType flag) const
 void Matrix::setValue(PetscInt row, PetscInt col, PetscScalar value)
 {
   PetscErrorCode ierr = 0;
-  ierr = MatSetValue(matrix, row, col, value, INSERT_VALUES); CHKERRV(ierr);
+  ierr                = MatSetValue(matrix, row, col, value, INSERT_VALUES);
+  CHKERRV(ierr);
 }
 
 void Matrix::fillWithRandoms()
 {
   PetscErrorCode ierr = 0;
-  PetscRandom rctx;
+  PetscRandom    rctx;
 
-  std::random_device rd;
+  std::random_device                     rd;
   std::uniform_real_distribution<double> dist(0, 1);
 
   PetscRandomCreate(getCommunicator(matrix), &rctx);
   PetscRandomSetType(rctx, PETSCRAND48);
   PetscRandomSetSeed(rctx, dist(rd));
-  PetscRandomSeed(rctx);     
-  ierr = MatSetRandom(matrix, rctx); CHKERRV(ierr);
+  PetscRandomSeed(rctx);
+  ierr = MatSetRandom(matrix, rctx);
+  CHKERRV(ierr);
   PetscRandomDestroy(&rctx);
 }
 
 void Matrix::setColumn(Vector &v, PetscInt col)
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode     ierr = 0;
   const PetscScalar *vec;
-  PetscInt range_start, range_end;
+  PetscInt           range_start, range_end;
   VecGetOwnershipRange(v.vector, &range_start, &range_end);
   std::vector<PetscInt> irow(range_end - range_start);
   std::iota(irow.begin(), irow.end(), range_start);
-      
-  ierr = VecGetArrayRead(v.vector, &vec); CHKERRV(ierr);
-  ierr = MatSetValues(matrix, range_end - range_start, irow.data(), 1, &col, vec, INSERT_VALUES); CHKERRV(ierr);
-  ierr = VecRestoreArrayRead(v.vector, &vec); CHKERRV(ierr);
-  ierr = MatAssemblyBegin(matrix, MAT_FINAL_ASSEMBLY); CHKERRV(ierr); 
-  ierr = MatAssemblyEnd(matrix, MAT_FINAL_ASSEMBLY); CHKERRV(ierr); 
+
+  ierr = VecGetArrayRead(v.vector, &vec);
+  CHKERRV(ierr);
+  ierr = MatSetValues(matrix, range_end - range_start, irow.data(), 1, &col, vec, INSERT_VALUES);
+  CHKERRV(ierr);
+  ierr = VecRestoreArrayRead(v.vector, &vec);
+  CHKERRV(ierr);
+  ierr = MatAssemblyBegin(matrix, MAT_FINAL_ASSEMBLY);
+  CHKERRV(ierr);
+  ierr = MatAssemblyEnd(matrix, MAT_FINAL_ASSEMBLY);
+  CHKERRV(ierr);
 }
 
 std::pair<PetscInt, PetscInt> Matrix::getSize() const
@@ -475,75 +510,90 @@ std::pair<PetscInt, PetscInt> Matrix::ownerRangeColumn() const
 PetscInt Matrix::blockSize() const
 {
   PetscErrorCode ierr = 0;
-  PetscInt bs;
-  ierr = MatGetBlockSize(matrix, &bs); CHKERRQ(ierr);
+  PetscInt       bs;
+  ierr = MatGetBlockSize(matrix, &bs);
+  CHKERRQ(ierr);
   return bs;
 }
 
 void Matrix::write(std::string filename, VIEWERFORMAT format) const
 {
   PetscErrorCode ierr = 0;
-  PetscViewer viewer;
+  PetscViewer    viewer;
   openViewer(viewer, filename, format, getCommunicator(matrix));
-  ierr = MatView(matrix, viewer); CHKERRV(ierr);
+  ierr = MatView(matrix, viewer);
+  CHKERRV(ierr);
   PetscViewerDestroy(&viewer);
 }
 
 void Matrix::read(std::string filename)
 {
-   PetscErrorCode ierr = 0;
-   PetscViewer viewer;
-   openViewer(viewer, filename, BINARY, getCommunicator(matrix));
-   ierr = MatLoad(matrix, viewer); CHKERRV(ierr);
-   PetscViewerDestroy(&viewer);
+  PetscErrorCode ierr = 0;
+  PetscViewer    viewer;
+  openViewer(viewer, filename, BINARY, getCommunicator(matrix));
+  ierr = MatLoad(matrix, viewer);
+  CHKERRV(ierr);
+  PetscViewerDestroy(&viewer);
 }
 
 void Matrix::view() const
 {
   PetscErrorCode ierr = 0;
-  PetscViewer viewer;
-  ierr = PetscViewerCreate(getCommunicator(matrix), &viewer); CHKERRV(ierr);
-  ierr = PetscViewerSetType(viewer, PETSCVIEWERASCII); CHKERRV(ierr); 
-  ierr = PetscViewerPushFormat(viewer, PETSC_VIEWER_ASCII_DENSE); CHKERRV(ierr);
-  ierr = MatView(matrix, viewer); CHKERRV(ierr);
-  ierr = PetscViewerPopFormat(viewer); CHKERRV(ierr);
-  ierr = PetscViewerDestroy(&viewer); CHKERRV(ierr); 
+  PetscViewer    viewer;
+  ierr = PetscViewerCreate(getCommunicator(matrix), &viewer);
+  CHKERRV(ierr);
+  ierr = PetscViewerSetType(viewer, PETSCVIEWERASCII);
+  CHKERRV(ierr);
+  ierr = PetscViewerPushFormat(viewer, PETSC_VIEWER_ASCII_DENSE);
+  CHKERRV(ierr);
+  ierr = MatView(matrix, viewer);
+  CHKERRV(ierr);
+  ierr = PetscViewerPopFormat(viewer);
+  CHKERRV(ierr);
+  ierr = PetscViewerDestroy(&viewer);
+  CHKERRV(ierr);
 }
 
 void Matrix::viewDraw() const
 {
   PetscErrorCode ierr = 0;
-  PetscViewer viewer;
-  PetscDraw draw;
-  ierr = PetscViewerCreate(getCommunicator(matrix), &viewer); CHKERRV(ierr);
-  ierr = PetscViewerSetType(viewer, PETSCVIEWERDRAW); CHKERRV(ierr); 
-  ierr = MatView(matrix, viewer); CHKERRV(ierr);
-  ierr = PetscViewerDrawGetDraw(viewer, 0, &draw); CHKERRV(ierr);
-  ierr = PetscDrawSetPause(draw, -1); CHKERRV(ierr); // Wait for user
-  ierr = PetscViewerDestroy(&viewer); CHKERRV(ierr);
+  PetscViewer    viewer;
+  PetscDraw      draw;
+  ierr = PetscViewerCreate(getCommunicator(matrix), &viewer);
+  CHKERRV(ierr);
+  ierr = PetscViewerSetType(viewer, PETSCVIEWERDRAW);
+  CHKERRV(ierr);
+  ierr = MatView(matrix, viewer);
+  CHKERRV(ierr);
+  ierr = PetscViewerDrawGetDraw(viewer, 0, &draw);
+  CHKERRV(ierr);
+  ierr = PetscDrawSetPause(draw, -1);
+  CHKERRV(ierr); // Wait for user
+  ierr = PetscViewerDestroy(&viewer);
+  CHKERRV(ierr);
 }
-
 
 /////////////////////////////////////////////////////////////////////////
 
 KSPSolver::KSPSolver(std::string name)
 {
   PetscErrorCode ierr = 0;
-  ierr = KSPCreate(utils::Parallel::getGlobalCommunicator(), &ksp); CHKERRV(ierr);
+  ierr                = KSPCreate(utils::Parallel::getGlobalCommunicator(), &ksp);
+  CHKERRV(ierr);
   setName(ksp, name);
 }
-
 
 KSPSolver::~KSPSolver()
 {
   PetscErrorCode ierr = 0;
-  PetscBool petscIsInitialized;
+  PetscBool      petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
   if (petscIsInitialized) // If PetscFinalize is called before ~KSPSolver
-    ierr = KSPDestroy(&ksp); CHKERRV(ierr);
+    ierr = KSPDestroy(&ksp);
+  CHKERRV(ierr);
 }
 
-KSPSolver::operator KSP&()
+KSPSolver::operator KSP &()
 {
   return ksp;
 }
@@ -551,64 +601,67 @@ KSPSolver::operator KSP&()
 void KSPSolver::reset()
 {
   PetscErrorCode ierr = 0;
-  ierr = KSPReset(ksp); CHKERRV(ierr);
+  ierr                = KSPReset(ksp);
+  CHKERRV(ierr);
 }
 
 bool KSPSolver::solve(Vector &b, Vector &x)
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode     ierr = 0;
   KSPConvergedReason convReason;
   KSPSolve(ksp, b, x);
-  ierr = KSPGetConvergedReason(ksp, &convReason); CHKERRQ(ierr);
+  ierr = KSPGetConvergedReason(ksp, &convReason);
+  CHKERRQ(ierr);
   return (convReason > 0);
 }
 
 bool KSPSolver::solveTranspose(Vector &b, Vector &x)
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode     ierr = 0;
   KSPConvergedReason convReason;
   KSPSolveTranspose(ksp, b, x);
-  ierr = KSPGetConvergedReason(ksp, &convReason); CHKERRQ(ierr);
+  ierr = KSPGetConvergedReason(ksp, &convReason);
+  CHKERRQ(ierr);
   return (convReason > 0);
 }
 
 PetscInt KSPSolver::getIterationNumber()
 {
   PetscErrorCode ierr = 0;
-  PetscInt its;
-  ierr = KSPGetIterationNumber(ksp, &its); CHKERRQ(ierr);
+  PetscInt       its;
+  ierr = KSPGetIterationNumber(ksp, &its);
+  CHKERRQ(ierr);
   return its;
 }
 
-
 /////////////////////////////////////////////////////////////////////////
 
-void destroy(ISLocalToGlobalMapping * IS)
+void destroy(ISLocalToGlobalMapping *IS)
 {
   PetscErrorCode ierr = 0;
-  PetscBool petscIsInitialized;
+  PetscBool      petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
-  
+
   if (IS and petscIsInitialized) {
-    ierr = ISLocalToGlobalMappingDestroy(IS); CHKERRV(ierr);
+    ierr = ISLocalToGlobalMappingDestroy(IS);
+    CHKERRV(ierr);
   }
 }
 
-void destroy(AO * ao)
+void destroy(AO *ao)
 {
   PetscErrorCode ierr = 0;
-  PetscBool petscIsInitialized;
+  PetscBool      petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
-  
+
   if (ao and petscIsInitialized) {
-    ierr = AODestroy(ao); CHKERRV(ierr);
+    ierr = AODestroy(ao);
+    CHKERRV(ierr);
   }
 }
 
-}}} // namespace precice, utils, petsc
+} // namespace petsc
+} // namespace utils
+} // namespace precice
 
 #endif // PRECICE_NO_PETSC
-
-
-
-

--- a/src/utils/Petsc.hpp
+++ b/src/utils/Petsc.hpp
@@ -6,8 +6,7 @@ namespace precice {
 namespace utils {
 
 /// Utility class for managing PETSc operations.
-class Petsc
-{
+class Petsc {
 public:
   /**
    * @brief Initializes the Petsc environment.
@@ -15,73 +14,72 @@ public:
    * @param[in] argc Parameter count, passed to PetscInitialize
    * @param[in] argv Parameter values, passed to PetscInitialize
    */
-  static void initialize (
-    int*               argc,
-    char***            argv);
+  static void initialize(
+      int *   argc,
+      char ***argv);
 
   /// Finalizes Petsc environment.
   static void finalize();
 
 private:
-  
   /// Whether we have initialized Petsc or if it was initialized by an application calling us.
   static bool weInitialized;
-  
+
   static logging::Logger _log;
 };
-}} // namespace precice, utils
-
+} // namespace utils
+} // namespace precice
 
 #ifndef PRECICE_NO_PETSC
 
 #include <string>
 #include <utility>
 
-#include "petscvec.h"
-#include "petscmat.h"
-#include "petscksp.h"
-#include "petscis.h"
 #include "petscao.h"
+#include "petscis.h"
+#include "petscksp.h"
+#include "petscmat.h"
+#include "petscvec.h"
 
 namespace precice {
 namespace utils {
 /// PETSc related utilities
 namespace petsc {
 
-enum VIEWERFORMAT { ASCII, BINARY };
+enum VIEWERFORMAT { ASCII,
+                    BINARY };
 
 class Matrix;
 
-class Vector
-{
+class Vector {
 public:
   Vec vector = nullptr;
 
-  enum LEFTRIGHT { LEFT, RIGHT };
-  
+  enum LEFTRIGHT { LEFT,
+                   RIGHT };
+
   /// Creates a new vector on the given MPI communicator.
-  explicit Vector(const std::string& name = "");
+  explicit Vector(const std::string &name = "");
 
   /** Copy construction from another vector
    * Duplicates the vector and copies the name
    */
-  Vector(const Vector& other);
+  Vector(const Vector &other);
 
   /** Copy assignement
    * Destroys the current vector and takes ownership of the other.
    */
-  Vector& operator=(Vector other);
+  Vector &operator=(Vector other);
 
   /** Move construction
    * Takes ownership of the other vector.
    */
-  Vector(Vector&& other);
+  Vector(Vector &&other);
 
   /** Constructs the object from another Vec
    * Takes ownership of the other Vec
    */
-  Vector(Vec& other, const std::string& name = "");
-
+  Vector(Vec &other, const std::string &name = "");
 
   ~Vector();
 
@@ -89,29 +87,29 @@ public:
   ///@{
 
   /// Allocates a new vector on the given MPI communicator.
-  static Vector allocate(const std::string& name = "");
+  static Vector allocate(const std::string &name = "");
 
   /** Allocated an uninitialized vector of identical shape.
    * Duplicates type, row layout etc. (not values) of v.
    */
-  static Vector allocate(Vector& other, const std::string& name = "");
+  static Vector allocate(Vector &other, const std::string &name = "");
 
   /// Allocated an uninitialized vector of identical shape.
-  static Vector allocate(Vec& other, const std::string& name = "");
+  static Vector allocate(Vec &other, const std::string &name = "");
 
   /// Allocates a vector with the same number of rows (default) or columns.
-  static Vector allocate(Matrix& m, const std::string& name = "", LEFTRIGHT type = LEFT);
+  static Vector allocate(Matrix &m, const std::string &name = "", LEFTRIGHT type = LEFT);
 
   /// Allocates a vector with the same number of rows (default) or columns.
-  static Vector allocate(Mat& m, const std::string& name = "", LEFTRIGHT type = LEFT);
+  static Vector allocate(Mat &m, const std::string &name = "", LEFTRIGHT type = LEFT);
 
   ///@}
 
   /// Swaps the ownership of two vectors
-  void swap(Vector& other) noexcept;
+  void swap(Vector &other) noexcept;
 
   /// Enables implicit conversion into a reference to a PETSc Vec type
-  operator Vec&();
+  operator Vec &();
 
   /// Sets the size and calls VecSetFromOptions
   void init(PetscInt rows);
@@ -119,7 +117,7 @@ public:
   PetscInt getSize() const;
 
   PetscInt getLocalSize() const;
-  
+
   void setValue(PetscInt row, PetscScalar value);
 
   void arange(double start, double stop);
@@ -144,10 +142,9 @@ public:
   void view() const;
 };
 
-void swap(Vector& lhs, Vector& rhs) noexcept;
-  
-class Matrix
-{
+void swap(Vector &lhs, Vector &rhs) noexcept;
+
+class Matrix {
 public:
   Mat matrix = nullptr;
 
@@ -155,21 +152,21 @@ public:
   /** Copying and assignment of this class would involve copying the pointer to
       the PETSc object and finallly cause double destruction of it.
   */
-  Matrix(const Matrix&) = delete;
-  Matrix& operator=(const Matrix&) = delete;
+  Matrix(const Matrix &) = delete;
+  Matrix &operator=(const Matrix &) = delete;
 
   explicit Matrix(std::string name = "");
 
   /// Move constructor, use the implicitly declared.
-  Matrix(Matrix&& other) = default;
+  Matrix(Matrix &&other) = default;
 
   ~Matrix();
 
   /// Enables implicit conversion into a reference to a PETSc Mat type
-  operator Mat&();
+  operator Mat &();
 
   void assemble(MatAssemblyType type = MAT_FINAL_ASSEMBLY);
-    
+
   /// Initializes matrix of given size and type
   /** @param[in] localRows,localCols The number of rows/cols that are local to the processor
       @param[in] globalRows,globalCols The number of global rows/cols.
@@ -181,15 +178,15 @@ public:
 
   /// Destroys and recreates the matrix on the same communicator
   void reset();
-  
+
   /// Get the MatInfo struct for the matrix.
   /** See http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Mat/MatInfo.html for description of fields. */
   MatInfo getInfo(MatInfoType flag) const;
-  
+
   void setValue(PetscInt row, PetscInt col, PetscScalar value);
-  
+
   void fillWithRandoms();
-  
+
   void setColumn(Vector &v, PetscInt col);
 
   /// Returns (rows, cols) global size
@@ -197,16 +194,16 @@ public:
 
   /// Returns (rows, cols) local size
   std::pair<PetscInt, PetscInt> getLocalSize() const;
-  
+
   /// Returns a pair that mark the beginning and end of the matrix' ownership range.
   std::pair<PetscInt, PetscInt> ownerRange() const;
-  
+
   /// Returns a pair that mark the beginning and end of the matrix' column ownership range.
   std::pair<PetscInt, PetscInt> ownerRangeColumn() const;
 
   /// Returns the block size of the matrix
   PetscInt blockSize() const;
-  
+
   /// Writes the matrix to file.
   void write(std::string filename, VIEWERFORMAT format = ASCII) const;
 
@@ -218,31 +215,29 @@ public:
 
   /// Graphically draws the matrix structure
   void viewDraw() const;
-
 };
 
-class KSPSolver
-{
+class KSPSolver {
 public:
   KSP ksp;
-  
+
   /// Delete copy and assignment constructor
   /** Copying and assignment of this class would involve copying the pointer to
       the PETSc object and finallly cause double destruction of it.
   */
-  KSPSolver(const KSPSolver&) = delete;
-  KSPSolver& operator=(const KSPSolver&) = delete;
+  KSPSolver(const KSPSolver &) = delete;
+  KSPSolver &operator=(const KSPSolver &) = delete;
 
   explicit KSPSolver(std::string name = "");
 
   /// Move constructor, use the implicitly declared.
-  KSPSolver(KSPSolver&& other) = default;
+  KSPSolver(KSPSolver &&other) = default;
 
   ~KSPSolver();
-  
+
   /// Enables implicit conversion into a reference to a PETSc KSP type
-  operator KSP&();
-  
+  operator KSP &();
+
   /// Destroys and recreates the ksp on the same communicator
   void reset();
 
@@ -256,21 +251,17 @@ public:
   PetscInt getIterationNumber();
 };
 
-
 /// Destroys an KSP, if ksp is not null and PetscIsInitialized
-void destroy(KSP * ksp);
+void destroy(KSP *ksp);
 
 /// Destroys an ISLocalToGlobalMapping, if IS is not null and PetscIsInitialized
-void destroy(ISLocalToGlobalMapping * IS);
+void destroy(ISLocalToGlobalMapping *IS);
 
 /// Destroys an application ordering, if ao is not null and PetscIsInitialized
-void destroy(AO * ao);
+void destroy(AO *ao);
 
-
-}}} // namespace precice, utils, petsc
+} // namespace petsc
+} // namespace utils
+} // namespace precice
 
 #endif // PRECICE_NO_PETSC
-
-
-
-

--- a/src/utils/PointerVector.hpp
+++ b/src/utils/PointerVector.hpp
@@ -9,109 +9,107 @@ namespace precice {
 namespace utils {
 
 /// Wrapper around std::vector for transparent handling of pointer objects.
-template< typename CONTENT_T >
-class ptr_vector
-{
+template <typename CONTENT_T>
+class ptr_vector {
 public:
+  /// Type of wrapped vector container.
+  typedef std::vector<CONTENT_T *> container;
+  typedef CONTENT_T                value_type; // necessary to be standard conform
 
-   /// Type of wrapped vector container.
-   typedef std::vector<CONTENT_T*> container;
-   typedef CONTENT_T value_type; // necessary to be standard conform
+  // The size_type of the wrapped vector
+  using size_type = typename container::size_type;
 
-   // The size_type of the wrapped vector
-   using size_type = typename container::size_type;
+  /// Type of iterator hiding pointers.
+  typedef boost::indirect_iterator<
+      typename container::iterator,
+      CONTENT_T *,
+      boost::use_default,
+      CONTENT_T &>
+      iterator;
 
-   /// Type of iterator hiding pointers.
-   typedef boost::indirect_iterator<
-              typename container::iterator,
-              CONTENT_T*,
-              boost::use_default,
-              CONTENT_T&
-           > iterator;
-
-   /// Type of const_iterator hiding pointers.
-   typedef boost::indirect_iterator<
-              typename container::const_iterator,
-              CONTENT_T *,
-              boost::use_default,
-              CONTENT_T &
-           > const_iterator;
+  /// Type of const_iterator hiding pointers.
+  typedef boost::indirect_iterator<
+      typename container::const_iterator,
+      CONTENT_T *,
+      boost::use_default,
+      CONTENT_T &>
+      const_iterator;
 
   /// Returns iterator to first element in vector.
-  iterator begin ()
-   {
-      return iterator(_content.begin());
-   }
+  iterator begin()
+  {
+    return iterator(_content.begin());
+  }
 
-   /**
+  /**
     * @brief Returns const interator to first element in vector.
     */
-   const_iterator begin () const
-   {
-      return const_iterator(_content.begin());
-   }
+  const_iterator begin() const
+  {
+    return const_iterator(_content.begin());
+  }
 
-   /**
+  /**
     * @brief Returns iterator behind last element in vector.
     */
-   iterator end ()
-   {
-      return iterator(_content.end());
-   }
+  iterator end()
+  {
+    return iterator(_content.end());
+  }
 
-   /**
+  /**
     * @brief Returns const_iterator behind last element in vector.
     */
-   const_iterator end () const
-   {
-      return const_iterator(_content.end());
-   }
+  const_iterator end() const
+  {
+    return const_iterator(_content.end());
+  }
 
-   /**
+  /**
     * @brief Returns count of elements in vector.
     */
-   size_t size () const
-   {
-      return _content.size ();
-   }
+  size_t size() const
+  {
+    return _content.size();
+  }
 
-   /**
+  /**
     * @brief Returns reference to element with given index [0, count[.
     */
-   CONTENT_T & operator[] ( size_t index )
-   {
-      PRECICE_ASSERT( index < _content.size() );
-      return *_content[index];
-   }
+  CONTENT_T &operator[](size_t index)
+  {
+    PRECICE_ASSERT(index < _content.size());
+    return *_content[index];
+  }
 
-   /**
+  /**
     * @brief Returns const reference to element with given index [0, count[.
     */
-   const CONTENT_T & operator[] ( size_t index ) const
-   {
-      PRECICE_ASSERT( index < _content.size() );
-      return *_content[index];
-   }
+  const CONTENT_T &operator[](size_t index) const
+  {
+    PRECICE_ASSERT(index < _content.size());
+    return *_content[index];
+  }
 
-   CONTENT_T& back()
-   {
-     return *_content.back();
-   }
+  CONTENT_T &back()
+  {
+    return *_content.back();
+  }
 
-   const CONTENT_T& back() const
-   {
-     return *_content.back();
-   }
+  const CONTENT_T &back() const
+  {
+    return *_content.back();
+  }
 
-   /**
+  /**
     * @brief Adds element to the end of the vector.
     */
-   void push_back ( CONTENT_T * content )
-   {
-      _content.push_back ( content );
-   }
+  void push_back(CONTENT_T *content)
+  {
+    _content.push_back(content);
+  }
 
-   /**
+  /**
     * @brief Inserts elements into vector.
     *
     * @param position [IN] Iterator at position before which the elements are
@@ -119,38 +117,38 @@ public:
     * @param from [IN] Iterator at position of first element to be inserted.
     * @param to [IN] Iterator at position behind last element to be inserted.
     */
-   void insert ( iterator position, iterator from, iterator to  )
-   {
-      _content.insert ( position.base(), from.base(), to.base() );
-   }
+  void insert(iterator position, iterator from, iterator to)
+  {
+    _content.insert(position.base(), from.base(), to.base());
+  }
 
-   /**
+  /**
     * @brief Removes all pointers to elements from the vector (no deletetion).
     */
-   void clear ()
-   {
-      _content.clear ();
-   }
+  void clear()
+  {
+    _content.clear();
+  }
 
-   /**
+  /**
     * @brief Returns true, if no pointers are contained in the vector.
     */
-   bool empty () const
-   {
-      return _content.empty ();
-   }
+  bool empty() const
+  {
+    return _content.empty();
+  }
 
-   void deleteElements ()
-   {
-      for ( CONTENT_T * elem : _content ) {
-         PRECICE_ASSERT( elem != NULL );
-         delete ( elem );
-      }
-   }
+  void deleteElements()
+  {
+    for (CONTENT_T *elem : _content) {
+      PRECICE_ASSERT(elem != NULL);
+      delete (elem);
+    }
+  }
 
 private:
-
-   container _content;
+  container _content;
 };
 
-}} // namespace precice, utils
+} // namespace utils
+} // namespace precice

--- a/src/utils/Statistics.hpp
+++ b/src/utils/Statistics.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <iosfwd>
 #include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics/stats.hpp>
-#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/count.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
-#include <boost/accumulators/statistics/count.hpp>
+#include <iosfwd>
 
 namespace precice {
 namespace utils {
@@ -45,7 +45,7 @@ public:
   /// Returns how many values have been accumulated
   std::size_t count() const
   {
-      return boost::accumulators::extract::count(_acc);
+    return boost::accumulators::extract::count(_acc);
   }
 
   /// Returns the sample variance based on all accumulated values
@@ -56,11 +56,11 @@ public:
 
 private:
   boost::accumulators::accumulator_set<double, boost::accumulators::stats<
-      boost::accumulators::tag::min,
-      boost::accumulators::tag::max,
-      boost::accumulators::tag::mean,
-      boost::accumulators::tag::lazy_variance
-          >> _acc;
+                                                   boost::accumulators::tag::min,
+                                                   boost::accumulators::tag::max,
+                                                   boost::accumulators::tag::mean,
+                                                   boost::accumulators::tag::lazy_variance>>
+      _acc;
 };
 
 inline std::ostream &operator<<(std::ostream &out, const DistanceAccumulator &accumulator)

--- a/src/utils/String.cpp
+++ b/src/utils/String.cpp
@@ -1,37 +1,36 @@
 #include "String.hpp"
-#include "utils/assertion.hpp"
-#include "boost/algorithm/string/split.hpp"
+#include <boost/algorithm/string/case_conv.hpp>
 #include "boost/algorithm/string/classification.hpp"
-#include  <boost/algorithm/string/case_conv.hpp>
+#include "boost/algorithm/string/split.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace utils {
 
-std::string wrapText (
-  const std::string& text,
-  int                linewidth,
-  int                indentation )
+std::string wrapText(
+    const std::string &text,
+    int                linewidth,
+    int                indentation)
 {
   std::vector<std::string> tokens;
   boost::algorithm::split(tokens, text, boost::algorithm::is_space());
-  PRECICE_ASSERT((int)tokens.size() > 0);
+  PRECICE_ASSERT((int) tokens.size() > 0);
   std::string wrapped;
-  int length = 0;
-  while (text[length] == ' '){
+  int         length = 0;
+  while (text[length] == ' ') {
     wrapped += ' ';
     length++;
   }
-  for (int i=0; i < (int)tokens.size()-1; i++){
-    length += (int)tokens[i].length();
+  for (int i = 0; i < (int) tokens.size() - 1; i++) {
+    length += (int) tokens[i].length();
     wrapped += tokens[i];
-    if (length + (int)tokens[i+1].length() + 1 > linewidth){
+    if (length + (int) tokens[i + 1].length() + 1 > linewidth) {
       wrapped += '\n';
-      for (int ws=0; ws < indentation; ws++){
+      for (int ws = 0; ws < indentation; ws++) {
         wrapped += ' ';
       }
       length = indentation;
-    }
-    else {
+    } else {
       wrapped += ' ';
       length += 1;
     }
@@ -40,27 +39,26 @@ std::string wrapText (
   return wrapped;
 }
 
-std::string& checkAppendExtension
-(
-  std::string&       filename,
-  const std::string& extension )
+std::string &checkAppendExtension(
+    std::string &      filename,
+    const std::string &extension)
 {
   size_t pos = filename.rfind(extension);
-  if ((pos == std::string::npos) || (pos != filename.size()-extension.size())){
+  if ((pos == std::string::npos) || (pos != filename.size() - extension.size())) {
     filename += extension;
   }
   return filename;
 }
 
-bool convertStringToBool(std::string const & value)
+bool convertStringToBool(std::string const &value)
 {
   std::string str = value;
   boost::algorithm::to_lower(str);
-  if ( str=="1" or str=="yes" or str=="true" or str=="on" )
+  if (str == "1" or str == "yes" or str == "true" or str == "on")
     return true;
-  
+
   return false;
 }
 
-
-}} // namespace precice, utils
+} // namespace utils
+} // namespace precice

--- a/src/utils/String.hpp
+++ b/src/utils/String.hpp
@@ -1,37 +1,36 @@
 #pragma once
 
-#include <string>
 #include <sstream>
+#include <string>
 
 namespace precice {
 namespace utils {
 
-std::string wrapText (
-  const std::string& text,
-  int                linewidth,
-  int                indentation );
+std::string wrapText(
+    const std::string &text,
+    int                linewidth,
+    int                indentation);
 
 /**
  * @brief Checks if filename has the given extension, if not appends it.
  *
  * @return filename with extension.
  */
-std::string & checkAppendExtension(std::string& filename, const std::string& extension);
+std::string &checkAppendExtension(std::string &filename, const std::string &extension);
 
 /// Evaluates a string to find out if it represents a bool.
 /**
  * Returns True if string is yes, true, 1 or on. Otherwise False.
  * This function is case-insensitive.
  */
-bool convertStringToBool(std::string const & value);
+bool convertStringToBool(std::string const &value);
 
 /// Turns stream-like code into a std::string.
-#define PRECICE_AS_STRING(message) [&]{ \
-        std::ostringstream oss;        \
-        oss << message;                \
-        return oss.str();              \
-    }()
+#define PRECICE_AS_STRING(message) [&] { \
+  std::ostringstream oss;                \
+  oss << message;                        \
+  return oss.str();                      \
+}()
 
-
-}} // namespace precice, utils
-
+} // namespace utils
+} // namespace precice

--- a/src/utils/TableWriter.cpp
+++ b/src/utils/TableWriter.cpp
@@ -1,59 +1,54 @@
 #include "TableWriter.hpp"
 
 #include <algorithm>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <numeric>
 #include <string>
 #include <vector>
 
+Column::Column(std::string const &name)
+    : name(name),
+      width(name.size())
+{
+}
 
-Column::Column(std::string const & name)
-  : name(name),
-    width(name.size())
-{}
-
-
-Column::Column(std::string const & name, int width) :
-  name(name),
-  width(std::max(width, static_cast<int>(name.size())))
+Column::Column(std::string const &name, int width)
+    : name(name),
+      width(std::max(width, static_cast<int>(name.size())))
 {
   precision = std::min(this->precision, this->width - 1);
 }
 
-
-Column::Column(std::string const & name, int width, int precision) :
-  name(name),
-  width(std::max(width, static_cast<int>(name.size())))
+Column::Column(std::string const &name, int width, int precision)
+    : name(name),
+      width(std::max(width, static_cast<int>(name.size())))
 {
   this->precision = std::min(precision, this->width - 1);
 }
 
-
 Table::Table()
-  :
-  out(std::cout)
-{}
+    : out(std::cout)
+{
+}
 
-
-Table::Table(std::ostream & out)
-  :
-  out(out)
-{}
-
+Table::Table(std::ostream &out)
+    : out(out)
+{
+}
 
 void Table::printHeader()
 {
   using namespace std;
 
-  for (auto & h : cols) {
+  for (auto &h : cols) {
     out << padding << setw(h.width) << h.name << padding << sepChar;
   }
 
   out << '\n';
-  int headerLength = std::accumulate(cols.begin(), cols.end(), 0, [this](int count, Column col){
+  int         headerLength = std::accumulate(cols.begin(), cols.end(), 0, [this](int count, Column col) {
     return count + col.width + sepChar.size() + 2;
-    });
+  });
   std::string sepLine(headerLength, '-');
   out << sepLine << '\n';
 }

--- a/src/utils/TableWriter.hpp
+++ b/src/utils/TableWriter.hpp
@@ -2,42 +2,38 @@
 
 #include <algorithm>
 #include <chrono>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <numeric>
 #include <string>
 #include <vector>
 
-struct Column
-{
+struct Column {
   std::string name;
-  int width;
-  int precision = 6;
+  int         width;
+  int         precision = 6;
 
-  explicit Column(std::string const & name);
+  explicit Column(std::string const &name);
 
-  Column(std::string const & name, int width);
+  Column(std::string const &name, int width);
 
-  Column(std::string const & name, int width, int precision);
+  Column(std::string const &name, int width, int precision);
 };
 
-
-class Table
-{
+class Table {
 public:
-
   std::vector<Column> cols;
-  std::string sepChar = "|";
-  char padding = ' ';
-  std::ostream & out = std::cout;
+  std::string         sepChar = "|";
+  char                padding = ' ';
+  std::ostream &      out     = std::cout;
 
   Table();
-  
-  Table(std::ostream & out);
+
+  Table(std::ostream &out);
 
   /// Adds a column of given name, width and float precision
-  template<class... T>
-  void addColumn(T&&... arg)
+  template <class... T>
+  void addColumn(T &&... arg)
   {
     cols.emplace_back(std::forward<T>(arg)...);
   }
@@ -46,38 +42,36 @@ public:
   void printHeader();
 
   /// Prints a line, accepting arbitrary arguments
-  template<class ... Ts>
+  template <class... Ts>
   void printRow(Ts... args)
   {
     printRow(static_cast<size_t>(0), args...);
   }
 
   /// Prints a ostream convertible type
-  template<class T, class ... Ts>
+  template <class T, class... Ts>
   void printRow(size_t index, T a, Ts... args)
   {
     out << padding << std::setw(cols[index].width) << std::setprecision(cols[index].precision)
-         << a << padding << sepChar;
-    printRow(index+1, args...);
+        << a << padding << sepChar;
+    printRow(index + 1, args...);
   }
 
   /// Prints a duration as milliseconds
-  template<class Rep, class Period, class ... Ts>
+  template <class Rep, class Period, class... Ts>
   void printRow(size_t index, std::chrono::duration<Rep, Period> duration, Ts... args)
   {
     double ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
     out << padding << std::setw(cols[index].width) << std::setprecision(cols[index].precision)
-         << ms << padding << sepChar;
-    printRow(index+1, args...);
+        << ms << padding << sepChar;
+    printRow(index + 1, args...);
   }
 
   /// Recursion anchor, prints the last entry and the endl
-  template<class T>
+  template <class T>
   void printRow(size_t index, T a)
   {
     out << padding << std::setw(cols[index].width) << std::setprecision(cols[index].precision)
-         << a << padding << sepChar << '\n';
+        << a << padding << sepChar << '\n';
   }
-
-
 };

--- a/src/utils/TypeNames.hpp
+++ b/src/utils/TypeNames.hpp
@@ -6,35 +6,36 @@
 
 #pragma once
 
-#include <string>
 #include <Eigen/Core>
+#include <string>
 
 namespace precice {
 namespace utils {
 
-inline std::string getTypeName(const double& var)
+inline std::string getTypeName(const double &var)
 {
   return "float";
 }
 
-inline std::string getTypeName(const std::string& var)
+inline std::string getTypeName(const std::string &var)
 {
   return "string";
 }
 
-inline std::string getTypeName(const bool& var)
+inline std::string getTypeName(const bool &var)
 {
   return "boolean";
 }
 
-inline std::string getTypeName(const int& var)
+inline std::string getTypeName(const int &var)
 {
   return "integer";
 }
 
-inline std::string getTypeName(Eigen::VectorXd const & var)
+inline std::string getTypeName(Eigen::VectorXd const &var)
 {
   return "vector";
 }
 
-}}
+} // namespace utils
+} // namespace precice

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -1,18 +1,19 @@
 #pragma once
 
-#include<algorithm>
-#include<array>
-#include<functional>
-#include<type_traits>
-#include<iterator>
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <iterator>
+#include <type_traits>
 
 namespace precice {
 namespace utils {
 
 /// Function that generates an array from given elements.
-template<typename... Elements>
-auto make_array(Elements&&... elements) -> std::array<typename std::common_type<Elements...>::type, sizeof...(Elements)> {
-    return { std::forward<Elements>(elements)... };
+template <typename... Elements>
+auto make_array(Elements &&... elements) -> std::array<typename std::common_type<Elements...>::type, sizeof...(Elements)>
+{
+  return {std::forward<Elements>(elements)...};
 }
 
 /** Checks weather the given elements contains no duplicates.
@@ -23,7 +24,7 @@ auto make_array(Elements&&... elements) -> std::array<typename std::common_type<
  * \returns weather all elements in c are unique.
  */
 template <typename Container, typename BinaryPredicate = std::equal_to<typename Container::value_type>>
-bool unique_elements(const Container& c, BinaryPredicate p = {})
+bool unique_elements(const Container &c, BinaryPredicate p = {})
 {
   // This algorithm runs on small containers, so the O(n^2) does not hurt.
   auto cbegin = c.begin();
@@ -35,15 +36,14 @@ bool unique_elements(const Container& c, BinaryPredicate p = {})
   auto cstart = cbegin + 1;
   for (; cstart < cend; ++cbegin, ++cstart) {
     if (std::find_if(cstart, cend,
-                [&p, cbegin](const typename Container::value_type &v) -> bool {
-                    return p(*cbegin, v); 
-                }) != cend) {
+                     [&p, cbegin](const typename Container::value_type &v) -> bool {
+                       return p(*cbegin, v);
+                     }) != cend) {
       return false;
     }
   }
   return true;
 }
-
 
 /** intersperse a the range [first, last[ with a given element.
  * 
@@ -52,87 +52,90 @@ bool unique_elements(const Container& c, BinaryPredicate p = {})
  * \tparam InputIter the type of the input iterators
  * \tparam ElemT the type of the element to intersperse
  */
-template<class InputIter, class ElemT>
-void intersperse(InputIter first, InputIter last, const ElemT& elem, std::ostream& out) {
-    if (first == last) return;
+template <class InputIter, class ElemT>
+void intersperse(InputIter first, InputIter last, const ElemT &elem, std::ostream &out)
+{
+  if (first == last)
+    return;
 
-    out << *first++;
-    for (;first != last; ++first) {
-        out << elem << *first;
-    }
+  out << *first++;
+  for (; first != last; ++first) {
+    out << elem << *first;
+  }
 }
-
 
 /** std::mismatch
  * @todo{Remove when migrating to c++14}
  */
-template<class InputIt1, class InputIt2>
+template <class InputIt1, class InputIt2>
 std::pair<InputIt1, InputIt2>
-    mismatch(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
+mismatch(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2)
 {
-    while (first1 != last1 && first2 != last2 && *first1 == *first2) {
-        ++first1, ++first2;
-    }
-    return std::make_pair(first1, first2);
+  while (first1 != last1 && first2 != last2 && *first1 == *first2) {
+    ++first1, ++first2;
+  }
+  return std::make_pair(first1, first2);
 }
 
-
 /// The RangePreview object used as a lazy proxy struct for proviewing the content of a Range
-template<typename InputIter>
+template <typename InputIter>
 struct RangePreview {
-    using Size = typename std::iterator_traits<InputIter>::difference_type;
-    Size n;
-    InputIter begin;
-    InputIter end;
+  using Size = typename std::iterator_traits<InputIter>::difference_type;
+  Size      n;
+  InputIter begin;
+  InputIter end;
 
-    RangePreview(Size n, InputIter begin, InputIter end) : n(n), begin(begin), end(end) {}
+  RangePreview(Size n, InputIter begin, InputIter end)
+      : n(n), begin(begin), end(end) {}
 
-    void print(std::ostream& out) const
-    {
-        if (begin == end) {
-            out << "<Empty Range>";
-            return;
-        }
-
-        out << '[';
-
-        if (n == 0) {
-            out << " ... ";
-        } else {
-            auto dist = std::distance(begin, end);
-            const std::string sep{", "};
-            if (dist <= n*2) {
-                intersperse(begin, end, sep, out);
-            } else {
-                auto last1 = begin;
-                std::advance(last1, n);
-                intersperse(begin, last1, sep, out);
-                out << sep << "... " << sep;
-                auto first2 = begin;
-                std::advance(first2, dist-n);
-                intersperse(first2, end, sep, out);
-            }
-        }
-
-        auto mm = std::minmax_element(begin, end);
-        out << "] min:" << *mm.first << " max:" << *mm.second;
+  void print(std::ostream &out) const
+  {
+    if (begin == end) {
+      out << "<Empty Range>";
+      return;
     }
+
+    out << '[';
+
+    if (n == 0) {
+      out << " ... ";
+    } else {
+      auto              dist = std::distance(begin, end);
+      const std::string sep{", "};
+      if (dist <= n * 2) {
+        intersperse(begin, end, sep, out);
+      } else {
+        auto last1 = begin;
+        std::advance(last1, n);
+        intersperse(begin, last1, sep, out);
+        out << sep << "... " << sep;
+        auto first2 = begin;
+        std::advance(first2, dist - n);
+        intersperse(first2, end, sep, out);
+      }
+    }
+
+    auto mm = std::minmax_element(begin, end);
+    out << "] min:" << *mm.first << " max:" << *mm.second;
+  }
 };
 
 /// Allows streaming of RangePreview objects
-template<typename Iter>
-std::ostream& operator<<(std::ostream& out, const RangePreview<Iter>& rp) {
-    rp.print(out);
-    return out;
+template <typename Iter>
+std::ostream &operator<<(std::ostream &out, const RangePreview<Iter> &rp)
+{
+  rp.print(out);
+  return out;
 }
 
 /** returns a display object which previews a range
  *
  * The preview contains the first and last n elements and the minmax-elements.
  */
-template<typename Range, typename Iter = typename Range::const_iterator, typename Size = typename std::iterator_traits<Iter>::difference_type>
-const RangePreview<Iter> previewRange(Size n, const Range& range) {
-    return {n, std::begin(range), std::end(range)};
+template <typename Range, typename Iter = typename Range::const_iterator, typename Size = typename std::iterator_traits<Iter>::difference_type>
+const RangePreview<Iter> previewRange(Size n, const Range &range)
+{
+  return {n, std::begin(range), std::end(range)};
 }
 
 } // namespace utils

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -3,37 +3,40 @@
 #include <cassert>
 #include <iostream>
 
-#include <boost/preprocessor/variadic/to_seq.hpp>
+#include <boost/current_function.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/stringize.hpp>
-#include <boost/current_function.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
 
-#include "stacktrace.hpp"
 #include "Parallel.hpp"
+#include "stacktrace.hpp"
 
 #ifdef NDEBUG
 
-#define PRECICE_ASSERT(...) {}
+#define PRECICE_ASSERT(...) \
+  {                         \
+  }
 
 #else
 
 /// Helper macro, used by assertion.
-#define PRECICE_PRINT_ARGUMENT(r, data, i, elem)                                \
+#define PRECICE_PRINT_ARGUMENT(r, data, i, elem) \
   std::cerr << "  Argument " << i << ": " << elem << '\n';
 
 /// Asserts that expr evaluates to true, prints all other arguments and calls assert(false).
-#define PRECICE_ASSERT(...) if (not (BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__))) { \
-    std::cerr << "ASSERTION FAILED\n"                                           \
-              << "  Location:          " << BOOST_CURRENT_FUNCTION << '\n'      \
-              << "  File:              " << __FILE__ << ":" << __LINE__ << '\n' \
-              << "  Rank:              " << precice::utils::Parallel::getProcessRank()  << '\n' \
-              << "  Failed expression: " << BOOST_PP_STRINGIZE(BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__)) \
-              <<  '\n';                                                         \
-    BOOST_PP_SEQ_FOR_EACH_I(PRECICE_PRINT_ARGUMENT,, BOOST_PP_SEQ_TAIL(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))); \
-    std::cerr << getStacktrace() << '\n';                                       \
-    std::cerr.flush();                                                          \
-    std::cout.flush();                                                          \
-    assert(false);                                                              \
+#define PRECICE_ASSERT(...)                                                                                      \
+  if (not(BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__))) {                                                             \
+    std::cerr << "ASSERTION FAILED\n"                                                                            \
+              << "  Location:          " << BOOST_CURRENT_FUNCTION << '\n'                                       \
+              << "  File:              " << __FILE__ << ":" << __LINE__ << '\n'                                  \
+              << "  Rank:              " << precice::utils::Parallel::getProcessRank() << '\n'                   \
+              << "  Failed expression: " << BOOST_PP_STRINGIZE(BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__))           \
+              << '\n';                                                                                           \
+    BOOST_PP_SEQ_FOR_EACH_I(PRECICE_PRINT_ARGUMENT, , BOOST_PP_SEQ_TAIL(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))); \
+    std::cerr << getStacktrace() << '\n';                                                                        \
+    std::cerr.flush();                                                                                           \
+    std::cout.flush();                                                                                           \
+    assert(false);                                                                                               \
   }
 
 #endif

--- a/src/utils/tests/AlgorithmTest.cpp
+++ b/src/utils/tests/AlgorithmTest.cpp
@@ -1,6 +1,6 @@
+#include <Eigen/Core>
 #include "testing/Testing.hpp"
 #include "utils/algorithm.hpp"
-#include <Eigen/Core>
 
 using namespace precice;
 namespace pu = precice::utils;
@@ -10,106 +10,106 @@ BOOST_AUTO_TEST_SUITE(AlgorithmTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(MakeArray)
 {
-    auto a = pu::make_array(1,2,3);
-    BOOST_TEST(a.size() == 3);
-    BOOST_TEST(a[0] == 1);
-    BOOST_TEST(a[1] == 2);
-    BOOST_TEST(a[2] == 3);
+  auto a = pu::make_array(1, 2, 3);
+  BOOST_TEST(a.size() == 3);
+  BOOST_TEST(a[0] == 1);
+  BOOST_TEST(a[1] == 2);
+  BOOST_TEST(a[2] == 3);
 }
 
 BOOST_AUTO_TEST_CASE(UniqueElements)
 {
-    std::vector<int> y{1,2,3,4,5,6,7,8,9};
-    BOOST_TEST(pu::unique_elements(y));
-    BOOST_TEST(pu::unique_elements(y, [](int l, int r){ return l == r; }));
+  std::vector<int> y{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  BOOST_TEST(pu::unique_elements(y));
+  BOOST_TEST(pu::unique_elements(y, [](int l, int r) { return l == r; }));
 
-    std::vector<int> n1{1,2,3,4,5,6,7,8,9,9};
-    BOOST_TEST(!pu::unique_elements(n1));
-    BOOST_TEST(!pu::unique_elements(n1, [](int l, int r){ return l == r; }));
+  std::vector<int> n1{1, 2, 3, 4, 5, 6, 7, 8, 9, 9};
+  BOOST_TEST(!pu::unique_elements(n1));
+  BOOST_TEST(!pu::unique_elements(n1, [](int l, int r) { return l == r; }));
 
-    std::vector<int> n2{1,1,3,4,5,6,7,8,9};
-    BOOST_TEST(!pu::unique_elements(n2));
-    BOOST_TEST(!pu::unique_elements(n2, [](int l, int r){ return l == r; }));
+  std::vector<int> n2{1, 1, 3, 4, 5, 6, 7, 8, 9};
+  BOOST_TEST(!pu::unique_elements(n2));
+  BOOST_TEST(!pu::unique_elements(n2, [](int l, int r) { return l == r; }));
 
-    std::vector<int> e;
-    BOOST_TEST(pu::unique_elements(e));
-    BOOST_TEST(pu::unique_elements(e, [](int l, int r){ return l == r; }));
+  std::vector<int> e;
+  BOOST_TEST(pu::unique_elements(e));
+  BOOST_TEST(pu::unique_elements(e, [](int l, int r) { return l == r; }));
 }
 
 BOOST_AUTO_TEST_CASE(UniqueEigenElements)
 {
-    Eigen::VectorXd v1(3);
-    v1 << 1.0, 0.1, 0.2;
-    Eigen::VectorXd v2(3);
-    v2 << 0.1, 1.0, 0.2;
-    Eigen::VectorXd v3(3);
-    v3 << 0.1, 0.2, 1.0;
+  Eigen::VectorXd v1(3);
+  v1 << 1.0, 0.1, 0.2;
+  Eigen::VectorXd v2(3);
+  v2 << 0.1, 1.0, 0.2;
+  Eigen::VectorXd v3(3);
+  v3 << 0.1, 0.2, 1.0;
 
-    std::vector<Eigen::VectorXd> case1{};
-    BOOST_TEST(pu::unique_elements(case1));
+  std::vector<Eigen::VectorXd> case1{};
+  BOOST_TEST(pu::unique_elements(case1));
 
-    std::vector<Eigen::VectorXd> case2{v1};
-    BOOST_TEST(pu::unique_elements(case2));
+  std::vector<Eigen::VectorXd> case2{v1};
+  BOOST_TEST(pu::unique_elements(case2));
 
-    std::vector<Eigen::VectorXd> case3{v1, v2};
-    BOOST_TEST(pu::unique_elements(case3));
+  std::vector<Eigen::VectorXd> case3{v1, v2};
+  BOOST_TEST(pu::unique_elements(case3));
 
-    std::vector<Eigen::VectorXd> case4{v1, v2, v1};
-    BOOST_TEST(!pu::unique_elements(case4));
+  std::vector<Eigen::VectorXd> case4{v1, v2, v1};
+  BOOST_TEST(!pu::unique_elements(case4));
 
-    std::vector<Eigen::VectorXd> case5{v1, v2, v3};
-    BOOST_TEST(pu::unique_elements(case5));
+  std::vector<Eigen::VectorXd> case5{v1, v2, v3};
+  BOOST_TEST(pu::unique_elements(case5));
 
-    std::vector<Eigen::VectorXd> case6{v1, v2, v3, v1};
-    BOOST_TEST(!pu::unique_elements(case6));
+  std::vector<Eigen::VectorXd> case6{v1, v2, v3, v1};
+  BOOST_TEST(!pu::unique_elements(case6));
 }
 
 BOOST_AUTO_TEST_CASE(Mismatch)
 {
-    std::vector<int> a{1,2,3,4,5,6,7,8,9};
-    std::vector<int> b{1,2,3,4,5,0,9};
+  std::vector<int> a{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<int> b{1, 2, 3, 4, 5, 0, 9};
 
-    auto aa = pu::mismatch(
-            a.begin(), a.end(),
-            a.begin(), a.end());
-    BOOST_TEST((aa.first == aa.second));
-    BOOST_TEST((aa.first == a.end()));
+  auto aa = pu::mismatch(
+      a.begin(), a.end(),
+      a.begin(), a.end());
+  BOOST_TEST((aa.first == aa.second));
+  BOOST_TEST((aa.first == a.end()));
 
-    auto ab = pu::mismatch(
-            a.begin(), a.end(),
-            b.begin(), b.end());
-    BOOST_TEST((ab.first != a.end()));
-    BOOST_TEST(*ab.first == 6);
-    BOOST_TEST(*ab.second == 0);
+  auto ab = pu::mismatch(
+      a.begin(), a.end(),
+      b.begin(), b.end());
+  BOOST_TEST((ab.first != a.end()));
+  BOOST_TEST(*ab.first == 6);
+  BOOST_TEST(*ab.second == 0);
 }
 
 BOOST_AUTO_TEST_SUITE(RangePreview)
 
 BOOST_AUTO_TEST_CASE(NormalRangePreview)
 {
-    std::vector<int> a{1, 2, 3, 4, 5, 6, 0};
-    std::ostringstream oss;
-    oss << pu::previewRange(2, a);
-    std::string str{oss.str()};
-    BOOST_TEST(str == "[1, 2, ... , 6, 0] min:0 max:6");
+  std::vector<int>   a{1, 2, 3, 4, 5, 6, 0};
+  std::ostringstream oss;
+  oss << pu::previewRange(2, a);
+  std::string str{oss.str()};
+  BOOST_TEST(str == "[1, 2, ... , 6, 0] min:0 max:6");
 }
 
 BOOST_AUTO_TEST_CASE(PrintNoElements)
 {
-    std::vector<int> a{1, 2, 3, 4, 5, 6, 0};
-    std::ostringstream oss;
-    oss << pu::previewRange(0, a);
-    std::string str{oss.str()};
-    BOOST_TEST(str == "[ ... ] min:0 max:6");
+  std::vector<int>   a{1, 2, 3, 4, 5, 6, 0};
+  std::ostringstream oss;
+  oss << pu::previewRange(0, a);
+  std::string str{oss.str()};
+  BOOST_TEST(str == "[ ... ] min:0 max:6");
 }
 
 BOOST_AUTO_TEST_CASE(EmptyRange)
 {
-    std::vector<int> a;
-    std::ostringstream oss;
-    oss << pu::previewRange(3, a);
-    std::string str{oss.str()};
-    BOOST_TEST(str == "<Empty Range>");
+  std::vector<int>   a;
+  std::ostringstream oss;
+  oss << pu::previewRange(3, a);
+  std::string str{oss.str()};
+  BOOST_TEST(str == "<Empty Range>");
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Range

--- a/src/utils/tests/EigenHelperFunctionsTest.cpp
+++ b/src/utils/tests/EigenHelperFunctionsTest.cpp
@@ -9,50 +9,49 @@ BOOST_AUTO_TEST_SUITE(EigenHelperFunctionsTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(FirstN)
 {
-    Eigen::VectorXd a(7);
-    a << 1, 2, 3, 4, 5, 6, 7;
-    Eigen::RowVectorXd b(3);
-    b << 1, 2, 3;
-    BOOST_TEST(firstN(a, 3) == b);
+  Eigen::VectorXd a(7);
+  a << 1, 2, 3, 4, 5, 6, 7;
+  Eigen::RowVectorXd b(3);
+  b << 1, 2, 3;
+  BOOST_TEST(firstN(a, 3) == b);
 }
 
 BOOST_AUTO_TEST_SUITE(RangePreview)
 
 BOOST_AUTO_TEST_CASE(EigenVector)
 {
-    Eigen::VectorXd a{7};
-    a << 1, 2, 3, 4, 5, 6, 0;
-    std::ostringstream oss;
-    oss << previewRange(2, a);
-    std::string str{oss.str()};
-    BOOST_TEST(str == "[1, 2, ... , 6, 0] min:0 max:6");
+  Eigen::VectorXd a{7};
+  a << 1, 2, 3, 4, 5, 6, 0;
+  std::ostringstream oss;
+  oss << previewRange(2, a);
+  std::string str{oss.str()};
+  BOOST_TEST(str == "[1, 2, ... , 6, 0] min:0 max:6");
 }
 
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_CASE(ComponentWiseLess)
 {
-    precice::utils::ComponentWiseLess cwl;
+  precice::utils::ComponentWiseLess cwl;
 
-    Eigen::VectorXd a(8);
-    a << 1, 2, 3, 4, 5, 6, 7, 9;
+  Eigen::VectorXd a(8);
+  a << 1, 2, 3, 4, 5, 6, 7, 9;
 
-    Eigen::VectorXd b(8);
-    b << 1, 2, 3, 4, 5, 6, 8, 0;
+  Eigen::VectorXd b(8);
+  b << 1, 2, 3, 4, 5, 6, 8, 0;
 
-    BOOST_TEST(componentWiseLess(a, b));
-    BOOST_TEST(!componentWiseLess(b, a));
-    BOOST_TEST(cwl(a, b));
-    BOOST_TEST(!cwl(b, a));
+  BOOST_TEST(componentWiseLess(a, b));
+  BOOST_TEST(!componentWiseLess(b, a));
+  BOOST_TEST(cwl(a, b));
+  BOOST_TEST(!cwl(b, a));
 
-    Eigen::VectorXd c = b;
+  Eigen::VectorXd c = b;
 
-    BOOST_TEST(componentWiseLess(c, b));
-    BOOST_TEST(componentWiseLess(b, c));
-    BOOST_TEST(cwl(c, b));
-    BOOST_TEST(cwl(b, c));
+  BOOST_TEST(componentWiseLess(c, b));
+  BOOST_TEST(componentWiseLess(b, c));
+  BOOST_TEST(cwl(c, b));
+  BOOST_TEST(cwl(b, c));
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/ManageUniqueIDsTest.cpp
+++ b/src/utils/tests/ManageUniqueIDsTest.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_SUITE(ManageUniqueIDsTests, *testing::OnMaster())
 BOOST_AUTO_TEST_CASE(UniqueIDs)
 {
   ManageUniqueIDs uniqueIDs;
-  int id = uniqueIDs.getFreeID();
+  int             id = uniqueIDs.getFreeID();
   BOOST_TEST(id == 0);
   id = uniqueIDs.getFreeID();
   BOOST_TEST(id == 1);

--- a/src/utils/tests/MultiLockTest.cpp
+++ b/src/utils/tests/MultiLockTest.cpp
@@ -10,40 +10,40 @@ BOOST_AUTO_TEST_SUITE(MultiLockTests, *testing::OnMaster())
 
 BOOST_AUTO_TEST_CASE(MultiLockTest)
 {
-    MultiLock<std::string> mlock; 
+  MultiLock<std::string> mlock;
 
-    BOOST_TEST( mlock.checkAll());
-    BOOST_TEST(!mlock.contains("A"));
-    BOOST_CHECK_THROW(mlock.check("A"), LockNotFoundException);
-    BOOST_CHECK_THROW(mlock.lock("A"), LockNotFoundException);
-    BOOST_CHECK_THROW(mlock.unlock("A"), LockNotFoundException);
+  BOOST_TEST(mlock.checkAll());
+  BOOST_TEST(!mlock.contains("A"));
+  BOOST_CHECK_THROW(mlock.check("A"), LockNotFoundException);
+  BOOST_CHECK_THROW(mlock.lock("A"), LockNotFoundException);
+  BOOST_CHECK_THROW(mlock.unlock("A"), LockNotFoundException);
 
-    mlock.add("A", true);
-    BOOST_TEST( mlock.contains("A"));
-    BOOST_TEST(!mlock.contains("B"));
-    BOOST_TEST( mlock.check("A"));
-    BOOST_TEST( mlock.checkAll());
+  mlock.add("A", true);
+  BOOST_TEST(mlock.contains("A"));
+  BOOST_TEST(!mlock.contains("B"));
+  BOOST_TEST(mlock.check("A"));
+  BOOST_TEST(mlock.checkAll());
 
-    mlock.add("B", false);
-    BOOST_TEST( mlock.check("A"));
-    BOOST_TEST( mlock.contains("B"));
-    BOOST_TEST(!mlock.check("B"));
-    BOOST_TEST(!mlock.checkAll());
+  mlock.add("B", false);
+  BOOST_TEST(mlock.check("A"));
+  BOOST_TEST(mlock.contains("B"));
+  BOOST_TEST(!mlock.check("B"));
+  BOOST_TEST(!mlock.checkAll());
 
-    mlock.lock("B");
-    BOOST_TEST(mlock.check("A"));
-    BOOST_TEST(mlock.check("B"));
-    BOOST_TEST(mlock.checkAll());
+  mlock.lock("B");
+  BOOST_TEST(mlock.check("A"));
+  BOOST_TEST(mlock.check("B"));
+  BOOST_TEST(mlock.checkAll());
 
-    mlock.unlockAll();
-    BOOST_TEST(!mlock.check("A"));
-    BOOST_TEST(!mlock.check("B"));
-    BOOST_TEST(!mlock.checkAll());
+  mlock.unlockAll();
+  BOOST_TEST(!mlock.check("A"));
+  BOOST_TEST(!mlock.check("B"));
+  BOOST_TEST(!mlock.checkAll());
 
-    mlock.lockAll();
-    BOOST_TEST(mlock.check("A"));
-    BOOST_TEST(mlock.check("B"));
-    BOOST_TEST(mlock.checkAll());
+  mlock.lockAll();
+  BOOST_TEST(mlock.check("A"));
+  BOOST_TEST(mlock.check("B"));
+  BOOST_TEST(mlock.checkAll());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/ParallelTest.cpp
+++ b/src/utils/tests/ParallelTest.cpp
@@ -10,12 +10,12 @@ BOOST_AUTO_TEST_SUITE(UtilsTests)
 
 BOOST_AUTO_TEST_CASE(Parallel, *testing::MinRanks{3})
 {
-  using Par = utils::Parallel;
+  using Par     = utils::Parallel;
   MPI_Comm comm = Par::getRestrictedCommunicator({0, 1, 2});
   if (Par::getProcessRank() <= 2) {
     Par::setGlobalCommunicator(comm);
     std::string group;
-    int rank = Par::getProcessRank();
+    int         rank = Par::getProcessRank();
     if ((rank == 0) || (rank == 1)) {
       group = "GroupOne";
     } else {

--- a/src/utils/tests/StatisticsTest.cpp
+++ b/src/utils/tests/StatisticsTest.cpp
@@ -1,6 +1,6 @@
+#include <Eigen/Core>
 #include "testing/Testing.hpp"
 #include "utils/Statistics.hpp"
-#include <Eigen/Core>
 
 using namespace precice;
 namespace pu = precice::utils;
@@ -9,18 +9,18 @@ BOOST_AUTO_TEST_SUITE(UtilsTests)
 
 BOOST_AUTO_TEST_CASE(DistanceAccumulator, *testing::OnMaster())
 {
-    pu::statistics::DistanceAccumulator acc;
-    acc(0);
-    BOOST_TEST(acc.min() == 0);
-    BOOST_TEST(acc.max() == 0);
+  pu::statistics::DistanceAccumulator acc;
+  acc(0);
+  BOOST_TEST(acc.min() == 0);
+  BOOST_TEST(acc.max() == 0);
 
-    acc(1);
-    acc(-1);
-    acc(23);
-    acc(11);
-    BOOST_TEST(acc.min() == -1);
-    BOOST_TEST(acc.min() != 0);
-    BOOST_TEST(acc.max() == 23);
+  acc(1);
+  acc(-1);
+  acc(23);
+  acc(11);
+  BOOST_TEST(acc.min() == -1);
+  BOOST_TEST(acc.min() != 0);
+  BOOST_TEST(acc.max() == 23);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/tests/StringTest.cpp
+++ b/src/utils/tests/StringTest.cpp
@@ -14,23 +14,23 @@ BOOST_AUTO_TEST_CASE(StringWrap)
   std::string wrapped = wrapText(text, 4, 0);
   BOOST_TEST(wrapped == std::string("123456\n1234567\n12345678"));
 
-  text = "1234 1234 1234";
+  text    = "1234 1234 1234";
   wrapped = wrapText(text, 5, 0);
   BOOST_TEST(wrapped == std::string("1234\n1234\n1234"));
 
-  text = "1234 123 5";
+  text    = "1234 123 5";
   wrapped = wrapText(text, 5, 0);
   BOOST_TEST(wrapped == std::string("1234\n123 5"));
 
-  text = "1234 1234 1234";
+  text    = "1234 1234 1234";
   wrapped = wrapText(text, 7, 2);
   BOOST_TEST(wrapped == std::string("1234\n  1234\n  1234"));
 
-  text = "1234 1234 1234";
+  text    = "1234 1234 1234";
   wrapped = wrapText(text, 5, 2);
   BOOST_TEST(wrapped == std::string("1234\n  1234\n  1234"));
 
-  text = "12345678 1234 1 1234";
+  text    = "12345678 1234 1 1234";
   wrapped = wrapText(text, 8, 2);
   BOOST_TEST(wrapped == std::string("12345678\n  1234 1\n  1234"));
 }
@@ -64,7 +64,6 @@ BOOST_AUTO_TEST_CASE(ConvertStringToBool)
   BOOST_TEST(convertStringToBool("yes") == true);
   BOOST_TEST(convertStringToBool("no") == false);
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -6,15 +6,12 @@
 #include "logging/Logger.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice
-{
-namespace xml
-{
+namespace precice {
+namespace xml {
 class XMLTag; // forward declaration to resolve circular import
 struct ConfigurationContext;
 
-class ConfigParser
-{
+class ConfigParser {
 public:
   /// Struct holding the read tag from xml file
   struct CTag {
@@ -23,12 +20,12 @@ public:
     bool        m_Used = false;
 
     using AttributePair = std::map<std::string, std::string>;
-    AttributePair m_aAttributes;
+    AttributePair                      m_aAttributes;
     std::vector<std::shared_ptr<CTag>> m_aSubTags;
   };
 
   using CTagPtrVec = std::vector<std::shared_ptr<CTag>>;
-  
+
 private:
   static precice::logging::Logger _log;
 
@@ -36,10 +33,10 @@ private:
   CTagPtrVec m_CurrentTags;
 
   std::shared_ptr<precice::xml::XMLTag> m_pXmlTag;
-   
+
 public:
   /// Parser ctor for Callback init
-  ConfigParser(const std::string &filePath, const ConfigurationContext& context, std::shared_ptr<XMLTag> pXmlTag);
+  ConfigParser(const std::string &filePath, const ConfigurationContext &context, std::shared_ptr<XMLTag> pXmlTag);
 
   /// Parser ctor without Callbacks
   ConfigParser(const std::string &filePath);
@@ -52,7 +49,7 @@ public:
    * @param DefTags predefined tags
    * @param SubTags actual tags from xml file
    */
-  void connectTags(const ConfigurationContext& context, std::vector<std::shared_ptr<precice::xml::XMLTag>> &DefTags, CTagPtrVec &SubTags);
+  void connectTags(const ConfigurationContext &context, std::vector<std::shared_ptr<precice::xml::XMLTag>> &DefTags, CTagPtrVec &SubTags);
 
   /// Callback for Start-Tag
   void OnStartElement(
@@ -64,10 +61,10 @@ public:
   void OnEndElement();
 
   /// Callback for text sections in xml file
-  void OnTextSection(const std::string& ch);
+  void OnTextSection(const std::string &ch);
 
   /// Proxy for error and warning messages from libxml2
-  static void MessageProxy(int level, const std::string& mess);
+  static void MessageProxy(int level, const std::string &mess);
 };
-}
-}
+} // namespace xml
+} // namespace precice

--- a/src/xml/Printer.cpp
+++ b/src/xml/Printer.cpp
@@ -1,6 +1,6 @@
+#include "xml/Printer.hpp"
 #include <iostream>
 #include <regex>
-#include "xml/Printer.hpp"
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
 
@@ -30,7 +30,7 @@ std::string toGHLink(const std::string &heading)
 
 /// Prints the DTD attribute spec for an XMLAttribute given its name.
 template <typename ATTRIBUTE_T>
-std::ostream& printDTD(std::ostream& out, const XMLAttribute<ATTRIBUTE_T> &attr, const std::string &ElementName)
+std::ostream &printDTD(std::ostream &out, const XMLAttribute<ATTRIBUTE_T> &attr, const std::string &ElementName)
 {
   out << "<!ATTLIST " << ElementName << " " << attr.getName() << " CDATA ";
 
@@ -46,7 +46,7 @@ std::ostream& printDTD(std::ostream& out, const XMLAttribute<ATTRIBUTE_T> &attr,
 
 /// Prints the attribute as a markdown table row.
 template <typename ATTRIBUTE_T>
-std::ostream& printMD(std::ostream& out, const XMLAttribute<ATTRIBUTE_T> &attr)
+std::ostream &printMD(std::ostream &out, const XMLAttribute<ATTRIBUTE_T> &attr)
 {
   out << "| " << attr.getName() << " | " << utils::getTypeName(attr.getDefaultValue()) << " | " << attr.getUserDocumentation() << " | ";
   if (attr.hasDefaultValue()) {
@@ -72,7 +72,7 @@ std::ostream& printMD(std::ostream& out, const XMLAttribute<ATTRIBUTE_T> &attr)
 
 /// Prints an example of a given XMLAttribute.
 template <typename ATTRIBUTE_T>
-std::ostream& printExample(std::ostream& out, const XMLAttribute<ATTRIBUTE_T> &attr)
+std::ostream &printExample(std::ostream &out, const XMLAttribute<ATTRIBUTE_T> &attr)
 {
   out << attr.getName() << "=\"";
   if (attr.hasDefaultValue()) {
@@ -86,7 +86,7 @@ std::ostream& printExample(std::ostream& out, const XMLAttribute<ATTRIBUTE_T> &a
 
 /// Prints the xml documentation of a given XMLAttribute
 template <typename ATTRIBUTE_T>
-std::ostream& printDocumentation(std::ostream& out, const XMLAttribute<ATTRIBUTE_T> &attr)
+std::ostream &printDocumentation(std::ostream &out, const XMLAttribute<ATTRIBUTE_T> &attr)
 {
   out << attr.getName() << "=\"{" << utils::getTypeName(attr.getDefaultValue());
   if (attr.hasValidation()) {
@@ -113,7 +113,7 @@ std::ostream& printDocumentation(std::ostream& out, const XMLAttribute<ATTRIBUTE
 /** Prints the dtd of a given XMLTag.
  * Also prints the doctype if start is true.
  */
-std::ostream& printDTD(std::ostream& out, const XMLTag &tag, bool start = false)
+std::ostream &printDTD(std::ostream &out, const XMLTag &tag, bool start = false)
 {
   if (start)
     out << "<!DOCTYPE " << tag.getFullName() << " [\n";
@@ -125,7 +125,7 @@ std::ostream& printDTD(std::ostream& out, const XMLTag &tag, bool start = false)
     out << "(";
 
     bool first = true;
-    for (auto const& subtag : tag.getSubtags()) {
+    for (auto const &subtag : tag.getSubtags()) {
 
       std::string occurrenceChar;
 
@@ -168,7 +168,7 @@ std::ostream& printDTD(std::ostream& out, const XMLTag &tag, bool start = false)
   }
 
   if (not tag.getSubtags().empty()) {
-    for (const auto& subtag : tag.getSubtags()) {
+    for (const auto &subtag : tag.getSubtags()) {
       printDTD(out, *subtag);
     }
   }
@@ -185,24 +185,29 @@ std::ostream& printDTD(std::ostream& out, const XMLTag &tag, bool start = false)
  * For the sake of readability, the example depth is trucated.
  * level is used to trucate and for indentation purposes.
  */
-std::ostream& printExample(std::ostream& out, const XMLTag &tag, int level)
+std::ostream &printExample(std::ostream &out, const XMLTag &tag, int level)
 {
-  std::string        prefix(level * 2, ' ');
+  std::string prefix(level * 2, ' ');
   out << prefix << '<' << tag.getFullName();
   for (const auto &pair : tag.getDoubleAttributes()) {
-    out << ' '; printExample(out, pair.second);
+    out << ' ';
+    printExample(out, pair.second);
   }
   for (const auto &pair : tag.getIntAttributes()) {
-    out << ' '; printExample(out, pair.second);
+    out << ' ';
+    printExample(out, pair.second);
   }
   for (const auto &pair : tag.getStringAttributes()) {
-    out << ' '; printExample(out, pair.second);
+    out << ' ';
+    printExample(out, pair.second);
   }
   for (const auto &pair : tag.getBooleanAttributes()) {
-    out << ' '; printExample(out, pair.second);
+    out << ' ';
+    printExample(out, pair.second);
   }
   for (const auto &pair : tag.getEigenVectorXdAttributes()) {
-    out << ' '; printExample(out, pair.second);
+    out << ' ';
+    printExample(out, pair.second);
   }
   if (tag.getSubtags().empty()) {
     out << "/>";
@@ -237,7 +242,7 @@ std::ostream& printExample(std::ostream& out, const XMLTag &tag, int level)
  * @param[in] level the level of nesting
  * @param[in] occurrences the occuences of tags, required to generate links
  */
-std::ostream& printMD(std::ostream& out, const XMLTag &tag, int level, std::map<std::string, int> &occurrences)
+std::ostream &printMD(std::ostream &out, const XMLTag &tag, int level, std::map<std::string, int> &occurrences)
 {
   out << std::string(level, '#') << ' ' << tag.getFullName() << "\n\n";
 
@@ -320,7 +325,7 @@ std::ostream& printMD(std::ostream& out, const XMLTag &tag, int level, std::map<
 /** Print the markdown reference for a given XMLTag.
  * @note Use this as an initial call
  */
-std::ostream& printMD(std::ostream& out, const XMLTag &tag, int level = 1)
+std::ostream &printMD(std::ostream &out, const XMLTag &tag, int level = 1)
 {
   std::map<std::string, int> occurrences;
   printMD(out, tag, level, occurrences);
@@ -328,7 +333,7 @@ std::ostream& printMD(std::ostream& out, const XMLTag &tag, int level = 1)
 }
 
 /// Print the xml documentation of an XMLTag at a given level of indentation.
-std::ostream& printDocumentation(std::ostream& out, const XMLTag &tag, int indentation)
+std::ostream &printDocumentation(std::ostream &out, const XMLTag &tag, int indentation)
 {
   const int   linewidth = 1000;
   std::string indent;
@@ -394,30 +399,35 @@ std::ostream& printDocumentation(std::ostream& out, const XMLTag &tag, int inden
   }
 
   for (const auto &pair : tag.getDoubleAttributes()) {
-    tagHead << indent << "   "; printDocumentation(tagHead, pair.second);
+    tagHead << indent << "   ";
+    printDocumentation(tagHead, pair.second);
   }
 
   for (const auto &pair : tag.getIntAttributes()) {
-    tagHead << indent << "   "; printDocumentation(tagHead, pair.second);
+    tagHead << indent << "   ";
+    printDocumentation(tagHead, pair.second);
   }
 
   for (const auto &pair : tag.getStringAttributes()) {
-    tagHead << indent << "   "; printDocumentation(tagHead, pair.second);
+    tagHead << indent << "   ";
+    printDocumentation(tagHead, pair.second);
   }
 
   for (const auto &pair : tag.getBooleanAttributes()) {
-    tagHead << indent << "   "; printDocumentation(tagHead, pair.second);
+    tagHead << indent << "   ";
+    printDocumentation(tagHead, pair.second);
   }
 
   for (const auto &pair : tag.getEigenVectorXdAttributes()) {
-    tagHead << indent << "   "; printDocumentation(tagHead, pair.second);
+    tagHead << indent << "   ";
+    printDocumentation(tagHead, pair.second);
   }
 
   out << utils::wrapText(tagHead.str(), linewidth, indentation + 3);
 
   if (not tag.getSubtags().empty()) {
     out << ">\n\n";
-    for (const auto& subtag : tag.getSubtags()) {
+    for (const auto &subtag : tag.getSubtags()) {
       printDocumentation(out, *subtag, indentation + 3);
     }
     out << indent << "</" << tag.getFullName() << ">\n\n";

--- a/src/xml/Printer.hpp
+++ b/src/xml/Printer.hpp
@@ -14,7 +14,7 @@ void toMarkdown(std::ostream &out, const XMLTag &tag);
 void toDTD(std::ostream &out, const XMLTag &tag);
 
 /// Prints the XML reference for the given tag.
-void toDocumentation(std::ostream & out, const XMLTag &tag);
+void toDocumentation(std::ostream &out, const XMLTag &tag);
 
 } // namespace xml
 } // namespace precice

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -1,62 +1,73 @@
 #pragma once
 
+#include <initializer_list>
 #include <iostream>
 #include <string>
-#include <vector>
 #include <type_traits>
-#include <initializer_list>
+#include <vector>
 
 #include "logging/Logger.hpp"
 #include "math/math.hpp"
+#include "utils/String.hpp"
 #include "utils/TypeNames.hpp"
 #include "utils/assertion.hpp"
-#include "utils/String.hpp"
 
-namespace precice
-{
-namespace xml
-{
+namespace precice {
+namespace xml {
 
 template <typename ATTRIBUTE_T>
-class XMLAttribute
-{
+class XMLAttribute {
 public:
   XMLAttribute() = delete;
 
-  explicit XMLAttribute(std::string name) : _name(std::move(name)) {};
+  explicit XMLAttribute(std::string name)
+      : _name(std::move(name)){};
 
-  XMLAttribute(std::string name, ATTRIBUTE_T defaultValue): _name(std::move(name)), _hasDefaultValue(true), _defaultValue(std::move(defaultValue)) {};
+  XMLAttribute(std::string name, ATTRIBUTE_T defaultValue)
+      : _name(std::move(name)), _hasDefaultValue(true), _defaultValue(std::move(defaultValue)){};
 
   XMLAttribute(const XMLAttribute<ATTRIBUTE_T> &other) = default;
 
-  XMLAttribute& operator=(const XMLAttribute<ATTRIBUTE_T> &other) = default;
+  XMLAttribute &operator=(const XMLAttribute<ATTRIBUTE_T> &other) = default;
 
   /// Sets a documentation string for the attribute.
-  XMLAttribute& setDocumentation(std::string documentation);
+  XMLAttribute &setDocumentation(std::string documentation);
 
   const std::string &getUserDocumentation() const
   {
     return _doc;
   }
 
-  XMLAttribute& setOptions(std::vector<ATTRIBUTE_T> options);
+  XMLAttribute &setOptions(std::vector<ATTRIBUTE_T> options);
 
-  template<class T>
-  XMLAttribute& setOptions(std::initializer_list<T>&& options)
+  template <class T>
+  XMLAttribute &setOptions(std::initializer_list<T> &&options)
   {
     static_assert(std::is_convertible<T, ATTRIBUTE_T>::value, "Type of initializer_list must be converible to ATTRIBUTE_T!");
     return setOptions(std::vector<ATTRIBUTE_T>(options.begin(), options.end()));
   }
 
-  const std::vector<ATTRIBUTE_T>& getOptions() const { return _options; };
+  const std::vector<ATTRIBUTE_T> &getOptions() const
+  {
+    return _options;
+  };
 
-  XMLAttribute& setDefaultValue(const ATTRIBUTE_T &defaultValue);
+  XMLAttribute &setDefaultValue(const ATTRIBUTE_T &defaultValue);
 
-  const ATTRIBUTE_T& getDefaultValue() const {return _defaultValue; };
+  const ATTRIBUTE_T &getDefaultValue() const
+  {
+    return _defaultValue;
+  };
 
-  bool hasDefaultValue() const { return _hasDefaultValue; };
+  bool hasDefaultValue() const
+  {
+    return _hasDefaultValue;
+  };
 
-  bool hasValidation() const { return _hasValidation; };
+  bool hasValidation() const
+  {
+    return _hasValidation;
+  };
 
   void readValue(std::map<std::string, std::string> &aAttributes);
 
@@ -125,23 +136,23 @@ private:
 };
 
 template <typename ATTRIBUTE_T>
-XMLAttribute<ATTRIBUTE_T>& XMLAttribute<ATTRIBUTE_T>::setDocumentation(std::string documentation)
+XMLAttribute<ATTRIBUTE_T> &XMLAttribute<ATTRIBUTE_T>::setDocumentation(std::string documentation)
 {
   _doc = std::move(documentation);
   return *this;
 }
 
 template <typename ATTRIBUTE_T>
-XMLAttribute<ATTRIBUTE_T>& XMLAttribute<ATTRIBUTE_T>::setOptions(std::vector<ATTRIBUTE_T> options)
+XMLAttribute<ATTRIBUTE_T> &XMLAttribute<ATTRIBUTE_T>::setOptions(std::vector<ATTRIBUTE_T> options)
 {
   const auto iter = std::unique(options.begin(), options.end());
-  _options     = std::vector<ATTRIBUTE_T>(options.begin(), iter);
-  _hasValidation = true;
+  _options        = std::vector<ATTRIBUTE_T>(options.begin(), iter);
+  _hasValidation  = true;
   return *this;
 }
 
 template <typename ATTRIBUTE_T>
-XMLAttribute<ATTRIBUTE_T>& XMLAttribute<ATTRIBUTE_T>::setDefaultValue(const ATTRIBUTE_T &defaultValue)
+XMLAttribute<ATTRIBUTE_T> &XMLAttribute<ATTRIBUTE_T>::setDefaultValue(const ATTRIBUTE_T &defaultValue)
 {
   PRECICE_TRACE(defaultValue);
   _hasDefaultValue = true;
@@ -176,8 +187,8 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(std::map<std::string, std::string> &aA
         stream << "value must be \"" << *first << '"';
         ++first;
         // print the remaining with separator
-        for(;first != _options.end();++first) {
-            stream << " or value must be \"" << *first << '"';
+        for (; first != _options.end(); ++first) {
+          stream << " or value must be \"" << *first << '"';
         }
 
         std::cout << stream.str() << '\n';
@@ -296,7 +307,6 @@ Eigen::VectorXd XMLAttribute<Eigen::VectorXd>::getAttributeValueAsEigenVectorXd(
   return vec;
 }*/
 
-
 template <typename ATTRIBUTE_T>
 template <typename VALUE_T>
 typename std::enable_if<
@@ -325,8 +335,9 @@ XMLAttribute<ATTRIBUTE_T>::set(
  *  @param[in] defaultValue the default value of the attribute
  *  @return an XMLAttribute with the above settings
  */
-inline XMLAttribute<std::string> makeXMLAttribute(std::string name, const char * defaultValue) {
-    return XMLAttribute<std::string>(std::move(name), defaultValue);
+inline XMLAttribute<std::string> makeXMLAttribute(std::string name, const char *defaultValue)
+{
+  return XMLAttribute<std::string>(std::move(name), defaultValue);
 }
 
 /** creates an XMLAttribute given a name and a default value.
@@ -335,10 +346,11 @@ inline XMLAttribute<std::string> makeXMLAttribute(std::string name, const char *
  *  @param[in] defaultValue the default value of the attribute
  *  @return an XMLAttribute with the above settings
  */
-template<typename T>
-XMLAttribute<T> makeXMLAttribute(std::string name, T defaultValue) {
-    return XMLAttribute<T>(std::move(name), std::move(defaultValue));
+template <typename T>
+XMLAttribute<T> makeXMLAttribute(std::string name, T defaultValue)
+{
+  return XMLAttribute<T>(std::move(name), std::move(defaultValue));
 }
 
-}
-} // namespace precice, xml
+} // namespace xml
+} // namespace precice

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -1,12 +1,10 @@
 #include "xml/XMLTag.hpp"
+#include <cctype>
 #include "utils/Helpers.hpp"
 #include "utils/String.hpp"
-#include <cctype>
 
-namespace precice
-{
-namespace xml
-{
+namespace precice {
+namespace xml {
 
 XMLTag::XMLTag(
     Listener &  listener,
@@ -25,19 +23,19 @@ XMLTag::XMLTag(
   }
 }
 
-XMLTag& XMLTag::setDocumentation(const std::string &documentation)
+XMLTag &XMLTag::setDocumentation(const std::string &documentation)
 {
   _doc = documentation;
   return *this;
 }
 
-XMLTag& XMLTag::addNamespace(const std::string &namespaceName)
+XMLTag &XMLTag::addNamespace(const std::string &namespaceName)
 {
   _namespaces.push_back(namespaceName);
   return *this;
 }
 
-XMLTag& XMLTag::addSubtag(const XMLTag &tag)
+XMLTag &XMLTag::addSubtag(const XMLTag &tag)
 {
   PRECICE_TRACE(tag._fullName);
   PRECICE_ASSERT(tag._name != std::string(""));
@@ -49,7 +47,7 @@ XMLTag& XMLTag::addSubtag(const XMLTag &tag)
   return *this;
 }
 
-XMLTag& XMLTag::addAttribute(const XMLAttribute<double> &attribute)
+XMLTag &XMLTag::addAttribute(const XMLAttribute<double> &attribute)
 {
   PRECICE_TRACE(attribute.getName());
   PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
@@ -58,7 +56,7 @@ XMLTag& XMLTag::addAttribute(const XMLAttribute<double> &attribute)
   return *this;
 }
 
-XMLTag& XMLTag::addAttribute(const XMLAttribute<int> &attribute)
+XMLTag &XMLTag::addAttribute(const XMLAttribute<int> &attribute)
 {
   PRECICE_TRACE(attribute.getName());
   PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
@@ -67,7 +65,7 @@ XMLTag& XMLTag::addAttribute(const XMLAttribute<int> &attribute)
   return *this;
 }
 
-XMLTag& XMLTag::addAttribute(const XMLAttribute<std::string> &attribute)
+XMLTag &XMLTag::addAttribute(const XMLAttribute<std::string> &attribute)
 {
   PRECICE_TRACE(attribute.getName());
   PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
@@ -76,7 +74,7 @@ XMLTag& XMLTag::addAttribute(const XMLAttribute<std::string> &attribute)
   return *this;
 }
 
-XMLTag& XMLTag::addAttribute(const XMLAttribute<bool> &attribute)
+XMLTag &XMLTag::addAttribute(const XMLAttribute<bool> &attribute)
 {
   PRECICE_TRACE(attribute.getName());
   PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
@@ -85,7 +83,7 @@ XMLTag& XMLTag::addAttribute(const XMLAttribute<bool> &attribute)
   return *this;
 }
 
-XMLTag& XMLTag::addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute)
+XMLTag &XMLTag::addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute)
 {
   PRECICE_TRACE(attribute.getName());
   PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
@@ -139,9 +137,9 @@ Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name, 
   auto iter = _eigenVectorXdAttributes.find(name);
   PRECICE_ASSERT(iter != _eigenVectorXdAttributes.end());
   PRECICE_CHECK(iter->second.getValue().size() >= dimensions,
-        "Vector attribute \"" << name << "\" of tag <" << getFullName()
-                              << "> has less dimensions than required (" << iter->second.getValue().size()
-                              << " instead of " << dimensions << ")!");
+                "Vector attribute \"" << name << "\" of tag <" << getFullName()
+                                      << "> has less dimensions than required (" << iter->second.getValue().size()
+                                      << " instead of " << dimensions << ")!");
 
   // Read only first "dimensions" components of the parsed vector values
   Eigen::VectorXd        result(dimensions);
@@ -346,9 +344,9 @@ XMLTag getRootTag()
 }
 
 void configure(
-    XMLTag &           tag,
-    const precice::xml::ConfigurationContext& context,
-    const std::string &configurationFilename)
+    XMLTag &                                  tag,
+    const precice::xml::ConfigurationContext &context,
+    const std::string &                       configurationFilename)
 {
   logging::Logger _log("xml");
   PRECICE_TRACE(tag.getFullName(), configurationFilename);
@@ -374,7 +372,8 @@ std::string XMLTag::getOccurrenceString(XMLTag::Occurrence occurrence)
   }
   return "";
 }
-}} // namespace precice, xml
+} // namespace xml
+} // namespace precice
 
 //std::ostream& operator<<
 //(

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -8,29 +8,24 @@
 #include "logging/Logger.hpp"
 #include "xml/ConfigParser.hpp"
 
-namespace precice
-{
-namespace xml
-{
+namespace precice {
+namespace xml {
 class ConfigParser;
 }
-}
+} // namespace precice
 
-namespace precice
-{
-namespace xml
-{
+namespace precice {
+namespace xml {
 
 /// Tightly coupled to the parameters of SolverInterface()
 struct ConfigurationContext {
-    std::string name;
-    int rank;
-    int size;
+  std::string name;
+  int         rank;
+  int         size;
 };
 
 /// Represents an XML tag to be configured automatically.
-class XMLTag
-{
+class XMLTag {
   friend class precice::xml::ConfigParser;
 
 public:
@@ -44,7 +39,7 @@ public:
   /// Callback interface for configuration classes using XMLTag.
   struct Listener {
 
-    Listener& operator=(Listener &&) = delete;
+    Listener &operator=(Listener &&) = delete;
 
     virtual ~Listener(){};
     /**
@@ -53,7 +48,7 @@ public:
      * At this callback, the attributes of the callingTag are already parsed and
      * available, while the subtags are not yet parsed.
      */
-    virtual void xmlTagCallback(ConfigurationContext const& context, XMLTag &callingTag) = 0;
+    virtual void xmlTagCallback(ConfigurationContext const &context, XMLTag &callingTag) = 0;
 
     /**
      * @brief Callback at end of XML tag and at end of subtag.
@@ -62,7 +57,7 @@ public:
      * This callback is first done for the listener, and then for the parent tag
      * listener (if existing).
      */
-    virtual void xmlEndTagCallback(ConfigurationContext const& context, XMLTag &callingTag) = 0;
+    virtual void xmlEndTagCallback(ConfigurationContext const &context, XMLTag &callingTag) = 0;
   };
 
   /// Types of occurrences of an XML tag.
@@ -95,9 +90,12 @@ public:
    *
    * The description and more information is printed with printDocumentation().
    */
-  XMLTag& setDocumentation(const std::string &documentation);
+  XMLTag &setDocumentation(const std::string &documentation);
 
-  std::string getDocumentation() const { return _doc; };
+  std::string getDocumentation() const
+  {
+    return _doc;
+  };
 
   /**
    * @brief Adds a namespace to the tag.
@@ -105,31 +103,33 @@ public:
    * Only used for outputting correct XML format, such that, e.g., internet
    * browsers display no errors when viewing an XML configuration.
    */
-  XMLTag& addNamespace(const std::string &namespaceName);
+  XMLTag &addNamespace(const std::string &namespaceName);
 
   /// Adds an XML tag as subtag by making a copy of the given tag.
-  XMLTag& addSubtag(const XMLTag &tag);
+  XMLTag &addSubtag(const XMLTag &tag);
 
-  const Subtags& getSubtags() const { return _subtags; };
-
+  const Subtags &getSubtags() const
+  {
+    return _subtags;
+  };
 
   /// Removes the XML subtag with given name
   //XMLTag& removeSubtag ( const std::string& tagName );
 
   /// Adds a XML attribute by making a copy of the given attribute.
-  XMLTag& addAttribute(const XMLAttribute<double> &attribute);
+  XMLTag &addAttribute(const XMLAttribute<double> &attribute);
 
   // Adds a XML attribute by making a copy of the given attribute.
-  XMLTag& addAttribute(const XMLAttribute<int> &attribute);
+  XMLTag &addAttribute(const XMLAttribute<int> &attribute);
 
   /// Adds a XML attribute by making a copy of the given attribute.
-  XMLTag& addAttribute(const XMLAttribute<std::string> &attribute);
+  XMLTag &addAttribute(const XMLAttribute<std::string> &attribute);
 
   /// Adds a XML attribute by making a copy of the given attribute.
-  XMLTag& addAttribute(const XMLAttribute<bool> &attribute);
+  XMLTag &addAttribute(const XMLAttribute<bool> &attribute);
 
   /// Adds a XML attribute by making a copy of the given attribute.
-  XMLTag& addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute);
+  XMLTag &addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute);
 
   bool hasAttribute(const std::string &attributeName);
 
@@ -149,7 +149,10 @@ public:
     return _namespace;
   }
 
-  const Namespaces& getNamespaces() const { return _namespaces; };
+  const Namespaces &getNamespaces() const
+  {
+    return _namespaces;
+  };
 
   /// Returns full name consisting of xml namespace + ":" + name.
   const std::string &getFullName() const
@@ -167,27 +170,27 @@ public:
 
   const AttributeMap<double> &getDoubleAttributes() const
   {
-      return _doubleAttributes;
+    return _doubleAttributes;
   };
 
   const AttributeMap<int> &getIntAttributes() const
   {
-      return _intAttributes;
+    return _intAttributes;
   };
 
   const AttributeMap<std::string> &getStringAttributes() const
   {
-      return _stringAttributes;
+    return _stringAttributes;
   };
 
   const AttributeMap<bool> &getBooleanAttributes() const
   {
-      return _booleanAttributes;
+    return _booleanAttributes;
   };
-  
+
   const AttributeMap<Eigen::VectorXd> &getEigenVectorXdAttributes() const
   {
-      return _eigenVectorXdAttributes;
+    return _eigenVectorXdAttributes;
   };
 
   /**
@@ -266,8 +269,8 @@ private:
 
 /// No operation listener for tests.
 struct NoPListener : public XMLTag::Listener {
-  void xmlTagCallback(ConfigurationContext const & context, XMLTag &callingTag) override {}
-  void xmlEndTagCallback(ConfigurationContext const & context, XMLTag &callingTag) override {}
+  void xmlTagCallback(ConfigurationContext const &context, XMLTag &callingTag) override {}
+  void xmlEndTagCallback(ConfigurationContext const &context, XMLTag &callingTag) override {}
 };
 
 /**
@@ -286,11 +289,12 @@ XMLTag getRootTag();
 
 /// Configures the given configuration from file configurationFilename.
 void configure(
-    XMLTag &           tag,
-    const precice::xml::ConfigurationContext& context,
-    const std::string &configurationFilename);
+    XMLTag &                                  tag,
+    const precice::xml::ConfigurationContext &context,
+    const std::string &                       configurationFilename);
 
-}} // namespace precice, xml
+} // namespace xml
+} // namespace precice
 
 /**
  * @brief Adds documentation of tag to output stream os.

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -17,7 +17,7 @@ struct CallbackHostAttr : public XMLTag::Listener {
   bool            boolValue;
   std::string     stringValue;
 
-  void xmlTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
+  void xmlTagCallback(const ConfigurationContext &context, XMLTag &callingTag) override
   {
     if (callingTag.getName() == "test-double") {
       doubleValue = callingTag.getDoubleAttributeValue("attribute");
@@ -40,7 +40,7 @@ struct CallbackHostAttr : public XMLTag::Listener {
     }
   }
 
-  void xmlEndTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
+  void xmlEndTagCallback(const ConfigurationContext &context, XMLTag &callingTag) override
   {
     std::ignore = callingTag;
   }
@@ -142,17 +142,18 @@ BOOST_AUTO_TEST_CASE(NamespaceTest)
   configure(rootTag, ConfigurationContext{}, filename);
 }
 
-struct ContextListener: public XMLTag::Listener {
+struct ContextListener : public XMLTag::Listener {
   ConfigurationContext startContext;
   ConfigurationContext endContext;
 
-  void xmlTagCallback(const ConfigurationContext& context, XMLTag &callingTag)
+  void xmlTagCallback(const ConfigurationContext &context, XMLTag &callingTag)
   {
-      startContext = context;
+    startContext = context;
   }
 
-  void xmlEndTagCallback(const ConfigurationContext& context, XMLTag &callingTag){
-      endContext = context;
+  void xmlEndTagCallback(const ConfigurationContext &context, XMLTag &callingTag)
+  {
+    endContext = context;
   }
 };
 
@@ -160,8 +161,8 @@ BOOST_AUTO_TEST_CASE(Context)
 {
   std::string filename(getPathToSources() + "/xml/tests/config_xmltest_context.xml");
 
-  ContextListener cl;
-  XMLTag          rootTag(cl, "configuration", XMLTag::OCCUR_ONCE);
+  ContextListener      cl;
+  XMLTag               rootTag(cl, "configuration", XMLTag::OCCUR_ONCE);
   ConfigurationContext context{"test", 12, 32};
   configure(rootTag, context, filename);
   BOOST_TEST(cl.startContext.name == "test");

--- a/src/xml/tests/PrinterTest.cpp
+++ b/src/xml/tests/PrinterTest.cpp
@@ -1,6 +1,6 @@
+#include "precice/config/Configuration.hpp"
 #include "testing/Testing.hpp"
 #include "xml/Printer.hpp"
-#include "precice/config/Configuration.hpp"
 
 #include <sstream>
 

--- a/src/xml/tests/XMLTest.cpp
+++ b/src/xml/tests/XMLTest.cpp
@@ -3,7 +3,6 @@
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
 
-
 using namespace precice;
 using namespace precice::xml;
 using precice::testing::getPathToSources;
@@ -13,14 +12,14 @@ BOOST_AUTO_TEST_SUITE(XML, *testing::OnMaster())
 struct CallbackHost : public XMLTag::Listener {
   Eigen::VectorXd eigenVectorXd;
 
-  void xmlTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
+  void xmlTagCallback(const ConfigurationContext &context, XMLTag &callingTag) override
   {
     if (callingTag.getName() == "test-eigen-vectorxd-attributes") {
       eigenVectorXd = callingTag.getEigenVectorXdAttributeValue("value", 3);
     }
   }
 
-  void xmlEndTagCallback(const ConfigurationContext& context, XMLTag &callingTag) override
+  void xmlEndTagCallback(const ConfigurationContext &context, XMLTag &callingTag) override
   {
     std::ignore = callingTag;
   }
@@ -61,6 +60,5 @@ BOOST_AUTO_TEST_CASE(VectorAttributes)
   BOOST_TEST(cb.eigenVectorXd(1) == 2.0);
   BOOST_TEST(cb.eigenVectorXd(2) == 1.0);
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/thirdparty/json/include/nlohmann/json.hpp
+++ b/thirdparty/json/include/nlohmann/json.hpp
@@ -34,35 +34,34 @@ SOFTWARE.
 #define NLOHMANN_JSON_VERSION_MINOR 5
 #define NLOHMANN_JSON_VERSION_PATCH 0
 
-#include <algorithm> // all_of, find, for_each
-#include <cassert> // assert
-#include <ciso646> // and, not, or
-#include <cstddef> // nullptr_t, ptrdiff_t, size_t
-#include <functional> // hash, less
+#include <algorithm>        // all_of, find, for_each
+#include <cassert>          // assert
+#include <ciso646>          // and, not, or
+#include <cstddef>          // nullptr_t, ptrdiff_t, size_t
+#include <functional>       // hash, less
 #include <initializer_list> // initializer_list
-#include <iosfwd> // istream, ostream
-#include <iterator> // random_access_iterator_tag
-#include <numeric> // accumulate
-#include <string> // string, stoi, to_string
-#include <utility> // declval, forward, move, pair, swap
+#include <iosfwd>           // istream, ostream
+#include <iterator>         // random_access_iterator_tag
+#include <numeric>          // accumulate
+#include <string>           // string, stoi, to_string
+#include <utility>          // declval, forward, move, pair, swap
 
 // #include <nlohmann/json_fwd.hpp>
 #ifndef NLOHMANN_JSON_FWD_HPP
 #define NLOHMANN_JSON_FWD_HPP
 
 #include <cstdint> // int64_t, uint64_t
-#include <map> // map
-#include <memory> // allocator
-#include <string> // string
-#include <vector> // vector
+#include <map>     // map
+#include <memory>  // allocator
+#include <string>  // string
+#include <vector>  // vector
 
 /*!
 @brief namespace for Niels Lohmann
 @see https://github.com/nlohmann
 @since version 1.0.0
 */
-namespace nlohmann
-{
+namespace nlohmann {
 /*!
 @brief default JSONSerializer template argument
 
@@ -70,19 +69,19 @@ This serializer ignores the template arguments and uses ADL
 ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
 for serialization.
 */
-template<typename T = void, typename SFINAE = void>
+template <typename T = void, typename SFINAE = void>
 struct adl_serializer;
 
-template<template<typename U, typename V, typename... Args> class ObjectType =
-         std::map,
-         template<typename U, typename... Args> class ArrayType = std::vector,
-         class StringType = std::string, class BooleanType = bool,
-         class NumberIntegerType = std::int64_t,
-         class NumberUnsignedType = std::uint64_t,
-         class NumberFloatType = double,
-         template<typename U> class AllocatorType = std::allocator,
-         template<typename T, typename SFINAE = void> class JSONSerializer =
-         adl_serializer>
+template <template <typename U, typename V, typename... Args> class ObjectType =
+              std::map,
+          template <typename U, typename... Args> class ArrayType = std::vector,
+          class StringType = std::string, class BooleanType = bool,
+          class NumberIntegerType                   = std::int64_t,
+          class NumberUnsignedType                  = std::uint64_t,
+          class NumberFloatType                     = double,
+          template <typename U> class AllocatorType = std::allocator,
+          template <typename T, typename SFINAE = void> class JSONSerializer =
+              adl_serializer>
 class basic_json;
 
 /*!
@@ -96,7 +95,7 @@ within a JSON document. It can be used with functions `at` and
 
 @since version 2.0.0
 */
-template<typename BasicJsonType>
+template <typename BasicJsonType>
 class json_pointer;
 
 /*!
@@ -108,98 +107,97 @@ uses the standard template types.
 @since version 1.0.0
 */
 using json = basic_json<>;
-}  // namespace nlohmann
+} // namespace nlohmann
 
 #endif
 
 // #include <nlohmann/detail/macro_scope.hpp>
-
 
 // This file contains all internal macro definitions
 // You MUST include macro_unscope.hpp at the end of json.hpp to undef all of them
 
 // exclude unsupported compilers
 #if !defined(JSON_SKIP_UNSUPPORTED_COMPILER_CHECK)
-    #if defined(__clang__)
-        #if (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) < 30400
-            #error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
-        #endif
-    #elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
-        #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40800
-            #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
-        #endif
-    #endif
+#if defined(__clang__)
+#if (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) < 30400
+#error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
+#endif
+#elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
+#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40800
+#error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
+#endif
+#endif
 #endif
 
 // disable float-equal warnings on GCC/clang
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 
 // disable documentation warnings on clang
 #if defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wdocumentation"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdocumentation"
 #endif
 
 // allow for portable deprecation warnings
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    #define JSON_DEPRECATED __attribute__((deprecated))
+#define JSON_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
-    #define JSON_DEPRECATED __declspec(deprecated)
+#define JSON_DEPRECATED __declspec(deprecated)
 #else
-    #define JSON_DEPRECATED
+#define JSON_DEPRECATED
 #endif
 
 // allow to disable exceptions
 #if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(JSON_NOEXCEPTION)
-    #define JSON_THROW(exception) throw exception
-    #define JSON_TRY try
-    #define JSON_CATCH(exception) catch(exception)
-    #define JSON_INTERNAL_CATCH(exception) catch(exception)
+#define JSON_THROW(exception) throw exception
+#define JSON_TRY try
+#define JSON_CATCH(exception) catch (exception)
+#define JSON_INTERNAL_CATCH(exception) catch (exception)
 #else
-    #define JSON_THROW(exception) std::abort()
-    #define JSON_TRY if(true)
-    #define JSON_CATCH(exception) if(false)
-    #define JSON_INTERNAL_CATCH(exception) if(false)
+#define JSON_THROW(exception) std::abort()
+#define JSON_TRY if (true)
+#define JSON_CATCH(exception) if (false)
+#define JSON_INTERNAL_CATCH(exception) if (false)
 #endif
 
 // override exception macros
 #if defined(JSON_THROW_USER)
-    #undef JSON_THROW
-    #define JSON_THROW JSON_THROW_USER
+#undef JSON_THROW
+#define JSON_THROW JSON_THROW_USER
 #endif
 #if defined(JSON_TRY_USER)
-    #undef JSON_TRY
-    #define JSON_TRY JSON_TRY_USER
+#undef JSON_TRY
+#define JSON_TRY JSON_TRY_USER
 #endif
 #if defined(JSON_CATCH_USER)
-    #undef JSON_CATCH
-    #define JSON_CATCH JSON_CATCH_USER
-    #undef JSON_INTERNAL_CATCH
-    #define JSON_INTERNAL_CATCH JSON_CATCH_USER
+#undef JSON_CATCH
+#define JSON_CATCH JSON_CATCH_USER
+#undef JSON_INTERNAL_CATCH
+#define JSON_INTERNAL_CATCH JSON_CATCH_USER
 #endif
 #if defined(JSON_INTERNAL_CATCH_USER)
-    #undef JSON_INTERNAL_CATCH
-    #define JSON_INTERNAL_CATCH JSON_INTERNAL_CATCH_USER
+#undef JSON_INTERNAL_CATCH
+#define JSON_INTERNAL_CATCH JSON_INTERNAL_CATCH_USER
 #endif
 
 // manual branch prediction
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    #define JSON_LIKELY(x)      __builtin_expect(!!(x), 1)
-    #define JSON_UNLIKELY(x)    __builtin_expect(!!(x), 0)
+#define JSON_LIKELY(x) __builtin_expect(!!(x), 1)
+#define JSON_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #else
-    #define JSON_LIKELY(x)      x
-    #define JSON_UNLIKELY(x)    x
+#define JSON_LIKELY(x) x
+#define JSON_UNLIKELY(x) x
 #endif
 
 // C++ language standard detection
 #if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
-    #define JSON_HAS_CPP_17
-    #define JSON_HAS_CPP_14
+#define JSON_HAS_CPP_17
+#define JSON_HAS_CPP_14
 #elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
-    #define JSON_HAS_CPP_14
+#define JSON_HAS_CPP_14
 #endif
 
 /*!
@@ -207,229 +205,215 @@ using json = basic_json<>;
 @def NLOHMANN_JSON_SERIALIZE_ENUM
 @since version 3.4.0
 */
-#define NLOHMANN_JSON_SERIALIZE_ENUM(ENUM_TYPE, ...)                                           \
-    template<typename BasicJsonType>                                                           \
-    inline void to_json(BasicJsonType& j, const ENUM_TYPE& e)                                  \
-    {                                                                                          \
-        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");         \
-        static const std::pair<ENUM_TYPE, BasicJsonType> m[] = __VA_ARGS__;                    \
-        auto it = std::find_if(std::begin(m), std::end(m),                                     \
-                               [e](const std::pair<ENUM_TYPE, BasicJsonType>& ej_pair) -> bool \
-        {                                                                                      \
-            return ej_pair.first == e;                                                         \
-        });                                                                                    \
-        j = ((it != std::end(m)) ? it : std::begin(m))->second;                                \
-    }                                                                                          \
-    template<typename BasicJsonType>                                                           \
-    inline void from_json(const BasicJsonType& j, ENUM_TYPE& e)                                \
-    {                                                                                          \
-        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");         \
-        static const std::pair<ENUM_TYPE, BasicJsonType> m[] = __VA_ARGS__;                    \
-        auto it = std::find_if(std::begin(m), std::end(m),                                     \
-                               [j](const std::pair<ENUM_TYPE, BasicJsonType>& ej_pair) -> bool \
-        {                                                                                      \
-            return ej_pair.second == j;                                                        \
-        });                                                                                    \
-        e = ((it != std::end(m)) ? it : std::begin(m))->first;                                 \
-    }
+#define NLOHMANN_JSON_SERIALIZE_ENUM(ENUM_TYPE, ...)                                                                                      \
+  template <typename BasicJsonType>                                                                                                       \
+  inline void to_json(BasicJsonType &j, const ENUM_TYPE &e)                                                                               \
+  {                                                                                                                                       \
+    static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");                                                        \
+    static const std::pair<ENUM_TYPE, BasicJsonType> m[] = __VA_ARGS__;                                                                   \
+    auto                                             it  = std::find_if(std::begin(m), std::end(m),                                       \
+                           [e](const std::pair<ENUM_TYPE, BasicJsonType> &ej_pair) -> bool { \
+                             return ej_pair.first == e;                                      \
+                           });                                                               \
+    j                                                    = ((it != std::end(m)) ? it : std::begin(m))->second;                            \
+  }                                                                                                                                       \
+  template <typename BasicJsonType>                                                                                                       \
+  inline void from_json(const BasicJsonType &j, ENUM_TYPE &e)                                                                             \
+  {                                                                                                                                       \
+    static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");                                                        \
+    static const std::pair<ENUM_TYPE, BasicJsonType> m[] = __VA_ARGS__;                                                                   \
+    auto                                             it  = std::find_if(std::begin(m), std::end(m),                                       \
+                           [j](const std::pair<ENUM_TYPE, BasicJsonType> &ej_pair) -> bool { \
+                             return ej_pair.second == j;                                     \
+                           });                                                               \
+    e                                                    = ((it != std::end(m)) ? it : std::begin(m))->first;                             \
+  }
 
 // Ugly macros to avoid uglier copy-paste when specializing basic_json. They
 // may be removed in the future once the class is split.
 
-#define NLOHMANN_BASIC_JSON_TPL_DECLARATION                                \
-    template<template<typename, typename, typename...> class ObjectType,   \
-             template<typename, typename...> class ArrayType,              \
-             class StringType, class BooleanType, class NumberIntegerType, \
-             class NumberUnsignedType, class NumberFloatType,              \
-             template<typename> class AllocatorType,                       \
-             template<typename, typename = void> class JSONSerializer>
+#define NLOHMANN_BASIC_JSON_TPL_DECLARATION                               \
+  template <template <typename, typename, typename...> class ObjectType,  \
+            template <typename, typename...> class ArrayType,             \
+            class StringType, class BooleanType, class NumberIntegerType, \
+            class NumberUnsignedType, class NumberFloatType,              \
+            template <typename> class AllocatorType,                      \
+            template <typename, typename = void> class JSONSerializer>
 
-#define NLOHMANN_BASIC_JSON_TPL                                            \
-    basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
-    NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
-    AllocatorType, JSONSerializer>
+#define NLOHMANN_BASIC_JSON_TPL                                      \
+  basic_json<ObjectType, ArrayType, StringType, BooleanType,         \
+             NumberIntegerType, NumberUnsignedType, NumberFloatType, \
+             AllocatorType, JSONSerializer>
 
 // #include <nlohmann/detail/meta/cpp_future.hpp>
 
-
-#include <ciso646> // not
-#include <cstddef> // size_t
+#include <ciso646>     // not
+#include <cstddef>     // size_t
 #include <type_traits> // conditional, enable_if, false_type, integral_constant, is_constructible, is_integral, is_same, remove_cv, remove_reference, true_type
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 // alias templates to reduce boilerplate
-template<bool B, typename T = void>
+template <bool B, typename T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;
 
-template<typename T>
+template <typename T>
 using uncvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
 
 // implementation of C++14 index_sequence and affiliates
 // source: https://stackoverflow.com/a/32223343
-template<std::size_t... Ints>
-struct index_sequence
-{
-    using type = index_sequence;
-    using value_type = std::size_t;
-    static constexpr std::size_t size() noexcept
-    {
-        return sizeof...(Ints);
-    }
+template <std::size_t... Ints>
+struct index_sequence {
+  using type       = index_sequence;
+  using value_type = std::size_t;
+  static constexpr std::size_t size() noexcept
+  {
+    return sizeof...(Ints);
+  }
 };
 
-template<class Sequence1, class Sequence2>
+template <class Sequence1, class Sequence2>
 struct merge_and_renumber;
 
-template<std::size_t... I1, std::size_t... I2>
+template <std::size_t... I1, std::size_t... I2>
 struct merge_and_renumber<index_sequence<I1...>, index_sequence<I2...>>
-        : index_sequence < I1..., (sizeof...(I1) + I2)... > {};
+    : index_sequence<I1..., (sizeof...(I1) + I2)...> {
+};
 
-template<std::size_t N>
+template <std::size_t N>
 struct make_index_sequence
-    : merge_and_renumber < typename make_index_sequence < N / 2 >::type,
-      typename make_index_sequence < N - N / 2 >::type > {};
+    : merge_and_renumber<typename make_index_sequence<N / 2>::type,
+                         typename make_index_sequence<N - N / 2>::type> {
+};
 
-template<> struct make_index_sequence<0> : index_sequence<> {};
-template<> struct make_index_sequence<1> : index_sequence<0> {};
+template <>
+struct make_index_sequence<0> : index_sequence<> {
+};
+template <>
+struct make_index_sequence<1> : index_sequence<0> {
+};
 
-template<typename... Ts>
+template <typename... Ts>
 using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
 
 // dispatch utility (taken from ranges-v3)
-template<unsigned N> struct priority_tag : priority_tag < N - 1 > {};
-template<> struct priority_tag<0> {};
-
-// taken from ranges-v3
-template<typename T>
-struct static_const
-{
-    static constexpr T value{};
+template <unsigned N>
+struct priority_tag : priority_tag<N - 1> {
+};
+template <>
+struct priority_tag<0> {
 };
 
-template<typename T>
+// taken from ranges-v3
+template <typename T>
+struct static_const {
+  static constexpr T value{};
+};
+
+template <typename T>
 constexpr T static_const<T>::value;
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/meta/type_traits.hpp>
 
-
-#include <ciso646> // not
-#include <limits> // numeric_limits
+#include <ciso646>     // not
+#include <limits>      // numeric_limits
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
-#include <utility> // declval
+#include <utility>     // declval
 
 // #include <nlohmann/json_fwd.hpp>
 
 // #include <nlohmann/detail/iterators/iterator_traits.hpp>
 
-
 #include <iterator> // random_access_iterator_tag
 
 // #include <nlohmann/detail/meta/void_t.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
-template <typename ...Ts> struct make_void
-{
-    using type = void;
+namespace nlohmann {
+namespace detail {
+template <typename... Ts>
+struct make_void {
+  using type = void;
 };
-template <typename ...Ts> using void_t = typename make_void<Ts...>::type;
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
 } // namespace detail
-}  // namespace nlohmann
+} // namespace nlohmann
 
 // #include <nlohmann/detail/meta/cpp_future.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 template <typename It, typename = void>
-struct iterator_types {};
+struct iterator_types {
+};
 
 template <typename It>
-struct iterator_types <
+struct iterator_types<
     It,
     void_t<typename It::difference_type, typename It::value_type, typename It::pointer,
-    typename It::reference, typename It::iterator_category >>
-{
-    using difference_type = typename It::difference_type;
-    using value_type = typename It::value_type;
-    using pointer = typename It::pointer;
-    using reference = typename It::reference;
-    using iterator_category = typename It::iterator_category;
+           typename It::reference, typename It::iterator_category>> {
+  using difference_type   = typename It::difference_type;
+  using value_type        = typename It::value_type;
+  using pointer           = typename It::pointer;
+  using reference         = typename It::reference;
+  using iterator_category = typename It::iterator_category;
 };
 
 // This is required as some compilers implement std::iterator_traits in a way that
 // doesn't work with SFINAE. See https://github.com/nlohmann/json/issues/1341.
 template <typename T, typename = void>
-struct iterator_traits
-{
+struct iterator_traits {
 };
 
 template <typename T>
-struct iterator_traits < T, enable_if_t < !std::is_pointer<T>::value >>
-            : iterator_types<T>
-{
+struct iterator_traits<T, enable_if_t<!std::is_pointer<T>::value>>
+    : iterator_types<T> {
 };
 
 template <typename T>
-struct iterator_traits<T*, enable_if_t<std::is_object<T>::value>>
-{
-    using iterator_category = std::random_access_iterator_tag;
-    using value_type = T;
-    using difference_type = ptrdiff_t;
-    using pointer = T*;
-    using reference = T&;
+struct iterator_traits<T *, enable_if_t<std::is_object<T>::value>> {
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type        = T;
+  using difference_type   = ptrdiff_t;
+  using pointer           = T *;
+  using reference         = T &;
 };
-}
-}
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/meta/cpp_future.hpp>
 
 // #include <nlohmann/detail/meta/detected.hpp>
 
-
 #include <type_traits>
 
 // #include <nlohmann/detail/meta/void_t.hpp>
 
-
 // http://en.cppreference.com/w/cpp/experimental/is_detected
-namespace nlohmann
-{
-namespace detail
-{
-struct nonesuch
-{
-    nonesuch() = delete;
-    ~nonesuch() = delete;
-    nonesuch(nonesuch const&) = delete;
-    void operator=(nonesuch const&) = delete;
+namespace nlohmann {
+namespace detail {
+struct nonesuch {
+  nonesuch()                 = delete;
+  ~nonesuch()                = delete;
+  nonesuch(nonesuch const &) = delete;
+  void operator=(nonesuch const &) = delete;
 };
 
 template <class Default,
           class AlwaysVoid,
           template <class...> class Op,
           class... Args>
-struct detector
-{
-    using value_t = std::false_type;
-    using type = Default;
+struct detector {
+  using value_t = std::false_type;
+  using type    = Default;
 };
 
 template <class Default, template <class...> class Op, class... Args>
-struct detector<Default, void_t<Op<Args...>>, Op, Args...>
-{
-    using value_t = std::true_type;
-    using type = Op<Args...>;
+struct detector<Default, void_t<Op<Args...>>, Op, Args...> {
+  using value_t = std::true_type;
+  using type    = Op<Args...>;
 };
 
 template <template <class...> class Op, class... Args>
@@ -450,14 +434,12 @@ using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
 template <class To, template <class...> class Op, class... Args>
 using is_detected_convertible =
     std::is_convertible<detected_t<Op, Args...>, To>;
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
-
-namespace nlohmann
-{
+namespace nlohmann {
 /*!
 @brief detail namespace with internal helper functions
 
@@ -466,8 +448,7 @@ implementations of some @ref basic_json methods, and meta-programming helpers.
 
 @since version 2.1.0
 */
-namespace detail
-{
+namespace detail {
 /////////////
 // helpers //
 /////////////
@@ -481,10 +462,13 @@ namespace detail
 // In this case, T has to be properly CV-qualified to constraint the function arguments
 // (e.g. to_json(BasicJsonType&, const T&))
 
-template<typename> struct is_basic_json : std::false_type {};
+template <typename>
+struct is_basic_json : std::false_type {
+};
 
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
-struct is_basic_json<NLOHMANN_BASIC_JSON_TPL> : std::true_type {};
+struct is_basic_json<NLOHMANN_BASIC_JSON_TPL> : std::true_type {
+};
 
 //////////////////////////
 // aliases for detected //
@@ -525,314 +509,316 @@ using get_template_function = decltype(std::declval<T>().template get<U>());
 
 // trait checking if JSONSerializer<T>::from_json(json const&, udt&) exists
 template <typename BasicJsonType, typename T, typename = void>
-struct has_from_json : std::false_type {};
+struct has_from_json : std::false_type {
+};
 
 template <typename BasicJsonType, typename T>
 struct has_from_json<BasicJsonType, T,
-           enable_if_t<not is_basic_json<T>::value>>
-{
-    using serializer = typename BasicJsonType::template json_serializer<T, void>;
+                     enable_if_t<not is_basic_json<T>::value>> {
+  using serializer = typename BasicJsonType::template json_serializer<T, void>;
 
-    static constexpr bool value =
-        is_detected_exact<void, from_json_function, serializer,
-        const BasicJsonType&, T&>::value;
+  static constexpr bool value =
+      is_detected_exact<void, from_json_function, serializer,
+                        const BasicJsonType &, T &>::value;
 };
 
 // This trait checks if JSONSerializer<T>::from_json(json const&) exists
 // this overload is used for non-default-constructible user-defined-types
 template <typename BasicJsonType, typename T, typename = void>
-struct has_non_default_from_json : std::false_type {};
+struct has_non_default_from_json : std::false_type {
+};
 
-template<typename BasicJsonType, typename T>
-struct has_non_default_from_json<BasicJsonType, T, enable_if_t<not is_basic_json<T>::value>>
-{
-    using serializer = typename BasicJsonType::template json_serializer<T, void>;
+template <typename BasicJsonType, typename T>
+struct has_non_default_from_json<BasicJsonType, T, enable_if_t<not is_basic_json<T>::value>> {
+  using serializer = typename BasicJsonType::template json_serializer<T, void>;
 
-    static constexpr bool value =
-        is_detected_exact<T, from_json_function, serializer,
-        const BasicJsonType&>::value;
+  static constexpr bool value =
+      is_detected_exact<T, from_json_function, serializer,
+                        const BasicJsonType &>::value;
 };
 
 // This trait checks if BasicJsonType::json_serializer<T>::to_json exists
 // Do not evaluate the trait when T is a basic_json type, to avoid template instantiation infinite recursion.
 template <typename BasicJsonType, typename T, typename = void>
-struct has_to_json : std::false_type {};
-
-template <typename BasicJsonType, typename T>
-struct has_to_json<BasicJsonType, T, enable_if_t<not is_basic_json<T>::value>>
-{
-    using serializer = typename BasicJsonType::template json_serializer<T, void>;
-
-    static constexpr bool value =
-        is_detected_exact<void, to_json_function, serializer, BasicJsonType&,
-        T>::value;
+struct has_to_json : std::false_type {
 };
 
+template <typename BasicJsonType, typename T>
+struct has_to_json<BasicJsonType, T, enable_if_t<not is_basic_json<T>::value>> {
+  using serializer = typename BasicJsonType::template json_serializer<T, void>;
+
+  static constexpr bool value =
+      is_detected_exact<void, to_json_function, serializer, BasicJsonType &,
+                        T>::value;
+};
 
 ///////////////////
 // is_ functions //
 ///////////////////
 
 template <typename T, typename = void>
-struct is_iterator_traits : std::false_type {};
+struct is_iterator_traits : std::false_type {
+};
 
 template <typename T>
-struct is_iterator_traits<iterator_traits<T>>
-{
-  private:
-    using traits = iterator_traits<T>;
+struct is_iterator_traits<iterator_traits<T>> {
+private:
+  using traits = iterator_traits<T>;
 
-  public:
-    static constexpr auto value =
-        is_detected<value_type_t, traits>::value &&
-        is_detected<difference_type_t, traits>::value &&
-        is_detected<pointer_t, traits>::value &&
-        is_detected<iterator_category_t, traits>::value &&
-        is_detected<reference_t, traits>::value;
+public:
+  static constexpr auto value =
+      is_detected<value_type_t, traits>::value &&
+      is_detected<difference_type_t, traits>::value &&
+      is_detected<pointer_t, traits>::value &&
+      is_detected<iterator_category_t, traits>::value &&
+      is_detected<reference_t, traits>::value;
 };
 
 // source: https://stackoverflow.com/a/37193089/4116453
 
 template <typename T, typename = void>
-struct is_complete_type : std::false_type {};
+struct is_complete_type : std::false_type {
+};
 
 template <typename T>
-struct is_complete_type<T, decltype(void(sizeof(T)))> : std::true_type {};
+struct is_complete_type<T, decltype(void(sizeof(T)))> : std::true_type {
+};
 
 template <typename BasicJsonType, typename CompatibleObjectType,
           typename = void>
-struct is_compatible_object_type_impl : std::false_type {};
+struct is_compatible_object_type_impl : std::false_type {
+};
 
 template <typename BasicJsonType, typename CompatibleObjectType>
-struct is_compatible_object_type_impl <
+struct is_compatible_object_type_impl<
     BasicJsonType, CompatibleObjectType,
     enable_if_t<is_detected<mapped_type_t, CompatibleObjectType>::value and
-    is_detected<key_type_t, CompatibleObjectType>::value >>
-{
+                is_detected<key_type_t, CompatibleObjectType>::value>> {
 
-    using object_t = typename BasicJsonType::object_t;
+  using object_t = typename BasicJsonType::object_t;
 
-    // macOS's is_constructible does not play well with nonesuch...
-    static constexpr bool value =
-        std::is_constructible<typename object_t::key_type,
-        typename CompatibleObjectType::key_type>::value and
-        std::is_constructible<typename object_t::mapped_type,
-        typename CompatibleObjectType::mapped_type>::value;
+  // macOS's is_constructible does not play well with nonesuch...
+  static constexpr bool value =
+      std::is_constructible<typename object_t::key_type,
+                            typename CompatibleObjectType::key_type>::value and
+      std::is_constructible<typename object_t::mapped_type,
+                            typename CompatibleObjectType::mapped_type>::value;
 };
 
 template <typename BasicJsonType, typename CompatibleObjectType>
 struct is_compatible_object_type
-    : is_compatible_object_type_impl<BasicJsonType, CompatibleObjectType> {};
+    : is_compatible_object_type_impl<BasicJsonType, CompatibleObjectType> {
+};
 
 template <typename BasicJsonType, typename ConstructibleObjectType,
           typename = void>
-struct is_constructible_object_type_impl : std::false_type {};
+struct is_constructible_object_type_impl : std::false_type {
+};
 
 template <typename BasicJsonType, typename ConstructibleObjectType>
-struct is_constructible_object_type_impl <
+struct is_constructible_object_type_impl<
     BasicJsonType, ConstructibleObjectType,
     enable_if_t<is_detected<mapped_type_t, ConstructibleObjectType>::value and
-    is_detected<key_type_t, ConstructibleObjectType>::value >>
-{
-    using object_t = typename BasicJsonType::object_t;
+                is_detected<key_type_t, ConstructibleObjectType>::value>> {
+  using object_t = typename BasicJsonType::object_t;
 
-    static constexpr bool value =
-        (std::is_constructible<typename ConstructibleObjectType::key_type, typename object_t::key_type>::value and
-         std::is_same<typename object_t::mapped_type, typename ConstructibleObjectType::mapped_type>::value) or
-        (has_from_json<BasicJsonType, typename ConstructibleObjectType::mapped_type>::value or
-         has_non_default_from_json<BasicJsonType, typename ConstructibleObjectType::mapped_type >::value);
+  static constexpr bool value =
+      (std::is_constructible<typename ConstructibleObjectType::key_type, typename object_t::key_type>::value and
+       std::is_same<typename object_t::mapped_type, typename ConstructibleObjectType::mapped_type>::value) or
+      (has_from_json<BasicJsonType, typename ConstructibleObjectType::mapped_type>::value or
+       has_non_default_from_json<BasicJsonType, typename ConstructibleObjectType::mapped_type>::value);
 };
 
 template <typename BasicJsonType, typename ConstructibleObjectType>
 struct is_constructible_object_type
     : is_constructible_object_type_impl<BasicJsonType,
-      ConstructibleObjectType> {};
+                                        ConstructibleObjectType> {
+};
 
 template <typename BasicJsonType, typename CompatibleStringType,
           typename = void>
-struct is_compatible_string_type_impl : std::false_type {};
+struct is_compatible_string_type_impl : std::false_type {
+};
 
 template <typename BasicJsonType, typename CompatibleStringType>
-struct is_compatible_string_type_impl <
+struct is_compatible_string_type_impl<
     BasicJsonType, CompatibleStringType,
     enable_if_t<is_detected_exact<typename BasicJsonType::string_t::value_type,
-    value_type_t, CompatibleStringType>::value >>
-{
-    static constexpr auto value =
-        std::is_constructible<typename BasicJsonType::string_t, CompatibleStringType>::value;
+                                  value_type_t, CompatibleStringType>::value>> {
+  static constexpr auto value =
+      std::is_constructible<typename BasicJsonType::string_t, CompatibleStringType>::value;
 };
 
 template <typename BasicJsonType, typename ConstructibleStringType>
 struct is_compatible_string_type
-    : is_compatible_string_type_impl<BasicJsonType, ConstructibleStringType> {};
+    : is_compatible_string_type_impl<BasicJsonType, ConstructibleStringType> {
+};
 
 template <typename BasicJsonType, typename ConstructibleStringType,
           typename = void>
-struct is_constructible_string_type_impl : std::false_type {};
+struct is_constructible_string_type_impl : std::false_type {
+};
 
 template <typename BasicJsonType, typename ConstructibleStringType>
-struct is_constructible_string_type_impl <
+struct is_constructible_string_type_impl<
     BasicJsonType, ConstructibleStringType,
     enable_if_t<is_detected_exact<typename BasicJsonType::string_t::value_type,
-    value_type_t, ConstructibleStringType>::value >>
-{
-    static constexpr auto value =
-        std::is_constructible<ConstructibleStringType,
-        typename BasicJsonType::string_t>::value;
+                                  value_type_t, ConstructibleStringType>::value>> {
+  static constexpr auto value =
+      std::is_constructible<ConstructibleStringType,
+                            typename BasicJsonType::string_t>::value;
 };
 
 template <typename BasicJsonType, typename ConstructibleStringType>
 struct is_constructible_string_type
-    : is_constructible_string_type_impl<BasicJsonType, ConstructibleStringType> {};
+    : is_constructible_string_type_impl<BasicJsonType, ConstructibleStringType> {
+};
 
 template <typename BasicJsonType, typename CompatibleArrayType, typename = void>
-struct is_compatible_array_type_impl : std::false_type {};
+struct is_compatible_array_type_impl : std::false_type {
+};
 
 template <typename BasicJsonType, typename CompatibleArrayType>
-struct is_compatible_array_type_impl <
+struct is_compatible_array_type_impl<
     BasicJsonType, CompatibleArrayType,
     enable_if_t<is_detected<value_type_t, CompatibleArrayType>::value and
-    is_detected<iterator_t, CompatibleArrayType>::value and
-// This is needed because json_reverse_iterator has a ::iterator type...
-// Therefore it is detected as a CompatibleArrayType.
-// The real fix would be to have an Iterable concept.
-    not is_iterator_traits<
-    iterator_traits<CompatibleArrayType>>::value >>
-{
-    static constexpr bool value =
-        std::is_constructible<BasicJsonType,
-        typename CompatibleArrayType::value_type>::value;
+                is_detected<iterator_t, CompatibleArrayType>::value and
+                // This is needed because json_reverse_iterator has a ::iterator type...
+                // Therefore it is detected as a CompatibleArrayType.
+                // The real fix would be to have an Iterable concept.
+                not is_iterator_traits<
+                    iterator_traits<CompatibleArrayType>>::value>> {
+  static constexpr bool value =
+      std::is_constructible<BasicJsonType,
+                            typename CompatibleArrayType::value_type>::value;
 };
 
 template <typename BasicJsonType, typename CompatibleArrayType>
 struct is_compatible_array_type
-    : is_compatible_array_type_impl<BasicJsonType, CompatibleArrayType> {};
+    : is_compatible_array_type_impl<BasicJsonType, CompatibleArrayType> {
+};
 
 template <typename BasicJsonType, typename ConstructibleArrayType, typename = void>
-struct is_constructible_array_type_impl : std::false_type {};
+struct is_constructible_array_type_impl : std::false_type {
+};
 
 template <typename BasicJsonType, typename ConstructibleArrayType>
-struct is_constructible_array_type_impl <
+struct is_constructible_array_type_impl<
     BasicJsonType, ConstructibleArrayType,
     enable_if_t<std::is_same<ConstructibleArrayType,
-    typename BasicJsonType::value_type>::value >>
-            : std::true_type {};
+                             typename BasicJsonType::value_type>::value>>
+    : std::true_type {
+};
 
 template <typename BasicJsonType, typename ConstructibleArrayType>
-struct is_constructible_array_type_impl <
+struct is_constructible_array_type_impl<
     BasicJsonType, ConstructibleArrayType,
     enable_if_t<not std::is_same<ConstructibleArrayType,
-    typename BasicJsonType::value_type>::value and
-    is_detected<value_type_t, ConstructibleArrayType>::value and
-    is_detected<iterator_t, ConstructibleArrayType>::value and
-    is_complete_type<
-    detected_t<value_type_t, ConstructibleArrayType>>::value >>
-{
-    static constexpr bool value =
-        // This is needed because json_reverse_iterator has a ::iterator type,
-        // furthermore, std::back_insert_iterator (and other iterators) have a base class `iterator`...
-        // Therefore it is detected as a ConstructibleArrayType.
-        // The real fix would be to have an Iterable concept.
-        not is_iterator_traits <
-        iterator_traits<ConstructibleArrayType >>::value and
+                                 typename BasicJsonType::value_type>::value and
+                is_detected<value_type_t, ConstructibleArrayType>::value and
+                is_detected<iterator_t, ConstructibleArrayType>::value and
+                is_complete_type<
+                    detected_t<value_type_t, ConstructibleArrayType>>::value>> {
+  static constexpr bool value =
+      // This is needed because json_reverse_iterator has a ::iterator type,
+      // furthermore, std::back_insert_iterator (and other iterators) have a base class `iterator`...
+      // Therefore it is detected as a ConstructibleArrayType.
+      // The real fix would be to have an Iterable concept.
+      not is_iterator_traits<
+          iterator_traits<ConstructibleArrayType>>::value and
 
-        (std::is_same<typename ConstructibleArrayType::value_type, typename BasicJsonType::array_t::value_type>::value or
-         has_from_json<BasicJsonType,
-         typename ConstructibleArrayType::value_type>::value or
-         has_non_default_from_json <
-         BasicJsonType, typename ConstructibleArrayType::value_type >::value);
+      (std::is_same<typename ConstructibleArrayType::value_type, typename BasicJsonType::array_t::value_type>::value or
+       has_from_json<BasicJsonType,
+                     typename ConstructibleArrayType::value_type>::value or
+       has_non_default_from_json<
+           BasicJsonType, typename ConstructibleArrayType::value_type>::value);
 };
 
 template <typename BasicJsonType, typename ConstructibleArrayType>
 struct is_constructible_array_type
-    : is_constructible_array_type_impl<BasicJsonType, ConstructibleArrayType> {};
+    : is_constructible_array_type_impl<BasicJsonType, ConstructibleArrayType> {
+};
 
 template <typename RealIntegerType, typename CompatibleNumberIntegerType,
           typename = void>
-struct is_compatible_integer_type_impl : std::false_type {};
+struct is_compatible_integer_type_impl : std::false_type {
+};
 
 template <typename RealIntegerType, typename CompatibleNumberIntegerType>
-struct is_compatible_integer_type_impl <
+struct is_compatible_integer_type_impl<
     RealIntegerType, CompatibleNumberIntegerType,
     enable_if_t<std::is_integral<RealIntegerType>::value and
-    std::is_integral<CompatibleNumberIntegerType>::value and
-    not std::is_same<bool, CompatibleNumberIntegerType>::value >>
-{
-    // is there an assert somewhere on overflows?
-    using RealLimits = std::numeric_limits<RealIntegerType>;
-    using CompatibleLimits = std::numeric_limits<CompatibleNumberIntegerType>;
+                std::is_integral<CompatibleNumberIntegerType>::value and
+                not std::is_same<bool, CompatibleNumberIntegerType>::value>> {
+  // is there an assert somewhere on overflows?
+  using RealLimits       = std::numeric_limits<RealIntegerType>;
+  using CompatibleLimits = std::numeric_limits<CompatibleNumberIntegerType>;
 
-    static constexpr auto value =
-        std::is_constructible<RealIntegerType,
-        CompatibleNumberIntegerType>::value and
-        CompatibleLimits::is_integer and
-        RealLimits::is_signed == CompatibleLimits::is_signed;
+  static constexpr auto value =
+      std::is_constructible<RealIntegerType,
+                            CompatibleNumberIntegerType>::value and
+      CompatibleLimits::is_integer and
+      RealLimits::is_signed == CompatibleLimits::is_signed;
 };
 
 template <typename RealIntegerType, typename CompatibleNumberIntegerType>
 struct is_compatible_integer_type
     : is_compatible_integer_type_impl<RealIntegerType,
-      CompatibleNumberIntegerType> {};
+                                      CompatibleNumberIntegerType> {
+};
 
 template <typename BasicJsonType, typename CompatibleType, typename = void>
-struct is_compatible_type_impl: std::false_type {};
+struct is_compatible_type_impl : std::false_type {
+};
 
 template <typename BasicJsonType, typename CompatibleType>
-struct is_compatible_type_impl <
+struct is_compatible_type_impl<
     BasicJsonType, CompatibleType,
-    enable_if_t<is_complete_type<CompatibleType>::value >>
-{
-    static constexpr bool value =
-        has_to_json<BasicJsonType, CompatibleType>::value;
+    enable_if_t<is_complete_type<CompatibleType>::value>> {
+  static constexpr bool value =
+      has_to_json<BasicJsonType, CompatibleType>::value;
 };
 
 template <typename BasicJsonType, typename CompatibleType>
 struct is_compatible_type
-    : is_compatible_type_impl<BasicJsonType, CompatibleType> {};
-}  // namespace detail
-}  // namespace nlohmann
+    : is_compatible_type_impl<BasicJsonType, CompatibleType> {
+};
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/exceptions.hpp>
 
-
 #include <exception> // exception
 #include <stdexcept> // runtime_error
-#include <string> // to_string
+#include <string>    // to_string
 
 // #include <nlohmann/detail/input/position_t.hpp>
 
-
 #include <cstddef> // size_t
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 /// struct to capture the start position of the current token
-struct position_t
-{
-    /// the total number of characters read
-    std::size_t chars_read_total = 0;
-    /// the number of characters read in the current line
-    std::size_t chars_read_current_line = 0;
-    /// the number of lines read
-    std::size_t lines_read = 0;
+struct position_t {
+  /// the total number of characters read
+  std::size_t chars_read_total = 0;
+  /// the number of characters read in the current line
+  std::size_t chars_read_current_line = 0;
+  /// the number of lines read
+  std::size_t lines_read = 0;
 
-    /// conversion to size_t to preserve SAX interface
-    constexpr operator size_t() const
-    {
-        return chars_read_total;
-    }
+  /// conversion to size_t to preserve SAX interface
+  constexpr operator size_t() const
+  {
+    return chars_read_total;
+  }
 };
 
-}
-}
+} // namespace detail
+} // namespace nlohmann
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 ////////////////
 // exceptions //
 ////////////////
@@ -865,29 +851,29 @@ caught.,exception}
 
 @since version 3.0.0
 */
-class exception : public std::exception
-{
-  public:
-    /// returns the explanatory string
-    const char* what() const noexcept override
-    {
-        return m.what();
-    }
+class exception : public std::exception {
+public:
+  /// returns the explanatory string
+  const char *what() const noexcept override
+  {
+    return m.what();
+  }
 
-    /// the id of the exception
-    const int id;
+  /// the id of the exception
+  const int id;
 
-  protected:
-    exception(int id_, const char* what_arg) : id(id_), m(what_arg) {}
+protected:
+  exception(int id_, const char *what_arg)
+      : id(id_), m(what_arg) {}
 
-    static std::string name(const std::string& ename, int id_)
-    {
-        return "[json.exception." + ename + "." + std::to_string(id_) + "] ";
-    }
+  static std::string name(const std::string &ename, int id_)
+  {
+    return "[json.exception." + ename + "." + std::to_string(id_) + "] ";
+  }
 
-  private:
-    /// an exception object as storage for error messages
-    std::runtime_error m;
+private:
+  /// an exception object as storage for error messages
+  std::runtime_error m;
 };
 
 /*!
@@ -934,10 +920,9 @@ caught.,parse_error}
 
 @since version 3.0.0
 */
-class parse_error : public exception
-{
-  public:
-    /*!
+class parse_error : public exception {
+public:
+  /*!
     @brief create a parse error exception
     @param[in] id_       the id of the exception
     @param[in] position  the position where the error occurred (or with
@@ -946,22 +931,22 @@ class parse_error : public exception
     @param[in] what_arg  the explanatory string
     @return parse_error object
     */
-    static parse_error create(int id_, const position_t& pos, const std::string& what_arg)
-    {
-        std::string w = exception::name("parse_error", id_) + "parse error" +
-                        position_string(pos) + ": " + what_arg;
-        return parse_error(id_, pos.chars_read_total, w.c_str());
-    }
+  static parse_error create(int id_, const position_t &pos, const std::string &what_arg)
+  {
+    std::string w = exception::name("parse_error", id_) + "parse error" +
+                    position_string(pos) + ": " + what_arg;
+    return parse_error(id_, pos.chars_read_total, w.c_str());
+  }
 
-    static parse_error create(int id_, std::size_t byte_, const std::string& what_arg)
-    {
-        std::string w = exception::name("parse_error", id_) + "parse error" +
-                        (byte_ != 0 ? (" at byte " + std::to_string(byte_)) : "") +
-                        ": " + what_arg;
-        return parse_error(id_, byte_, w.c_str());
-    }
+  static parse_error create(int id_, std::size_t byte_, const std::string &what_arg)
+  {
+    std::string w = exception::name("parse_error", id_) + "parse error" +
+                    (byte_ != 0 ? (" at byte " + std::to_string(byte_)) : "") +
+                    ": " + what_arg;
+    return parse_error(id_, byte_, w.c_str());
+  }
 
-    /*!
+  /*!
     @brief byte index of the parse error
 
     The byte index of the last read character in the input file.
@@ -970,17 +955,17 @@ class parse_error : public exception
           n+1 is the index of the terminating null byte or the end of file.
           This also holds true when reading a byte vector (CBOR or MessagePack).
     */
-    const std::size_t byte;
+  const std::size_t byte;
 
-  private:
-    parse_error(int id_, std::size_t byte_, const char* what_arg)
-        : exception(id_, what_arg), byte(byte_) {}
+private:
+  parse_error(int id_, std::size_t byte_, const char *what_arg)
+      : exception(id_, what_arg), byte(byte_) {}
 
-    static std::string position_string(const position_t& pos)
-    {
-        return " at line " + std::to_string(pos.lines_read + 1) +
-               ", column " + std::to_string(pos.chars_read_current_line);
-    }
+  static std::string position_string(const position_t &pos)
+  {
+    return " at line " + std::to_string(pos.lines_read + 1) +
+           ", column " + std::to_string(pos.chars_read_current_line);
+  }
 };
 
 /*!
@@ -1020,18 +1005,17 @@ caught.,invalid_iterator}
 
 @since version 3.0.0
 */
-class invalid_iterator : public exception
-{
-  public:
-    static invalid_iterator create(int id_, const std::string& what_arg)
-    {
-        std::string w = exception::name("invalid_iterator", id_) + what_arg;
-        return invalid_iterator(id_, w.c_str());
-    }
+class invalid_iterator : public exception {
+public:
+  static invalid_iterator create(int id_, const std::string &what_arg)
+  {
+    std::string w = exception::name("invalid_iterator", id_) + what_arg;
+    return invalid_iterator(id_, w.c_str());
+  }
 
-  private:
-    invalid_iterator(int id_, const char* what_arg)
-        : exception(id_, what_arg) {}
+private:
+  invalid_iterator(int id_, const char *what_arg)
+      : exception(id_, what_arg) {}
 };
 
 /*!
@@ -1073,17 +1057,17 @@ caught.,type_error}
 
 @since version 3.0.0
 */
-class type_error : public exception
-{
-  public:
-    static type_error create(int id_, const std::string& what_arg)
-    {
-        std::string w = exception::name("type_error", id_) + what_arg;
-        return type_error(id_, w.c_str());
-    }
+class type_error : public exception {
+public:
+  static type_error create(int id_, const std::string &what_arg)
+  {
+    std::string w = exception::name("type_error", id_) + what_arg;
+    return type_error(id_, w.c_str());
+  }
 
-  private:
-    type_error(int id_, const char* what_arg) : exception(id_, what_arg) {}
+private:
+  type_error(int id_, const char *what_arg)
+      : exception(id_, what_arg) {}
 };
 
 /*!
@@ -1119,17 +1103,17 @@ caught.,out_of_range}
 
 @since version 3.0.0
 */
-class out_of_range : public exception
-{
-  public:
-    static out_of_range create(int id_, const std::string& what_arg)
-    {
-        std::string w = exception::name("out_of_range", id_) + what_arg;
-        return out_of_range(id_, w.c_str());
-    }
+class out_of_range : public exception {
+public:
+  static out_of_range create(int id_, const std::string &what_arg)
+  {
+    std::string w = exception::name("out_of_range", id_) + what_arg;
+    return out_of_range(id_, w.c_str());
+  }
 
-  private:
-    out_of_range(int id_, const char* what_arg) : exception(id_, what_arg) {}
+private:
+  out_of_range(int id_, const char *what_arg)
+      : exception(id_, what_arg) {}
 };
 
 /*!
@@ -1156,33 +1140,30 @@ caught.,other_error}
 
 @since version 3.0.0
 */
-class other_error : public exception
-{
-  public:
-    static other_error create(int id_, const std::string& what_arg)
-    {
-        std::string w = exception::name("other_error", id_) + what_arg;
-        return other_error(id_, w.c_str());
-    }
+class other_error : public exception {
+public:
+  static other_error create(int id_, const std::string &what_arg)
+  {
+    std::string w = exception::name("other_error", id_) + what_arg;
+    return other_error(id_, w.c_str());
+  }
 
-  private:
-    other_error(int id_, const char* what_arg) : exception(id_, what_arg) {}
+private:
+  other_error(int id_, const char *what_arg)
+      : exception(id_, what_arg) {}
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/value_t.hpp>
 
-
-#include <array> // array
+#include <array>   // array
 #include <ciso646> // and
 #include <cstddef> // size_t
 #include <cstdint> // uint8_t
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 ///////////////////////////
 // JSON type enumeration //
 ///////////////////////////
@@ -1211,17 +1192,16 @@ value with the default value for a given type
 
 @since version 1.0.0
 */
-enum class value_t : std::uint8_t
-{
-    null,             ///< null value
-    object,           ///< object (unordered set of name/value pairs)
-    array,            ///< array (ordered collection of values)
-    string,           ///< string value
-    boolean,          ///< boolean value
-    number_integer,   ///< number value (signed integer)
-    number_unsigned,  ///< number value (unsigned integer)
-    number_float,     ///< number value (floating-point)
-    discarded         ///< discarded by the the parser callback function
+enum class value_t : std::uint8_t {
+  null,            ///< null value
+  object,          ///< object (unordered set of name/value pairs)
+  array,           ///< array (ordered collection of values)
+  string,          ///< string value
+  boolean,         ///< boolean value
+  number_integer,  ///< number value (signed integer)
+  number_unsigned, ///< number value (unsigned integer)
+  number_float,    ///< number value (floating-point)
+  discarded        ///< discarded by the the parser callback function
 };
 
 /*!
@@ -1236,34 +1216,32 @@ Returns an ordering that is similar to Python:
 */
 inline bool operator<(const value_t lhs, const value_t rhs) noexcept
 {
-    static constexpr std::array<std::uint8_t, 8> order = {{
-            0 /* null */, 3 /* object */, 4 /* array */, 5 /* string */,
-            1 /* boolean */, 2 /* integer */, 2 /* unsigned */, 2 /* float */
-        }
-    };
+  static constexpr std::array<std::uint8_t, 8> order = {{
+      0 /* null */, 3 /* object */, 4 /* array */, 5 /* string */,
+      1 /* boolean */, 2 /* integer */, 2 /* unsigned */, 2 /* float */
+  }};
 
-    const auto l_index = static_cast<std::size_t>(lhs);
-    const auto r_index = static_cast<std::size_t>(rhs);
-    return l_index < order.size() and r_index < order.size() and order[l_index] < order[r_index];
+  const auto l_index = static_cast<std::size_t>(lhs);
+  const auto r_index = static_cast<std::size_t>(rhs);
+  return l_index < order.size() and r_index < order.size() and order[l_index] < order[r_index];
 }
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/conversions/from_json.hpp>
 
-
-#include <algorithm> // transform
-#include <array> // array
-#include <ciso646> // and, not
-#include <forward_list> // forward_list
-#include <iterator> // inserter, front_inserter, end
-#include <map> // map
-#include <string> // string
-#include <tuple> // tuple, make_tuple
-#include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
+#include <algorithm>     // transform
+#include <array>         // array
+#include <ciso646>       // and, not
+#include <forward_list>  // forward_list
+#include <iterator>      // inserter, front_inserter, end
+#include <map>           // map
+#include <string>        // string
+#include <tuple>         // tuple, make_tuple
+#include <type_traits>   // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
 #include <unordered_map> // unordered_map
-#include <utility> // pair, declval
-#include <valarray> // valarray
+#include <utility>       // pair, declval
+#include <valarray>      // valarray
 
 // #include <nlohmann/detail/exceptions.hpp>
 
@@ -1275,367 +1253,333 @@ inline bool operator<(const value_t lhs, const value_t rhs) noexcept
 
 // #include <nlohmann/detail/value_t.hpp>
 
-
-namespace nlohmann
+namespace nlohmann {
+namespace detail {
+template <typename BasicJsonType>
+void from_json(const BasicJsonType &j, typename std::nullptr_t &n)
 {
-namespace detail
-{
-template<typename BasicJsonType>
-void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
-{
-    if (JSON_UNLIKELY(not j.is_null()))
-    {
-        JSON_THROW(type_error::create(302, "type must be null, but is " + std::string(j.type_name())));
-    }
-    n = nullptr;
+  if (JSON_UNLIKELY(not j.is_null())) {
+    JSON_THROW(type_error::create(302, "type must be null, but is " + std::string(j.type_name())));
+  }
+  n = nullptr;
 }
 
 // overloads for basic_json template parameters
-template<typename BasicJsonType, typename ArithmeticType,
-         enable_if_t<std::is_arithmetic<ArithmeticType>::value and
-                     not std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
-                     int> = 0>
-void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
+template <typename BasicJsonType, typename ArithmeticType,
+          enable_if_t<std::is_arithmetic<ArithmeticType>::value and
+                          not std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
+                      int> = 0>
+void get_arithmetic_value(const BasicJsonType &j, ArithmeticType &val)
 {
-    switch (static_cast<value_t>(j))
-    {
-        case value_t::number_unsigned:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
-            break;
-        }
-        case value_t::number_integer:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
-            break;
-        }
-        case value_t::number_float:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
-            break;
-        }
+  switch (static_cast<value_t>(j)) {
+  case value_t::number_unsigned: {
+    val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t *>());
+    break;
+  }
+  case value_t::number_integer: {
+    val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t *>());
+    break;
+  }
+  case value_t::number_float: {
+    val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t *>());
+    break;
+  }
 
-        default:
-            JSON_THROW(type_error::create(302, "type must be number, but is " + std::string(j.type_name())));
-    }
+  default:
+    JSON_THROW(type_error::create(302, "type must be number, but is " + std::string(j.type_name())));
+  }
 }
 
-template<typename BasicJsonType>
-void from_json(const BasicJsonType& j, typename BasicJsonType::boolean_t& b)
+template <typename BasicJsonType>
+void from_json(const BasicJsonType &j, typename BasicJsonType::boolean_t &b)
 {
-    if (JSON_UNLIKELY(not j.is_boolean()))
-    {
-        JSON_THROW(type_error::create(302, "type must be boolean, but is " + std::string(j.type_name())));
-    }
-    b = *j.template get_ptr<const typename BasicJsonType::boolean_t*>();
+  if (JSON_UNLIKELY(not j.is_boolean())) {
+    JSON_THROW(type_error::create(302, "type must be boolean, but is " + std::string(j.type_name())));
+  }
+  b = *j.template get_ptr<const typename BasicJsonType::boolean_t *>();
 }
 
-template<typename BasicJsonType>
-void from_json(const BasicJsonType& j, typename BasicJsonType::string_t& s)
+template <typename BasicJsonType>
+void from_json(const BasicJsonType &j, typename BasicJsonType::string_t &s)
 {
-    if (JSON_UNLIKELY(not j.is_string()))
-    {
-        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name())));
-    }
-    s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+  if (JSON_UNLIKELY(not j.is_string())) {
+    JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name())));
+  }
+  s = *j.template get_ptr<const typename BasicJsonType::string_t *>();
 }
 
 template <
     typename BasicJsonType, typename ConstructibleStringType,
-    enable_if_t <
+    enable_if_t<
         is_constructible_string_type<BasicJsonType, ConstructibleStringType>::value and
-        not std::is_same<typename BasicJsonType::string_t,
-                         ConstructibleStringType>::value,
-        int > = 0 >
-void from_json(const BasicJsonType& j, ConstructibleStringType& s)
+            not std::is_same<typename BasicJsonType::string_t,
+                             ConstructibleStringType>::value,
+        int> = 0>
+void from_json(const BasicJsonType &j, ConstructibleStringType &s)
 {
-    if (JSON_UNLIKELY(not j.is_string()))
-    {
-        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name())));
-    }
+  if (JSON_UNLIKELY(not j.is_string())) {
+    JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name())));
+  }
 
-    s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+  s = *j.template get_ptr<const typename BasicJsonType::string_t *>();
 }
 
-template<typename BasicJsonType>
-void from_json(const BasicJsonType& j, typename BasicJsonType::number_float_t& val)
+template <typename BasicJsonType>
+void from_json(const BasicJsonType &j, typename BasicJsonType::number_float_t &val)
 {
-    get_arithmetic_value(j, val);
+  get_arithmetic_value(j, val);
 }
 
-template<typename BasicJsonType>
-void from_json(const BasicJsonType& j, typename BasicJsonType::number_unsigned_t& val)
+template <typename BasicJsonType>
+void from_json(const BasicJsonType &j, typename BasicJsonType::number_unsigned_t &val)
 {
-    get_arithmetic_value(j, val);
+  get_arithmetic_value(j, val);
 }
 
-template<typename BasicJsonType>
-void from_json(const BasicJsonType& j, typename BasicJsonType::number_integer_t& val)
+template <typename BasicJsonType>
+void from_json(const BasicJsonType &j, typename BasicJsonType::number_integer_t &val)
 {
-    get_arithmetic_value(j, val);
+  get_arithmetic_value(j, val);
 }
 
-template<typename BasicJsonType, typename EnumType,
-         enable_if_t<std::is_enum<EnumType>::value, int> = 0>
-void from_json(const BasicJsonType& j, EnumType& e)
+template <typename BasicJsonType, typename EnumType,
+          enable_if_t<std::is_enum<EnumType>::value, int> = 0>
+void from_json(const BasicJsonType &j, EnumType &e)
 {
-    typename std::underlying_type<EnumType>::type val;
-    get_arithmetic_value(j, val);
-    e = static_cast<EnumType>(val);
+  typename std::underlying_type<EnumType>::type val;
+  get_arithmetic_value(j, val);
+  e = static_cast<EnumType>(val);
 }
 
 // forward_list doesn't have an insert method
-template<typename BasicJsonType, typename T, typename Allocator,
-         enable_if_t<std::is_convertible<BasicJsonType, T>::value, int> = 0>
-void from_json(const BasicJsonType& j, std::forward_list<T, Allocator>& l)
+template <typename BasicJsonType, typename T, typename Allocator,
+          enable_if_t<std::is_convertible<BasicJsonType, T>::value, int> = 0>
+void from_json(const BasicJsonType &j, std::forward_list<T, Allocator> &l)
 {
-    if (JSON_UNLIKELY(not j.is_array()))
-    {
-        JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
-    }
-    std::transform(j.rbegin(), j.rend(),
-                   std::front_inserter(l), [](const BasicJsonType & i)
-    {
-        return i.template get<T>();
-    });
+  if (JSON_UNLIKELY(not j.is_array())) {
+    JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
+  }
+  std::transform(j.rbegin(), j.rend(),
+                 std::front_inserter(l), [](const BasicJsonType &i) {
+                   return i.template get<T>();
+                 });
 }
 
 // valarray doesn't have an insert method
-template<typename BasicJsonType, typename T,
-         enable_if_t<std::is_convertible<BasicJsonType, T>::value, int> = 0>
-void from_json(const BasicJsonType& j, std::valarray<T>& l)
+template <typename BasicJsonType, typename T,
+          enable_if_t<std::is_convertible<BasicJsonType, T>::value, int> = 0>
+void from_json(const BasicJsonType &j, std::valarray<T> &l)
 {
-    if (JSON_UNLIKELY(not j.is_array()))
-    {
-        JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
-    }
-    l.resize(j.size());
-    std::copy(j.m_value.array->begin(), j.m_value.array->end(), std::begin(l));
+  if (JSON_UNLIKELY(not j.is_array())) {
+    JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
+  }
+  l.resize(j.size());
+  std::copy(j.m_value.array->begin(), j.m_value.array->end(), std::begin(l));
 }
 
-template<typename BasicJsonType>
-void from_json_array_impl(const BasicJsonType& j, typename BasicJsonType::array_t& arr, priority_tag<3> /*unused*/)
+template <typename BasicJsonType>
+void from_json_array_impl(const BasicJsonType &j, typename BasicJsonType::array_t &arr, priority_tag<3> /*unused*/)
 {
-    arr = *j.template get_ptr<const typename BasicJsonType::array_t*>();
+  arr = *j.template get_ptr<const typename BasicJsonType::array_t *>();
 }
 
 template <typename BasicJsonType, typename T, std::size_t N>
-auto from_json_array_impl(const BasicJsonType& j, std::array<T, N>& arr,
+auto from_json_array_impl(const BasicJsonType &j, std::array<T, N> &arr,
                           priority_tag<2> /*unused*/)
--> decltype(j.template get<T>(), void())
+    -> decltype(j.template get<T>(), void())
 {
-    for (std::size_t i = 0; i < N; ++i)
-    {
-        arr[i] = j.at(i).template get<T>();
-    }
-}
-
-template<typename BasicJsonType, typename ConstructibleArrayType>
-auto from_json_array_impl(const BasicJsonType& j, ConstructibleArrayType& arr, priority_tag<1> /*unused*/)
--> decltype(
-    arr.reserve(std::declval<typename ConstructibleArrayType::size_type>()),
-    j.template get<typename ConstructibleArrayType::value_type>(),
-    void())
-{
-    using std::end;
-
-    arr.reserve(j.size());
-    std::transform(j.begin(), j.end(),
-                   std::inserter(arr, end(arr)), [](const BasicJsonType & i)
-    {
-        // get<BasicJsonType>() returns *this, this won't call a from_json
-        // method when value_type is BasicJsonType
-        return i.template get<typename ConstructibleArrayType::value_type>();
-    });
+  for (std::size_t i = 0; i < N; ++i) {
+    arr[i] = j.at(i).template get<T>();
+  }
 }
 
 template <typename BasicJsonType, typename ConstructibleArrayType>
-void from_json_array_impl(const BasicJsonType& j, ConstructibleArrayType& arr,
+auto from_json_array_impl(const BasicJsonType &j, ConstructibleArrayType &arr, priority_tag<1> /*unused*/)
+    -> decltype(
+        arr.reserve(std::declval<typename ConstructibleArrayType::size_type>()),
+        j.template get<typename ConstructibleArrayType::value_type>(),
+        void())
+{
+  using std::end;
+
+  arr.reserve(j.size());
+  std::transform(j.begin(), j.end(),
+                 std::inserter(arr, end(arr)), [](const BasicJsonType &i) {
+                   // get<BasicJsonType>() returns *this, this won't call a from_json
+                   // method when value_type is BasicJsonType
+                   return i.template get<typename ConstructibleArrayType::value_type>();
+                 });
+}
+
+template <typename BasicJsonType, typename ConstructibleArrayType>
+void from_json_array_impl(const BasicJsonType &j, ConstructibleArrayType &arr,
                           priority_tag<0> /*unused*/)
 {
-    using std::end;
+  using std::end;
 
-    std::transform(
-        j.begin(), j.end(), std::inserter(arr, end(arr)),
-        [](const BasicJsonType & i)
-    {
+  std::transform(
+      j.begin(), j.end(), std::inserter(arr, end(arr)),
+      [](const BasicJsonType &i) {
         // get<BasicJsonType>() returns *this, this won't call a from_json
         // method when value_type is BasicJsonType
         return i.template get<typename ConstructibleArrayType::value_type>();
-    });
+      });
 }
 
 template <typename BasicJsonType, typename ConstructibleArrayType,
-          enable_if_t <
+          enable_if_t<
               is_constructible_array_type<BasicJsonType, ConstructibleArrayType>::value and
-              not is_constructible_object_type<BasicJsonType, ConstructibleArrayType>::value and
-              not is_constructible_string_type<BasicJsonType, ConstructibleArrayType>::value and
-              not is_basic_json<ConstructibleArrayType>::value,
-              int > = 0 >
+                  not is_constructible_object_type<BasicJsonType, ConstructibleArrayType>::value and
+                  not is_constructible_string_type<BasicJsonType, ConstructibleArrayType>::value and
+                  not is_basic_json<ConstructibleArrayType>::value,
+              int> = 0>
 
-auto from_json(const BasicJsonType& j, ConstructibleArrayType& arr)
--> decltype(from_json_array_impl(j, arr, priority_tag<3> {}),
-j.template get<typename ConstructibleArrayType::value_type>(),
-void())
+auto from_json(const BasicJsonType &j, ConstructibleArrayType &arr)
+    -> decltype(from_json_array_impl(j, arr, priority_tag<3>{}),
+                j.template get<typename ConstructibleArrayType::value_type>(),
+                void())
 {
-    if (JSON_UNLIKELY(not j.is_array()))
-    {
-        JSON_THROW(type_error::create(302, "type must be array, but is " +
-                                      std::string(j.type_name())));
-    }
+  if (JSON_UNLIKELY(not j.is_array())) {
+    JSON_THROW(type_error::create(302, "type must be array, but is " +
+                                           std::string(j.type_name())));
+  }
 
-    from_json_array_impl(j, arr, priority_tag<3> {});
+  from_json_array_impl(j, arr, priority_tag<3>{});
 }
 
-template<typename BasicJsonType, typename ConstructibleObjectType,
-         enable_if_t<is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value, int> = 0>
-void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
+template <typename BasicJsonType, typename ConstructibleObjectType,
+          enable_if_t<is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value, int> = 0>
+void from_json(const BasicJsonType &j, ConstructibleObjectType &obj)
 {
-    if (JSON_UNLIKELY(not j.is_object()))
-    {
-        JSON_THROW(type_error::create(302, "type must be object, but is " + std::string(j.type_name())));
-    }
+  if (JSON_UNLIKELY(not j.is_object())) {
+    JSON_THROW(type_error::create(302, "type must be object, but is " + std::string(j.type_name())));
+  }
 
-    auto inner_object = j.template get_ptr<const typename BasicJsonType::object_t*>();
-    using value_type = typename ConstructibleObjectType::value_type;
-    std::transform(
-        inner_object->begin(), inner_object->end(),
-        std::inserter(obj, obj.begin()),
-        [](typename BasicJsonType::object_t::value_type const & p)
-    {
+  auto inner_object = j.template get_ptr<const typename BasicJsonType::object_t *>();
+  using value_type  = typename ConstructibleObjectType::value_type;
+  std::transform(
+      inner_object->begin(), inner_object->end(),
+      std::inserter(obj, obj.begin()),
+      [](typename BasicJsonType::object_t::value_type const &p) {
         return value_type(p.first, p.second.template get<typename ConstructibleObjectType::mapped_type>());
-    });
+      });
 }
 
 // overload for arithmetic types, not chosen for basic_json template arguments
 // (BooleanType, etc..); note: Is it really necessary to provide explicit
 // overloads for boolean_t etc. in case of a custom BooleanType which is not
 // an arithmetic type?
-template<typename BasicJsonType, typename ArithmeticType,
-         enable_if_t <
-             std::is_arithmetic<ArithmeticType>::value and
-             not std::is_same<ArithmeticType, typename BasicJsonType::number_unsigned_t>::value and
-             not std::is_same<ArithmeticType, typename BasicJsonType::number_integer_t>::value and
-             not std::is_same<ArithmeticType, typename BasicJsonType::number_float_t>::value and
-             not std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
-             int> = 0>
-void from_json(const BasicJsonType& j, ArithmeticType& val)
+template <typename BasicJsonType, typename ArithmeticType,
+          enable_if_t<
+              std::is_arithmetic<ArithmeticType>::value and
+                  not std::is_same<ArithmeticType, typename BasicJsonType::number_unsigned_t>::value and
+                  not std::is_same<ArithmeticType, typename BasicJsonType::number_integer_t>::value and
+                  not std::is_same<ArithmeticType, typename BasicJsonType::number_float_t>::value and
+                  not std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
+              int> = 0>
+void from_json(const BasicJsonType &j, ArithmeticType &val)
 {
-    switch (static_cast<value_t>(j))
-    {
-        case value_t::number_unsigned:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
-            break;
-        }
-        case value_t::number_integer:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
-            break;
-        }
-        case value_t::number_float:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
-            break;
-        }
-        case value_t::boolean:
-        {
-            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
-            break;
-        }
+  switch (static_cast<value_t>(j)) {
+  case value_t::number_unsigned: {
+    val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t *>());
+    break;
+  }
+  case value_t::number_integer: {
+    val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t *>());
+    break;
+  }
+  case value_t::number_float: {
+    val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t *>());
+    break;
+  }
+  case value_t::boolean: {
+    val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t *>());
+    break;
+  }
 
-        default:
-            JSON_THROW(type_error::create(302, "type must be number, but is " + std::string(j.type_name())));
-    }
+  default:
+    JSON_THROW(type_error::create(302, "type must be number, but is " + std::string(j.type_name())));
+  }
 }
 
-template<typename BasicJsonType, typename A1, typename A2>
-void from_json(const BasicJsonType& j, std::pair<A1, A2>& p)
+template <typename BasicJsonType, typename A1, typename A2>
+void from_json(const BasicJsonType &j, std::pair<A1, A2> &p)
 {
-    p = {j.at(0).template get<A1>(), j.at(1).template get<A2>()};
+  p = {j.at(0).template get<A1>(), j.at(1).template get<A2>()};
 }
 
-template<typename BasicJsonType, typename Tuple, std::size_t... Idx>
-void from_json_tuple_impl(const BasicJsonType& j, Tuple& t, index_sequence<Idx...> /*unused*/)
+template <typename BasicJsonType, typename Tuple, std::size_t... Idx>
+void from_json_tuple_impl(const BasicJsonType &j, Tuple &t, index_sequence<Idx...> /*unused*/)
 {
-    t = std::make_tuple(j.at(Idx).template get<typename std::tuple_element<Idx, Tuple>::type>()...);
+  t = std::make_tuple(j.at(Idx).template get<typename std::tuple_element<Idx, Tuple>::type>()...);
 }
 
-template<typename BasicJsonType, typename... Args>
-void from_json(const BasicJsonType& j, std::tuple<Args...>& t)
+template <typename BasicJsonType, typename... Args>
+void from_json(const BasicJsonType &j, std::tuple<Args...> &t)
 {
-    from_json_tuple_impl(j, t, index_sequence_for<Args...> {});
+  from_json_tuple_impl(j, t, index_sequence_for<Args...>{});
 }
 
 template <typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
           typename = enable_if_t<not std::is_constructible<
-                                     typename BasicJsonType::string_t, Key>::value>>
-void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
+              typename BasicJsonType::string_t, Key>::value>>
+void from_json(const BasicJsonType &j, std::map<Key, Value, Compare, Allocator> &m)
 {
-    if (JSON_UNLIKELY(not j.is_array()))
-    {
-        JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
+  if (JSON_UNLIKELY(not j.is_array())) {
+    JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
+  }
+  for (const auto &p : j) {
+    if (JSON_UNLIKELY(not p.is_array())) {
+      JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(p.type_name())));
     }
-    for (const auto& p : j)
-    {
-        if (JSON_UNLIKELY(not p.is_array()))
-        {
-            JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(p.type_name())));
-        }
-        m.emplace(p.at(0).template get<Key>(), p.at(1).template get<Value>());
-    }
+    m.emplace(p.at(0).template get<Key>(), p.at(1).template get<Value>());
+  }
 }
 
 template <typename BasicJsonType, typename Key, typename Value, typename Hash, typename KeyEqual, typename Allocator,
           typename = enable_if_t<not std::is_constructible<
-                                     typename BasicJsonType::string_t, Key>::value>>
-void from_json(const BasicJsonType& j, std::unordered_map<Key, Value, Hash, KeyEqual, Allocator>& m)
+              typename BasicJsonType::string_t, Key>::value>>
+void from_json(const BasicJsonType &j, std::unordered_map<Key, Value, Hash, KeyEqual, Allocator> &m)
 {
-    if (JSON_UNLIKELY(not j.is_array()))
-    {
-        JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
+  if (JSON_UNLIKELY(not j.is_array())) {
+    JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(j.type_name())));
+  }
+  for (const auto &p : j) {
+    if (JSON_UNLIKELY(not p.is_array())) {
+      JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(p.type_name())));
     }
-    for (const auto& p : j)
-    {
-        if (JSON_UNLIKELY(not p.is_array()))
-        {
-            JSON_THROW(type_error::create(302, "type must be array, but is " + std::string(p.type_name())));
-        }
-        m.emplace(p.at(0).template get<Key>(), p.at(1).template get<Value>());
-    }
+    m.emplace(p.at(0).template get<Key>(), p.at(1).template get<Value>());
+  }
 }
 
-struct from_json_fn
-{
-    template<typename BasicJsonType, typename T>
-    auto operator()(const BasicJsonType& j, T& val) const
-    noexcept(noexcept(from_json(j, val)))
-    -> decltype(from_json(j, val), void())
-    {
-        return from_json(j, val);
-    }
+struct from_json_fn {
+  template <typename BasicJsonType, typename T>
+  auto operator()(const BasicJsonType &j, T &val) const
+      noexcept(noexcept(from_json(j, val)))
+          -> decltype(from_json(j, val), void())
+  {
+    return from_json(j, val);
+  }
 };
-}  // namespace detail
+} // namespace detail
 
 /// namespace to hold default `from_json` function
 /// to see why this is required:
 /// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html
-namespace
-{
-constexpr const auto& from_json = detail::static_const<detail::from_json_fn>::value;
+namespace {
+constexpr const auto &from_json = detail::static_const<detail::from_json_fn>::value;
 } // namespace
-}  // namespace nlohmann
+} // namespace nlohmann
 
 // #include <nlohmann/detail/conversions/to_json.hpp>
 
-
-#include <ciso646> // or, and, not
-#include <iterator> // begin, end
-#include <tuple> // tuple, get
+#include <ciso646>     // or, and, not
+#include <iterator>    // begin, end
+#include <tuple>       // tuple, get
 #include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type
-#include <utility> // move, forward, declval, pair
-#include <valarray> // valarray
-#include <vector> // vector
+#include <utility>     // move, forward, declval, pair
+#include <valarray>    // valarray
+#include <vector>      // vector
 
 // #include <nlohmann/detail/meta/cpp_future.hpp>
 
@@ -1645,522 +1589,504 @@ constexpr const auto& from_json = detail::static_const<detail::from_json_fn>::va
 
 // #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 
-
-#include <cstddef> // size_t
-#include <string> // string, to_string
+#include <cstddef>  // size_t
 #include <iterator> // input_iterator_tag
-#include <tuple> // tuple_size, get, tuple_element
+#include <string>   // string, to_string
+#include <tuple>    // tuple_size, get, tuple_element
 
 // #include <nlohmann/detail/value_t.hpp>
 
 // #include <nlohmann/detail/meta/type_traits.hpp>
 
+namespace nlohmann {
+namespace detail {
+template <typename IteratorType>
+class iteration_proxy_value {
+public:
+  using difference_type   = std::ptrdiff_t;
+  using value_type        = iteration_proxy_value;
+  using pointer           = value_type *;
+  using reference         = value_type &;
+  using iterator_category = std::input_iterator_tag;
 
-namespace nlohmann
-{
-namespace detail
-{
-template <typename IteratorType> class iteration_proxy_value
-{
-  public:
-    using difference_type = std::ptrdiff_t;
-    using value_type = iteration_proxy_value;
-    using pointer = value_type * ;
-    using reference = value_type & ;
-    using iterator_category = std::input_iterator_tag;
+private:
+  /// the iterator
+  IteratorType anchor;
+  /// an index for arrays (used to create key names)
+  std::size_t array_index = 0;
+  /// last stringified array index
+  mutable std::size_t array_index_last = 0;
+  /// a string representation of the array index
+  mutable std::string array_index_str = "0";
+  /// an empty string (to return a reference for primitive values)
+  const std::string empty_str = "";
 
-  private:
-    /// the iterator
-    IteratorType anchor;
-    /// an index for arrays (used to create key names)
-    std::size_t array_index = 0;
-    /// last stringified array index
-    mutable std::size_t array_index_last = 0;
-    /// a string representation of the array index
-    mutable std::string array_index_str = "0";
-    /// an empty string (to return a reference for primitive values)
-    const std::string empty_str = "";
+public:
+  explicit iteration_proxy_value(IteratorType it) noexcept
+      : anchor(it) {}
 
-  public:
-    explicit iteration_proxy_value(IteratorType it) noexcept : anchor(it) {}
+  /// dereference operator (needed for range-based for)
+  iteration_proxy_value &operator*()
+  {
+    return *this;
+  }
 
-    /// dereference operator (needed for range-based for)
-    iteration_proxy_value& operator*()
-    {
-        return *this;
+  /// increment operator (needed for range-based for)
+  iteration_proxy_value &operator++()
+  {
+    ++anchor;
+    ++array_index;
+
+    return *this;
+  }
+
+  /// equality operator (needed for InputIterator)
+  bool operator==(const iteration_proxy_value &o) const noexcept
+  {
+    return anchor == o.anchor;
+  }
+
+  /// inequality operator (needed for range-based for)
+  bool operator!=(const iteration_proxy_value &o) const noexcept
+  {
+    return anchor != o.anchor;
+  }
+
+  /// return key of the iterator
+  const std::string &key() const
+  {
+    assert(anchor.m_object != nullptr);
+
+    switch (anchor.m_object->type()) {
+    // use integer array index as key
+    case value_t::array: {
+      if (array_index != array_index_last) {
+        array_index_str  = std::to_string(array_index);
+        array_index_last = array_index;
+      }
+      return array_index_str;
     }
 
-    /// increment operator (needed for range-based for)
-    iteration_proxy_value& operator++()
-    {
-        ++anchor;
-        ++array_index;
+    // use key from the object
+    case value_t::object:
+      return anchor.key();
 
-        return *this;
+    // use an empty key for all primitive types
+    default:
+      return empty_str;
     }
+  }
 
-    /// equality operator (needed for InputIterator)
-    bool operator==(const iteration_proxy_value& o) const noexcept
-    {
-        return anchor == o.anchor;
-    }
-
-    /// inequality operator (needed for range-based for)
-    bool operator!=(const iteration_proxy_value& o) const noexcept
-    {
-        return anchor != o.anchor;
-    }
-
-    /// return key of the iterator
-    const std::string& key() const
-    {
-        assert(anchor.m_object != nullptr);
-
-        switch (anchor.m_object->type())
-        {
-            // use integer array index as key
-            case value_t::array:
-            {
-                if (array_index != array_index_last)
-                {
-                    array_index_str = std::to_string(array_index);
-                    array_index_last = array_index;
-                }
-                return array_index_str;
-            }
-
-            // use key from the object
-            case value_t::object:
-                return anchor.key();
-
-            // use an empty key for all primitive types
-            default:
-                return empty_str;
-        }
-    }
-
-    /// return value of the iterator
-    typename IteratorType::reference value() const
-    {
-        return anchor.value();
-    }
+  /// return value of the iterator
+  typename IteratorType::reference value() const
+  {
+    return anchor.value();
+  }
 };
 
 /// proxy class for the items() function
-template<typename IteratorType> class iteration_proxy
-{
-  private:
-    /// the container to iterate
-    typename IteratorType::reference container;
+template <typename IteratorType>
+class iteration_proxy {
+private:
+  /// the container to iterate
+  typename IteratorType::reference container;
 
-  public:
-    /// construct iteration proxy from a container
-    explicit iteration_proxy(typename IteratorType::reference cont) noexcept
-        : container(cont) {}
+public:
+  /// construct iteration proxy from a container
+  explicit iteration_proxy(typename IteratorType::reference cont) noexcept
+      : container(cont) {}
 
-    /// return iterator begin (needed for range-based for)
-    iteration_proxy_value<IteratorType> begin() noexcept
-    {
-        return iteration_proxy_value<IteratorType>(container.begin());
-    }
+  /// return iterator begin (needed for range-based for)
+  iteration_proxy_value<IteratorType> begin() noexcept
+  {
+    return iteration_proxy_value<IteratorType>(container.begin());
+  }
 
-    /// return iterator end (needed for range-based for)
-    iteration_proxy_value<IteratorType> end() noexcept
-    {
-        return iteration_proxy_value<IteratorType>(container.end());
-    }
+  /// return iterator end (needed for range-based for)
+  iteration_proxy_value<IteratorType> end() noexcept
+  {
+    return iteration_proxy_value<IteratorType>(container.end());
+  }
 };
 // Structured Bindings Support
 // For further reference see https://blog.tartanllama.xyz/structured-bindings/
 // And see https://github.com/nlohmann/json/pull/1391
 template <std::size_t N, typename IteratorType, enable_if_t<N == 0, int> = 0>
-auto get(const nlohmann::detail::iteration_proxy_value<IteratorType>& i) -> decltype(i.key())
+auto get(const nlohmann::detail::iteration_proxy_value<IteratorType> &i) -> decltype(i.key())
 {
-    return i.key();
+  return i.key();
 }
 // Structured Bindings Support
 // For further reference see https://blog.tartanllama.xyz/structured-bindings/
 // And see https://github.com/nlohmann/json/pull/1391
 template <std::size_t N, typename IteratorType, enable_if_t<N == 1, int> = 0>
-auto get(const nlohmann::detail::iteration_proxy_value<IteratorType>& i) -> decltype(i.value())
+auto get(const nlohmann::detail::iteration_proxy_value<IteratorType> &i) -> decltype(i.value())
 {
-    return i.value();
+  return i.value();
 }
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // The Addition to the STD Namespace is required to add
 // Structured Bindings Support to the iteration_proxy_value class
 // For further reference see https://blog.tartanllama.xyz/structured-bindings/
 // And see https://github.com/nlohmann/json/pull/1391
-namespace std
-{
+namespace std {
 template <typename IteratorType>
 class tuple_size<::nlohmann::detail::iteration_proxy_value<IteratorType>>
-            : public std::integral_constant<std::size_t, 2> {};
+    : public std::integral_constant<std::size_t, 2> {
+};
 
 template <std::size_t N, typename IteratorType>
-class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >>
-{
-  public:
-    using type = decltype(
-                     get<N>(std::declval <
-                            ::nlohmann::detail::iteration_proxy_value<IteratorType >> ()));
+class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType>> {
+public:
+  using type = decltype(
+      get<N>(std::declval<
+             ::nlohmann::detail::iteration_proxy_value<IteratorType>>()));
 };
-}
+} // namespace std
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 //////////////////
 // constructors //
 //////////////////
 
-template<value_t> struct external_constructor;
+template <value_t>
+struct external_constructor;
 
-template<>
-struct external_constructor<value_t::boolean>
-{
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, typename BasicJsonType::boolean_t b) noexcept
-    {
-        j.m_type = value_t::boolean;
-        j.m_value = b;
-        j.assert_invariant();
-    }
+template <>
+struct external_constructor<value_t::boolean> {
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, typename BasicJsonType::boolean_t b) noexcept
+  {
+    j.m_type  = value_t::boolean;
+    j.m_value = b;
+    j.assert_invariant();
+  }
 };
 
-template<>
-struct external_constructor<value_t::string>
-{
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, const typename BasicJsonType::string_t& s)
-    {
-        j.m_type = value_t::string;
-        j.m_value = s;
-        j.assert_invariant();
-    }
+template <>
+struct external_constructor<value_t::string> {
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, const typename BasicJsonType::string_t &s)
+  {
+    j.m_type  = value_t::string;
+    j.m_value = s;
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, typename BasicJsonType::string_t&& s)
-    {
-        j.m_type = value_t::string;
-        j.m_value = std::move(s);
-        j.assert_invariant();
-    }
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, typename BasicJsonType::string_t &&s)
+  {
+    j.m_type  = value_t::string;
+    j.m_value = std::move(s);
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType, typename CompatibleStringType,
-             enable_if_t<not std::is_same<CompatibleStringType, typename BasicJsonType::string_t>::value,
-                         int> = 0>
-    static void construct(BasicJsonType& j, const CompatibleStringType& str)
-    {
-        j.m_type = value_t::string;
-        j.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
-        j.assert_invariant();
-    }
+  template <typename BasicJsonType, typename CompatibleStringType,
+            enable_if_t<not std::is_same<CompatibleStringType, typename BasicJsonType::string_t>::value,
+                        int> = 0>
+  static void construct(BasicJsonType &j, const CompatibleStringType &str)
+  {
+    j.m_type         = value_t::string;
+    j.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
+    j.assert_invariant();
+  }
 };
 
-template<>
-struct external_constructor<value_t::number_float>
-{
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, typename BasicJsonType::number_float_t val) noexcept
-    {
-        j.m_type = value_t::number_float;
-        j.m_value = val;
-        j.assert_invariant();
-    }
+template <>
+struct external_constructor<value_t::number_float> {
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, typename BasicJsonType::number_float_t val) noexcept
+  {
+    j.m_type  = value_t::number_float;
+    j.m_value = val;
+    j.assert_invariant();
+  }
 };
 
-template<>
-struct external_constructor<value_t::number_unsigned>
-{
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, typename BasicJsonType::number_unsigned_t val) noexcept
-    {
-        j.m_type = value_t::number_unsigned;
-        j.m_value = val;
-        j.assert_invariant();
-    }
+template <>
+struct external_constructor<value_t::number_unsigned> {
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, typename BasicJsonType::number_unsigned_t val) noexcept
+  {
+    j.m_type  = value_t::number_unsigned;
+    j.m_value = val;
+    j.assert_invariant();
+  }
 };
 
-template<>
-struct external_constructor<value_t::number_integer>
-{
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, typename BasicJsonType::number_integer_t val) noexcept
-    {
-        j.m_type = value_t::number_integer;
-        j.m_value = val;
-        j.assert_invariant();
-    }
+template <>
+struct external_constructor<value_t::number_integer> {
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, typename BasicJsonType::number_integer_t val) noexcept
+  {
+    j.m_type  = value_t::number_integer;
+    j.m_value = val;
+    j.assert_invariant();
+  }
 };
 
-template<>
-struct external_constructor<value_t::array>
-{
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, const typename BasicJsonType::array_t& arr)
-    {
-        j.m_type = value_t::array;
-        j.m_value = arr;
-        j.assert_invariant();
-    }
+template <>
+struct external_constructor<value_t::array> {
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, const typename BasicJsonType::array_t &arr)
+  {
+    j.m_type  = value_t::array;
+    j.m_value = arr;
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
-    {
-        j.m_type = value_t::array;
-        j.m_value = std::move(arr);
-        j.assert_invariant();
-    }
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, typename BasicJsonType::array_t &&arr)
+  {
+    j.m_type  = value_t::array;
+    j.m_value = std::move(arr);
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType, typename CompatibleArrayType,
-             enable_if_t<not std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value,
-                         int> = 0>
-    static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
-    {
-        using std::begin;
-        using std::end;
-        j.m_type = value_t::array;
-        j.m_value.array = j.template create<typename BasicJsonType::array_t>(begin(arr), end(arr));
-        j.assert_invariant();
-    }
+  template <typename BasicJsonType, typename CompatibleArrayType,
+            enable_if_t<not std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value,
+                        int> = 0>
+  static void construct(BasicJsonType &j, const CompatibleArrayType &arr)
+  {
+    using std::begin;
+    using std::end;
+    j.m_type        = value_t::array;
+    j.m_value.array = j.template create<typename BasicJsonType::array_t>(begin(arr), end(arr));
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, const std::vector<bool>& arr)
-    {
-        j.m_type = value_t::array;
-        j.m_value = value_t::array;
-        j.m_value.array->reserve(arr.size());
-        for (const bool x : arr)
-        {
-            j.m_value.array->push_back(x);
-        }
-        j.assert_invariant();
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, const std::vector<bool> &arr)
+  {
+    j.m_type  = value_t::array;
+    j.m_value = value_t::array;
+    j.m_value.array->reserve(arr.size());
+    for (const bool x : arr) {
+      j.m_value.array->push_back(x);
     }
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType, typename T,
-             enable_if_t<std::is_convertible<T, BasicJsonType>::value, int> = 0>
-    static void construct(BasicJsonType& j, const std::valarray<T>& arr)
-    {
-        j.m_type = value_t::array;
-        j.m_value = value_t::array;
-        j.m_value.array->resize(arr.size());
-        std::copy(std::begin(arr), std::end(arr), j.m_value.array->begin());
-        j.assert_invariant();
-    }
+  template <typename BasicJsonType, typename T,
+            enable_if_t<std::is_convertible<T, BasicJsonType>::value, int> = 0>
+  static void construct(BasicJsonType &j, const std::valarray<T> &arr)
+  {
+    j.m_type  = value_t::array;
+    j.m_value = value_t::array;
+    j.m_value.array->resize(arr.size());
+    std::copy(std::begin(arr), std::end(arr), j.m_value.array->begin());
+    j.assert_invariant();
+  }
 };
 
-template<>
-struct external_constructor<value_t::object>
-{
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, const typename BasicJsonType::object_t& obj)
-    {
-        j.m_type = value_t::object;
-        j.m_value = obj;
-        j.assert_invariant();
-    }
+template <>
+struct external_constructor<value_t::object> {
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, const typename BasicJsonType::object_t &obj)
+  {
+    j.m_type  = value_t::object;
+    j.m_value = obj;
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, typename BasicJsonType::object_t&& obj)
-    {
-        j.m_type = value_t::object;
-        j.m_value = std::move(obj);
-        j.assert_invariant();
-    }
+  template <typename BasicJsonType>
+  static void construct(BasicJsonType &j, typename BasicJsonType::object_t &&obj)
+  {
+    j.m_type  = value_t::object;
+    j.m_value = std::move(obj);
+    j.assert_invariant();
+  }
 
-    template<typename BasicJsonType, typename CompatibleObjectType,
-             enable_if_t<not std::is_same<CompatibleObjectType, typename BasicJsonType::object_t>::value, int> = 0>
-    static void construct(BasicJsonType& j, const CompatibleObjectType& obj)
-    {
-        using std::begin;
-        using std::end;
+  template <typename BasicJsonType, typename CompatibleObjectType,
+            enable_if_t<not std::is_same<CompatibleObjectType, typename BasicJsonType::object_t>::value, int> = 0>
+  static void construct(BasicJsonType &j, const CompatibleObjectType &obj)
+  {
+    using std::begin;
+    using std::end;
 
-        j.m_type = value_t::object;
-        j.m_value.object = j.template create<typename BasicJsonType::object_t>(begin(obj), end(obj));
-        j.assert_invariant();
-    }
+    j.m_type         = value_t::object;
+    j.m_value.object = j.template create<typename BasicJsonType::object_t>(begin(obj), end(obj));
+    j.assert_invariant();
+  }
 };
 
 /////////////
 // to_json //
 /////////////
 
-template<typename BasicJsonType, typename T,
-         enable_if_t<std::is_same<T, typename BasicJsonType::boolean_t>::value, int> = 0>
-void to_json(BasicJsonType& j, T b) noexcept
+template <typename BasicJsonType, typename T,
+          enable_if_t<std::is_same<T, typename BasicJsonType::boolean_t>::value, int> = 0>
+void to_json(BasicJsonType &j, T b) noexcept
 {
-    external_constructor<value_t::boolean>::construct(j, b);
+  external_constructor<value_t::boolean>::construct(j, b);
 }
 
-template<typename BasicJsonType, typename CompatibleString,
-         enable_if_t<std::is_constructible<typename BasicJsonType::string_t, CompatibleString>::value, int> = 0>
-void to_json(BasicJsonType& j, const CompatibleString& s)
+template <typename BasicJsonType, typename CompatibleString,
+          enable_if_t<std::is_constructible<typename BasicJsonType::string_t, CompatibleString>::value, int> = 0>
+void to_json(BasicJsonType &j, const CompatibleString &s)
 {
-    external_constructor<value_t::string>::construct(j, s);
+  external_constructor<value_t::string>::construct(j, s);
 }
 
-template<typename BasicJsonType>
-void to_json(BasicJsonType& j, typename BasicJsonType::string_t&& s)
+template <typename BasicJsonType>
+void to_json(BasicJsonType &j, typename BasicJsonType::string_t &&s)
 {
-    external_constructor<value_t::string>::construct(j, std::move(s));
+  external_constructor<value_t::string>::construct(j, std::move(s));
 }
 
-template<typename BasicJsonType, typename FloatType,
-         enable_if_t<std::is_floating_point<FloatType>::value, int> = 0>
-void to_json(BasicJsonType& j, FloatType val) noexcept
+template <typename BasicJsonType, typename FloatType,
+          enable_if_t<std::is_floating_point<FloatType>::value, int> = 0>
+void to_json(BasicJsonType &j, FloatType val) noexcept
 {
-    external_constructor<value_t::number_float>::construct(j, static_cast<typename BasicJsonType::number_float_t>(val));
+  external_constructor<value_t::number_float>::construct(j, static_cast<typename BasicJsonType::number_float_t>(val));
 }
 
-template<typename BasicJsonType, typename CompatibleNumberUnsignedType,
-         enable_if_t<is_compatible_integer_type<typename BasicJsonType::number_unsigned_t, CompatibleNumberUnsignedType>::value, int> = 0>
-void to_json(BasicJsonType& j, CompatibleNumberUnsignedType val) noexcept
+template <typename BasicJsonType, typename CompatibleNumberUnsignedType,
+          enable_if_t<is_compatible_integer_type<typename BasicJsonType::number_unsigned_t, CompatibleNumberUnsignedType>::value, int> = 0>
+void to_json(BasicJsonType &j, CompatibleNumberUnsignedType val) noexcept
 {
-    external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
+  external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
 }
 
-template<typename BasicJsonType, typename CompatibleNumberIntegerType,
-         enable_if_t<is_compatible_integer_type<typename BasicJsonType::number_integer_t, CompatibleNumberIntegerType>::value, int> = 0>
-void to_json(BasicJsonType& j, CompatibleNumberIntegerType val) noexcept
+template <typename BasicJsonType, typename CompatibleNumberIntegerType,
+          enable_if_t<is_compatible_integer_type<typename BasicJsonType::number_integer_t, CompatibleNumberIntegerType>::value, int> = 0>
+void to_json(BasicJsonType &j, CompatibleNumberIntegerType val) noexcept
 {
-    external_constructor<value_t::number_integer>::construct(j, static_cast<typename BasicJsonType::number_integer_t>(val));
+  external_constructor<value_t::number_integer>::construct(j, static_cast<typename BasicJsonType::number_integer_t>(val));
 }
 
-template<typename BasicJsonType, typename EnumType,
-         enable_if_t<std::is_enum<EnumType>::value, int> = 0>
-void to_json(BasicJsonType& j, EnumType e) noexcept
+template <typename BasicJsonType, typename EnumType,
+          enable_if_t<std::is_enum<EnumType>::value, int> = 0>
+void to_json(BasicJsonType &j, EnumType e) noexcept
 {
-    using underlying_type = typename std::underlying_type<EnumType>::type;
-    external_constructor<value_t::number_integer>::construct(j, static_cast<underlying_type>(e));
+  using underlying_type = typename std::underlying_type<EnumType>::type;
+  external_constructor<value_t::number_integer>::construct(j, static_cast<underlying_type>(e));
 }
 
-template<typename BasicJsonType>
-void to_json(BasicJsonType& j, const std::vector<bool>& e)
+template <typename BasicJsonType>
+void to_json(BasicJsonType &j, const std::vector<bool> &e)
 {
-    external_constructor<value_t::array>::construct(j, e);
+  external_constructor<value_t::array>::construct(j, e);
 }
 
 template <typename BasicJsonType, typename CompatibleArrayType,
           enable_if_t<is_compatible_array_type<BasicJsonType,
-                      CompatibleArrayType>::value and
-                      not is_compatible_object_type<
-                          BasicJsonType, CompatibleArrayType>::value and
-                      not is_compatible_string_type<BasicJsonType, CompatibleArrayType>::value and
-                      not is_basic_json<CompatibleArrayType>::value,
+                                               CompatibleArrayType>::value and
+                          not is_compatible_object_type<
+                              BasicJsonType, CompatibleArrayType>::value and
+                          not is_compatible_string_type<BasicJsonType, CompatibleArrayType>::value and
+                          not is_basic_json<CompatibleArrayType>::value,
                       int> = 0>
-void to_json(BasicJsonType& j, const CompatibleArrayType& arr)
+void to_json(BasicJsonType &j, const CompatibleArrayType &arr)
 {
-    external_constructor<value_t::array>::construct(j, arr);
+  external_constructor<value_t::array>::construct(j, arr);
 }
 
-template<typename BasicJsonType, typename T,
-         enable_if_t<std::is_convertible<T, BasicJsonType>::value, int> = 0>
-void to_json(BasicJsonType& j, const std::valarray<T>& arr)
+template <typename BasicJsonType, typename T,
+          enable_if_t<std::is_convertible<T, BasicJsonType>::value, int> = 0>
+void to_json(BasicJsonType &j, const std::valarray<T> &arr)
 {
-    external_constructor<value_t::array>::construct(j, std::move(arr));
+  external_constructor<value_t::array>::construct(j, std::move(arr));
 }
 
-template<typename BasicJsonType>
-void to_json(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
+template <typename BasicJsonType>
+void to_json(BasicJsonType &j, typename BasicJsonType::array_t &&arr)
 {
-    external_constructor<value_t::array>::construct(j, std::move(arr));
+  external_constructor<value_t::array>::construct(j, std::move(arr));
 }
 
-template<typename BasicJsonType, typename CompatibleObjectType,
-         enable_if_t<is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value and not is_basic_json<CompatibleObjectType>::value, int> = 0>
-void to_json(BasicJsonType& j, const CompatibleObjectType& obj)
+template <typename BasicJsonType, typename CompatibleObjectType,
+          enable_if_t<is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value and not is_basic_json<CompatibleObjectType>::value, int> = 0>
+void to_json(BasicJsonType &j, const CompatibleObjectType &obj)
 {
-    external_constructor<value_t::object>::construct(j, obj);
+  external_constructor<value_t::object>::construct(j, obj);
 }
 
-template<typename BasicJsonType>
-void to_json(BasicJsonType& j, typename BasicJsonType::object_t&& obj)
+template <typename BasicJsonType>
+void to_json(BasicJsonType &j, typename BasicJsonType::object_t &&obj)
 {
-    external_constructor<value_t::object>::construct(j, std::move(obj));
+  external_constructor<value_t::object>::construct(j, std::move(obj));
 }
 
 template <
     typename BasicJsonType, typename T, std::size_t N,
     enable_if_t<not std::is_constructible<typename BasicJsonType::string_t,
-                const T(&)[N]>::value,
-                int> = 0 >
-void to_json(BasicJsonType& j, const T(&arr)[N])
+                                          const T (&)[N]>::value,
+                int> = 0>
+void to_json(BasicJsonType &j, const T (&arr)[N])
 {
-    external_constructor<value_t::array>::construct(j, arr);
+  external_constructor<value_t::array>::construct(j, arr);
 }
 
-template<typename BasicJsonType, typename... Args>
-void to_json(BasicJsonType& j, const std::pair<Args...>& p)
+template <typename BasicJsonType, typename... Args>
+void to_json(BasicJsonType &j, const std::pair<Args...> &p)
 {
-    j = { p.first, p.second };
+  j = {p.first, p.second};
 }
 
 // for https://github.com/nlohmann/json/pull/1134
-template < typename BasicJsonType, typename T,
-           enable_if_t<std::is_same<T, iteration_proxy_value<typename BasicJsonType::iterator>>::value, int> = 0>
-void to_json(BasicJsonType& j, const T& b)
+template <typename BasicJsonType, typename T,
+          enable_if_t<std::is_same<T, iteration_proxy_value<typename BasicJsonType::iterator>>::value, int> = 0>
+void to_json(BasicJsonType &j, const T &b)
 {
-    j = { {b.key(), b.value()} };
+  j = {{b.key(), b.value()}};
 }
 
-template<typename BasicJsonType, typename Tuple, std::size_t... Idx>
-void to_json_tuple_impl(BasicJsonType& j, const Tuple& t, index_sequence<Idx...> /*unused*/)
+template <typename BasicJsonType, typename Tuple, std::size_t... Idx>
+void to_json_tuple_impl(BasicJsonType &j, const Tuple &t, index_sequence<Idx...> /*unused*/)
 {
-    j = { std::get<Idx>(t)... };
+  j = {std::get<Idx>(t)...};
 }
 
-template<typename BasicJsonType, typename... Args>
-void to_json(BasicJsonType& j, const std::tuple<Args...>& t)
+template <typename BasicJsonType, typename... Args>
+void to_json(BasicJsonType &j, const std::tuple<Args...> &t)
 {
-    to_json_tuple_impl(j, t, index_sequence_for<Args...> {});
+  to_json_tuple_impl(j, t, index_sequence_for<Args...>{});
 }
 
-struct to_json_fn
-{
-    template<typename BasicJsonType, typename T>
-    auto operator()(BasicJsonType& j, T&& val) const noexcept(noexcept(to_json(j, std::forward<T>(val))))
-    -> decltype(to_json(j, std::forward<T>(val)), void())
-    {
-        return to_json(j, std::forward<T>(val));
-    }
+struct to_json_fn {
+  template <typename BasicJsonType, typename T>
+  auto operator()(BasicJsonType &j, T &&val) const noexcept(noexcept(to_json(j, std::forward<T>(val))))
+      -> decltype(to_json(j, std::forward<T>(val)), void())
+  {
+    return to_json(j, std::forward<T>(val));
+  }
 };
-}  // namespace detail
+} // namespace detail
 
 /// namespace to hold default `to_json` function
-namespace
-{
-constexpr const auto& to_json = detail::static_const<detail::to_json_fn>::value;
+namespace {
+constexpr const auto &to_json = detail::static_const<detail::to_json_fn>::value;
 } // namespace
-}  // namespace nlohmann
+} // namespace nlohmann
 
 // #include <nlohmann/detail/input/input_adapters.hpp>
 
-
-#include <cassert> // assert
-#include <cstddef> // size_t
-#include <cstring> // strlen
-#include <istream> // istream
-#include <iterator> // begin, end, iterator_traits, random_access_iterator_tag, distance, next
-#include <memory> // shared_ptr, make_shared, addressof
-#include <numeric> // accumulate
-#include <string> // string, char_traits
+#include <cassert>     // assert
+#include <cstddef>     // size_t
+#include <cstdio>      //FILE *
+#include <cstring>     // strlen
+#include <istream>     // istream
+#include <iterator>    // begin, end, iterator_traits, random_access_iterator_tag, distance, next
+#include <memory>      // shared_ptr, make_shared, addressof
+#include <numeric>     // accumulate
+#include <string>      // string, char_traits
 #include <type_traits> // enable_if, is_base_of, is_pointer, is_integral, remove_pointer
-#include <utility> // pair, declval
-#include <cstdio> //FILE *
+#include <utility>     // pair, declval
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 /// the supported input formats
-enum class input_format_t { json, cbor, msgpack, ubjson, bson };
+enum class input_format_t { json,
+                            cbor,
+                            msgpack,
+                            ubjson,
+                            bson };
 
 ////////////////////
 // input adapters //
@@ -2177,11 +2103,10 @@ unsigned char), plus an EOF value outside that range, specified by the value
 of the function std::char_traits<char>::eof(). This value is typically -1, but
 could be any arbitrary value which is not a valid char value.
 */
-struct input_adapter_protocol
-{
-    /// get a character [0,255] or std::char_traits<char>::eof().
-    virtual std::char_traits<char>::int_type get_character() = 0;
-    virtual ~input_adapter_protocol() = default;
+struct input_adapter_protocol {
+  /// get a character [0,255] or std::char_traits<char>::eof().
+  virtual std::char_traits<char>::int_type get_character() = 0;
+  virtual ~input_adapter_protocol()                        = default;
 };
 
 /// a type to simplify interfaces
@@ -2191,22 +2116,22 @@ using input_adapter_t = std::shared_ptr<input_adapter_protocol>;
 Input adapter for stdio file access. This adapter read only 1 byte and do not use any
  buffer. This adapter is a very low level adapter.
 */
-class file_input_adapter : public input_adapter_protocol
-{
-  public:
-    explicit file_input_adapter(std::FILE* f)  noexcept
-        : m_file(f)
-    {}
+class file_input_adapter : public input_adapter_protocol {
+public:
+  explicit file_input_adapter(std::FILE *f) noexcept
+      : m_file(f)
+  {
+  }
 
-    std::char_traits<char>::int_type get_character() noexcept override
-    {
-        return std::fgetc(m_file);
-    }
-  private:
-    /// the file pointer to read from
-    std::FILE* m_file;
+  std::char_traits<char>::int_type get_character() noexcept override
+  {
+    return std::fgetc(m_file);
+  }
+
+private:
+  /// the file pointer to read from
+  std::FILE *m_file;
 };
-
 
 /*!
 Input adapter for a (caching) istream. Ignores a UFT Byte Order Mark at
@@ -2217,360 +2142,324 @@ characters following those used in parsing the JSON input.  Clears the
 std::istream flags; any input errors (e.g., EOF) will be detected by the first
 subsequent call for input from the std::istream.
 */
-class input_stream_adapter : public input_adapter_protocol
-{
-  public:
-    ~input_stream_adapter() override
-    {
-        // clear stream flags; we use underlying streambuf I/O, do not
-        // maintain ifstream flags, except eof
-        is.clear(is.rdstate() & std::ios::eofbit);
+class input_stream_adapter : public input_adapter_protocol {
+public:
+  ~input_stream_adapter() override
+  {
+    // clear stream flags; we use underlying streambuf I/O, do not
+    // maintain ifstream flags, except eof
+    is.clear(is.rdstate() & std::ios::eofbit);
+  }
+
+  explicit input_stream_adapter(std::istream &i)
+      : is(i), sb(*i.rdbuf())
+  {
+  }
+
+  // delete because of pointer members
+  input_stream_adapter(const input_stream_adapter &) = delete;
+  input_stream_adapter &operator=(input_stream_adapter &) = delete;
+  input_stream_adapter(input_stream_adapter &&)           = delete;
+  input_stream_adapter &operator=(input_stream_adapter &&) = delete;
+
+  // std::istream/std::streambuf use std::char_traits<char>::to_int_type, to
+  // ensure that std::char_traits<char>::eof() and the character 0xFF do not
+  // end up as the same value, eg. 0xFFFFFFFF.
+  std::char_traits<char>::int_type get_character() override
+  {
+    auto res = sb.sbumpc();
+    // set eof manually, as we don't use the istream interface.
+    if (res == EOF) {
+      is.clear(is.rdstate() | std::ios::eofbit);
     }
+    return res;
+  }
 
-    explicit input_stream_adapter(std::istream& i)
-        : is(i), sb(*i.rdbuf())
-    {}
-
-    // delete because of pointer members
-    input_stream_adapter(const input_stream_adapter&) = delete;
-    input_stream_adapter& operator=(input_stream_adapter&) = delete;
-    input_stream_adapter(input_stream_adapter&&) = delete;
-    input_stream_adapter& operator=(input_stream_adapter&&) = delete;
-
-    // std::istream/std::streambuf use std::char_traits<char>::to_int_type, to
-    // ensure that std::char_traits<char>::eof() and the character 0xFF do not
-    // end up as the same value, eg. 0xFFFFFFFF.
-    std::char_traits<char>::int_type get_character() override
-    {
-        auto res = sb.sbumpc();
-        // set eof manually, as we don't use the istream interface.
-        if (res == EOF)
-        {
-            is.clear(is.rdstate() | std::ios::eofbit);
-        }
-        return res;
-    }
-
-  private:
-    /// the associated input stream
-    std::istream& is;
-    std::streambuf& sb;
+private:
+  /// the associated input stream
+  std::istream &  is;
+  std::streambuf &sb;
 };
 
 /// input adapter for buffer input
-class input_buffer_adapter : public input_adapter_protocol
-{
-  public:
-    input_buffer_adapter(const char* b, const std::size_t l) noexcept
-        : cursor(b), limit(b + l)
-    {}
+class input_buffer_adapter : public input_adapter_protocol {
+public:
+  input_buffer_adapter(const char *b, const std::size_t l) noexcept
+      : cursor(b), limit(b + l)
+  {
+  }
 
-    // delete because of pointer members
-    input_buffer_adapter(const input_buffer_adapter&) = delete;
-    input_buffer_adapter& operator=(input_buffer_adapter&) = delete;
-    input_buffer_adapter(input_buffer_adapter&&) = delete;
-    input_buffer_adapter& operator=(input_buffer_adapter&&) = delete;
-    ~input_buffer_adapter() override = default;
+  // delete because of pointer members
+  input_buffer_adapter(const input_buffer_adapter &) = delete;
+  input_buffer_adapter &operator=(input_buffer_adapter &) = delete;
+  input_buffer_adapter(input_buffer_adapter &&)           = delete;
+  input_buffer_adapter &operator=(input_buffer_adapter &&) = delete;
+  ~input_buffer_adapter() override                         = default;
 
-    std::char_traits<char>::int_type get_character() noexcept override
-    {
-        if (JSON_LIKELY(cursor < limit))
-        {
-            return std::char_traits<char>::to_int_type(*(cursor++));
-        }
-
-        return std::char_traits<char>::eof();
+  std::char_traits<char>::int_type get_character() noexcept override
+  {
+    if (JSON_LIKELY(cursor < limit)) {
+      return std::char_traits<char>::to_int_type(*(cursor++));
     }
 
-  private:
-    /// pointer to the current character
-    const char* cursor;
-    /// pointer past the last character
-    const char* const limit;
+    return std::char_traits<char>::eof();
+  }
+
+private:
+  /// pointer to the current character
+  const char *cursor;
+  /// pointer past the last character
+  const char *const limit;
 };
 
-template<typename WideStringType, size_t T>
-struct wide_string_input_helper
-{
-    // UTF-32
-    static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
-    {
-        utf8_bytes_index = 0;
+template <typename WideStringType, size_t T>
+struct wide_string_input_helper {
+  // UTF-32
+  static void fill_buffer(const WideStringType &str, size_t &current_wchar, std::array<std::char_traits<char>::int_type, 4> &utf8_bytes, size_t &utf8_bytes_index, size_t &utf8_bytes_filled)
+  {
+    utf8_bytes_index = 0;
 
-        if (current_wchar == str.size())
-        {
-            utf8_bytes[0] = std::char_traits<char>::eof();
-            utf8_bytes_filled = 1;
-        }
-        else
-        {
-            // get the current character
-            const auto wc = static_cast<int>(str[current_wchar++]);
+    if (current_wchar == str.size()) {
+      utf8_bytes[0]     = std::char_traits<char>::eof();
+      utf8_bytes_filled = 1;
+    } else {
+      // get the current character
+      const auto wc = static_cast<int>(str[current_wchar++]);
 
-            // UTF-32 to UTF-8 encoding
-            if (wc < 0x80)
-            {
-                utf8_bytes[0] = wc;
-                utf8_bytes_filled = 1;
-            }
-            else if (wc <= 0x7FF)
-            {
-                utf8_bytes[0] = 0xC0 | ((wc >> 6) & 0x1F);
-                utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 2;
-            }
-            else if (wc <= 0xFFFF)
-            {
-                utf8_bytes[0] = 0xE0 | ((wc >> 12) & 0x0F);
-                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 3;
-            }
-            else if (wc <= 0x10FFFF)
-            {
-                utf8_bytes[0] = 0xF0 | ((wc >> 18) & 0x07);
-                utf8_bytes[1] = 0x80 | ((wc >> 12) & 0x3F);
-                utf8_bytes[2] = 0x80 | ((wc >> 6) & 0x3F);
-                utf8_bytes[3] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 4;
-            }
-            else
-            {
-                // unknown character
-                utf8_bytes[0] = wc;
-                utf8_bytes_filled = 1;
-            }
-        }
+      // UTF-32 to UTF-8 encoding
+      if (wc < 0x80) {
+        utf8_bytes[0]     = wc;
+        utf8_bytes_filled = 1;
+      } else if (wc <= 0x7FF) {
+        utf8_bytes[0]     = 0xC0 | ((wc >> 6) & 0x1F);
+        utf8_bytes[1]     = 0x80 | (wc & 0x3F);
+        utf8_bytes_filled = 2;
+      } else if (wc <= 0xFFFF) {
+        utf8_bytes[0]     = 0xE0 | ((wc >> 12) & 0x0F);
+        utf8_bytes[1]     = 0x80 | ((wc >> 6) & 0x3F);
+        utf8_bytes[2]     = 0x80 | (wc & 0x3F);
+        utf8_bytes_filled = 3;
+      } else if (wc <= 0x10FFFF) {
+        utf8_bytes[0]     = 0xF0 | ((wc >> 18) & 0x07);
+        utf8_bytes[1]     = 0x80 | ((wc >> 12) & 0x3F);
+        utf8_bytes[2]     = 0x80 | ((wc >> 6) & 0x3F);
+        utf8_bytes[3]     = 0x80 | (wc & 0x3F);
+        utf8_bytes_filled = 4;
+      } else {
+        // unknown character
+        utf8_bytes[0]     = wc;
+        utf8_bytes_filled = 1;
+      }
     }
+  }
 };
 
-template<typename WideStringType>
-struct wide_string_input_helper<WideStringType, 2>
-{
-    // UTF-16
-    static void fill_buffer(const WideStringType& str, size_t& current_wchar, std::array<std::char_traits<char>::int_type, 4>& utf8_bytes, size_t& utf8_bytes_index, size_t& utf8_bytes_filled)
-    {
-        utf8_bytes_index = 0;
+template <typename WideStringType>
+struct wide_string_input_helper<WideStringType, 2> {
+  // UTF-16
+  static void fill_buffer(const WideStringType &str, size_t &current_wchar, std::array<std::char_traits<char>::int_type, 4> &utf8_bytes, size_t &utf8_bytes_index, size_t &utf8_bytes_filled)
+  {
+    utf8_bytes_index = 0;
 
-        if (current_wchar == str.size())
-        {
-            utf8_bytes[0] = std::char_traits<char>::eof();
-            utf8_bytes_filled = 1;
-        }
-        else
-        {
-            // get the current character
-            const auto wc = static_cast<int>(str[current_wchar++]);
+    if (current_wchar == str.size()) {
+      utf8_bytes[0]     = std::char_traits<char>::eof();
+      utf8_bytes_filled = 1;
+    } else {
+      // get the current character
+      const auto wc = static_cast<int>(str[current_wchar++]);
 
-            // UTF-16 to UTF-8 encoding
-            if (wc < 0x80)
-            {
-                utf8_bytes[0] = wc;
-                utf8_bytes_filled = 1;
-            }
-            else if (wc <= 0x7FF)
-            {
-                utf8_bytes[0] = 0xC0 | ((wc >> 6));
-                utf8_bytes[1] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 2;
-            }
-            else if (0xD800 > wc or wc >= 0xE000)
-            {
-                utf8_bytes[0] = 0xE0 | ((wc >> 12));
-                utf8_bytes[1] = 0x80 | ((wc >> 6) & 0x3F);
-                utf8_bytes[2] = 0x80 | (wc & 0x3F);
-                utf8_bytes_filled = 3;
-            }
-            else
-            {
-                if (current_wchar < str.size())
-                {
-                    const auto wc2 = static_cast<int>(str[current_wchar++]);
-                    const int charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
-                    utf8_bytes[0] = 0xf0 | (charcode >> 18);
-                    utf8_bytes[1] = 0x80 | ((charcode >> 12) & 0x3F);
-                    utf8_bytes[2] = 0x80 | ((charcode >> 6) & 0x3F);
-                    utf8_bytes[3] = 0x80 | (charcode & 0x3F);
-                    utf8_bytes_filled = 4;
-                }
-                else
-                {
-                    // unknown character
-                    ++current_wchar;
-                    utf8_bytes[0] = wc;
-                    utf8_bytes_filled = 1;
-                }
-            }
+      // UTF-16 to UTF-8 encoding
+      if (wc < 0x80) {
+        utf8_bytes[0]     = wc;
+        utf8_bytes_filled = 1;
+      } else if (wc <= 0x7FF) {
+        utf8_bytes[0]     = 0xC0 | ((wc >> 6));
+        utf8_bytes[1]     = 0x80 | (wc & 0x3F);
+        utf8_bytes_filled = 2;
+      } else if (0xD800 > wc or wc >= 0xE000) {
+        utf8_bytes[0]     = 0xE0 | ((wc >> 12));
+        utf8_bytes[1]     = 0x80 | ((wc >> 6) & 0x3F);
+        utf8_bytes[2]     = 0x80 | (wc & 0x3F);
+        utf8_bytes_filled = 3;
+      } else {
+        if (current_wchar < str.size()) {
+          const auto wc2      = static_cast<int>(str[current_wchar++]);
+          const int  charcode = 0x10000 + (((wc & 0x3FF) << 10) | (wc2 & 0x3FF));
+          utf8_bytes[0]       = 0xf0 | (charcode >> 18);
+          utf8_bytes[1]       = 0x80 | ((charcode >> 12) & 0x3F);
+          utf8_bytes[2]       = 0x80 | ((charcode >> 6) & 0x3F);
+          utf8_bytes[3]       = 0x80 | (charcode & 0x3F);
+          utf8_bytes_filled   = 4;
+        } else {
+          // unknown character
+          ++current_wchar;
+          utf8_bytes[0]     = wc;
+          utf8_bytes_filled = 1;
         }
+      }
     }
+  }
 };
 
-template<typename WideStringType>
-class wide_string_input_adapter : public input_adapter_protocol
-{
-  public:
-    explicit wide_string_input_adapter(const WideStringType& w)  noexcept
-        : str(w)
-    {}
+template <typename WideStringType>
+class wide_string_input_adapter : public input_adapter_protocol {
+public:
+  explicit wide_string_input_adapter(const WideStringType &w) noexcept
+      : str(w)
+  {
+  }
 
-    std::char_traits<char>::int_type get_character() noexcept override
-    {
-        // check if buffer needs to be filled
-        if (utf8_bytes_index == utf8_bytes_filled)
-        {
-            fill_buffer<sizeof(typename WideStringType::value_type)>();
+  std::char_traits<char>::int_type get_character() noexcept override
+  {
+    // check if buffer needs to be filled
+    if (utf8_bytes_index == utf8_bytes_filled) {
+      fill_buffer<sizeof(typename WideStringType::value_type)>();
 
-            assert(utf8_bytes_filled > 0);
-            assert(utf8_bytes_index == 0);
-        }
-
-        // use buffer
-        assert(utf8_bytes_filled > 0);
-        assert(utf8_bytes_index < utf8_bytes_filled);
-        return utf8_bytes[utf8_bytes_index++];
+      assert(utf8_bytes_filled > 0);
+      assert(utf8_bytes_index == 0);
     }
 
-  private:
-    template<size_t T>
-    void fill_buffer()
-    {
-        wide_string_input_helper<WideStringType, T>::fill_buffer(str, current_wchar, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
-    }
+    // use buffer
+    assert(utf8_bytes_filled > 0);
+    assert(utf8_bytes_index < utf8_bytes_filled);
+    return utf8_bytes[utf8_bytes_index++];
+  }
 
-    /// the wstring to process
-    const WideStringType& str;
+private:
+  template <size_t T>
+  void fill_buffer()
+  {
+    wide_string_input_helper<WideStringType, T>::fill_buffer(str, current_wchar, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
+  }
 
-    /// index of the current wchar in str
-    std::size_t current_wchar = 0;
+  /// the wstring to process
+  const WideStringType &str;
 
-    /// a buffer for UTF-8 bytes
-    std::array<std::char_traits<char>::int_type, 4> utf8_bytes = {{0, 0, 0, 0}};
+  /// index of the current wchar in str
+  std::size_t current_wchar = 0;
 
-    /// index to the utf8_codes array for the next valid byte
-    std::size_t utf8_bytes_index = 0;
-    /// number of valid bytes in the utf8_codes array
-    std::size_t utf8_bytes_filled = 0;
+  /// a buffer for UTF-8 bytes
+  std::array<std::char_traits<char>::int_type, 4> utf8_bytes = {{0, 0, 0, 0}};
+
+  /// index to the utf8_codes array for the next valid byte
+  std::size_t utf8_bytes_index = 0;
+  /// number of valid bytes in the utf8_codes array
+  std::size_t utf8_bytes_filled = 0;
 };
 
-class input_adapter
-{
-  public:
-    // native support
-    input_adapter(std::FILE* file)
-        : ia(std::make_shared<file_input_adapter>(file)) {}
-    /// input adapter for input stream
-    input_adapter(std::istream& i)
-        : ia(std::make_shared<input_stream_adapter>(i)) {}
+class input_adapter {
+public:
+  // native support
+  input_adapter(std::FILE *file)
+      : ia(std::make_shared<file_input_adapter>(file)) {}
+  /// input adapter for input stream
+  input_adapter(std::istream &i)
+      : ia(std::make_shared<input_stream_adapter>(i)) {}
 
-    /// input adapter for input stream
-    input_adapter(std::istream&& i)
-        : ia(std::make_shared<input_stream_adapter>(i)) {}
+  /// input adapter for input stream
+  input_adapter(std::istream &&i)
+      : ia(std::make_shared<input_stream_adapter>(i)) {}
 
-    input_adapter(const std::wstring& ws)
-        : ia(std::make_shared<wide_string_input_adapter<std::wstring>>(ws)) {}
+  input_adapter(const std::wstring &ws)
+      : ia(std::make_shared<wide_string_input_adapter<std::wstring>>(ws)) {}
 
-    input_adapter(const std::u16string& ws)
-        : ia(std::make_shared<wide_string_input_adapter<std::u16string>>(ws)) {}
+  input_adapter(const std::u16string &ws)
+      : ia(std::make_shared<wide_string_input_adapter<std::u16string>>(ws)) {}
 
-    input_adapter(const std::u32string& ws)
-        : ia(std::make_shared<wide_string_input_adapter<std::u32string>>(ws)) {}
+  input_adapter(const std::u32string &ws)
+      : ia(std::make_shared<wide_string_input_adapter<std::u32string>>(ws)) {}
 
-    /// input adapter for buffer
-    template<typename CharT,
-             typename std::enable_if<
-                 std::is_pointer<CharT>::value and
-                 std::is_integral<typename std::remove_pointer<CharT>::type>::value and
-                 sizeof(typename std::remove_pointer<CharT>::type) == 1,
-                 int>::type = 0>
-    input_adapter(CharT b, std::size_t l)
-        : ia(std::make_shared<input_buffer_adapter>(reinterpret_cast<const char*>(b), l)) {}
+  /// input adapter for buffer
+  template <typename CharT,
+            typename std::enable_if<
+                std::is_pointer<CharT>::value and
+                    std::is_integral<typename std::remove_pointer<CharT>::type>::value and
+                    sizeof(typename std::remove_pointer<CharT>::type) == 1,
+                int>::type = 0>
+  input_adapter(CharT b, std::size_t l)
+      : ia(std::make_shared<input_buffer_adapter>(reinterpret_cast<const char *>(b), l)) {}
 
-    // derived support
+  // derived support
 
-    /// input adapter for string literal
-    template<typename CharT,
-             typename std::enable_if<
-                 std::is_pointer<CharT>::value and
-                 std::is_integral<typename std::remove_pointer<CharT>::type>::value and
-                 sizeof(typename std::remove_pointer<CharT>::type) == 1,
-                 int>::type = 0>
-    input_adapter(CharT b)
-        : input_adapter(reinterpret_cast<const char*>(b),
-                        std::strlen(reinterpret_cast<const char*>(b))) {}
+  /// input adapter for string literal
+  template <typename CharT,
+            typename std::enable_if<
+                std::is_pointer<CharT>::value and
+                    std::is_integral<typename std::remove_pointer<CharT>::type>::value and
+                    sizeof(typename std::remove_pointer<CharT>::type) == 1,
+                int>::type = 0>
+  input_adapter(CharT b)
+      : input_adapter(reinterpret_cast<const char *>(b),
+                      std::strlen(reinterpret_cast<const char *>(b))) {}
 
-    /// input adapter for iterator range with contiguous storage
-    template<class IteratorType,
-             typename std::enable_if<
-                 std::is_same<typename iterator_traits<IteratorType>::iterator_category, std::random_access_iterator_tag>::value,
-                 int>::type = 0>
-    input_adapter(IteratorType first, IteratorType last)
-    {
+  /// input adapter for iterator range with contiguous storage
+  template <class IteratorType,
+            typename std::enable_if<
+                std::is_same<typename iterator_traits<IteratorType>::iterator_category, std::random_access_iterator_tag>::value,
+                int>::type = 0>
+  input_adapter(IteratorType first, IteratorType last)
+  {
 #ifndef NDEBUG
-        // assertion to check that the iterator range is indeed contiguous,
-        // see http://stackoverflow.com/a/35008842/266378 for more discussion
-        const auto is_contiguous = std::accumulate(
-                                       first, last, std::pair<bool, int>(true, 0),
-                                       [&first](std::pair<bool, int> res, decltype(*first) val)
-        {
-            res.first &= (val == *(std::next(std::addressof(*first), res.second++)));
-            return res;
-        }).first;
-        assert(is_contiguous);
+    // assertion to check that the iterator range is indeed contiguous,
+    // see http://stackoverflow.com/a/35008842/266378 for more discussion
+    const auto is_contiguous = std::accumulate(
+                                   first, last, std::pair<bool, int>(true, 0),
+                                   [&first](std::pair<bool, int> res, decltype(*first) val) {
+                                     res.first &= (val == *(std::next(std::addressof(*first), res.second++)));
+                                     return res;
+                                   })
+                                   .first;
+    assert(is_contiguous);
 #endif
 
-        // assertion to check that each element is 1 byte long
-        static_assert(
-            sizeof(typename iterator_traits<IteratorType>::value_type) == 1,
-            "each element in the iterator range must have the size of 1 byte");
+    // assertion to check that each element is 1 byte long
+    static_assert(
+        sizeof(typename iterator_traits<IteratorType>::value_type) == 1,
+        "each element in the iterator range must have the size of 1 byte");
 
-        const auto len = static_cast<size_t>(std::distance(first, last));
-        if (JSON_LIKELY(len > 0))
-        {
-            // there is at least one element: use the address of first
-            ia = std::make_shared<input_buffer_adapter>(reinterpret_cast<const char*>(&(*first)), len);
-        }
-        else
-        {
-            // the address of first cannot be used: use nullptr
-            ia = std::make_shared<input_buffer_adapter>(nullptr, len);
-        }
+    const auto len = static_cast<size_t>(std::distance(first, last));
+    if (JSON_LIKELY(len > 0)) {
+      // there is at least one element: use the address of first
+      ia = std::make_shared<input_buffer_adapter>(reinterpret_cast<const char *>(&(*first)), len);
+    } else {
+      // the address of first cannot be used: use nullptr
+      ia = std::make_shared<input_buffer_adapter>(nullptr, len);
     }
+  }
 
-    /// input adapter for array
-    template<class T, std::size_t N>
-    input_adapter(T (&array)[N])
-        : input_adapter(std::begin(array), std::end(array)) {}
+  /// input adapter for array
+  template <class T, std::size_t N>
+  input_adapter(T (&array)[N])
+      : input_adapter(std::begin(array), std::end(array)) {}
 
-    /// input adapter for contiguous container
-    template<class ContiguousContainer, typename
-             std::enable_if<not std::is_pointer<ContiguousContainer>::value and
-                            std::is_base_of<std::random_access_iterator_tag, typename iterator_traits<decltype(std::begin(std::declval<ContiguousContainer const>()))>::iterator_category>::value,
-                            int>::type = 0>
-    input_adapter(const ContiguousContainer& c)
-        : input_adapter(std::begin(c), std::end(c)) {}
+  /// input adapter for contiguous container
+  template <class ContiguousContainer, typename std::enable_if<not std::is_pointer<ContiguousContainer>::value and
+                                                                   std::is_base_of<std::random_access_iterator_tag, typename iterator_traits<decltype(std::begin(std::declval<ContiguousContainer const>()))>::iterator_category>::value,
+                                                               int>::type = 0>
+  input_adapter(const ContiguousContainer &c)
+      : input_adapter(std::begin(c), std::end(c)) {}
 
-    operator input_adapter_t()
-    {
-        return ia;
-    }
+  operator input_adapter_t()
+  {
+    return ia;
+  }
 
-  private:
-    /// the actual adapter
-    input_adapter_t ia = nullptr;
+private:
+  /// the actual adapter
+  input_adapter_t ia = nullptr;
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/input/lexer.hpp>
 
-
-#include <clocale> // localeconv
-#include <cstddef> // size_t
-#include <cstdlib> // strtof, strtod, strtold, strtoll, strtoull
-#include <cstdio> // snprintf
+#include <clocale>          // localeconv
+#include <cstddef>          // size_t
+#include <cstdio>           // snprintf
+#include <cstdlib>          // strtof, strtod, strtold, strtoll, strtoull
 #include <initializer_list> // initializer_list
-#include <string> // char_traits, string
-#include <vector> // vector
+#include <string>           // char_traits, string
+#include <vector>           // vector
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
@@ -2578,11 +2467,8 @@ class input_adapter
 
 // #include <nlohmann/detail/input/position_t.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 ///////////
 // lexer //
 ///////////
@@ -2592,109 +2478,106 @@ namespace detail
 
 This class organizes the lexical analysis during JSON deserialization.
 */
-template<typename BasicJsonType>
-class lexer
-{
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
+template <typename BasicJsonType>
+class lexer {
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
 
-  public:
-    /// token types for the parser
-    enum class token_type
-    {
-        uninitialized,    ///< indicating the scanner is uninitialized
-        literal_true,     ///< the `true` literal
-        literal_false,    ///< the `false` literal
-        literal_null,     ///< the `null` literal
-        value_string,     ///< a string -- use get_string() for actual value
-        value_unsigned,   ///< an unsigned integer -- use get_number_unsigned() for actual value
-        value_integer,    ///< a signed integer -- use get_number_integer() for actual value
-        value_float,      ///< an floating point number -- use get_number_float() for actual value
-        begin_array,      ///< the character for array begin `[`
-        begin_object,     ///< the character for object begin `{`
-        end_array,        ///< the character for array end `]`
-        end_object,       ///< the character for object end `}`
-        name_separator,   ///< the name separator `:`
-        value_separator,  ///< the value separator `,`
-        parse_error,      ///< indicating a parse error
-        end_of_input,     ///< indicating the end of the input buffer
-        literal_or_value  ///< a literal or the begin of a value (only for diagnostics)
-    };
+public:
+  /// token types for the parser
+  enum class token_type {
+    uninitialized,   ///< indicating the scanner is uninitialized
+    literal_true,    ///< the `true` literal
+    literal_false,   ///< the `false` literal
+    literal_null,    ///< the `null` literal
+    value_string,    ///< a string -- use get_string() for actual value
+    value_unsigned,  ///< an unsigned integer -- use get_number_unsigned() for actual value
+    value_integer,   ///< a signed integer -- use get_number_integer() for actual value
+    value_float,     ///< an floating point number -- use get_number_float() for actual value
+    begin_array,     ///< the character for array begin `[`
+    begin_object,    ///< the character for object begin `{`
+    end_array,       ///< the character for array end `]`
+    end_object,      ///< the character for object end `}`
+    name_separator,  ///< the name separator `:`
+    value_separator, ///< the value separator `,`
+    parse_error,     ///< indicating a parse error
+    end_of_input,    ///< indicating the end of the input buffer
+    literal_or_value ///< a literal or the begin of a value (only for diagnostics)
+  };
 
-    /// return name of values of type token_type (only used for errors)
-    static const char* token_type_name(const token_type t) noexcept
-    {
-        switch (t)
-        {
-            case token_type::uninitialized:
-                return "<uninitialized>";
-            case token_type::literal_true:
-                return "true literal";
-            case token_type::literal_false:
-                return "false literal";
-            case token_type::literal_null:
-                return "null literal";
-            case token_type::value_string:
-                return "string literal";
-            case lexer::token_type::value_unsigned:
-            case lexer::token_type::value_integer:
-            case lexer::token_type::value_float:
-                return "number literal";
-            case token_type::begin_array:
-                return "'['";
-            case token_type::begin_object:
-                return "'{'";
-            case token_type::end_array:
-                return "']'";
-            case token_type::end_object:
-                return "'}'";
-            case token_type::name_separator:
-                return "':'";
-            case token_type::value_separator:
-                return "','";
-            case token_type::parse_error:
-                return "<parse error>";
-            case token_type::end_of_input:
-                return "end of input";
-            case token_type::literal_or_value:
-                return "'[', '{', or a literal";
-            // LCOV_EXCL_START
-            default: // catch non-enum values
-                return "unknown token";
-                // LCOV_EXCL_STOP
-        }
+  /// return name of values of type token_type (only used for errors)
+  static const char *token_type_name(const token_type t) noexcept
+  {
+    switch (t) {
+    case token_type::uninitialized:
+      return "<uninitialized>";
+    case token_type::literal_true:
+      return "true literal";
+    case token_type::literal_false:
+      return "false literal";
+    case token_type::literal_null:
+      return "null literal";
+    case token_type::value_string:
+      return "string literal";
+    case lexer::token_type::value_unsigned:
+    case lexer::token_type::value_integer:
+    case lexer::token_type::value_float:
+      return "number literal";
+    case token_type::begin_array:
+      return "'['";
+    case token_type::begin_object:
+      return "'{'";
+    case token_type::end_array:
+      return "']'";
+    case token_type::end_object:
+      return "'}'";
+    case token_type::name_separator:
+      return "':'";
+    case token_type::value_separator:
+      return "','";
+    case token_type::parse_error:
+      return "<parse error>";
+    case token_type::end_of_input:
+      return "end of input";
+    case token_type::literal_or_value:
+      return "'[', '{', or a literal";
+    // LCOV_EXCL_START
+    default: // catch non-enum values
+      return "unknown token";
+      // LCOV_EXCL_STOP
     }
+  }
 
-    explicit lexer(detail::input_adapter_t&& adapter)
-        : ia(std::move(adapter)), decimal_point_char(get_decimal_point()) {}
+  explicit lexer(detail::input_adapter_t &&adapter)
+      : ia(std::move(adapter)), decimal_point_char(get_decimal_point()) {}
 
-    // delete because of pointer members
-    lexer(const lexer&) = delete;
-    lexer(lexer&&) = delete;
-    lexer& operator=(lexer&) = delete;
-    lexer& operator=(lexer&&) = delete;
-    ~lexer() = default;
+  // delete because of pointer members
+  lexer(const lexer &) = delete;
+  lexer(lexer &&)      = delete;
+  lexer &operator=(lexer &) = delete;
+  lexer &operator=(lexer &&) = delete;
+  ~lexer()                   = default;
 
-  private:
-    /////////////////////
-    // locales
-    /////////////////////
+private:
+  /////////////////////
+  // locales
+  /////////////////////
 
-    /// return the locale-dependent decimal point
-    static char get_decimal_point() noexcept
-    {
-        const auto loc = localeconv();
-        assert(loc != nullptr);
-        return (loc->decimal_point == nullptr) ? '.' : *(loc->decimal_point);
-    }
+  /// return the locale-dependent decimal point
+  static char get_decimal_point() noexcept
+  {
+    const auto loc = localeconv();
+    assert(loc != nullptr);
+    return (loc->decimal_point == nullptr) ? '.' : *(loc->decimal_point);
+  }
 
-    /////////////////////
-    // scan functions
-    /////////////////////
+  /////////////////////
+  // scan functions
+  /////////////////////
 
-    /*!
+  /*!
     @brief get codepoint from 4 hex characters following `\u`
 
     For input "\u c1 c2 c3 c4" the codepoint is:
@@ -2709,40 +2592,32 @@ class lexer
     @return codepoint (0x0000..0xFFFF) or -1 in case of an error (e.g. EOF or
             non-hex character)
     */
-    int get_codepoint()
-    {
-        // this function only makes sense after reading `\u`
-        assert(current == 'u');
-        int codepoint = 0;
+  int get_codepoint()
+  {
+    // this function only makes sense after reading `\u`
+    assert(current == 'u');
+    int codepoint = 0;
 
-        const auto factors = { 12, 8, 4, 0 };
-        for (const auto factor : factors)
-        {
-            get();
+    const auto factors = {12, 8, 4, 0};
+    for (const auto factor : factors) {
+      get();
 
-            if (current >= '0' and current <= '9')
-            {
-                codepoint += ((current - 0x30) << factor);
-            }
-            else if (current >= 'A' and current <= 'F')
-            {
-                codepoint += ((current - 0x37) << factor);
-            }
-            else if (current >= 'a' and current <= 'f')
-            {
-                codepoint += ((current - 0x57) << factor);
-            }
-            else
-            {
-                return -1;
-            }
-        }
-
-        assert(0x0000 <= codepoint and codepoint <= 0xFFFF);
-        return codepoint;
+      if (current >= '0' and current <= '9') {
+        codepoint += ((current - 0x30) << factor);
+      } else if (current >= 'A' and current <= 'F') {
+        codepoint += ((current - 0x37) << factor);
+      } else if (current >= 'a' and current <= 'f') {
+        codepoint += ((current - 0x57) << factor);
+      } else {
+        return -1;
+      }
     }
 
-    /*!
+    assert(0x0000 <= codepoint and codepoint <= 0xFFFF);
+    return codepoint;
+  }
+
+  /*!
     @brief check if the next byte(s) are inside a given range
 
     Adds the current byte and, for each passed range, reads a new byte and
@@ -2757,29 +2632,25 @@ class lexer
 
     @return true if and only if no range violation was detected
     */
-    bool next_byte_in_range(std::initializer_list<int> ranges)
-    {
-        assert(ranges.size() == 2 or ranges.size() == 4 or ranges.size() == 6);
+  bool next_byte_in_range(std::initializer_list<int> ranges)
+  {
+    assert(ranges.size() == 2 or ranges.size() == 4 or ranges.size() == 6);
+    add(current);
+
+    for (auto range = ranges.begin(); range != ranges.end(); ++range) {
+      get();
+      if (JSON_LIKELY(*range <= current and current <= *(++range))) {
         add(current);
-
-        for (auto range = ranges.begin(); range != ranges.end(); ++range)
-        {
-            get();
-            if (JSON_LIKELY(*range <= current and current <= *(++range)))
-            {
-                add(current);
-            }
-            else
-            {
-                error_message = "invalid string: ill-formed UTF-8 byte";
-                return false;
-            }
-        }
-
-        return true;
+      } else {
+        error_message = "invalid string: ill-formed UTF-8 byte";
+        return false;
+      }
     }
 
-    /*!
+    return true;
+  }
+
+  /*!
     @brief scan a string literal
 
     This function scans a string according to Sect. 7 of RFC 7159. While
@@ -2794,608 +2665,534 @@ class lexer
     @note In case of errors, variable error_message contains a textual
           description.
     */
-    token_type scan_string()
-    {
-        // reset token_buffer (ignore opening quote)
-        reset();
+  token_type scan_string()
+  {
+    // reset token_buffer (ignore opening quote)
+    reset();
 
-        // we entered the function by reading an open quote
-        assert(current == '\"');
+    // we entered the function by reading an open quote
+    assert(current == '\"');
 
-        while (true)
-        {
-            // get next character
-            switch (get())
-            {
-                // end of file while parsing string
-                case std::char_traits<char>::eof():
-                {
-                    error_message = "invalid string: missing closing quote";
-                    return token_type::parse_error;
-                }
+    while (true) {
+      // get next character
+      switch (get()) {
+      // end of file while parsing string
+      case std::char_traits<char>::eof(): {
+        error_message = "invalid string: missing closing quote";
+        return token_type::parse_error;
+      }
 
-                // closing quote
-                case '\"':
-                {
-                    return token_type::value_string;
-                }
+      // closing quote
+      case '\"': {
+        return token_type::value_string;
+      }
 
-                // escapes
-                case '\\':
-                {
-                    switch (get())
-                    {
-                        // quotation mark
-                        case '\"':
-                            add('\"');
-                            break;
-                        // reverse solidus
-                        case '\\':
-                            add('\\');
-                            break;
-                        // solidus
-                        case '/':
-                            add('/');
-                            break;
-                        // backspace
-                        case 'b':
-                            add('\b');
-                            break;
-                        // form feed
-                        case 'f':
-                            add('\f');
-                            break;
-                        // line feed
-                        case 'n':
-                            add('\n');
-                            break;
-                        // carriage return
-                        case 'r':
-                            add('\r');
-                            break;
-                        // tab
-                        case 't':
-                            add('\t');
-                            break;
+      // escapes
+      case '\\': {
+        switch (get()) {
+        // quotation mark
+        case '\"':
+          add('\"');
+          break;
+        // reverse solidus
+        case '\\':
+          add('\\');
+          break;
+        // solidus
+        case '/':
+          add('/');
+          break;
+        // backspace
+        case 'b':
+          add('\b');
+          break;
+        // form feed
+        case 'f':
+          add('\f');
+          break;
+        // line feed
+        case 'n':
+          add('\n');
+          break;
+        // carriage return
+        case 'r':
+          add('\r');
+          break;
+        // tab
+        case 't':
+          add('\t');
+          break;
 
-                        // unicode escapes
-                        case 'u':
-                        {
-                            const int codepoint1 = get_codepoint();
-                            int codepoint = codepoint1; // start with codepoint1
+        // unicode escapes
+        case 'u': {
+          const int codepoint1 = get_codepoint();
+          int       codepoint  = codepoint1; // start with codepoint1
 
-                            if (JSON_UNLIKELY(codepoint1 == -1))
-                            {
-                                error_message = "invalid string: '\\u' must be followed by 4 hex digits";
-                                return token_type::parse_error;
-                            }
+          if (JSON_UNLIKELY(codepoint1 == -1)) {
+            error_message = "invalid string: '\\u' must be followed by 4 hex digits";
+            return token_type::parse_error;
+          }
 
-                            // check if code point is a high surrogate
-                            if (0xD800 <= codepoint1 and codepoint1 <= 0xDBFF)
-                            {
-                                // expect next \uxxxx entry
-                                if (JSON_LIKELY(get() == '\\' and get() == 'u'))
-                                {
-                                    const int codepoint2 = get_codepoint();
+          // check if code point is a high surrogate
+          if (0xD800 <= codepoint1 and codepoint1 <= 0xDBFF) {
+            // expect next \uxxxx entry
+            if (JSON_LIKELY(get() == '\\' and get() == 'u')) {
+              const int codepoint2 = get_codepoint();
 
-                                    if (JSON_UNLIKELY(codepoint2 == -1))
-                                    {
-                                        error_message = "invalid string: '\\u' must be followed by 4 hex digits";
-                                        return token_type::parse_error;
-                                    }
+              if (JSON_UNLIKELY(codepoint2 == -1)) {
+                error_message = "invalid string: '\\u' must be followed by 4 hex digits";
+                return token_type::parse_error;
+              }
 
-                                    // check if codepoint2 is a low surrogate
-                                    if (JSON_LIKELY(0xDC00 <= codepoint2 and codepoint2 <= 0xDFFF))
-                                    {
-                                        // overwrite codepoint
-                                        codepoint =
-                                            // high surrogate occupies the most significant 22 bits
-                                            (codepoint1 << 10)
-                                            // low surrogate occupies the least significant 15 bits
-                                            + codepoint2
-                                            // there is still the 0xD800, 0xDC00 and 0x10000 noise
-                                            // in the result so we have to subtract with:
-                                            // (0xD800 << 10) + DC00 - 0x10000 = 0x35FDC00
-                                            - 0x35FDC00;
-                                    }
-                                    else
-                                    {
-                                        error_message = "invalid string: surrogate U+DC00..U+DFFF must be followed by U+DC00..U+DFFF";
-                                        return token_type::parse_error;
-                                    }
-                                }
-                                else
-                                {
-                                    error_message = "invalid string: surrogate U+DC00..U+DFFF must be followed by U+DC00..U+DFFF";
-                                    return token_type::parse_error;
-                                }
-                            }
-                            else
-                            {
-                                if (JSON_UNLIKELY(0xDC00 <= codepoint1 and codepoint1 <= 0xDFFF))
-                                {
-                                    error_message = "invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF";
-                                    return token_type::parse_error;
-                                }
-                            }
-
-                            // result of the above calculation yields a proper codepoint
-                            assert(0x00 <= codepoint and codepoint <= 0x10FFFF);
-
-                            // translate codepoint into bytes
-                            if (codepoint < 0x80)
-                            {
-                                // 1-byte characters: 0xxxxxxx (ASCII)
-                                add(codepoint);
-                            }
-                            else if (codepoint <= 0x7FF)
-                            {
-                                // 2-byte characters: 110xxxxx 10xxxxxx
-                                add(0xC0 | (codepoint >> 6));
-                                add(0x80 | (codepoint & 0x3F));
-                            }
-                            else if (codepoint <= 0xFFFF)
-                            {
-                                // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
-                                add(0xE0 | (codepoint >> 12));
-                                add(0x80 | ((codepoint >> 6) & 0x3F));
-                                add(0x80 | (codepoint & 0x3F));
-                            }
-                            else
-                            {
-                                // 4-byte characters: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-                                add(0xF0 | (codepoint >> 18));
-                                add(0x80 | ((codepoint >> 12) & 0x3F));
-                                add(0x80 | ((codepoint >> 6) & 0x3F));
-                                add(0x80 | (codepoint & 0x3F));
-                            }
-
-                            break;
-                        }
-
-                        // other characters after escape
-                        default:
-                            error_message = "invalid string: forbidden character after backslash";
-                            return token_type::parse_error;
-                    }
-
-                    break;
-                }
-
-                // invalid control characters
-                case 0x00:
-                {
-                    error_message = "invalid string: control character U+0000 (NUL) must be escaped to \\u0000";
-                    return token_type::parse_error;
-                }
-
-                case 0x01:
-                {
-                    error_message = "invalid string: control character U+0001 (SOH) must be escaped to \\u0001";
-                    return token_type::parse_error;
-                }
-
-                case 0x02:
-                {
-                    error_message = "invalid string: control character U+0002 (STX) must be escaped to \\u0002";
-                    return token_type::parse_error;
-                }
-
-                case 0x03:
-                {
-                    error_message = "invalid string: control character U+0003 (ETX) must be escaped to \\u0003";
-                    return token_type::parse_error;
-                }
-
-                case 0x04:
-                {
-                    error_message = "invalid string: control character U+0004 (EOT) must be escaped to \\u0004";
-                    return token_type::parse_error;
-                }
-
-                case 0x05:
-                {
-                    error_message = "invalid string: control character U+0005 (ENQ) must be escaped to \\u0005";
-                    return token_type::parse_error;
-                }
-
-                case 0x06:
-                {
-                    error_message = "invalid string: control character U+0006 (ACK) must be escaped to \\u0006";
-                    return token_type::parse_error;
-                }
-
-                case 0x07:
-                {
-                    error_message = "invalid string: control character U+0007 (BEL) must be escaped to \\u0007";
-                    return token_type::parse_error;
-                }
-
-                case 0x08:
-                {
-                    error_message = "invalid string: control character U+0008 (BS) must be escaped to \\u0008 or \\b";
-                    return token_type::parse_error;
-                }
-
-                case 0x09:
-                {
-                    error_message = "invalid string: control character U+0009 (HT) must be escaped to \\u0009 or \\t";
-                    return token_type::parse_error;
-                }
-
-                case 0x0A:
-                {
-                    error_message = "invalid string: control character U+000A (LF) must be escaped to \\u000A or \\n";
-                    return token_type::parse_error;
-                }
-
-                case 0x0B:
-                {
-                    error_message = "invalid string: control character U+000B (VT) must be escaped to \\u000B";
-                    return token_type::parse_error;
-                }
-
-                case 0x0C:
-                {
-                    error_message = "invalid string: control character U+000C (FF) must be escaped to \\u000C or \\f";
-                    return token_type::parse_error;
-                }
-
-                case 0x0D:
-                {
-                    error_message = "invalid string: control character U+000D (CR) must be escaped to \\u000D or \\r";
-                    return token_type::parse_error;
-                }
-
-                case 0x0E:
-                {
-                    error_message = "invalid string: control character U+000E (SO) must be escaped to \\u000E";
-                    return token_type::parse_error;
-                }
-
-                case 0x0F:
-                {
-                    error_message = "invalid string: control character U+000F (SI) must be escaped to \\u000F";
-                    return token_type::parse_error;
-                }
-
-                case 0x10:
-                {
-                    error_message = "invalid string: control character U+0010 (DLE) must be escaped to \\u0010";
-                    return token_type::parse_error;
-                }
-
-                case 0x11:
-                {
-                    error_message = "invalid string: control character U+0011 (DC1) must be escaped to \\u0011";
-                    return token_type::parse_error;
-                }
-
-                case 0x12:
-                {
-                    error_message = "invalid string: control character U+0012 (DC2) must be escaped to \\u0012";
-                    return token_type::parse_error;
-                }
-
-                case 0x13:
-                {
-                    error_message = "invalid string: control character U+0013 (DC3) must be escaped to \\u0013";
-                    return token_type::parse_error;
-                }
-
-                case 0x14:
-                {
-                    error_message = "invalid string: control character U+0014 (DC4) must be escaped to \\u0014";
-                    return token_type::parse_error;
-                }
-
-                case 0x15:
-                {
-                    error_message = "invalid string: control character U+0015 (NAK) must be escaped to \\u0015";
-                    return token_type::parse_error;
-                }
-
-                case 0x16:
-                {
-                    error_message = "invalid string: control character U+0016 (SYN) must be escaped to \\u0016";
-                    return token_type::parse_error;
-                }
-
-                case 0x17:
-                {
-                    error_message = "invalid string: control character U+0017 (ETB) must be escaped to \\u0017";
-                    return token_type::parse_error;
-                }
-
-                case 0x18:
-                {
-                    error_message = "invalid string: control character U+0018 (CAN) must be escaped to \\u0018";
-                    return token_type::parse_error;
-                }
-
-                case 0x19:
-                {
-                    error_message = "invalid string: control character U+0019 (EM) must be escaped to \\u0019";
-                    return token_type::parse_error;
-                }
-
-                case 0x1A:
-                {
-                    error_message = "invalid string: control character U+001A (SUB) must be escaped to \\u001A";
-                    return token_type::parse_error;
-                }
-
-                case 0x1B:
-                {
-                    error_message = "invalid string: control character U+001B (ESC) must be escaped to \\u001B";
-                    return token_type::parse_error;
-                }
-
-                case 0x1C:
-                {
-                    error_message = "invalid string: control character U+001C (FS) must be escaped to \\u001C";
-                    return token_type::parse_error;
-                }
-
-                case 0x1D:
-                {
-                    error_message = "invalid string: control character U+001D (GS) must be escaped to \\u001D";
-                    return token_type::parse_error;
-                }
-
-                case 0x1E:
-                {
-                    error_message = "invalid string: control character U+001E (RS) must be escaped to \\u001E";
-                    return token_type::parse_error;
-                }
-
-                case 0x1F:
-                {
-                    error_message = "invalid string: control character U+001F (US) must be escaped to \\u001F";
-                    return token_type::parse_error;
-                }
-
-                // U+0020..U+007F (except U+0022 (quote) and U+005C (backspace))
-                case 0x20:
-                case 0x21:
-                case 0x23:
-                case 0x24:
-                case 0x25:
-                case 0x26:
-                case 0x27:
-                case 0x28:
-                case 0x29:
-                case 0x2A:
-                case 0x2B:
-                case 0x2C:
-                case 0x2D:
-                case 0x2E:
-                case 0x2F:
-                case 0x30:
-                case 0x31:
-                case 0x32:
-                case 0x33:
-                case 0x34:
-                case 0x35:
-                case 0x36:
-                case 0x37:
-                case 0x38:
-                case 0x39:
-                case 0x3A:
-                case 0x3B:
-                case 0x3C:
-                case 0x3D:
-                case 0x3E:
-                case 0x3F:
-                case 0x40:
-                case 0x41:
-                case 0x42:
-                case 0x43:
-                case 0x44:
-                case 0x45:
-                case 0x46:
-                case 0x47:
-                case 0x48:
-                case 0x49:
-                case 0x4A:
-                case 0x4B:
-                case 0x4C:
-                case 0x4D:
-                case 0x4E:
-                case 0x4F:
-                case 0x50:
-                case 0x51:
-                case 0x52:
-                case 0x53:
-                case 0x54:
-                case 0x55:
-                case 0x56:
-                case 0x57:
-                case 0x58:
-                case 0x59:
-                case 0x5A:
-                case 0x5B:
-                case 0x5D:
-                case 0x5E:
-                case 0x5F:
-                case 0x60:
-                case 0x61:
-                case 0x62:
-                case 0x63:
-                case 0x64:
-                case 0x65:
-                case 0x66:
-                case 0x67:
-                case 0x68:
-                case 0x69:
-                case 0x6A:
-                case 0x6B:
-                case 0x6C:
-                case 0x6D:
-                case 0x6E:
-                case 0x6F:
-                case 0x70:
-                case 0x71:
-                case 0x72:
-                case 0x73:
-                case 0x74:
-                case 0x75:
-                case 0x76:
-                case 0x77:
-                case 0x78:
-                case 0x79:
-                case 0x7A:
-                case 0x7B:
-                case 0x7C:
-                case 0x7D:
-                case 0x7E:
-                case 0x7F:
-                {
-                    add(current);
-                    break;
-                }
-
-                // U+0080..U+07FF: bytes C2..DF 80..BF
-                case 0xC2:
-                case 0xC3:
-                case 0xC4:
-                case 0xC5:
-                case 0xC6:
-                case 0xC7:
-                case 0xC8:
-                case 0xC9:
-                case 0xCA:
-                case 0xCB:
-                case 0xCC:
-                case 0xCD:
-                case 0xCE:
-                case 0xCF:
-                case 0xD0:
-                case 0xD1:
-                case 0xD2:
-                case 0xD3:
-                case 0xD4:
-                case 0xD5:
-                case 0xD6:
-                case 0xD7:
-                case 0xD8:
-                case 0xD9:
-                case 0xDA:
-                case 0xDB:
-                case 0xDC:
-                case 0xDD:
-                case 0xDE:
-                case 0xDF:
-                {
-                    if (JSON_UNLIKELY(not next_byte_in_range({0x80, 0xBF})))
-                    {
-                        return token_type::parse_error;
-                    }
-                    break;
-                }
-
-                // U+0800..U+0FFF: bytes E0 A0..BF 80..BF
-                case 0xE0:
-                {
-                    if (JSON_UNLIKELY(not (next_byte_in_range({0xA0, 0xBF, 0x80, 0xBF}))))
-                    {
-                        return token_type::parse_error;
-                    }
-                    break;
-                }
-
-                // U+1000..U+CFFF: bytes E1..EC 80..BF 80..BF
-                // U+E000..U+FFFF: bytes EE..EF 80..BF 80..BF
-                case 0xE1:
-                case 0xE2:
-                case 0xE3:
-                case 0xE4:
-                case 0xE5:
-                case 0xE6:
-                case 0xE7:
-                case 0xE8:
-                case 0xE9:
-                case 0xEA:
-                case 0xEB:
-                case 0xEC:
-                case 0xEE:
-                case 0xEF:
-                {
-                    if (JSON_UNLIKELY(not (next_byte_in_range({0x80, 0xBF, 0x80, 0xBF}))))
-                    {
-                        return token_type::parse_error;
-                    }
-                    break;
-                }
-
-                // U+D000..U+D7FF: bytes ED 80..9F 80..BF
-                case 0xED:
-                {
-                    if (JSON_UNLIKELY(not (next_byte_in_range({0x80, 0x9F, 0x80, 0xBF}))))
-                    {
-                        return token_type::parse_error;
-                    }
-                    break;
-                }
-
-                // U+10000..U+3FFFF F0 90..BF 80..BF 80..BF
-                case 0xF0:
-                {
-                    if (JSON_UNLIKELY(not (next_byte_in_range({0x90, 0xBF, 0x80, 0xBF, 0x80, 0xBF}))))
-                    {
-                        return token_type::parse_error;
-                    }
-                    break;
-                }
-
-                // U+40000..U+FFFFF F1..F3 80..BF 80..BF 80..BF
-                case 0xF1:
-                case 0xF2:
-                case 0xF3:
-                {
-                    if (JSON_UNLIKELY(not (next_byte_in_range({0x80, 0xBF, 0x80, 0xBF, 0x80, 0xBF}))))
-                    {
-                        return token_type::parse_error;
-                    }
-                    break;
-                }
-
-                // U+100000..U+10FFFF F4 80..8F 80..BF 80..BF
-                case 0xF4:
-                {
-                    if (JSON_UNLIKELY(not (next_byte_in_range({0x80, 0x8F, 0x80, 0xBF, 0x80, 0xBF}))))
-                    {
-                        return token_type::parse_error;
-                    }
-                    break;
-                }
-
-                // remaining bytes (80..C1 and F5..FF) are ill-formed
-                default:
-                {
-                    error_message = "invalid string: ill-formed UTF-8 byte";
-                    return token_type::parse_error;
-                }
+              // check if codepoint2 is a low surrogate
+              if (JSON_LIKELY(0xDC00 <= codepoint2 and codepoint2 <= 0xDFFF)) {
+                // overwrite codepoint
+                codepoint =
+                    // high surrogate occupies the most significant 22 bits
+                    (codepoint1 << 10)
+                    // low surrogate occupies the least significant 15 bits
+                    + codepoint2
+                    // there is still the 0xD800, 0xDC00 and 0x10000 noise
+                    // in the result so we have to subtract with:
+                    // (0xD800 << 10) + DC00 - 0x10000 = 0x35FDC00
+                    - 0x35FDC00;
+              } else {
+                error_message = "invalid string: surrogate U+DC00..U+DFFF must be followed by U+DC00..U+DFFF";
+                return token_type::parse_error;
+              }
+            } else {
+              error_message = "invalid string: surrogate U+DC00..U+DFFF must be followed by U+DC00..U+DFFF";
+              return token_type::parse_error;
             }
+          } else {
+            if (JSON_UNLIKELY(0xDC00 <= codepoint1 and codepoint1 <= 0xDFFF)) {
+              error_message = "invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF";
+              return token_type::parse_error;
+            }
+          }
+
+          // result of the above calculation yields a proper codepoint
+          assert(0x00 <= codepoint and codepoint <= 0x10FFFF);
+
+          // translate codepoint into bytes
+          if (codepoint < 0x80) {
+            // 1-byte characters: 0xxxxxxx (ASCII)
+            add(codepoint);
+          } else if (codepoint <= 0x7FF) {
+            // 2-byte characters: 110xxxxx 10xxxxxx
+            add(0xC0 | (codepoint >> 6));
+            add(0x80 | (codepoint & 0x3F));
+          } else if (codepoint <= 0xFFFF) {
+            // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
+            add(0xE0 | (codepoint >> 12));
+            add(0x80 | ((codepoint >> 6) & 0x3F));
+            add(0x80 | (codepoint & 0x3F));
+          } else {
+            // 4-byte characters: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+            add(0xF0 | (codepoint >> 18));
+            add(0x80 | ((codepoint >> 12) & 0x3F));
+            add(0x80 | ((codepoint >> 6) & 0x3F));
+            add(0x80 | (codepoint & 0x3F));
+          }
+
+          break;
         }
-    }
 
-    static void strtof(float& f, const char* str, char** endptr) noexcept
-    {
-        f = std::strtof(str, endptr);
-    }
+        // other characters after escape
+        default:
+          error_message = "invalid string: forbidden character after backslash";
+          return token_type::parse_error;
+        }
 
-    static void strtof(double& f, const char* str, char** endptr) noexcept
-    {
-        f = std::strtod(str, endptr);
-    }
+        break;
+      }
 
-    static void strtof(long double& f, const char* str, char** endptr) noexcept
-    {
-        f = std::strtold(str, endptr);
-    }
+      // invalid control characters
+      case 0x00: {
+        error_message = "invalid string: control character U+0000 (NUL) must be escaped to \\u0000";
+        return token_type::parse_error;
+      }
 
-    /*!
+      case 0x01: {
+        error_message = "invalid string: control character U+0001 (SOH) must be escaped to \\u0001";
+        return token_type::parse_error;
+      }
+
+      case 0x02: {
+        error_message = "invalid string: control character U+0002 (STX) must be escaped to \\u0002";
+        return token_type::parse_error;
+      }
+
+      case 0x03: {
+        error_message = "invalid string: control character U+0003 (ETX) must be escaped to \\u0003";
+        return token_type::parse_error;
+      }
+
+      case 0x04: {
+        error_message = "invalid string: control character U+0004 (EOT) must be escaped to \\u0004";
+        return token_type::parse_error;
+      }
+
+      case 0x05: {
+        error_message = "invalid string: control character U+0005 (ENQ) must be escaped to \\u0005";
+        return token_type::parse_error;
+      }
+
+      case 0x06: {
+        error_message = "invalid string: control character U+0006 (ACK) must be escaped to \\u0006";
+        return token_type::parse_error;
+      }
+
+      case 0x07: {
+        error_message = "invalid string: control character U+0007 (BEL) must be escaped to \\u0007";
+        return token_type::parse_error;
+      }
+
+      case 0x08: {
+        error_message = "invalid string: control character U+0008 (BS) must be escaped to \\u0008 or \\b";
+        return token_type::parse_error;
+      }
+
+      case 0x09: {
+        error_message = "invalid string: control character U+0009 (HT) must be escaped to \\u0009 or \\t";
+        return token_type::parse_error;
+      }
+
+      case 0x0A: {
+        error_message = "invalid string: control character U+000A (LF) must be escaped to \\u000A or \\n";
+        return token_type::parse_error;
+      }
+
+      case 0x0B: {
+        error_message = "invalid string: control character U+000B (VT) must be escaped to \\u000B";
+        return token_type::parse_error;
+      }
+
+      case 0x0C: {
+        error_message = "invalid string: control character U+000C (FF) must be escaped to \\u000C or \\f";
+        return token_type::parse_error;
+      }
+
+      case 0x0D: {
+        error_message = "invalid string: control character U+000D (CR) must be escaped to \\u000D or \\r";
+        return token_type::parse_error;
+      }
+
+      case 0x0E: {
+        error_message = "invalid string: control character U+000E (SO) must be escaped to \\u000E";
+        return token_type::parse_error;
+      }
+
+      case 0x0F: {
+        error_message = "invalid string: control character U+000F (SI) must be escaped to \\u000F";
+        return token_type::parse_error;
+      }
+
+      case 0x10: {
+        error_message = "invalid string: control character U+0010 (DLE) must be escaped to \\u0010";
+        return token_type::parse_error;
+      }
+
+      case 0x11: {
+        error_message = "invalid string: control character U+0011 (DC1) must be escaped to \\u0011";
+        return token_type::parse_error;
+      }
+
+      case 0x12: {
+        error_message = "invalid string: control character U+0012 (DC2) must be escaped to \\u0012";
+        return token_type::parse_error;
+      }
+
+      case 0x13: {
+        error_message = "invalid string: control character U+0013 (DC3) must be escaped to \\u0013";
+        return token_type::parse_error;
+      }
+
+      case 0x14: {
+        error_message = "invalid string: control character U+0014 (DC4) must be escaped to \\u0014";
+        return token_type::parse_error;
+      }
+
+      case 0x15: {
+        error_message = "invalid string: control character U+0015 (NAK) must be escaped to \\u0015";
+        return token_type::parse_error;
+      }
+
+      case 0x16: {
+        error_message = "invalid string: control character U+0016 (SYN) must be escaped to \\u0016";
+        return token_type::parse_error;
+      }
+
+      case 0x17: {
+        error_message = "invalid string: control character U+0017 (ETB) must be escaped to \\u0017";
+        return token_type::parse_error;
+      }
+
+      case 0x18: {
+        error_message = "invalid string: control character U+0018 (CAN) must be escaped to \\u0018";
+        return token_type::parse_error;
+      }
+
+      case 0x19: {
+        error_message = "invalid string: control character U+0019 (EM) must be escaped to \\u0019";
+        return token_type::parse_error;
+      }
+
+      case 0x1A: {
+        error_message = "invalid string: control character U+001A (SUB) must be escaped to \\u001A";
+        return token_type::parse_error;
+      }
+
+      case 0x1B: {
+        error_message = "invalid string: control character U+001B (ESC) must be escaped to \\u001B";
+        return token_type::parse_error;
+      }
+
+      case 0x1C: {
+        error_message = "invalid string: control character U+001C (FS) must be escaped to \\u001C";
+        return token_type::parse_error;
+      }
+
+      case 0x1D: {
+        error_message = "invalid string: control character U+001D (GS) must be escaped to \\u001D";
+        return token_type::parse_error;
+      }
+
+      case 0x1E: {
+        error_message = "invalid string: control character U+001E (RS) must be escaped to \\u001E";
+        return token_type::parse_error;
+      }
+
+      case 0x1F: {
+        error_message = "invalid string: control character U+001F (US) must be escaped to \\u001F";
+        return token_type::parse_error;
+      }
+
+      // U+0020..U+007F (except U+0022 (quote) and U+005C (backspace))
+      case 0x20:
+      case 0x21:
+      case 0x23:
+      case 0x24:
+      case 0x25:
+      case 0x26:
+      case 0x27:
+      case 0x28:
+      case 0x29:
+      case 0x2A:
+      case 0x2B:
+      case 0x2C:
+      case 0x2D:
+      case 0x2E:
+      case 0x2F:
+      case 0x30:
+      case 0x31:
+      case 0x32:
+      case 0x33:
+      case 0x34:
+      case 0x35:
+      case 0x36:
+      case 0x37:
+      case 0x38:
+      case 0x39:
+      case 0x3A:
+      case 0x3B:
+      case 0x3C:
+      case 0x3D:
+      case 0x3E:
+      case 0x3F:
+      case 0x40:
+      case 0x41:
+      case 0x42:
+      case 0x43:
+      case 0x44:
+      case 0x45:
+      case 0x46:
+      case 0x47:
+      case 0x48:
+      case 0x49:
+      case 0x4A:
+      case 0x4B:
+      case 0x4C:
+      case 0x4D:
+      case 0x4E:
+      case 0x4F:
+      case 0x50:
+      case 0x51:
+      case 0x52:
+      case 0x53:
+      case 0x54:
+      case 0x55:
+      case 0x56:
+      case 0x57:
+      case 0x58:
+      case 0x59:
+      case 0x5A:
+      case 0x5B:
+      case 0x5D:
+      case 0x5E:
+      case 0x5F:
+      case 0x60:
+      case 0x61:
+      case 0x62:
+      case 0x63:
+      case 0x64:
+      case 0x65:
+      case 0x66:
+      case 0x67:
+      case 0x68:
+      case 0x69:
+      case 0x6A:
+      case 0x6B:
+      case 0x6C:
+      case 0x6D:
+      case 0x6E:
+      case 0x6F:
+      case 0x70:
+      case 0x71:
+      case 0x72:
+      case 0x73:
+      case 0x74:
+      case 0x75:
+      case 0x76:
+      case 0x77:
+      case 0x78:
+      case 0x79:
+      case 0x7A:
+      case 0x7B:
+      case 0x7C:
+      case 0x7D:
+      case 0x7E:
+      case 0x7F: {
+        add(current);
+        break;
+      }
+
+      // U+0080..U+07FF: bytes C2..DF 80..BF
+      case 0xC2:
+      case 0xC3:
+      case 0xC4:
+      case 0xC5:
+      case 0xC6:
+      case 0xC7:
+      case 0xC8:
+      case 0xC9:
+      case 0xCA:
+      case 0xCB:
+      case 0xCC:
+      case 0xCD:
+      case 0xCE:
+      case 0xCF:
+      case 0xD0:
+      case 0xD1:
+      case 0xD2:
+      case 0xD3:
+      case 0xD4:
+      case 0xD5:
+      case 0xD6:
+      case 0xD7:
+      case 0xD8:
+      case 0xD9:
+      case 0xDA:
+      case 0xDB:
+      case 0xDC:
+      case 0xDD:
+      case 0xDE:
+      case 0xDF: {
+        if (JSON_UNLIKELY(not next_byte_in_range({0x80, 0xBF}))) {
+          return token_type::parse_error;
+        }
+        break;
+      }
+
+      // U+0800..U+0FFF: bytes E0 A0..BF 80..BF
+      case 0xE0: {
+        if (JSON_UNLIKELY(not(next_byte_in_range({0xA0, 0xBF, 0x80, 0xBF})))) {
+          return token_type::parse_error;
+        }
+        break;
+      }
+
+      // U+1000..U+CFFF: bytes E1..EC 80..BF 80..BF
+      // U+E000..U+FFFF: bytes EE..EF 80..BF 80..BF
+      case 0xE1:
+      case 0xE2:
+      case 0xE3:
+      case 0xE4:
+      case 0xE5:
+      case 0xE6:
+      case 0xE7:
+      case 0xE8:
+      case 0xE9:
+      case 0xEA:
+      case 0xEB:
+      case 0xEC:
+      case 0xEE:
+      case 0xEF: {
+        if (JSON_UNLIKELY(not(next_byte_in_range({0x80, 0xBF, 0x80, 0xBF})))) {
+          return token_type::parse_error;
+        }
+        break;
+      }
+
+      // U+D000..U+D7FF: bytes ED 80..9F 80..BF
+      case 0xED: {
+        if (JSON_UNLIKELY(not(next_byte_in_range({0x80, 0x9F, 0x80, 0xBF})))) {
+          return token_type::parse_error;
+        }
+        break;
+      }
+
+      // U+10000..U+3FFFF F0 90..BF 80..BF 80..BF
+      case 0xF0: {
+        if (JSON_UNLIKELY(not(next_byte_in_range({0x90, 0xBF, 0x80, 0xBF, 0x80, 0xBF})))) {
+          return token_type::parse_error;
+        }
+        break;
+      }
+
+      // U+40000..U+FFFFF F1..F3 80..BF 80..BF 80..BF
+      case 0xF1:
+      case 0xF2:
+      case 0xF3: {
+        if (JSON_UNLIKELY(not(next_byte_in_range({0x80, 0xBF, 0x80, 0xBF, 0x80, 0xBF})))) {
+          return token_type::parse_error;
+        }
+        break;
+      }
+
+      // U+100000..U+10FFFF F4 80..8F 80..BF 80..BF
+      case 0xF4: {
+        if (JSON_UNLIKELY(not(next_byte_in_range({0x80, 0x8F, 0x80, 0xBF, 0x80, 0xBF})))) {
+          return token_type::parse_error;
+        }
+        break;
+      }
+
+      // remaining bytes (80..C1 and F5..FF) are ill-formed
+      default: {
+        error_message = "invalid string: ill-formed UTF-8 byte";
+        return token_type::parse_error;
+      }
+      }
+    }
+  }
+
+  static void strtof(float &f, const char *str, char **endptr) noexcept
+  {
+    f = std::strtof(str, endptr);
+  }
+
+  static void strtof(double &f, const char *str, char **endptr) noexcept
+  {
+    f = std::strtod(str, endptr);
+  }
+
+  static void strtof(long double &f, const char *str, char **endptr) noexcept
+  {
+    f = std::strtold(str, endptr);
+  }
+
+  /*!
     @brief scan a number literal
 
     This function scans a string according to Sect. 6 of RFC 7159.
@@ -3435,368 +3232,328 @@ class lexer
           locale's decimal point is used instead of `.` to work with the
           locale-dependent converters.
     */
-    token_type scan_number()  // lgtm [cpp/use-of-goto]
-    {
-        // reset token_buffer to store the number's bytes
-        reset();
+  token_type scan_number() // lgtm [cpp/use-of-goto]
+  {
+    // reset token_buffer to store the number's bytes
+    reset();
 
-        // the type of the parsed number; initially set to unsigned; will be
-        // changed if minus sign, decimal point or exponent is read
-        token_type number_type = token_type::value_unsigned;
+    // the type of the parsed number; initially set to unsigned; will be
+    // changed if minus sign, decimal point or exponent is read
+    token_type number_type = token_type::value_unsigned;
 
-        // state (init): we just found out we need to scan a number
-        switch (current)
-        {
-            case '-':
-            {
-                add(current);
-                goto scan_number_minus;
-            }
-
-            case '0':
-            {
-                add(current);
-                goto scan_number_zero;
-            }
-
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_any1;
-            }
-
-            // LCOV_EXCL_START
-            default:
-            {
-                // all other characters are rejected outside scan_number()
-                assert(false);
-            }
-                // LCOV_EXCL_STOP
-        }
-
-scan_number_minus:
-        // state: we just parsed a leading minus sign
-        number_type = token_type::value_integer;
-        switch (get())
-        {
-            case '0':
-            {
-                add(current);
-                goto scan_number_zero;
-            }
-
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_any1;
-            }
-
-            default:
-            {
-                error_message = "invalid number; expected digit after '-'";
-                return token_type::parse_error;
-            }
-        }
-
-scan_number_zero:
-        // state: we just parse a zero (maybe with a leading minus sign)
-        switch (get())
-        {
-            case '.':
-            {
-                add(decimal_point_char);
-                goto scan_number_decimal1;
-            }
-
-            case 'e':
-            case 'E':
-            {
-                add(current);
-                goto scan_number_exponent;
-            }
-
-            default:
-                goto scan_number_done;
-        }
-
-scan_number_any1:
-        // state: we just parsed a number 0-9 (maybe with a leading minus sign)
-        switch (get())
-        {
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_any1;
-            }
-
-            case '.':
-            {
-                add(decimal_point_char);
-                goto scan_number_decimal1;
-            }
-
-            case 'e':
-            case 'E':
-            {
-                add(current);
-                goto scan_number_exponent;
-            }
-
-            default:
-                goto scan_number_done;
-        }
-
-scan_number_decimal1:
-        // state: we just parsed a decimal point
-        number_type = token_type::value_float;
-        switch (get())
-        {
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_decimal2;
-            }
-
-            default:
-            {
-                error_message = "invalid number; expected digit after '.'";
-                return token_type::parse_error;
-            }
-        }
-
-scan_number_decimal2:
-        // we just parsed at least one number after a decimal point
-        switch (get())
-        {
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_decimal2;
-            }
-
-            case 'e':
-            case 'E':
-            {
-                add(current);
-                goto scan_number_exponent;
-            }
-
-            default:
-                goto scan_number_done;
-        }
-
-scan_number_exponent:
-        // we just parsed an exponent
-        number_type = token_type::value_float;
-        switch (get())
-        {
-            case '+':
-            case '-':
-            {
-                add(current);
-                goto scan_number_sign;
-            }
-
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_any2;
-            }
-
-            default:
-            {
-                error_message =
-                    "invalid number; expected '+', '-', or digit after exponent";
-                return token_type::parse_error;
-            }
-        }
-
-scan_number_sign:
-        // we just parsed an exponent sign
-        switch (get())
-        {
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_any2;
-            }
-
-            default:
-            {
-                error_message = "invalid number; expected digit after exponent sign";
-                return token_type::parse_error;
-            }
-        }
-
-scan_number_any2:
-        // we just parsed a number after the exponent or exponent sign
-        switch (get())
-        {
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-            {
-                add(current);
-                goto scan_number_any2;
-            }
-
-            default:
-                goto scan_number_done;
-        }
-
-scan_number_done:
-        // unget the character after the number (we only read it to know that
-        // we are done scanning a number)
-        unget();
-
-        char* endptr = nullptr;
-        errno = 0;
-
-        // try to parse integers first and fall back to floats
-        if (number_type == token_type::value_unsigned)
-        {
-            const auto x = std::strtoull(token_buffer.data(), &endptr, 10);
-
-            // we checked the number format before
-            assert(endptr == token_buffer.data() + token_buffer.size());
-
-            if (errno == 0)
-            {
-                value_unsigned = static_cast<number_unsigned_t>(x);
-                if (value_unsigned == x)
-                {
-                    return token_type::value_unsigned;
-                }
-            }
-        }
-        else if (number_type == token_type::value_integer)
-        {
-            const auto x = std::strtoll(token_buffer.data(), &endptr, 10);
-
-            // we checked the number format before
-            assert(endptr == token_buffer.data() + token_buffer.size());
-
-            if (errno == 0)
-            {
-                value_integer = static_cast<number_integer_t>(x);
-                if (value_integer == x)
-                {
-                    return token_type::value_integer;
-                }
-            }
-        }
-
-        // this code is reached if we parse a floating-point number or if an
-        // integer conversion above failed
-        strtof(value_float, token_buffer.data(), &endptr);
-
-        // we checked the number format before
-        assert(endptr == token_buffer.data() + token_buffer.size());
-
-        return token_type::value_float;
+    // state (init): we just found out we need to scan a number
+    switch (current) {
+    case '-': {
+      add(current);
+      goto scan_number_minus;
     }
 
-    /*!
+    case '0': {
+      add(current);
+      goto scan_number_zero;
+    }
+
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_any1;
+    }
+
+    // LCOV_EXCL_START
+    default: {
+      // all other characters are rejected outside scan_number()
+      assert(false);
+    }
+      // LCOV_EXCL_STOP
+    }
+
+  scan_number_minus:
+    // state: we just parsed a leading minus sign
+    number_type = token_type::value_integer;
+    switch (get()) {
+    case '0': {
+      add(current);
+      goto scan_number_zero;
+    }
+
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_any1;
+    }
+
+    default: {
+      error_message = "invalid number; expected digit after '-'";
+      return token_type::parse_error;
+    }
+    }
+
+  scan_number_zero:
+    // state: we just parse a zero (maybe with a leading minus sign)
+    switch (get()) {
+    case '.': {
+      add(decimal_point_char);
+      goto scan_number_decimal1;
+    }
+
+    case 'e':
+    case 'E': {
+      add(current);
+      goto scan_number_exponent;
+    }
+
+    default:
+      goto scan_number_done;
+    }
+
+  scan_number_any1:
+    // state: we just parsed a number 0-9 (maybe with a leading minus sign)
+    switch (get()) {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_any1;
+    }
+
+    case '.': {
+      add(decimal_point_char);
+      goto scan_number_decimal1;
+    }
+
+    case 'e':
+    case 'E': {
+      add(current);
+      goto scan_number_exponent;
+    }
+
+    default:
+      goto scan_number_done;
+    }
+
+  scan_number_decimal1:
+    // state: we just parsed a decimal point
+    number_type = token_type::value_float;
+    switch (get()) {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_decimal2;
+    }
+
+    default: {
+      error_message = "invalid number; expected digit after '.'";
+      return token_type::parse_error;
+    }
+    }
+
+  scan_number_decimal2:
+    // we just parsed at least one number after a decimal point
+    switch (get()) {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_decimal2;
+    }
+
+    case 'e':
+    case 'E': {
+      add(current);
+      goto scan_number_exponent;
+    }
+
+    default:
+      goto scan_number_done;
+    }
+
+  scan_number_exponent:
+    // we just parsed an exponent
+    number_type = token_type::value_float;
+    switch (get()) {
+    case '+':
+    case '-': {
+      add(current);
+      goto scan_number_sign;
+    }
+
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_any2;
+    }
+
+    default: {
+      error_message =
+          "invalid number; expected '+', '-', or digit after exponent";
+      return token_type::parse_error;
+    }
+    }
+
+  scan_number_sign:
+    // we just parsed an exponent sign
+    switch (get()) {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_any2;
+    }
+
+    default: {
+      error_message = "invalid number; expected digit after exponent sign";
+      return token_type::parse_error;
+    }
+    }
+
+  scan_number_any2:
+    // we just parsed a number after the exponent or exponent sign
+    switch (get()) {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      add(current);
+      goto scan_number_any2;
+    }
+
+    default:
+      goto scan_number_done;
+    }
+
+  scan_number_done:
+    // unget the character after the number (we only read it to know that
+    // we are done scanning a number)
+    unget();
+
+    char *endptr = nullptr;
+    errno        = 0;
+
+    // try to parse integers first and fall back to floats
+    if (number_type == token_type::value_unsigned) {
+      const auto x = std::strtoull(token_buffer.data(), &endptr, 10);
+
+      // we checked the number format before
+      assert(endptr == token_buffer.data() + token_buffer.size());
+
+      if (errno == 0) {
+        value_unsigned = static_cast<number_unsigned_t>(x);
+        if (value_unsigned == x) {
+          return token_type::value_unsigned;
+        }
+      }
+    } else if (number_type == token_type::value_integer) {
+      const auto x = std::strtoll(token_buffer.data(), &endptr, 10);
+
+      // we checked the number format before
+      assert(endptr == token_buffer.data() + token_buffer.size());
+
+      if (errno == 0) {
+        value_integer = static_cast<number_integer_t>(x);
+        if (value_integer == x) {
+          return token_type::value_integer;
+        }
+      }
+    }
+
+    // this code is reached if we parse a floating-point number or if an
+    // integer conversion above failed
+    strtof(value_float, token_buffer.data(), &endptr);
+
+    // we checked the number format before
+    assert(endptr == token_buffer.data() + token_buffer.size());
+
+    return token_type::value_float;
+  }
+
+  /*!
     @param[in] literal_text  the literal text to expect
     @param[in] length        the length of the passed literal text
     @param[in] return_type   the token type to return on success
     */
-    token_type scan_literal(const char* literal_text, const std::size_t length,
-                            token_type return_type)
-    {
-        assert(current == literal_text[0]);
-        for (std::size_t i = 1; i < length; ++i)
-        {
-            if (JSON_UNLIKELY(get() != literal_text[i]))
-            {
-                error_message = "invalid literal";
-                return token_type::parse_error;
-            }
-        }
-        return return_type;
+  token_type scan_literal(const char *literal_text, const std::size_t length,
+                          token_type return_type)
+  {
+    assert(current == literal_text[0]);
+    for (std::size_t i = 1; i < length; ++i) {
+      if (JSON_UNLIKELY(get() != literal_text[i])) {
+        error_message = "invalid literal";
+        return token_type::parse_error;
+      }
     }
+    return return_type;
+  }
 
-    /////////////////////
-    // input management
-    /////////////////////
+  /////////////////////
+  // input management
+  /////////////////////
 
-    /// reset token_buffer; current character is beginning of token
-    void reset() noexcept
-    {
-        token_buffer.clear();
-        token_string.clear();
-        token_string.push_back(std::char_traits<char>::to_char_type(current));
-    }
+  /// reset token_buffer; current character is beginning of token
+  void reset() noexcept
+  {
+    token_buffer.clear();
+    token_string.clear();
+    token_string.push_back(std::char_traits<char>::to_char_type(current));
+  }
 
-    /*
+  /*
     @brief get next character from the input
 
     This function provides the interface to the used input adapter. It does
@@ -3806,36 +3563,31 @@ scan_number_done:
 
     @return character read from the input
     */
-    std::char_traits<char>::int_type get()
-    {
-        ++position.chars_read_total;
-        ++position.chars_read_current_line;
+  std::char_traits<char>::int_type get()
+  {
+    ++position.chars_read_total;
+    ++position.chars_read_current_line;
 
-        if (next_unget)
-        {
-            // just reset the next_unget variable and work with current
-            next_unget = false;
-        }
-        else
-        {
-            current = ia->get_character();
-        }
-
-        if (JSON_LIKELY(current != std::char_traits<char>::eof()))
-        {
-            token_string.push_back(std::char_traits<char>::to_char_type(current));
-        }
-
-        if (current == '\n')
-        {
-            ++position.lines_read;
-            position.chars_read_current_line = 0;
-        }
-
-        return current;
+    if (next_unget) {
+      // just reset the next_unget variable and work with current
+      next_unget = false;
+    } else {
+      current = ia->get_character();
     }
 
-    /*!
+    if (JSON_LIKELY(current != std::char_traits<char>::eof())) {
+      token_string.push_back(std::char_traits<char>::to_char_type(current));
+    }
+
+    if (current == '\n') {
+      ++position.lines_read;
+      position.chars_read_current_line = 0;
+    }
+
+    return current;
+  }
+
+  /*!
     @brief unget current character (read it again on next get)
 
     We implement unget by setting variable next_unget to true. The input is not
@@ -3843,251 +3595,235 @@ scan_number_done:
     chars_read_current_line, and token_string. The next call to get() will
     behave as if the unget character is read again.
     */
-    void unget()
-    {
-        next_unget = true;
+  void unget()
+  {
+    next_unget = true;
 
-        --position.chars_read_total;
+    --position.chars_read_total;
 
-        // in case we "unget" a newline, we have to also decrement the lines_read
-        if (position.chars_read_current_line == 0)
-        {
-            if (position.lines_read > 0)
-            {
-                --position.lines_read;
-            }
-        }
-        else
-        {
-            --position.chars_read_current_line;
-        }
-
-        if (JSON_LIKELY(current != std::char_traits<char>::eof()))
-        {
-            assert(token_string.size() != 0);
-            token_string.pop_back();
-        }
+    // in case we "unget" a newline, we have to also decrement the lines_read
+    if (position.chars_read_current_line == 0) {
+      if (position.lines_read > 0) {
+        --position.lines_read;
+      }
+    } else {
+      --position.chars_read_current_line;
     }
 
-    /// add a character to token_buffer
-    void add(int c)
-    {
-        token_buffer.push_back(std::char_traits<char>::to_char_type(c));
+    if (JSON_LIKELY(current != std::char_traits<char>::eof())) {
+      assert(token_string.size() != 0);
+      token_string.pop_back();
     }
+  }
 
-  public:
-    /////////////////////
-    // value getters
-    /////////////////////
+  /// add a character to token_buffer
+  void add(int c)
+  {
+    token_buffer.push_back(std::char_traits<char>::to_char_type(c));
+  }
 
-    /// return integer value
-    constexpr number_integer_t get_number_integer() const noexcept
-    {
-        return value_integer;
-    }
+public:
+  /////////////////////
+  // value getters
+  /////////////////////
 
-    /// return unsigned integer value
-    constexpr number_unsigned_t get_number_unsigned() const noexcept
-    {
-        return value_unsigned;
-    }
+  /// return integer value
+  constexpr number_integer_t get_number_integer() const noexcept
+  {
+    return value_integer;
+  }
 
-    /// return floating-point value
-    constexpr number_float_t get_number_float() const noexcept
-    {
-        return value_float;
-    }
+  /// return unsigned integer value
+  constexpr number_unsigned_t get_number_unsigned() const noexcept
+  {
+    return value_unsigned;
+  }
 
-    /// return current string value (implicitly resets the token; useful only once)
-    string_t& get_string()
-    {
-        return token_buffer;
-    }
+  /// return floating-point value
+  constexpr number_float_t get_number_float() const noexcept
+  {
+    return value_float;
+  }
 
-    /////////////////////
-    // diagnostics
-    /////////////////////
+  /// return current string value (implicitly resets the token; useful only once)
+  string_t &get_string()
+  {
+    return token_buffer;
+  }
 
-    /// return position of last read token
-    constexpr position_t get_position() const noexcept
-    {
-        return position;
-    }
+  /////////////////////
+  // diagnostics
+  /////////////////////
 
-    /// return the last read token (for errors only).  Will never contain EOF
-    /// (an arbitrary value that is not a valid char value, often -1), because
-    /// 255 may legitimately occur.  May contain NUL, which should be escaped.
-    std::string get_token_string() const
-    {
+  /// return position of last read token
+  constexpr position_t get_position() const noexcept
+  {
+    return position;
+  }
+
+  /// return the last read token (for errors only).  Will never contain EOF
+  /// (an arbitrary value that is not a valid char value, often -1), because
+  /// 255 may legitimately occur.  May contain NUL, which should be escaped.
+  std::string get_token_string() const
+  {
+    // escape control characters
+    std::string result;
+    for (const auto c : token_string) {
+      if ('\x00' <= c and c <= '\x1F') {
         // escape control characters
-        std::string result;
-        for (const auto c : token_string)
-        {
-            if ('\x00' <= c and c <= '\x1F')
-            {
-                // escape control characters
-                char cs[9];
-                (std::snprintf)(cs, 9, "<U+%.4X>", static_cast<unsigned char>(c));
-                result += cs;
-            }
-            else
-            {
-                // add character as is
-                result.push_back(c);
-            }
-        }
-
-        return result;
+        char cs[9];
+        (std::snprintf)(cs, 9, "<U+%.4X>", static_cast<unsigned char>(c));
+        result += cs;
+      } else {
+        // add character as is
+        result.push_back(c);
+      }
     }
 
-    /// return syntax error message
-    constexpr const char* get_error_message() const noexcept
-    {
-        return error_message;
-    }
+    return result;
+  }
 
-    /////////////////////
-    // actual scanner
-    /////////////////////
+  /// return syntax error message
+  constexpr const char *get_error_message() const noexcept
+  {
+    return error_message;
+  }
 
-    /*!
+  /////////////////////
+  // actual scanner
+  /////////////////////
+
+  /*!
     @brief skip the UTF-8 byte order mark
     @return true iff there is no BOM or the correct BOM has been skipped
     */
-    bool skip_bom()
-    {
-        if (get() == 0xEF)
-        {
-            // check if we completely parse the BOM
-            return get() == 0xBB and get() == 0xBF;
-        }
-
-        // the first character is not the beginning of the BOM; unget it to
-        // process is later
-        unget();
-        return true;
+  bool skip_bom()
+  {
+    if (get() == 0xEF) {
+      // check if we completely parse the BOM
+      return get() == 0xBB and get() == 0xBF;
     }
 
-    token_type scan()
-    {
-        // initially, skip the BOM
-        if (position.chars_read_total == 0 and not skip_bom())
-        {
-            error_message = "invalid BOM; must be 0xEF 0xBB 0xBF if given";
-            return token_type::parse_error;
-        }
+    // the first character is not the beginning of the BOM; unget it to
+    // process is later
+    unget();
+    return true;
+  }
 
-        // read next character and ignore whitespace
-        do
-        {
-            get();
-        }
-        while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
-
-        switch (current)
-        {
-            // structural characters
-            case '[':
-                return token_type::begin_array;
-            case ']':
-                return token_type::end_array;
-            case '{':
-                return token_type::begin_object;
-            case '}':
-                return token_type::end_object;
-            case ':':
-                return token_type::name_separator;
-            case ',':
-                return token_type::value_separator;
-
-            // literals
-            case 't':
-                return scan_literal("true", 4, token_type::literal_true);
-            case 'f':
-                return scan_literal("false", 5, token_type::literal_false);
-            case 'n':
-                return scan_literal("null", 4, token_type::literal_null);
-
-            // string
-            case '\"':
-                return scan_string();
-
-            // number
-            case '-':
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                return scan_number();
-
-            // end of input (the null byte is needed when parsing from
-            // string literals)
-            case '\0':
-            case std::char_traits<char>::eof():
-                return token_type::end_of_input;
-
-            // error
-            default:
-                error_message = "invalid literal";
-                return token_type::parse_error;
-        }
+  token_type scan()
+  {
+    // initially, skip the BOM
+    if (position.chars_read_total == 0 and not skip_bom()) {
+      error_message = "invalid BOM; must be 0xEF 0xBB 0xBF if given";
+      return token_type::parse_error;
     }
 
-  private:
-    /// input adapter
-    detail::input_adapter_t ia = nullptr;
+    // read next character and ignore whitespace
+    do {
+      get();
+    } while (current == ' ' or current == '\t' or current == '\n' or current == '\r');
 
-    /// the current character
-    std::char_traits<char>::int_type current = std::char_traits<char>::eof();
+    switch (current) {
+    // structural characters
+    case '[':
+      return token_type::begin_array;
+    case ']':
+      return token_type::end_array;
+    case '{':
+      return token_type::begin_object;
+    case '}':
+      return token_type::end_object;
+    case ':':
+      return token_type::name_separator;
+    case ',':
+      return token_type::value_separator;
 
-    /// whether the next get() call should just return current
-    bool next_unget = false;
+    // literals
+    case 't':
+      return scan_literal("true", 4, token_type::literal_true);
+    case 'f':
+      return scan_literal("false", 5, token_type::literal_false);
+    case 'n':
+      return scan_literal("null", 4, token_type::literal_null);
 
-    /// the start position of the current token
-    position_t position;
+    // string
+    case '\"':
+      return scan_string();
 
-    /// raw input token string (for error messages)
-    std::vector<char> token_string {};
+    // number
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      return scan_number();
 
-    /// buffer for variable-length tokens (numbers, strings)
-    string_t token_buffer {};
+    // end of input (the null byte is needed when parsing from
+    // string literals)
+    case '\0':
+    case std::char_traits<char>::eof():
+      return token_type::end_of_input;
 
-    /// a description of occurred lexer errors
-    const char* error_message = "";
+    // error
+    default:
+      error_message = "invalid literal";
+      return token_type::parse_error;
+    }
+  }
 
-    // number values
-    number_integer_t value_integer = 0;
-    number_unsigned_t value_unsigned = 0;
-    number_float_t value_float = 0;
+private:
+  /// input adapter
+  detail::input_adapter_t ia = nullptr;
 
-    /// the decimal point
-    const char decimal_point_char = '.';
+  /// the current character
+  std::char_traits<char>::int_type current = std::char_traits<char>::eof();
+
+  /// whether the next get() call should just return current
+  bool next_unget = false;
+
+  /// the start position of the current token
+  position_t position;
+
+  /// raw input token string (for error messages)
+  std::vector<char> token_string{};
+
+  /// buffer for variable-length tokens (numbers, strings)
+  string_t token_buffer{};
+
+  /// a description of occurred lexer errors
+  const char *error_message = "";
+
+  // number values
+  number_integer_t  value_integer  = 0;
+  number_unsigned_t value_unsigned = 0;
+  number_float_t    value_float    = 0;
+
+  /// the decimal point
+  const char decimal_point_char = '.';
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/input/parser.hpp>
 
-
-#include <cassert> // assert
-#include <cmath> // isfinite
-#include <cstdint> // uint8_t
+#include <cassert>    // assert
+#include <cmath>      // isfinite
+#include <cstdint>    // uint8_t
 #include <functional> // function
-#include <string> // string
-#include <utility> // move
+#include <string>     // string
+#include <utility>    // move
 
 // #include <nlohmann/detail/exceptions.hpp>
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
 // #include <nlohmann/detail/meta/is_sax.hpp>
-
 
 #include <cstdint> // size_t
 #include <utility> // declval
@@ -4096,145 +3832,139 @@ scan_number_done:
 
 // #include <nlohmann/detail/meta/type_traits.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 template <typename T>
-using null_function_t = decltype(std::declval<T&>().null());
+using null_function_t = decltype(std::declval<T &>().null());
 
 template <typename T>
 using boolean_function_t =
-    decltype(std::declval<T&>().boolean(std::declval<bool>()));
+    decltype(std::declval<T &>().boolean(std::declval<bool>()));
 
 template <typename T, typename Integer>
 using number_integer_function_t =
-    decltype(std::declval<T&>().number_integer(std::declval<Integer>()));
+    decltype(std::declval<T &>().number_integer(std::declval<Integer>()));
 
 template <typename T, typename Unsigned>
 using number_unsigned_function_t =
-    decltype(std::declval<T&>().number_unsigned(std::declval<Unsigned>()));
+    decltype(std::declval<T &>().number_unsigned(std::declval<Unsigned>()));
 
 template <typename T, typename Float, typename String>
-using number_float_function_t = decltype(std::declval<T&>().number_float(
-                                    std::declval<Float>(), std::declval<const String&>()));
+using number_float_function_t = decltype(std::declval<T &>().number_float(
+    std::declval<Float>(), std::declval<const String &>()));
 
 template <typename T, typename String>
 using string_function_t =
-    decltype(std::declval<T&>().string(std::declval<String&>()));
+    decltype(std::declval<T &>().string(std::declval<String &>()));
 
 template <typename T>
 using start_object_function_t =
-    decltype(std::declval<T&>().start_object(std::declval<std::size_t>()));
+    decltype(std::declval<T &>().start_object(std::declval<std::size_t>()));
 
 template <typename T, typename String>
 using key_function_t =
-    decltype(std::declval<T&>().key(std::declval<String&>()));
+    decltype(std::declval<T &>().key(std::declval<String &>()));
 
 template <typename T>
-using end_object_function_t = decltype(std::declval<T&>().end_object());
+using end_object_function_t = decltype(std::declval<T &>().end_object());
 
 template <typename T>
 using start_array_function_t =
-    decltype(std::declval<T&>().start_array(std::declval<std::size_t>()));
+    decltype(std::declval<T &>().start_array(std::declval<std::size_t>()));
 
 template <typename T>
-using end_array_function_t = decltype(std::declval<T&>().end_array());
+using end_array_function_t = decltype(std::declval<T &>().end_array());
 
 template <typename T, typename Exception>
-using parse_error_function_t = decltype(std::declval<T&>().parse_error(
-        std::declval<std::size_t>(), std::declval<const std::string&>(),
-        std::declval<const Exception&>()));
+using parse_error_function_t = decltype(std::declval<T &>().parse_error(
+    std::declval<std::size_t>(), std::declval<const std::string &>(),
+    std::declval<const Exception &>()));
 
 template <typename SAX, typename BasicJsonType>
-struct is_sax
-{
-  private:
-    static_assert(is_basic_json<BasicJsonType>::value,
-                  "BasicJsonType must be of type basic_json<...>");
+struct is_sax {
+private:
+  static_assert(is_basic_json<BasicJsonType>::value,
+                "BasicJsonType must be of type basic_json<...>");
 
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
-    using exception_t = typename BasicJsonType::exception;
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
+  using exception_t       = typename BasicJsonType::exception;
 
-  public:
-    static constexpr bool value =
-        is_detected_exact<bool, null_function_t, SAX>::value &&
-        is_detected_exact<bool, boolean_function_t, SAX>::value &&
-        is_detected_exact<bool, number_integer_function_t, SAX,
-        number_integer_t>::value &&
-        is_detected_exact<bool, number_unsigned_function_t, SAX,
-        number_unsigned_t>::value &&
-        is_detected_exact<bool, number_float_function_t, SAX, number_float_t,
-        string_t>::value &&
-        is_detected_exact<bool, string_function_t, SAX, string_t>::value &&
-        is_detected_exact<bool, start_object_function_t, SAX>::value &&
-        is_detected_exact<bool, key_function_t, SAX, string_t>::value &&
-        is_detected_exact<bool, end_object_function_t, SAX>::value &&
-        is_detected_exact<bool, start_array_function_t, SAX>::value &&
-        is_detected_exact<bool, end_array_function_t, SAX>::value &&
-        is_detected_exact<bool, parse_error_function_t, SAX, exception_t>::value;
+public:
+  static constexpr bool value =
+      is_detected_exact<bool, null_function_t, SAX>::value &&
+      is_detected_exact<bool, boolean_function_t, SAX>::value &&
+      is_detected_exact<bool, number_integer_function_t, SAX,
+                        number_integer_t>::value &&
+      is_detected_exact<bool, number_unsigned_function_t, SAX,
+                        number_unsigned_t>::value &&
+      is_detected_exact<bool, number_float_function_t, SAX, number_float_t,
+                        string_t>::value &&
+      is_detected_exact<bool, string_function_t, SAX, string_t>::value &&
+      is_detected_exact<bool, start_object_function_t, SAX>::value &&
+      is_detected_exact<bool, key_function_t, SAX, string_t>::value &&
+      is_detected_exact<bool, end_object_function_t, SAX>::value &&
+      is_detected_exact<bool, start_array_function_t, SAX>::value &&
+      is_detected_exact<bool, end_array_function_t, SAX>::value &&
+      is_detected_exact<bool, parse_error_function_t, SAX, exception_t>::value;
 };
 
 template <typename SAX, typename BasicJsonType>
-struct is_sax_static_asserts
-{
-  private:
-    static_assert(is_basic_json<BasicJsonType>::value,
-                  "BasicJsonType must be of type basic_json<...>");
+struct is_sax_static_asserts {
+private:
+  static_assert(is_basic_json<BasicJsonType>::value,
+                "BasicJsonType must be of type basic_json<...>");
 
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
-    using exception_t = typename BasicJsonType::exception;
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
+  using exception_t       = typename BasicJsonType::exception;
 
-  public:
-    static_assert(is_detected_exact<bool, null_function_t, SAX>::value,
-                  "Missing/invalid function: bool null()");
-    static_assert(is_detected_exact<bool, boolean_function_t, SAX>::value,
-                  "Missing/invalid function: bool boolean(bool)");
-    static_assert(is_detected_exact<bool, boolean_function_t, SAX>::value,
-                  "Missing/invalid function: bool boolean(bool)");
-    static_assert(
-        is_detected_exact<bool, number_integer_function_t, SAX,
-        number_integer_t>::value,
-        "Missing/invalid function: bool number_integer(number_integer_t)");
-    static_assert(
-        is_detected_exact<bool, number_unsigned_function_t, SAX,
-        number_unsigned_t>::value,
-        "Missing/invalid function: bool number_unsigned(number_unsigned_t)");
-    static_assert(is_detected_exact<bool, number_float_function_t, SAX,
-                  number_float_t, string_t>::value,
-                  "Missing/invalid function: bool number_float(number_float_t, const string_t&)");
-    static_assert(
-        is_detected_exact<bool, string_function_t, SAX, string_t>::value,
-        "Missing/invalid function: bool string(string_t&)");
-    static_assert(is_detected_exact<bool, start_object_function_t, SAX>::value,
-                  "Missing/invalid function: bool start_object(std::size_t)");
-    static_assert(is_detected_exact<bool, key_function_t, SAX, string_t>::value,
-                  "Missing/invalid function: bool key(string_t&)");
-    static_assert(is_detected_exact<bool, end_object_function_t, SAX>::value,
-                  "Missing/invalid function: bool end_object()");
-    static_assert(is_detected_exact<bool, start_array_function_t, SAX>::value,
-                  "Missing/invalid function: bool start_array(std::size_t)");
-    static_assert(is_detected_exact<bool, end_array_function_t, SAX>::value,
-                  "Missing/invalid function: bool end_array()");
-    static_assert(
-        is_detected_exact<bool, parse_error_function_t, SAX, exception_t>::value,
-        "Missing/invalid function: bool parse_error(std::size_t, const "
-        "std::string&, const exception&)");
+public:
+  static_assert(is_detected_exact<bool, null_function_t, SAX>::value,
+                "Missing/invalid function: bool null()");
+  static_assert(is_detected_exact<bool, boolean_function_t, SAX>::value,
+                "Missing/invalid function: bool boolean(bool)");
+  static_assert(is_detected_exact<bool, boolean_function_t, SAX>::value,
+                "Missing/invalid function: bool boolean(bool)");
+  static_assert(
+      is_detected_exact<bool, number_integer_function_t, SAX,
+                        number_integer_t>::value,
+      "Missing/invalid function: bool number_integer(number_integer_t)");
+  static_assert(
+      is_detected_exact<bool, number_unsigned_function_t, SAX,
+                        number_unsigned_t>::value,
+      "Missing/invalid function: bool number_unsigned(number_unsigned_t)");
+  static_assert(is_detected_exact<bool, number_float_function_t, SAX,
+                                  number_float_t, string_t>::value,
+                "Missing/invalid function: bool number_float(number_float_t, const string_t&)");
+  static_assert(
+      is_detected_exact<bool, string_function_t, SAX, string_t>::value,
+      "Missing/invalid function: bool string(string_t&)");
+  static_assert(is_detected_exact<bool, start_object_function_t, SAX>::value,
+                "Missing/invalid function: bool start_object(std::size_t)");
+  static_assert(is_detected_exact<bool, key_function_t, SAX, string_t>::value,
+                "Missing/invalid function: bool key(string_t&)");
+  static_assert(is_detected_exact<bool, end_object_function_t, SAX>::value,
+                "Missing/invalid function: bool end_object()");
+  static_assert(is_detected_exact<bool, start_array_function_t, SAX>::value,
+                "Missing/invalid function: bool start_array(std::size_t)");
+  static_assert(is_detected_exact<bool, end_array_function_t, SAX>::value,
+                "Missing/invalid function: bool end_array()");
+  static_assert(
+      is_detected_exact<bool, parse_error_function_t, SAX, exception_t>::value,
+      "Missing/invalid function: bool parse_error(std::size_t, const "
+      "std::string&, const exception&)");
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/input/input_adapters.hpp>
 
 // #include <nlohmann/detail/input/json_sax.hpp>
-
 
 #include <cstddef>
 #include <string>
@@ -4244,9 +3974,7 @@ struct is_sax_static_asserts
 
 // #include <nlohmann/detail/exceptions.hpp>
 
-
-namespace nlohmann
-{
+namespace nlohmann {
 
 /*!
 @brief SAX interface
@@ -4256,114 +3984,111 @@ Each function is called in different situations while the input is parsed. The
 boolean return value informs the parser whether to continue processing the
 input.
 */
-template<typename BasicJsonType>
-struct json_sax
-{
-    /// type for (signed) integers
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    /// type for unsigned integers
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    /// type for floating-point numbers
-    using number_float_t = typename BasicJsonType::number_float_t;
-    /// type for strings
-    using string_t = typename BasicJsonType::string_t;
+template <typename BasicJsonType>
+struct json_sax {
+  /// type for (signed) integers
+  using number_integer_t = typename BasicJsonType::number_integer_t;
+  /// type for unsigned integers
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  /// type for floating-point numbers
+  using number_float_t = typename BasicJsonType::number_float_t;
+  /// type for strings
+  using string_t = typename BasicJsonType::string_t;
 
-    /*!
+  /*!
     @brief a null value was read
     @return whether parsing should proceed
     */
-    virtual bool null() = 0;
+  virtual bool null() = 0;
 
-    /*!
+  /*!
     @brief a boolean value was read
     @param[in] val  boolean value
     @return whether parsing should proceed
     */
-    virtual bool boolean(bool val) = 0;
+  virtual bool boolean(bool val) = 0;
 
-    /*!
+  /*!
     @brief an integer number was read
     @param[in] val  integer value
     @return whether parsing should proceed
     */
-    virtual bool number_integer(number_integer_t val) = 0;
+  virtual bool number_integer(number_integer_t val) = 0;
 
-    /*!
+  /*!
     @brief an unsigned integer number was read
     @param[in] val  unsigned integer value
     @return whether parsing should proceed
     */
-    virtual bool number_unsigned(number_unsigned_t val) = 0;
+  virtual bool number_unsigned(number_unsigned_t val) = 0;
 
-    /*!
+  /*!
     @brief an floating-point number was read
     @param[in] val  floating-point value
     @param[in] s    raw token value
     @return whether parsing should proceed
     */
-    virtual bool number_float(number_float_t val, const string_t& s) = 0;
+  virtual bool number_float(number_float_t val, const string_t &s) = 0;
 
-    /*!
+  /*!
     @brief a string was read
     @param[in] val  string value
     @return whether parsing should proceed
     @note It is safe to move the passed string.
     */
-    virtual bool string(string_t& val) = 0;
+  virtual bool string(string_t &val) = 0;
 
-    /*!
+  /*!
     @brief the beginning of an object was read
     @param[in] elements  number of object elements or -1 if unknown
     @return whether parsing should proceed
     @note binary formats may report the number of elements
     */
-    virtual bool start_object(std::size_t elements) = 0;
+  virtual bool start_object(std::size_t elements) = 0;
 
-    /*!
+  /*!
     @brief an object key was read
     @param[in] val  object key
     @return whether parsing should proceed
     @note It is safe to move the passed string.
     */
-    virtual bool key(string_t& val) = 0;
+  virtual bool key(string_t &val) = 0;
 
-    /*!
+  /*!
     @brief the end of an object was read
     @return whether parsing should proceed
     */
-    virtual bool end_object() = 0;
+  virtual bool end_object() = 0;
 
-    /*!
+  /*!
     @brief the beginning of an array was read
     @param[in] elements  number of array elements or -1 if unknown
     @return whether parsing should proceed
     @note binary formats may report the number of elements
     */
-    virtual bool start_array(std::size_t elements) = 0;
+  virtual bool start_array(std::size_t elements) = 0;
 
-    /*!
+  /*!
     @brief the end of an array was read
     @return whether parsing should proceed
     */
-    virtual bool end_array() = 0;
+  virtual bool end_array() = 0;
 
-    /*!
+  /*!
     @brief a parse error occurred
     @param[in] position    the position in the input where the error occurs
     @param[in] last_token  the last read token
     @param[in] ex          an exception object describing the error
     @return whether parsing should proceed (must return false)
     */
-    virtual bool parse_error(std::size_t position,
-                             const std::string& last_token,
-                             const detail::exception& ex) = 0;
+  virtual bool parse_error(std::size_t              position,
+                           const std::string &      last_token,
+                           const detail::exception &ex) = 0;
 
-    virtual ~json_sax() = default;
+  virtual ~json_sax() = default;
 };
 
-
-namespace detail
-{
+namespace detail {
 /*!
 @brief SAX implementation to create a JSON value from SAX events
 
@@ -4377,397 +4102,371 @@ constructor contains the parsed value.
 
 @tparam BasicJsonType  the JSON type
 */
-template<typename BasicJsonType>
-class json_sax_dom_parser
-{
-  public:
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
+template <typename BasicJsonType>
+class json_sax_dom_parser {
+public:
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
 
-    /*!
+  /*!
     @param[in, out] r  reference to a JSON value that is manipulated while
                        parsing
     @param[in] allow_exceptions_  whether parse errors yield exceptions
     */
-    explicit json_sax_dom_parser(BasicJsonType& r, const bool allow_exceptions_ = true)
-        : root(r), allow_exceptions(allow_exceptions_)
-    {}
+  explicit json_sax_dom_parser(BasicJsonType &r, const bool allow_exceptions_ = true)
+      : root(r), allow_exceptions(allow_exceptions_)
+  {
+  }
 
-    bool null()
-    {
-        handle_value(nullptr);
-        return true;
+  bool null()
+  {
+    handle_value(nullptr);
+    return true;
+  }
+
+  bool boolean(bool val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool number_integer(number_integer_t val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool number_unsigned(number_unsigned_t val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool number_float(number_float_t val, const string_t & /*unused*/)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool string(string_t &val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool start_object(std::size_t len)
+  {
+    ref_stack.push_back(handle_value(BasicJsonType::value_t::object));
+
+    if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size())) {
+      JSON_THROW(out_of_range::create(408,
+                                      "excessive object size: " + std::to_string(len)));
     }
 
-    bool boolean(bool val)
-    {
-        handle_value(val);
-        return true;
+    return true;
+  }
+
+  bool key(string_t &val)
+  {
+    // add null at given key and store the reference for later
+    object_element = &(ref_stack.back()->m_value.object->operator[](val));
+    return true;
+  }
+
+  bool end_object()
+  {
+    ref_stack.pop_back();
+    return true;
+  }
+
+  bool start_array(std::size_t len)
+  {
+    ref_stack.push_back(handle_value(BasicJsonType::value_t::array));
+
+    if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size())) {
+      JSON_THROW(out_of_range::create(408,
+                                      "excessive array size: " + std::to_string(len)));
     }
 
-    bool number_integer(number_integer_t val)
-    {
-        handle_value(val);
-        return true;
+    return true;
+  }
+
+  bool end_array()
+  {
+    ref_stack.pop_back();
+    return true;
+  }
+
+  bool parse_error(std::size_t /*unused*/, const std::string & /*unused*/,
+                   const detail::exception &ex)
+  {
+    errored = true;
+    if (allow_exceptions) {
+      // determine the proper exception type from the id
+      switch ((ex.id / 100) % 100) {
+      case 1:
+        JSON_THROW(*reinterpret_cast<const detail::parse_error *>(&ex));
+      case 4:
+        JSON_THROW(*reinterpret_cast<const detail::out_of_range *>(&ex));
+      // LCOV_EXCL_START
+      case 2:
+        JSON_THROW(*reinterpret_cast<const detail::invalid_iterator *>(&ex));
+      case 3:
+        JSON_THROW(*reinterpret_cast<const detail::type_error *>(&ex));
+      case 5:
+        JSON_THROW(*reinterpret_cast<const detail::other_error *>(&ex));
+      default:
+        assert(false);
+        // LCOV_EXCL_STOP
+      }
     }
+    return false;
+  }
 
-    bool number_unsigned(number_unsigned_t val)
-    {
-        handle_value(val);
-        return true;
-    }
+  constexpr bool is_errored() const
+  {
+    return errored;
+  }
 
-    bool number_float(number_float_t val, const string_t& /*unused*/)
-    {
-        handle_value(val);
-        return true;
-    }
-
-    bool string(string_t& val)
-    {
-        handle_value(val);
-        return true;
-    }
-
-    bool start_object(std::size_t len)
-    {
-        ref_stack.push_back(handle_value(BasicJsonType::value_t::object));
-
-        if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size()))
-        {
-            JSON_THROW(out_of_range::create(408,
-                                            "excessive object size: " + std::to_string(len)));
-        }
-
-        return true;
-    }
-
-    bool key(string_t& val)
-    {
-        // add null at given key and store the reference for later
-        object_element = &(ref_stack.back()->m_value.object->operator[](val));
-        return true;
-    }
-
-    bool end_object()
-    {
-        ref_stack.pop_back();
-        return true;
-    }
-
-    bool start_array(std::size_t len)
-    {
-        ref_stack.push_back(handle_value(BasicJsonType::value_t::array));
-
-        if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size()))
-        {
-            JSON_THROW(out_of_range::create(408,
-                                            "excessive array size: " + std::to_string(len)));
-        }
-
-        return true;
-    }
-
-    bool end_array()
-    {
-        ref_stack.pop_back();
-        return true;
-    }
-
-    bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
-                     const detail::exception& ex)
-    {
-        errored = true;
-        if (allow_exceptions)
-        {
-            // determine the proper exception type from the id
-            switch ((ex.id / 100) % 100)
-            {
-                case 1:
-                    JSON_THROW(*reinterpret_cast<const detail::parse_error*>(&ex));
-                case 4:
-                    JSON_THROW(*reinterpret_cast<const detail::out_of_range*>(&ex));
-                // LCOV_EXCL_START
-                case 2:
-                    JSON_THROW(*reinterpret_cast<const detail::invalid_iterator*>(&ex));
-                case 3:
-                    JSON_THROW(*reinterpret_cast<const detail::type_error*>(&ex));
-                case 5:
-                    JSON_THROW(*reinterpret_cast<const detail::other_error*>(&ex));
-                default:
-                    assert(false);
-                    // LCOV_EXCL_STOP
-            }
-        }
-        return false;
-    }
-
-    constexpr bool is_errored() const
-    {
-        return errored;
-    }
-
-  private:
-    /*!
+private:
+  /*!
     @invariant If the ref stack is empty, then the passed value will be the new
                root.
     @invariant If the ref stack contains a value, then it is an array or an
                object to which we can add elements
     */
-    template<typename Value>
-    BasicJsonType* handle_value(Value&& v)
-    {
-        if (ref_stack.empty())
-        {
-            root = BasicJsonType(std::forward<Value>(v));
-            return &root;
-        }
-
-        assert(ref_stack.back()->is_array() or ref_stack.back()->is_object());
-
-        if (ref_stack.back()->is_array())
-        {
-            ref_stack.back()->m_value.array->emplace_back(std::forward<Value>(v));
-            return &(ref_stack.back()->m_value.array->back());
-        }
-        else
-        {
-            assert(object_element);
-            *object_element = BasicJsonType(std::forward<Value>(v));
-            return object_element;
-        }
+  template <typename Value>
+  BasicJsonType *handle_value(Value &&v)
+  {
+    if (ref_stack.empty()) {
+      root = BasicJsonType(std::forward<Value>(v));
+      return &root;
     }
 
-    /// the parsed JSON value
-    BasicJsonType& root;
-    /// stack to model hierarchy of values
-    std::vector<BasicJsonType*> ref_stack;
-    /// helper to hold the reference for the next object element
-    BasicJsonType* object_element = nullptr;
-    /// whether a syntax error occurred
-    bool errored = false;
-    /// whether to throw exceptions in case of errors
-    const bool allow_exceptions = true;
+    assert(ref_stack.back()->is_array() or ref_stack.back()->is_object());
+
+    if (ref_stack.back()->is_array()) {
+      ref_stack.back()->m_value.array->emplace_back(std::forward<Value>(v));
+      return &(ref_stack.back()->m_value.array->back());
+    } else {
+      assert(object_element);
+      *object_element = BasicJsonType(std::forward<Value>(v));
+      return object_element;
+    }
+  }
+
+  /// the parsed JSON value
+  BasicJsonType &root;
+  /// stack to model hierarchy of values
+  std::vector<BasicJsonType *> ref_stack;
+  /// helper to hold the reference for the next object element
+  BasicJsonType *object_element = nullptr;
+  /// whether a syntax error occurred
+  bool errored = false;
+  /// whether to throw exceptions in case of errors
+  const bool allow_exceptions = true;
 };
 
-template<typename BasicJsonType>
-class json_sax_dom_callback_parser
-{
-  public:
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
-    using parser_callback_t = typename BasicJsonType::parser_callback_t;
-    using parse_event_t = typename BasicJsonType::parse_event_t;
+template <typename BasicJsonType>
+class json_sax_dom_callback_parser {
+public:
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
+  using parser_callback_t = typename BasicJsonType::parser_callback_t;
+  using parse_event_t     = typename BasicJsonType::parse_event_t;
 
-    json_sax_dom_callback_parser(BasicJsonType& r,
-                                 const parser_callback_t cb,
-                                 const bool allow_exceptions_ = true)
-        : root(r), callback(cb), allow_exceptions(allow_exceptions_)
-    {
-        keep_stack.push_back(true);
+  json_sax_dom_callback_parser(BasicJsonType &         r,
+                               const parser_callback_t cb,
+                               const bool              allow_exceptions_ = true)
+      : root(r), callback(cb), allow_exceptions(allow_exceptions_)
+  {
+    keep_stack.push_back(true);
+  }
+
+  bool null()
+  {
+    handle_value(nullptr);
+    return true;
+  }
+
+  bool boolean(bool val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool number_integer(number_integer_t val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool number_unsigned(number_unsigned_t val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool number_float(number_float_t val, const string_t & /*unused*/)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool string(string_t &val)
+  {
+    handle_value(val);
+    return true;
+  }
+
+  bool start_object(std::size_t len)
+  {
+    // check callback for object start
+    const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::object_start, discarded);
+    keep_stack.push_back(keep);
+
+    auto val = handle_value(BasicJsonType::value_t::object, true);
+    ref_stack.push_back(val.second);
+
+    // check object limit
+    if (ref_stack.back()) {
+      if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size())) {
+        JSON_THROW(out_of_range::create(408,
+                                        "excessive object size: " + std::to_string(len)));
+      }
     }
 
-    bool null()
-    {
-        handle_value(nullptr);
-        return true;
+    return true;
+  }
+
+  bool key(string_t &val)
+  {
+    BasicJsonType k = BasicJsonType(val);
+
+    // check callback for key
+    const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::key, k);
+    key_keep_stack.push_back(keep);
+
+    // add discarded value at given key and store the reference for later
+    if (keep and ref_stack.back()) {
+      object_element = &(ref_stack.back()->m_value.object->operator[](val) = discarded);
     }
 
-    bool boolean(bool val)
-    {
-        handle_value(val);
-        return true;
+    return true;
+  }
+
+  bool end_object()
+  {
+    if (ref_stack.back()) {
+      if (not callback(static_cast<int>(ref_stack.size()) - 1, parse_event_t::object_end, *ref_stack.back())) {
+        // discard object
+        *ref_stack.back() = discarded;
+      }
     }
 
-    bool number_integer(number_integer_t val)
-    {
-        handle_value(val);
-        return true;
-    }
+    assert(not ref_stack.empty());
+    assert(not keep_stack.empty());
+    ref_stack.pop_back();
+    keep_stack.pop_back();
 
-    bool number_unsigned(number_unsigned_t val)
-    {
-        handle_value(val);
-        return true;
-    }
-
-    bool number_float(number_float_t val, const string_t& /*unused*/)
-    {
-        handle_value(val);
-        return true;
-    }
-
-    bool string(string_t& val)
-    {
-        handle_value(val);
-        return true;
-    }
-
-    bool start_object(std::size_t len)
-    {
-        // check callback for object start
-        const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::object_start, discarded);
-        keep_stack.push_back(keep);
-
-        auto val = handle_value(BasicJsonType::value_t::object, true);
-        ref_stack.push_back(val.second);
-
-        // check object limit
-        if (ref_stack.back())
-        {
-            if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size()))
-            {
-                JSON_THROW(out_of_range::create(408,
-                                                "excessive object size: " + std::to_string(len)));
-            }
+    if (not ref_stack.empty() and ref_stack.back()) {
+      // remove discarded value
+      if (ref_stack.back()->is_object()) {
+        for (auto it = ref_stack.back()->begin(); it != ref_stack.back()->end(); ++it) {
+          if (it->is_discarded()) {
+            ref_stack.back()->erase(it);
+            break;
+          }
         }
-
-        return true;
+      }
     }
 
-    bool key(string_t& val)
-    {
-        BasicJsonType k = BasicJsonType(val);
+    return true;
+  }
 
-        // check callback for key
-        const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::key, k);
-        key_keep_stack.push_back(keep);
+  bool start_array(std::size_t len)
+  {
+    const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::array_start, discarded);
+    keep_stack.push_back(keep);
 
-        // add discarded value at given key and store the reference for later
-        if (keep and ref_stack.back())
-        {
-            object_element = &(ref_stack.back()->m_value.object->operator[](val) = discarded);
-        }
+    auto val = handle_value(BasicJsonType::value_t::array, true);
+    ref_stack.push_back(val.second);
 
-        return true;
+    // check array limit
+    if (ref_stack.back()) {
+      if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size())) {
+        JSON_THROW(out_of_range::create(408,
+                                        "excessive array size: " + std::to_string(len)));
+      }
     }
 
-    bool end_object()
-    {
-        if (ref_stack.back())
-        {
-            if (not callback(static_cast<int>(ref_stack.size()) - 1, parse_event_t::object_end, *ref_stack.back()))
-            {
-                // discard object
-                *ref_stack.back() = discarded;
-            }
-        }
+    return true;
+  }
 
-        assert(not ref_stack.empty());
-        assert(not keep_stack.empty());
-        ref_stack.pop_back();
-        keep_stack.pop_back();
+  bool end_array()
+  {
+    bool keep = true;
 
-        if (not ref_stack.empty() and ref_stack.back())
-        {
-            // remove discarded value
-            if (ref_stack.back()->is_object())
-            {
-                for (auto it = ref_stack.back()->begin(); it != ref_stack.back()->end(); ++it)
-                {
-                    if (it->is_discarded())
-                    {
-                        ref_stack.back()->erase(it);
-                        break;
-                    }
-                }
-            }
-        }
-
-        return true;
+    if (ref_stack.back()) {
+      keep = callback(static_cast<int>(ref_stack.size()) - 1, parse_event_t::array_end, *ref_stack.back());
+      if (not keep) {
+        // discard array
+        *ref_stack.back() = discarded;
+      }
     }
 
-    bool start_array(std::size_t len)
-    {
-        const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::array_start, discarded);
-        keep_stack.push_back(keep);
+    assert(not ref_stack.empty());
+    assert(not keep_stack.empty());
+    ref_stack.pop_back();
+    keep_stack.pop_back();
 
-        auto val = handle_value(BasicJsonType::value_t::array, true);
-        ref_stack.push_back(val.second);
-
-        // check array limit
-        if (ref_stack.back())
-        {
-            if (JSON_UNLIKELY(len != std::size_t(-1) and len > ref_stack.back()->max_size()))
-            {
-                JSON_THROW(out_of_range::create(408,
-                                                "excessive array size: " + std::to_string(len)));
-            }
-        }
-
-        return true;
+    // remove discarded value
+    if (not keep and not ref_stack.empty()) {
+      if (ref_stack.back()->is_array()) {
+        ref_stack.back()->m_value.array->pop_back();
+      }
     }
 
-    bool end_array()
-    {
-        bool keep = true;
+    return true;
+  }
 
-        if (ref_stack.back())
-        {
-            keep = callback(static_cast<int>(ref_stack.size()) - 1, parse_event_t::array_end, *ref_stack.back());
-            if (not keep)
-            {
-                // discard array
-                *ref_stack.back() = discarded;
-            }
-        }
-
-        assert(not ref_stack.empty());
-        assert(not keep_stack.empty());
-        ref_stack.pop_back();
-        keep_stack.pop_back();
-
-        // remove discarded value
-        if (not keep and not ref_stack.empty())
-        {
-            if (ref_stack.back()->is_array())
-            {
-                ref_stack.back()->m_value.array->pop_back();
-            }
-        }
-
-        return true;
+  bool parse_error(std::size_t /*unused*/, const std::string & /*unused*/,
+                   const detail::exception &ex)
+  {
+    errored = true;
+    if (allow_exceptions) {
+      // determine the proper exception type from the id
+      switch ((ex.id / 100) % 100) {
+      case 1:
+        JSON_THROW(*reinterpret_cast<const detail::parse_error *>(&ex));
+      case 4:
+        JSON_THROW(*reinterpret_cast<const detail::out_of_range *>(&ex));
+      // LCOV_EXCL_START
+      case 2:
+        JSON_THROW(*reinterpret_cast<const detail::invalid_iterator *>(&ex));
+      case 3:
+        JSON_THROW(*reinterpret_cast<const detail::type_error *>(&ex));
+      case 5:
+        JSON_THROW(*reinterpret_cast<const detail::other_error *>(&ex));
+      default:
+        assert(false);
+        // LCOV_EXCL_STOP
+      }
     }
+    return false;
+  }
 
-    bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
-                     const detail::exception& ex)
-    {
-        errored = true;
-        if (allow_exceptions)
-        {
-            // determine the proper exception type from the id
-            switch ((ex.id / 100) % 100)
-            {
-                case 1:
-                    JSON_THROW(*reinterpret_cast<const detail::parse_error*>(&ex));
-                case 4:
-                    JSON_THROW(*reinterpret_cast<const detail::out_of_range*>(&ex));
-                // LCOV_EXCL_START
-                case 2:
-                    JSON_THROW(*reinterpret_cast<const detail::invalid_iterator*>(&ex));
-                case 3:
-                    JSON_THROW(*reinterpret_cast<const detail::type_error*>(&ex));
-                case 5:
-                    JSON_THROW(*reinterpret_cast<const detail::other_error*>(&ex));
-                default:
-                    assert(false);
-                    // LCOV_EXCL_STOP
-            }
-        }
-        return false;
-    }
+  constexpr bool is_errored() const
+  {
+    return errored;
+  }
 
-    constexpr bool is_errored() const
-    {
-        return errored;
-    }
-
-  private:
-    /*!
+private:
+  /*!
     @param[in] v  value to add to the JSON value we build during parsing
     @param[in] skip_callback  whether we should skip calling the callback
                function; this is required after start_array() and
@@ -4782,171 +4481,159 @@ class json_sax_dom_callback_parser
     @return pair of boolean (whether value should be kept) and pointer (to the
             passed value in the ref_stack hierarchy; nullptr if not kept)
     */
-    template<typename Value>
-    std::pair<bool, BasicJsonType*> handle_value(Value&& v, const bool skip_callback = false)
-    {
-        assert(not keep_stack.empty());
+  template <typename Value>
+  std::pair<bool, BasicJsonType *> handle_value(Value &&v, const bool skip_callback = false)
+  {
+    assert(not keep_stack.empty());
 
-        // do not handle this value if we know it would be added to a discarded
-        // container
-        if (not keep_stack.back())
-        {
-            return {false, nullptr};
-        }
-
-        // create value
-        auto value = BasicJsonType(std::forward<Value>(v));
-
-        // check callback
-        const bool keep = skip_callback or callback(static_cast<int>(ref_stack.size()), parse_event_t::value, value);
-
-        // do not handle this value if we just learnt it shall be discarded
-        if (not keep)
-        {
-            return {false, nullptr};
-        }
-
-        if (ref_stack.empty())
-        {
-            root = std::move(value);
-            return {true, &root};
-        }
-
-        // skip this value if we already decided to skip the parent
-        // (https://github.com/nlohmann/json/issues/971#issuecomment-413678360)
-        if (not ref_stack.back())
-        {
-            return {false, nullptr};
-        }
-
-        // we now only expect arrays and objects
-        assert(ref_stack.back()->is_array() or ref_stack.back()->is_object());
-
-        if (ref_stack.back()->is_array())
-        {
-            ref_stack.back()->m_value.array->push_back(std::move(value));
-            return {true, &(ref_stack.back()->m_value.array->back())};
-        }
-        else
-        {
-            // check if we should store an element for the current key
-            assert(not key_keep_stack.empty());
-            const bool store_element = key_keep_stack.back();
-            key_keep_stack.pop_back();
-
-            if (not store_element)
-            {
-                return {false, nullptr};
-            }
-
-            assert(object_element);
-            *object_element = std::move(value);
-            return {true, object_element};
-        }
+    // do not handle this value if we know it would be added to a discarded
+    // container
+    if (not keep_stack.back()) {
+      return {false, nullptr};
     }
 
-    /// the parsed JSON value
-    BasicJsonType& root;
-    /// stack to model hierarchy of values
-    std::vector<BasicJsonType*> ref_stack;
-    /// stack to manage which values to keep
-    std::vector<bool> keep_stack;
-    /// stack to manage which object keys to keep
-    std::vector<bool> key_keep_stack;
-    /// helper to hold the reference for the next object element
-    BasicJsonType* object_element = nullptr;
-    /// whether a syntax error occurred
-    bool errored = false;
-    /// callback function
-    const parser_callback_t callback = nullptr;
-    /// whether to throw exceptions in case of errors
-    const bool allow_exceptions = true;
-    /// a discarded value for the callback
-    BasicJsonType discarded = BasicJsonType::value_t::discarded;
+    // create value
+    auto value = BasicJsonType(std::forward<Value>(v));
+
+    // check callback
+    const bool keep = skip_callback or callback(static_cast<int>(ref_stack.size()), parse_event_t::value, value);
+
+    // do not handle this value if we just learnt it shall be discarded
+    if (not keep) {
+      return {false, nullptr};
+    }
+
+    if (ref_stack.empty()) {
+      root = std::move(value);
+      return {true, &root};
+    }
+
+    // skip this value if we already decided to skip the parent
+    // (https://github.com/nlohmann/json/issues/971#issuecomment-413678360)
+    if (not ref_stack.back()) {
+      return {false, nullptr};
+    }
+
+    // we now only expect arrays and objects
+    assert(ref_stack.back()->is_array() or ref_stack.back()->is_object());
+
+    if (ref_stack.back()->is_array()) {
+      ref_stack.back()->m_value.array->push_back(std::move(value));
+      return {true, &(ref_stack.back()->m_value.array->back())};
+    } else {
+      // check if we should store an element for the current key
+      assert(not key_keep_stack.empty());
+      const bool store_element = key_keep_stack.back();
+      key_keep_stack.pop_back();
+
+      if (not store_element) {
+        return {false, nullptr};
+      }
+
+      assert(object_element);
+      *object_element = std::move(value);
+      return {true, object_element};
+    }
+  }
+
+  /// the parsed JSON value
+  BasicJsonType &root;
+  /// stack to model hierarchy of values
+  std::vector<BasicJsonType *> ref_stack;
+  /// stack to manage which values to keep
+  std::vector<bool> keep_stack;
+  /// stack to manage which object keys to keep
+  std::vector<bool> key_keep_stack;
+  /// helper to hold the reference for the next object element
+  BasicJsonType *object_element = nullptr;
+  /// whether a syntax error occurred
+  bool errored = false;
+  /// callback function
+  const parser_callback_t callback = nullptr;
+  /// whether to throw exceptions in case of errors
+  const bool allow_exceptions = true;
+  /// a discarded value for the callback
+  BasicJsonType discarded = BasicJsonType::value_t::discarded;
 };
 
-template<typename BasicJsonType>
-class json_sax_acceptor
-{
-  public:
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
+template <typename BasicJsonType>
+class json_sax_acceptor {
+public:
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
 
-    bool null()
-    {
-        return true;
-    }
+  bool null()
+  {
+    return true;
+  }
 
-    bool boolean(bool /*unused*/)
-    {
-        return true;
-    }
+  bool boolean(bool /*unused*/)
+  {
+    return true;
+  }
 
-    bool number_integer(number_integer_t /*unused*/)
-    {
-        return true;
-    }
+  bool number_integer(number_integer_t /*unused*/)
+  {
+    return true;
+  }
 
-    bool number_unsigned(number_unsigned_t /*unused*/)
-    {
-        return true;
-    }
+  bool number_unsigned(number_unsigned_t /*unused*/)
+  {
+    return true;
+  }
 
-    bool number_float(number_float_t /*unused*/, const string_t& /*unused*/)
-    {
-        return true;
-    }
+  bool number_float(number_float_t /*unused*/, const string_t & /*unused*/)
+  {
+    return true;
+  }
 
-    bool string(string_t& /*unused*/)
-    {
-        return true;
-    }
+  bool string(string_t & /*unused*/)
+  {
+    return true;
+  }
 
-    bool start_object(std::size_t  /*unused*/ = std::size_t(-1))
-    {
-        return true;
-    }
+  bool start_object(std::size_t /*unused*/ = std::size_t(-1))
+  {
+    return true;
+  }
 
-    bool key(string_t& /*unused*/)
-    {
-        return true;
-    }
+  bool key(string_t & /*unused*/)
+  {
+    return true;
+  }
 
-    bool end_object()
-    {
-        return true;
-    }
+  bool end_object()
+  {
+    return true;
+  }
 
-    bool start_array(std::size_t  /*unused*/ = std::size_t(-1))
-    {
-        return true;
-    }
+  bool start_array(std::size_t /*unused*/ = std::size_t(-1))
+  {
+    return true;
+  }
 
-    bool end_array()
-    {
-        return true;
-    }
+  bool end_array()
+  {
+    return true;
+  }
 
-    bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/, const detail::exception& /*unused*/)
-    {
-        return false;
-    }
+  bool parse_error(std::size_t /*unused*/, const std::string & /*unused*/, const detail::exception & /*unused*/)
+  {
+    return false;
+  }
 };
-}  // namespace detail
+} // namespace detail
 
-}  // namespace nlohmann
+} // namespace nlohmann
 
 // #include <nlohmann/detail/input/lexer.hpp>
 
 // #include <nlohmann/detail/value_t.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 ////////////
 // parser //
 ////////////
@@ -4956,47 +4643,45 @@ namespace detail
 
 This class implements a recursive decent parser.
 */
-template<typename BasicJsonType>
-class parser
-{
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
-    using lexer_t = lexer<BasicJsonType>;
-    using token_type = typename lexer_t::token_type;
+template <typename BasicJsonType>
+class parser {
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
+  using lexer_t           = lexer<BasicJsonType>;
+  using token_type        = typename lexer_t::token_type;
 
-  public:
-    enum class parse_event_t : uint8_t
-    {
-        /// the parser read `{` and started to process a JSON object
-        object_start,
-        /// the parser read `}` and finished processing a JSON object
-        object_end,
-        /// the parser read `[` and started to process a JSON array
-        array_start,
-        /// the parser read `]` and finished processing a JSON array
-        array_end,
-        /// the parser read a key of a value in an object
-        key,
-        /// the parser finished reading a JSON value
-        value
-    };
+public:
+  enum class parse_event_t : uint8_t {
+    /// the parser read `{` and started to process a JSON object
+    object_start,
+    /// the parser read `}` and finished processing a JSON object
+    object_end,
+    /// the parser read `[` and started to process a JSON array
+    array_start,
+    /// the parser read `]` and finished processing a JSON array
+    array_end,
+    /// the parser read a key of a value in an object
+    key,
+    /// the parser finished reading a JSON value
+    value
+  };
 
-    using parser_callback_t =
-        std::function<bool(int depth, parse_event_t event, BasicJsonType& parsed)>;
+  using parser_callback_t =
+      std::function<bool(int depth, parse_event_t event, BasicJsonType &parsed)>;
 
-    /// a parser reading from an input adapter
-    explicit parser(detail::input_adapter_t&& adapter,
-                    const parser_callback_t cb = nullptr,
-                    const bool allow_exceptions_ = true)
-        : callback(cb), m_lexer(std::move(adapter)), allow_exceptions(allow_exceptions_)
-    {
-        // read first token
-        get_token();
-    }
+  /// a parser reading from an input adapter
+  explicit parser(detail::input_adapter_t &&adapter,
+                  const parser_callback_t   cb                = nullptr,
+                  const bool                allow_exceptions_ = true)
+      : callback(cb), m_lexer(std::move(adapter)), allow_exceptions(allow_exceptions_)
+  {
+    // read first token
+    get_token();
+  }
 
-    /*!
+  /*!
     @brief public parser interface
 
     @param[in] strict      whether to expect the last token to be EOF
@@ -5006,441 +4691,371 @@ class parser
     @throw parse_error.102 if to_unicode fails or surrogate error
     @throw parse_error.103 if to_unicode fails
     */
-    void parse(const bool strict, BasicJsonType& result)
-    {
-        if (callback)
-        {
-            json_sax_dom_callback_parser<BasicJsonType> sdp(result, callback, allow_exceptions);
-            sax_parse_internal(&sdp);
-            result.assert_invariant();
+  void parse(const bool strict, BasicJsonType &result)
+  {
+    if (callback) {
+      json_sax_dom_callback_parser<BasicJsonType> sdp(result, callback, allow_exceptions);
+      sax_parse_internal(&sdp);
+      result.assert_invariant();
 
-            // in strict mode, input must be completely read
-            if (strict and (get_token() != token_type::end_of_input))
-            {
-                sdp.parse_error(m_lexer.get_position(),
-                                m_lexer.get_token_string(),
-                                parse_error::create(101, m_lexer.get_position(),
-                                                    exception_message(token_type::end_of_input, "value")));
-            }
+      // in strict mode, input must be completely read
+      if (strict and (get_token() != token_type::end_of_input)) {
+        sdp.parse_error(m_lexer.get_position(),
+                        m_lexer.get_token_string(),
+                        parse_error::create(101, m_lexer.get_position(),
+                                            exception_message(token_type::end_of_input, "value")));
+      }
 
-            // in case of an error, return discarded value
-            if (sdp.is_errored())
-            {
-                result = value_t::discarded;
-                return;
-            }
+      // in case of an error, return discarded value
+      if (sdp.is_errored()) {
+        result = value_t::discarded;
+        return;
+      }
 
-            // set top-level value to null if it was discarded by the callback
-            // function
-            if (result.is_discarded())
-            {
-                result = nullptr;
-            }
-        }
-        else
-        {
-            json_sax_dom_parser<BasicJsonType> sdp(result, allow_exceptions);
-            sax_parse_internal(&sdp);
-            result.assert_invariant();
+      // set top-level value to null if it was discarded by the callback
+      // function
+      if (result.is_discarded()) {
+        result = nullptr;
+      }
+    } else {
+      json_sax_dom_parser<BasicJsonType> sdp(result, allow_exceptions);
+      sax_parse_internal(&sdp);
+      result.assert_invariant();
 
-            // in strict mode, input must be completely read
-            if (strict and (get_token() != token_type::end_of_input))
-            {
-                sdp.parse_error(m_lexer.get_position(),
-                                m_lexer.get_token_string(),
-                                parse_error::create(101, m_lexer.get_position(),
-                                                    exception_message(token_type::end_of_input, "value")));
-            }
+      // in strict mode, input must be completely read
+      if (strict and (get_token() != token_type::end_of_input)) {
+        sdp.parse_error(m_lexer.get_position(),
+                        m_lexer.get_token_string(),
+                        parse_error::create(101, m_lexer.get_position(),
+                                            exception_message(token_type::end_of_input, "value")));
+      }
 
-            // in case of an error, return discarded value
-            if (sdp.is_errored())
-            {
-                result = value_t::discarded;
-                return;
-            }
-        }
+      // in case of an error, return discarded value
+      if (sdp.is_errored()) {
+        result = value_t::discarded;
+        return;
+      }
     }
+  }
 
-    /*!
+  /*!
     @brief public accept interface
 
     @param[in] strict  whether to expect the last token to be EOF
     @return whether the input is a proper JSON text
     */
-    bool accept(const bool strict = true)
-    {
-        json_sax_acceptor<BasicJsonType> sax_acceptor;
-        return sax_parse(&sax_acceptor, strict);
+  bool accept(const bool strict = true)
+  {
+    json_sax_acceptor<BasicJsonType> sax_acceptor;
+    return sax_parse(&sax_acceptor, strict);
+  }
+
+  template <typename SAX>
+  bool sax_parse(SAX *sax, const bool strict = true)
+  {
+    (void) detail::is_sax_static_asserts<SAX, BasicJsonType>{};
+    const bool result = sax_parse_internal(sax);
+
+    // strict mode: next byte must be EOF
+    if (result and strict and (get_token() != token_type::end_of_input)) {
+      return sax->parse_error(m_lexer.get_position(),
+                              m_lexer.get_token_string(),
+                              parse_error::create(101, m_lexer.get_position(),
+                                                  exception_message(token_type::end_of_input, "value")));
     }
 
-    template <typename SAX>
-    bool sax_parse(SAX* sax, const bool strict = true)
-    {
-        (void)detail::is_sax_static_asserts<SAX, BasicJsonType> {};
-        const bool result = sax_parse_internal(sax);
+    return result;
+  }
 
-        // strict mode: next byte must be EOF
-        if (result and strict and (get_token() != token_type::end_of_input))
-        {
+private:
+  template <typename SAX>
+  bool sax_parse_internal(SAX *sax)
+  {
+    // stack to remember the hierarchy of structured values we are parsing
+    // true = array; false = object
+    std::vector<bool> states;
+    // value to avoid a goto (see comment where set to true)
+    bool skip_to_state_evaluation = false;
+
+    while (true) {
+      if (not skip_to_state_evaluation) {
+        // invariant: get_token() was called before each iteration
+        switch (last_token) {
+        case token_type::begin_object: {
+          if (JSON_UNLIKELY(not sax->start_object(std::size_t(-1)))) {
+            return false;
+          }
+
+          // closing } -> we are done
+          if (get_token() == token_type::end_object) {
+            if (JSON_UNLIKELY(not sax->end_object())) {
+              return false;
+            }
+            break;
+          }
+
+          // parse key
+          if (JSON_UNLIKELY(last_token != token_type::value_string)) {
             return sax->parse_error(m_lexer.get_position(),
                                     m_lexer.get_token_string(),
                                     parse_error::create(101, m_lexer.get_position(),
-                                            exception_message(token_type::end_of_input, "value")));
+                                                        exception_message(token_type::value_string, "object key")));
+          }
+          if (JSON_UNLIKELY(not sax->key(m_lexer.get_string()))) {
+            return false;
+          }
+
+          // parse separator (:)
+          if (JSON_UNLIKELY(get_token() != token_type::name_separator)) {
+            return sax->parse_error(m_lexer.get_position(),
+                                    m_lexer.get_token_string(),
+                                    parse_error::create(101, m_lexer.get_position(),
+                                                        exception_message(token_type::name_separator, "object separator")));
+          }
+
+          // remember we are now inside an object
+          states.push_back(false);
+
+          // parse values
+          get_token();
+          continue;
         }
 
-        return result;
-    }
+        case token_type::begin_array: {
+          if (JSON_UNLIKELY(not sax->start_array(std::size_t(-1)))) {
+            return false;
+          }
 
-  private:
-    template <typename SAX>
-    bool sax_parse_internal(SAX* sax)
-    {
-        // stack to remember the hierarchy of structured values we are parsing
-        // true = array; false = object
-        std::vector<bool> states;
-        // value to avoid a goto (see comment where set to true)
-        bool skip_to_state_evaluation = false;
+          // closing ] -> we are done
+          if (get_token() == token_type::end_array) {
+            if (JSON_UNLIKELY(not sax->end_array())) {
+              return false;
+            }
+            break;
+          }
 
-        while (true)
+          // remember we are now inside an array
+          states.push_back(true);
+
+          // parse values (no need to call get_token)
+          continue;
+        }
+
+        case token_type::value_float: {
+          const auto res = m_lexer.get_number_float();
+
+          if (JSON_UNLIKELY(not std::isfinite(res))) {
+            return sax->parse_error(m_lexer.get_position(),
+                                    m_lexer.get_token_string(),
+                                    out_of_range::create(406, "number overflow parsing '" + m_lexer.get_token_string() + "'"));
+          } else {
+            if (JSON_UNLIKELY(not sax->number_float(res, m_lexer.get_string()))) {
+              return false;
+            }
+            break;
+          }
+        }
+
+        case token_type::literal_false: {
+          if (JSON_UNLIKELY(not sax->boolean(false))) {
+            return false;
+          }
+          break;
+        }
+
+        case token_type::literal_null: {
+          if (JSON_UNLIKELY(not sax->null())) {
+            return false;
+          }
+          break;
+        }
+
+        case token_type::literal_true: {
+          if (JSON_UNLIKELY(not sax->boolean(true))) {
+            return false;
+          }
+          break;
+        }
+
+        case token_type::value_integer: {
+          if (JSON_UNLIKELY(not sax->number_integer(m_lexer.get_number_integer()))) {
+            return false;
+          }
+          break;
+        }
+
+        case token_type::value_string: {
+          if (JSON_UNLIKELY(not sax->string(m_lexer.get_string()))) {
+            return false;
+          }
+          break;
+        }
+
+        case token_type::value_unsigned: {
+          if (JSON_UNLIKELY(not sax->number_unsigned(m_lexer.get_number_unsigned()))) {
+            return false;
+          }
+          break;
+        }
+
+        case token_type::parse_error: {
+          // using "uninitialized" to avoid "expected" message
+          return sax->parse_error(m_lexer.get_position(),
+                                  m_lexer.get_token_string(),
+                                  parse_error::create(101, m_lexer.get_position(),
+                                                      exception_message(token_type::uninitialized, "value")));
+        }
+
+        default: // the last token was unexpected
         {
-            if (not skip_to_state_evaluation)
-            {
-                // invariant: get_token() was called before each iteration
-                switch (last_token)
-                {
-                    case token_type::begin_object:
-                    {
-                        if (JSON_UNLIKELY(not sax->start_object(std::size_t(-1))))
-                        {
-                            return false;
-                        }
+          return sax->parse_error(m_lexer.get_position(),
+                                  m_lexer.get_token_string(),
+                                  parse_error::create(101, m_lexer.get_position(),
+                                                      exception_message(token_type::literal_or_value, "value")));
+        }
+        }
+      } else {
+        skip_to_state_evaluation = false;
+      }
 
-                        // closing } -> we are done
-                        if (get_token() == token_type::end_object)
-                        {
-                            if (JSON_UNLIKELY(not sax->end_object()))
-                            {
-                                return false;
-                            }
-                            break;
-                        }
+      // we reached this line after we successfully parsed a value
+      if (states.empty()) {
+        // empty stack: we reached the end of the hierarchy: done
+        return true;
+      } else {
+        if (states.back()) // array
+        {
+          // comma -> next value
+          if (get_token() == token_type::value_separator) {
+            // parse a new value
+            get_token();
+            continue;
+          }
 
-                        // parse key
-                        if (JSON_UNLIKELY(last_token != token_type::value_string))
-                        {
-                            return sax->parse_error(m_lexer.get_position(),
-                                                    m_lexer.get_token_string(),
-                                                    parse_error::create(101, m_lexer.get_position(),
-                                                            exception_message(token_type::value_string, "object key")));
-                        }
-                        if (JSON_UNLIKELY(not sax->key(m_lexer.get_string())))
-                        {
-                            return false;
-                        }
-
-                        // parse separator (:)
-                        if (JSON_UNLIKELY(get_token() != token_type::name_separator))
-                        {
-                            return sax->parse_error(m_lexer.get_position(),
-                                                    m_lexer.get_token_string(),
-                                                    parse_error::create(101, m_lexer.get_position(),
-                                                            exception_message(token_type::name_separator, "object separator")));
-                        }
-
-                        // remember we are now inside an object
-                        states.push_back(false);
-
-                        // parse values
-                        get_token();
-                        continue;
-                    }
-
-                    case token_type::begin_array:
-                    {
-                        if (JSON_UNLIKELY(not sax->start_array(std::size_t(-1))))
-                        {
-                            return false;
-                        }
-
-                        // closing ] -> we are done
-                        if (get_token() == token_type::end_array)
-                        {
-                            if (JSON_UNLIKELY(not sax->end_array()))
-                            {
-                                return false;
-                            }
-                            break;
-                        }
-
-                        // remember we are now inside an array
-                        states.push_back(true);
-
-                        // parse values (no need to call get_token)
-                        continue;
-                    }
-
-                    case token_type::value_float:
-                    {
-                        const auto res = m_lexer.get_number_float();
-
-                        if (JSON_UNLIKELY(not std::isfinite(res)))
-                        {
-                            return sax->parse_error(m_lexer.get_position(),
-                                                    m_lexer.get_token_string(),
-                                                    out_of_range::create(406, "number overflow parsing '" + m_lexer.get_token_string() + "'"));
-                        }
-                        else
-                        {
-                            if (JSON_UNLIKELY(not sax->number_float(res, m_lexer.get_string())))
-                            {
-                                return false;
-                            }
-                            break;
-                        }
-                    }
-
-                    case token_type::literal_false:
-                    {
-                        if (JSON_UNLIKELY(not sax->boolean(false)))
-                        {
-                            return false;
-                        }
-                        break;
-                    }
-
-                    case token_type::literal_null:
-                    {
-                        if (JSON_UNLIKELY(not sax->null()))
-                        {
-                            return false;
-                        }
-                        break;
-                    }
-
-                    case token_type::literal_true:
-                    {
-                        if (JSON_UNLIKELY(not sax->boolean(true)))
-                        {
-                            return false;
-                        }
-                        break;
-                    }
-
-                    case token_type::value_integer:
-                    {
-                        if (JSON_UNLIKELY(not sax->number_integer(m_lexer.get_number_integer())))
-                        {
-                            return false;
-                        }
-                        break;
-                    }
-
-                    case token_type::value_string:
-                    {
-                        if (JSON_UNLIKELY(not sax->string(m_lexer.get_string())))
-                        {
-                            return false;
-                        }
-                        break;
-                    }
-
-                    case token_type::value_unsigned:
-                    {
-                        if (JSON_UNLIKELY(not sax->number_unsigned(m_lexer.get_number_unsigned())))
-                        {
-                            return false;
-                        }
-                        break;
-                    }
-
-                    case token_type::parse_error:
-                    {
-                        // using "uninitialized" to avoid "expected" message
-                        return sax->parse_error(m_lexer.get_position(),
-                                                m_lexer.get_token_string(),
-                                                parse_error::create(101, m_lexer.get_position(),
-                                                        exception_message(token_type::uninitialized, "value")));
-                    }
-
-                    default: // the last token was unexpected
-                    {
-                        return sax->parse_error(m_lexer.get_position(),
-                                                m_lexer.get_token_string(),
-                                                parse_error::create(101, m_lexer.get_position(),
-                                                        exception_message(token_type::literal_or_value, "value")));
-                    }
-                }
-            }
-            else
-            {
-                skip_to_state_evaluation = false;
+          // closing ]
+          if (JSON_LIKELY(last_token == token_type::end_array)) {
+            if (JSON_UNLIKELY(not sax->end_array())) {
+              return false;
             }
 
-            // we reached this line after we successfully parsed a value
-            if (states.empty())
-            {
-                // empty stack: we reached the end of the hierarchy: done
-                return true;
-            }
-            else
-            {
-                if (states.back())  // array
-                {
-                    // comma -> next value
-                    if (get_token() == token_type::value_separator)
-                    {
-                        // parse a new value
-                        get_token();
-                        continue;
-                    }
-
-                    // closing ]
-                    if (JSON_LIKELY(last_token == token_type::end_array))
-                    {
-                        if (JSON_UNLIKELY(not sax->end_array()))
-                        {
-                            return false;
-                        }
-
-                        // We are done with this array. Before we can parse a
-                        // new value, we need to evaluate the new state first.
-                        // By setting skip_to_state_evaluation to false, we
-                        // are effectively jumping to the beginning of this if.
-                        assert(not states.empty());
-                        states.pop_back();
-                        skip_to_state_evaluation = true;
-                        continue;
-                    }
-                    else
-                    {
-                        return sax->parse_error(m_lexer.get_position(),
-                                                m_lexer.get_token_string(),
-                                                parse_error::create(101, m_lexer.get_position(),
+            // We are done with this array. Before we can parse a
+            // new value, we need to evaluate the new state first.
+            // By setting skip_to_state_evaluation to false, we
+            // are effectively jumping to the beginning of this if.
+            assert(not states.empty());
+            states.pop_back();
+            skip_to_state_evaluation = true;
+            continue;
+          } else {
+            return sax->parse_error(m_lexer.get_position(),
+                                    m_lexer.get_token_string(),
+                                    parse_error::create(101, m_lexer.get_position(),
                                                         exception_message(token_type::end_array, "array")));
-                    }
-                }
-                else  // object
-                {
-                    // comma -> next value
-                    if (get_token() == token_type::value_separator)
-                    {
-                        // parse key
-                        if (JSON_UNLIKELY(get_token() != token_type::value_string))
-                        {
-                            return sax->parse_error(m_lexer.get_position(),
-                                                    m_lexer.get_token_string(),
-                                                    parse_error::create(101, m_lexer.get_position(),
-                                                            exception_message(token_type::value_string, "object key")));
-                        }
-                        else
-                        {
-                            if (JSON_UNLIKELY(not sax->key(m_lexer.get_string())))
-                            {
-                                return false;
-                            }
-                        }
-
-                        // parse separator (:)
-                        if (JSON_UNLIKELY(get_token() != token_type::name_separator))
-                        {
-                            return sax->parse_error(m_lexer.get_position(),
-                                                    m_lexer.get_token_string(),
-                                                    parse_error::create(101, m_lexer.get_position(),
-                                                            exception_message(token_type::name_separator, "object separator")));
-                        }
-
-                        // parse values
-                        get_token();
-                        continue;
-                    }
-
-                    // closing }
-                    if (JSON_LIKELY(last_token == token_type::end_object))
-                    {
-                        if (JSON_UNLIKELY(not sax->end_object()))
-                        {
-                            return false;
-                        }
-
-                        // We are done with this object. Before we can parse a
-                        // new value, we need to evaluate the new state first.
-                        // By setting skip_to_state_evaluation to false, we
-                        // are effectively jumping to the beginning of this if.
-                        assert(not states.empty());
-                        states.pop_back();
-                        skip_to_state_evaluation = true;
-                        continue;
-                    }
-                    else
-                    {
-                        return sax->parse_error(m_lexer.get_position(),
-                                                m_lexer.get_token_string(),
-                                                parse_error::create(101, m_lexer.get_position(),
-                                                        exception_message(token_type::end_object, "object")));
-                    }
-                }
+          }
+        } else // object
+        {
+          // comma -> next value
+          if (get_token() == token_type::value_separator) {
+            // parse key
+            if (JSON_UNLIKELY(get_token() != token_type::value_string)) {
+              return sax->parse_error(m_lexer.get_position(),
+                                      m_lexer.get_token_string(),
+                                      parse_error::create(101, m_lexer.get_position(),
+                                                          exception_message(token_type::value_string, "object key")));
+            } else {
+              if (JSON_UNLIKELY(not sax->key(m_lexer.get_string()))) {
+                return false;
+              }
             }
+
+            // parse separator (:)
+            if (JSON_UNLIKELY(get_token() != token_type::name_separator)) {
+              return sax->parse_error(m_lexer.get_position(),
+                                      m_lexer.get_token_string(),
+                                      parse_error::create(101, m_lexer.get_position(),
+                                                          exception_message(token_type::name_separator, "object separator")));
+            }
+
+            // parse values
+            get_token();
+            continue;
+          }
+
+          // closing }
+          if (JSON_LIKELY(last_token == token_type::end_object)) {
+            if (JSON_UNLIKELY(not sax->end_object())) {
+              return false;
+            }
+
+            // We are done with this object. Before we can parse a
+            // new value, we need to evaluate the new state first.
+            // By setting skip_to_state_evaluation to false, we
+            // are effectively jumping to the beginning of this if.
+            assert(not states.empty());
+            states.pop_back();
+            skip_to_state_evaluation = true;
+            continue;
+          } else {
+            return sax->parse_error(m_lexer.get_position(),
+                                    m_lexer.get_token_string(),
+                                    parse_error::create(101, m_lexer.get_position(),
+                                                        exception_message(token_type::end_object, "object")));
+          }
         }
+      }
+    }
+  }
+
+  /// get next token from lexer
+  token_type get_token()
+  {
+    return (last_token = m_lexer.scan());
+  }
+
+  std::string exception_message(const token_type expected, const std::string &context)
+  {
+    std::string error_msg = "syntax error ";
+
+    if (not context.empty()) {
+      error_msg += "while parsing " + context + " ";
     }
 
-    /// get next token from lexer
-    token_type get_token()
-    {
-        return (last_token = m_lexer.scan());
+    error_msg += "- ";
+
+    if (last_token == token_type::parse_error) {
+      error_msg += std::string(m_lexer.get_error_message()) + "; last read: '" +
+                   m_lexer.get_token_string() + "'";
+    } else {
+      error_msg += "unexpected " + std::string(lexer_t::token_type_name(last_token));
     }
 
-    std::string exception_message(const token_type expected, const std::string& context)
-    {
-        std::string error_msg = "syntax error ";
-
-        if (not context.empty())
-        {
-            error_msg += "while parsing " + context + " ";
-        }
-
-        error_msg += "- ";
-
-        if (last_token == token_type::parse_error)
-        {
-            error_msg += std::string(m_lexer.get_error_message()) + "; last read: '" +
-                         m_lexer.get_token_string() + "'";
-        }
-        else
-        {
-            error_msg += "unexpected " + std::string(lexer_t::token_type_name(last_token));
-        }
-
-        if (expected != token_type::uninitialized)
-        {
-            error_msg += "; expected " + std::string(lexer_t::token_type_name(expected));
-        }
-
-        return error_msg;
+    if (expected != token_type::uninitialized) {
+      error_msg += "; expected " + std::string(lexer_t::token_type_name(expected));
     }
 
-  private:
-    /// callback function
-    const parser_callback_t callback = nullptr;
-    /// the type of the last read token
-    token_type last_token = token_type::uninitialized;
-    /// the lexer
-    lexer_t m_lexer;
-    /// whether to throw exceptions in case of errors
-    const bool allow_exceptions = true;
+    return error_msg;
+  }
+
+private:
+  /// callback function
+  const parser_callback_t callback = nullptr;
+  /// the type of the last read token
+  token_type last_token = token_type::uninitialized;
+  /// the lexer
+  lexer_t m_lexer;
+  /// whether to throw exceptions in case of errors
+  const bool allow_exceptions = true;
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/iterators/primitive_iterator.hpp>
-
 
 #include <cstddef> // ptrdiff_t
 #include <limits>  // numeric_limits
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 /*
 @brief an iterator for primitive JSON types
 
@@ -5450,142 +5065,136 @@ to "iterate" over primitive values. Internally, the iterator is modeled by
 a `difference_type` variable. Value begin_value (`0`) models the begin,
 end_value (`1`) models past the end.
 */
-class primitive_iterator_t
-{
-  private:
-    using difference_type = std::ptrdiff_t;
-    static constexpr difference_type begin_value = 0;
-    static constexpr difference_type end_value = begin_value + 1;
+class primitive_iterator_t {
+private:
+  using difference_type                        = std::ptrdiff_t;
+  static constexpr difference_type begin_value = 0;
+  static constexpr difference_type end_value   = begin_value + 1;
 
-    /// iterator as signed integer type
-    difference_type m_it = (std::numeric_limits<std::ptrdiff_t>::min)();
+  /// iterator as signed integer type
+  difference_type m_it = (std::numeric_limits<std::ptrdiff_t>::min)();
 
-  public:
-    constexpr difference_type get_value() const noexcept
-    {
-        return m_it;
-    }
+public:
+  constexpr difference_type get_value() const noexcept
+  {
+    return m_it;
+  }
 
-    /// set iterator to a defined beginning
-    void set_begin() noexcept
-    {
-        m_it = begin_value;
-    }
+  /// set iterator to a defined beginning
+  void set_begin() noexcept
+  {
+    m_it = begin_value;
+  }
 
-    /// set iterator to a defined past the end
-    void set_end() noexcept
-    {
-        m_it = end_value;
-    }
+  /// set iterator to a defined past the end
+  void set_end() noexcept
+  {
+    m_it = end_value;
+  }
 
-    /// return whether the iterator can be dereferenced
-    constexpr bool is_begin() const noexcept
-    {
-        return m_it == begin_value;
-    }
+  /// return whether the iterator can be dereferenced
+  constexpr bool is_begin() const noexcept
+  {
+    return m_it == begin_value;
+  }
 
-    /// return whether the iterator is at end
-    constexpr bool is_end() const noexcept
-    {
-        return m_it == end_value;
-    }
+  /// return whether the iterator is at end
+  constexpr bool is_end() const noexcept
+  {
+    return m_it == end_value;
+  }
 
-    friend constexpr bool operator==(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-    {
-        return lhs.m_it == rhs.m_it;
-    }
+  friend constexpr bool operator==(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
+  {
+    return lhs.m_it == rhs.m_it;
+  }
 
-    friend constexpr bool operator<(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-    {
-        return lhs.m_it < rhs.m_it;
-    }
+  friend constexpr bool operator<(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
+  {
+    return lhs.m_it < rhs.m_it;
+  }
 
-    primitive_iterator_t operator+(difference_type n) noexcept
-    {
-        auto result = *this;
-        result += n;
-        return result;
-    }
+  primitive_iterator_t operator+(difference_type n) noexcept
+  {
+    auto result = *this;
+    result += n;
+    return result;
+  }
 
-    friend constexpr difference_type operator-(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
-    {
-        return lhs.m_it - rhs.m_it;
-    }
+  friend constexpr difference_type operator-(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
+  {
+    return lhs.m_it - rhs.m_it;
+  }
 
-    primitive_iterator_t& operator++() noexcept
-    {
-        ++m_it;
-        return *this;
-    }
+  primitive_iterator_t &operator++() noexcept
+  {
+    ++m_it;
+    return *this;
+  }
 
-    primitive_iterator_t const operator++(int) noexcept
-    {
-        auto result = *this;
-        ++m_it;
-        return result;
-    }
+  primitive_iterator_t const operator++(int) noexcept
+  {
+    auto result = *this;
+    ++m_it;
+    return result;
+  }
 
-    primitive_iterator_t& operator--() noexcept
-    {
-        --m_it;
-        return *this;
-    }
+  primitive_iterator_t &operator--() noexcept
+  {
+    --m_it;
+    return *this;
+  }
 
-    primitive_iterator_t const operator--(int) noexcept
-    {
-        auto result = *this;
-        --m_it;
-        return result;
-    }
+  primitive_iterator_t const operator--(int) noexcept
+  {
+    auto result = *this;
+    --m_it;
+    return result;
+  }
 
-    primitive_iterator_t& operator+=(difference_type n) noexcept
-    {
-        m_it += n;
-        return *this;
-    }
+  primitive_iterator_t &operator+=(difference_type n) noexcept
+  {
+    m_it += n;
+    return *this;
+  }
 
-    primitive_iterator_t& operator-=(difference_type n) noexcept
-    {
-        m_it -= n;
-        return *this;
-    }
+  primitive_iterator_t &operator-=(difference_type n) noexcept
+  {
+    m_it -= n;
+    return *this;
+  }
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/iterators/internal_iterator.hpp>
 
-
 // #include <nlohmann/detail/iterators/primitive_iterator.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 /*!
 @brief an iterator value
 
 @note This structure could easily be a union, but MSVC currently does not allow
 unions members with complex constructors, see https://github.com/nlohmann/json/pull/105.
 */
-template<typename BasicJsonType> struct internal_iterator
-{
-    /// iterator for JSON objects
-    typename BasicJsonType::object_t::iterator object_iterator {};
-    /// iterator for JSON arrays
-    typename BasicJsonType::array_t::iterator array_iterator {};
-    /// generic iterator for all other types
-    primitive_iterator_t primitive_iterator {};
+template <typename BasicJsonType>
+struct internal_iterator {
+  /// iterator for JSON objects
+  typename BasicJsonType::object_t::iterator object_iterator{};
+  /// iterator for JSON arrays
+  typename BasicJsonType::array_t::iterator array_iterator{};
+  /// generic iterator for all other types
+  primitive_iterator_t primitive_iterator{};
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/iterators/iter_impl.hpp>
 
-
-#include <ciso646> // not
-#include <iterator> // iterator, random_access_iterator_tag, bidirectional_iterator_tag, advance, next
+#include <ciso646>     // not
+#include <iterator>    // iterator, random_access_iterator_tag, bidirectional_iterator_tag, advance, next
 #include <type_traits> // conditional, is_const, remove_const
 
 // #include <nlohmann/detail/exceptions.hpp>
@@ -5600,14 +5209,13 @@ template<typename BasicJsonType> struct internal_iterator
 
 // #include <nlohmann/detail/value_t.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 // forward declare, to be able to friend it later on
-template<typename IteratorType> class iteration_proxy;
-template<typename IteratorType> class iteration_proxy_value;
+template <typename IteratorType>
+class iteration_proxy;
+template <typename IteratorType>
+class iteration_proxy_value;
 
 /*!
 @brief a template for a bidirectional iterator for the @ref basic_json class
@@ -5625,80 +5233,75 @@ This class implements a both iterators (iterator and const_iterator) for the
 @since version 1.0.0, simplified in version 2.0.9, change to bidirectional
        iterators in version 3.0.0 (see https://github.com/nlohmann/json/issues/593)
 */
-template<typename BasicJsonType>
-class iter_impl
-{
-    /// allow basic_json to access private members
-    friend iter_impl<typename std::conditional<std::is_const<BasicJsonType>::value, typename std::remove_const<BasicJsonType>::type, const BasicJsonType>::type>;
-    friend BasicJsonType;
-    friend iteration_proxy<iter_impl>;
-    friend iteration_proxy_value<iter_impl>;
+template <typename BasicJsonType>
+class iter_impl {
+  /// allow basic_json to access private members
+  friend iter_impl<typename std::conditional<std::is_const<BasicJsonType>::value, typename std::remove_const<BasicJsonType>::type, const BasicJsonType>::type>;
+  friend BasicJsonType;
+  friend iteration_proxy<iter_impl>;
+  friend iteration_proxy_value<iter_impl>;
 
-    using object_t = typename BasicJsonType::object_t;
-    using array_t = typename BasicJsonType::array_t;
-    // make sure BasicJsonType is basic_json or const basic_json
-    static_assert(is_basic_json<typename std::remove_const<BasicJsonType>::type>::value,
-                  "iter_impl only accepts (const) basic_json");
+  using object_t = typename BasicJsonType::object_t;
+  using array_t  = typename BasicJsonType::array_t;
+  // make sure BasicJsonType is basic_json or const basic_json
+  static_assert(is_basic_json<typename std::remove_const<BasicJsonType>::type>::value,
+                "iter_impl only accepts (const) basic_json");
 
-  public:
+public:
+  /// The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17.
+  /// The C++ Standard has never required user-defined iterators to derive from std::iterator.
+  /// A user-defined iterator should provide publicly accessible typedefs named
+  /// iterator_category, value_type, difference_type, pointer, and reference.
+  /// Note that value_type is required to be non-const, even for constant iterators.
+  using iterator_category = std::bidirectional_iterator_tag;
 
-    /// The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17.
-    /// The C++ Standard has never required user-defined iterators to derive from std::iterator.
-    /// A user-defined iterator should provide publicly accessible typedefs named
-    /// iterator_category, value_type, difference_type, pointer, and reference.
-    /// Note that value_type is required to be non-const, even for constant iterators.
-    using iterator_category = std::bidirectional_iterator_tag;
+  /// the type of the values when the iterator is dereferenced
+  using value_type = typename BasicJsonType::value_type;
+  /// a type to represent differences between iterators
+  using difference_type = typename BasicJsonType::difference_type;
+  /// defines a pointer to the type iterated over (value_type)
+  using pointer = typename std::conditional<std::is_const<BasicJsonType>::value,
+                                            typename BasicJsonType::const_pointer,
+                                            typename BasicJsonType::pointer>::type;
+  /// defines a reference to the type iterated over (value_type)
+  using reference =
+      typename std::conditional<std::is_const<BasicJsonType>::value,
+                                typename BasicJsonType::const_reference,
+                                typename BasicJsonType::reference>::type;
 
-    /// the type of the values when the iterator is dereferenced
-    using value_type = typename BasicJsonType::value_type;
-    /// a type to represent differences between iterators
-    using difference_type = typename BasicJsonType::difference_type;
-    /// defines a pointer to the type iterated over (value_type)
-    using pointer = typename std::conditional<std::is_const<BasicJsonType>::value,
-          typename BasicJsonType::const_pointer,
-          typename BasicJsonType::pointer>::type;
-    /// defines a reference to the type iterated over (value_type)
-    using reference =
-        typename std::conditional<std::is_const<BasicJsonType>::value,
-        typename BasicJsonType::const_reference,
-        typename BasicJsonType::reference>::type;
+  /// default constructor
+  iter_impl() = default;
 
-    /// default constructor
-    iter_impl() = default;
-
-    /*!
+  /*!
     @brief constructor for a given JSON instance
     @param[in] object  pointer to a JSON object for this iterator
     @pre object != nullptr
     @post The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    explicit iter_impl(pointer object) noexcept : m_object(object)
-    {
-        assert(m_object != nullptr);
+  explicit iter_impl(pointer object) noexcept
+      : m_object(object)
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-            {
-                m_it.object_iterator = typename object_t::iterator();
-                break;
-            }
-
-            case value_t::array:
-            {
-                m_it.array_iterator = typename array_t::iterator();
-                break;
-            }
-
-            default:
-            {
-                m_it.primitive_iterator = primitive_iterator_t();
-                break;
-            }
-        }
+    switch (m_object->m_type) {
+    case value_t::object: {
+      m_it.object_iterator = typename object_t::iterator();
+      break;
     }
 
-    /*!
+    case value_t::array: {
+      m_it.array_iterator = typename array_t::iterator();
+      break;
+    }
+
+    default: {
+      m_it.primitive_iterator = primitive_iterator_t();
+      break;
+    }
+    }
+  }
+
+  /*!
     @note The conventional copy constructor and copy assignment are implicitly
           defined. Combined with the following converting constructor and
           assignment, they support: (1) copy from iterator to iterator, (2)
@@ -5707,512 +5310,470 @@ class iter_impl
           to iterator is not defined.
     */
 
-    /*!
+  /*!
     @brief converting constructor
     @param[in] other  non-const iterator to copy from
     @note It is not checked whether @a other is initialized.
     */
-    iter_impl(const iter_impl<typename std::remove_const<BasicJsonType>::type>& other) noexcept
-        : m_object(other.m_object), m_it(other.m_it) {}
+  iter_impl(const iter_impl<typename std::remove_const<BasicJsonType>::type> &other) noexcept
+      : m_object(other.m_object), m_it(other.m_it) {}
 
-    /*!
+  /*!
     @brief converting assignment
     @param[in,out] other  non-const iterator to copy from
     @return const/non-const iterator
     @note It is not checked whether @a other is initialized.
     */
-    iter_impl& operator=(const iter_impl<typename std::remove_const<BasicJsonType>::type>& other) noexcept
-    {
-        m_object = other.m_object;
-        m_it = other.m_it;
-        return *this;
-    }
+  iter_impl &operator=(const iter_impl<typename std::remove_const<BasicJsonType>::type> &other) noexcept
+  {
+    m_object = other.m_object;
+    m_it     = other.m_it;
+    return *this;
+  }
 
-  private:
-    /*!
+private:
+  /*!
     @brief set the iterator to the first value
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    void set_begin() noexcept
-    {
-        assert(m_object != nullptr);
+  void set_begin() noexcept
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-            {
-                m_it.object_iterator = m_object->m_value.object->begin();
-                break;
-            }
-
-            case value_t::array:
-            {
-                m_it.array_iterator = m_object->m_value.array->begin();
-                break;
-            }
-
-            case value_t::null:
-            {
-                // set to end so begin()==end() is true: null is empty
-                m_it.primitive_iterator.set_end();
-                break;
-            }
-
-            default:
-            {
-                m_it.primitive_iterator.set_begin();
-                break;
-            }
-        }
+    switch (m_object->m_type) {
+    case value_t::object: {
+      m_it.object_iterator = m_object->m_value.object->begin();
+      break;
     }
 
-    /*!
+    case value_t::array: {
+      m_it.array_iterator = m_object->m_value.array->begin();
+      break;
+    }
+
+    case value_t::null: {
+      // set to end so begin()==end() is true: null is empty
+      m_it.primitive_iterator.set_end();
+      break;
+    }
+
+    default: {
+      m_it.primitive_iterator.set_begin();
+      break;
+    }
+    }
+  }
+
+  /*!
     @brief set the iterator past the last value
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    void set_end() noexcept
-    {
-        assert(m_object != nullptr);
+  void set_end() noexcept
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-            {
-                m_it.object_iterator = m_object->m_value.object->end();
-                break;
-            }
-
-            case value_t::array:
-            {
-                m_it.array_iterator = m_object->m_value.array->end();
-                break;
-            }
-
-            default:
-            {
-                m_it.primitive_iterator.set_end();
-                break;
-            }
-        }
+    switch (m_object->m_type) {
+    case value_t::object: {
+      m_it.object_iterator = m_object->m_value.object->end();
+      break;
     }
 
-  public:
-    /*!
+    case value_t::array: {
+      m_it.array_iterator = m_object->m_value.array->end();
+      break;
+    }
+
+    default: {
+      m_it.primitive_iterator.set_end();
+      break;
+    }
+    }
+  }
+
+public:
+  /*!
     @brief return a reference to the value pointed to by the iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    reference operator*() const
-    {
-        assert(m_object != nullptr);
+  reference operator*() const
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-            {
-                assert(m_it.object_iterator != m_object->m_value.object->end());
-                return m_it.object_iterator->second;
-            }
-
-            case value_t::array:
-            {
-                assert(m_it.array_iterator != m_object->m_value.array->end());
-                return *m_it.array_iterator;
-            }
-
-            case value_t::null:
-                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
-
-            default:
-            {
-                if (JSON_LIKELY(m_it.primitive_iterator.is_begin()))
-                {
-                    return *m_object;
-                }
-
-                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
-            }
-        }
+    switch (m_object->m_type) {
+    case value_t::object: {
+      assert(m_it.object_iterator != m_object->m_value.object->end());
+      return m_it.object_iterator->second;
     }
 
-    /*!
+    case value_t::array: {
+      assert(m_it.array_iterator != m_object->m_value.array->end());
+      return *m_it.array_iterator;
+    }
+
+    case value_t::null:
+      JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+
+    default: {
+      if (JSON_LIKELY(m_it.primitive_iterator.is_begin())) {
+        return *m_object;
+      }
+
+      JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+    }
+    }
+  }
+
+  /*!
     @brief dereference the iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    pointer operator->() const
-    {
-        assert(m_object != nullptr);
+  pointer operator->() const
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-            {
-                assert(m_it.object_iterator != m_object->m_value.object->end());
-                return &(m_it.object_iterator->second);
-            }
-
-            case value_t::array:
-            {
-                assert(m_it.array_iterator != m_object->m_value.array->end());
-                return &*m_it.array_iterator;
-            }
-
-            default:
-            {
-                if (JSON_LIKELY(m_it.primitive_iterator.is_begin()))
-                {
-                    return m_object;
-                }
-
-                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
-            }
-        }
+    switch (m_object->m_type) {
+    case value_t::object: {
+      assert(m_it.object_iterator != m_object->m_value.object->end());
+      return &(m_it.object_iterator->second);
     }
 
-    /*!
+    case value_t::array: {
+      assert(m_it.array_iterator != m_object->m_value.array->end());
+      return &*m_it.array_iterator;
+    }
+
+    default: {
+      if (JSON_LIKELY(m_it.primitive_iterator.is_begin())) {
+        return m_object;
+      }
+
+      JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+    }
+    }
+  }
+
+  /*!
     @brief post-increment (it++)
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl const operator++(int)
-    {
-        auto result = *this;
-        ++(*this);
-        return result;
-    }
+  iter_impl const operator++(int)
+  {
+    auto result = *this;
+    ++(*this);
+    return result;
+  }
 
-    /*!
+  /*!
     @brief pre-increment (++it)
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl& operator++()
-    {
-        assert(m_object != nullptr);
+  iter_impl &operator++()
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-            {
-                std::advance(m_it.object_iterator, 1);
-                break;
-            }
-
-            case value_t::array:
-            {
-                std::advance(m_it.array_iterator, 1);
-                break;
-            }
-
-            default:
-            {
-                ++m_it.primitive_iterator;
-                break;
-            }
-        }
-
-        return *this;
+    switch (m_object->m_type) {
+    case value_t::object: {
+      std::advance(m_it.object_iterator, 1);
+      break;
     }
 
-    /*!
+    case value_t::array: {
+      std::advance(m_it.array_iterator, 1);
+      break;
+    }
+
+    default: {
+      ++m_it.primitive_iterator;
+      break;
+    }
+    }
+
+    return *this;
+  }
+
+  /*!
     @brief post-decrement (it--)
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl const operator--(int)
-    {
-        auto result = *this;
-        --(*this);
-        return result;
-    }
+  iter_impl const operator--(int)
+  {
+    auto result = *this;
+    --(*this);
+    return result;
+  }
 
-    /*!
+  /*!
     @brief pre-decrement (--it)
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl& operator--()
-    {
-        assert(m_object != nullptr);
+  iter_impl &operator--()
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-            {
-                std::advance(m_it.object_iterator, -1);
-                break;
-            }
-
-            case value_t::array:
-            {
-                std::advance(m_it.array_iterator, -1);
-                break;
-            }
-
-            default:
-            {
-                --m_it.primitive_iterator;
-                break;
-            }
-        }
-
-        return *this;
+    switch (m_object->m_type) {
+    case value_t::object: {
+      std::advance(m_it.object_iterator, -1);
+      break;
     }
 
-    /*!
+    case value_t::array: {
+      std::advance(m_it.array_iterator, -1);
+      break;
+    }
+
+    default: {
+      --m_it.primitive_iterator;
+      break;
+    }
+    }
+
+    return *this;
+  }
+
+  /*!
     @brief  comparison: equal
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    bool operator==(const iter_impl& other) const
-    {
-        // if objects are not the same, the comparison is undefined
-        if (JSON_UNLIKELY(m_object != other.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(212, "cannot compare iterators of different containers"));
-        }
-
-        assert(m_object != nullptr);
-
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-                return (m_it.object_iterator == other.m_it.object_iterator);
-
-            case value_t::array:
-                return (m_it.array_iterator == other.m_it.array_iterator);
-
-            default:
-                return (m_it.primitive_iterator == other.m_it.primitive_iterator);
-        }
+  bool operator==(const iter_impl &other) const
+  {
+    // if objects are not the same, the comparison is undefined
+    if (JSON_UNLIKELY(m_object != other.m_object)) {
+      JSON_THROW(invalid_iterator::create(212, "cannot compare iterators of different containers"));
     }
 
-    /*!
+    assert(m_object != nullptr);
+
+    switch (m_object->m_type) {
+    case value_t::object:
+      return (m_it.object_iterator == other.m_it.object_iterator);
+
+    case value_t::array:
+      return (m_it.array_iterator == other.m_it.array_iterator);
+
+    default:
+      return (m_it.primitive_iterator == other.m_it.primitive_iterator);
+    }
+  }
+
+  /*!
     @brief  comparison: not equal
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    bool operator!=(const iter_impl& other) const
-    {
-        return not operator==(other);
-    }
+  bool operator!=(const iter_impl &other) const
+  {
+    return not operator==(other);
+  }
 
-    /*!
+  /*!
     @brief  comparison: smaller
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    bool operator<(const iter_impl& other) const
-    {
-        // if objects are not the same, the comparison is undefined
-        if (JSON_UNLIKELY(m_object != other.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(212, "cannot compare iterators of different containers"));
-        }
-
-        assert(m_object != nullptr);
-
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-                JSON_THROW(invalid_iterator::create(213, "cannot compare order of object iterators"));
-
-            case value_t::array:
-                return (m_it.array_iterator < other.m_it.array_iterator);
-
-            default:
-                return (m_it.primitive_iterator < other.m_it.primitive_iterator);
-        }
+  bool operator<(const iter_impl &other) const
+  {
+    // if objects are not the same, the comparison is undefined
+    if (JSON_UNLIKELY(m_object != other.m_object)) {
+      JSON_THROW(invalid_iterator::create(212, "cannot compare iterators of different containers"));
     }
 
-    /*!
+    assert(m_object != nullptr);
+
+    switch (m_object->m_type) {
+    case value_t::object:
+      JSON_THROW(invalid_iterator::create(213, "cannot compare order of object iterators"));
+
+    case value_t::array:
+      return (m_it.array_iterator < other.m_it.array_iterator);
+
+    default:
+      return (m_it.primitive_iterator < other.m_it.primitive_iterator);
+    }
+  }
+
+  /*!
     @brief  comparison: less than or equal
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    bool operator<=(const iter_impl& other) const
-    {
-        return not other.operator < (*this);
-    }
+  bool operator<=(const iter_impl &other) const
+  {
+    return not other.operator<(*this);
+  }
 
-    /*!
+  /*!
     @brief  comparison: greater than
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    bool operator>(const iter_impl& other) const
-    {
-        return not operator<=(other);
-    }
+  bool operator>(const iter_impl &other) const
+  {
+    return not operator<=(other);
+  }
 
-    /*!
+  /*!
     @brief  comparison: greater than or equal
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    bool operator>=(const iter_impl& other) const
-    {
-        return not operator<(other);
-    }
+  bool operator>=(const iter_impl &other) const
+  {
+    return not operator<(other);
+  }
 
-    /*!
+  /*!
     @brief  add to iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl& operator+=(difference_type i)
-    {
-        assert(m_object != nullptr);
+  iter_impl &operator+=(difference_type i)
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-                JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators"));
+    switch (m_object->m_type) {
+    case value_t::object:
+      JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators"));
 
-            case value_t::array:
-            {
-                std::advance(m_it.array_iterator, i);
-                break;
-            }
-
-            default:
-            {
-                m_it.primitive_iterator += i;
-                break;
-            }
-        }
-
-        return *this;
+    case value_t::array: {
+      std::advance(m_it.array_iterator, i);
+      break;
     }
 
-    /*!
+    default: {
+      m_it.primitive_iterator += i;
+      break;
+    }
+    }
+
+    return *this;
+  }
+
+  /*!
     @brief  subtract from iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl& operator-=(difference_type i)
-    {
-        return operator+=(-i);
-    }
+  iter_impl &operator-=(difference_type i)
+  {
+    return operator+=(-i);
+  }
 
-    /*!
+  /*!
     @brief  add to iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl operator+(difference_type i) const
-    {
-        auto result = *this;
-        result += i;
-        return result;
-    }
+  iter_impl operator+(difference_type i) const
+  {
+    auto result = *this;
+    result += i;
+    return result;
+  }
 
-    /*!
+  /*!
     @brief  addition of distance and iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    friend iter_impl operator+(difference_type i, const iter_impl& it)
-    {
-        auto result = it;
-        result += i;
-        return result;
-    }
+  friend iter_impl operator+(difference_type i, const iter_impl &it)
+  {
+    auto result = it;
+    result += i;
+    return result;
+  }
 
-    /*!
+  /*!
     @brief  subtract from iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    iter_impl operator-(difference_type i) const
-    {
-        auto result = *this;
-        result -= i;
-        return result;
-    }
+  iter_impl operator-(difference_type i) const
+  {
+    auto result = *this;
+    result -= i;
+    return result;
+  }
 
-    /*!
+  /*!
     @brief  return difference
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    difference_type operator-(const iter_impl& other) const
-    {
-        assert(m_object != nullptr);
+  difference_type operator-(const iter_impl &other) const
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-                JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators"));
+    switch (m_object->m_type) {
+    case value_t::object:
+      JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators"));
 
-            case value_t::array:
-                return m_it.array_iterator - other.m_it.array_iterator;
+    case value_t::array:
+      return m_it.array_iterator - other.m_it.array_iterator;
 
-            default:
-                return m_it.primitive_iterator - other.m_it.primitive_iterator;
-        }
+    default:
+      return m_it.primitive_iterator - other.m_it.primitive_iterator;
     }
+  }
 
-    /*!
+  /*!
     @brief  access to successor
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    reference operator[](difference_type n) const
-    {
-        assert(m_object != nullptr);
+  reference operator[](difference_type n) const
+  {
+    assert(m_object != nullptr);
 
-        switch (m_object->m_type)
-        {
-            case value_t::object:
-                JSON_THROW(invalid_iterator::create(208, "cannot use operator[] for object iterators"));
+    switch (m_object->m_type) {
+    case value_t::object:
+      JSON_THROW(invalid_iterator::create(208, "cannot use operator[] for object iterators"));
 
-            case value_t::array:
-                return *std::next(m_it.array_iterator, n);
+    case value_t::array:
+      return *std::next(m_it.array_iterator, n);
 
-            case value_t::null:
-                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
+    case value_t::null:
+      JSON_THROW(invalid_iterator::create(214, "cannot get value"));
 
-            default:
-            {
-                if (JSON_LIKELY(m_it.primitive_iterator.get_value() == -n))
-                {
-                    return *m_object;
-                }
+    default: {
+      if (JSON_LIKELY(m_it.primitive_iterator.get_value() == -n)) {
+        return *m_object;
+      }
 
-                JSON_THROW(invalid_iterator::create(214, "cannot get value"));
-            }
-        }
+      JSON_THROW(invalid_iterator::create(214, "cannot get value"));
     }
+    }
+  }
 
-    /*!
+  /*!
     @brief  return the key of an object iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    const typename object_t::key_type& key() const
-    {
-        assert(m_object != nullptr);
+  const typename object_t::key_type &key() const
+  {
+    assert(m_object != nullptr);
 
-        if (JSON_LIKELY(m_object->is_object()))
-        {
-            return m_it.object_iterator->first;
-        }
-
-        JSON_THROW(invalid_iterator::create(207, "cannot use key() for non-object iterators"));
+    if (JSON_LIKELY(m_object->is_object())) {
+      return m_it.object_iterator->first;
     }
 
-    /*!
+    JSON_THROW(invalid_iterator::create(207, "cannot use key() for non-object iterators"));
+  }
+
+  /*!
     @brief  return the value of an iterator
     @pre The iterator is initialized; i.e. `m_object != nullptr`.
     */
-    reference value() const
-    {
-        return operator*();
-    }
+  reference value() const
+  {
+    return operator*();
+  }
 
-  private:
-    /// associated JSON instance
-    pointer m_object = nullptr;
-    /// the actual iterator of the associated instance
-    internal_iterator<typename std::remove_const<BasicJsonType>::type> m_it;
+private:
+  /// associated JSON instance
+  pointer m_object = nullptr;
+  /// the actual iterator of the associated instance
+  internal_iterator<typename std::remove_const<BasicJsonType>::type> m_it;
 };
-}  // namespace detail
+} // namespace detail
 } // namespace nlohmann
 // #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 
 // #include <nlohmann/detail/iterators/json_reverse_iterator.hpp>
 
-
-#include <cstddef> // ptrdiff_t
+#include <cstddef>  // ptrdiff_t
 #include <iterator> // reverse_iterator
-#include <utility> // declval
+#include <utility>  // declval
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 //////////////////////
 // reverse_iterator //
 //////////////////////
@@ -6235,230 +5796,225 @@ create @ref const_reverse_iterator).
 
 @since version 1.0.0
 */
-template<typename Base>
-class json_reverse_iterator : public std::reverse_iterator<Base>
-{
-  public:
-    using difference_type = std::ptrdiff_t;
-    /// shortcut to the reverse iterator adapter
-    using base_iterator = std::reverse_iterator<Base>;
-    /// the reference type for the pointed-to element
-    using reference = typename Base::reference;
+template <typename Base>
+class json_reverse_iterator : public std::reverse_iterator<Base> {
+public:
+  using difference_type = std::ptrdiff_t;
+  /// shortcut to the reverse iterator adapter
+  using base_iterator = std::reverse_iterator<Base>;
+  /// the reference type for the pointed-to element
+  using reference = typename Base::reference;
 
-    /// create reverse iterator from iterator
-    explicit json_reverse_iterator(const typename base_iterator::iterator_type& it) noexcept
-        : base_iterator(it) {}
+  /// create reverse iterator from iterator
+  explicit json_reverse_iterator(const typename base_iterator::iterator_type &it) noexcept
+      : base_iterator(it) {}
 
-    /// create reverse iterator from base class
-    explicit json_reverse_iterator(const base_iterator& it) noexcept : base_iterator(it) {}
+  /// create reverse iterator from base class
+  explicit json_reverse_iterator(const base_iterator &it) noexcept
+      : base_iterator(it) {}
 
-    /// post-increment (it++)
-    json_reverse_iterator const operator++(int)
-    {
-        return static_cast<json_reverse_iterator>(base_iterator::operator++(1));
-    }
+  /// post-increment (it++)
+  json_reverse_iterator const operator++(int)
+  {
+    return static_cast<json_reverse_iterator>(base_iterator::operator++(1));
+  }
 
-    /// pre-increment (++it)
-    json_reverse_iterator& operator++()
-    {
-        return static_cast<json_reverse_iterator&>(base_iterator::operator++());
-    }
+  /// pre-increment (++it)
+  json_reverse_iterator &operator++()
+  {
+    return static_cast<json_reverse_iterator &>(base_iterator::operator++());
+  }
 
-    /// post-decrement (it--)
-    json_reverse_iterator const operator--(int)
-    {
-        return static_cast<json_reverse_iterator>(base_iterator::operator--(1));
-    }
+  /// post-decrement (it--)
+  json_reverse_iterator const operator--(int)
+  {
+    return static_cast<json_reverse_iterator>(base_iterator::operator--(1));
+  }
 
-    /// pre-decrement (--it)
-    json_reverse_iterator& operator--()
-    {
-        return static_cast<json_reverse_iterator&>(base_iterator::operator--());
-    }
+  /// pre-decrement (--it)
+  json_reverse_iterator &operator--()
+  {
+    return static_cast<json_reverse_iterator &>(base_iterator::operator--());
+  }
 
-    /// add to iterator
-    json_reverse_iterator& operator+=(difference_type i)
-    {
-        return static_cast<json_reverse_iterator&>(base_iterator::operator+=(i));
-    }
+  /// add to iterator
+  json_reverse_iterator &operator+=(difference_type i)
+  {
+    return static_cast<json_reverse_iterator &>(base_iterator::operator+=(i));
+  }
 
-    /// add to iterator
-    json_reverse_iterator operator+(difference_type i) const
-    {
-        return static_cast<json_reverse_iterator>(base_iterator::operator+(i));
-    }
+  /// add to iterator
+  json_reverse_iterator operator+(difference_type i) const
+  {
+    return static_cast<json_reverse_iterator>(base_iterator::operator+(i));
+  }
 
-    /// subtract from iterator
-    json_reverse_iterator operator-(difference_type i) const
-    {
-        return static_cast<json_reverse_iterator>(base_iterator::operator-(i));
-    }
+  /// subtract from iterator
+  json_reverse_iterator operator-(difference_type i) const
+  {
+    return static_cast<json_reverse_iterator>(base_iterator::operator-(i));
+  }
 
-    /// return difference
-    difference_type operator-(const json_reverse_iterator& other) const
-    {
-        return base_iterator(*this) - base_iterator(other);
-    }
+  /// return difference
+  difference_type operator-(const json_reverse_iterator &other) const
+  {
+    return base_iterator(*this) - base_iterator(other);
+  }
 
-    /// access to successor
-    reference operator[](difference_type n) const
-    {
-        return *(this->operator+(n));
-    }
+  /// access to successor
+  reference operator[](difference_type n) const
+  {
+    return *(this->operator+(n));
+  }
 
-    /// return the key of an object iterator
-    auto key() const -> decltype(std::declval<Base>().key())
-    {
-        auto it = --this->base();
-        return it.key();
-    }
+  /// return the key of an object iterator
+  auto key() const -> decltype(std::declval<Base>().key())
+  {
+    auto it = --this->base();
+    return it.key();
+  }
 
-    /// return the value of an iterator
-    reference value() const
-    {
-        auto it = --this->base();
-        return it.operator * ();
-    }
+  /// return the value of an iterator
+  reference value() const
+  {
+    auto      it = --this->base();
+    return it.operator*();
+  }
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/output/output_adapters.hpp>
 
-
 #include <algorithm> // copy
-#include <cstddef> // size_t
-#include <ios> // streamsize
-#include <iterator> // back_inserter
-#include <memory> // shared_ptr, make_shared
-#include <ostream> // basic_ostream
-#include <string> // basic_string
-#include <vector> // vector
+#include <cstddef>   // size_t
+#include <ios>       // streamsize
+#include <iterator>  // back_inserter
+#include <memory>    // shared_ptr, make_shared
+#include <ostream>   // basic_ostream
+#include <string>    // basic_string
+#include <vector>    // vector
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 /// abstract output adapter interface
-template<typename CharType> struct output_adapter_protocol
-{
-    virtual void write_character(CharType c) = 0;
-    virtual void write_characters(const CharType* s, std::size_t length) = 0;
-    virtual ~output_adapter_protocol() = default;
+template <typename CharType>
+struct output_adapter_protocol {
+  virtual void write_character(CharType c)                             = 0;
+  virtual void write_characters(const CharType *s, std::size_t length) = 0;
+  virtual ~output_adapter_protocol()                                   = default;
 };
 
 /// a type to simplify interfaces
-template<typename CharType>
+template <typename CharType>
 using output_adapter_t = std::shared_ptr<output_adapter_protocol<CharType>>;
 
 /// output adapter for byte vectors
-template<typename CharType>
-class output_vector_adapter : public output_adapter_protocol<CharType>
-{
-  public:
-    explicit output_vector_adapter(std::vector<CharType>& vec) noexcept
-        : v(vec)
-    {}
+template <typename CharType>
+class output_vector_adapter : public output_adapter_protocol<CharType> {
+public:
+  explicit output_vector_adapter(std::vector<CharType> &vec) noexcept
+      : v(vec)
+  {
+  }
 
-    void write_character(CharType c) override
-    {
-        v.push_back(c);
-    }
+  void write_character(CharType c) override
+  {
+    v.push_back(c);
+  }
 
-    void write_characters(const CharType* s, std::size_t length) override
-    {
-        std::copy(s, s + length, std::back_inserter(v));
-    }
+  void write_characters(const CharType *s, std::size_t length) override
+  {
+    std::copy(s, s + length, std::back_inserter(v));
+  }
 
-  private:
-    std::vector<CharType>& v;
+private:
+  std::vector<CharType> &v;
 };
 
 /// output adapter for output streams
-template<typename CharType>
-class output_stream_adapter : public output_adapter_protocol<CharType>
-{
-  public:
-    explicit output_stream_adapter(std::basic_ostream<CharType>& s) noexcept
-        : stream(s)
-    {}
+template <typename CharType>
+class output_stream_adapter : public output_adapter_protocol<CharType> {
+public:
+  explicit output_stream_adapter(std::basic_ostream<CharType> &s) noexcept
+      : stream(s)
+  {
+  }
 
-    void write_character(CharType c) override
-    {
-        stream.put(c);
-    }
+  void write_character(CharType c) override
+  {
+    stream.put(c);
+  }
 
-    void write_characters(const CharType* s, std::size_t length) override
-    {
-        stream.write(s, static_cast<std::streamsize>(length));
-    }
+  void write_characters(const CharType *s, std::size_t length) override
+  {
+    stream.write(s, static_cast<std::streamsize>(length));
+  }
 
-  private:
-    std::basic_ostream<CharType>& stream;
+private:
+  std::basic_ostream<CharType> &stream;
 };
 
 /// output adapter for basic_string
-template<typename CharType, typename StringType = std::basic_string<CharType>>
-class output_string_adapter : public output_adapter_protocol<CharType>
-{
-  public:
-    explicit output_string_adapter(StringType& s) noexcept
-        : str(s)
-    {}
+template <typename CharType, typename StringType = std::basic_string<CharType>>
+class output_string_adapter : public output_adapter_protocol<CharType> {
+public:
+  explicit output_string_adapter(StringType &s) noexcept
+      : str(s)
+  {
+  }
 
-    void write_character(CharType c) override
-    {
-        str.push_back(c);
-    }
+  void write_character(CharType c) override
+  {
+    str.push_back(c);
+  }
 
-    void write_characters(const CharType* s, std::size_t length) override
-    {
-        str.append(s, length);
-    }
+  void write_characters(const CharType *s, std::size_t length) override
+  {
+    str.append(s, length);
+  }
 
-  private:
-    StringType& str;
+private:
+  StringType &str;
 };
 
-template<typename CharType, typename StringType = std::basic_string<CharType>>
-class output_adapter
-{
-  public:
-    output_adapter(std::vector<CharType>& vec)
-        : oa(std::make_shared<output_vector_adapter<CharType>>(vec)) {}
+template <typename CharType, typename StringType = std::basic_string<CharType>>
+class output_adapter {
+public:
+  output_adapter(std::vector<CharType> &vec)
+      : oa(std::make_shared<output_vector_adapter<CharType>>(vec)) {}
 
-    output_adapter(std::basic_ostream<CharType>& s)
-        : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
+  output_adapter(std::basic_ostream<CharType> &s)
+      : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
 
-    output_adapter(StringType& s)
-        : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s)) {}
+  output_adapter(StringType &s)
+      : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s)) {}
 
-    operator output_adapter_t<CharType>()
-    {
-        return oa;
-    }
+  operator output_adapter_t<CharType>()
+  {
+    return oa;
+  }
 
-  private:
-    output_adapter_t<CharType> oa = nullptr;
+private:
+  output_adapter_t<CharType> oa = nullptr;
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/input/binary_reader.hpp>
 
-
 #include <algorithm> // generate_n
-#include <array> // array
-#include <cassert> // assert
-#include <cmath> // ldexp
-#include <cstddef> // size_t
-#include <cstdint> // uint8_t, uint16_t, uint32_t, uint64_t
-#include <cstdio> // snprintf
-#include <cstring> // memcpy
-#include <iterator> // back_inserter
-#include <limits> // numeric_limits
-#include <string> // char_traits, string
-#include <utility> // make_pair, move
+#include <array>     // array
+#include <cassert>   // assert
+#include <cmath>     // ldexp
+#include <cstddef>   // size_t
+#include <cstdint>   // uint8_t, uint16_t, uint32_t, uint64_t
+#include <cstdio>    // snprintf
+#include <cstring>   // memcpy
+#include <iterator>  // back_inserter
+#include <limits>    // numeric_limits
+#include <string>    // char_traits, string
+#include <utility>   // make_pair, move
 
 // #include <nlohmann/detail/input/input_adapters.hpp>
 
@@ -6472,11 +6028,8 @@ class output_adapter
 
 // #include <nlohmann/detail/value_t.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 ///////////////////
 // binary reader //
 ///////////////////
@@ -6484,154 +6037,143 @@ namespace detail
 /*!
 @brief deserialization of CBOR, MessagePack, and UBJSON values
 */
-template<typename BasicJsonType, typename SAX = json_sax_dom_parser<BasicJsonType>>
-class binary_reader
-{
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using string_t = typename BasicJsonType::string_t;
-    using json_sax_t = SAX;
+template <typename BasicJsonType, typename SAX = json_sax_dom_parser<BasicJsonType>>
+class binary_reader {
+  using number_integer_t  = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+  using number_float_t    = typename BasicJsonType::number_float_t;
+  using string_t          = typename BasicJsonType::string_t;
+  using json_sax_t        = SAX;
 
-  public:
-    /*!
+public:
+  /*!
     @brief create a binary reader
 
     @param[in] adapter  input adapter to read from
     */
-    explicit binary_reader(input_adapter_t adapter) : ia(std::move(adapter))
-    {
-        (void)detail::is_sax_static_asserts<SAX, BasicJsonType> {};
-        assert(ia);
-    }
+  explicit binary_reader(input_adapter_t adapter)
+      : ia(std::move(adapter))
+  {
+    (void) detail::is_sax_static_asserts<SAX, BasicJsonType>{};
+    assert(ia);
+  }
 
-    /*!
+  /*!
     @param[in] format  the binary format to parse
     @param[in] sax_    a SAX event processor
     @param[in] strict  whether to expect the input to be consumed completed
 
     @return
     */
-    bool sax_parse(const input_format_t format,
-                   json_sax_t* sax_,
-                   const bool strict = true)
-    {
-        sax = sax_;
-        bool result = false;
+  bool sax_parse(const input_format_t format,
+                 json_sax_t *         sax_,
+                 const bool           strict = true)
+  {
+    sax         = sax_;
+    bool result = false;
 
-        switch (format)
-        {
-            case input_format_t::bson:
-                result = parse_bson_internal();
-                break;
+    switch (format) {
+    case input_format_t::bson:
+      result = parse_bson_internal();
+      break;
 
-            case input_format_t::cbor:
-                result = parse_cbor_internal();
-                break;
+    case input_format_t::cbor:
+      result = parse_cbor_internal();
+      break;
 
-            case input_format_t::msgpack:
-                result = parse_msgpack_internal();
-                break;
+    case input_format_t::msgpack:
+      result = parse_msgpack_internal();
+      break;
 
-            case input_format_t::ubjson:
-                result = parse_ubjson_internal();
-                break;
+    case input_format_t::ubjson:
+      result = parse_ubjson_internal();
+      break;
 
-            // LCOV_EXCL_START
-            default:
-                assert(false);
-                // LCOV_EXCL_STOP
-        }
-
-        // strict mode: next byte must be EOF
-        if (result and strict)
-        {
-            if (format == input_format_t::ubjson)
-            {
-                get_ignore_noop();
-            }
-            else
-            {
-                get();
-            }
-
-            if (JSON_UNLIKELY(current != std::char_traits<char>::eof()))
-            {
-                return sax->parse_error(chars_read, get_token_string(),
-                                        parse_error::create(110, chars_read, exception_message(format, "expected end of input; last byte: 0x" + get_token_string(), "value")));
-            }
-        }
-
-        return result;
+    // LCOV_EXCL_START
+    default:
+      assert(false);
+      // LCOV_EXCL_STOP
     }
 
-    /*!
+    // strict mode: next byte must be EOF
+    if (result and strict) {
+      if (format == input_format_t::ubjson) {
+        get_ignore_noop();
+      } else {
+        get();
+      }
+
+      if (JSON_UNLIKELY(current != std::char_traits<char>::eof())) {
+        return sax->parse_error(chars_read, get_token_string(),
+                                parse_error::create(110, chars_read, exception_message(format, "expected end of input; last byte: 0x" + get_token_string(), "value")));
+      }
+    }
+
+    return result;
+  }
+
+  /*!
     @brief determine system byte order
 
     @return true if and only if system's byte order is little endian
 
     @note from http://stackoverflow.com/a/1001328/266378
     */
-    static constexpr bool little_endianess(int num = 1) noexcept
-    {
-        return (*reinterpret_cast<char*>(&num) == 1);
-    }
+  static constexpr bool little_endianess(int num = 1) noexcept
+  {
+    return (*reinterpret_cast<char *>(&num) == 1);
+  }
 
-  private:
-    //////////
-    // BSON //
-    //////////
+private:
+  //////////
+  // BSON //
+  //////////
 
-    /*!
+  /*!
     @brief Reads in a BSON-object and passes it to the SAX-parser.
     @return whether a valid BSON-value was passed to the SAX parser
     */
-    bool parse_bson_internal()
-    {
-        std::int32_t document_size;
-        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+  bool parse_bson_internal()
+  {
+    std::int32_t document_size;
+    get_number<std::int32_t, true>(input_format_t::bson, document_size);
 
-        if (JSON_UNLIKELY(not sax->start_object(std::size_t(-1))))
-        {
-            return false;
-        }
-
-        if (JSON_UNLIKELY(not parse_bson_element_list(/*is_array*/false)))
-        {
-            return false;
-        }
-
-        return sax->end_object();
+    if (JSON_UNLIKELY(not sax->start_object(std::size_t(-1)))) {
+      return false;
     }
 
-    /*!
+    if (JSON_UNLIKELY(not parse_bson_element_list(/*is_array*/ false))) {
+      return false;
+    }
+
+    return sax->end_object();
+  }
+
+  /*!
     @brief Parses a C-style string from the BSON input.
     @param[in, out] result  A reference to the string variable where the read
                             string is to be stored.
     @return `true` if the \x00-byte indicating the end of the string was
              encountered before the EOF; false` indicates an unexpected EOF.
     */
-    bool get_bson_cstr(string_t& result)
-    {
-        auto out = std::back_inserter(result);
-        while (true)
-        {
-            get();
-            if (JSON_UNLIKELY(not unexpect_eof(input_format_t::bson, "cstring")))
-            {
-                return false;
-            }
-            if (current == 0x00)
-            {
-                return true;
-            }
-            *out++ = static_cast<char>(current);
-        }
-
+  bool get_bson_cstr(string_t &result)
+  {
+    auto out = std::back_inserter(result);
+    while (true) {
+      get();
+      if (JSON_UNLIKELY(not unexpect_eof(input_format_t::bson, "cstring"))) {
+        return false;
+      }
+      if (current == 0x00) {
         return true;
+      }
+      *out++ = static_cast<char>(current);
     }
 
-    /*!
+    return true;
+  }
+
+  /*!
     @brief Parses a zero-terminated string of length @a len from the BSON
            input.
     @param[in] len  The length (including the zero-byte at the end) of the
@@ -6642,19 +6184,18 @@ class binary_reader
     @pre len >= 1
     @return `true` if the string was successfully parsed
     */
-    template<typename NumberType>
-    bool get_bson_string(const NumberType len, string_t& result)
-    {
-        if (JSON_UNLIKELY(len < 1))
-        {
-            auto last_token = get_token_string();
-            return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::bson, "string length must be at least 1, is " + std::to_string(len), "string")));
-        }
-
-        return get_string(input_format_t::bson, len - static_cast<NumberType>(1), result) and get() != std::char_traits<char>::eof();
+  template <typename NumberType>
+  bool get_bson_string(const NumberType len, string_t &result)
+  {
+    if (JSON_UNLIKELY(len < 1)) {
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::bson, "string length must be at least 1, is " + std::to_string(len), "string")));
     }
 
-    /*!
+    return get_string(input_format_t::bson, len - static_cast<NumberType>(1), result) and get() != std::char_traits<char>::eof();
+  }
+
+  /*!
     @brief Read a BSON document element of the given @a element_type.
     @param[in] element_type The BSON element type, c.f. http://bsonspec.org/spec.html
     @param[in] element_type_parse_position The position in the input stream,
@@ -6664,66 +6205,65 @@ class binary_reader
              Unsupported BSON record type 0x...
     @return whether a valid BSON-object/array was passed to the SAX parser
     */
-    bool parse_bson_element_internal(const int element_type,
-                                     const std::size_t element_type_parse_position)
+  bool parse_bson_element_internal(const int         element_type,
+                                   const std::size_t element_type_parse_position)
+  {
+    switch (element_type) {
+    case 0x01: // double
     {
-        switch (element_type)
-        {
-            case 0x01: // double
-            {
-                double number;
-                return get_number<double, true>(input_format_t::bson, number) and sax->number_float(static_cast<number_float_t>(number), "");
-            }
-
-            case 0x02: // string
-            {
-                std::int32_t len;
-                string_t value;
-                return get_number<std::int32_t, true>(input_format_t::bson, len) and get_bson_string(len, value) and sax->string(value);
-            }
-
-            case 0x03: // object
-            {
-                return parse_bson_internal();
-            }
-
-            case 0x04: // array
-            {
-                return parse_bson_array();
-            }
-
-            case 0x08: // boolean
-            {
-                return sax->boolean(get() != 0);
-            }
-
-            case 0x0A: // null
-            {
-                return sax->null();
-            }
-
-            case 0x10: // int32
-            {
-                std::int32_t value;
-                return get_number<std::int32_t, true>(input_format_t::bson, value) and sax->number_integer(value);
-            }
-
-            case 0x12: // int64
-            {
-                std::int64_t value;
-                return get_number<std::int64_t, true>(input_format_t::bson, value) and sax->number_integer(value);
-            }
-
-            default: // anything else not supported (yet)
-            {
-                char cr[3];
-                (std::snprintf)(cr, sizeof(cr), "%.2hhX", static_cast<unsigned char>(element_type));
-                return sax->parse_error(element_type_parse_position, std::string(cr), parse_error::create(114, element_type_parse_position, "Unsupported BSON record type 0x" + std::string(cr)));
-            }
-        }
+      double number;
+      return get_number<double, true>(input_format_t::bson, number) and sax->number_float(static_cast<number_float_t>(number), "");
     }
 
-    /*!
+    case 0x02: // string
+    {
+      std::int32_t len;
+      string_t     value;
+      return get_number<std::int32_t, true>(input_format_t::bson, len) and get_bson_string(len, value) and sax->string(value);
+    }
+
+    case 0x03: // object
+    {
+      return parse_bson_internal();
+    }
+
+    case 0x04: // array
+    {
+      return parse_bson_array();
+    }
+
+    case 0x08: // boolean
+    {
+      return sax->boolean(get() != 0);
+    }
+
+    case 0x0A: // null
+    {
+      return sax->null();
+    }
+
+    case 0x10: // int32
+    {
+      std::int32_t value;
+      return get_number<std::int32_t, true>(input_format_t::bson, value) and sax->number_integer(value);
+    }
+
+    case 0x12: // int64
+    {
+      std::int64_t value;
+      return get_number<std::int64_t, true>(input_format_t::bson, value) and sax->number_integer(value);
+    }
+
+    default: // anything else not supported (yet)
+    {
+      char cr[3];
+      (std::snprintf)(cr, sizeof(cr), "%.2hhX", static_cast<unsigned char>(element_type));
+      return sax->parse_error(element_type_parse_position, std::string(cr), parse_error::create(114, element_type_parse_position, "Unsupported BSON record type 0x" + std::string(cr)));
+    }
+    }
+  }
+
+  /*!
     @brief Read a BSON element list (as specified in the BSON-spec)
 
     The same binary layout is used for objects and arrays, hence it must be
@@ -6735,407 +6275,394 @@ class binary_reader
                         array (@a is_array == true).
     @return whether a valid BSON-object/array was passed to the SAX parser
     */
-    bool parse_bson_element_list(const bool is_array)
-    {
-        string_t key;
-        while (int element_type = get())
-        {
-            if (JSON_UNLIKELY(not unexpect_eof(input_format_t::bson, "element list")))
-            {
-                return false;
-            }
+  bool parse_bson_element_list(const bool is_array)
+  {
+    string_t key;
+    while (int element_type = get()) {
+      if (JSON_UNLIKELY(not unexpect_eof(input_format_t::bson, "element list"))) {
+        return false;
+      }
 
-            const std::size_t element_type_parse_position = chars_read;
-            if (JSON_UNLIKELY(not get_bson_cstr(key)))
-            {
-                return false;
-            }
+      const std::size_t element_type_parse_position = chars_read;
+      if (JSON_UNLIKELY(not get_bson_cstr(key))) {
+        return false;
+      }
 
-            if (not is_array)
-            {
-                if (not sax->key(key))
-                {
-                    return false;
-                }
-            }
-
-            if (JSON_UNLIKELY(not parse_bson_element_internal(element_type, element_type_parse_position)))
-            {
-                return false;
-            }
-
-            // get_bson_cstr only appends
-            key.clear();
+      if (not is_array) {
+        if (not sax->key(key)) {
+          return false;
         }
+      }
 
-        return true;
+      if (JSON_UNLIKELY(not parse_bson_element_internal(element_type, element_type_parse_position))) {
+        return false;
+      }
+
+      // get_bson_cstr only appends
+      key.clear();
     }
 
-    /*!
+    return true;
+  }
+
+  /*!
     @brief Reads an array from the BSON input and passes it to the SAX-parser.
     @return whether a valid BSON-array was passed to the SAX parser
     */
-    bool parse_bson_array()
-    {
-        std::int32_t document_size;
-        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+  bool parse_bson_array()
+  {
+    std::int32_t document_size;
+    get_number<std::int32_t, true>(input_format_t::bson, document_size);
 
-        if (JSON_UNLIKELY(not sax->start_array(std::size_t(-1))))
-        {
-            return false;
-        }
-
-        if (JSON_UNLIKELY(not parse_bson_element_list(/*is_array*/true)))
-        {
-            return false;
-        }
-
-        return sax->end_array();
+    if (JSON_UNLIKELY(not sax->start_array(std::size_t(-1)))) {
+      return false;
     }
 
-    //////////
-    // CBOR //
-    //////////
+    if (JSON_UNLIKELY(not parse_bson_element_list(/*is_array*/ true))) {
+      return false;
+    }
 
-    /*!
+    return sax->end_array();
+  }
+
+  //////////
+  // CBOR //
+  //////////
+
+  /*!
     @param[in] get_char  whether a new character should be retrieved from the
                          input (true, default) or whether the last read
                          character should be considered instead
 
     @return whether a valid CBOR value was passed to the SAX parser
     */
-    bool parse_cbor_internal(const bool get_char = true)
+  bool parse_cbor_internal(const bool get_char = true)
+  {
+    switch (get_char ? get() : current) {
+    // EOF
+    case std::char_traits<char>::eof():
+      return unexpect_eof(input_format_t::cbor, "value");
+
+    // Integer 0x00..0x17 (0..23)
+    case 0x00:
+    case 0x01:
+    case 0x02:
+    case 0x03:
+    case 0x04:
+    case 0x05:
+    case 0x06:
+    case 0x07:
+    case 0x08:
+    case 0x09:
+    case 0x0A:
+    case 0x0B:
+    case 0x0C:
+    case 0x0D:
+    case 0x0E:
+    case 0x0F:
+    case 0x10:
+    case 0x11:
+    case 0x12:
+    case 0x13:
+    case 0x14:
+    case 0x15:
+    case 0x16:
+    case 0x17:
+      return sax->number_unsigned(static_cast<number_unsigned_t>(current));
+
+    case 0x18: // Unsigned integer (one-byte uint8_t follows)
     {
-        switch (get_char ? get() : current)
-        {
-            // EOF
-            case std::char_traits<char>::eof():
-                return unexpect_eof(input_format_t::cbor, "value");
-
-            // Integer 0x00..0x17 (0..23)
-            case 0x00:
-            case 0x01:
-            case 0x02:
-            case 0x03:
-            case 0x04:
-            case 0x05:
-            case 0x06:
-            case 0x07:
-            case 0x08:
-            case 0x09:
-            case 0x0A:
-            case 0x0B:
-            case 0x0C:
-            case 0x0D:
-            case 0x0E:
-            case 0x0F:
-            case 0x10:
-            case 0x11:
-            case 0x12:
-            case 0x13:
-            case 0x14:
-            case 0x15:
-            case 0x16:
-            case 0x17:
-                return sax->number_unsigned(static_cast<number_unsigned_t>(current));
-
-            case 0x18: // Unsigned integer (one-byte uint8_t follows)
-            {
-                uint8_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
-            }
-
-            case 0x19: // Unsigned integer (two-byte uint16_t follows)
-            {
-                uint16_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
-            }
-
-            case 0x1A: // Unsigned integer (four-byte uint32_t follows)
-            {
-                uint32_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
-            }
-
-            case 0x1B: // Unsigned integer (eight-byte uint64_t follows)
-            {
-                uint64_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
-            }
-
-            // Negative integer -1-0x00..-1-0x17 (-1..-24)
-            case 0x20:
-            case 0x21:
-            case 0x22:
-            case 0x23:
-            case 0x24:
-            case 0x25:
-            case 0x26:
-            case 0x27:
-            case 0x28:
-            case 0x29:
-            case 0x2A:
-            case 0x2B:
-            case 0x2C:
-            case 0x2D:
-            case 0x2E:
-            case 0x2F:
-            case 0x30:
-            case 0x31:
-            case 0x32:
-            case 0x33:
-            case 0x34:
-            case 0x35:
-            case 0x36:
-            case 0x37:
-                return sax->number_integer(static_cast<int8_t>(0x20 - 1 - current));
-
-            case 0x38: // Negative integer (one-byte uint8_t follows)
-            {
-                uint8_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
-
-            case 0x39: // Negative integer -1-n (two-byte uint16_t follows)
-            {
-                uint16_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
-
-            case 0x3A: // Negative integer -1-n (four-byte uint32_t follows)
-            {
-                uint32_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1) - number);
-            }
-
-            case 0x3B: // Negative integer -1-n (eight-byte uint64_t follows)
-            {
-                uint64_t number;
-                return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1)
-                        - static_cast<number_integer_t>(number));
-            }
-
-            // UTF-8 string (0x00..0x17 bytes follow)
-            case 0x60:
-            case 0x61:
-            case 0x62:
-            case 0x63:
-            case 0x64:
-            case 0x65:
-            case 0x66:
-            case 0x67:
-            case 0x68:
-            case 0x69:
-            case 0x6A:
-            case 0x6B:
-            case 0x6C:
-            case 0x6D:
-            case 0x6E:
-            case 0x6F:
-            case 0x70:
-            case 0x71:
-            case 0x72:
-            case 0x73:
-            case 0x74:
-            case 0x75:
-            case 0x76:
-            case 0x77:
-            case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
-            case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
-            case 0x7A: // UTF-8 string (four-byte uint32_t for n follow)
-            case 0x7B: // UTF-8 string (eight-byte uint64_t for n follow)
-            case 0x7F: // UTF-8 string (indefinite length)
-            {
-                string_t s;
-                return get_cbor_string(s) and sax->string(s);
-            }
-
-            // array (0x00..0x17 data items follow)
-            case 0x80:
-            case 0x81:
-            case 0x82:
-            case 0x83:
-            case 0x84:
-            case 0x85:
-            case 0x86:
-            case 0x87:
-            case 0x88:
-            case 0x89:
-            case 0x8A:
-            case 0x8B:
-            case 0x8C:
-            case 0x8D:
-            case 0x8E:
-            case 0x8F:
-            case 0x90:
-            case 0x91:
-            case 0x92:
-            case 0x93:
-            case 0x94:
-            case 0x95:
-            case 0x96:
-            case 0x97:
-                return get_cbor_array(static_cast<std::size_t>(current & 0x1F));
-
-            case 0x98: // array (one-byte uint8_t for n follows)
-            {
-                uint8_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
-            }
-
-            case 0x99: // array (two-byte uint16_t for n follow)
-            {
-                uint16_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
-            }
-
-            case 0x9A: // array (four-byte uint32_t for n follow)
-            {
-                uint32_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
-            }
-
-            case 0x9B: // array (eight-byte uint64_t for n follow)
-            {
-                uint64_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
-            }
-
-            case 0x9F: // array (indefinite length)
-                return get_cbor_array(std::size_t(-1));
-
-            // map (0x00..0x17 pairs of data items follow)
-            case 0xA0:
-            case 0xA1:
-            case 0xA2:
-            case 0xA3:
-            case 0xA4:
-            case 0xA5:
-            case 0xA6:
-            case 0xA7:
-            case 0xA8:
-            case 0xA9:
-            case 0xAA:
-            case 0xAB:
-            case 0xAC:
-            case 0xAD:
-            case 0xAE:
-            case 0xAF:
-            case 0xB0:
-            case 0xB1:
-            case 0xB2:
-            case 0xB3:
-            case 0xB4:
-            case 0xB5:
-            case 0xB6:
-            case 0xB7:
-                return get_cbor_object(static_cast<std::size_t>(current & 0x1F));
-
-            case 0xB8: // map (one-byte uint8_t for n follows)
-            {
-                uint8_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
-            }
-
-            case 0xB9: // map (two-byte uint16_t for n follow)
-            {
-                uint16_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
-            }
-
-            case 0xBA: // map (four-byte uint32_t for n follow)
-            {
-                uint32_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
-            }
-
-            case 0xBB: // map (eight-byte uint64_t for n follow)
-            {
-                uint64_t len;
-                return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
-            }
-
-            case 0xBF: // map (indefinite length)
-                return get_cbor_object(std::size_t(-1));
-
-            case 0xF4: // false
-                return sax->boolean(false);
-
-            case 0xF5: // true
-                return sax->boolean(true);
-
-            case 0xF6: // null
-                return sax->null();
-
-            case 0xF9: // Half-Precision Float (two-byte IEEE 754)
-            {
-                const int byte1_raw = get();
-                if (JSON_UNLIKELY(not unexpect_eof(input_format_t::cbor, "number")))
-                {
-                    return false;
-                }
-                const int byte2_raw = get();
-                if (JSON_UNLIKELY(not unexpect_eof(input_format_t::cbor, "number")))
-                {
-                    return false;
-                }
-
-                const auto byte1 = static_cast<unsigned char>(byte1_raw);
-                const auto byte2 = static_cast<unsigned char>(byte2_raw);
-
-                // code from RFC 7049, Appendix D, Figure 3:
-                // As half-precision floating-point numbers were only added
-                // to IEEE 754 in 2008, today's programming platforms often
-                // still only have limited support for them. It is very
-                // easy to include at least decoding support for them even
-                // without such support. An example of a small decoder for
-                // half-precision floating-point numbers in the C language
-                // is shown in Fig. 3.
-                const int half = (byte1 << 8) + byte2;
-                const double val = [&half]
-                {
-                    const int exp = (half >> 10) & 0x1F;
-                    const int mant = half & 0x3FF;
-                    assert(0 <= exp and exp <= 32);
-                    assert(0 <= mant and mant <= 1024);
-                    switch (exp)
-                    {
-                        case 0:
-                            return std::ldexp(mant, -24);
-                        case 31:
-                            return (mant == 0)
-                            ? std::numeric_limits<double>::infinity()
-                            : std::numeric_limits<double>::quiet_NaN();
-                        default:
-                            return std::ldexp(mant + 1024, exp - 25);
-                    }
-                }();
-                return sax->number_float((half & 0x8000) != 0
-                                         ? static_cast<number_float_t>(-val)
-                                         : static_cast<number_float_t>(val), "");
-            }
-
-            case 0xFA: // Single-Precision Float (four-byte IEEE 754)
-            {
-                float number;
-                return get_number(input_format_t::cbor, number) and sax->number_float(static_cast<number_float_t>(number), "");
-            }
-
-            case 0xFB: // Double-Precision Float (eight-byte IEEE 754)
-            {
-                double number;
-                return get_number(input_format_t::cbor, number) and sax->number_float(static_cast<number_float_t>(number), "");
-            }
-
-            default: // anything else (0xFF is handled inside the other types)
-            {
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::cbor, "invalid byte: 0x" + last_token, "value")));
-            }
-        }
+      uint8_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
     }
 
-    /*!
+    case 0x19: // Unsigned integer (two-byte uint16_t follows)
+    {
+      uint16_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
+    }
+
+    case 0x1A: // Unsigned integer (four-byte uint32_t follows)
+    {
+      uint32_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
+    }
+
+    case 0x1B: // Unsigned integer (eight-byte uint64_t follows)
+    {
+      uint64_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_unsigned(number);
+    }
+
+    // Negative integer -1-0x00..-1-0x17 (-1..-24)
+    case 0x20:
+    case 0x21:
+    case 0x22:
+    case 0x23:
+    case 0x24:
+    case 0x25:
+    case 0x26:
+    case 0x27:
+    case 0x28:
+    case 0x29:
+    case 0x2A:
+    case 0x2B:
+    case 0x2C:
+    case 0x2D:
+    case 0x2E:
+    case 0x2F:
+    case 0x30:
+    case 0x31:
+    case 0x32:
+    case 0x33:
+    case 0x34:
+    case 0x35:
+    case 0x36:
+    case 0x37:
+      return sax->number_integer(static_cast<int8_t>(0x20 - 1 - current));
+
+    case 0x38: // Negative integer (one-byte uint8_t follows)
+    {
+      uint8_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1) - number);
+    }
+
+    case 0x39: // Negative integer -1-n (two-byte uint16_t follows)
+    {
+      uint16_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1) - number);
+    }
+
+    case 0x3A: // Negative integer -1-n (four-byte uint32_t follows)
+    {
+      uint32_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1) - number);
+    }
+
+    case 0x3B: // Negative integer -1-n (eight-byte uint64_t follows)
+    {
+      uint64_t number;
+      return get_number(input_format_t::cbor, number) and sax->number_integer(static_cast<number_integer_t>(-1) - static_cast<number_integer_t>(number));
+    }
+
+    // UTF-8 string (0x00..0x17 bytes follow)
+    case 0x60:
+    case 0x61:
+    case 0x62:
+    case 0x63:
+    case 0x64:
+    case 0x65:
+    case 0x66:
+    case 0x67:
+    case 0x68:
+    case 0x69:
+    case 0x6A:
+    case 0x6B:
+    case 0x6C:
+    case 0x6D:
+    case 0x6E:
+    case 0x6F:
+    case 0x70:
+    case 0x71:
+    case 0x72:
+    case 0x73:
+    case 0x74:
+    case 0x75:
+    case 0x76:
+    case 0x77:
+    case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
+    case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
+    case 0x7A: // UTF-8 string (four-byte uint32_t for n follow)
+    case 0x7B: // UTF-8 string (eight-byte uint64_t for n follow)
+    case 0x7F: // UTF-8 string (indefinite length)
+    {
+      string_t s;
+      return get_cbor_string(s) and sax->string(s);
+    }
+
+    // array (0x00..0x17 data items follow)
+    case 0x80:
+    case 0x81:
+    case 0x82:
+    case 0x83:
+    case 0x84:
+    case 0x85:
+    case 0x86:
+    case 0x87:
+    case 0x88:
+    case 0x89:
+    case 0x8A:
+    case 0x8B:
+    case 0x8C:
+    case 0x8D:
+    case 0x8E:
+    case 0x8F:
+    case 0x90:
+    case 0x91:
+    case 0x92:
+    case 0x93:
+    case 0x94:
+    case 0x95:
+    case 0x96:
+    case 0x97:
+      return get_cbor_array(static_cast<std::size_t>(current & 0x1F));
+
+    case 0x98: // array (one-byte uint8_t for n follows)
+    {
+      uint8_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
+    }
+
+    case 0x99: // array (two-byte uint16_t for n follow)
+    {
+      uint16_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
+    }
+
+    case 0x9A: // array (four-byte uint32_t for n follow)
+    {
+      uint32_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
+    }
+
+    case 0x9B: // array (eight-byte uint64_t for n follow)
+    {
+      uint64_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_array(static_cast<std::size_t>(len));
+    }
+
+    case 0x9F: // array (indefinite length)
+      return get_cbor_array(std::size_t(-1));
+
+    // map (0x00..0x17 pairs of data items follow)
+    case 0xA0:
+    case 0xA1:
+    case 0xA2:
+    case 0xA3:
+    case 0xA4:
+    case 0xA5:
+    case 0xA6:
+    case 0xA7:
+    case 0xA8:
+    case 0xA9:
+    case 0xAA:
+    case 0xAB:
+    case 0xAC:
+    case 0xAD:
+    case 0xAE:
+    case 0xAF:
+    case 0xB0:
+    case 0xB1:
+    case 0xB2:
+    case 0xB3:
+    case 0xB4:
+    case 0xB5:
+    case 0xB6:
+    case 0xB7:
+      return get_cbor_object(static_cast<std::size_t>(current & 0x1F));
+
+    case 0xB8: // map (one-byte uint8_t for n follows)
+    {
+      uint8_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
+    }
+
+    case 0xB9: // map (two-byte uint16_t for n follow)
+    {
+      uint16_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
+    }
+
+    case 0xBA: // map (four-byte uint32_t for n follow)
+    {
+      uint32_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
+    }
+
+    case 0xBB: // map (eight-byte uint64_t for n follow)
+    {
+      uint64_t len;
+      return get_number(input_format_t::cbor, len) and get_cbor_object(static_cast<std::size_t>(len));
+    }
+
+    case 0xBF: // map (indefinite length)
+      return get_cbor_object(std::size_t(-1));
+
+    case 0xF4: // false
+      return sax->boolean(false);
+
+    case 0xF5: // true
+      return sax->boolean(true);
+
+    case 0xF6: // null
+      return sax->null();
+
+    case 0xF9: // Half-Precision Float (two-byte IEEE 754)
+    {
+      const int byte1_raw = get();
+      if (JSON_UNLIKELY(not unexpect_eof(input_format_t::cbor, "number"))) {
+        return false;
+      }
+      const int byte2_raw = get();
+      if (JSON_UNLIKELY(not unexpect_eof(input_format_t::cbor, "number"))) {
+        return false;
+      }
+
+      const auto byte1 = static_cast<unsigned char>(byte1_raw);
+      const auto byte2 = static_cast<unsigned char>(byte2_raw);
+
+      // code from RFC 7049, Appendix D, Figure 3:
+      // As half-precision floating-point numbers were only added
+      // to IEEE 754 in 2008, today's programming platforms often
+      // still only have limited support for them. It is very
+      // easy to include at least decoding support for them even
+      // without such support. An example of a small decoder for
+      // half-precision floating-point numbers in the C language
+      // is shown in Fig. 3.
+      const int    half = (byte1 << 8) + byte2;
+      const double val  = [&half] {
+        const int exp  = (half >> 10) & 0x1F;
+        const int mant = half & 0x3FF;
+        assert(0 <= exp and exp <= 32);
+        assert(0 <= mant and mant <= 1024);
+        switch (exp) {
+        case 0:
+          return std::ldexp(mant, -24);
+        case 31:
+          return (mant == 0)
+                     ? std::numeric_limits<double>::infinity()
+                     : std::numeric_limits<double>::quiet_NaN();
+        default:
+          return std::ldexp(mant + 1024, exp - 25);
+        }
+      }();
+      return sax->number_float((half & 0x8000) != 0
+                                   ? static_cast<number_float_t>(-val)
+                                   : static_cast<number_float_t>(val),
+                               "");
+    }
+
+    case 0xFA: // Single-Precision Float (four-byte IEEE 754)
+    {
+      float number;
+      return get_number(input_format_t::cbor, number) and sax->number_float(static_cast<number_float_t>(number), "");
+    }
+
+    case 0xFB: // Double-Precision Float (eight-byte IEEE 754)
+    {
+      double number;
+      return get_number(input_format_t::cbor, number) and sax->number_float(static_cast<number_float_t>(number), "");
+    }
+
+    default: // anything else (0xFF is handled inside the other types)
+    {
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::cbor, "invalid byte: 0x" + last_token, "value")));
+    }
+    }
+  }
+
+  /*!
     @brief reads a CBOR string
 
     This function first reads starting bytes to determine the expected
@@ -7146,543 +6673,517 @@ class binary_reader
 
     @return whether string creation completed
     */
-    bool get_cbor_string(string_t& result)
-    {
-        if (JSON_UNLIKELY(not unexpect_eof(input_format_t::cbor, "string")))
-        {
-            return false;
-        }
-
-        switch (current)
-        {
-            // UTF-8 string (0x00..0x17 bytes follow)
-            case 0x60:
-            case 0x61:
-            case 0x62:
-            case 0x63:
-            case 0x64:
-            case 0x65:
-            case 0x66:
-            case 0x67:
-            case 0x68:
-            case 0x69:
-            case 0x6A:
-            case 0x6B:
-            case 0x6C:
-            case 0x6D:
-            case 0x6E:
-            case 0x6F:
-            case 0x70:
-            case 0x71:
-            case 0x72:
-            case 0x73:
-            case 0x74:
-            case 0x75:
-            case 0x76:
-            case 0x77:
-            {
-                return get_string(input_format_t::cbor, current & 0x1F, result);
-            }
-
-            case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
-            {
-                uint8_t len;
-                return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
-            }
-
-            case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
-            {
-                uint16_t len;
-                return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
-            }
-
-            case 0x7A: // UTF-8 string (four-byte uint32_t for n follow)
-            {
-                uint32_t len;
-                return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
-            }
-
-            case 0x7B: // UTF-8 string (eight-byte uint64_t for n follow)
-            {
-                uint64_t len;
-                return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
-            }
-
-            case 0x7F: // UTF-8 string (indefinite length)
-            {
-                while (get() != 0xFF)
-                {
-                    string_t chunk;
-                    if (not get_cbor_string(chunk))
-                    {
-                        return false;
-                    }
-                    result.append(chunk);
-                }
-                return true;
-            }
-
-            default:
-            {
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::cbor, "expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0x" + last_token, "string")));
-            }
-        }
+  bool get_cbor_string(string_t &result)
+  {
+    if (JSON_UNLIKELY(not unexpect_eof(input_format_t::cbor, "string"))) {
+      return false;
     }
 
-    /*!
+    switch (current) {
+    // UTF-8 string (0x00..0x17 bytes follow)
+    case 0x60:
+    case 0x61:
+    case 0x62:
+    case 0x63:
+    case 0x64:
+    case 0x65:
+    case 0x66:
+    case 0x67:
+    case 0x68:
+    case 0x69:
+    case 0x6A:
+    case 0x6B:
+    case 0x6C:
+    case 0x6D:
+    case 0x6E:
+    case 0x6F:
+    case 0x70:
+    case 0x71:
+    case 0x72:
+    case 0x73:
+    case 0x74:
+    case 0x75:
+    case 0x76:
+    case 0x77: {
+      return get_string(input_format_t::cbor, current & 0x1F, result);
+    }
+
+    case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
+    {
+      uint8_t len;
+      return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
+    }
+
+    case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
+    {
+      uint16_t len;
+      return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
+    }
+
+    case 0x7A: // UTF-8 string (four-byte uint32_t for n follow)
+    {
+      uint32_t len;
+      return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
+    }
+
+    case 0x7B: // UTF-8 string (eight-byte uint64_t for n follow)
+    {
+      uint64_t len;
+      return get_number(input_format_t::cbor, len) and get_string(input_format_t::cbor, len, result);
+    }
+
+    case 0x7F: // UTF-8 string (indefinite length)
+    {
+      while (get() != 0xFF) {
+        string_t chunk;
+        if (not get_cbor_string(chunk)) {
+          return false;
+        }
+        result.append(chunk);
+      }
+      return true;
+    }
+
+    default: {
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::cbor, "expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0x" + last_token, "string")));
+    }
+    }
+  }
+
+  /*!
     @param[in] len  the length of the array or std::size_t(-1) for an
                     array of indefinite size
     @return whether array creation completed
     */
-    bool get_cbor_array(const std::size_t len)
-    {
-        if (JSON_UNLIKELY(not sax->start_array(len)))
-        {
-            return false;
-        }
-
-        if (len != std::size_t(-1))
-        {
-            for (std::size_t i = 0; i < len; ++i)
-            {
-                if (JSON_UNLIKELY(not parse_cbor_internal()))
-                {
-                    return false;
-                }
-            }
-        }
-        else
-        {
-            while (get() != 0xFF)
-            {
-                if (JSON_UNLIKELY(not parse_cbor_internal(false)))
-                {
-                    return false;
-                }
-            }
-        }
-
-        return sax->end_array();
+  bool get_cbor_array(const std::size_t len)
+  {
+    if (JSON_UNLIKELY(not sax->start_array(len))) {
+      return false;
     }
 
-    /*!
+    if (len != std::size_t(-1)) {
+      for (std::size_t i = 0; i < len; ++i) {
+        if (JSON_UNLIKELY(not parse_cbor_internal())) {
+          return false;
+        }
+      }
+    } else {
+      while (get() != 0xFF) {
+        if (JSON_UNLIKELY(not parse_cbor_internal(false))) {
+          return false;
+        }
+      }
+    }
+
+    return sax->end_array();
+  }
+
+  /*!
     @param[in] len  the length of the object or std::size_t(-1) for an
                     object of indefinite size
     @return whether object creation completed
     */
-    bool get_cbor_object(const std::size_t len)
-    {
-        if (not JSON_UNLIKELY(sax->start_object(len)))
-        {
-            return false;
-        }
-
-        string_t key;
-        if (len != std::size_t(-1))
-        {
-            for (std::size_t i = 0; i < len; ++i)
-            {
-                get();
-                if (JSON_UNLIKELY(not get_cbor_string(key) or not sax->key(key)))
-                {
-                    return false;
-                }
-
-                if (JSON_UNLIKELY(not parse_cbor_internal()))
-                {
-                    return false;
-                }
-                key.clear();
-            }
-        }
-        else
-        {
-            while (get() != 0xFF)
-            {
-                if (JSON_UNLIKELY(not get_cbor_string(key) or not sax->key(key)))
-                {
-                    return false;
-                }
-
-                if (JSON_UNLIKELY(not parse_cbor_internal()))
-                {
-                    return false;
-                }
-                key.clear();
-            }
-        }
-
-        return sax->end_object();
+  bool get_cbor_object(const std::size_t len)
+  {
+    if (not JSON_UNLIKELY(sax->start_object(len))) {
+      return false;
     }
 
-    /////////////
-    // MsgPack //
-    /////////////
+    string_t key;
+    if (len != std::size_t(-1)) {
+      for (std::size_t i = 0; i < len; ++i) {
+        get();
+        if (JSON_UNLIKELY(not get_cbor_string(key) or not sax->key(key))) {
+          return false;
+        }
 
-    /*!
+        if (JSON_UNLIKELY(not parse_cbor_internal())) {
+          return false;
+        }
+        key.clear();
+      }
+    } else {
+      while (get() != 0xFF) {
+        if (JSON_UNLIKELY(not get_cbor_string(key) or not sax->key(key))) {
+          return false;
+        }
+
+        if (JSON_UNLIKELY(not parse_cbor_internal())) {
+          return false;
+        }
+        key.clear();
+      }
+    }
+
+    return sax->end_object();
+  }
+
+  /////////////
+  // MsgPack //
+  /////////////
+
+  /*!
     @return whether a valid MessagePack value was passed to the SAX parser
     */
-    bool parse_msgpack_internal()
-    {
-        switch (get())
-        {
-            // EOF
-            case std::char_traits<char>::eof():
-                return unexpect_eof(input_format_t::msgpack, "value");
+  bool parse_msgpack_internal()
+  {
+    switch (get()) {
+    // EOF
+    case std::char_traits<char>::eof():
+      return unexpect_eof(input_format_t::msgpack, "value");
 
-            // positive fixint
-            case 0x00:
-            case 0x01:
-            case 0x02:
-            case 0x03:
-            case 0x04:
-            case 0x05:
-            case 0x06:
-            case 0x07:
-            case 0x08:
-            case 0x09:
-            case 0x0A:
-            case 0x0B:
-            case 0x0C:
-            case 0x0D:
-            case 0x0E:
-            case 0x0F:
-            case 0x10:
-            case 0x11:
-            case 0x12:
-            case 0x13:
-            case 0x14:
-            case 0x15:
-            case 0x16:
-            case 0x17:
-            case 0x18:
-            case 0x19:
-            case 0x1A:
-            case 0x1B:
-            case 0x1C:
-            case 0x1D:
-            case 0x1E:
-            case 0x1F:
-            case 0x20:
-            case 0x21:
-            case 0x22:
-            case 0x23:
-            case 0x24:
-            case 0x25:
-            case 0x26:
-            case 0x27:
-            case 0x28:
-            case 0x29:
-            case 0x2A:
-            case 0x2B:
-            case 0x2C:
-            case 0x2D:
-            case 0x2E:
-            case 0x2F:
-            case 0x30:
-            case 0x31:
-            case 0x32:
-            case 0x33:
-            case 0x34:
-            case 0x35:
-            case 0x36:
-            case 0x37:
-            case 0x38:
-            case 0x39:
-            case 0x3A:
-            case 0x3B:
-            case 0x3C:
-            case 0x3D:
-            case 0x3E:
-            case 0x3F:
-            case 0x40:
-            case 0x41:
-            case 0x42:
-            case 0x43:
-            case 0x44:
-            case 0x45:
-            case 0x46:
-            case 0x47:
-            case 0x48:
-            case 0x49:
-            case 0x4A:
-            case 0x4B:
-            case 0x4C:
-            case 0x4D:
-            case 0x4E:
-            case 0x4F:
-            case 0x50:
-            case 0x51:
-            case 0x52:
-            case 0x53:
-            case 0x54:
-            case 0x55:
-            case 0x56:
-            case 0x57:
-            case 0x58:
-            case 0x59:
-            case 0x5A:
-            case 0x5B:
-            case 0x5C:
-            case 0x5D:
-            case 0x5E:
-            case 0x5F:
-            case 0x60:
-            case 0x61:
-            case 0x62:
-            case 0x63:
-            case 0x64:
-            case 0x65:
-            case 0x66:
-            case 0x67:
-            case 0x68:
-            case 0x69:
-            case 0x6A:
-            case 0x6B:
-            case 0x6C:
-            case 0x6D:
-            case 0x6E:
-            case 0x6F:
-            case 0x70:
-            case 0x71:
-            case 0x72:
-            case 0x73:
-            case 0x74:
-            case 0x75:
-            case 0x76:
-            case 0x77:
-            case 0x78:
-            case 0x79:
-            case 0x7A:
-            case 0x7B:
-            case 0x7C:
-            case 0x7D:
-            case 0x7E:
-            case 0x7F:
-                return sax->number_unsigned(static_cast<number_unsigned_t>(current));
+    // positive fixint
+    case 0x00:
+    case 0x01:
+    case 0x02:
+    case 0x03:
+    case 0x04:
+    case 0x05:
+    case 0x06:
+    case 0x07:
+    case 0x08:
+    case 0x09:
+    case 0x0A:
+    case 0x0B:
+    case 0x0C:
+    case 0x0D:
+    case 0x0E:
+    case 0x0F:
+    case 0x10:
+    case 0x11:
+    case 0x12:
+    case 0x13:
+    case 0x14:
+    case 0x15:
+    case 0x16:
+    case 0x17:
+    case 0x18:
+    case 0x19:
+    case 0x1A:
+    case 0x1B:
+    case 0x1C:
+    case 0x1D:
+    case 0x1E:
+    case 0x1F:
+    case 0x20:
+    case 0x21:
+    case 0x22:
+    case 0x23:
+    case 0x24:
+    case 0x25:
+    case 0x26:
+    case 0x27:
+    case 0x28:
+    case 0x29:
+    case 0x2A:
+    case 0x2B:
+    case 0x2C:
+    case 0x2D:
+    case 0x2E:
+    case 0x2F:
+    case 0x30:
+    case 0x31:
+    case 0x32:
+    case 0x33:
+    case 0x34:
+    case 0x35:
+    case 0x36:
+    case 0x37:
+    case 0x38:
+    case 0x39:
+    case 0x3A:
+    case 0x3B:
+    case 0x3C:
+    case 0x3D:
+    case 0x3E:
+    case 0x3F:
+    case 0x40:
+    case 0x41:
+    case 0x42:
+    case 0x43:
+    case 0x44:
+    case 0x45:
+    case 0x46:
+    case 0x47:
+    case 0x48:
+    case 0x49:
+    case 0x4A:
+    case 0x4B:
+    case 0x4C:
+    case 0x4D:
+    case 0x4E:
+    case 0x4F:
+    case 0x50:
+    case 0x51:
+    case 0x52:
+    case 0x53:
+    case 0x54:
+    case 0x55:
+    case 0x56:
+    case 0x57:
+    case 0x58:
+    case 0x59:
+    case 0x5A:
+    case 0x5B:
+    case 0x5C:
+    case 0x5D:
+    case 0x5E:
+    case 0x5F:
+    case 0x60:
+    case 0x61:
+    case 0x62:
+    case 0x63:
+    case 0x64:
+    case 0x65:
+    case 0x66:
+    case 0x67:
+    case 0x68:
+    case 0x69:
+    case 0x6A:
+    case 0x6B:
+    case 0x6C:
+    case 0x6D:
+    case 0x6E:
+    case 0x6F:
+    case 0x70:
+    case 0x71:
+    case 0x72:
+    case 0x73:
+    case 0x74:
+    case 0x75:
+    case 0x76:
+    case 0x77:
+    case 0x78:
+    case 0x79:
+    case 0x7A:
+    case 0x7B:
+    case 0x7C:
+    case 0x7D:
+    case 0x7E:
+    case 0x7F:
+      return sax->number_unsigned(static_cast<number_unsigned_t>(current));
 
-            // fixmap
-            case 0x80:
-            case 0x81:
-            case 0x82:
-            case 0x83:
-            case 0x84:
-            case 0x85:
-            case 0x86:
-            case 0x87:
-            case 0x88:
-            case 0x89:
-            case 0x8A:
-            case 0x8B:
-            case 0x8C:
-            case 0x8D:
-            case 0x8E:
-            case 0x8F:
-                return get_msgpack_object(static_cast<std::size_t>(current & 0x0F));
+    // fixmap
+    case 0x80:
+    case 0x81:
+    case 0x82:
+    case 0x83:
+    case 0x84:
+    case 0x85:
+    case 0x86:
+    case 0x87:
+    case 0x88:
+    case 0x89:
+    case 0x8A:
+    case 0x8B:
+    case 0x8C:
+    case 0x8D:
+    case 0x8E:
+    case 0x8F:
+      return get_msgpack_object(static_cast<std::size_t>(current & 0x0F));
 
-            // fixarray
-            case 0x90:
-            case 0x91:
-            case 0x92:
-            case 0x93:
-            case 0x94:
-            case 0x95:
-            case 0x96:
-            case 0x97:
-            case 0x98:
-            case 0x99:
-            case 0x9A:
-            case 0x9B:
-            case 0x9C:
-            case 0x9D:
-            case 0x9E:
-            case 0x9F:
-                return get_msgpack_array(static_cast<std::size_t>(current & 0x0F));
+    // fixarray
+    case 0x90:
+    case 0x91:
+    case 0x92:
+    case 0x93:
+    case 0x94:
+    case 0x95:
+    case 0x96:
+    case 0x97:
+    case 0x98:
+    case 0x99:
+    case 0x9A:
+    case 0x9B:
+    case 0x9C:
+    case 0x9D:
+    case 0x9E:
+    case 0x9F:
+      return get_msgpack_array(static_cast<std::size_t>(current & 0x0F));
 
-            // fixstr
-            case 0xA0:
-            case 0xA1:
-            case 0xA2:
-            case 0xA3:
-            case 0xA4:
-            case 0xA5:
-            case 0xA6:
-            case 0xA7:
-            case 0xA8:
-            case 0xA9:
-            case 0xAA:
-            case 0xAB:
-            case 0xAC:
-            case 0xAD:
-            case 0xAE:
-            case 0xAF:
-            case 0xB0:
-            case 0xB1:
-            case 0xB2:
-            case 0xB3:
-            case 0xB4:
-            case 0xB5:
-            case 0xB6:
-            case 0xB7:
-            case 0xB8:
-            case 0xB9:
-            case 0xBA:
-            case 0xBB:
-            case 0xBC:
-            case 0xBD:
-            case 0xBE:
-            case 0xBF:
-            {
-                string_t s;
-                return get_msgpack_string(s) and sax->string(s);
-            }
-
-            case 0xC0: // nil
-                return sax->null();
-
-            case 0xC2: // false
-                return sax->boolean(false);
-
-            case 0xC3: // true
-                return sax->boolean(true);
-
-            case 0xCA: // float 32
-            {
-                float number;
-                return get_number(input_format_t::msgpack, number) and sax->number_float(static_cast<number_float_t>(number), "");
-            }
-
-            case 0xCB: // float 64
-            {
-                double number;
-                return get_number(input_format_t::msgpack, number) and sax->number_float(static_cast<number_float_t>(number), "");
-            }
-
-            case 0xCC: // uint 8
-            {
-                uint8_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
-            }
-
-            case 0xCD: // uint 16
-            {
-                uint16_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
-            }
-
-            case 0xCE: // uint 32
-            {
-                uint32_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
-            }
-
-            case 0xCF: // uint 64
-            {
-                uint64_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
-            }
-
-            case 0xD0: // int 8
-            {
-                int8_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
-            }
-
-            case 0xD1: // int 16
-            {
-                int16_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
-            }
-
-            case 0xD2: // int 32
-            {
-                int32_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
-            }
-
-            case 0xD3: // int 64
-            {
-                int64_t number;
-                return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
-            }
-
-            case 0xD9: // str 8
-            case 0xDA: // str 16
-            case 0xDB: // str 32
-            {
-                string_t s;
-                return get_msgpack_string(s) and sax->string(s);
-            }
-
-            case 0xDC: // array 16
-            {
-                uint16_t len;
-                return get_number(input_format_t::msgpack, len) and get_msgpack_array(static_cast<std::size_t>(len));
-            }
-
-            case 0xDD: // array 32
-            {
-                uint32_t len;
-                return get_number(input_format_t::msgpack, len) and get_msgpack_array(static_cast<std::size_t>(len));
-            }
-
-            case 0xDE: // map 16
-            {
-                uint16_t len;
-                return get_number(input_format_t::msgpack, len) and get_msgpack_object(static_cast<std::size_t>(len));
-            }
-
-            case 0xDF: // map 32
-            {
-                uint32_t len;
-                return get_number(input_format_t::msgpack, len) and get_msgpack_object(static_cast<std::size_t>(len));
-            }
-
-            // negative fixint
-            case 0xE0:
-            case 0xE1:
-            case 0xE2:
-            case 0xE3:
-            case 0xE4:
-            case 0xE5:
-            case 0xE6:
-            case 0xE7:
-            case 0xE8:
-            case 0xE9:
-            case 0xEA:
-            case 0xEB:
-            case 0xEC:
-            case 0xED:
-            case 0xEE:
-            case 0xEF:
-            case 0xF0:
-            case 0xF1:
-            case 0xF2:
-            case 0xF3:
-            case 0xF4:
-            case 0xF5:
-            case 0xF6:
-            case 0xF7:
-            case 0xF8:
-            case 0xF9:
-            case 0xFA:
-            case 0xFB:
-            case 0xFC:
-            case 0xFD:
-            case 0xFE:
-            case 0xFF:
-                return sax->number_integer(static_cast<int8_t>(current));
-
-            default: // anything else
-            {
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::msgpack, "invalid byte: 0x" + last_token, "value")));
-            }
-        }
+    // fixstr
+    case 0xA0:
+    case 0xA1:
+    case 0xA2:
+    case 0xA3:
+    case 0xA4:
+    case 0xA5:
+    case 0xA6:
+    case 0xA7:
+    case 0xA8:
+    case 0xA9:
+    case 0xAA:
+    case 0xAB:
+    case 0xAC:
+    case 0xAD:
+    case 0xAE:
+    case 0xAF:
+    case 0xB0:
+    case 0xB1:
+    case 0xB2:
+    case 0xB3:
+    case 0xB4:
+    case 0xB5:
+    case 0xB6:
+    case 0xB7:
+    case 0xB8:
+    case 0xB9:
+    case 0xBA:
+    case 0xBB:
+    case 0xBC:
+    case 0xBD:
+    case 0xBE:
+    case 0xBF: {
+      string_t s;
+      return get_msgpack_string(s) and sax->string(s);
     }
 
-    /*!
+    case 0xC0: // nil
+      return sax->null();
+
+    case 0xC2: // false
+      return sax->boolean(false);
+
+    case 0xC3: // true
+      return sax->boolean(true);
+
+    case 0xCA: // float 32
+    {
+      float number;
+      return get_number(input_format_t::msgpack, number) and sax->number_float(static_cast<number_float_t>(number), "");
+    }
+
+    case 0xCB: // float 64
+    {
+      double number;
+      return get_number(input_format_t::msgpack, number) and sax->number_float(static_cast<number_float_t>(number), "");
+    }
+
+    case 0xCC: // uint 8
+    {
+      uint8_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
+    }
+
+    case 0xCD: // uint 16
+    {
+      uint16_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
+    }
+
+    case 0xCE: // uint 32
+    {
+      uint32_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
+    }
+
+    case 0xCF: // uint 64
+    {
+      uint64_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_unsigned(number);
+    }
+
+    case 0xD0: // int 8
+    {
+      int8_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
+    }
+
+    case 0xD1: // int 16
+    {
+      int16_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
+    }
+
+    case 0xD2: // int 32
+    {
+      int32_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
+    }
+
+    case 0xD3: // int 64
+    {
+      int64_t number;
+      return get_number(input_format_t::msgpack, number) and sax->number_integer(number);
+    }
+
+    case 0xD9: // str 8
+    case 0xDA: // str 16
+    case 0xDB: // str 32
+    {
+      string_t s;
+      return get_msgpack_string(s) and sax->string(s);
+    }
+
+    case 0xDC: // array 16
+    {
+      uint16_t len;
+      return get_number(input_format_t::msgpack, len) and get_msgpack_array(static_cast<std::size_t>(len));
+    }
+
+    case 0xDD: // array 32
+    {
+      uint32_t len;
+      return get_number(input_format_t::msgpack, len) and get_msgpack_array(static_cast<std::size_t>(len));
+    }
+
+    case 0xDE: // map 16
+    {
+      uint16_t len;
+      return get_number(input_format_t::msgpack, len) and get_msgpack_object(static_cast<std::size_t>(len));
+    }
+
+    case 0xDF: // map 32
+    {
+      uint32_t len;
+      return get_number(input_format_t::msgpack, len) and get_msgpack_object(static_cast<std::size_t>(len));
+    }
+
+    // negative fixint
+    case 0xE0:
+    case 0xE1:
+    case 0xE2:
+    case 0xE3:
+    case 0xE4:
+    case 0xE5:
+    case 0xE6:
+    case 0xE7:
+    case 0xE8:
+    case 0xE9:
+    case 0xEA:
+    case 0xEB:
+    case 0xEC:
+    case 0xED:
+    case 0xEE:
+    case 0xEF:
+    case 0xF0:
+    case 0xF1:
+    case 0xF2:
+    case 0xF3:
+    case 0xF4:
+    case 0xF5:
+    case 0xF6:
+    case 0xF7:
+    case 0xF8:
+    case 0xF9:
+    case 0xFA:
+    case 0xFB:
+    case 0xFC:
+    case 0xFD:
+    case 0xFE:
+    case 0xFF:
+      return sax->number_integer(static_cast<int8_t>(current));
+
+    default: // anything else
+    {
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::msgpack, "invalid byte: 0x" + last_token, "value")));
+    }
+    }
+  }
+
+  /*!
     @brief reads a MessagePack string
 
     This function first reads starting bytes to determine the expected
@@ -7692,147 +7193,136 @@ class binary_reader
 
     @return whether string creation completed
     */
-    bool get_msgpack_string(string_t& result)
-    {
-        if (JSON_UNLIKELY(not unexpect_eof(input_format_t::msgpack, "string")))
-        {
-            return false;
-        }
-
-        switch (current)
-        {
-            // fixstr
-            case 0xA0:
-            case 0xA1:
-            case 0xA2:
-            case 0xA3:
-            case 0xA4:
-            case 0xA5:
-            case 0xA6:
-            case 0xA7:
-            case 0xA8:
-            case 0xA9:
-            case 0xAA:
-            case 0xAB:
-            case 0xAC:
-            case 0xAD:
-            case 0xAE:
-            case 0xAF:
-            case 0xB0:
-            case 0xB1:
-            case 0xB2:
-            case 0xB3:
-            case 0xB4:
-            case 0xB5:
-            case 0xB6:
-            case 0xB7:
-            case 0xB8:
-            case 0xB9:
-            case 0xBA:
-            case 0xBB:
-            case 0xBC:
-            case 0xBD:
-            case 0xBE:
-            case 0xBF:
-            {
-                return get_string(input_format_t::msgpack, current & 0x1F, result);
-            }
-
-            case 0xD9: // str 8
-            {
-                uint8_t len;
-                return get_number(input_format_t::msgpack, len) and get_string(input_format_t::msgpack, len, result);
-            }
-
-            case 0xDA: // str 16
-            {
-                uint16_t len;
-                return get_number(input_format_t::msgpack, len) and get_string(input_format_t::msgpack, len, result);
-            }
-
-            case 0xDB: // str 32
-            {
-                uint32_t len;
-                return get_number(input_format_t::msgpack, len) and get_string(input_format_t::msgpack, len, result);
-            }
-
-            default:
-            {
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::msgpack, "expected length specification (0xA0-0xBF, 0xD9-0xDB); last byte: 0x" + last_token, "string")));
-            }
-        }
+  bool get_msgpack_string(string_t &result)
+  {
+    if (JSON_UNLIKELY(not unexpect_eof(input_format_t::msgpack, "string"))) {
+      return false;
     }
 
-    /*!
+    switch (current) {
+    // fixstr
+    case 0xA0:
+    case 0xA1:
+    case 0xA2:
+    case 0xA3:
+    case 0xA4:
+    case 0xA5:
+    case 0xA6:
+    case 0xA7:
+    case 0xA8:
+    case 0xA9:
+    case 0xAA:
+    case 0xAB:
+    case 0xAC:
+    case 0xAD:
+    case 0xAE:
+    case 0xAF:
+    case 0xB0:
+    case 0xB1:
+    case 0xB2:
+    case 0xB3:
+    case 0xB4:
+    case 0xB5:
+    case 0xB6:
+    case 0xB7:
+    case 0xB8:
+    case 0xB9:
+    case 0xBA:
+    case 0xBB:
+    case 0xBC:
+    case 0xBD:
+    case 0xBE:
+    case 0xBF: {
+      return get_string(input_format_t::msgpack, current & 0x1F, result);
+    }
+
+    case 0xD9: // str 8
+    {
+      uint8_t len;
+      return get_number(input_format_t::msgpack, len) and get_string(input_format_t::msgpack, len, result);
+    }
+
+    case 0xDA: // str 16
+    {
+      uint16_t len;
+      return get_number(input_format_t::msgpack, len) and get_string(input_format_t::msgpack, len, result);
+    }
+
+    case 0xDB: // str 32
+    {
+      uint32_t len;
+      return get_number(input_format_t::msgpack, len) and get_string(input_format_t::msgpack, len, result);
+    }
+
+    default: {
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::msgpack, "expected length specification (0xA0-0xBF, 0xD9-0xDB); last byte: 0x" + last_token, "string")));
+    }
+    }
+  }
+
+  /*!
     @param[in] len  the length of the array
     @return whether array creation completed
     */
-    bool get_msgpack_array(const std::size_t len)
-    {
-        if (JSON_UNLIKELY(not sax->start_array(len)))
-        {
-            return false;
-        }
-
-        for (std::size_t i = 0; i < len; ++i)
-        {
-            if (JSON_UNLIKELY(not parse_msgpack_internal()))
-            {
-                return false;
-            }
-        }
-
-        return sax->end_array();
+  bool get_msgpack_array(const std::size_t len)
+  {
+    if (JSON_UNLIKELY(not sax->start_array(len))) {
+      return false;
     }
 
-    /*!
+    for (std::size_t i = 0; i < len; ++i) {
+      if (JSON_UNLIKELY(not parse_msgpack_internal())) {
+        return false;
+      }
+    }
+
+    return sax->end_array();
+  }
+
+  /*!
     @param[in] len  the length of the object
     @return whether object creation completed
     */
-    bool get_msgpack_object(const std::size_t len)
-    {
-        if (JSON_UNLIKELY(not sax->start_object(len)))
-        {
-            return false;
-        }
-
-        string_t key;
-        for (std::size_t i = 0; i < len; ++i)
-        {
-            get();
-            if (JSON_UNLIKELY(not get_msgpack_string(key) or not sax->key(key)))
-            {
-                return false;
-            }
-
-            if (JSON_UNLIKELY(not parse_msgpack_internal()))
-            {
-                return false;
-            }
-            key.clear();
-        }
-
-        return sax->end_object();
+  bool get_msgpack_object(const std::size_t len)
+  {
+    if (JSON_UNLIKELY(not sax->start_object(len))) {
+      return false;
     }
 
-    ////////////
-    // UBJSON //
-    ////////////
+    string_t key;
+    for (std::size_t i = 0; i < len; ++i) {
+      get();
+      if (JSON_UNLIKELY(not get_msgpack_string(key) or not sax->key(key))) {
+        return false;
+      }
 
-    /*!
+      if (JSON_UNLIKELY(not parse_msgpack_internal())) {
+        return false;
+      }
+      key.clear();
+    }
+
+    return sax->end_object();
+  }
+
+  ////////////
+  // UBJSON //
+  ////////////
+
+  /*!
     @param[in] get_char  whether a new character should be retrieved from the
                          input (true, default) or whether the last read
                          character should be considered instead
 
     @return whether a valid UBJSON value was passed to the SAX parser
     */
-    bool parse_ubjson_internal(const bool get_char = true)
-    {
-        return get_ubjson_value(get_char ? get_ignore_noop() : current);
-    }
+  bool parse_ubjson_internal(const bool get_char = true)
+  {
+    return get_ubjson_value(get_char ? get_ignore_noop() : current);
+  }
 
-    /*!
+  /*!
     @brief reads a UBJSON string
 
     This function is either called after reading the 'S' byte explicitly
@@ -7846,128 +7336,108 @@ class binary_reader
 
     @return whether string creation completed
     */
-    bool get_ubjson_string(string_t& result, const bool get_char = true)
-    {
-        if (get_char)
-        {
-            get();  // TODO: may we ignore N here?
-        }
-
-        if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "value")))
-        {
-            return false;
-        }
-
-        switch (current)
-        {
-            case 'U':
-            {
-                uint8_t len;
-                return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
-            }
-
-            case 'i':
-            {
-                int8_t len;
-                return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
-            }
-
-            case 'I':
-            {
-                int16_t len;
-                return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
-            }
-
-            case 'l':
-            {
-                int32_t len;
-                return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
-            }
-
-            case 'L':
-            {
-                int64_t len;
-                return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
-            }
-
-            default:
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::ubjson, "expected length type specification (U, i, I, l, L); last byte: 0x" + last_token, "string")));
-        }
+  bool get_ubjson_string(string_t &result, const bool get_char = true)
+  {
+    if (get_char) {
+      get(); // TODO: may we ignore N here?
     }
 
-    /*!
+    if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "value"))) {
+      return false;
+    }
+
+    switch (current) {
+    case 'U': {
+      uint8_t len;
+      return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
+    }
+
+    case 'i': {
+      int8_t len;
+      return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
+    }
+
+    case 'I': {
+      int16_t len;
+      return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
+    }
+
+    case 'l': {
+      int32_t len;
+      return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
+    }
+
+    case 'L': {
+      int64_t len;
+      return get_number(input_format_t::ubjson, len) and get_string(input_format_t::ubjson, len, result);
+    }
+
+    default:
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::ubjson, "expected length type specification (U, i, I, l, L); last byte: 0x" + last_token, "string")));
+    }
+  }
+
+  /*!
     @param[out] result  determined size
     @return whether size determination completed
     */
-    bool get_ubjson_size_value(std::size_t& result)
-    {
-        switch (get_ignore_noop())
-        {
-            case 'U':
-            {
-                uint8_t number;
-                if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number)))
-                {
-                    return false;
-                }
-                result = static_cast<std::size_t>(number);
-                return true;
-            }
-
-            case 'i':
-            {
-                int8_t number;
-                if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number)))
-                {
-                    return false;
-                }
-                result = static_cast<std::size_t>(number);
-                return true;
-            }
-
-            case 'I':
-            {
-                int16_t number;
-                if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number)))
-                {
-                    return false;
-                }
-                result = static_cast<std::size_t>(number);
-                return true;
-            }
-
-            case 'l':
-            {
-                int32_t number;
-                if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number)))
-                {
-                    return false;
-                }
-                result = static_cast<std::size_t>(number);
-                return true;
-            }
-
-            case 'L':
-            {
-                int64_t number;
-                if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number)))
-                {
-                    return false;
-                }
-                result = static_cast<std::size_t>(number);
-                return true;
-            }
-
-            default:
-            {
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::ubjson, "expected length type specification (U, i, I, l, L) after '#'; last byte: 0x" + last_token, "size")));
-            }
-        }
+  bool get_ubjson_size_value(std::size_t &result)
+  {
+    switch (get_ignore_noop()) {
+    case 'U': {
+      uint8_t number;
+      if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number))) {
+        return false;
+      }
+      result = static_cast<std::size_t>(number);
+      return true;
     }
 
-    /*!
+    case 'i': {
+      int8_t number;
+      if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number))) {
+        return false;
+      }
+      result = static_cast<std::size_t>(number);
+      return true;
+    }
+
+    case 'I': {
+      int16_t number;
+      if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number))) {
+        return false;
+      }
+      result = static_cast<std::size_t>(number);
+      return true;
+    }
+
+    case 'l': {
+      int32_t number;
+      if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number))) {
+        return false;
+      }
+      result = static_cast<std::size_t>(number);
+      return true;
+    }
+
+    case 'L': {
+      int64_t number;
+      if (JSON_UNLIKELY(not get_number(input_format_t::ubjson, number))) {
+        return false;
+      }
+      result = static_cast<std::size_t>(number);
+      return true;
+    }
+
+    default: {
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::ubjson, "expected length type specification (U, i, I, l, L) after '#'; last byte: 0x" + last_token, "size")));
+    }
+    }
+  }
+
+  /*!
     @brief determine the type and size for a container
 
     In the optimized UBJSON format, a type and a size can be provided to allow
@@ -7977,280 +7447,230 @@ class binary_reader
 
     @return whether pair creation completed
     */
-    bool get_ubjson_size_type(std::pair<std::size_t, int>& result)
-    {
-        result.first = string_t::npos; // size
-        result.second = 0; // type
+  bool get_ubjson_size_type(std::pair<std::size_t, int> &result)
+  {
+    result.first  = string_t::npos; // size
+    result.second = 0;              // type
 
-        get_ignore_noop();
+    get_ignore_noop();
 
-        if (current == '$')
-        {
-            result.second = get();  // must not ignore 'N', because 'N' maybe the type
-            if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "type")))
-            {
-                return false;
-            }
+    if (current == '$') {
+      result.second = get(); // must not ignore 'N', because 'N' maybe the type
+      if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "type"))) {
+        return false;
+      }
 
-            get_ignore_noop();
-            if (JSON_UNLIKELY(current != '#'))
-            {
-                if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "value")))
-                {
-                    return false;
-                }
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::ubjson, "expected '#' after type information; last byte: 0x" + last_token, "size")));
-            }
-
-            return get_ubjson_size_value(result.first);
+      get_ignore_noop();
+      if (JSON_UNLIKELY(current != '#')) {
+        if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "value"))) {
+          return false;
         }
-        else if (current == '#')
-        {
-            return get_ubjson_size_value(result.first);
-        }
-        return true;
+        auto last_token = get_token_string();
+        return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::ubjson, "expected '#' after type information; last byte: 0x" + last_token, "size")));
+      }
+
+      return get_ubjson_size_value(result.first);
+    } else if (current == '#') {
+      return get_ubjson_size_value(result.first);
     }
+    return true;
+  }
 
-    /*!
+  /*!
     @param prefix  the previously read or set type prefix
     @return whether value creation completed
     */
-    bool get_ubjson_value(const int prefix)
-    {
-        switch (prefix)
-        {
-            case std::char_traits<char>::eof():  // EOF
-                return unexpect_eof(input_format_t::ubjson, "value");
+  bool get_ubjson_value(const int prefix)
+  {
+    switch (prefix) {
+    case std::char_traits<char>::eof(): // EOF
+      return unexpect_eof(input_format_t::ubjson, "value");
 
-            case 'T':  // true
-                return sax->boolean(true);
-            case 'F':  // false
-                return sax->boolean(false);
+    case 'T': // true
+      return sax->boolean(true);
+    case 'F': // false
+      return sax->boolean(false);
 
-            case 'Z':  // null
-                return sax->null();
+    case 'Z': // null
+      return sax->null();
 
-            case 'U':
-            {
-                uint8_t number;
-                return get_number(input_format_t::ubjson, number) and sax->number_unsigned(number);
-            }
-
-            case 'i':
-            {
-                int8_t number;
-                return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
-            }
-
-            case 'I':
-            {
-                int16_t number;
-                return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
-            }
-
-            case 'l':
-            {
-                int32_t number;
-                return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
-            }
-
-            case 'L':
-            {
-                int64_t number;
-                return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
-            }
-
-            case 'd':
-            {
-                float number;
-                return get_number(input_format_t::ubjson, number) and sax->number_float(static_cast<number_float_t>(number), "");
-            }
-
-            case 'D':
-            {
-                double number;
-                return get_number(input_format_t::ubjson, number) and sax->number_float(static_cast<number_float_t>(number), "");
-            }
-
-            case 'C':  // char
-            {
-                get();
-                if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "char")))
-                {
-                    return false;
-                }
-                if (JSON_UNLIKELY(current > 127))
-                {
-                    auto last_token = get_token_string();
-                    return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::ubjson, "byte after 'C' must be in range 0x00..0x7F; last byte: 0x" + last_token, "char")));
-                }
-                string_t s(1, static_cast<char>(current));
-                return sax->string(s);
-            }
-
-            case 'S':  // string
-            {
-                string_t s;
-                return get_ubjson_string(s) and sax->string(s);
-            }
-
-            case '[':  // array
-                return get_ubjson_array();
-
-            case '{':  // object
-                return get_ubjson_object();
-
-            default: // anything else
-            {
-                auto last_token = get_token_string();
-                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::ubjson, "invalid byte: 0x" + last_token, "value")));
-            }
-        }
+    case 'U': {
+      uint8_t number;
+      return get_number(input_format_t::ubjson, number) and sax->number_unsigned(number);
     }
 
-    /*!
+    case 'i': {
+      int8_t number;
+      return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
+    }
+
+    case 'I': {
+      int16_t number;
+      return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
+    }
+
+    case 'l': {
+      int32_t number;
+      return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
+    }
+
+    case 'L': {
+      int64_t number;
+      return get_number(input_format_t::ubjson, number) and sax->number_integer(number);
+    }
+
+    case 'd': {
+      float number;
+      return get_number(input_format_t::ubjson, number) and sax->number_float(static_cast<number_float_t>(number), "");
+    }
+
+    case 'D': {
+      double number;
+      return get_number(input_format_t::ubjson, number) and sax->number_float(static_cast<number_float_t>(number), "");
+    }
+
+    case 'C': // char
+    {
+      get();
+      if (JSON_UNLIKELY(not unexpect_eof(input_format_t::ubjson, "char"))) {
+        return false;
+      }
+      if (JSON_UNLIKELY(current > 127)) {
+        auto last_token = get_token_string();
+        return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format_t::ubjson, "byte after 'C' must be in range 0x00..0x7F; last byte: 0x" + last_token, "char")));
+      }
+      string_t s(1, static_cast<char>(current));
+      return sax->string(s);
+    }
+
+    case 'S': // string
+    {
+      string_t s;
+      return get_ubjson_string(s) and sax->string(s);
+    }
+
+    case '[': // array
+      return get_ubjson_array();
+
+    case '{': // object
+      return get_ubjson_object();
+
+    default: // anything else
+    {
+      auto last_token = get_token_string();
+      return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format_t::ubjson, "invalid byte: 0x" + last_token, "value")));
+    }
+    }
+  }
+
+  /*!
     @return whether array creation completed
     */
-    bool get_ubjson_array()
-    {
-        std::pair<std::size_t, int> size_and_type;
-        if (JSON_UNLIKELY(not get_ubjson_size_type(size_and_type)))
-        {
-            return false;
-        }
-
-        if (size_and_type.first != string_t::npos)
-        {
-            if (JSON_UNLIKELY(not sax->start_array(size_and_type.first)))
-            {
-                return false;
-            }
-
-            if (size_and_type.second != 0)
-            {
-                if (size_and_type.second != 'N')
-                {
-                    for (std::size_t i = 0; i < size_and_type.first; ++i)
-                    {
-                        if (JSON_UNLIKELY(not get_ubjson_value(size_and_type.second)))
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                for (std::size_t i = 0; i < size_and_type.first; ++i)
-                {
-                    if (JSON_UNLIKELY(not parse_ubjson_internal()))
-                    {
-                        return false;
-                    }
-                }
-            }
-        }
-        else
-        {
-            if (JSON_UNLIKELY(not sax->start_array(std::size_t(-1))))
-            {
-                return false;
-            }
-
-            while (current != ']')
-            {
-                if (JSON_UNLIKELY(not parse_ubjson_internal(false)))
-                {
-                    return false;
-                }
-                get_ignore_noop();
-            }
-        }
-
-        return sax->end_array();
+  bool get_ubjson_array()
+  {
+    std::pair<std::size_t, int> size_and_type;
+    if (JSON_UNLIKELY(not get_ubjson_size_type(size_and_type))) {
+      return false;
     }
 
-    /*!
+    if (size_and_type.first != string_t::npos) {
+      if (JSON_UNLIKELY(not sax->start_array(size_and_type.first))) {
+        return false;
+      }
+
+      if (size_and_type.second != 0) {
+        if (size_and_type.second != 'N') {
+          for (std::size_t i = 0; i < size_and_type.first; ++i) {
+            if (JSON_UNLIKELY(not get_ubjson_value(size_and_type.second))) {
+              return false;
+            }
+          }
+        }
+      } else {
+        for (std::size_t i = 0; i < size_and_type.first; ++i) {
+          if (JSON_UNLIKELY(not parse_ubjson_internal())) {
+            return false;
+          }
+        }
+      }
+    } else {
+      if (JSON_UNLIKELY(not sax->start_array(std::size_t(-1)))) {
+        return false;
+      }
+
+      while (current != ']') {
+        if (JSON_UNLIKELY(not parse_ubjson_internal(false))) {
+          return false;
+        }
+        get_ignore_noop();
+      }
+    }
+
+    return sax->end_array();
+  }
+
+  /*!
     @return whether object creation completed
     */
-    bool get_ubjson_object()
-    {
-        std::pair<std::size_t, int> size_and_type;
-        if (JSON_UNLIKELY(not get_ubjson_size_type(size_and_type)))
-        {
-            return false;
-        }
-
-        string_t key;
-        if (size_and_type.first != string_t::npos)
-        {
-            if (JSON_UNLIKELY(not sax->start_object(size_and_type.first)))
-            {
-                return false;
-            }
-
-            if (size_and_type.second != 0)
-            {
-                for (std::size_t i = 0; i < size_and_type.first; ++i)
-                {
-                    if (JSON_UNLIKELY(not get_ubjson_string(key) or not sax->key(key)))
-                    {
-                        return false;
-                    }
-                    if (JSON_UNLIKELY(not get_ubjson_value(size_and_type.second)))
-                    {
-                        return false;
-                    }
-                    key.clear();
-                }
-            }
-            else
-            {
-                for (std::size_t i = 0; i < size_and_type.first; ++i)
-                {
-                    if (JSON_UNLIKELY(not get_ubjson_string(key) or not sax->key(key)))
-                    {
-                        return false;
-                    }
-                    if (JSON_UNLIKELY(not parse_ubjson_internal()))
-                    {
-                        return false;
-                    }
-                    key.clear();
-                }
-            }
-        }
-        else
-        {
-            if (JSON_UNLIKELY(not sax->start_object(std::size_t(-1))))
-            {
-                return false;
-            }
-
-            while (current != '}')
-            {
-                if (JSON_UNLIKELY(not get_ubjson_string(key, false) or not sax->key(key)))
-                {
-                    return false;
-                }
-                if (JSON_UNLIKELY(not parse_ubjson_internal()))
-                {
-                    return false;
-                }
-                get_ignore_noop();
-                key.clear();
-            }
-        }
-
-        return sax->end_object();
+  bool get_ubjson_object()
+  {
+    std::pair<std::size_t, int> size_and_type;
+    if (JSON_UNLIKELY(not get_ubjson_size_type(size_and_type))) {
+      return false;
     }
 
-    ///////////////////////
-    // Utility functions //
-    ///////////////////////
+    string_t key;
+    if (size_and_type.first != string_t::npos) {
+      if (JSON_UNLIKELY(not sax->start_object(size_and_type.first))) {
+        return false;
+      }
 
-    /*!
+      if (size_and_type.second != 0) {
+        for (std::size_t i = 0; i < size_and_type.first; ++i) {
+          if (JSON_UNLIKELY(not get_ubjson_string(key) or not sax->key(key))) {
+            return false;
+          }
+          if (JSON_UNLIKELY(not get_ubjson_value(size_and_type.second))) {
+            return false;
+          }
+          key.clear();
+        }
+      } else {
+        for (std::size_t i = 0; i < size_and_type.first; ++i) {
+          if (JSON_UNLIKELY(not get_ubjson_string(key) or not sax->key(key))) {
+            return false;
+          }
+          if (JSON_UNLIKELY(not parse_ubjson_internal())) {
+            return false;
+          }
+          key.clear();
+        }
+      }
+    } else {
+      if (JSON_UNLIKELY(not sax->start_object(std::size_t(-1)))) {
+        return false;
+      }
+
+      while (current != '}') {
+        if (JSON_UNLIKELY(not get_ubjson_string(key, false) or not sax->key(key))) {
+          return false;
+        }
+        if (JSON_UNLIKELY(not parse_ubjson_internal())) {
+          return false;
+        }
+        get_ignore_noop();
+        key.clear();
+      }
+    }
+
+    return sax->end_object();
+  }
+
+  ///////////////////////
+  // Utility functions //
+  ///////////////////////
+
+  /*!
     @brief get next character from the input
 
     This function provides the interface to the used input adapter. It does
@@ -8259,27 +7679,25 @@ class binary_reader
 
     @return character read from the input
     */
-    int get()
-    {
-        ++chars_read;
-        return (current = ia->get_character());
-    }
+  int get()
+  {
+    ++chars_read;
+    return (current = ia->get_character());
+  }
 
-    /*!
+  /*!
     @return character read from the input after ignoring all 'N' entries
     */
-    int get_ignore_noop()
-    {
-        do
-        {
-            get();
-        }
-        while (current == 'N');
+  int get_ignore_noop()
+  {
+    do {
+      get();
+    } while (current == 'N');
 
-        return current;
-    }
+    return current;
+  }
 
-    /*
+  /*
     @brief read a number from the input
 
     @tparam NumberType the type of the number
@@ -8292,36 +7710,31 @@ class binary_reader
           bytes in CBOR, MessagePack, and UBJSON are stored in network order
           (big endian) and therefore need reordering on little endian systems.
     */
-    template<typename NumberType, bool InputIsLittleEndian = false>
-    bool get_number(const input_format_t format, NumberType& result)
-    {
-        // step 1: read input into array with system's byte order
-        std::array<uint8_t, sizeof(NumberType)> vec;
-        for (std::size_t i = 0; i < sizeof(NumberType); ++i)
-        {
-            get();
-            if (JSON_UNLIKELY(not unexpect_eof(format, "number")))
-            {
-                return false;
-            }
+  template <typename NumberType, bool InputIsLittleEndian = false>
+  bool get_number(const input_format_t format, NumberType &result)
+  {
+    // step 1: read input into array with system's byte order
+    std::array<uint8_t, sizeof(NumberType)> vec;
+    for (std::size_t i = 0; i < sizeof(NumberType); ++i) {
+      get();
+      if (JSON_UNLIKELY(not unexpect_eof(format, "number"))) {
+        return false;
+      }
 
-            // reverse byte order prior to conversion if necessary
-            if (is_little_endian && !InputIsLittleEndian)
-            {
-                vec[sizeof(NumberType) - i - 1] = static_cast<uint8_t>(current);
-            }
-            else
-            {
-                vec[i] = static_cast<uint8_t>(current); // LCOV_EXCL_LINE
-            }
-        }
-
-        // step 2: convert array into number of type T and return
-        std::memcpy(&result, vec.data(), sizeof(NumberType));
-        return true;
+      // reverse byte order prior to conversion if necessary
+      if (is_little_endian && !InputIsLittleEndian) {
+        vec[sizeof(NumberType) - i - 1] = static_cast<uint8_t>(current);
+      } else {
+        vec[i] = static_cast<uint8_t>(current); // LCOV_EXCL_LINE
+      }
     }
 
-    /*!
+    // step 2: convert array into number of type T and return
+    std::memcpy(&result, vec.data(), sizeof(NumberType));
+    return true;
+  }
+
+  /*!
     @brief create a string by reading characters from the input
 
     @tparam NumberType the type of the number
@@ -8335,125 +7748,117 @@ class binary_reader
           may be too large. Usually, @ref unexpect_eof() detects the end of
           the input before we run out of string memory.
     */
-    template<typename NumberType>
-    bool get_string(const input_format_t format,
-                    const NumberType len,
-                    string_t& result)
-    {
-        bool success = true;
-        std::generate_n(std::back_inserter(result), len, [this, &success, &format]()
-        {
-            get();
-            if (JSON_UNLIKELY(not unexpect_eof(format, "string")))
-            {
-                success = false;
-            }
-            return static_cast<char>(current);
-        });
-        return success;
-    }
+  template <typename NumberType>
+  bool get_string(const input_format_t format,
+                  const NumberType     len,
+                  string_t &           result)
+  {
+    bool success = true;
+    std::generate_n(std::back_inserter(result), len, [this, &success, &format]() {
+      get();
+      if (JSON_UNLIKELY(not unexpect_eof(format, "string"))) {
+        success = false;
+      }
+      return static_cast<char>(current);
+    });
+    return success;
+  }
 
-    /*!
+  /*!
     @param[in] format   the current format (for diagnostics)
     @param[in] context  further context information (for diagnostics)
     @return whether the last read character is not EOF
     */
-    bool unexpect_eof(const input_format_t format, const char* context) const
-    {
-        if (JSON_UNLIKELY(current == std::char_traits<char>::eof()))
-        {
-            return sax->parse_error(chars_read, "<end of file>",
-                                    parse_error::create(110, chars_read, exception_message(format, "unexpected end of input", context)));
-        }
-        return true;
+  bool unexpect_eof(const input_format_t format, const char *context) const
+  {
+    if (JSON_UNLIKELY(current == std::char_traits<char>::eof())) {
+      return sax->parse_error(chars_read, "<end of file>",
+                              parse_error::create(110, chars_read, exception_message(format, "unexpected end of input", context)));
     }
+    return true;
+  }
 
-    /*!
+  /*!
     @return a string representation of the last read byte
     */
-    std::string get_token_string() const
-    {
-        char cr[3];
-        (std::snprintf)(cr, 3, "%.2hhX", static_cast<unsigned char>(current));
-        return std::string{cr};
-    }
+  std::string get_token_string() const
+  {
+    char cr[3];
+    (std::snprintf)(cr, 3, "%.2hhX", static_cast<unsigned char>(current));
+    return std::string{cr};
+  }
 
-    /*!
+  /*!
     @param[in] format   the current format
     @param[in] detail   a detailed error message
     @param[in] context  further contect information
     @return a message string to use in the parse_error exceptions
     */
-    std::string exception_message(const input_format_t format,
-                                  const std::string& detail,
-                                  const std::string& context) const
-    {
-        std::string error_msg = "syntax error while parsing ";
+  std::string exception_message(const input_format_t format,
+                                const std::string &  detail,
+                                const std::string &  context) const
+  {
+    std::string error_msg = "syntax error while parsing ";
 
-        switch (format)
-        {
-            case input_format_t::cbor:
-                error_msg += "CBOR";
-                break;
+    switch (format) {
+    case input_format_t::cbor:
+      error_msg += "CBOR";
+      break;
 
-            case input_format_t::msgpack:
-                error_msg += "MessagePack";
-                break;
+    case input_format_t::msgpack:
+      error_msg += "MessagePack";
+      break;
 
-            case input_format_t::ubjson:
-                error_msg += "UBJSON";
-                break;
+    case input_format_t::ubjson:
+      error_msg += "UBJSON";
+      break;
 
-            case input_format_t::bson:
-                error_msg += "BSON";
-                break;
+    case input_format_t::bson:
+      error_msg += "BSON";
+      break;
 
-            // LCOV_EXCL_START
-            default:
-                assert(false);
-                // LCOV_EXCL_STOP
-        }
-
-        return error_msg + " " + context + ": " + detail;
+    // LCOV_EXCL_START
+    default:
+      assert(false);
+      // LCOV_EXCL_STOP
     }
 
-  private:
-    /// input adapter
-    input_adapter_t ia = nullptr;
+    return error_msg + " " + context + ": " + detail;
+  }
 
-    /// the current character
-    int current = std::char_traits<char>::eof();
+private:
+  /// input adapter
+  input_adapter_t ia = nullptr;
 
-    /// the number of characters read
-    std::size_t chars_read = 0;
+  /// the current character
+  int current = std::char_traits<char>::eof();
 
-    /// whether we can assume little endianess
-    const bool is_little_endian = little_endianess();
+  /// the number of characters read
+  std::size_t chars_read = 0;
 
-    /// the SAX parser
-    json_sax_t* sax = nullptr;
+  /// whether we can assume little endianess
+  const bool is_little_endian = little_endianess();
+
+  /// the SAX parser
+  json_sax_t *sax = nullptr;
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/output/binary_writer.hpp>
 
-
 #include <algorithm> // reverse
-#include <array> // array
-#include <cstdint> // uint8_t, uint16_t, uint32_t, uint64_t
-#include <cstring> // memcpy
-#include <limits> // numeric_limits
+#include <array>     // array
+#include <cstdint>   // uint8_t, uint16_t, uint32_t, uint64_t
+#include <cstring>   // memcpy
+#include <limits>    // numeric_limits
 
 // #include <nlohmann/detail/input/binary_reader.hpp>
 
 // #include <nlohmann/detail/output/output_adapters.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 ///////////////////
 // binary writer //
 ///////////////////
@@ -8461,1152 +7866,953 @@ namespace detail
 /*!
 @brief serialization to CBOR and MessagePack values
 */
-template<typename BasicJsonType, typename CharType>
-class binary_writer
-{
-    using string_t = typename BasicJsonType::string_t;
+template <typename BasicJsonType, typename CharType>
+class binary_writer {
+  using string_t = typename BasicJsonType::string_t;
 
-  public:
-    /*!
+public:
+  /*!
     @brief create a binary writer
 
     @param[in] adapter  output adapter to write to
     */
-    explicit binary_writer(output_adapter_t<CharType> adapter) : oa(adapter)
-    {
-        assert(oa);
-    }
+  explicit binary_writer(output_adapter_t<CharType> adapter)
+      : oa(adapter)
+  {
+    assert(oa);
+  }
 
-    /*!
+  /*!
     @param[in] j  JSON value to serialize
     @pre       j.type() == value_t::object
     */
-    void write_bson(const BasicJsonType& j)
-    {
-        switch (j.type())
-        {
-            case value_t::object:
-            {
-                write_bson_object(*j.m_value.object);
-                break;
-            }
-
-            default:
-            {
-                JSON_THROW(type_error::create(317, "to serialize to BSON, top-level type must be object, but is " + std::string(j.type_name())));
-            }
-        }
+  void write_bson(const BasicJsonType &j)
+  {
+    switch (j.type()) {
+    case value_t::object: {
+      write_bson_object(*j.m_value.object);
+      break;
     }
 
-    /*!
+    default: {
+      JSON_THROW(type_error::create(317, "to serialize to BSON, top-level type must be object, but is " + std::string(j.type_name())));
+    }
+    }
+  }
+
+  /*!
     @param[in] j  JSON value to serialize
     */
-    void write_cbor(const BasicJsonType& j)
-    {
-        switch (j.type())
-        {
-            case value_t::null:
-            {
-                oa->write_character(to_char_type(0xF6));
-                break;
-            }
-
-            case value_t::boolean:
-            {
-                oa->write_character(j.m_value.boolean
-                                    ? to_char_type(0xF5)
-                                    : to_char_type(0xF4));
-                break;
-            }
-
-            case value_t::number_integer:
-            {
-                if (j.m_value.number_integer >= 0)
-                {
-                    // CBOR does not differentiate between positive signed
-                    // integers and unsigned integers. Therefore, we used the
-                    // code from the value_t::number_unsigned case here.
-                    if (j.m_value.number_integer <= 0x17)
-                    {
-                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_integer <= (std::numeric_limits<uint8_t>::max)())
-                    {
-                        oa->write_character(to_char_type(0x18));
-                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_integer <= (std::numeric_limits<uint16_t>::max)())
-                    {
-                        oa->write_character(to_char_type(0x19));
-                        write_number(static_cast<uint16_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_integer <= (std::numeric_limits<uint32_t>::max)())
-                    {
-                        oa->write_character(to_char_type(0x1A));
-                        write_number(static_cast<uint32_t>(j.m_value.number_integer));
-                    }
-                    else
-                    {
-                        oa->write_character(to_char_type(0x1B));
-                        write_number(static_cast<uint64_t>(j.m_value.number_integer));
-                    }
-                }
-                else
-                {
-                    // The conversions below encode the sign in the first
-                    // byte, and the value is converted to a positive number.
-                    const auto positive_number = -1 - j.m_value.number_integer;
-                    if (j.m_value.number_integer >= -24)
-                    {
-                        write_number(static_cast<uint8_t>(0x20 + positive_number));
-                    }
-                    else if (positive_number <= (std::numeric_limits<uint8_t>::max)())
-                    {
-                        oa->write_character(to_char_type(0x38));
-                        write_number(static_cast<uint8_t>(positive_number));
-                    }
-                    else if (positive_number <= (std::numeric_limits<uint16_t>::max)())
-                    {
-                        oa->write_character(to_char_type(0x39));
-                        write_number(static_cast<uint16_t>(positive_number));
-                    }
-                    else if (positive_number <= (std::numeric_limits<uint32_t>::max)())
-                    {
-                        oa->write_character(to_char_type(0x3A));
-                        write_number(static_cast<uint32_t>(positive_number));
-                    }
-                    else
-                    {
-                        oa->write_character(to_char_type(0x3B));
-                        write_number(static_cast<uint64_t>(positive_number));
-                    }
-                }
-                break;
-            }
-
-            case value_t::number_unsigned:
-            {
-                if (j.m_value.number_unsigned <= 0x17)
-                {
-                    write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
-                }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x18));
-                    write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
-                }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x19));
-                    write_number(static_cast<uint16_t>(j.m_value.number_unsigned));
-                }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x1A));
-                    write_number(static_cast<uint32_t>(j.m_value.number_unsigned));
-                }
-                else
-                {
-                    oa->write_character(to_char_type(0x1B));
-                    write_number(static_cast<uint64_t>(j.m_value.number_unsigned));
-                }
-                break;
-            }
-
-            case value_t::number_float:
-            {
-                oa->write_character(get_cbor_float_prefix(j.m_value.number_float));
-                write_number(j.m_value.number_float);
-                break;
-            }
-
-            case value_t::string:
-            {
-                // step 1: write control byte and the string length
-                const auto N = j.m_value.string->size();
-                if (N <= 0x17)
-                {
-                    write_number(static_cast<uint8_t>(0x60 + N));
-                }
-                else if (N <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x78));
-                    write_number(static_cast<uint8_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x79));
-                    write_number(static_cast<uint16_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x7A));
-                    write_number(static_cast<uint32_t>(N));
-                }
-                // LCOV_EXCL_START
-                else if (N <= (std::numeric_limits<uint64_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x7B));
-                    write_number(static_cast<uint64_t>(N));
-                }
-                // LCOV_EXCL_STOP
-
-                // step 2: write the string
-                oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.string->c_str()),
-                    j.m_value.string->size());
-                break;
-            }
-
-            case value_t::array:
-            {
-                // step 1: write control byte and the array size
-                const auto N = j.m_value.array->size();
-                if (N <= 0x17)
-                {
-                    write_number(static_cast<uint8_t>(0x80 + N));
-                }
-                else if (N <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x98));
-                    write_number(static_cast<uint8_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x99));
-                    write_number(static_cast<uint16_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x9A));
-                    write_number(static_cast<uint32_t>(N));
-                }
-                // LCOV_EXCL_START
-                else if (N <= (std::numeric_limits<uint64_t>::max)())
-                {
-                    oa->write_character(to_char_type(0x9B));
-                    write_number(static_cast<uint64_t>(N));
-                }
-                // LCOV_EXCL_STOP
-
-                // step 2: write each element
-                for (const auto& el : *j.m_value.array)
-                {
-                    write_cbor(el);
-                }
-                break;
-            }
-
-            case value_t::object:
-            {
-                // step 1: write control byte and the object size
-                const auto N = j.m_value.object->size();
-                if (N <= 0x17)
-                {
-                    write_number(static_cast<uint8_t>(0xA0 + N));
-                }
-                else if (N <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    oa->write_character(to_char_type(0xB8));
-                    write_number(static_cast<uint8_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    oa->write_character(to_char_type(0xB9));
-                    write_number(static_cast<uint16_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    oa->write_character(to_char_type(0xBA));
-                    write_number(static_cast<uint32_t>(N));
-                }
-                // LCOV_EXCL_START
-                else if (N <= (std::numeric_limits<uint64_t>::max)())
-                {
-                    oa->write_character(to_char_type(0xBB));
-                    write_number(static_cast<uint64_t>(N));
-                }
-                // LCOV_EXCL_STOP
-
-                // step 2: write each element
-                for (const auto& el : *j.m_value.object)
-                {
-                    write_cbor(el.first);
-                    write_cbor(el.second);
-                }
-                break;
-            }
-
-            default:
-                break;
-        }
+  void write_cbor(const BasicJsonType &j)
+  {
+    switch (j.type()) {
+    case value_t::null: {
+      oa->write_character(to_char_type(0xF6));
+      break;
     }
 
-    /*!
+    case value_t::boolean: {
+      oa->write_character(j.m_value.boolean
+                              ? to_char_type(0xF5)
+                              : to_char_type(0xF4));
+      break;
+    }
+
+    case value_t::number_integer: {
+      if (j.m_value.number_integer >= 0) {
+        // CBOR does not differentiate between positive signed
+        // integers and unsigned integers. Therefore, we used the
+        // code from the value_t::number_unsigned case here.
+        if (j.m_value.number_integer <= 0x17) {
+          write_number(static_cast<uint8_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_integer <= (std::numeric_limits<uint8_t>::max)()) {
+          oa->write_character(to_char_type(0x18));
+          write_number(static_cast<uint8_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_integer <= (std::numeric_limits<uint16_t>::max)()) {
+          oa->write_character(to_char_type(0x19));
+          write_number(static_cast<uint16_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_integer <= (std::numeric_limits<uint32_t>::max)()) {
+          oa->write_character(to_char_type(0x1A));
+          write_number(static_cast<uint32_t>(j.m_value.number_integer));
+        } else {
+          oa->write_character(to_char_type(0x1B));
+          write_number(static_cast<uint64_t>(j.m_value.number_integer));
+        }
+      } else {
+        // The conversions below encode the sign in the first
+        // byte, and the value is converted to a positive number.
+        const auto positive_number = -1 - j.m_value.number_integer;
+        if (j.m_value.number_integer >= -24) {
+          write_number(static_cast<uint8_t>(0x20 + positive_number));
+        } else if (positive_number <= (std::numeric_limits<uint8_t>::max)()) {
+          oa->write_character(to_char_type(0x38));
+          write_number(static_cast<uint8_t>(positive_number));
+        } else if (positive_number <= (std::numeric_limits<uint16_t>::max)()) {
+          oa->write_character(to_char_type(0x39));
+          write_number(static_cast<uint16_t>(positive_number));
+        } else if (positive_number <= (std::numeric_limits<uint32_t>::max)()) {
+          oa->write_character(to_char_type(0x3A));
+          write_number(static_cast<uint32_t>(positive_number));
+        } else {
+          oa->write_character(to_char_type(0x3B));
+          write_number(static_cast<uint64_t>(positive_number));
+        }
+      }
+      break;
+    }
+
+    case value_t::number_unsigned: {
+      if (j.m_value.number_unsigned <= 0x17) {
+        write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
+      } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)()) {
+        oa->write_character(to_char_type(0x18));
+        write_number(static_cast<uint8_t>(j.m_value.number_unsigned));
+      } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)()) {
+        oa->write_character(to_char_type(0x19));
+        write_number(static_cast<uint16_t>(j.m_value.number_unsigned));
+      } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)()) {
+        oa->write_character(to_char_type(0x1A));
+        write_number(static_cast<uint32_t>(j.m_value.number_unsigned));
+      } else {
+        oa->write_character(to_char_type(0x1B));
+        write_number(static_cast<uint64_t>(j.m_value.number_unsigned));
+      }
+      break;
+    }
+
+    case value_t::number_float: {
+      oa->write_character(get_cbor_float_prefix(j.m_value.number_float));
+      write_number(j.m_value.number_float);
+      break;
+    }
+
+    case value_t::string: {
+      // step 1: write control byte and the string length
+      const auto N = j.m_value.string->size();
+      if (N <= 0x17) {
+        write_number(static_cast<uint8_t>(0x60 + N));
+      } else if (N <= (std::numeric_limits<uint8_t>::max)()) {
+        oa->write_character(to_char_type(0x78));
+        write_number(static_cast<uint8_t>(N));
+      } else if (N <= (std::numeric_limits<uint16_t>::max)()) {
+        oa->write_character(to_char_type(0x79));
+        write_number(static_cast<uint16_t>(N));
+      } else if (N <= (std::numeric_limits<uint32_t>::max)()) {
+        oa->write_character(to_char_type(0x7A));
+        write_number(static_cast<uint32_t>(N));
+      }
+      // LCOV_EXCL_START
+      else if (N <= (std::numeric_limits<uint64_t>::max)()) {
+        oa->write_character(to_char_type(0x7B));
+        write_number(static_cast<uint64_t>(N));
+      }
+      // LCOV_EXCL_STOP
+
+      // step 2: write the string
+      oa->write_characters(
+          reinterpret_cast<const CharType *>(j.m_value.string->c_str()),
+          j.m_value.string->size());
+      break;
+    }
+
+    case value_t::array: {
+      // step 1: write control byte and the array size
+      const auto N = j.m_value.array->size();
+      if (N <= 0x17) {
+        write_number(static_cast<uint8_t>(0x80 + N));
+      } else if (N <= (std::numeric_limits<uint8_t>::max)()) {
+        oa->write_character(to_char_type(0x98));
+        write_number(static_cast<uint8_t>(N));
+      } else if (N <= (std::numeric_limits<uint16_t>::max)()) {
+        oa->write_character(to_char_type(0x99));
+        write_number(static_cast<uint16_t>(N));
+      } else if (N <= (std::numeric_limits<uint32_t>::max)()) {
+        oa->write_character(to_char_type(0x9A));
+        write_number(static_cast<uint32_t>(N));
+      }
+      // LCOV_EXCL_START
+      else if (N <= (std::numeric_limits<uint64_t>::max)()) {
+        oa->write_character(to_char_type(0x9B));
+        write_number(static_cast<uint64_t>(N));
+      }
+      // LCOV_EXCL_STOP
+
+      // step 2: write each element
+      for (const auto &el : *j.m_value.array) {
+        write_cbor(el);
+      }
+      break;
+    }
+
+    case value_t::object: {
+      // step 1: write control byte and the object size
+      const auto N = j.m_value.object->size();
+      if (N <= 0x17) {
+        write_number(static_cast<uint8_t>(0xA0 + N));
+      } else if (N <= (std::numeric_limits<uint8_t>::max)()) {
+        oa->write_character(to_char_type(0xB8));
+        write_number(static_cast<uint8_t>(N));
+      } else if (N <= (std::numeric_limits<uint16_t>::max)()) {
+        oa->write_character(to_char_type(0xB9));
+        write_number(static_cast<uint16_t>(N));
+      } else if (N <= (std::numeric_limits<uint32_t>::max)()) {
+        oa->write_character(to_char_type(0xBA));
+        write_number(static_cast<uint32_t>(N));
+      }
+      // LCOV_EXCL_START
+      else if (N <= (std::numeric_limits<uint64_t>::max)()) {
+        oa->write_character(to_char_type(0xBB));
+        write_number(static_cast<uint64_t>(N));
+      }
+      // LCOV_EXCL_STOP
+
+      // step 2: write each element
+      for (const auto &el : *j.m_value.object) {
+        write_cbor(el.first);
+        write_cbor(el.second);
+      }
+      break;
+    }
+
+    default:
+      break;
+    }
+  }
+
+  /*!
     @param[in] j  JSON value to serialize
     */
-    void write_msgpack(const BasicJsonType& j)
+  void write_msgpack(const BasicJsonType &j)
+  {
+    switch (j.type()) {
+    case value_t::null: // nil
     {
-        switch (j.type())
-        {
-            case value_t::null: // nil
-            {
-                oa->write_character(to_char_type(0xC0));
-                break;
-            }
-
-            case value_t::boolean: // true and false
-            {
-                oa->write_character(j.m_value.boolean
-                                    ? to_char_type(0xC3)
-                                    : to_char_type(0xC2));
-                break;
-            }
-
-            case value_t::number_integer:
-            {
-                if (j.m_value.number_integer >= 0)
-                {
-                    // MessagePack does not differentiate between positive
-                    // signed integers and unsigned integers. Therefore, we used
-                    // the code from the value_t::number_unsigned case here.
-                    if (j.m_value.number_unsigned < 128)
-                    {
-                        // positive fixnum
-                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)())
-                    {
-                        // uint 8
-                        oa->write_character(to_char_type(0xCC));
-                        write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)())
-                    {
-                        // uint 16
-                        oa->write_character(to_char_type(0xCD));
-                        write_number(static_cast<uint16_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)())
-                    {
-                        // uint 32
-                        oa->write_character(to_char_type(0xCE));
-                        write_number(static_cast<uint32_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<uint64_t>::max)())
-                    {
-                        // uint 64
-                        oa->write_character(to_char_type(0xCF));
-                        write_number(static_cast<uint64_t>(j.m_value.number_integer));
-                    }
-                }
-                else
-                {
-                    if (j.m_value.number_integer >= -32)
-                    {
-                        // negative fixnum
-                        write_number(static_cast<int8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<int8_t>::min)() and
-                             j.m_value.number_integer <= (std::numeric_limits<int8_t>::max)())
-                    {
-                        // int 8
-                        oa->write_character(to_char_type(0xD0));
-                        write_number(static_cast<int8_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<int16_t>::min)() and
-                             j.m_value.number_integer <= (std::numeric_limits<int16_t>::max)())
-                    {
-                        // int 16
-                        oa->write_character(to_char_type(0xD1));
-                        write_number(static_cast<int16_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<int32_t>::min)() and
-                             j.m_value.number_integer <= (std::numeric_limits<int32_t>::max)())
-                    {
-                        // int 32
-                        oa->write_character(to_char_type(0xD2));
-                        write_number(static_cast<int32_t>(j.m_value.number_integer));
-                    }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<int64_t>::min)() and
-                             j.m_value.number_integer <= (std::numeric_limits<int64_t>::max)())
-                    {
-                        // int 64
-                        oa->write_character(to_char_type(0xD3));
-                        write_number(static_cast<int64_t>(j.m_value.number_integer));
-                    }
-                }
-                break;
-            }
-
-            case value_t::number_unsigned:
-            {
-                if (j.m_value.number_unsigned < 128)
-                {
-                    // positive fixnum
-                    write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    // uint 8
-                    oa->write_character(to_char_type(0xCC));
-                    write_number(static_cast<uint8_t>(j.m_value.number_integer));
-                }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    // uint 16
-                    oa->write_character(to_char_type(0xCD));
-                    write_number(static_cast<uint16_t>(j.m_value.number_integer));
-                }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    // uint 32
-                    oa->write_character(to_char_type(0xCE));
-                    write_number(static_cast<uint32_t>(j.m_value.number_integer));
-                }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<uint64_t>::max)())
-                {
-                    // uint 64
-                    oa->write_character(to_char_type(0xCF));
-                    write_number(static_cast<uint64_t>(j.m_value.number_integer));
-                }
-                break;
-            }
-
-            case value_t::number_float:
-            {
-                oa->write_character(get_msgpack_float_prefix(j.m_value.number_float));
-                write_number(j.m_value.number_float);
-                break;
-            }
-
-            case value_t::string:
-            {
-                // step 1: write control byte and the string length
-                const auto N = j.m_value.string->size();
-                if (N <= 31)
-                {
-                    // fixstr
-                    write_number(static_cast<uint8_t>(0xA0 | N));
-                }
-                else if (N <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    // str 8
-                    oa->write_character(to_char_type(0xD9));
-                    write_number(static_cast<uint8_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    // str 16
-                    oa->write_character(to_char_type(0xDA));
-                    write_number(static_cast<uint16_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    // str 32
-                    oa->write_character(to_char_type(0xDB));
-                    write_number(static_cast<uint32_t>(N));
-                }
-
-                // step 2: write the string
-                oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.string->c_str()),
-                    j.m_value.string->size());
-                break;
-            }
-
-            case value_t::array:
-            {
-                // step 1: write control byte and the array size
-                const auto N = j.m_value.array->size();
-                if (N <= 15)
-                {
-                    // fixarray
-                    write_number(static_cast<uint8_t>(0x90 | N));
-                }
-                else if (N <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    // array 16
-                    oa->write_character(to_char_type(0xDC));
-                    write_number(static_cast<uint16_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    // array 32
-                    oa->write_character(to_char_type(0xDD));
-                    write_number(static_cast<uint32_t>(N));
-                }
-
-                // step 2: write each element
-                for (const auto& el : *j.m_value.array)
-                {
-                    write_msgpack(el);
-                }
-                break;
-            }
-
-            case value_t::object:
-            {
-                // step 1: write control byte and the object size
-                const auto N = j.m_value.object->size();
-                if (N <= 15)
-                {
-                    // fixmap
-                    write_number(static_cast<uint8_t>(0x80 | (N & 0xF)));
-                }
-                else if (N <= (std::numeric_limits<uint16_t>::max)())
-                {
-                    // map 16
-                    oa->write_character(to_char_type(0xDE));
-                    write_number(static_cast<uint16_t>(N));
-                }
-                else if (N <= (std::numeric_limits<uint32_t>::max)())
-                {
-                    // map 32
-                    oa->write_character(to_char_type(0xDF));
-                    write_number(static_cast<uint32_t>(N));
-                }
-
-                // step 2: write each element
-                for (const auto& el : *j.m_value.object)
-                {
-                    write_msgpack(el.first);
-                    write_msgpack(el.second);
-                }
-                break;
-            }
-
-            default:
-                break;
-        }
+      oa->write_character(to_char_type(0xC0));
+      break;
     }
 
-    /*!
+    case value_t::boolean: // true and false
+    {
+      oa->write_character(j.m_value.boolean
+                              ? to_char_type(0xC3)
+                              : to_char_type(0xC2));
+      break;
+    }
+
+    case value_t::number_integer: {
+      if (j.m_value.number_integer >= 0) {
+        // MessagePack does not differentiate between positive
+        // signed integers and unsigned integers. Therefore, we used
+        // the code from the value_t::number_unsigned case here.
+        if (j.m_value.number_unsigned < 128) {
+          // positive fixnum
+          write_number(static_cast<uint8_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)()) {
+          // uint 8
+          oa->write_character(to_char_type(0xCC));
+          write_number(static_cast<uint8_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)()) {
+          // uint 16
+          oa->write_character(to_char_type(0xCD));
+          write_number(static_cast<uint16_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)()) {
+          // uint 32
+          oa->write_character(to_char_type(0xCE));
+          write_number(static_cast<uint32_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint64_t>::max)()) {
+          // uint 64
+          oa->write_character(to_char_type(0xCF));
+          write_number(static_cast<uint64_t>(j.m_value.number_integer));
+        }
+      } else {
+        if (j.m_value.number_integer >= -32) {
+          // negative fixnum
+          write_number(static_cast<int8_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_integer >= (std::numeric_limits<int8_t>::min)() and
+                   j.m_value.number_integer <= (std::numeric_limits<int8_t>::max)()) {
+          // int 8
+          oa->write_character(to_char_type(0xD0));
+          write_number(static_cast<int8_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_integer >= (std::numeric_limits<int16_t>::min)() and
+                   j.m_value.number_integer <= (std::numeric_limits<int16_t>::max)()) {
+          // int 16
+          oa->write_character(to_char_type(0xD1));
+          write_number(static_cast<int16_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_integer >= (std::numeric_limits<int32_t>::min)() and
+                   j.m_value.number_integer <= (std::numeric_limits<int32_t>::max)()) {
+          // int 32
+          oa->write_character(to_char_type(0xD2));
+          write_number(static_cast<int32_t>(j.m_value.number_integer));
+        } else if (j.m_value.number_integer >= (std::numeric_limits<int64_t>::min)() and
+                   j.m_value.number_integer <= (std::numeric_limits<int64_t>::max)()) {
+          // int 64
+          oa->write_character(to_char_type(0xD3));
+          write_number(static_cast<int64_t>(j.m_value.number_integer));
+        }
+      }
+      break;
+    }
+
+    case value_t::number_unsigned: {
+      if (j.m_value.number_unsigned < 128) {
+        // positive fixnum
+        write_number(static_cast<uint8_t>(j.m_value.number_integer));
+      } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)()) {
+        // uint 8
+        oa->write_character(to_char_type(0xCC));
+        write_number(static_cast<uint8_t>(j.m_value.number_integer));
+      } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint16_t>::max)()) {
+        // uint 16
+        oa->write_character(to_char_type(0xCD));
+        write_number(static_cast<uint16_t>(j.m_value.number_integer));
+      } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint32_t>::max)()) {
+        // uint 32
+        oa->write_character(to_char_type(0xCE));
+        write_number(static_cast<uint32_t>(j.m_value.number_integer));
+      } else if (j.m_value.number_unsigned <= (std::numeric_limits<uint64_t>::max)()) {
+        // uint 64
+        oa->write_character(to_char_type(0xCF));
+        write_number(static_cast<uint64_t>(j.m_value.number_integer));
+      }
+      break;
+    }
+
+    case value_t::number_float: {
+      oa->write_character(get_msgpack_float_prefix(j.m_value.number_float));
+      write_number(j.m_value.number_float);
+      break;
+    }
+
+    case value_t::string: {
+      // step 1: write control byte and the string length
+      const auto N = j.m_value.string->size();
+      if (N <= 31) {
+        // fixstr
+        write_number(static_cast<uint8_t>(0xA0 | N));
+      } else if (N <= (std::numeric_limits<uint8_t>::max)()) {
+        // str 8
+        oa->write_character(to_char_type(0xD9));
+        write_number(static_cast<uint8_t>(N));
+      } else if (N <= (std::numeric_limits<uint16_t>::max)()) {
+        // str 16
+        oa->write_character(to_char_type(0xDA));
+        write_number(static_cast<uint16_t>(N));
+      } else if (N <= (std::numeric_limits<uint32_t>::max)()) {
+        // str 32
+        oa->write_character(to_char_type(0xDB));
+        write_number(static_cast<uint32_t>(N));
+      }
+
+      // step 2: write the string
+      oa->write_characters(
+          reinterpret_cast<const CharType *>(j.m_value.string->c_str()),
+          j.m_value.string->size());
+      break;
+    }
+
+    case value_t::array: {
+      // step 1: write control byte and the array size
+      const auto N = j.m_value.array->size();
+      if (N <= 15) {
+        // fixarray
+        write_number(static_cast<uint8_t>(0x90 | N));
+      } else if (N <= (std::numeric_limits<uint16_t>::max)()) {
+        // array 16
+        oa->write_character(to_char_type(0xDC));
+        write_number(static_cast<uint16_t>(N));
+      } else if (N <= (std::numeric_limits<uint32_t>::max)()) {
+        // array 32
+        oa->write_character(to_char_type(0xDD));
+        write_number(static_cast<uint32_t>(N));
+      }
+
+      // step 2: write each element
+      for (const auto &el : *j.m_value.array) {
+        write_msgpack(el);
+      }
+      break;
+    }
+
+    case value_t::object: {
+      // step 1: write control byte and the object size
+      const auto N = j.m_value.object->size();
+      if (N <= 15) {
+        // fixmap
+        write_number(static_cast<uint8_t>(0x80 | (N & 0xF)));
+      } else if (N <= (std::numeric_limits<uint16_t>::max)()) {
+        // map 16
+        oa->write_character(to_char_type(0xDE));
+        write_number(static_cast<uint16_t>(N));
+      } else if (N <= (std::numeric_limits<uint32_t>::max)()) {
+        // map 32
+        oa->write_character(to_char_type(0xDF));
+        write_number(static_cast<uint32_t>(N));
+      }
+
+      // step 2: write each element
+      for (const auto &el : *j.m_value.object) {
+        write_msgpack(el.first);
+        write_msgpack(el.second);
+      }
+      break;
+    }
+
+    default:
+      break;
+    }
+  }
+
+  /*!
     @param[in] j  JSON value to serialize
     @param[in] use_count   whether to use '#' prefixes (optimized format)
     @param[in] use_type    whether to use '$' prefixes (optimized format)
     @param[in] add_prefix  whether prefixes need to be used for this value
     */
-    void write_ubjson(const BasicJsonType& j, const bool use_count,
-                      const bool use_type, const bool add_prefix = true)
-    {
-        switch (j.type())
-        {
-            case value_t::null:
-            {
-                if (add_prefix)
-                {
-                    oa->write_character(to_char_type('Z'));
-                }
-                break;
-            }
-
-            case value_t::boolean:
-            {
-                if (add_prefix)
-                {
-                    oa->write_character(j.m_value.boolean
-                                        ? to_char_type('T')
-                                        : to_char_type('F'));
-                }
-                break;
-            }
-
-            case value_t::number_integer:
-            {
-                write_number_with_ubjson_prefix(j.m_value.number_integer, add_prefix);
-                break;
-            }
-
-            case value_t::number_unsigned:
-            {
-                write_number_with_ubjson_prefix(j.m_value.number_unsigned, add_prefix);
-                break;
-            }
-
-            case value_t::number_float:
-            {
-                write_number_with_ubjson_prefix(j.m_value.number_float, add_prefix);
-                break;
-            }
-
-            case value_t::string:
-            {
-                if (add_prefix)
-                {
-                    oa->write_character(to_char_type('S'));
-                }
-                write_number_with_ubjson_prefix(j.m_value.string->size(), true);
-                oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.string->c_str()),
-                    j.m_value.string->size());
-                break;
-            }
-
-            case value_t::array:
-            {
-                if (add_prefix)
-                {
-                    oa->write_character(to_char_type('['));
-                }
-
-                bool prefix_required = true;
-                if (use_type and not j.m_value.array->empty())
-                {
-                    assert(use_count);
-                    const CharType first_prefix = ubjson_prefix(j.front());
-                    const bool same_prefix = std::all_of(j.begin() + 1, j.end(),
-                                                         [this, first_prefix](const BasicJsonType & v)
-                    {
-                        return ubjson_prefix(v) == first_prefix;
-                    });
-
-                    if (same_prefix)
-                    {
-                        prefix_required = false;
-                        oa->write_character(to_char_type('$'));
-                        oa->write_character(first_prefix);
-                    }
-                }
-
-                if (use_count)
-                {
-                    oa->write_character(to_char_type('#'));
-                    write_number_with_ubjson_prefix(j.m_value.array->size(), true);
-                }
-
-                for (const auto& el : *j.m_value.array)
-                {
-                    write_ubjson(el, use_count, use_type, prefix_required);
-                }
-
-                if (not use_count)
-                {
-                    oa->write_character(to_char_type(']'));
-                }
-
-                break;
-            }
-
-            case value_t::object:
-            {
-                if (add_prefix)
-                {
-                    oa->write_character(to_char_type('{'));
-                }
-
-                bool prefix_required = true;
-                if (use_type and not j.m_value.object->empty())
-                {
-                    assert(use_count);
-                    const CharType first_prefix = ubjson_prefix(j.front());
-                    const bool same_prefix = std::all_of(j.begin(), j.end(),
-                                                         [this, first_prefix](const BasicJsonType & v)
-                    {
-                        return ubjson_prefix(v) == first_prefix;
-                    });
-
-                    if (same_prefix)
-                    {
-                        prefix_required = false;
-                        oa->write_character(to_char_type('$'));
-                        oa->write_character(first_prefix);
-                    }
-                }
-
-                if (use_count)
-                {
-                    oa->write_character(to_char_type('#'));
-                    write_number_with_ubjson_prefix(j.m_value.object->size(), true);
-                }
-
-                for (const auto& el : *j.m_value.object)
-                {
-                    write_number_with_ubjson_prefix(el.first.size(), true);
-                    oa->write_characters(
-                        reinterpret_cast<const CharType*>(el.first.c_str()),
-                        el.first.size());
-                    write_ubjson(el.second, use_count, use_type, prefix_required);
-                }
-
-                if (not use_count)
-                {
-                    oa->write_character(to_char_type('}'));
-                }
-
-                break;
-            }
-
-            default:
-                break;
-        }
+  void write_ubjson(const BasicJsonType &j, const bool use_count,
+                    const bool use_type, const bool add_prefix = true)
+  {
+    switch (j.type()) {
+    case value_t::null: {
+      if (add_prefix) {
+        oa->write_character(to_char_type('Z'));
+      }
+      break;
     }
 
-  private:
-    //////////
-    // BSON //
-    //////////
+    case value_t::boolean: {
+      if (add_prefix) {
+        oa->write_character(j.m_value.boolean
+                                ? to_char_type('T')
+                                : to_char_type('F'));
+      }
+      break;
+    }
 
-    /*!
+    case value_t::number_integer: {
+      write_number_with_ubjson_prefix(j.m_value.number_integer, add_prefix);
+      break;
+    }
+
+    case value_t::number_unsigned: {
+      write_number_with_ubjson_prefix(j.m_value.number_unsigned, add_prefix);
+      break;
+    }
+
+    case value_t::number_float: {
+      write_number_with_ubjson_prefix(j.m_value.number_float, add_prefix);
+      break;
+    }
+
+    case value_t::string: {
+      if (add_prefix) {
+        oa->write_character(to_char_type('S'));
+      }
+      write_number_with_ubjson_prefix(j.m_value.string->size(), true);
+      oa->write_characters(
+          reinterpret_cast<const CharType *>(j.m_value.string->c_str()),
+          j.m_value.string->size());
+      break;
+    }
+
+    case value_t::array: {
+      if (add_prefix) {
+        oa->write_character(to_char_type('['));
+      }
+
+      bool prefix_required = true;
+      if (use_type and not j.m_value.array->empty()) {
+        assert(use_count);
+        const CharType first_prefix = ubjson_prefix(j.front());
+        const bool     same_prefix  = std::all_of(j.begin() + 1, j.end(),
+                                             [this, first_prefix](const BasicJsonType &v) {
+                                               return ubjson_prefix(v) == first_prefix;
+                                             });
+
+        if (same_prefix) {
+          prefix_required = false;
+          oa->write_character(to_char_type('$'));
+          oa->write_character(first_prefix);
+        }
+      }
+
+      if (use_count) {
+        oa->write_character(to_char_type('#'));
+        write_number_with_ubjson_prefix(j.m_value.array->size(), true);
+      }
+
+      for (const auto &el : *j.m_value.array) {
+        write_ubjson(el, use_count, use_type, prefix_required);
+      }
+
+      if (not use_count) {
+        oa->write_character(to_char_type(']'));
+      }
+
+      break;
+    }
+
+    case value_t::object: {
+      if (add_prefix) {
+        oa->write_character(to_char_type('{'));
+      }
+
+      bool prefix_required = true;
+      if (use_type and not j.m_value.object->empty()) {
+        assert(use_count);
+        const CharType first_prefix = ubjson_prefix(j.front());
+        const bool     same_prefix  = std::all_of(j.begin(), j.end(),
+                                             [this, first_prefix](const BasicJsonType &v) {
+                                               return ubjson_prefix(v) == first_prefix;
+                                             });
+
+        if (same_prefix) {
+          prefix_required = false;
+          oa->write_character(to_char_type('$'));
+          oa->write_character(first_prefix);
+        }
+      }
+
+      if (use_count) {
+        oa->write_character(to_char_type('#'));
+        write_number_with_ubjson_prefix(j.m_value.object->size(), true);
+      }
+
+      for (const auto &el : *j.m_value.object) {
+        write_number_with_ubjson_prefix(el.first.size(), true);
+        oa->write_characters(
+            reinterpret_cast<const CharType *>(el.first.c_str()),
+            el.first.size());
+        write_ubjson(el.second, use_count, use_type, prefix_required);
+      }
+
+      if (not use_count) {
+        oa->write_character(to_char_type('}'));
+      }
+
+      break;
+    }
+
+    default:
+      break;
+    }
+  }
+
+private:
+  //////////
+  // BSON //
+  //////////
+
+  /*!
     @return The size of a BSON document entry header, including the id marker
             and the entry name size (and its null-terminator).
     */
-    static std::size_t calc_bson_entry_header_size(const string_t& name)
-    {
-        const auto it = name.find(static_cast<typename string_t::value_type>(0));
-        if (JSON_UNLIKELY(it != BasicJsonType::string_t::npos))
-        {
-            JSON_THROW(out_of_range::create(409,
-                                            "BSON key cannot contain code point U+0000 (at byte " + std::to_string(it) + ")"));
-        }
-
-        return /*id*/ 1ul + name.size() + /*zero-terminator*/1u;
+  static std::size_t calc_bson_entry_header_size(const string_t &name)
+  {
+    const auto it = name.find(static_cast<typename string_t::value_type>(0));
+    if (JSON_UNLIKELY(it != BasicJsonType::string_t::npos)) {
+      JSON_THROW(out_of_range::create(409,
+                                      "BSON key cannot contain code point U+0000 (at byte " + std::to_string(it) + ")"));
     }
 
-    /*!
+    return /*id*/ 1ul + name.size() + /*zero-terminator*/ 1u;
+  }
+
+  /*!
     @brief Writes the given @a element_type and @a name to the output adapter
     */
-    void write_bson_entry_header(const string_t& name,
-                                 const std::uint8_t element_type)
-    {
-        oa->write_character(to_char_type(element_type)); // boolean
-        oa->write_characters(
-            reinterpret_cast<const CharType*>(name.c_str()),
-            name.size() + 1u);
-    }
+  void write_bson_entry_header(const string_t &   name,
+                               const std::uint8_t element_type)
+  {
+    oa->write_character(to_char_type(element_type)); // boolean
+    oa->write_characters(
+        reinterpret_cast<const CharType *>(name.c_str()),
+        name.size() + 1u);
+  }
 
-    /*!
+  /*!
     @brief Writes a BSON element with key @a name and boolean value @a value
     */
-    void write_bson_boolean(const string_t& name,
-                            const bool value)
-    {
-        write_bson_entry_header(name, 0x08);
-        oa->write_character(value ? to_char_type(0x01) : to_char_type(0x00));
-    }
+  void write_bson_boolean(const string_t &name,
+                          const bool      value)
+  {
+    write_bson_entry_header(name, 0x08);
+    oa->write_character(value ? to_char_type(0x01) : to_char_type(0x00));
+  }
 
-    /*!
+  /*!
     @brief Writes a BSON element with key @a name and double value @a value
     */
-    void write_bson_double(const string_t& name,
-                           const double value)
-    {
-        write_bson_entry_header(name, 0x01);
-        write_number<double, true>(value);
-    }
+  void write_bson_double(const string_t &name,
+                         const double    value)
+  {
+    write_bson_entry_header(name, 0x01);
+    write_number<double, true>(value);
+  }
 
-    /*!
+  /*!
     @return The size of the BSON-encoded string in @a value
     */
-    static std::size_t calc_bson_string_size(const string_t& value)
-    {
-        return sizeof(std::int32_t) + value.size() + 1ul;
-    }
+  static std::size_t calc_bson_string_size(const string_t &value)
+  {
+    return sizeof(std::int32_t) + value.size() + 1ul;
+  }
 
-    /*!
+  /*!
     @brief Writes a BSON element with key @a name and string value @a value
     */
-    void write_bson_string(const string_t& name,
-                           const string_t& value)
-    {
-        write_bson_entry_header(name, 0x02);
+  void write_bson_string(const string_t &name,
+                         const string_t &value)
+  {
+    write_bson_entry_header(name, 0x02);
 
-        write_number<std::int32_t, true>(static_cast<std::int32_t>(value.size() + 1ul));
-        oa->write_characters(
-            reinterpret_cast<const CharType*>(value.c_str()),
-            value.size() + 1);
-    }
+    write_number<std::int32_t, true>(static_cast<std::int32_t>(value.size() + 1ul));
+    oa->write_characters(
+        reinterpret_cast<const CharType *>(value.c_str()),
+        value.size() + 1);
+  }
 
-    /*!
+  /*!
     @brief Writes a BSON element with key @a name and null value
     */
-    void write_bson_null(const string_t& name)
-    {
-        write_bson_entry_header(name, 0x0A);
-    }
+  void write_bson_null(const string_t &name)
+  {
+    write_bson_entry_header(name, 0x0A);
+  }
 
-    /*!
+  /*!
     @return The size of the BSON-encoded integer @a value
     */
-    static std::size_t calc_bson_integer_size(const std::int64_t value)
-    {
-        if ((std::numeric_limits<std::int32_t>::min)() <= value and value <= (std::numeric_limits<std::int32_t>::max)())
-        {
-            return sizeof(std::int32_t);
-        }
-        else
-        {
-            return sizeof(std::int64_t);
-        }
+  static std::size_t calc_bson_integer_size(const std::int64_t value)
+  {
+    if ((std::numeric_limits<std::int32_t>::min)() <= value and value <= (std::numeric_limits<std::int32_t>::max)()) {
+      return sizeof(std::int32_t);
+    } else {
+      return sizeof(std::int64_t);
     }
+  }
 
-    /*!
+  /*!
     @brief Writes a BSON element with key @a name and integer @a value
     */
-    void write_bson_integer(const string_t& name,
-                            const std::int64_t value)
-    {
-        if ((std::numeric_limits<std::int32_t>::min)() <= value and value <= (std::numeric_limits<std::int32_t>::max)())
-        {
-            write_bson_entry_header(name, 0x10); // int32
-            write_number<std::int32_t, true>(static_cast<std::int32_t>(value));
-        }
-        else
-        {
-            write_bson_entry_header(name, 0x12); // int64
-            write_number<std::int64_t, true>(static_cast<std::int64_t>(value));
-        }
+  void write_bson_integer(const string_t &   name,
+                          const std::int64_t value)
+  {
+    if ((std::numeric_limits<std::int32_t>::min)() <= value and value <= (std::numeric_limits<std::int32_t>::max)()) {
+      write_bson_entry_header(name, 0x10); // int32
+      write_number<std::int32_t, true>(static_cast<std::int32_t>(value));
+    } else {
+      write_bson_entry_header(name, 0x12); // int64
+      write_number<std::int64_t, true>(static_cast<std::int64_t>(value));
     }
+  }
 
-    /*!
+  /*!
     @return The size of the BSON-encoded unsigned integer in @a j
     */
-    static constexpr std::size_t calc_bson_unsigned_size(const std::uint64_t value) noexcept
-    {
-        return (value <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
+  static constexpr std::size_t calc_bson_unsigned_size(const std::uint64_t value) noexcept
+  {
+    return (value <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
                ? sizeof(std::int32_t)
                : sizeof(std::int64_t);
-    }
+  }
 
-    /*!
+  /*!
     @brief Writes a BSON element with key @a name and unsigned @a value
     */
-    void write_bson_unsigned(const string_t& name,
-                             const std::uint64_t value)
-    {
-        if (value <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
-        {
-            write_bson_entry_header(name, 0x10 /* int32 */);
-            write_number<std::int32_t, true>(static_cast<std::int32_t>(value));
-        }
-        else if (value <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
-        {
-            write_bson_entry_header(name, 0x12 /* int64 */);
-            write_number<std::int64_t, true>(static_cast<std::int64_t>(value));
-        }
-        else
-        {
-            JSON_THROW(out_of_range::create(407, "integer number " + std::to_string(value) + " cannot be represented by BSON as it does not fit int64"));
-        }
+  void write_bson_unsigned(const string_t &    name,
+                           const std::uint64_t value)
+  {
+    if (value <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)())) {
+      write_bson_entry_header(name, 0x10 /* int32 */);
+      write_number<std::int32_t, true>(static_cast<std::int32_t>(value));
+    } else if (value <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)())) {
+      write_bson_entry_header(name, 0x12 /* int64 */);
+      write_number<std::int64_t, true>(static_cast<std::int64_t>(value));
+    } else {
+      JSON_THROW(out_of_range::create(407, "integer number " + std::to_string(value) + " cannot be represented by BSON as it does not fit int64"));
     }
+  }
 
-    /*!
+  /*!
     @brief Writes a BSON element with key @a name and object @a value
     */
-    void write_bson_object_entry(const string_t& name,
-                                 const typename BasicJsonType::object_t& value)
-    {
-        write_bson_entry_header(name, 0x03); // object
-        write_bson_object(value);
-    }
+  void write_bson_object_entry(const string_t &                        name,
+                               const typename BasicJsonType::object_t &value)
+  {
+    write_bson_entry_header(name, 0x03); // object
+    write_bson_object(value);
+  }
 
-    /*!
+  /*!
     @return The size of the BSON-encoded array @a value
     */
-    static std::size_t calc_bson_array_size(const typename BasicJsonType::array_t& value)
-    {
-        std::size_t embedded_document_size = 0ul;
-        std::size_t array_index = 0ul;
+  static std::size_t calc_bson_array_size(const typename BasicJsonType::array_t &value)
+  {
+    std::size_t embedded_document_size = 0ul;
+    std::size_t array_index            = 0ul;
 
-        for (const auto& el : value)
-        {
-            embedded_document_size += calc_bson_element_size(std::to_string(array_index++), el);
-        }
-
-        return sizeof(std::int32_t) + embedded_document_size + 1ul;
+    for (const auto &el : value) {
+      embedded_document_size += calc_bson_element_size(std::to_string(array_index++), el);
     }
 
-    /*!
+    return sizeof(std::int32_t) + embedded_document_size + 1ul;
+  }
+
+  /*!
     @brief Writes a BSON element with key @a name and array @a value
     */
-    void write_bson_array(const string_t& name,
-                          const typename BasicJsonType::array_t& value)
-    {
-        write_bson_entry_header(name, 0x04); // array
-        write_number<std::int32_t, true>(static_cast<std::int32_t>(calc_bson_array_size(value)));
+  void write_bson_array(const string_t &                       name,
+                        const typename BasicJsonType::array_t &value)
+  {
+    write_bson_entry_header(name, 0x04); // array
+    write_number<std::int32_t, true>(static_cast<std::int32_t>(calc_bson_array_size(value)));
 
-        std::size_t array_index = 0ul;
+    std::size_t array_index = 0ul;
 
-        for (const auto& el : value)
-        {
-            write_bson_element(std::to_string(array_index++), el);
-        }
-
-        oa->write_character(to_char_type(0x00));
+    for (const auto &el : value) {
+      write_bson_element(std::to_string(array_index++), el);
     }
 
-    /*!
+    oa->write_character(to_char_type(0x00));
+  }
+
+  /*!
     @brief Calculates the size necessary to serialize the JSON value @a j with its @a name
     @return The calculated size for the BSON document entry for @a j with the given @a name.
     */
-    static std::size_t calc_bson_element_size(const string_t& name,
-            const BasicJsonType& j)
-    {
-        const auto header_size = calc_bson_entry_header_size(name);
-        switch (j.type())
-        {
-            case value_t::object:
-                return header_size + calc_bson_object_size(*j.m_value.object);
+  static std::size_t calc_bson_element_size(const string_t &     name,
+                                            const BasicJsonType &j)
+  {
+    const auto header_size = calc_bson_entry_header_size(name);
+    switch (j.type()) {
+    case value_t::object:
+      return header_size + calc_bson_object_size(*j.m_value.object);
 
-            case value_t::array:
-                return header_size + calc_bson_array_size(*j.m_value.array);
+    case value_t::array:
+      return header_size + calc_bson_array_size(*j.m_value.array);
 
-            case value_t::boolean:
-                return header_size + 1ul;
+    case value_t::boolean:
+      return header_size + 1ul;
 
-            case value_t::number_float:
-                return header_size + 8ul;
+    case value_t::number_float:
+      return header_size + 8ul;
 
-            case value_t::number_integer:
-                return header_size + calc_bson_integer_size(j.m_value.number_integer);
+    case value_t::number_integer:
+      return header_size + calc_bson_integer_size(j.m_value.number_integer);
 
-            case value_t::number_unsigned:
-                return header_size + calc_bson_unsigned_size(j.m_value.number_unsigned);
+    case value_t::number_unsigned:
+      return header_size + calc_bson_unsigned_size(j.m_value.number_unsigned);
 
-            case value_t::string:
-                return header_size + calc_bson_string_size(*j.m_value.string);
+    case value_t::string:
+      return header_size + calc_bson_string_size(*j.m_value.string);
 
-            case value_t::null:
-                return header_size + 0ul;
+    case value_t::null:
+      return header_size + 0ul;
 
-            // LCOV_EXCL_START
-            default:
-                assert(false);
-                return 0ul;
-                // LCOV_EXCL_STOP
-        }
+    // LCOV_EXCL_START
+    default:
+      assert(false);
+      return 0ul;
+      // LCOV_EXCL_STOP
     }
+  }
 
-    /*!
+  /*!
     @brief Serializes the JSON value @a j to BSON and associates it with the
            key @a name.
     @param name The name to associate with the JSON entity @a j within the
                 current BSON document
     @return The size of the BSON entry
     */
-    void write_bson_element(const string_t& name,
-                            const BasicJsonType& j)
-    {
-        switch (j.type())
-        {
-            case value_t::object:
-                return write_bson_object_entry(name, *j.m_value.object);
+  void write_bson_element(const string_t &     name,
+                          const BasicJsonType &j)
+  {
+    switch (j.type()) {
+    case value_t::object:
+      return write_bson_object_entry(name, *j.m_value.object);
 
-            case value_t::array:
-                return write_bson_array(name, *j.m_value.array);
+    case value_t::array:
+      return write_bson_array(name, *j.m_value.array);
 
-            case value_t::boolean:
-                return write_bson_boolean(name, j.m_value.boolean);
+    case value_t::boolean:
+      return write_bson_boolean(name, j.m_value.boolean);
 
-            case value_t::number_float:
-                return write_bson_double(name, j.m_value.number_float);
+    case value_t::number_float:
+      return write_bson_double(name, j.m_value.number_float);
 
-            case value_t::number_integer:
-                return write_bson_integer(name, j.m_value.number_integer);
+    case value_t::number_integer:
+      return write_bson_integer(name, j.m_value.number_integer);
 
-            case value_t::number_unsigned:
-                return write_bson_unsigned(name, j.m_value.number_unsigned);
+    case value_t::number_unsigned:
+      return write_bson_unsigned(name, j.m_value.number_unsigned);
 
-            case value_t::string:
-                return write_bson_string(name, *j.m_value.string);
+    case value_t::string:
+      return write_bson_string(name, *j.m_value.string);
 
-            case value_t::null:
-                return write_bson_null(name);
+    case value_t::null:
+      return write_bson_null(name);
 
-            // LCOV_EXCL_START
-            default:
-                assert(false);
-                return;
-                // LCOV_EXCL_STOP
-        }
+    // LCOV_EXCL_START
+    default:
+      assert(false);
+      return;
+      // LCOV_EXCL_STOP
     }
+  }
 
-    /*!
+  /*!
     @brief Calculates the size of the BSON serialization of the given
            JSON-object @a j.
     @param[in] j  JSON value to serialize
     @pre       j.type() == value_t::object
     */
-    static std::size_t calc_bson_object_size(const typename BasicJsonType::object_t& value)
-    {
-        std::size_t document_size = std::accumulate(value.begin(), value.end(), 0ul,
-                                    [](size_t result, const typename BasicJsonType::object_t::value_type & el)
-        {
-            return result += calc_bson_element_size(el.first, el.second);
-        });
+  static std::size_t calc_bson_object_size(const typename BasicJsonType::object_t &value)
+  {
+    std::size_t document_size = std::accumulate(value.begin(), value.end(), 0ul,
+                                                [](size_t result, const typename BasicJsonType::object_t::value_type &el) {
+                                                  return result += calc_bson_element_size(el.first, el.second);
+                                                });
 
-        return sizeof(std::int32_t) + document_size + 1ul;
-    }
+    return sizeof(std::int32_t) + document_size + 1ul;
+  }
 
-    /*!
+  /*!
     @param[in] j  JSON value to serialize
     @pre       j.type() == value_t::object
     */
-    void write_bson_object(const typename BasicJsonType::object_t& value)
-    {
-        write_number<std::int32_t, true>(static_cast<std::int32_t>(calc_bson_object_size(value)));
+  void write_bson_object(const typename BasicJsonType::object_t &value)
+  {
+    write_number<std::int32_t, true>(static_cast<std::int32_t>(calc_bson_object_size(value)));
 
-        for (const auto& el : value)
-        {
-            write_bson_element(el.first, el.second);
-        }
-
-        oa->write_character(to_char_type(0x00));
+    for (const auto &el : value) {
+      write_bson_element(el.first, el.second);
     }
 
-    //////////
-    // CBOR //
-    //////////
+    oa->write_character(to_char_type(0x00));
+  }
 
-    static constexpr CharType get_cbor_float_prefix(float /*unused*/)
-    {
-        return to_char_type(0xFA);  // Single-Precision Float
+  //////////
+  // CBOR //
+  //////////
+
+  static constexpr CharType get_cbor_float_prefix(float /*unused*/)
+  {
+    return to_char_type(0xFA); // Single-Precision Float
+  }
+
+  static constexpr CharType get_cbor_float_prefix(double /*unused*/)
+  {
+    return to_char_type(0xFB); // Double-Precision Float
+  }
+
+  /////////////
+  // MsgPack //
+  /////////////
+
+  static constexpr CharType get_msgpack_float_prefix(float /*unused*/)
+  {
+    return to_char_type(0xCA); // float 32
+  }
+
+  static constexpr CharType get_msgpack_float_prefix(double /*unused*/)
+  {
+    return to_char_type(0xCB); // float 64
+  }
+
+  ////////////
+  // UBJSON //
+  ////////////
+
+  // UBJSON: write number (floating point)
+  template <typename NumberType, typename std::enable_if<
+                                     std::is_floating_point<NumberType>::value, int>::type = 0>
+  void write_number_with_ubjson_prefix(const NumberType n,
+                                       const bool       add_prefix)
+  {
+    if (add_prefix) {
+      oa->write_character(get_ubjson_float_prefix(n));
     }
+    write_number(n);
+  }
 
-    static constexpr CharType get_cbor_float_prefix(double /*unused*/)
-    {
-        return to_char_type(0xFB);  // Double-Precision Float
+  // UBJSON: write number (unsigned integer)
+  template <typename NumberType, typename std::enable_if<
+                                     std::is_unsigned<NumberType>::value, int>::type = 0>
+  void write_number_with_ubjson_prefix(const NumberType n,
+                                       const bool       add_prefix)
+  {
+    if (n <= static_cast<uint64_t>((std::numeric_limits<int8_t>::max)())) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('i')); // int8
+      }
+      write_number(static_cast<uint8_t>(n));
+    } else if (n <= (std::numeric_limits<uint8_t>::max)()) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('U')); // uint8
+      }
+      write_number(static_cast<uint8_t>(n));
+    } else if (n <= static_cast<uint64_t>((std::numeric_limits<int16_t>::max)())) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('I')); // int16
+      }
+      write_number(static_cast<int16_t>(n));
+    } else if (n <= static_cast<uint64_t>((std::numeric_limits<int32_t>::max)())) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('l')); // int32
+      }
+      write_number(static_cast<int32_t>(n));
+    } else if (n <= static_cast<uint64_t>((std::numeric_limits<int64_t>::max)())) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('L')); // int64
+      }
+      write_number(static_cast<int64_t>(n));
+    } else {
+      JSON_THROW(out_of_range::create(407, "integer number " + std::to_string(n) + " cannot be represented by UBJSON as it does not fit int64"));
     }
+  }
 
-    /////////////
-    // MsgPack //
-    /////////////
-
-    static constexpr CharType get_msgpack_float_prefix(float /*unused*/)
-    {
-        return to_char_type(0xCA);  // float 32
+  // UBJSON: write number (signed integer)
+  template <typename NumberType, typename std::enable_if<
+                                     std::is_signed<NumberType>::value and
+                                         not std::is_floating_point<NumberType>::value,
+                                     int>::type = 0>
+  void write_number_with_ubjson_prefix(const NumberType n,
+                                       const bool       add_prefix)
+  {
+    if ((std::numeric_limits<int8_t>::min)() <= n and n <= (std::numeric_limits<int8_t>::max)()) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('i')); // int8
+      }
+      write_number(static_cast<int8_t>(n));
+    } else if (static_cast<int64_t>((std::numeric_limits<uint8_t>::min)()) <= n and n <= static_cast<int64_t>((std::numeric_limits<uint8_t>::max)())) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('U')); // uint8
+      }
+      write_number(static_cast<uint8_t>(n));
+    } else if ((std::numeric_limits<int16_t>::min)() <= n and n <= (std::numeric_limits<int16_t>::max)()) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('I')); // int16
+      }
+      write_number(static_cast<int16_t>(n));
+    } else if ((std::numeric_limits<int32_t>::min)() <= n and n <= (std::numeric_limits<int32_t>::max)()) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('l')); // int32
+      }
+      write_number(static_cast<int32_t>(n));
+    } else if ((std::numeric_limits<int64_t>::min)() <= n and n <= (std::numeric_limits<int64_t>::max)()) {
+      if (add_prefix) {
+        oa->write_character(to_char_type('L')); // int64
+      }
+      write_number(static_cast<int64_t>(n));
     }
-
-    static constexpr CharType get_msgpack_float_prefix(double /*unused*/)
-    {
-        return to_char_type(0xCB);  // float 64
+    // LCOV_EXCL_START
+    else {
+      JSON_THROW(out_of_range::create(407, "integer number " + std::to_string(n) + " cannot be represented by UBJSON as it does not fit int64"));
     }
+    // LCOV_EXCL_STOP
+  }
 
-    ////////////
-    // UBJSON //
-    ////////////
-
-    // UBJSON: write number (floating point)
-    template<typename NumberType, typename std::enable_if<
-                 std::is_floating_point<NumberType>::value, int>::type = 0>
-    void write_number_with_ubjson_prefix(const NumberType n,
-                                         const bool add_prefix)
-    {
-        if (add_prefix)
-        {
-            oa->write_character(get_ubjson_float_prefix(n));
-        }
-        write_number(n);
-    }
-
-    // UBJSON: write number (unsigned integer)
-    template<typename NumberType, typename std::enable_if<
-                 std::is_unsigned<NumberType>::value, int>::type = 0>
-    void write_number_with_ubjson_prefix(const NumberType n,
-                                         const bool add_prefix)
-    {
-        if (n <= static_cast<uint64_t>((std::numeric_limits<int8_t>::max)()))
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('i'));  // int8
-            }
-            write_number(static_cast<uint8_t>(n));
-        }
-        else if (n <= (std::numeric_limits<uint8_t>::max)())
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('U'));  // uint8
-            }
-            write_number(static_cast<uint8_t>(n));
-        }
-        else if (n <= static_cast<uint64_t>((std::numeric_limits<int16_t>::max)()))
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('I'));  // int16
-            }
-            write_number(static_cast<int16_t>(n));
-        }
-        else if (n <= static_cast<uint64_t>((std::numeric_limits<int32_t>::max)()))
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('l'));  // int32
-            }
-            write_number(static_cast<int32_t>(n));
-        }
-        else if (n <= static_cast<uint64_t>((std::numeric_limits<int64_t>::max)()))
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('L'));  // int64
-            }
-            write_number(static_cast<int64_t>(n));
-        }
-        else
-        {
-            JSON_THROW(out_of_range::create(407, "integer number " + std::to_string(n) + " cannot be represented by UBJSON as it does not fit int64"));
-        }
-    }
-
-    // UBJSON: write number (signed integer)
-    template<typename NumberType, typename std::enable_if<
-                 std::is_signed<NumberType>::value and
-                 not std::is_floating_point<NumberType>::value, int>::type = 0>
-    void write_number_with_ubjson_prefix(const NumberType n,
-                                         const bool add_prefix)
-    {
-        if ((std::numeric_limits<int8_t>::min)() <= n and n <= (std::numeric_limits<int8_t>::max)())
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('i'));  // int8
-            }
-            write_number(static_cast<int8_t>(n));
-        }
-        else if (static_cast<int64_t>((std::numeric_limits<uint8_t>::min)()) <= n and n <= static_cast<int64_t>((std::numeric_limits<uint8_t>::max)()))
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('U'));  // uint8
-            }
-            write_number(static_cast<uint8_t>(n));
-        }
-        else if ((std::numeric_limits<int16_t>::min)() <= n and n <= (std::numeric_limits<int16_t>::max)())
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('I'));  // int16
-            }
-            write_number(static_cast<int16_t>(n));
-        }
-        else if ((std::numeric_limits<int32_t>::min)() <= n and n <= (std::numeric_limits<int32_t>::max)())
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('l'));  // int32
-            }
-            write_number(static_cast<int32_t>(n));
-        }
-        else if ((std::numeric_limits<int64_t>::min)() <= n and n <= (std::numeric_limits<int64_t>::max)())
-        {
-            if (add_prefix)
-            {
-                oa->write_character(to_char_type('L'));  // int64
-            }
-            write_number(static_cast<int64_t>(n));
-        }
-        // LCOV_EXCL_START
-        else
-        {
-            JSON_THROW(out_of_range::create(407, "integer number " + std::to_string(n) + " cannot be represented by UBJSON as it does not fit int64"));
-        }
-        // LCOV_EXCL_STOP
-    }
-
-    /*!
+  /*!
     @brief determine the type prefix of container values
 
     @note This function does not need to be 100% accurate when it comes to
@@ -9615,92 +8821,81 @@ class binary_writer
           write_number_with_ubjson_prefix. Therefore, we return 'L' for any
           value that does not fit the previous limits.
     */
-    CharType ubjson_prefix(const BasicJsonType& j) const noexcept
-    {
-        switch (j.type())
-        {
-            case value_t::null:
-                return 'Z';
+  CharType ubjson_prefix(const BasicJsonType &j) const noexcept
+  {
+    switch (j.type()) {
+    case value_t::null:
+      return 'Z';
 
-            case value_t::boolean:
-                return j.m_value.boolean ? 'T' : 'F';
+    case value_t::boolean:
+      return j.m_value.boolean ? 'T' : 'F';
 
-            case value_t::number_integer:
-            {
-                if ((std::numeric_limits<int8_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<int8_t>::max)())
-                {
-                    return 'i';
-                }
-                if ((std::numeric_limits<uint8_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    return 'U';
-                }
-                if ((std::numeric_limits<int16_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<int16_t>::max)())
-                {
-                    return 'I';
-                }
-                if ((std::numeric_limits<int32_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<int32_t>::max)())
-                {
-                    return 'l';
-                }
-                // no check and assume int64_t (see note above)
-                return 'L';
-            }
-
-            case value_t::number_unsigned:
-            {
-                if (j.m_value.number_unsigned <= (std::numeric_limits<int8_t>::max)())
-                {
-                    return 'i';
-                }
-                if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)())
-                {
-                    return 'U';
-                }
-                if (j.m_value.number_unsigned <= (std::numeric_limits<int16_t>::max)())
-                {
-                    return 'I';
-                }
-                if (j.m_value.number_unsigned <= (std::numeric_limits<int32_t>::max)())
-                {
-                    return 'l';
-                }
-                // no check and assume int64_t (see note above)
-                return 'L';
-            }
-
-            case value_t::number_float:
-                return get_ubjson_float_prefix(j.m_value.number_float);
-
-            case value_t::string:
-                return 'S';
-
-            case value_t::array:
-                return '[';
-
-            case value_t::object:
-                return '{';
-
-            default:  // discarded values
-                return 'N';
-        }
+    case value_t::number_integer: {
+      if ((std::numeric_limits<int8_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<int8_t>::max)()) {
+        return 'i';
+      }
+      if ((std::numeric_limits<uint8_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<uint8_t>::max)()) {
+        return 'U';
+      }
+      if ((std::numeric_limits<int16_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<int16_t>::max)()) {
+        return 'I';
+      }
+      if ((std::numeric_limits<int32_t>::min)() <= j.m_value.number_integer and j.m_value.number_integer <= (std::numeric_limits<int32_t>::max)()) {
+        return 'l';
+      }
+      // no check and assume int64_t (see note above)
+      return 'L';
     }
 
-    static constexpr CharType get_ubjson_float_prefix(float /*unused*/)
-    {
-        return 'd';  // float 32
+    case value_t::number_unsigned: {
+      if (j.m_value.number_unsigned <= (std::numeric_limits<int8_t>::max)()) {
+        return 'i';
+      }
+      if (j.m_value.number_unsigned <= (std::numeric_limits<uint8_t>::max)()) {
+        return 'U';
+      }
+      if (j.m_value.number_unsigned <= (std::numeric_limits<int16_t>::max)()) {
+        return 'I';
+      }
+      if (j.m_value.number_unsigned <= (std::numeric_limits<int32_t>::max)()) {
+        return 'l';
+      }
+      // no check and assume int64_t (see note above)
+      return 'L';
     }
 
-    static constexpr CharType get_ubjson_float_prefix(double /*unused*/)
-    {
-        return 'D';  // float 64
+    case value_t::number_float:
+      return get_ubjson_float_prefix(j.m_value.number_float);
+
+    case value_t::string:
+      return 'S';
+
+    case value_t::array:
+      return '[';
+
+    case value_t::object:
+      return '{';
+
+    default: // discarded values
+      return 'N';
     }
+  }
 
-    ///////////////////////
-    // Utility functions //
-    ///////////////////////
+  static constexpr CharType get_ubjson_float_prefix(float /*unused*/)
+  {
+    return 'd'; // float 32
+  }
 
-    /*
+  static constexpr CharType get_ubjson_float_prefix(double /*unused*/)
+  {
+    return 'D'; // float 64
+  }
+
+  ///////////////////////
+  // Utility functions //
+  ///////////////////////
+
+  /*
     @brief write a number to output input
     @param[in] n number of type @a NumberType
     @tparam NumberType the type of the number
@@ -9711,94 +8906,90 @@ class binary_writer
           in CBOR, MessagePack, and UBJSON are stored in network order (big
           endian) and therefore need reordering on little endian systems.
     */
-    template<typename NumberType, bool OutputIsLittleEndian = false>
-    void write_number(const NumberType n)
-    {
-        // step 1: write number to array of length NumberType
-        std::array<CharType, sizeof(NumberType)> vec;
-        std::memcpy(vec.data(), &n, sizeof(NumberType));
+  template <typename NumberType, bool OutputIsLittleEndian = false>
+  void write_number(const NumberType n)
+  {
+    // step 1: write number to array of length NumberType
+    std::array<CharType, sizeof(NumberType)> vec;
+    std::memcpy(vec.data(), &n, sizeof(NumberType));
 
-        // step 2: write array to output (with possible reordering)
-        if (is_little_endian and not OutputIsLittleEndian)
-        {
-            // reverse byte order prior to conversion if necessary
-            std::reverse(vec.begin(), vec.end());
-        }
-
-        oa->write_characters(vec.data(), sizeof(NumberType));
+    // step 2: write array to output (with possible reordering)
+    if (is_little_endian and not OutputIsLittleEndian) {
+      // reverse byte order prior to conversion if necessary
+      std::reverse(vec.begin(), vec.end());
     }
 
-  public:
-    // The following to_char_type functions are implement the conversion
-    // between uint8_t and CharType. In case CharType is not unsigned,
-    // such a conversion is required to allow values greater than 128.
-    // See <https://github.com/nlohmann/json/issues/1286> for a discussion.
-    template < typename C = CharType,
-               enable_if_t < std::is_signed<C>::value and std::is_signed<char>::value > * = nullptr >
-    static constexpr CharType to_char_type(std::uint8_t x) noexcept
-    {
-        return *reinterpret_cast<char*>(&x);
-    }
+    oa->write_characters(vec.data(), sizeof(NumberType));
+  }
 
-    template < typename C = CharType,
-               enable_if_t < std::is_signed<C>::value and std::is_unsigned<char>::value > * = nullptr >
-    static CharType to_char_type(std::uint8_t x) noexcept
-    {
-        static_assert(sizeof(std::uint8_t) == sizeof(CharType), "size of CharType must be equal to std::uint8_t");
-        static_assert(std::is_pod<CharType>::value, "CharType must be POD");
-        CharType result;
-        std::memcpy(&result, &x, sizeof(x));
-        return result;
-    }
+public:
+  // The following to_char_type functions are implement the conversion
+  // between uint8_t and CharType. In case CharType is not unsigned,
+  // such a conversion is required to allow values greater than 128.
+  // See <https://github.com/nlohmann/json/issues/1286> for a discussion.
+  template <typename C                                                              = CharType,
+            enable_if_t<std::is_signed<C>::value and std::is_signed<char>::value> * = nullptr>
+  static constexpr CharType to_char_type(std::uint8_t x) noexcept
+  {
+    return *reinterpret_cast<char *>(&x);
+  }
 
-    template<typename C = CharType,
-             enable_if_t<std::is_unsigned<C>::value>* = nullptr>
-    static constexpr CharType to_char_type(std::uint8_t x) noexcept
-    {
-        return x;
-    }
+  template <typename C                                                                = CharType,
+            enable_if_t<std::is_signed<C>::value and std::is_unsigned<char>::value> * = nullptr>
+  static CharType to_char_type(std::uint8_t x) noexcept
+  {
+    static_assert(sizeof(std::uint8_t) == sizeof(CharType), "size of CharType must be equal to std::uint8_t");
+    static_assert(std::is_pod<CharType>::value, "CharType must be POD");
+    CharType result;
+    std::memcpy(&result, &x, sizeof(x));
+    return result;
+  }
 
-    template < typename InputCharType, typename C = CharType,
-               enable_if_t <
-                   std::is_signed<C>::value and
-                   std::is_signed<char>::value and
-                   std::is_same<char, typename std::remove_cv<InputCharType>::type>::value
-                   > * = nullptr >
-    static constexpr CharType to_char_type(InputCharType x) noexcept
-    {
-        return x;
-    }
+  template <typename C                                = CharType,
+            enable_if_t<std::is_unsigned<C>::value> * = nullptr>
+  static constexpr CharType to_char_type(std::uint8_t x) noexcept
+  {
+    return x;
+  }
 
-  private:
-    /// whether we can assume little endianess
-    const bool is_little_endian = binary_reader<BasicJsonType>::little_endianess();
+  template <typename InputCharType, typename C = CharType,
+            enable_if_t<
+                std::is_signed<C>::value and
+                std::is_signed<char>::value and
+                std::is_same<char, typename std::remove_cv<InputCharType>::type>::value> * = nullptr>
+  static constexpr CharType to_char_type(InputCharType x) noexcept
+  {
+    return x;
+  }
 
-    /// the output
-    output_adapter_t<CharType> oa = nullptr;
+private:
+  /// whether we can assume little endianess
+  const bool is_little_endian = binary_reader<BasicJsonType>::little_endianess();
+
+  /// the output
+  output_adapter_t<CharType> oa = nullptr;
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/output/serializer.hpp>
 
-
-#include <algorithm> // reverse, remove, fill, find, none_of
-#include <array> // array
-#include <cassert> // assert
-#include <ciso646> // and, or
-#include <clocale> // localeconv, lconv
-#include <cmath> // labs, isfinite, isnan, signbit
-#include <cstddef> // size_t, ptrdiff_t
-#include <cstdint> // uint8_t
-#include <cstdio> // snprintf
-#include <limits> // numeric_limits
-#include <string> // string
+#include <algorithm>   // reverse, remove, fill, find, none_of
+#include <array>       // array
+#include <cassert>     // assert
+#include <ciso646>     // and, or
+#include <clocale>     // localeconv, lconv
+#include <cmath>       // labs, isfinite, isnan, signbit
+#include <cstddef>     // size_t, ptrdiff_t
+#include <cstdint>     // uint8_t
+#include <cstdio>      // snprintf
+#include <limits>      // numeric_limits
+#include <string>      // string
 #include <type_traits> // is_same
 
 // #include <nlohmann/detail/exceptions.hpp>
 
 // #include <nlohmann/detail/conversions/to_chars.hpp>
-
 
 #include <cassert> // assert
 #include <ciso646> // or, and, not
@@ -9806,10 +8997,8 @@ class binary_writer
 #include <cstdint> // intN_t, uintN_t
 #include <cstring> // memcpy, memmove
 
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 
 /*!
 @brief implements the Grisu2 algorithm for binary to decimal floating-point
@@ -9830,142 +9019,140 @@ For a detailed description of the algorithm see:
     Proceedings of the ACM SIGPLAN 1996 Conference on Programming Language
     Design and Implementation, PLDI 1996
 */
-namespace dtoa_impl
-{
+namespace dtoa_impl {
 
 template <typename Target, typename Source>
 Target reinterpret_bits(const Source source)
 {
-    static_assert(sizeof(Target) == sizeof(Source), "size mismatch");
+  static_assert(sizeof(Target) == sizeof(Source), "size mismatch");
 
-    Target target;
-    std::memcpy(&target, &source, sizeof(Source));
-    return target;
+  Target target;
+  std::memcpy(&target, &source, sizeof(Source));
+  return target;
 }
 
 struct diyfp // f * 2^e
 {
-    static constexpr int kPrecision = 64; // = q
+  static constexpr int kPrecision = 64; // = q
 
-    uint64_t f = 0;
-    int e = 0;
+  uint64_t f = 0;
+  int      e = 0;
 
-    constexpr diyfp(uint64_t f_, int e_) noexcept : f(f_), e(e_) {}
+  constexpr diyfp(uint64_t f_, int e_) noexcept
+      : f(f_), e(e_) {}
 
-    /*!
+  /*!
     @brief returns x - y
     @pre x.e == y.e and x.f >= y.f
     */
-    static diyfp sub(const diyfp& x, const diyfp& y) noexcept
-    {
-        assert(x.e == y.e);
-        assert(x.f >= y.f);
+  static diyfp sub(const diyfp &x, const diyfp &y) noexcept
+  {
+    assert(x.e == y.e);
+    assert(x.f >= y.f);
 
-        return {x.f - y.f, x.e};
-    }
+    return {x.f - y.f, x.e};
+  }
 
-    /*!
+  /*!
     @brief returns x * y
     @note The result is rounded. (Only the upper q bits are returned.)
     */
-    static diyfp mul(const diyfp& x, const diyfp& y) noexcept
-    {
-        static_assert(kPrecision == 64, "internal error");
+  static diyfp mul(const diyfp &x, const diyfp &y) noexcept
+  {
+    static_assert(kPrecision == 64, "internal error");
 
-        // Computes:
-        //  f = round((x.f * y.f) / 2^q)
-        //  e = x.e + y.e + q
+    // Computes:
+    //  f = round((x.f * y.f) / 2^q)
+    //  e = x.e + y.e + q
 
-        // Emulate the 64-bit * 64-bit multiplication:
-        //
-        // p = u * v
-        //   = (u_lo + 2^32 u_hi) (v_lo + 2^32 v_hi)
-        //   = (u_lo v_lo         ) + 2^32 ((u_lo v_hi         ) + (u_hi v_lo         )) + 2^64 (u_hi v_hi         )
-        //   = (p0                ) + 2^32 ((p1                ) + (p2                )) + 2^64 (p3                )
-        //   = (p0_lo + 2^32 p0_hi) + 2^32 ((p1_lo + 2^32 p1_hi) + (p2_lo + 2^32 p2_hi)) + 2^64 (p3                )
-        //   = (p0_lo             ) + 2^32 (p0_hi + p1_lo + p2_lo                      ) + 2^64 (p1_hi + p2_hi + p3)
-        //   = (p0_lo             ) + 2^32 (Q                                          ) + 2^64 (H                 )
-        //   = (p0_lo             ) + 2^32 (Q_lo + 2^32 Q_hi                           ) + 2^64 (H                 )
-        //
-        // (Since Q might be larger than 2^32 - 1)
-        //
-        //   = (p0_lo + 2^32 Q_lo) + 2^64 (Q_hi + H)
-        //
-        // (Q_hi + H does not overflow a 64-bit int)
-        //
-        //   = p_lo + 2^64 p_hi
+    // Emulate the 64-bit * 64-bit multiplication:
+    //
+    // p = u * v
+    //   = (u_lo + 2^32 u_hi) (v_lo + 2^32 v_hi)
+    //   = (u_lo v_lo         ) + 2^32 ((u_lo v_hi         ) + (u_hi v_lo         )) + 2^64 (u_hi v_hi         )
+    //   = (p0                ) + 2^32 ((p1                ) + (p2                )) + 2^64 (p3                )
+    //   = (p0_lo + 2^32 p0_hi) + 2^32 ((p1_lo + 2^32 p1_hi) + (p2_lo + 2^32 p2_hi)) + 2^64 (p3                )
+    //   = (p0_lo             ) + 2^32 (p0_hi + p1_lo + p2_lo                      ) + 2^64 (p1_hi + p2_hi + p3)
+    //   = (p0_lo             ) + 2^32 (Q                                          ) + 2^64 (H                 )
+    //   = (p0_lo             ) + 2^32 (Q_lo + 2^32 Q_hi                           ) + 2^64 (H                 )
+    //
+    // (Since Q might be larger than 2^32 - 1)
+    //
+    //   = (p0_lo + 2^32 Q_lo) + 2^64 (Q_hi + H)
+    //
+    // (Q_hi + H does not overflow a 64-bit int)
+    //
+    //   = p_lo + 2^64 p_hi
 
-        const uint64_t u_lo = x.f & 0xFFFFFFFF;
-        const uint64_t u_hi = x.f >> 32;
-        const uint64_t v_lo = y.f & 0xFFFFFFFF;
-        const uint64_t v_hi = y.f >> 32;
+    const uint64_t u_lo = x.f & 0xFFFFFFFF;
+    const uint64_t u_hi = x.f >> 32;
+    const uint64_t v_lo = y.f & 0xFFFFFFFF;
+    const uint64_t v_hi = y.f >> 32;
 
-        const uint64_t p0 = u_lo * v_lo;
-        const uint64_t p1 = u_lo * v_hi;
-        const uint64_t p2 = u_hi * v_lo;
-        const uint64_t p3 = u_hi * v_hi;
+    const uint64_t p0 = u_lo * v_lo;
+    const uint64_t p1 = u_lo * v_hi;
+    const uint64_t p2 = u_hi * v_lo;
+    const uint64_t p3 = u_hi * v_hi;
 
-        const uint64_t p0_hi = p0 >> 32;
-        const uint64_t p1_lo = p1 & 0xFFFFFFFF;
-        const uint64_t p1_hi = p1 >> 32;
-        const uint64_t p2_lo = p2 & 0xFFFFFFFF;
-        const uint64_t p2_hi = p2 >> 32;
+    const uint64_t p0_hi = p0 >> 32;
+    const uint64_t p1_lo = p1 & 0xFFFFFFFF;
+    const uint64_t p1_hi = p1 >> 32;
+    const uint64_t p2_lo = p2 & 0xFFFFFFFF;
+    const uint64_t p2_hi = p2 >> 32;
 
-        uint64_t Q = p0_hi + p1_lo + p2_lo;
+    uint64_t Q = p0_hi + p1_lo + p2_lo;
 
-        // The full product might now be computed as
-        //
-        // p_hi = p3 + p2_hi + p1_hi + (Q >> 32)
-        // p_lo = p0_lo + (Q << 32)
-        //
-        // But in this particular case here, the full p_lo is not required.
-        // Effectively we only need to add the highest bit in p_lo to p_hi (and
-        // Q_hi + 1 does not overflow).
+    // The full product might now be computed as
+    //
+    // p_hi = p3 + p2_hi + p1_hi + (Q >> 32)
+    // p_lo = p0_lo + (Q << 32)
+    //
+    // But in this particular case here, the full p_lo is not required.
+    // Effectively we only need to add the highest bit in p_lo to p_hi (and
+    // Q_hi + 1 does not overflow).
 
-        Q += uint64_t{1} << (64 - 32 - 1); // round, ties up
+    Q += uint64_t{1} << (64 - 32 - 1); // round, ties up
 
-        const uint64_t h = p3 + p2_hi + p1_hi + (Q >> 32);
+    const uint64_t h = p3 + p2_hi + p1_hi + (Q >> 32);
 
-        return {h, x.e + y.e + 64};
-    }
+    return {h, x.e + y.e + 64};
+  }
 
-    /*!
+  /*!
     @brief normalize x such that the significand is >= 2^(q-1)
     @pre x.f != 0
     */
-    static diyfp normalize(diyfp x) noexcept
-    {
-        assert(x.f != 0);
+  static diyfp normalize(diyfp x) noexcept
+  {
+    assert(x.f != 0);
 
-        while ((x.f >> 63) == 0)
-        {
-            x.f <<= 1;
-            x.e--;
-        }
-
-        return x;
+    while ((x.f >> 63) == 0) {
+      x.f <<= 1;
+      x.e--;
     }
 
-    /*!
+    return x;
+  }
+
+  /*!
     @brief normalize x such that the result has the exponent E
     @pre e >= x.e and the upper e - x.e bits of x.f must be zero.
     */
-    static diyfp normalize_to(const diyfp& x, const int target_exponent) noexcept
-    {
-        const int delta = x.e - target_exponent;
+  static diyfp normalize_to(const diyfp &x, const int target_exponent) noexcept
+  {
+    const int delta = x.e - target_exponent;
 
-        assert(delta >= 0);
-        assert(((x.f << delta) >> delta) == x.f);
+    assert(delta >= 0);
+    assert(((x.f << delta) >> delta) == x.f);
 
-        return {x.f << delta, target_exponent};
-    }
+    return {x.f << delta, target_exponent};
+  }
 };
 
-struct boundaries
-{
-    diyfp w;
-    diyfp minus;
-    diyfp plus;
+struct boundaries {
+  diyfp w;
+  diyfp minus;
+  diyfp plus;
 };
 
 /*!
@@ -9977,69 +9164,69 @@ boundaries.
 template <typename FloatType>
 boundaries compute_boundaries(FloatType value)
 {
-    assert(std::isfinite(value));
-    assert(value > 0);
+  assert(std::isfinite(value));
+  assert(value > 0);
 
-    // Convert the IEEE representation into a diyfp.
-    //
-    // If v is denormal:
-    //      value = 0.F * 2^(1 - bias) = (          F) * 2^(1 - bias - (p-1))
-    // If v is normalized:
-    //      value = 1.F * 2^(E - bias) = (2^(p-1) + F) * 2^(E - bias - (p-1))
+  // Convert the IEEE representation into a diyfp.
+  //
+  // If v is denormal:
+  //      value = 0.F * 2^(1 - bias) = (          F) * 2^(1 - bias - (p-1))
+  // If v is normalized:
+  //      value = 1.F * 2^(E - bias) = (2^(p-1) + F) * 2^(E - bias - (p-1))
 
-    static_assert(std::numeric_limits<FloatType>::is_iec559,
-                  "internal error: dtoa_short requires an IEEE-754 floating-point implementation");
+  static_assert(std::numeric_limits<FloatType>::is_iec559,
+                "internal error: dtoa_short requires an IEEE-754 floating-point implementation");
 
-    constexpr int      kPrecision = std::numeric_limits<FloatType>::digits; // = p (includes the hidden bit)
-    constexpr int      kBias      = std::numeric_limits<FloatType>::max_exponent - 1 + (kPrecision - 1);
-    constexpr int      kMinExp    = 1 - kBias;
-    constexpr uint64_t kHiddenBit = uint64_t{1} << (kPrecision - 1); // = 2^(p-1)
+  constexpr int      kPrecision = std::numeric_limits<FloatType>::digits; // = p (includes the hidden bit)
+  constexpr int      kBias      = std::numeric_limits<FloatType>::max_exponent - 1 + (kPrecision - 1);
+  constexpr int      kMinExp    = 1 - kBias;
+  constexpr uint64_t kHiddenBit = uint64_t{1} << (kPrecision - 1); // = 2^(p-1)
 
-    using bits_type = typename std::conditional< kPrecision == 24, uint32_t, uint64_t >::type;
+  using bits_type = typename std::conditional<kPrecision == 24, uint32_t, uint64_t>::type;
 
-    const uint64_t bits = reinterpret_bits<bits_type>(value);
-    const uint64_t E = bits >> (kPrecision - 1);
-    const uint64_t F = bits & (kHiddenBit - 1);
+  const uint64_t bits = reinterpret_bits<bits_type>(value);
+  const uint64_t E    = bits >> (kPrecision - 1);
+  const uint64_t F    = bits & (kHiddenBit - 1);
 
-    const bool is_denormal = (E == 0);
-    const diyfp v = is_denormal
-                    ? diyfp(F, kMinExp)
-                    : diyfp(F + kHiddenBit, static_cast<int>(E) - kBias);
+  const bool  is_denormal = (E == 0);
+  const diyfp v           = is_denormal
+                      ? diyfp(F, kMinExp)
+                      : diyfp(F + kHiddenBit, static_cast<int>(E) - kBias);
 
-    // Compute the boundaries m- and m+ of the floating-point value
-    // v = f * 2^e.
-    //
-    // Determine v- and v+, the floating-point predecessor and successor if v,
-    // respectively.
-    //
-    //      v- = v - 2^e        if f != 2^(p-1) or e == e_min                (A)
-    //         = v - 2^(e-1)    if f == 2^(p-1) and e > e_min                (B)
-    //
-    //      v+ = v + 2^e
-    //
-    // Let m- = (v- + v) / 2 and m+ = (v + v+) / 2. All real numbers _strictly_
-    // between m- and m+ round to v, regardless of how the input rounding
-    // algorithm breaks ties.
-    //
-    //      ---+-------------+-------------+-------------+-------------+---  (A)
-    //         v-            m-            v             m+            v+
-    //
-    //      -----------------+------+------+-------------+-------------+---  (B)
-    //                       v-     m-     v             m+            v+
+  // Compute the boundaries m- and m+ of the floating-point value
+  // v = f * 2^e.
+  //
+  // Determine v- and v+, the floating-point predecessor and successor if v,
+  // respectively.
+  //
+  //      v- = v - 2^e        if f != 2^(p-1) or e == e_min                (A)
+  //         = v - 2^(e-1)    if f == 2^(p-1) and e > e_min                (B)
+  //
+  //      v+ = v + 2^e
+  //
+  // Let m- = (v- + v) / 2 and m+ = (v + v+) / 2. All real numbers _strictly_
+  // between m- and m+ round to v, regardless of how the input rounding
+  // algorithm breaks ties.
+  //
+  //      ---+-------------+-------------+-------------+-------------+---  (A)
+  //         v-            m-            v             m+            v+
+  //
+  //      -----------------+------+------+-------------+-------------+---  (B)
+  //                       v-     m-     v             m+            v+
 
-    const bool lower_boundary_is_closer = (F == 0 and E > 1);
-    const diyfp m_plus = diyfp(2 * v.f + 1, v.e - 1);
-    const diyfp m_minus = lower_boundary_is_closer
-                          ? diyfp(4 * v.f - 1, v.e - 2)  // (B)
-                          : diyfp(2 * v.f - 1, v.e - 1); // (A)
+  const bool  lower_boundary_is_closer = (F == 0 and E > 1);
+  const diyfp m_plus                   = diyfp(2 * v.f + 1, v.e - 1);
+  const diyfp m_minus                  = lower_boundary_is_closer
+                            ? diyfp(4 * v.f - 1, v.e - 2)  // (B)
+                            : diyfp(2 * v.f - 1, v.e - 1); // (A)
 
-    // Determine the normalized w+ = m+.
-    const diyfp w_plus = diyfp::normalize(m_plus);
+  // Determine the normalized w+ = m+.
+  const diyfp w_plus = diyfp::normalize(m_plus);
 
-    // Determine w- = m- such that e_(w-) = e_(w+).
-    const diyfp w_minus = diyfp::normalize_to(m_minus, w_plus.e);
+  // Determine w- = m- such that e_(w-) = e_(w+).
+  const diyfp w_minus = diyfp::normalize_to(m_minus, w_plus.e);
 
-    return {diyfp::normalize(v), w_minus, w_plus};
+  return {diyfp::normalize(v), w_minus, w_plus};
 }
 
 // Given normalized diyfp w, Grisu needs to find a (normalized) cached
@@ -10102,9 +9289,9 @@ constexpr int kGamma = -32;
 
 struct cached_power // c = f * 2^e ~= 10^k
 {
-    uint64_t f;
-    int e;
-    int k;
+  uint64_t f;
+  int      e;
+  int      k;
 };
 
 /*!
@@ -10116,498 +9303,473 @@ satisfies (Definition 3.2 from [1])
 */
 inline cached_power get_cached_power_for_binary_exponent(int e)
 {
-    // Now
-    //
-    //      alpha <= e_c + e + q <= gamma                                    (1)
-    //      ==> f_c * 2^alpha <= c * 2^e * 2^q
-    //
-    // and since the c's are normalized, 2^(q-1) <= f_c,
-    //
-    //      ==> 2^(q - 1 + alpha) <= c * 2^(e + q)
-    //      ==> 2^(alpha - e - 1) <= c
-    //
-    // If c were an exakt power of ten, i.e. c = 10^k, one may determine k as
-    //
-    //      k = ceil( log_10( 2^(alpha - e - 1) ) )
-    //        = ceil( (alpha - e - 1) * log_10(2) )
-    //
-    // From the paper:
-    // "In theory the result of the procedure could be wrong since c is rounded,
-    //  and the computation itself is approximated [...]. In practice, however,
-    //  this simple function is sufficient."
-    //
-    // For IEEE double precision floating-point numbers converted into
-    // normalized diyfp's w = f * 2^e, with q = 64,
-    //
-    //      e >= -1022      (min IEEE exponent)
-    //           -52        (p - 1)
-    //           -52        (p - 1, possibly normalize denormal IEEE numbers)
-    //           -11        (normalize the diyfp)
-    //         = -1137
-    //
-    // and
-    //
-    //      e <= +1023      (max IEEE exponent)
-    //           -52        (p - 1)
-    //           -11        (normalize the diyfp)
-    //         = 960
-    //
-    // This binary exponent range [-1137,960] results in a decimal exponent
-    // range [-307,324]. One does not need to store a cached power for each
-    // k in this range. For each such k it suffices to find a cached power
-    // such that the exponent of the product lies in [alpha,gamma].
-    // This implies that the difference of the decimal exponents of adjacent
-    // table entries must be less than or equal to
-    //
-    //      floor( (gamma - alpha) * log_10(2) ) = 8.
-    //
-    // (A smaller distance gamma-alpha would require a larger table.)
+  // Now
+  //
+  //      alpha <= e_c + e + q <= gamma                                    (1)
+  //      ==> f_c * 2^alpha <= c * 2^e * 2^q
+  //
+  // and since the c's are normalized, 2^(q-1) <= f_c,
+  //
+  //      ==> 2^(q - 1 + alpha) <= c * 2^(e + q)
+  //      ==> 2^(alpha - e - 1) <= c
+  //
+  // If c were an exakt power of ten, i.e. c = 10^k, one may determine k as
+  //
+  //      k = ceil( log_10( 2^(alpha - e - 1) ) )
+  //        = ceil( (alpha - e - 1) * log_10(2) )
+  //
+  // From the paper:
+  // "In theory the result of the procedure could be wrong since c is rounded,
+  //  and the computation itself is approximated [...]. In practice, however,
+  //  this simple function is sufficient."
+  //
+  // For IEEE double precision floating-point numbers converted into
+  // normalized diyfp's w = f * 2^e, with q = 64,
+  //
+  //      e >= -1022      (min IEEE exponent)
+  //           -52        (p - 1)
+  //           -52        (p - 1, possibly normalize denormal IEEE numbers)
+  //           -11        (normalize the diyfp)
+  //         = -1137
+  //
+  // and
+  //
+  //      e <= +1023      (max IEEE exponent)
+  //           -52        (p - 1)
+  //           -11        (normalize the diyfp)
+  //         = 960
+  //
+  // This binary exponent range [-1137,960] results in a decimal exponent
+  // range [-307,324]. One does not need to store a cached power for each
+  // k in this range. For each such k it suffices to find a cached power
+  // such that the exponent of the product lies in [alpha,gamma].
+  // This implies that the difference of the decimal exponents of adjacent
+  // table entries must be less than or equal to
+  //
+  //      floor( (gamma - alpha) * log_10(2) ) = 8.
+  //
+  // (A smaller distance gamma-alpha would require a larger table.)
 
-    // NB:
-    // Actually this function returns c, such that -60 <= e_c + e + 64 <= -34.
+  // NB:
+  // Actually this function returns c, such that -60 <= e_c + e + 64 <= -34.
 
-    constexpr int kCachedPowersSize = 79;
-    constexpr int kCachedPowersMinDecExp = -300;
-    constexpr int kCachedPowersDecStep = 8;
+  constexpr int kCachedPowersSize      = 79;
+  constexpr int kCachedPowersMinDecExp = -300;
+  constexpr int kCachedPowersDecStep   = 8;
 
-    static constexpr cached_power kCachedPowers[] =
-    {
-        { 0xAB70FE17C79AC6CA, -1060, -300 },
-        { 0xFF77B1FCBEBCDC4F, -1034, -292 },
-        { 0xBE5691EF416BD60C, -1007, -284 },
-        { 0x8DD01FAD907FFC3C,  -980, -276 },
-        { 0xD3515C2831559A83,  -954, -268 },
-        { 0x9D71AC8FADA6C9B5,  -927, -260 },
-        { 0xEA9C227723EE8BCB,  -901, -252 },
-        { 0xAECC49914078536D,  -874, -244 },
-        { 0x823C12795DB6CE57,  -847, -236 },
-        { 0xC21094364DFB5637,  -821, -228 },
-        { 0x9096EA6F3848984F,  -794, -220 },
-        { 0xD77485CB25823AC7,  -768, -212 },
-        { 0xA086CFCD97BF97F4,  -741, -204 },
-        { 0xEF340A98172AACE5,  -715, -196 },
-        { 0xB23867FB2A35B28E,  -688, -188 },
-        { 0x84C8D4DFD2C63F3B,  -661, -180 },
-        { 0xC5DD44271AD3CDBA,  -635, -172 },
-        { 0x936B9FCEBB25C996,  -608, -164 },
-        { 0xDBAC6C247D62A584,  -582, -156 },
-        { 0xA3AB66580D5FDAF6,  -555, -148 },
-        { 0xF3E2F893DEC3F126,  -529, -140 },
-        { 0xB5B5ADA8AAFF80B8,  -502, -132 },
-        { 0x87625F056C7C4A8B,  -475, -124 },
-        { 0xC9BCFF6034C13053,  -449, -116 },
-        { 0x964E858C91BA2655,  -422, -108 },
-        { 0xDFF9772470297EBD,  -396, -100 },
-        { 0xA6DFBD9FB8E5B88F,  -369,  -92 },
-        { 0xF8A95FCF88747D94,  -343,  -84 },
-        { 0xB94470938FA89BCF,  -316,  -76 },
-        { 0x8A08F0F8BF0F156B,  -289,  -68 },
-        { 0xCDB02555653131B6,  -263,  -60 },
-        { 0x993FE2C6D07B7FAC,  -236,  -52 },
-        { 0xE45C10C42A2B3B06,  -210,  -44 },
-        { 0xAA242499697392D3,  -183,  -36 },
-        { 0xFD87B5F28300CA0E,  -157,  -28 },
-        { 0xBCE5086492111AEB,  -130,  -20 },
-        { 0x8CBCCC096F5088CC,  -103,  -12 },
-        { 0xD1B71758E219652C,   -77,   -4 },
-        { 0x9C40000000000000,   -50,    4 },
-        { 0xE8D4A51000000000,   -24,   12 },
-        { 0xAD78EBC5AC620000,     3,   20 },
-        { 0x813F3978F8940984,    30,   28 },
-        { 0xC097CE7BC90715B3,    56,   36 },
-        { 0x8F7E32CE7BEA5C70,    83,   44 },
-        { 0xD5D238A4ABE98068,   109,   52 },
-        { 0x9F4F2726179A2245,   136,   60 },
-        { 0xED63A231D4C4FB27,   162,   68 },
-        { 0xB0DE65388CC8ADA8,   189,   76 },
-        { 0x83C7088E1AAB65DB,   216,   84 },
-        { 0xC45D1DF942711D9A,   242,   92 },
-        { 0x924D692CA61BE758,   269,  100 },
-        { 0xDA01EE641A708DEA,   295,  108 },
-        { 0xA26DA3999AEF774A,   322,  116 },
-        { 0xF209787BB47D6B85,   348,  124 },
-        { 0xB454E4A179DD1877,   375,  132 },
-        { 0x865B86925B9BC5C2,   402,  140 },
-        { 0xC83553C5C8965D3D,   428,  148 },
-        { 0x952AB45CFA97A0B3,   455,  156 },
-        { 0xDE469FBD99A05FE3,   481,  164 },
-        { 0xA59BC234DB398C25,   508,  172 },
-        { 0xF6C69A72A3989F5C,   534,  180 },
-        { 0xB7DCBF5354E9BECE,   561,  188 },
-        { 0x88FCF317F22241E2,   588,  196 },
-        { 0xCC20CE9BD35C78A5,   614,  204 },
-        { 0x98165AF37B2153DF,   641,  212 },
-        { 0xE2A0B5DC971F303A,   667,  220 },
-        { 0xA8D9D1535CE3B396,   694,  228 },
-        { 0xFB9B7CD9A4A7443C,   720,  236 },
-        { 0xBB764C4CA7A44410,   747,  244 },
-        { 0x8BAB8EEFB6409C1A,   774,  252 },
-        { 0xD01FEF10A657842C,   800,  260 },
-        { 0x9B10A4E5E9913129,   827,  268 },
-        { 0xE7109BFBA19C0C9D,   853,  276 },
-        { 0xAC2820D9623BF429,   880,  284 },
-        { 0x80444B5E7AA7CF85,   907,  292 },
-        { 0xBF21E44003ACDD2D,   933,  300 },
-        { 0x8E679C2F5E44FF8F,   960,  308 },
-        { 0xD433179D9C8CB841,   986,  316 },
-        { 0x9E19DB92B4E31BA9,  1013,  324 },
-    };
+  static constexpr cached_power kCachedPowers[] =
+      {
+          {0xAB70FE17C79AC6CA, -1060, -300},
+          {0xFF77B1FCBEBCDC4F, -1034, -292},
+          {0xBE5691EF416BD60C, -1007, -284},
+          {0x8DD01FAD907FFC3C, -980, -276},
+          {0xD3515C2831559A83, -954, -268},
+          {0x9D71AC8FADA6C9B5, -927, -260},
+          {0xEA9C227723EE8BCB, -901, -252},
+          {0xAECC49914078536D, -874, -244},
+          {0x823C12795DB6CE57, -847, -236},
+          {0xC21094364DFB5637, -821, -228},
+          {0x9096EA6F3848984F, -794, -220},
+          {0xD77485CB25823AC7, -768, -212},
+          {0xA086CFCD97BF97F4, -741, -204},
+          {0xEF340A98172AACE5, -715, -196},
+          {0xB23867FB2A35B28E, -688, -188},
+          {0x84C8D4DFD2C63F3B, -661, -180},
+          {0xC5DD44271AD3CDBA, -635, -172},
+          {0x936B9FCEBB25C996, -608, -164},
+          {0xDBAC6C247D62A584, -582, -156},
+          {0xA3AB66580D5FDAF6, -555, -148},
+          {0xF3E2F893DEC3F126, -529, -140},
+          {0xB5B5ADA8AAFF80B8, -502, -132},
+          {0x87625F056C7C4A8B, -475, -124},
+          {0xC9BCFF6034C13053, -449, -116},
+          {0x964E858C91BA2655, -422, -108},
+          {0xDFF9772470297EBD, -396, -100},
+          {0xA6DFBD9FB8E5B88F, -369, -92},
+          {0xF8A95FCF88747D94, -343, -84},
+          {0xB94470938FA89BCF, -316, -76},
+          {0x8A08F0F8BF0F156B, -289, -68},
+          {0xCDB02555653131B6, -263, -60},
+          {0x993FE2C6D07B7FAC, -236, -52},
+          {0xE45C10C42A2B3B06, -210, -44},
+          {0xAA242499697392D3, -183, -36},
+          {0xFD87B5F28300CA0E, -157, -28},
+          {0xBCE5086492111AEB, -130, -20},
+          {0x8CBCCC096F5088CC, -103, -12},
+          {0xD1B71758E219652C, -77, -4},
+          {0x9C40000000000000, -50, 4},
+          {0xE8D4A51000000000, -24, 12},
+          {0xAD78EBC5AC620000, 3, 20},
+          {0x813F3978F8940984, 30, 28},
+          {0xC097CE7BC90715B3, 56, 36},
+          {0x8F7E32CE7BEA5C70, 83, 44},
+          {0xD5D238A4ABE98068, 109, 52},
+          {0x9F4F2726179A2245, 136, 60},
+          {0xED63A231D4C4FB27, 162, 68},
+          {0xB0DE65388CC8ADA8, 189, 76},
+          {0x83C7088E1AAB65DB, 216, 84},
+          {0xC45D1DF942711D9A, 242, 92},
+          {0x924D692CA61BE758, 269, 100},
+          {0xDA01EE641A708DEA, 295, 108},
+          {0xA26DA3999AEF774A, 322, 116},
+          {0xF209787BB47D6B85, 348, 124},
+          {0xB454E4A179DD1877, 375, 132},
+          {0x865B86925B9BC5C2, 402, 140},
+          {0xC83553C5C8965D3D, 428, 148},
+          {0x952AB45CFA97A0B3, 455, 156},
+          {0xDE469FBD99A05FE3, 481, 164},
+          {0xA59BC234DB398C25, 508, 172},
+          {0xF6C69A72A3989F5C, 534, 180},
+          {0xB7DCBF5354E9BECE, 561, 188},
+          {0x88FCF317F22241E2, 588, 196},
+          {0xCC20CE9BD35C78A5, 614, 204},
+          {0x98165AF37B2153DF, 641, 212},
+          {0xE2A0B5DC971F303A, 667, 220},
+          {0xA8D9D1535CE3B396, 694, 228},
+          {0xFB9B7CD9A4A7443C, 720, 236},
+          {0xBB764C4CA7A44410, 747, 244},
+          {0x8BAB8EEFB6409C1A, 774, 252},
+          {0xD01FEF10A657842C, 800, 260},
+          {0x9B10A4E5E9913129, 827, 268},
+          {0xE7109BFBA19C0C9D, 853, 276},
+          {0xAC2820D9623BF429, 880, 284},
+          {0x80444B5E7AA7CF85, 907, 292},
+          {0xBF21E44003ACDD2D, 933, 300},
+          {0x8E679C2F5E44FF8F, 960, 308},
+          {0xD433179D9C8CB841, 986, 316},
+          {0x9E19DB92B4E31BA9, 1013, 324},
+      };
 
-    // This computation gives exactly the same results for k as
-    //      k = ceil((kAlpha - e - 1) * 0.30102999566398114)
-    // for |e| <= 1500, but doesn't require floating-point operations.
-    // NB: log_10(2) ~= 78913 / 2^18
-    assert(e >= -1500);
-    assert(e <=  1500);
-    const int f = kAlpha - e - 1;
-    const int k = (f * 78913) / (1 << 18) + static_cast<int>(f > 0);
+  // This computation gives exactly the same results for k as
+  //      k = ceil((kAlpha - e - 1) * 0.30102999566398114)
+  // for |e| <= 1500, but doesn't require floating-point operations.
+  // NB: log_10(2) ~= 78913 / 2^18
+  assert(e >= -1500);
+  assert(e <= 1500);
+  const int f = kAlpha - e - 1;
+  const int k = (f * 78913) / (1 << 18) + static_cast<int>(f > 0);
 
-    const int index = (-kCachedPowersMinDecExp + k + (kCachedPowersDecStep - 1)) / kCachedPowersDecStep;
-    assert(index >= 0);
-    assert(index < kCachedPowersSize);
-    static_cast<void>(kCachedPowersSize); // Fix warning.
+  const int index = (-kCachedPowersMinDecExp + k + (kCachedPowersDecStep - 1)) / kCachedPowersDecStep;
+  assert(index >= 0);
+  assert(index < kCachedPowersSize);
+  static_cast<void>(kCachedPowersSize); // Fix warning.
 
-    const cached_power cached = kCachedPowers[index];
-    assert(kAlpha <= cached.e + e + 64);
-    assert(kGamma >= cached.e + e + 64);
+  const cached_power cached = kCachedPowers[index];
+  assert(kAlpha <= cached.e + e + 64);
+  assert(kGamma >= cached.e + e + 64);
 
-    return cached;
+  return cached;
 }
 
 /*!
 For n != 0, returns k, such that pow10 := 10^(k-1) <= n < 10^k.
 For n == 0, returns 1 and sets pow10 := 1.
 */
-inline int find_largest_pow10(const uint32_t n, uint32_t& pow10)
+inline int find_largest_pow10(const uint32_t n, uint32_t &pow10)
 {
-    // LCOV_EXCL_START
-    if (n >= 1000000000)
-    {
-        pow10 = 1000000000;
-        return 10;
-    }
-    // LCOV_EXCL_STOP
-    else if (n >= 100000000)
-    {
-        pow10 = 100000000;
-        return  9;
-    }
-    else if (n >= 10000000)
-    {
-        pow10 = 10000000;
-        return  8;
-    }
-    else if (n >= 1000000)
-    {
-        pow10 = 1000000;
-        return  7;
-    }
-    else if (n >= 100000)
-    {
-        pow10 = 100000;
-        return  6;
-    }
-    else if (n >= 10000)
-    {
-        pow10 = 10000;
-        return  5;
-    }
-    else if (n >= 1000)
-    {
-        pow10 = 1000;
-        return  4;
-    }
-    else if (n >= 100)
-    {
-        pow10 = 100;
-        return  3;
-    }
-    else if (n >= 10)
-    {
-        pow10 = 10;
-        return  2;
-    }
-    else
-    {
-        pow10 = 1;
-        return 1;
-    }
+  // LCOV_EXCL_START
+  if (n >= 1000000000) {
+    pow10 = 1000000000;
+    return 10;
+  }
+  // LCOV_EXCL_STOP
+  else if (n >= 100000000) {
+    pow10 = 100000000;
+    return 9;
+  } else if (n >= 10000000) {
+    pow10 = 10000000;
+    return 8;
+  } else if (n >= 1000000) {
+    pow10 = 1000000;
+    return 7;
+  } else if (n >= 100000) {
+    pow10 = 100000;
+    return 6;
+  } else if (n >= 10000) {
+    pow10 = 10000;
+    return 5;
+  } else if (n >= 1000) {
+    pow10 = 1000;
+    return 4;
+  } else if (n >= 100) {
+    pow10 = 100;
+    return 3;
+  } else if (n >= 10) {
+    pow10 = 10;
+    return 2;
+  } else {
+    pow10 = 1;
+    return 1;
+  }
 }
 
-inline void grisu2_round(char* buf, int len, uint64_t dist, uint64_t delta,
+inline void grisu2_round(char *buf, int len, uint64_t dist, uint64_t delta,
                          uint64_t rest, uint64_t ten_k)
 {
-    assert(len >= 1);
-    assert(dist <= delta);
-    assert(rest <= delta);
-    assert(ten_k > 0);
+  assert(len >= 1);
+  assert(dist <= delta);
+  assert(rest <= delta);
+  assert(ten_k > 0);
 
-    //               <--------------------------- delta ---->
-    //                                  <---- dist --------->
-    // --------------[------------------+-------------------]--------------
-    //               M-                 w                   M+
-    //
-    //                                  ten_k
-    //                                <------>
-    //                                       <---- rest ---->
-    // --------------[------------------+----+--------------]--------------
-    //                                  w    V
-    //                                       = buf * 10^k
-    //
-    // ten_k represents a unit-in-the-last-place in the decimal representation
-    // stored in buf.
-    // Decrement buf by ten_k while this takes buf closer to w.
+  //               <--------------------------- delta ---->
+  //                                  <---- dist --------->
+  // --------------[------------------+-------------------]--------------
+  //               M-                 w                   M+
+  //
+  //                                  ten_k
+  //                                <------>
+  //                                       <---- rest ---->
+  // --------------[------------------+----+--------------]--------------
+  //                                  w    V
+  //                                       = buf * 10^k
+  //
+  // ten_k represents a unit-in-the-last-place in the decimal representation
+  // stored in buf.
+  // Decrement buf by ten_k while this takes buf closer to w.
 
-    // The tests are written in this order to avoid overflow in unsigned
-    // integer arithmetic.
+  // The tests are written in this order to avoid overflow in unsigned
+  // integer arithmetic.
 
-    while (rest < dist
-            and delta - rest >= ten_k
-            and (rest + ten_k < dist or dist - rest > rest + ten_k - dist))
-    {
-        assert(buf[len - 1] != '0');
-        buf[len - 1]--;
-        rest += ten_k;
-    }
+  while (rest < dist and delta - rest >= ten_k and (rest + ten_k < dist or dist - rest > rest + ten_k - dist)) {
+    assert(buf[len - 1] != '0');
+    buf[len - 1]--;
+    rest += ten_k;
+  }
 }
 
 /*!
 Generates V = buffer * 10^decimal_exponent, such that M- <= V <= M+.
 M- and M+ must be normalized and share the same exponent -60 <= e <= -32.
 */
-inline void grisu2_digit_gen(char* buffer, int& length, int& decimal_exponent,
+inline void grisu2_digit_gen(char *buffer, int &length, int &decimal_exponent,
                              diyfp M_minus, diyfp w, diyfp M_plus)
 {
-    static_assert(kAlpha >= -60, "internal error");
-    static_assert(kGamma <= -32, "internal error");
+  static_assert(kAlpha >= -60, "internal error");
+  static_assert(kGamma <= -32, "internal error");
 
-    // Generates the digits (and the exponent) of a decimal floating-point
-    // number V = buffer * 10^decimal_exponent in the range [M-, M+]. The diyfp's
-    // w, M- and M+ share the same exponent e, which satisfies alpha <= e <= gamma.
+  // Generates the digits (and the exponent) of a decimal floating-point
+  // number V = buffer * 10^decimal_exponent in the range [M-, M+]. The diyfp's
+  // w, M- and M+ share the same exponent e, which satisfies alpha <= e <= gamma.
+  //
+  //               <--------------------------- delta ---->
+  //                                  <---- dist --------->
+  // --------------[------------------+-------------------]--------------
+  //               M-                 w                   M+
+  //
+  // Grisu2 generates the digits of M+ from left to right and stops as soon as
+  // V is in [M-,M+].
+
+  assert(M_plus.e >= kAlpha);
+  assert(M_plus.e <= kGamma);
+
+  uint64_t delta = diyfp::sub(M_plus, M_minus).f; // (significand of (M+ - M-), implicit exponent is e)
+  uint64_t dist  = diyfp::sub(M_plus, w).f;       // (significand of (M+ - w ), implicit exponent is e)
+
+  // Split M+ = f * 2^e into two parts p1 and p2 (note: e < 0):
+  //
+  //      M+ = f * 2^e
+  //         = ((f div 2^-e) * 2^-e + (f mod 2^-e)) * 2^e
+  //         = ((p1        ) * 2^-e + (p2        )) * 2^e
+  //         = p1 + p2 * 2^e
+
+  const diyfp one(uint64_t{1} << -M_plus.e, M_plus.e);
+
+  auto     p1 = static_cast<uint32_t>(M_plus.f >> -one.e); // p1 = f div 2^-e (Since -e >= 32, p1 fits into a 32-bit int.)
+  uint64_t p2 = M_plus.f & (one.f - 1);                    // p2 = f mod 2^-e
+
+  // 1)
+  //
+  // Generate the digits of the integral part p1 = d[n-1]...d[1]d[0]
+
+  assert(p1 > 0);
+
+  uint32_t  pow10;
+  const int k = find_largest_pow10(p1, pow10);
+
+  //      10^(k-1) <= p1 < 10^k, pow10 = 10^(k-1)
+  //
+  //      p1 = (p1 div 10^(k-1)) * 10^(k-1) + (p1 mod 10^(k-1))
+  //         = (d[k-1]         ) * 10^(k-1) + (p1 mod 10^(k-1))
+  //
+  //      M+ = p1                                             + p2 * 2^e
+  //         = d[k-1] * 10^(k-1) + (p1 mod 10^(k-1))          + p2 * 2^e
+  //         = d[k-1] * 10^(k-1) + ((p1 mod 10^(k-1)) * 2^-e + p2) * 2^e
+  //         = d[k-1] * 10^(k-1) + (                         rest) * 2^e
+  //
+  // Now generate the digits d[n] of p1 from left to right (n = k-1,...,0)
+  //
+  //      p1 = d[k-1]...d[n] * 10^n + d[n-1]...d[0]
+  //
+  // but stop as soon as
+  //
+  //      rest * 2^e = (d[n-1]...d[0] * 2^-e + p2) * 2^e <= delta * 2^e
+
+  int n = k;
+  while (n > 0) {
+    // Invariants:
+    //      M+ = buffer * 10^n + (p1 + p2 * 2^e)    (buffer = 0 for n = k)
+    //      pow10 = 10^(n-1) <= p1 < 10^n
     //
-    //               <--------------------------- delta ---->
-    //                                  <---- dist --------->
-    // --------------[------------------+-------------------]--------------
-    //               M-                 w                   M+
+    const uint32_t d = p1 / pow10; // d = p1 div 10^(n-1)
+    const uint32_t r = p1 % pow10; // r = p1 mod 10^(n-1)
     //
-    // Grisu2 generates the digits of M+ from left to right and stops as soon as
-    // V is in [M-,M+].
-
-    assert(M_plus.e >= kAlpha);
-    assert(M_plus.e <= kGamma);
-
-    uint64_t delta = diyfp::sub(M_plus, M_minus).f; // (significand of (M+ - M-), implicit exponent is e)
-    uint64_t dist  = diyfp::sub(M_plus, w      ).f; // (significand of (M+ - w ), implicit exponent is e)
-
-    // Split M+ = f * 2^e into two parts p1 and p2 (note: e < 0):
+    //      M+ = buffer * 10^n + (d * 10^(n-1) + r) + p2 * 2^e
+    //         = (buffer * 10 + d) * 10^(n-1) + (r + p2 * 2^e)
     //
-    //      M+ = f * 2^e
-    //         = ((f div 2^-e) * 2^-e + (f mod 2^-e)) * 2^e
-    //         = ((p1        ) * 2^-e + (p2        )) * 2^e
-    //         = p1 + p2 * 2^e
-
-    const diyfp one(uint64_t{1} << -M_plus.e, M_plus.e);
-
-    auto p1 = static_cast<uint32_t>(M_plus.f >> -one.e); // p1 = f div 2^-e (Since -e >= 32, p1 fits into a 32-bit int.)
-    uint64_t p2 = M_plus.f & (one.f - 1);                    // p2 = f mod 2^-e
-
-    // 1)
+    assert(d <= 9);
+    buffer[length++] = static_cast<char>('0' + d); // buffer := buffer * 10 + d
     //
-    // Generate the digits of the integral part p1 = d[n-1]...d[1]d[0]
-
-    assert(p1 > 0);
-
-    uint32_t pow10;
-    const int k = find_largest_pow10(p1, pow10);
-
-    //      10^(k-1) <= p1 < 10^k, pow10 = 10^(k-1)
+    //      M+ = buffer * 10^(n-1) + (r + p2 * 2^e)
     //
-    //      p1 = (p1 div 10^(k-1)) * 10^(k-1) + (p1 mod 10^(k-1))
-    //         = (d[k-1]         ) * 10^(k-1) + (p1 mod 10^(k-1))
+    p1 = r;
+    n--;
     //
-    //      M+ = p1                                             + p2 * 2^e
-    //         = d[k-1] * 10^(k-1) + (p1 mod 10^(k-1))          + p2 * 2^e
-    //         = d[k-1] * 10^(k-1) + ((p1 mod 10^(k-1)) * 2^-e + p2) * 2^e
-    //         = d[k-1] * 10^(k-1) + (                         rest) * 2^e
+    //      M+ = buffer * 10^n + (p1 + p2 * 2^e)
+    //      pow10 = 10^n
     //
-    // Now generate the digits d[n] of p1 from left to right (n = k-1,...,0)
-    //
-    //      p1 = d[k-1]...d[n] * 10^n + d[n-1]...d[0]
-    //
-    // but stop as soon as
-    //
-    //      rest * 2^e = (d[n-1]...d[0] * 2^-e + p2) * 2^e <= delta * 2^e
 
-    int n = k;
-    while (n > 0)
-    {
-        // Invariants:
-        //      M+ = buffer * 10^n + (p1 + p2 * 2^e)    (buffer = 0 for n = k)
-        //      pow10 = 10^(n-1) <= p1 < 10^n
-        //
-        const uint32_t d = p1 / pow10;  // d = p1 div 10^(n-1)
-        const uint32_t r = p1 % pow10;  // r = p1 mod 10^(n-1)
-        //
-        //      M+ = buffer * 10^n + (d * 10^(n-1) + r) + p2 * 2^e
-        //         = (buffer * 10 + d) * 10^(n-1) + (r + p2 * 2^e)
-        //
-        assert(d <= 9);
-        buffer[length++] = static_cast<char>('0' + d); // buffer := buffer * 10 + d
-        //
-        //      M+ = buffer * 10^(n-1) + (r + p2 * 2^e)
-        //
-        p1 = r;
-        n--;
-        //
-        //      M+ = buffer * 10^n + (p1 + p2 * 2^e)
-        //      pow10 = 10^n
-        //
-
-        // Now check if enough digits have been generated.
-        // Compute
-        //
-        //      p1 + p2 * 2^e = (p1 * 2^-e + p2) * 2^e = rest * 2^e
-        //
-        // Note:
-        // Since rest and delta share the same exponent e, it suffices to
-        // compare the significands.
-        const uint64_t rest = (uint64_t{p1} << -one.e) + p2;
-        if (rest <= delta)
-        {
-            // V = buffer * 10^n, with M- <= V <= M+.
-
-            decimal_exponent += n;
-
-            // We may now just stop. But instead look if the buffer could be
-            // decremented to bring V closer to w.
-            //
-            // pow10 = 10^n is now 1 ulp in the decimal representation V.
-            // The rounding procedure works with diyfp's with an implicit
-            // exponent of e.
-            //
-            //      10^n = (10^n * 2^-e) * 2^e = ulp * 2^e
-            //
-            const uint64_t ten_n = uint64_t{pow10} << -one.e;
-            grisu2_round(buffer, length, dist, delta, rest, ten_n);
-
-            return;
-        }
-
-        pow10 /= 10;
-        //
-        //      pow10 = 10^(n-1) <= p1 < 10^n
-        // Invariants restored.
-    }
-
-    // 2)
+    // Now check if enough digits have been generated.
+    // Compute
     //
-    // The digits of the integral part have been generated:
-    //
-    //      M+ = d[k-1]...d[1]d[0] + p2 * 2^e
-    //         = buffer            + p2 * 2^e
-    //
-    // Now generate the digits of the fractional part p2 * 2^e.
+    //      p1 + p2 * 2^e = (p1 * 2^-e + p2) * 2^e = rest * 2^e
     //
     // Note:
-    // No decimal point is generated: the exponent is adjusted instead.
-    //
-    // p2 actually represents the fraction
-    //
-    //      p2 * 2^e
-    //          = p2 / 2^-e
-    //          = d[-1] / 10^1 + d[-2] / 10^2 + ...
-    //
-    // Now generate the digits d[-m] of p1 from left to right (m = 1,2,...)
-    //
-    //      p2 * 2^e = d[-1]d[-2]...d[-m] * 10^-m
-    //                      + 10^-m * (d[-m-1] / 10^1 + d[-m-2] / 10^2 + ...)
-    //
-    // using
-    //
-    //      10^m * p2 = ((10^m * p2) div 2^-e) * 2^-e + ((10^m * p2) mod 2^-e)
-    //                = (                   d) * 2^-e + (                   r)
-    //
-    // or
-    //      10^m * p2 * 2^e = d + r * 2^e
-    //
-    // i.e.
-    //
-    //      M+ = buffer + p2 * 2^e
-    //         = buffer + 10^-m * (d + r * 2^e)
-    //         = (buffer * 10^m + d) * 10^-m + 10^-m * r * 2^e
-    //
-    // and stop as soon as 10^-m * r * 2^e <= delta * 2^e
+    // Since rest and delta share the same exponent e, it suffices to
+    // compare the significands.
+    const uint64_t rest = (uint64_t{p1} << -one.e) + p2;
+    if (rest <= delta) {
+      // V = buffer * 10^n, with M- <= V <= M+.
 
-    assert(p2 > delta);
+      decimal_exponent += n;
 
-    int m = 0;
-    for (;;)
-    {
-        // Invariant:
-        //      M+ = buffer * 10^-m + 10^-m * (d[-m-1] / 10 + d[-m-2] / 10^2 + ...) * 2^e
-        //         = buffer * 10^-m + 10^-m * (p2                                 ) * 2^e
-        //         = buffer * 10^-m + 10^-m * (1/10 * (10 * p2)                   ) * 2^e
-        //         = buffer * 10^-m + 10^-m * (1/10 * ((10*p2 div 2^-e) * 2^-e + (10*p2 mod 2^-e)) * 2^e
-        //
-        assert(p2 <= UINT64_MAX / 10);
-        p2 *= 10;
-        const uint64_t d = p2 >> -one.e;     // d = (10 * p2) div 2^-e
-        const uint64_t r = p2 & (one.f - 1); // r = (10 * p2) mod 2^-e
-        //
-        //      M+ = buffer * 10^-m + 10^-m * (1/10 * (d * 2^-e + r) * 2^e
-        //         = buffer * 10^-m + 10^-m * (1/10 * (d + r * 2^e))
-        //         = (buffer * 10 + d) * 10^(-m-1) + 10^(-m-1) * r * 2^e
-        //
-        assert(d <= 9);
-        buffer[length++] = static_cast<char>('0' + d); // buffer := buffer * 10 + d
-        //
-        //      M+ = buffer * 10^(-m-1) + 10^(-m-1) * r * 2^e
-        //
-        p2 = r;
-        m++;
-        //
-        //      M+ = buffer * 10^-m + 10^-m * p2 * 2^e
-        // Invariant restored.
+      // We may now just stop. But instead look if the buffer could be
+      // decremented to bring V closer to w.
+      //
+      // pow10 = 10^n is now 1 ulp in the decimal representation V.
+      // The rounding procedure works with diyfp's with an implicit
+      // exponent of e.
+      //
+      //      10^n = (10^n * 2^-e) * 2^e = ulp * 2^e
+      //
+      const uint64_t ten_n = uint64_t{pow10} << -one.e;
+      grisu2_round(buffer, length, dist, delta, rest, ten_n);
 
-        // Check if enough digits have been generated.
-        //
-        //      10^-m * p2 * 2^e <= delta * 2^e
-        //              p2 * 2^e <= 10^m * delta * 2^e
-        //                    p2 <= 10^m * delta
-        delta *= 10;
-        dist  *= 10;
-        if (p2 <= delta)
-        {
-            break;
-        }
+      return;
     }
 
-    // V = buffer * 10^-m, with M- <= V <= M+.
+    pow10 /= 10;
+    //
+    //      pow10 = 10^(n-1) <= p1 < 10^n
+    // Invariants restored.
+  }
 
-    decimal_exponent -= m;
+  // 2)
+  //
+  // The digits of the integral part have been generated:
+  //
+  //      M+ = d[k-1]...d[1]d[0] + p2 * 2^e
+  //         = buffer            + p2 * 2^e
+  //
+  // Now generate the digits of the fractional part p2 * 2^e.
+  //
+  // Note:
+  // No decimal point is generated: the exponent is adjusted instead.
+  //
+  // p2 actually represents the fraction
+  //
+  //      p2 * 2^e
+  //          = p2 / 2^-e
+  //          = d[-1] / 10^1 + d[-2] / 10^2 + ...
+  //
+  // Now generate the digits d[-m] of p1 from left to right (m = 1,2,...)
+  //
+  //      p2 * 2^e = d[-1]d[-2]...d[-m] * 10^-m
+  //                      + 10^-m * (d[-m-1] / 10^1 + d[-m-2] / 10^2 + ...)
+  //
+  // using
+  //
+  //      10^m * p2 = ((10^m * p2) div 2^-e) * 2^-e + ((10^m * p2) mod 2^-e)
+  //                = (                   d) * 2^-e + (                   r)
+  //
+  // or
+  //      10^m * p2 * 2^e = d + r * 2^e
+  //
+  // i.e.
+  //
+  //      M+ = buffer + p2 * 2^e
+  //         = buffer + 10^-m * (d + r * 2^e)
+  //         = (buffer * 10^m + d) * 10^-m + 10^-m * r * 2^e
+  //
+  // and stop as soon as 10^-m * r * 2^e <= delta * 2^e
 
-    // 1 ulp in the decimal representation is now 10^-m.
-    // Since delta and dist are now scaled by 10^m, we need to do the
-    // same with ulp in order to keep the units in sync.
-    //
-    //      10^m * 10^-m = 1 = 2^-e * 2^e = ten_m * 2^e
-    //
-    const uint64_t ten_m = one.f;
-    grisu2_round(buffer, length, dist, delta, p2, ten_m);
+  assert(p2 > delta);
 
-    // By construction this algorithm generates the shortest possible decimal
-    // number (Loitsch, Theorem 6.2) which rounds back to w.
-    // For an input number of precision p, at least
+  int m = 0;
+  for (;;) {
+    // Invariant:
+    //      M+ = buffer * 10^-m + 10^-m * (d[-m-1] / 10 + d[-m-2] / 10^2 + ...) * 2^e
+    //         = buffer * 10^-m + 10^-m * (p2                                 ) * 2^e
+    //         = buffer * 10^-m + 10^-m * (1/10 * (10 * p2)                   ) * 2^e
+    //         = buffer * 10^-m + 10^-m * (1/10 * ((10*p2 div 2^-e) * 2^-e + (10*p2 mod 2^-e)) * 2^e
     //
-    //      N = 1 + ceil(p * log_10(2))
+    assert(p2 <= UINT64_MAX / 10);
+    p2 *= 10;
+    const uint64_t d = p2 >> -one.e;     // d = (10 * p2) div 2^-e
+    const uint64_t r = p2 & (one.f - 1); // r = (10 * p2) mod 2^-e
     //
-    // decimal digits are sufficient to identify all binary floating-point
-    // numbers (Matula, "In-and-Out conversions").
-    // This implies that the algorithm does not produce more than N decimal
-    // digits.
+    //      M+ = buffer * 10^-m + 10^-m * (1/10 * (d * 2^-e + r) * 2^e
+    //         = buffer * 10^-m + 10^-m * (1/10 * (d + r * 2^e))
+    //         = (buffer * 10 + d) * 10^(-m-1) + 10^(-m-1) * r * 2^e
     //
-    //      N = 17 for p = 53 (IEEE double precision)
-    //      N = 9  for p = 24 (IEEE single precision)
+    assert(d <= 9);
+    buffer[length++] = static_cast<char>('0' + d); // buffer := buffer * 10 + d
+    //
+    //      M+ = buffer * 10^(-m-1) + 10^(-m-1) * r * 2^e
+    //
+    p2 = r;
+    m++;
+    //
+    //      M+ = buffer * 10^-m + 10^-m * p2 * 2^e
+    // Invariant restored.
+
+    // Check if enough digits have been generated.
+    //
+    //      10^-m * p2 * 2^e <= delta * 2^e
+    //              p2 * 2^e <= 10^m * delta * 2^e
+    //                    p2 <= 10^m * delta
+    delta *= 10;
+    dist *= 10;
+    if (p2 <= delta) {
+      break;
+    }
+  }
+
+  // V = buffer * 10^-m, with M- <= V <= M+.
+
+  decimal_exponent -= m;
+
+  // 1 ulp in the decimal representation is now 10^-m.
+  // Since delta and dist are now scaled by 10^m, we need to do the
+  // same with ulp in order to keep the units in sync.
+  //
+  //      10^m * 10^-m = 1 = 2^-e * 2^e = ten_m * 2^e
+  //
+  const uint64_t ten_m = one.f;
+  grisu2_round(buffer, length, dist, delta, p2, ten_m);
+
+  // By construction this algorithm generates the shortest possible decimal
+  // number (Loitsch, Theorem 6.2) which rounds back to w.
+  // For an input number of precision p, at least
+  //
+  //      N = 1 + ceil(p * log_10(2))
+  //
+  // decimal digits are sufficient to identify all binary floating-point
+  // numbers (Matula, "In-and-Out conversions").
+  // This implies that the algorithm does not produce more than N decimal
+  // digits.
+  //
+  //      N = 17 for p = 53 (IEEE double precision)
+  //      N = 9  for p = 24 (IEEE single precision)
 }
 
 /*!
@@ -10615,57 +9777,57 @@ v = buf * 10^decimal_exponent
 len is the length of the buffer (number of decimal digits)
 The buffer must be large enough, i.e. >= max_digits10.
 */
-inline void grisu2(char* buf, int& len, int& decimal_exponent,
+inline void grisu2(char *buf, int &len, int &decimal_exponent,
                    diyfp m_minus, diyfp v, diyfp m_plus)
 {
-    assert(m_plus.e == m_minus.e);
-    assert(m_plus.e == v.e);
+  assert(m_plus.e == m_minus.e);
+  assert(m_plus.e == v.e);
 
-    //  --------(-----------------------+-----------------------)--------    (A)
-    //          m-                      v                       m+
-    //
-    //  --------------------(-----------+-----------------------)--------    (B)
-    //                      m-          v                       m+
-    //
-    // First scale v (and m- and m+) such that the exponent is in the range
-    // [alpha, gamma].
+  //  --------(-----------------------+-----------------------)--------    (A)
+  //          m-                      v                       m+
+  //
+  //  --------------------(-----------+-----------------------)--------    (B)
+  //                      m-          v                       m+
+  //
+  // First scale v (and m- and m+) such that the exponent is in the range
+  // [alpha, gamma].
 
-    const cached_power cached = get_cached_power_for_binary_exponent(m_plus.e);
+  const cached_power cached = get_cached_power_for_binary_exponent(m_plus.e);
 
-    const diyfp c_minus_k(cached.f, cached.e); // = c ~= 10^-k
+  const diyfp c_minus_k(cached.f, cached.e); // = c ~= 10^-k
 
-    // The exponent of the products is = v.e + c_minus_k.e + q and is in the range [alpha,gamma]
-    const diyfp w       = diyfp::mul(v,       c_minus_k);
-    const diyfp w_minus = diyfp::mul(m_minus, c_minus_k);
-    const diyfp w_plus  = diyfp::mul(m_plus,  c_minus_k);
+  // The exponent of the products is = v.e + c_minus_k.e + q and is in the range [alpha,gamma]
+  const diyfp w       = diyfp::mul(v, c_minus_k);
+  const diyfp w_minus = diyfp::mul(m_minus, c_minus_k);
+  const diyfp w_plus  = diyfp::mul(m_plus, c_minus_k);
 
-    //  ----(---+---)---------------(---+---)---------------(---+---)----
-    //          w-                      w                       w+
-    //          = c*m-                  = c*v                   = c*m+
-    //
-    // diyfp::mul rounds its result and c_minus_k is approximated too. w, w- and
-    // w+ are now off by a small amount.
-    // In fact:
-    //
-    //      w - v * 10^k < 1 ulp
-    //
-    // To account for this inaccuracy, add resp. subtract 1 ulp.
-    //
-    //  --------+---[---------------(---+---)---------------]---+--------
-    //          w-  M-                  w                   M+  w+
-    //
-    // Now any number in [M-, M+] (bounds included) will round to w when input,
-    // regardless of how the input rounding algorithm breaks ties.
-    //
-    // And digit_gen generates the shortest possible such number in [M-, M+].
-    // Note that this does not mean that Grisu2 always generates the shortest
-    // possible number in the interval (m-, m+).
-    const diyfp M_minus(w_minus.f + 1, w_minus.e);
-    const diyfp M_plus (w_plus.f  - 1, w_plus.e );
+  //  ----(---+---)---------------(---+---)---------------(---+---)----
+  //          w-                      w                       w+
+  //          = c*m-                  = c*v                   = c*m+
+  //
+  // diyfp::mul rounds its result and c_minus_k is approximated too. w, w- and
+  // w+ are now off by a small amount.
+  // In fact:
+  //
+  //      w - v * 10^k < 1 ulp
+  //
+  // To account for this inaccuracy, add resp. subtract 1 ulp.
+  //
+  //  --------+---[---------------(---+---)---------------]---+--------
+  //          w-  M-                  w                   M+  w+
+  //
+  // Now any number in [M-, M+] (bounds included) will round to w when input,
+  // regardless of how the input rounding algorithm breaks ties.
+  //
+  // And digit_gen generates the shortest possible such number in [M-, M+].
+  // Note that this does not mean that Grisu2 always generates the shortest
+  // possible number in the interval (m-, m+).
+  const diyfp M_minus(w_minus.f + 1, w_minus.e);
+  const diyfp M_plus(w_plus.f - 1, w_plus.e);
 
-    decimal_exponent = -cached.k; // = -(-k) = k
+  decimal_exponent = -cached.k; // = -(-k) = k
 
-    grisu2_digit_gen(buf, len, decimal_exponent, M_minus, w, M_plus);
+  grisu2_digit_gen(buf, len, decimal_exponent, M_minus, w, M_plus);
 }
 
 /*!
@@ -10674,37 +9836,37 @@ len is the length of the buffer (number of decimal digits)
 The buffer must be large enough, i.e. >= max_digits10.
 */
 template <typename FloatType>
-void grisu2(char* buf, int& len, int& decimal_exponent, FloatType value)
+void grisu2(char *buf, int &len, int &decimal_exponent, FloatType value)
 {
-    static_assert(diyfp::kPrecision >= std::numeric_limits<FloatType>::digits + 3,
-                  "internal error: not enough precision");
+  static_assert(diyfp::kPrecision >= std::numeric_limits<FloatType>::digits + 3,
+                "internal error: not enough precision");
 
-    assert(std::isfinite(value));
-    assert(value > 0);
+  assert(std::isfinite(value));
+  assert(value > 0);
 
-    // If the neighbors (and boundaries) of 'value' are always computed for double-precision
-    // numbers, all float's can be recovered using strtod (and strtof). However, the resulting
-    // decimal representations are not exactly "short".
-    //
-    // The documentation for 'std::to_chars' (https://en.cppreference.com/w/cpp/utility/to_chars)
-    // says "value is converted to a string as if by std::sprintf in the default ("C") locale"
-    // and since sprintf promotes float's to double's, I think this is exactly what 'std::to_chars'
-    // does.
-    // On the other hand, the documentation for 'std::to_chars' requires that "parsing the
-    // representation using the corresponding std::from_chars function recovers value exactly". That
-    // indicates that single precision floating-point numbers should be recovered using
-    // 'std::strtof'.
-    //
-    // NB: If the neighbors are computed for single-precision numbers, there is a single float
-    //     (7.0385307e-26f) which can't be recovered using strtod. The resulting double precision
-    //     value is off by 1 ulp.
+  // If the neighbors (and boundaries) of 'value' are always computed for double-precision
+  // numbers, all float's can be recovered using strtod (and strtof). However, the resulting
+  // decimal representations are not exactly "short".
+  //
+  // The documentation for 'std::to_chars' (https://en.cppreference.com/w/cpp/utility/to_chars)
+  // says "value is converted to a string as if by std::sprintf in the default ("C") locale"
+  // and since sprintf promotes float's to double's, I think this is exactly what 'std::to_chars'
+  // does.
+  // On the other hand, the documentation for 'std::to_chars' requires that "parsing the
+  // representation using the corresponding std::from_chars function recovers value exactly". That
+  // indicates that single precision floating-point numbers should be recovered using
+  // 'std::strtof'.
+  //
+  // NB: If the neighbors are computed for single-precision numbers, there is a single float
+  //     (7.0385307e-26f) which can't be recovered using strtod. The resulting double precision
+  //     value is off by 1 ulp.
 #if 0
     const boundaries w = compute_boundaries(static_cast<double>(value));
 #else
-    const boundaries w = compute_boundaries(value);
+  const boundaries w = compute_boundaries(value);
 #endif
 
-    grisu2(buf, len, decimal_exponent, w.minus, w.w, w.plus);
+  grisu2(buf, len, decimal_exponent, w.minus, w.w, w.plus);
 }
 
 /*!
@@ -10712,45 +9874,37 @@ void grisu2(char* buf, int& len, int& decimal_exponent, FloatType value)
 @return a pointer to the element following the exponent.
 @pre -1000 < e < 1000
 */
-inline char* append_exponent(char* buf, int e)
+inline char *append_exponent(char *buf, int e)
 {
-    assert(e > -1000);
-    assert(e <  1000);
+  assert(e > -1000);
+  assert(e < 1000);
 
-    if (e < 0)
-    {
-        e = -e;
-        *buf++ = '-';
-    }
-    else
-    {
-        *buf++ = '+';
-    }
+  if (e < 0) {
+    e      = -e;
+    *buf++ = '-';
+  } else {
+    *buf++ = '+';
+  }
 
-    auto k = static_cast<uint32_t>(e);
-    if (k < 10)
-    {
-        // Always print at least two digits in the exponent.
-        // This is for compatibility with printf("%g").
-        *buf++ = '0';
-        *buf++ = static_cast<char>('0' + k);
-    }
-    else if (k < 100)
-    {
-        *buf++ = static_cast<char>('0' + k / 10);
-        k %= 10;
-        *buf++ = static_cast<char>('0' + k);
-    }
-    else
-    {
-        *buf++ = static_cast<char>('0' + k / 100);
-        k %= 100;
-        *buf++ = static_cast<char>('0' + k / 10);
-        k %= 10;
-        *buf++ = static_cast<char>('0' + k);
-    }
+  auto k = static_cast<uint32_t>(e);
+  if (k < 10) {
+    // Always print at least two digits in the exponent.
+    // This is for compatibility with printf("%g").
+    *buf++ = '0';
+    *buf++ = static_cast<char>('0' + k);
+  } else if (k < 100) {
+    *buf++ = static_cast<char>('0' + k / 10);
+    k %= 10;
+    *buf++ = static_cast<char>('0' + k);
+  } else {
+    *buf++ = static_cast<char>('0' + k / 100);
+    k %= 100;
+    *buf++ = static_cast<char>('0' + k / 10);
+    k %= 10;
+    *buf++ = static_cast<char>('0' + k);
+  }
 
-    return buf;
+  return buf;
 }
 
 /*!
@@ -10762,74 +9916,68 @@ notation. Otherwise it will be printed in exponential notation.
 @pre min_exp < 0
 @pre max_exp > 0
 */
-inline char* format_buffer(char* buf, int len, int decimal_exponent,
+inline char *format_buffer(char *buf, int len, int decimal_exponent,
                            int min_exp, int max_exp)
 {
-    assert(min_exp < 0);
-    assert(max_exp > 0);
+  assert(min_exp < 0);
+  assert(max_exp > 0);
 
-    const int k = len;
-    const int n = len + decimal_exponent;
+  const int k = len;
+  const int n = len + decimal_exponent;
 
-    // v = buf * 10^(n-k)
-    // k is the length of the buffer (number of decimal digits)
-    // n is the position of the decimal point relative to the start of the buffer.
+  // v = buf * 10^(n-k)
+  // k is the length of the buffer (number of decimal digits)
+  // n is the position of the decimal point relative to the start of the buffer.
 
-    if (k <= n and n <= max_exp)
-    {
-        // digits[000]
-        // len <= max_exp + 2
+  if (k <= n and n <= max_exp) {
+    // digits[000]
+    // len <= max_exp + 2
 
-        std::memset(buf + k, '0', static_cast<size_t>(n - k));
-        // Make it look like a floating-point number (#362, #378)
-        buf[n + 0] = '.';
-        buf[n + 1] = '0';
-        return buf + (n + 2);
-    }
+    std::memset(buf + k, '0', static_cast<size_t>(n - k));
+    // Make it look like a floating-point number (#362, #378)
+    buf[n + 0] = '.';
+    buf[n + 1] = '0';
+    return buf + (n + 2);
+  }
 
-    if (0 < n and n <= max_exp)
-    {
-        // dig.its
-        // len <= max_digits10 + 1
+  if (0 < n and n <= max_exp) {
+    // dig.its
+    // len <= max_digits10 + 1
 
-        assert(k > n);
+    assert(k > n);
 
-        std::memmove(buf + (n + 1), buf + n, static_cast<size_t>(k - n));
-        buf[n] = '.';
-        return buf + (k + 1);
-    }
+    std::memmove(buf + (n + 1), buf + n, static_cast<size_t>(k - n));
+    buf[n] = '.';
+    return buf + (k + 1);
+  }
 
-    if (min_exp < n and n <= 0)
-    {
-        // 0.[000]digits
-        // len <= 2 + (-min_exp - 1) + max_digits10
+  if (min_exp < n and n <= 0) {
+    // 0.[000]digits
+    // len <= 2 + (-min_exp - 1) + max_digits10
 
-        std::memmove(buf + (2 + -n), buf, static_cast<size_t>(k));
-        buf[0] = '0';
-        buf[1] = '.';
-        std::memset(buf + 2, '0', static_cast<size_t>(-n));
-        return buf + (2 + (-n) + k);
-    }
+    std::memmove(buf + (2 + -n), buf, static_cast<size_t>(k));
+    buf[0] = '0';
+    buf[1] = '.';
+    std::memset(buf + 2, '0', static_cast<size_t>(-n));
+    return buf + (2 + (-n) + k);
+  }
 
-    if (k == 1)
-    {
-        // dE+123
-        // len <= 1 + 5
+  if (k == 1) {
+    // dE+123
+    // len <= 1 + 5
 
-        buf += 1;
-    }
-    else
-    {
-        // d.igitsE+123
-        // len <= max_digits10 + 1 + 5
+    buf += 1;
+  } else {
+    // d.igitsE+123
+    // len <= max_digits10 + 1 + 5
 
-        std::memmove(buf + 2, buf + 1, static_cast<size_t>(k - 1));
-        buf[1] = '.';
-        buf += 1 + k;
-    }
+    std::memmove(buf + 2, buf + 1, static_cast<size_t>(k - 1));
+    buf[1] = '.';
+    buf += 1 + k;
+  }
 
-    *buf++ = 'e';
-    return append_exponent(buf, n - 1);
+  *buf++ = 'e';
+  return append_exponent(buf, n - 1);
 }
 
 } // namespace dtoa_impl
@@ -10845,49 +9993,48 @@ format. Returns an iterator pointing past-the-end of the decimal representation.
 @note The result is NOT null-terminated.
 */
 template <typename FloatType>
-char* to_chars(char* first, const char* last, FloatType value)
+char *to_chars(char *first, const char *last, FloatType value)
 {
-    static_cast<void>(last); // maybe unused - fix warning
-    assert(std::isfinite(value));
+  static_cast<void>(last); // maybe unused - fix warning
+  assert(std::isfinite(value));
 
-    // Use signbit(value) instead of (value < 0) since signbit works for -0.
-    if (std::signbit(value))
-    {
-        value = -value;
-        *first++ = '-';
-    }
+  // Use signbit(value) instead of (value < 0) since signbit works for -0.
+  if (std::signbit(value)) {
+    value    = -value;
+    *first++ = '-';
+  }
 
-    if (value == 0) // +-0
-    {
-        *first++ = '0';
-        // Make it look like a floating-point number (#362, #378)
-        *first++ = '.';
-        *first++ = '0';
-        return first;
-    }
+  if (value == 0) // +-0
+  {
+    *first++ = '0';
+    // Make it look like a floating-point number (#362, #378)
+    *first++ = '.';
+    *first++ = '0';
+    return first;
+  }
 
-    assert(last - first >= std::numeric_limits<FloatType>::max_digits10);
+  assert(last - first >= std::numeric_limits<FloatType>::max_digits10);
 
-    // Compute v = buffer * 10^decimal_exponent.
-    // The decimal digits are stored in the buffer, which needs to be interpreted
-    // as an unsigned decimal integer.
-    // len is the length of the buffer, i.e. the number of decimal digits.
-    int len = 0;
-    int decimal_exponent = 0;
-    dtoa_impl::grisu2(first, len, decimal_exponent, value);
+  // Compute v = buffer * 10^decimal_exponent.
+  // The decimal digits are stored in the buffer, which needs to be interpreted
+  // as an unsigned decimal integer.
+  // len is the length of the buffer, i.e. the number of decimal digits.
+  int len              = 0;
+  int decimal_exponent = 0;
+  dtoa_impl::grisu2(first, len, decimal_exponent, value);
 
-    assert(len <= std::numeric_limits<FloatType>::max_digits10);
+  assert(len <= std::numeric_limits<FloatType>::max_digits10);
 
-    // Format the buffer like printf("%.*g", prec, value)
-    constexpr int kMinExp = -4;
-    // Use digits10 here to increase compatibility with version 2.
-    constexpr int kMaxExp = std::numeric_limits<FloatType>::digits10;
+  // Format the buffer like printf("%.*g", prec, value)
+  constexpr int kMinExp = -4;
+  // Use digits10 here to increase compatibility with version 2.
+  constexpr int kMaxExp = std::numeric_limits<FloatType>::digits10;
 
-    assert(last - first >= kMaxExp + 2);
-    assert(last - first >= 2 + (-kMinExp - 1) + std::numeric_limits<FloatType>::max_digits10);
-    assert(last - first >= std::numeric_limits<FloatType>::max_digits10 + 6);
+  assert(last - first >= kMaxExp + 2);
+  assert(last - first >= 2 + (-kMinExp - 1) + std::numeric_limits<FloatType>::max_digits10);
+  assert(last - first >= std::numeric_limits<FloatType>::max_digits10 + 6);
 
-    return dtoa_impl::format_buffer(first, len, decimal_exponent, kMinExp, kMaxExp);
+  return dtoa_impl::format_buffer(first, len, decimal_exponent, kMinExp, kMaxExp);
 }
 
 } // namespace detail
@@ -10903,58 +10050,48 @@ char* to_chars(char* first, const char* last, FloatType value)
 
 // #include <nlohmann/detail/value_t.hpp>
 
-
-namespace nlohmann
-{
-namespace detail
-{
+namespace nlohmann {
+namespace detail {
 ///////////////////
 // serialization //
 ///////////////////
 
 /// how to treat decoding errors
-enum class error_handler_t
-{
-    strict,  ///< throw a type_error exception in case of invalid UTF-8
-    replace, ///< replace invalid UTF-8 sequences with U+FFFD
-    ignore   ///< ignore invalid UTF-8 sequences
+enum class error_handler_t {
+  strict,  ///< throw a type_error exception in case of invalid UTF-8
+  replace, ///< replace invalid UTF-8 sequences with U+FFFD
+  ignore   ///< ignore invalid UTF-8 sequences
 };
 
-template<typename BasicJsonType>
-class serializer
-{
-    using string_t = typename BasicJsonType::string_t;
-    using number_float_t = typename BasicJsonType::number_float_t;
-    using number_integer_t = typename BasicJsonType::number_integer_t;
-    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-    static constexpr uint8_t UTF8_ACCEPT = 0;
-    static constexpr uint8_t UTF8_REJECT = 1;
+template <typename BasicJsonType>
+class serializer {
+  using string_t                       = typename BasicJsonType::string_t;
+  using number_float_t                 = typename BasicJsonType::number_float_t;
+  using number_integer_t               = typename BasicJsonType::number_integer_t;
+  using number_unsigned_t              = typename BasicJsonType::number_unsigned_t;
+  static constexpr uint8_t UTF8_ACCEPT = 0;
+  static constexpr uint8_t UTF8_REJECT = 1;
 
-  public:
-    /*!
+public:
+  /*!
     @param[in] s  output stream to serialize to
     @param[in] ichar  indentation character to use
     @param[in] error_handler_  how to react on decoding errors
     */
-    serializer(output_adapter_t<char> s, const char ichar,
-               error_handler_t error_handler_ = error_handler_t::strict)
-        : o(std::move(s))
-        , loc(std::localeconv())
-        , thousands_sep(loc->thousands_sep == nullptr ? '\0' : * (loc->thousands_sep))
-        , decimal_point(loc->decimal_point == nullptr ? '\0' : * (loc->decimal_point))
-        , indent_char(ichar)
-        , indent_string(512, indent_char)
-        , error_handler(error_handler_)
-    {}
+  serializer(output_adapter_t<char> s, const char ichar,
+             error_handler_t error_handler_ = error_handler_t::strict)
+      : o(std::move(s)), loc(std::localeconv()), thousands_sep(loc->thousands_sep == nullptr ? '\0' : *(loc->thousands_sep)), decimal_point(loc->decimal_point == nullptr ? '\0' : *(loc->decimal_point)), indent_char(ichar), indent_string(512, indent_char), error_handler(error_handler_)
+  {
+  }
 
-    // delete because of pointer members
-    serializer(const serializer&) = delete;
-    serializer& operator=(const serializer&) = delete;
-    serializer(serializer&&) = delete;
-    serializer& operator=(serializer&&) = delete;
-    ~serializer() = default;
+  // delete because of pointer members
+  serializer(const serializer &) = delete;
+  serializer &operator=(const serializer &) = delete;
+  serializer(serializer &&)                 = delete;
+  serializer &operator=(serializer &&) = delete;
+  ~serializer()                        = default;
 
-    /*!
+  /*!
     @brief internal implementation of the serialization function
 
     This function is called by the public member function dump and organizes
@@ -10971,200 +10108,173 @@ class serializer
     @param[in] indent_step     the indent level
     @param[in] current_indent  the current indent level (only used internally)
     */
-    void dump(const BasicJsonType& val, const bool pretty_print,
-              const bool ensure_ascii,
-              const unsigned int indent_step,
-              const unsigned int current_indent = 0)
-    {
-        switch (val.m_type)
-        {
-            case value_t::object:
-            {
-                if (val.m_value.object->empty())
-                {
-                    o->write_characters("{}", 2);
-                    return;
-                }
+  void dump(const BasicJsonType &val, const bool pretty_print,
+            const bool         ensure_ascii,
+            const unsigned int indent_step,
+            const unsigned int current_indent = 0)
+  {
+    switch (val.m_type) {
+    case value_t::object: {
+      if (val.m_value.object->empty()) {
+        o->write_characters("{}", 2);
+        return;
+      }
 
-                if (pretty_print)
-                {
-                    o->write_characters("{\n", 2);
+      if (pretty_print) {
+        o->write_characters("{\n", 2);
 
-                    // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
-
-                    // first n-1 elements
-                    auto i = val.m_value.object->cbegin();
-                    for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i)
-                    {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        o->write_character('\"');
-                        dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\": ", 3);
-                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
-                    }
-
-                    // last element
-                    assert(i != val.m_value.object->cend());
-                    assert(std::next(i) == val.m_value.object->cend());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    o->write_character('\"');
-                    dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\": ", 3);
-                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
-
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character('}');
-                }
-                else
-                {
-                    o->write_character('{');
-
-                    // first n-1 elements
-                    auto i = val.m_value.object->cbegin();
-                    for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i)
-                    {
-                        o->write_character('\"');
-                        dump_escaped(i->first, ensure_ascii);
-                        o->write_characters("\":", 2);
-                        dump(i->second, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
-                    }
-
-                    // last element
-                    assert(i != val.m_value.object->cend());
-                    assert(std::next(i) == val.m_value.object->cend());
-                    o->write_character('\"');
-                    dump_escaped(i->first, ensure_ascii);
-                    o->write_characters("\":", 2);
-                    dump(i->second, false, ensure_ascii, indent_step, current_indent);
-
-                    o->write_character('}');
-                }
-
-                return;
-            }
-
-            case value_t::array:
-            {
-                if (val.m_value.array->empty())
-                {
-                    o->write_characters("[]", 2);
-                    return;
-                }
-
-                if (pretty_print)
-                {
-                    o->write_characters("[\n", 2);
-
-                    // variable to hold indentation for recursive calls
-                    const auto new_indent = current_indent + indent_step;
-                    if (JSON_UNLIKELY(indent_string.size() < new_indent))
-                    {
-                        indent_string.resize(indent_string.size() * 2, ' ');
-                    }
-
-                    // first n-1 elements
-                    for (auto i = val.m_value.array->cbegin();
-                            i != val.m_value.array->cend() - 1; ++i)
-                    {
-                        o->write_characters(indent_string.c_str(), new_indent);
-                        dump(*i, true, ensure_ascii, indent_step, new_indent);
-                        o->write_characters(",\n", 2);
-                    }
-
-                    // last element
-                    assert(not val.m_value.array->empty());
-                    o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
-
-                    o->write_character('\n');
-                    o->write_characters(indent_string.c_str(), current_indent);
-                    o->write_character(']');
-                }
-                else
-                {
-                    o->write_character('[');
-
-                    // first n-1 elements
-                    for (auto i = val.m_value.array->cbegin();
-                            i != val.m_value.array->cend() - 1; ++i)
-                    {
-                        dump(*i, false, ensure_ascii, indent_step, current_indent);
-                        o->write_character(',');
-                    }
-
-                    // last element
-                    assert(not val.m_value.array->empty());
-                    dump(val.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
-
-                    o->write_character(']');
-                }
-
-                return;
-            }
-
-            case value_t::string:
-            {
-                o->write_character('\"');
-                dump_escaped(*val.m_value.string, ensure_ascii);
-                o->write_character('\"');
-                return;
-            }
-
-            case value_t::boolean:
-            {
-                if (val.m_value.boolean)
-                {
-                    o->write_characters("true", 4);
-                }
-                else
-                {
-                    o->write_characters("false", 5);
-                }
-                return;
-            }
-
-            case value_t::number_integer:
-            {
-                dump_integer(val.m_value.number_integer);
-                return;
-            }
-
-            case value_t::number_unsigned:
-            {
-                dump_integer(val.m_value.number_unsigned);
-                return;
-            }
-
-            case value_t::number_float:
-            {
-                dump_float(val.m_value.number_float);
-                return;
-            }
-
-            case value_t::discarded:
-            {
-                o->write_characters("<discarded>", 11);
-                return;
-            }
-
-            case value_t::null:
-            {
-                o->write_characters("null", 4);
-                return;
-            }
+        // variable to hold indentation for recursive calls
+        const auto new_indent = current_indent + indent_step;
+        if (JSON_UNLIKELY(indent_string.size() < new_indent)) {
+          indent_string.resize(indent_string.size() * 2, ' ');
         }
+
+        // first n-1 elements
+        auto i = val.m_value.object->cbegin();
+        for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i) {
+          o->write_characters(indent_string.c_str(), new_indent);
+          o->write_character('\"');
+          dump_escaped(i->first, ensure_ascii);
+          o->write_characters("\": ", 3);
+          dump(i->second, true, ensure_ascii, indent_step, new_indent);
+          o->write_characters(",\n", 2);
+        }
+
+        // last element
+        assert(i != val.m_value.object->cend());
+        assert(std::next(i) == val.m_value.object->cend());
+        o->write_characters(indent_string.c_str(), new_indent);
+        o->write_character('\"');
+        dump_escaped(i->first, ensure_ascii);
+        o->write_characters("\": ", 3);
+        dump(i->second, true, ensure_ascii, indent_step, new_indent);
+
+        o->write_character('\n');
+        o->write_characters(indent_string.c_str(), current_indent);
+        o->write_character('}');
+      } else {
+        o->write_character('{');
+
+        // first n-1 elements
+        auto i = val.m_value.object->cbegin();
+        for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i) {
+          o->write_character('\"');
+          dump_escaped(i->first, ensure_ascii);
+          o->write_characters("\":", 2);
+          dump(i->second, false, ensure_ascii, indent_step, current_indent);
+          o->write_character(',');
+        }
+
+        // last element
+        assert(i != val.m_value.object->cend());
+        assert(std::next(i) == val.m_value.object->cend());
+        o->write_character('\"');
+        dump_escaped(i->first, ensure_ascii);
+        o->write_characters("\":", 2);
+        dump(i->second, false, ensure_ascii, indent_step, current_indent);
+
+        o->write_character('}');
+      }
+
+      return;
     }
 
-  private:
-    /*!
+    case value_t::array: {
+      if (val.m_value.array->empty()) {
+        o->write_characters("[]", 2);
+        return;
+      }
+
+      if (pretty_print) {
+        o->write_characters("[\n", 2);
+
+        // variable to hold indentation for recursive calls
+        const auto new_indent = current_indent + indent_step;
+        if (JSON_UNLIKELY(indent_string.size() < new_indent)) {
+          indent_string.resize(indent_string.size() * 2, ' ');
+        }
+
+        // first n-1 elements
+        for (auto i = val.m_value.array->cbegin();
+             i != val.m_value.array->cend() - 1; ++i) {
+          o->write_characters(indent_string.c_str(), new_indent);
+          dump(*i, true, ensure_ascii, indent_step, new_indent);
+          o->write_characters(",\n", 2);
+        }
+
+        // last element
+        assert(not val.m_value.array->empty());
+        o->write_characters(indent_string.c_str(), new_indent);
+        dump(val.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+
+        o->write_character('\n');
+        o->write_characters(indent_string.c_str(), current_indent);
+        o->write_character(']');
+      } else {
+        o->write_character('[');
+
+        // first n-1 elements
+        for (auto i = val.m_value.array->cbegin();
+             i != val.m_value.array->cend() - 1; ++i) {
+          dump(*i, false, ensure_ascii, indent_step, current_indent);
+          o->write_character(',');
+        }
+
+        // last element
+        assert(not val.m_value.array->empty());
+        dump(val.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+
+        o->write_character(']');
+      }
+
+      return;
+    }
+
+    case value_t::string: {
+      o->write_character('\"');
+      dump_escaped(*val.m_value.string, ensure_ascii);
+      o->write_character('\"');
+      return;
+    }
+
+    case value_t::boolean: {
+      if (val.m_value.boolean) {
+        o->write_characters("true", 4);
+      } else {
+        o->write_characters("false", 5);
+      }
+      return;
+    }
+
+    case value_t::number_integer: {
+      dump_integer(val.m_value.number_integer);
+      return;
+    }
+
+    case value_t::number_unsigned: {
+      dump_integer(val.m_value.number_unsigned);
+      return;
+    }
+
+    case value_t::number_float: {
+      dump_float(val.m_value.number_float);
+      return;
+    }
+
+    case value_t::discarded: {
+      o->write_characters("<discarded>", 11);
+      return;
+    }
+
+    case value_t::null: {
+      o->write_characters("null", 4);
+      return;
+    }
+    }
+  }
+
+private:
+  /*!
     @brief dump escaped string
 
     Escape a string by replacing certain special characters by a sequence of an
@@ -11178,239 +10288,208 @@ class serializer
 
     @complexity Linear in the length of string @a s.
     */
-    void dump_escaped(const string_t& s, const bool ensure_ascii)
-    {
-        uint32_t codepoint;
-        uint8_t state = UTF8_ACCEPT;
-        std::size_t bytes = 0;  // number of bytes written to string_buffer
+  void dump_escaped(const string_t &s, const bool ensure_ascii)
+  {
+    uint32_t    codepoint;
+    uint8_t     state = UTF8_ACCEPT;
+    std::size_t bytes = 0; // number of bytes written to string_buffer
 
-        // number of bytes written at the point of the last valid byte
-        std::size_t bytes_after_last_accept = 0;
-        std::size_t undumped_chars = 0;
+    // number of bytes written at the point of the last valid byte
+    std::size_t bytes_after_last_accept = 0;
+    std::size_t undumped_chars          = 0;
 
-        for (std::size_t i = 0; i < s.size(); ++i)
+    for (std::size_t i = 0; i < s.size(); ++i) {
+      const auto byte = static_cast<uint8_t>(s[i]);
+
+      switch (decode(state, codepoint, byte)) {
+      case UTF8_ACCEPT: // decode found a new code point
+      {
+        switch (codepoint) {
+        case 0x08: // backspace
         {
-            const auto byte = static_cast<uint8_t>(s[i]);
-
-            switch (decode(state, codepoint, byte))
-            {
-                case UTF8_ACCEPT:  // decode found a new code point
-                {
-                    switch (codepoint)
-                    {
-                        case 0x08: // backspace
-                        {
-                            string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = 'b';
-                            break;
-                        }
-
-                        case 0x09: // horizontal tab
-                        {
-                            string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = 't';
-                            break;
-                        }
-
-                        case 0x0A: // newline
-                        {
-                            string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = 'n';
-                            break;
-                        }
-
-                        case 0x0C: // formfeed
-                        {
-                            string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = 'f';
-                            break;
-                        }
-
-                        case 0x0D: // carriage return
-                        {
-                            string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = 'r';
-                            break;
-                        }
-
-                        case 0x22: // quotation mark
-                        {
-                            string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = '\"';
-                            break;
-                        }
-
-                        case 0x5C: // reverse solidus
-                        {
-                            string_buffer[bytes++] = '\\';
-                            string_buffer[bytes++] = '\\';
-                            break;
-                        }
-
-                        default:
-                        {
-                            // escape control characters (0x00..0x1F) or, if
-                            // ensure_ascii parameter is used, non-ASCII characters
-                            if ((codepoint <= 0x1F) or (ensure_ascii and (codepoint >= 0x7F)))
-                            {
-                                if (codepoint <= 0xFFFF)
-                                {
-                                    (std::snprintf)(string_buffer.data() + bytes, 7, "\\u%04x",
-                                                    static_cast<uint16_t>(codepoint));
-                                    bytes += 6;
-                                }
-                                else
-                                {
-                                    (std::snprintf)(string_buffer.data() + bytes, 13, "\\u%04x\\u%04x",
-                                                    static_cast<uint16_t>(0xD7C0 + (codepoint >> 10)),
-                                                    static_cast<uint16_t>(0xDC00 + (codepoint & 0x3FF)));
-                                    bytes += 12;
-                                }
-                            }
-                            else
-                            {
-                                // copy byte to buffer (all previous bytes
-                                // been copied have in default case above)
-                                string_buffer[bytes++] = s[i];
-                            }
-                            break;
-                        }
-                    }
-
-                    // write buffer and reset index; there must be 13 bytes
-                    // left, as this is the maximal number of bytes to be
-                    // written ("\uxxxx\uxxxx\0") for one code point
-                    if (string_buffer.size() - bytes < 13)
-                    {
-                        o->write_characters(string_buffer.data(), bytes);
-                        bytes = 0;
-                    }
-
-                    // remember the byte position of this accept
-                    bytes_after_last_accept = bytes;
-                    undumped_chars = 0;
-                    break;
-                }
-
-                case UTF8_REJECT:  // decode found invalid UTF-8 byte
-                {
-                    switch (error_handler)
-                    {
-                        case error_handler_t::strict:
-                        {
-                            std::string sn(3, '\0');
-                            (std::snprintf)(&sn[0], sn.size(), "%.2X", byte);
-                            JSON_THROW(type_error::create(316, "invalid UTF-8 byte at index " + std::to_string(i) + ": 0x" + sn));
-                        }
-
-                        case error_handler_t::ignore:
-                        case error_handler_t::replace:
-                        {
-                            // in case we saw this character the first time, we
-                            // would like to read it again, because the byte
-                            // may be OK for itself, but just not OK for the
-                            // previous sequence
-                            if (undumped_chars > 0)
-                            {
-                                --i;
-                            }
-
-                            // reset length buffer to the last accepted index;
-                            // thus removing/ignoring the invalid characters
-                            bytes = bytes_after_last_accept;
-
-                            if (error_handler == error_handler_t::replace)
-                            {
-                                // add a replacement character
-                                if (ensure_ascii)
-                                {
-                                    string_buffer[bytes++] = '\\';
-                                    string_buffer[bytes++] = 'u';
-                                    string_buffer[bytes++] = 'f';
-                                    string_buffer[bytes++] = 'f';
-                                    string_buffer[bytes++] = 'f';
-                                    string_buffer[bytes++] = 'd';
-                                }
-                                else
-                                {
-                                    string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xEF');
-                                    string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xBF');
-                                    string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xBD');
-                                }
-                                bytes_after_last_accept = bytes;
-                            }
-
-                            undumped_chars = 0;
-
-                            // continue processing the string
-                            state = UTF8_ACCEPT;
-                            break;
-                        }
-                    }
-                    break;
-                }
-
-                default:  // decode found yet incomplete multi-byte code point
-                {
-                    if (not ensure_ascii)
-                    {
-                        // code point will not be escaped - copy byte to buffer
-                        string_buffer[bytes++] = s[i];
-                    }
-                    ++undumped_chars;
-                    break;
-                }
-            }
+          string_buffer[bytes++] = '\\';
+          string_buffer[bytes++] = 'b';
+          break;
         }
 
-        // we finished processing the string
-        if (JSON_LIKELY(state == UTF8_ACCEPT))
+        case 0x09: // horizontal tab
         {
-            // write buffer
-            if (bytes > 0)
-            {
-                o->write_characters(string_buffer.data(), bytes);
-            }
+          string_buffer[bytes++] = '\\';
+          string_buffer[bytes++] = 't';
+          break;
         }
-        else
+
+        case 0x0A: // newline
         {
-            // we finish reading, but do not accept: string was incomplete
-            switch (error_handler)
-            {
-                case error_handler_t::strict:
-                {
-                    std::string sn(3, '\0');
-                    (std::snprintf)(&sn[0], sn.size(), "%.2X", static_cast<uint8_t>(s.back()));
-                    JSON_THROW(type_error::create(316, "incomplete UTF-8 string; last byte: 0x" + sn));
-                }
-
-                case error_handler_t::ignore:
-                {
-                    // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
-                    break;
-                }
-
-                case error_handler_t::replace:
-                {
-                    // write all accepted bytes
-                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
-                    // add a replacement character
-                    if (ensure_ascii)
-                    {
-                        o->write_characters("\\ufffd", 6);
-                    }
-                    else
-                    {
-                        o->write_characters("\xEF\xBF\xBD", 3);
-                    }
-                    break;
-                }
-            }
+          string_buffer[bytes++] = '\\';
+          string_buffer[bytes++] = 'n';
+          break;
         }
+
+        case 0x0C: // formfeed
+        {
+          string_buffer[bytes++] = '\\';
+          string_buffer[bytes++] = 'f';
+          break;
+        }
+
+        case 0x0D: // carriage return
+        {
+          string_buffer[bytes++] = '\\';
+          string_buffer[bytes++] = 'r';
+          break;
+        }
+
+        case 0x22: // quotation mark
+        {
+          string_buffer[bytes++] = '\\';
+          string_buffer[bytes++] = '\"';
+          break;
+        }
+
+        case 0x5C: // reverse solidus
+        {
+          string_buffer[bytes++] = '\\';
+          string_buffer[bytes++] = '\\';
+          break;
+        }
+
+        default: {
+          // escape control characters (0x00..0x1F) or, if
+          // ensure_ascii parameter is used, non-ASCII characters
+          if ((codepoint <= 0x1F) or (ensure_ascii and (codepoint >= 0x7F))) {
+            if (codepoint <= 0xFFFF) {
+              (std::snprintf)(string_buffer.data() + bytes, 7, "\\u%04x",
+                              static_cast<uint16_t>(codepoint));
+              bytes += 6;
+            } else {
+              (std::snprintf)(string_buffer.data() + bytes, 13, "\\u%04x\\u%04x",
+                              static_cast<uint16_t>(0xD7C0 + (codepoint >> 10)),
+                              static_cast<uint16_t>(0xDC00 + (codepoint & 0x3FF)));
+              bytes += 12;
+            }
+          } else {
+            // copy byte to buffer (all previous bytes
+            // been copied have in default case above)
+            string_buffer[bytes++] = s[i];
+          }
+          break;
+        }
+        }
+
+        // write buffer and reset index; there must be 13 bytes
+        // left, as this is the maximal number of bytes to be
+        // written ("\uxxxx\uxxxx\0") for one code point
+        if (string_buffer.size() - bytes < 13) {
+          o->write_characters(string_buffer.data(), bytes);
+          bytes = 0;
+        }
+
+        // remember the byte position of this accept
+        bytes_after_last_accept = bytes;
+        undumped_chars          = 0;
+        break;
+      }
+
+      case UTF8_REJECT: // decode found invalid UTF-8 byte
+      {
+        switch (error_handler) {
+        case error_handler_t::strict: {
+          std::string sn(3, '\0');
+          (std::snprintf)(&sn[0], sn.size(), "%.2X", byte);
+          JSON_THROW(type_error::create(316, "invalid UTF-8 byte at index " + std::to_string(i) + ": 0x" + sn));
+        }
+
+        case error_handler_t::ignore:
+        case error_handler_t::replace: {
+          // in case we saw this character the first time, we
+          // would like to read it again, because the byte
+          // may be OK for itself, but just not OK for the
+          // previous sequence
+          if (undumped_chars > 0) {
+            --i;
+          }
+
+          // reset length buffer to the last accepted index;
+          // thus removing/ignoring the invalid characters
+          bytes = bytes_after_last_accept;
+
+          if (error_handler == error_handler_t::replace) {
+            // add a replacement character
+            if (ensure_ascii) {
+              string_buffer[bytes++] = '\\';
+              string_buffer[bytes++] = 'u';
+              string_buffer[bytes++] = 'f';
+              string_buffer[bytes++] = 'f';
+              string_buffer[bytes++] = 'f';
+              string_buffer[bytes++] = 'd';
+            } else {
+              string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xEF');
+              string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xBF');
+              string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xBD');
+            }
+            bytes_after_last_accept = bytes;
+          }
+
+          undumped_chars = 0;
+
+          // continue processing the string
+          state = UTF8_ACCEPT;
+          break;
+        }
+        }
+        break;
+      }
+
+      default: // decode found yet incomplete multi-byte code point
+      {
+        if (not ensure_ascii) {
+          // code point will not be escaped - copy byte to buffer
+          string_buffer[bytes++] = s[i];
+        }
+        ++undumped_chars;
+        break;
+      }
+      }
     }
 
-    /*!
+    // we finished processing the string
+    if (JSON_LIKELY(state == UTF8_ACCEPT)) {
+      // write buffer
+      if (bytes > 0) {
+        o->write_characters(string_buffer.data(), bytes);
+      }
+    } else {
+      // we finish reading, but do not accept: string was incomplete
+      switch (error_handler) {
+      case error_handler_t::strict: {
+        std::string sn(3, '\0');
+        (std::snprintf)(&sn[0], sn.size(), "%.2X", static_cast<uint8_t>(s.back()));
+        JSON_THROW(type_error::create(316, "incomplete UTF-8 string; last byte: 0x" + sn));
+      }
+
+      case error_handler_t::ignore: {
+        // write all accepted bytes
+        o->write_characters(string_buffer.data(), bytes_after_last_accept);
+        break;
+      }
+
+      case error_handler_t::replace: {
+        // write all accepted bytes
+        o->write_characters(string_buffer.data(), bytes_after_last_accept);
+        // add a replacement character
+        if (ensure_ascii) {
+          o->write_characters("\\ufffd", 6);
+        } else {
+          o->write_characters("\xEF\xBF\xBD", 3);
+        }
+        break;
+      }
+      }
+    }
+  }
+
+  /*!
     @brief dump an integer
 
     Dump a given integer to output stream @a o. Works internally with
@@ -11419,44 +10498,41 @@ class serializer
     @param[in] x  integer number (signed or unsigned) to dump
     @tparam NumberType either @a number_integer_t or @a number_unsigned_t
     */
-    template<typename NumberType, detail::enable_if_t<
-                 std::is_same<NumberType, number_unsigned_t>::value or
-                 std::is_same<NumberType, number_integer_t>::value,
-                 int> = 0>
-    void dump_integer(NumberType x)
-    {
-        // special case for "0"
-        if (x == 0)
-        {
-            o->write_character('0');
-            return;
-        }
-
-        const bool is_negative = std::is_same<NumberType, number_integer_t>::value and not (x >= 0);  // see issue #755
-        std::size_t i = 0;
-
-        while (x != 0)
-        {
-            // spare 1 byte for '\0'
-            assert(i < number_buffer.size() - 1);
-
-            const auto digit = std::labs(static_cast<long>(x % 10));
-            number_buffer[i++] = static_cast<char>('0' + digit);
-            x /= 10;
-        }
-
-        if (is_negative)
-        {
-            // make sure there is capacity for the '-'
-            assert(i < number_buffer.size() - 2);
-            number_buffer[i++] = '-';
-        }
-
-        std::reverse(number_buffer.begin(), number_buffer.begin() + i);
-        o->write_characters(number_buffer.data(), i);
+  template <typename NumberType, detail::enable_if_t<
+                                     std::is_same<NumberType, number_unsigned_t>::value or
+                                         std::is_same<NumberType, number_integer_t>::value,
+                                     int> = 0>
+  void dump_integer(NumberType x)
+  {
+    // special case for "0"
+    if (x == 0) {
+      o->write_character('0');
+      return;
     }
 
-    /*!
+    const bool  is_negative = std::is_same<NumberType, number_integer_t>::value and not(x >= 0); // see issue #755
+    std::size_t i           = 0;
+
+    while (x != 0) {
+      // spare 1 byte for '\0'
+      assert(i < number_buffer.size() - 1);
+
+      const auto digit   = std::labs(static_cast<long>(x % 10));
+      number_buffer[i++] = static_cast<char>('0' + digit);
+      x /= 10;
+    }
+
+    if (is_negative) {
+      // make sure there is capacity for the '-'
+      assert(i < number_buffer.size() - 2);
+      number_buffer[i++] = '-';
+    }
+
+    std::reverse(number_buffer.begin(), number_buffer.begin() + i);
+    o->write_characters(number_buffer.data(), i);
+  }
+
+  /*!
     @brief dump a floating-point number
 
     Dump a given floating-point number to output stream @a o. Works internally
@@ -11464,85 +10540,78 @@ class serializer
 
     @param[in] x  floating-point number to dump
     */
-    void dump_float(number_float_t x)
-    {
-        // NaN / inf
-        if (not std::isfinite(x))
-        {
-            o->write_characters("null", 4);
-            return;
-        }
-
-        // If number_float_t is an IEEE-754 single or double precision number,
-        // use the Grisu2 algorithm to produce short numbers which are
-        // guaranteed to round-trip, using strtof and strtod, resp.
-        //
-        // NB: The test below works if <long double> == <double>.
-        static constexpr bool is_ieee_single_or_double
-            = (std::numeric_limits<number_float_t>::is_iec559 and std::numeric_limits<number_float_t>::digits == 24 and std::numeric_limits<number_float_t>::max_exponent == 128) or
-              (std::numeric_limits<number_float_t>::is_iec559 and std::numeric_limits<number_float_t>::digits == 53 and std::numeric_limits<number_float_t>::max_exponent == 1024);
-
-        dump_float(x, std::integral_constant<bool, is_ieee_single_or_double>());
+  void dump_float(number_float_t x)
+  {
+    // NaN / inf
+    if (not std::isfinite(x)) {
+      o->write_characters("null", 4);
+      return;
     }
 
-    void dump_float(number_float_t x, std::true_type /*is_ieee_single_or_double*/)
-    {
-        char* begin = number_buffer.data();
-        char* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
+    // If number_float_t is an IEEE-754 single or double precision number,
+    // use the Grisu2 algorithm to produce short numbers which are
+    // guaranteed to round-trip, using strtof and strtod, resp.
+    //
+    // NB: The test below works if <long double> == <double>.
+    static constexpr bool is_ieee_single_or_double = (std::numeric_limits<number_float_t>::is_iec559 and std::numeric_limits<number_float_t>::digits == 24 and std::numeric_limits<number_float_t>::max_exponent == 128) or
+                                                     (std::numeric_limits<number_float_t>::is_iec559 and std::numeric_limits<number_float_t>::digits == 53 and std::numeric_limits<number_float_t>::max_exponent == 1024);
 
-        o->write_characters(begin, static_cast<size_t>(end - begin));
+    dump_float(x, std::integral_constant<bool, is_ieee_single_or_double>());
+  }
+
+  void dump_float(number_float_t x, std::true_type /*is_ieee_single_or_double*/)
+  {
+    char *begin = number_buffer.data();
+    char *end   = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
+
+    o->write_characters(begin, static_cast<size_t>(end - begin));
+  }
+
+  void dump_float(number_float_t x, std::false_type /*is_ieee_single_or_double*/)
+  {
+    // get number of digits for a float -> text -> float round-trip
+    static constexpr auto d = std::numeric_limits<number_float_t>::max_digits10;
+
+    // the actual conversion
+    std::ptrdiff_t len = (std::snprintf)(number_buffer.data(), number_buffer.size(), "%.*g", d, x);
+
+    // negative value indicates an error
+    assert(len > 0);
+    // check if buffer was large enough
+    assert(static_cast<std::size_t>(len) < number_buffer.size());
+
+    // erase thousands separator
+    if (thousands_sep != '\0') {
+      const auto end = std::remove(number_buffer.begin(),
+                                   number_buffer.begin() + len, thousands_sep);
+      std::fill(end, number_buffer.end(), '\0');
+      assert((end - number_buffer.begin()) <= len);
+      len = (end - number_buffer.begin());
     }
 
-    void dump_float(number_float_t x, std::false_type /*is_ieee_single_or_double*/)
-    {
-        // get number of digits for a float -> text -> float round-trip
-        static constexpr auto d = std::numeric_limits<number_float_t>::max_digits10;
-
-        // the actual conversion
-        std::ptrdiff_t len = (std::snprintf)(number_buffer.data(), number_buffer.size(), "%.*g", d, x);
-
-        // negative value indicates an error
-        assert(len > 0);
-        // check if buffer was large enough
-        assert(static_cast<std::size_t>(len) < number_buffer.size());
-
-        // erase thousands separator
-        if (thousands_sep != '\0')
-        {
-            const auto end = std::remove(number_buffer.begin(),
-                                         number_buffer.begin() + len, thousands_sep);
-            std::fill(end, number_buffer.end(), '\0');
-            assert((end - number_buffer.begin()) <= len);
-            len = (end - number_buffer.begin());
-        }
-
-        // convert decimal point to '.'
-        if (decimal_point != '\0' and decimal_point != '.')
-        {
-            const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), decimal_point);
-            if (dec_pos != number_buffer.end())
-            {
-                *dec_pos = '.';
-            }
-        }
-
-        o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
-
-        // determine if need to append ".0"
-        const bool value_is_int_like =
-            std::none_of(number_buffer.begin(), number_buffer.begin() + len + 1,
-                         [](char c)
-        {
-            return (c == '.' or c == 'e');
-        });
-
-        if (value_is_int_like)
-        {
-            o->write_characters(".0", 2);
-        }
+    // convert decimal point to '.'
+    if (decimal_point != '\0' and decimal_point != '.') {
+      const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), decimal_point);
+      if (dec_pos != number_buffer.end()) {
+        *dec_pos = '.';
+      }
     }
 
-    /*!
+    o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
+
+    // determine if need to append ".0"
+    const bool value_is_int_like =
+        std::none_of(number_buffer.begin(), number_buffer.begin() + len + 1,
+                     [](char c) {
+                       return (c == '.' or c == 'e');
+                     });
+
+    if (value_is_int_like) {
+      o->write_characters(".0", 2);
+    }
+  }
+
+  /*!
     @brief check whether a string is UTF-8 encoded
 
     The function checks each byte of a string whether it is UTF-8 encoded. The
@@ -11563,9 +10632,9 @@ class serializer
     @copyright Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
     @sa http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
     */
-    static uint8_t decode(uint8_t& state, uint32_t& codep, const uint8_t byte) noexcept
-    {
-        static const std::array<uint8_t, 400> utf8d =
+  static uint8_t decode(uint8_t &state, uint32_t &codep, const uint8_t byte) noexcept
+  {
+    static const std::array<uint8_t, 400> utf8d =
         {
             {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 00..1F
@@ -11575,133 +10644,128 @@ class serializer
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, // 80..9F
                 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, // A0..BF
                 8, 8, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // C0..DF
-                0xA, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x4, 0x3, 0x3, // E0..EF
-                0xB, 0x6, 0x6, 0x6, 0x5, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, // F0..FF
-                0x0, 0x1, 0x2, 0x3, 0x5, 0x8, 0x7, 0x1, 0x1, 0x1, 0x4, 0x6, 0x1, 0x1, 0x1, 0x1, // s0..s0
+                0xA, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x4, 0x3, 0x3,                 // E0..EF
+                0xB, 0x6, 0x6, 0x6, 0x5, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8,                 // F0..FF
+                0x0, 0x1, 0x2, 0x3, 0x5, 0x8, 0x7, 0x1, 0x1, 0x1, 0x4, 0x6, 0x1, 0x1, 0x1, 0x1,                 // s0..s0
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, // s1..s2
                 1, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, // s3..s4
                 1, 2, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, // s5..s6
-                1, 3, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 // s7..s8
-            }
-        };
+                1, 3, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1  // s7..s8
+            }};
 
-        const uint8_t type = utf8d[byte];
+    const uint8_t type = utf8d[byte];
 
-        codep = (state != UTF8_ACCEPT)
+    codep = (state != UTF8_ACCEPT)
                 ? (byte & 0x3fu) | (codep << 6)
                 : static_cast<uint32_t>(0xff >> type) & (byte);
 
-        state = utf8d[256u + state * 16u + type];
-        return state;
-    }
+    state = utf8d[256u + state * 16u + type];
+    return state;
+  }
 
-  private:
-    /// the output of the serializer
-    output_adapter_t<char> o = nullptr;
+private:
+  /// the output of the serializer
+  output_adapter_t<char> o = nullptr;
 
-    /// a (hopefully) large enough character buffer
-    std::array<char, 64> number_buffer{{}};
+  /// a (hopefully) large enough character buffer
+  std::array<char, 64> number_buffer{{}};
 
-    /// the locale
-    const std::lconv* loc = nullptr;
-    /// the locale's thousand separator character
-    const char thousands_sep = '\0';
-    /// the locale's decimal point character
-    const char decimal_point = '\0';
+  /// the locale
+  const std::lconv *loc = nullptr;
+  /// the locale's thousand separator character
+  const char thousands_sep = '\0';
+  /// the locale's decimal point character
+  const char decimal_point = '\0';
 
-    /// string buffer
-    std::array<char, 512> string_buffer{{}};
+  /// string buffer
+  std::array<char, 512> string_buffer{{}};
 
-    /// the indentation character
-    const char indent_char;
-    /// the indentation string
-    string_t indent_string;
+  /// the indentation character
+  const char indent_char;
+  /// the indentation string
+  string_t indent_string;
 
-    /// error_handler how to react on decoding errors
-    const error_handler_t error_handler;
+  /// error_handler how to react on decoding errors
+  const error_handler_t error_handler;
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/json_ref.hpp>
-
 
 #include <initializer_list>
 #include <utility>
 
 // #include <nlohmann/detail/meta/type_traits.hpp>
 
+namespace nlohmann {
+namespace detail {
+template <typename BasicJsonType>
+class json_ref {
+public:
+  using value_type = BasicJsonType;
 
-namespace nlohmann
-{
-namespace detail
-{
-template<typename BasicJsonType>
-class json_ref
-{
-  public:
-    using value_type = BasicJsonType;
+  json_ref(value_type &&value)
+      : owned_value(std::move(value)), value_ref(&owned_value), is_rvalue(true)
+  {
+  }
 
-    json_ref(value_type&& value)
-        : owned_value(std::move(value)), value_ref(&owned_value), is_rvalue(true)
-    {}
+  json_ref(const value_type &value)
+      : value_ref(const_cast<value_type *>(&value)), is_rvalue(false)
+  {
+  }
 
-    json_ref(const value_type& value)
-        : value_ref(const_cast<value_type*>(&value)), is_rvalue(false)
-    {}
+  json_ref(std::initializer_list<json_ref> init)
+      : owned_value(init), value_ref(&owned_value), is_rvalue(true)
+  {
+  }
 
-    json_ref(std::initializer_list<json_ref> init)
-        : owned_value(init), value_ref(&owned_value), is_rvalue(true)
-    {}
+  template <
+      class... Args,
+      enable_if_t<std::is_constructible<value_type, Args...>::value, int> = 0>
+  json_ref(Args &&... args)
+      : owned_value(std::forward<Args>(args)...), value_ref(&owned_value),
+        is_rvalue(true) {}
 
-    template <
-        class... Args,
-        enable_if_t<std::is_constructible<value_type, Args...>::value, int> = 0 >
-    json_ref(Args && ... args)
-        : owned_value(std::forward<Args>(args)...), value_ref(&owned_value),
-          is_rvalue(true) {}
+  // class should be movable only
+  json_ref(json_ref &&)      = default;
+  json_ref(const json_ref &) = delete;
+  json_ref &operator=(const json_ref &) = delete;
+  json_ref &operator=(json_ref &&) = delete;
+  ~json_ref()                      = default;
 
-    // class should be movable only
-    json_ref(json_ref&&) = default;
-    json_ref(const json_ref&) = delete;
-    json_ref& operator=(const json_ref&) = delete;
-    json_ref& operator=(json_ref&&) = delete;
-    ~json_ref() = default;
-
-    value_type moved_or_copied() const
-    {
-        if (is_rvalue)
-        {
-            return std::move(*value_ref);
-        }
-        return *value_ref;
+  value_type moved_or_copied() const
+  {
+    if (is_rvalue) {
+      return std::move(*value_ref);
     }
+    return *value_ref;
+  }
 
-    value_type const& operator*() const
-    {
-        return *static_cast<value_type const*>(value_ref);
-    }
+  value_type const &operator*() const
+  {
+    return *static_cast<value_type const *>(value_ref);
+  }
 
-    value_type const* operator->() const
-    {
-        return static_cast<value_type const*>(value_ref);
-    }
+  value_type const *operator->() const
+  {
+    return static_cast<value_type const *>(value_ref);
+  }
 
-  private:
-    mutable value_type owned_value = nullptr;
-    value_type* value_ref = nullptr;
-    const bool is_rvalue;
+private:
+  mutable value_type owned_value = nullptr;
+  value_type *       value_ref   = nullptr;
+  const bool         is_rvalue;
 };
-}  // namespace detail
-}  // namespace nlohmann
+} // namespace detail
+} // namespace nlohmann
 
 // #include <nlohmann/detail/json_pointer.hpp>
 
-
 #include <cassert> // assert
 #include <numeric> // accumulate
-#include <string> // string
-#include <vector> // vector
+#include <string>  // string
+#include <vector>  // vector
 
 // #include <nlohmann/detail/macro_scope.hpp>
 
@@ -11709,18 +10773,15 @@ class json_ref
 
 // #include <nlohmann/detail/value_t.hpp>
 
+namespace nlohmann {
+template <typename BasicJsonType>
+class json_pointer {
+  // allow basic_json to access private members
+  NLOHMANN_BASIC_JSON_TPL_DECLARATION
+  friend class basic_json;
 
-namespace nlohmann
-{
-template<typename BasicJsonType>
-class json_pointer
-{
-    // allow basic_json to access private members
-    NLOHMANN_BASIC_JSON_TPL_DECLARATION
-    friend class basic_json;
-
-  public:
-    /*!
+public:
+  /*!
     @brief create JSON pointer
 
     Create a JSON pointer according to the syntax described in
@@ -11741,11 +10802,12 @@ class json_pointer
 
     @since version 2.0.0
     */
-    explicit json_pointer(const std::string& s = "")
-        : reference_tokens(split(s))
-    {}
+  explicit json_pointer(const std::string &s = "")
+      : reference_tokens(split(s))
+  {
+  }
 
-    /*!
+  /*!
     @brief return a string representation of the JSON pointer
 
     @invariant For each JSON pointer `ptr`, it holds:
@@ -11760,79 +10822,75 @@ class json_pointer
 
     @since version 2.0.0
     */
-    std::string to_string() const
-    {
-        return std::accumulate(reference_tokens.begin(), reference_tokens.end(),
-                               std::string{},
-                               [](const std::string & a, const std::string & b)
-        {
-            return a + "/" + escape(b);
-        });
-    }
+  std::string to_string() const
+  {
+    return std::accumulate(reference_tokens.begin(), reference_tokens.end(),
+                           std::string{},
+                           [](const std::string &a, const std::string &b) {
+                             return a + "/" + escape(b);
+                           });
+  }
 
-    /// @copydoc to_string()
-    operator std::string() const
-    {
-        return to_string();
-    }
+  /// @copydoc to_string()
+  operator std::string() const
+  {
+    return to_string();
+  }
 
-    /*!
+  /*!
     @param[in] s  reference token to be converted into an array index
 
     @return integer representation of @a s
 
     @throw out_of_range.404 if string @a s could not be converted to an integer
     */
-    static int array_index(const std::string& s)
-    {
-        std::size_t processed_chars = 0;
-        const int res = std::stoi(s, &processed_chars);
+  static int array_index(const std::string &s)
+  {
+    std::size_t processed_chars = 0;
+    const int   res             = std::stoi(s, &processed_chars);
 
-        // check if the string was completely read
-        if (JSON_UNLIKELY(processed_chars != s.size()))
-        {
-            JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + s + "'"));
-        }
-
-        return res;
+    // check if the string was completely read
+    if (JSON_UNLIKELY(processed_chars != s.size())) {
+      JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + s + "'"));
     }
 
-  private:
-    /*!
+    return res;
+  }
+
+private:
+  /*!
     @brief remove and return last reference pointer
     @throw out_of_range.405 if JSON pointer has no parent
     */
-    std::string pop_back()
-    {
-        if (JSON_UNLIKELY(is_root()))
-        {
-            JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
-        }
-
-        auto last = reference_tokens.back();
-        reference_tokens.pop_back();
-        return last;
+  std::string pop_back()
+  {
+    if (JSON_UNLIKELY(is_root())) {
+      JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
     }
 
-    /// return whether pointer points to the root document
-    bool is_root() const noexcept
-    {
-        return reference_tokens.empty();
+    auto last = reference_tokens.back();
+    reference_tokens.pop_back();
+    return last;
+  }
+
+  /// return whether pointer points to the root document
+  bool is_root() const noexcept
+  {
+    return reference_tokens.empty();
+  }
+
+  json_pointer top() const
+  {
+    if (JSON_UNLIKELY(is_root())) {
+      JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
     }
 
-    json_pointer top() const
-    {
-        if (JSON_UNLIKELY(is_root()))
-        {
-            JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent"));
-        }
+    json_pointer result     = *this;
+    result.reference_tokens = {reference_tokens[0]};
+    return result;
+  }
 
-        json_pointer result = *this;
-        result.reference_tokens = {reference_tokens[0]};
-        return result;
-    }
-
-    /*!
+  /*!
     @brief create and return a reference to the pointed to value
 
     @complexity Linear in the number of reference tokens.
@@ -11840,68 +10898,60 @@ class json_pointer
     @throw parse_error.109 if array index is not a number
     @throw type_error.313 if value cannot be unflattened
     */
-    BasicJsonType& get_and_create(BasicJsonType& j) const
-    {
-        using size_type = typename BasicJsonType::size_type;
-        auto result = &j;
+  BasicJsonType &get_and_create(BasicJsonType &j) const
+  {
+    using size_type = typename BasicJsonType::size_type;
+    auto result     = &j;
 
-        // in case no reference tokens exist, return a reference to the JSON value
-        // j which will be overwritten by a primitive value
-        for (const auto& reference_token : reference_tokens)
+    // in case no reference tokens exist, return a reference to the JSON value
+    // j which will be overwritten by a primitive value
+    for (const auto &reference_token : reference_tokens) {
+      switch (result->m_type) {
+      case detail::value_t::null: {
+        if (reference_token == "0") {
+          // start a new array if reference token is 0
+          result = &result->operator[](0);
+        } else {
+          // start a new object otherwise
+          result = &result->operator[](reference_token);
+        }
+        break;
+      }
+
+      case detail::value_t::object: {
+        // create an entry in the object
+        result = &result->operator[](reference_token);
+        break;
+      }
+
+      case detail::value_t::array: {
+        // create an entry in the array
+        JSON_TRY
         {
-            switch (result->m_type)
-            {
-                case detail::value_t::null:
-                {
-                    if (reference_token == "0")
-                    {
-                        // start a new array if reference token is 0
-                        result = &result->operator[](0);
-                    }
-                    else
-                    {
-                        // start a new object otherwise
-                        result = &result->operator[](reference_token);
-                    }
-                    break;
-                }
+          result = &result->operator[](static_cast<size_type>(array_index(reference_token)));
+        }
+        JSON_CATCH(std::invalid_argument &)
+        {
+          JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
+        }
+        break;
+      }
 
-                case detail::value_t::object:
-                {
-                    // create an entry in the object
-                    result = &result->operator[](reference_token);
-                    break;
-                }
-
-                case detail::value_t::array:
-                {
-                    // create an entry in the array
-                    JSON_TRY
-                    {
-                        result = &result->operator[](static_cast<size_type>(array_index(reference_token)));
-                    }
-                    JSON_CATCH(std::invalid_argument&)
-                    {
-                        JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                    }
-                    break;
-                }
-
-                /*
+      /*
                 The following code is only reached if there exists a reference
                 token _and_ the current value is primitive. In this case, we have
                 an error situation, because primitive values may only occur as
                 single value; that is, with an empty list of reference tokens.
                 */
-                default:
-                    JSON_THROW(detail::type_error::create(313, "invalid value to unflatten"));
-            }
-        }
-
-        return *result;
+      default:
+        JSON_THROW(detail::type_error::create(313, "invalid value to unflatten"));
+      }
     }
 
-    /*!
+    return *result;
+  }
+
+  /*!
     @brief return a reference to the pointed to value
 
     @note This version does not throw if a value is not present, but tries to
@@ -11920,135 +10970,119 @@ class json_pointer
     @throw parse_error.109   if an array index was not a number
     @throw out_of_range.404  if the JSON pointer can not be resolved
     */
-    BasicJsonType& get_unchecked(BasicJsonType* ptr) const
-    {
-        using size_type = typename BasicJsonType::size_type;
-        for (const auto& reference_token : reference_tokens)
-        {
-            // convert null values to arrays or objects before continuing
-            if (ptr->m_type == detail::value_t::null)
-            {
-                // check if reference token is a number
-                const bool nums =
-                    std::all_of(reference_token.begin(), reference_token.end(),
-                                [](const char x)
-                {
-                    return (x >= '0' and x <= '9');
-                });
+  BasicJsonType &get_unchecked(BasicJsonType *ptr) const
+  {
+    using size_type = typename BasicJsonType::size_type;
+    for (const auto &reference_token : reference_tokens) {
+      // convert null values to arrays or objects before continuing
+      if (ptr->m_type == detail::value_t::null) {
+        // check if reference token is a number
+        const bool nums =
+            std::all_of(reference_token.begin(), reference_token.end(),
+                        [](const char x) {
+                          return (x >= '0' and x <= '9');
+                        });
 
-                // change value to array for numbers or "-" or to object otherwise
-                *ptr = (nums or reference_token == "-")
-                       ? detail::value_t::array
-                       : detail::value_t::object;
-            }
+        // change value to array for numbers or "-" or to object otherwise
+        *ptr = (nums or reference_token == "-")
+                   ? detail::value_t::array
+                   : detail::value_t::object;
+      }
 
-            switch (ptr->m_type)
-            {
-                case detail::value_t::object:
-                {
-                    // use unchecked object access
-                    ptr = &ptr->operator[](reference_token);
-                    break;
-                }
+      switch (ptr->m_type) {
+      case detail::value_t::object: {
+        // use unchecked object access
+        ptr = &ptr->operator[](reference_token);
+        break;
+      }
 
-                case detail::value_t::array:
-                {
-                    // error condition (cf. RFC 6901, Sect. 4)
-                    if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0'))
-                    {
-                        JSON_THROW(detail::parse_error::create(106, 0,
-                                                               "array index '" + reference_token +
-                                                               "' must not begin with '0'"));
-                    }
-
-                    if (reference_token == "-")
-                    {
-                        // explicitly treat "-" as index beyond the end
-                        ptr = &ptr->operator[](ptr->m_value.array->size());
-                    }
-                    else
-                    {
-                        // convert array index to number; unchecked access
-                        JSON_TRY
-                        {
-                            ptr = &ptr->operator[](
-                                static_cast<size_type>(array_index(reference_token)));
-                        }
-                        JSON_CATCH(std::invalid_argument&)
-                        {
-                            JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                        }
-                    }
-                    break;
-                }
-
-                default:
-                    JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-            }
+      case detail::value_t::array: {
+        // error condition (cf. RFC 6901, Sect. 4)
+        if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0')) {
+          JSON_THROW(detail::parse_error::create(106, 0,
+                                                 "array index '" + reference_token +
+                                                     "' must not begin with '0'"));
         }
 
-        return *ptr;
+        if (reference_token == "-") {
+          // explicitly treat "-" as index beyond the end
+          ptr = &ptr->operator[](ptr->m_value.array->size());
+        } else {
+          // convert array index to number; unchecked access
+          JSON_TRY
+          {
+            ptr = &ptr->operator[](
+                static_cast<size_type>(array_index(reference_token)));
+          }
+          JSON_CATCH(std::invalid_argument &)
+          {
+            JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
+          }
+        }
+        break;
+      }
+
+      default:
+        JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
+      }
     }
 
-    /*!
+    return *ptr;
+  }
+
+  /*!
     @throw parse_error.106   if an array index begins with '0'
     @throw parse_error.109   if an array index was not a number
     @throw out_of_range.402  if the array index '-' is used
     @throw out_of_range.404  if the JSON pointer can not be resolved
     */
-    BasicJsonType& get_checked(BasicJsonType* ptr) const
-    {
-        using size_type = typename BasicJsonType::size_type;
-        for (const auto& reference_token : reference_tokens)
-        {
-            switch (ptr->m_type)
-            {
-                case detail::value_t::object:
-                {
-                    // note: at performs range check
-                    ptr = &ptr->at(reference_token);
-                    break;
-                }
+  BasicJsonType &get_checked(BasicJsonType *ptr) const
+  {
+    using size_type = typename BasicJsonType::size_type;
+    for (const auto &reference_token : reference_tokens) {
+      switch (ptr->m_type) {
+      case detail::value_t::object: {
+        // note: at performs range check
+        ptr = &ptr->at(reference_token);
+        break;
+      }
 
-                case detail::value_t::array:
-                {
-                    if (JSON_UNLIKELY(reference_token == "-"))
-                    {
-                        // "-" always fails the range check
-                        JSON_THROW(detail::out_of_range::create(402,
-                                                                "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
-                                                                ") is out of range"));
-                    }
-
-                    // error condition (cf. RFC 6901, Sect. 4)
-                    if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0'))
-                    {
-                        JSON_THROW(detail::parse_error::create(106, 0,
-                                                               "array index '" + reference_token +
-                                                               "' must not begin with '0'"));
-                    }
-
-                    // note: at performs range check
-                    JSON_TRY
-                    {
-                        ptr = &ptr->at(static_cast<size_type>(array_index(reference_token)));
-                    }
-                    JSON_CATCH(std::invalid_argument&)
-                    {
-                        JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                    }
-                    break;
-                }
-
-                default:
-                    JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-            }
+      case detail::value_t::array: {
+        if (JSON_UNLIKELY(reference_token == "-")) {
+          // "-" always fails the range check
+          JSON_THROW(detail::out_of_range::create(402,
+                                                  "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
+                                                      ") is out of range"));
         }
 
-        return *ptr;
+        // error condition (cf. RFC 6901, Sect. 4)
+        if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0')) {
+          JSON_THROW(detail::parse_error::create(106, 0,
+                                                 "array index '" + reference_token +
+                                                     "' must not begin with '0'"));
+        }
+
+        // note: at performs range check
+        JSON_TRY
+        {
+          ptr = &ptr->at(static_cast<size_type>(array_index(reference_token)));
+        }
+        JSON_CATCH(std::invalid_argument &)
+        {
+          JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
+        }
+        break;
+      }
+
+      default:
+        JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
+      }
     }
 
-    /*!
+    return *ptr;
+  }
+
+  /*!
     @brief return a const reference to the pointed to value
 
     @param[in] ptr  a JSON value
@@ -12061,118 +11095,106 @@ class json_pointer
     @throw out_of_range.402  if the array index '-' is used
     @throw out_of_range.404  if the JSON pointer can not be resolved
     */
-    const BasicJsonType& get_unchecked(const BasicJsonType* ptr) const
-    {
-        using size_type = typename BasicJsonType::size_type;
-        for (const auto& reference_token : reference_tokens)
-        {
-            switch (ptr->m_type)
-            {
-                case detail::value_t::object:
-                {
-                    // use unchecked object access
-                    ptr = &ptr->operator[](reference_token);
-                    break;
-                }
+  const BasicJsonType &get_unchecked(const BasicJsonType *ptr) const
+  {
+    using size_type = typename BasicJsonType::size_type;
+    for (const auto &reference_token : reference_tokens) {
+      switch (ptr->m_type) {
+      case detail::value_t::object: {
+        // use unchecked object access
+        ptr = &ptr->operator[](reference_token);
+        break;
+      }
 
-                case detail::value_t::array:
-                {
-                    if (JSON_UNLIKELY(reference_token == "-"))
-                    {
-                        // "-" cannot be used for const access
-                        JSON_THROW(detail::out_of_range::create(402,
-                                                                "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
-                                                                ") is out of range"));
-                    }
-
-                    // error condition (cf. RFC 6901, Sect. 4)
-                    if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0'))
-                    {
-                        JSON_THROW(detail::parse_error::create(106, 0,
-                                                               "array index '" + reference_token +
-                                                               "' must not begin with '0'"));
-                    }
-
-                    // use unchecked array access
-                    JSON_TRY
-                    {
-                        ptr = &ptr->operator[](
-                            static_cast<size_type>(array_index(reference_token)));
-                    }
-                    JSON_CATCH(std::invalid_argument&)
-                    {
-                        JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                    }
-                    break;
-                }
-
-                default:
-                    JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-            }
+      case detail::value_t::array: {
+        if (JSON_UNLIKELY(reference_token == "-")) {
+          // "-" cannot be used for const access
+          JSON_THROW(detail::out_of_range::create(402,
+                                                  "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
+                                                      ") is out of range"));
         }
 
-        return *ptr;
+        // error condition (cf. RFC 6901, Sect. 4)
+        if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0')) {
+          JSON_THROW(detail::parse_error::create(106, 0,
+                                                 "array index '" + reference_token +
+                                                     "' must not begin with '0'"));
+        }
+
+        // use unchecked array access
+        JSON_TRY
+        {
+          ptr = &ptr->operator[](
+              static_cast<size_type>(array_index(reference_token)));
+        }
+        JSON_CATCH(std::invalid_argument &)
+        {
+          JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
+        }
+        break;
+      }
+
+      default:
+        JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
+      }
     }
 
-    /*!
+    return *ptr;
+  }
+
+  /*!
     @throw parse_error.106   if an array index begins with '0'
     @throw parse_error.109   if an array index was not a number
     @throw out_of_range.402  if the array index '-' is used
     @throw out_of_range.404  if the JSON pointer can not be resolved
     */
-    const BasicJsonType& get_checked(const BasicJsonType* ptr) const
-    {
-        using size_type = typename BasicJsonType::size_type;
-        for (const auto& reference_token : reference_tokens)
-        {
-            switch (ptr->m_type)
-            {
-                case detail::value_t::object:
-                {
-                    // note: at performs range check
-                    ptr = &ptr->at(reference_token);
-                    break;
-                }
+  const BasicJsonType &get_checked(const BasicJsonType *ptr) const
+  {
+    using size_type = typename BasicJsonType::size_type;
+    for (const auto &reference_token : reference_tokens) {
+      switch (ptr->m_type) {
+      case detail::value_t::object: {
+        // note: at performs range check
+        ptr = &ptr->at(reference_token);
+        break;
+      }
 
-                case detail::value_t::array:
-                {
-                    if (JSON_UNLIKELY(reference_token == "-"))
-                    {
-                        // "-" always fails the range check
-                        JSON_THROW(detail::out_of_range::create(402,
-                                                                "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
-                                                                ") is out of range"));
-                    }
-
-                    // error condition (cf. RFC 6901, Sect. 4)
-                    if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0'))
-                    {
-                        JSON_THROW(detail::parse_error::create(106, 0,
-                                                               "array index '" + reference_token +
-                                                               "' must not begin with '0'"));
-                    }
-
-                    // note: at performs range check
-                    JSON_TRY
-                    {
-                        ptr = &ptr->at(static_cast<size_type>(array_index(reference_token)));
-                    }
-                    JSON_CATCH(std::invalid_argument&)
-                    {
-                        JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
-                    }
-                    break;
-                }
-
-                default:
-                    JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
-            }
+      case detail::value_t::array: {
+        if (JSON_UNLIKELY(reference_token == "-")) {
+          // "-" always fails the range check
+          JSON_THROW(detail::out_of_range::create(402,
+                                                  "array index '-' (" + std::to_string(ptr->m_value.array->size()) +
+                                                      ") is out of range"));
         }
 
-        return *ptr;
+        // error condition (cf. RFC 6901, Sect. 4)
+        if (JSON_UNLIKELY(reference_token.size() > 1 and reference_token[0] == '0')) {
+          JSON_THROW(detail::parse_error::create(106, 0,
+                                                 "array index '" + reference_token +
+                                                     "' must not begin with '0'"));
+        }
+
+        // note: at performs range check
+        JSON_TRY
+        {
+          ptr = &ptr->at(static_cast<size_type>(array_index(reference_token)));
+        }
+        JSON_CATCH(std::invalid_argument &)
+        {
+          JSON_THROW(detail::parse_error::create(109, 0, "array index '" + reference_token + "' is not a number"));
+        }
+        break;
+      }
+
+      default:
+        JSON_THROW(detail::out_of_range::create(404, "unresolved reference token '" + reference_token + "'"));
+      }
     }
 
-    /*!
+    return *ptr;
+  }
+
+  /*!
     @brief split the string input to reference tokens
 
     @note This function is only called by the json_pointer constructor.
@@ -12181,69 +11203,64 @@ class json_pointer
     @throw parse_error.107  if the pointer is not empty or begins with '/'
     @throw parse_error.108  if character '~' is not followed by '0' or '1'
     */
-    static std::vector<std::string> split(const std::string& reference_string)
-    {
-        std::vector<std::string> result;
+  static std::vector<std::string> split(const std::string &reference_string)
+  {
+    std::vector<std::string> result;
 
-        // special case: empty reference string -> no reference tokens
-        if (reference_string.empty())
-        {
-            return result;
-        }
-
-        // check if nonempty reference string begins with slash
-        if (JSON_UNLIKELY(reference_string[0] != '/'))
-        {
-            JSON_THROW(detail::parse_error::create(107, 1,
-                                                   "JSON pointer must be empty or begin with '/' - was: '" +
-                                                   reference_string + "'"));
-        }
-
-        // extract the reference tokens:
-        // - slash: position of the last read slash (or end of string)
-        // - start: position after the previous slash
-        for (
-            // search for the first slash after the first character
-            std::size_t slash = reference_string.find_first_of('/', 1),
-            // set the beginning of the first reference token
-            start = 1;
-            // we can stop if start == 0 (if slash == std::string::npos)
-            start != 0;
-            // set the beginning of the next reference token
-            // (will eventually be 0 if slash == std::string::npos)
-            start = (slash == std::string::npos) ? 0 : slash + 1,
-            // find next slash
-            slash = reference_string.find_first_of('/', start))
-        {
-            // use the text between the beginning of the reference token
-            // (start) and the last slash (slash).
-            auto reference_token = reference_string.substr(start, slash - start);
-
-            // check reference tokens are properly escaped
-            for (std::size_t pos = reference_token.find_first_of('~');
-                    pos != std::string::npos;
-                    pos = reference_token.find_first_of('~', pos + 1))
-            {
-                assert(reference_token[pos] == '~');
-
-                // ~ must be followed by 0 or 1
-                if (JSON_UNLIKELY(pos == reference_token.size() - 1 or
-                                  (reference_token[pos + 1] != '0' and
-                                   reference_token[pos + 1] != '1')))
-                {
-                    JSON_THROW(detail::parse_error::create(108, 0, "escape character '~' must be followed with '0' or '1'"));
-                }
-            }
-
-            // finally, store the reference token
-            unescape(reference_token);
-            result.push_back(reference_token);
-        }
-
-        return result;
+    // special case: empty reference string -> no reference tokens
+    if (reference_string.empty()) {
+      return result;
     }
 
-    /*!
+    // check if nonempty reference string begins with slash
+    if (JSON_UNLIKELY(reference_string[0] != '/')) {
+      JSON_THROW(detail::parse_error::create(107, 1,
+                                             "JSON pointer must be empty or begin with '/' - was: '" +
+                                                 reference_string + "'"));
+    }
+
+    // extract the reference tokens:
+    // - slash: position of the last read slash (or end of string)
+    // - start: position after the previous slash
+    for (
+        // search for the first slash after the first character
+        std::size_t slash = reference_string.find_first_of('/', 1),
+                    // set the beginning of the first reference token
+        start = 1;
+        // we can stop if start == 0 (if slash == std::string::npos)
+        start != 0;
+        // set the beginning of the next reference token
+        // (will eventually be 0 if slash == std::string::npos)
+        start = (slash == std::string::npos) ? 0 : slash + 1,
+                    // find next slash
+        slash = reference_string.find_first_of('/', start)) {
+      // use the text between the beginning of the reference token
+      // (start) and the last slash (slash).
+      auto reference_token = reference_string.substr(start, slash - start);
+
+      // check reference tokens are properly escaped
+      for (std::size_t pos = reference_token.find_first_of('~');
+           pos != std::string::npos;
+           pos = reference_token.find_first_of('~', pos + 1)) {
+        assert(reference_token[pos] == '~');
+
+        // ~ must be followed by 0 or 1
+        if (JSON_UNLIKELY(pos == reference_token.size() - 1 or
+                          (reference_token[pos + 1] != '0' and
+                           reference_token[pos + 1] != '1'))) {
+          JSON_THROW(detail::parse_error::create(108, 0, "escape character '~' must be followed with '0' or '1'"));
+        }
+      }
+
+      // finally, store the reference token
+      unescape(reference_token);
+      result.push_back(reference_token);
+    }
+
+    return result;
+  }
+
+  /*!
     @brief replace all occurrences of a substring by another string
 
     @param[in,out] s  the string to manipulate; changed so that all
@@ -12256,92 +11273,81 @@ class json_pointer
 
     @since version 2.0.0
     */
-    static void replace_substring(std::string& s, const std::string& f,
-                                  const std::string& t)
+  static void replace_substring(std::string &s, const std::string &f,
+                                const std::string &t)
+  {
+    assert(not f.empty());
+    for (auto pos = s.find(f);            // find first occurrence of f
+         pos != std::string::npos;        // make sure f was found
+         s.replace(pos, f.size(), t),     // replace with t, and
+         pos = s.find(f, pos + t.size())) // find next occurrence of f
     {
-        assert(not f.empty());
-        for (auto pos = s.find(f);                // find first occurrence of f
-                pos != std::string::npos;         // make sure f was found
-                s.replace(pos, f.size(), t),      // replace with t, and
-                pos = s.find(f, pos + t.size()))  // find next occurrence of f
-        {}
     }
+  }
 
-    /// escape "~" to "~0" and "/" to "~1"
-    static std::string escape(std::string s)
-    {
-        replace_substring(s, "~", "~0");
-        replace_substring(s, "/", "~1");
-        return s;
-    }
+  /// escape "~" to "~0" and "/" to "~1"
+  static std::string escape(std::string s)
+  {
+    replace_substring(s, "~", "~0");
+    replace_substring(s, "/", "~1");
+    return s;
+  }
 
-    /// unescape "~1" to tilde and "~0" to slash (order is important!)
-    static void unescape(std::string& s)
-    {
-        replace_substring(s, "~1", "/");
-        replace_substring(s, "~0", "~");
-    }
+  /// unescape "~1" to tilde and "~0" to slash (order is important!)
+  static void unescape(std::string &s)
+  {
+    replace_substring(s, "~1", "/");
+    replace_substring(s, "~0", "~");
+  }
 
-    /*!
+  /*!
     @param[in] reference_string  the reference string to the current value
     @param[in] value             the value to consider
     @param[in,out] result        the result object to insert values to
 
     @note Empty objects or arrays are flattened to `null`.
     */
-    static void flatten(const std::string& reference_string,
-                        const BasicJsonType& value,
-                        BasicJsonType& result)
-    {
-        switch (value.m_type)
-        {
-            case detail::value_t::array:
-            {
-                if (value.m_value.array->empty())
-                {
-                    // flatten empty array as null
-                    result[reference_string] = nullptr;
-                }
-                else
-                {
-                    // iterate array and use index as reference string
-                    for (std::size_t i = 0; i < value.m_value.array->size(); ++i)
-                    {
-                        flatten(reference_string + "/" + std::to_string(i),
-                                value.m_value.array->operator[](i), result);
-                    }
-                }
-                break;
-            }
-
-            case detail::value_t::object:
-            {
-                if (value.m_value.object->empty())
-                {
-                    // flatten empty object as null
-                    result[reference_string] = nullptr;
-                }
-                else
-                {
-                    // iterate object and use keys as reference string
-                    for (const auto& element : *value.m_value.object)
-                    {
-                        flatten(reference_string + "/" + escape(element.first), element.second, result);
-                    }
-                }
-                break;
-            }
-
-            default:
-            {
-                // add primitive value with its reference string
-                result[reference_string] = value;
-                break;
-            }
+  static void flatten(const std::string &  reference_string,
+                      const BasicJsonType &value,
+                      BasicJsonType &      result)
+  {
+    switch (value.m_type) {
+    case detail::value_t::array: {
+      if (value.m_value.array->empty()) {
+        // flatten empty array as null
+        result[reference_string] = nullptr;
+      } else {
+        // iterate array and use index as reference string
+        for (std::size_t i = 0; i < value.m_value.array->size(); ++i) {
+          flatten(reference_string + "/" + std::to_string(i),
+                  value.m_value.array->operator[](i), result);
         }
+      }
+      break;
     }
 
-    /*!
+    case detail::value_t::object: {
+      if (value.m_value.object->empty()) {
+        // flatten empty object as null
+        result[reference_string] = nullptr;
+      } else {
+        // iterate object and use keys as reference string
+        for (const auto &element : *value.m_value.object) {
+          flatten(reference_string + "/" + escape(element.first), element.second, result);
+        }
+      }
+      break;
+    }
+
+    default: {
+      // add primitive value with its reference string
+      result[reference_string] = value;
+      break;
+    }
+    }
+  }
+
+  /*!
     @param[in] value  flattened JSON
 
     @return unflattened JSON
@@ -12351,53 +11357,49 @@ class json_pointer
     @throw type_error.315  if object values are not primitive
     @throw type_error.313  if value cannot be unflattened
     */
-    static BasicJsonType
-    unflatten(const BasicJsonType& value)
-    {
-        if (JSON_UNLIKELY(not value.is_object()))
-        {
-            JSON_THROW(detail::type_error::create(314, "only objects can be unflattened"));
-        }
-
-        BasicJsonType result;
-
-        // iterate the JSON object values
-        for (const auto& element : *value.m_value.object)
-        {
-            if (JSON_UNLIKELY(not element.second.is_primitive()))
-            {
-                JSON_THROW(detail::type_error::create(315, "values in object must be primitive"));
-            }
-
-            // assign value to reference pointed to by JSON pointer; Note that if
-            // the JSON pointer is "" (i.e., points to the whole value), function
-            // get_and_create returns a reference to result itself. An assignment
-            // will then create a primitive value.
-            json_pointer(element.first).get_and_create(result) = element.second;
-        }
-
-        return result;
+  static BasicJsonType
+  unflatten(const BasicJsonType &value)
+  {
+    if (JSON_UNLIKELY(not value.is_object())) {
+      JSON_THROW(detail::type_error::create(314, "only objects can be unflattened"));
     }
 
-    friend bool operator==(json_pointer const& lhs,
-                           json_pointer const& rhs) noexcept
-    {
-        return (lhs.reference_tokens == rhs.reference_tokens);
+    BasicJsonType result;
+
+    // iterate the JSON object values
+    for (const auto &element : *value.m_value.object) {
+      if (JSON_UNLIKELY(not element.second.is_primitive())) {
+        JSON_THROW(detail::type_error::create(315, "values in object must be primitive"));
+      }
+
+      // assign value to reference pointed to by JSON pointer; Note that if
+      // the JSON pointer is "" (i.e., points to the whole value), function
+      // get_and_create returns a reference to result itself. An assignment
+      // will then create a primitive value.
+      json_pointer(element.first).get_and_create(result) = element.second;
     }
 
-    friend bool operator!=(json_pointer const& lhs,
-                           json_pointer const& rhs) noexcept
-    {
-        return not (lhs == rhs);
-    }
+    return result;
+  }
 
-    /// the reference tokens
-    std::vector<std::string> reference_tokens;
+  friend bool operator==(json_pointer const &lhs,
+                         json_pointer const &rhs) noexcept
+  {
+    return (lhs.reference_tokens == rhs.reference_tokens);
+  }
+
+  friend bool operator!=(json_pointer const &lhs,
+                         json_pointer const &rhs) noexcept
+  {
+    return not(lhs == rhs);
+  }
+
+  /// the reference tokens
+  std::vector<std::string> reference_tokens;
 };
-}  // namespace nlohmann
+} // namespace nlohmann
 
 // #include <nlohmann/adl_serializer.hpp>
-
 
 #include <utility>
 
@@ -12405,14 +11407,11 @@ class json_pointer
 
 // #include <nlohmann/detail/conversions/to_json.hpp>
 
+namespace nlohmann {
 
-namespace nlohmann
-{
-
-template<typename, typename>
-struct adl_serializer
-{
-    /*!
+template <typename, typename>
+struct adl_serializer {
+  /*!
     @brief convert a JSON value to any value type
 
     This function is usually called by the `get()` function of the
@@ -12421,15 +11420,15 @@ struct adl_serializer
     @param[in] j        JSON value to read from
     @param[in,out] val  value to write to
     */
-    template<typename BasicJsonType, typename ValueType>
-    static auto from_json(BasicJsonType&& j, ValueType& val) noexcept(
-        noexcept(::nlohmann::from_json(std::forward<BasicJsonType>(j), val)))
-    -> decltype(::nlohmann::from_json(std::forward<BasicJsonType>(j), val), void())
-    {
-        ::nlohmann::from_json(std::forward<BasicJsonType>(j), val);
-    }
+  template <typename BasicJsonType, typename ValueType>
+  static auto from_json(BasicJsonType &&j, ValueType &val) noexcept(
+      noexcept(::nlohmann::from_json(std::forward<BasicJsonType>(j), val)))
+      -> decltype(::nlohmann::from_json(std::forward<BasicJsonType>(j), val), void())
+  {
+    ::nlohmann::from_json(std::forward<BasicJsonType>(j), val);
+  }
 
-    /*!
+  /*!
     @brief convert any value type to a JSON value
 
     This function is usually called by the constructors of the @ref basic_json
@@ -12438,25 +11437,23 @@ struct adl_serializer
     @param[in,out] j  JSON value to write to
     @param[in] val    value to read from
     */
-    template <typename BasicJsonType, typename ValueType>
-    static auto to_json(BasicJsonType& j, ValueType&& val) noexcept(
-        noexcept(::nlohmann::to_json(j, std::forward<ValueType>(val))))
-    -> decltype(::nlohmann::to_json(j, std::forward<ValueType>(val)), void())
-    {
-        ::nlohmann::to_json(j, std::forward<ValueType>(val));
-    }
+  template <typename BasicJsonType, typename ValueType>
+  static auto to_json(BasicJsonType &j, ValueType &&val) noexcept(
+      noexcept(::nlohmann::to_json(j, std::forward<ValueType>(val))))
+      -> decltype(::nlohmann::to_json(j, std::forward<ValueType>(val)), void())
+  {
+    ::nlohmann::to_json(j, std::forward<ValueType>(val));
+  }
 };
 
-}  // namespace nlohmann
-
+} // namespace nlohmann
 
 /*!
 @brief namespace for Niels Lohmann
 @see https://github.com/nlohmann
 @since version 1.0.0
 */
-namespace nlohmann
-{
+namespace nlohmann {
 
 /*!
 @brief a class to store JSON values
@@ -12540,138 +11537,138 @@ Format](http://rfc7159.net/rfc7159)
 @nosubgrouping
 */
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
-class basic_json
-{
-  private:
-    template<detail::value_t> friend struct detail::external_constructor;
-    friend ::nlohmann::json_pointer<basic_json>;
-    friend ::nlohmann::detail::parser<basic_json>;
-    friend ::nlohmann::detail::serializer<basic_json>;
-    template<typename BasicJsonType>
-    friend class ::nlohmann::detail::iter_impl;
-    template<typename BasicJsonType, typename CharType>
-    friend class ::nlohmann::detail::binary_writer;
-    template<typename BasicJsonType, typename SAX>
-    friend class ::nlohmann::detail::binary_reader;
-    template<typename BasicJsonType>
-    friend class ::nlohmann::detail::json_sax_dom_parser;
-    template<typename BasicJsonType>
-    friend class ::nlohmann::detail::json_sax_dom_callback_parser;
+class basic_json {
+private:
+  template <detail::value_t>
+  friend struct detail::external_constructor;
+  friend ::nlohmann::json_pointer<basic_json>;
+  friend ::nlohmann::detail::parser<basic_json>;
+  friend ::nlohmann::detail::serializer<basic_json>;
+  template <typename BasicJsonType>
+  friend class ::nlohmann::detail::iter_impl;
+  template <typename BasicJsonType, typename CharType>
+  friend class ::nlohmann::detail::binary_writer;
+  template <typename BasicJsonType, typename SAX>
+  friend class ::nlohmann::detail::binary_reader;
+  template <typename BasicJsonType>
+  friend class ::nlohmann::detail::json_sax_dom_parser;
+  template <typename BasicJsonType>
+  friend class ::nlohmann::detail::json_sax_dom_callback_parser;
 
-    /// workaround type for MSVC
-    using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
+  /// workaround type for MSVC
+  using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
 
-    // convenience aliases for types residing in namespace detail;
-    using lexer = ::nlohmann::detail::lexer<basic_json>;
-    using parser = ::nlohmann::detail::parser<basic_json>;
+  // convenience aliases for types residing in namespace detail;
+  using lexer  = ::nlohmann::detail::lexer<basic_json>;
+  using parser = ::nlohmann::detail::parser<basic_json>;
 
-    using primitive_iterator_t = ::nlohmann::detail::primitive_iterator_t;
-    template<typename BasicJsonType>
-    using internal_iterator = ::nlohmann::detail::internal_iterator<BasicJsonType>;
-    template<typename BasicJsonType>
-    using iter_impl = ::nlohmann::detail::iter_impl<BasicJsonType>;
-    template<typename Iterator>
-    using iteration_proxy = ::nlohmann::detail::iteration_proxy<Iterator>;
-    template<typename Base> using json_reverse_iterator = ::nlohmann::detail::json_reverse_iterator<Base>;
+  using primitive_iterator_t = ::nlohmann::detail::primitive_iterator_t;
+  template <typename BasicJsonType>
+  using internal_iterator = ::nlohmann::detail::internal_iterator<BasicJsonType>;
+  template <typename BasicJsonType>
+  using iter_impl = ::nlohmann::detail::iter_impl<BasicJsonType>;
+  template <typename Iterator>
+  using iteration_proxy = ::nlohmann::detail::iteration_proxy<Iterator>;
+  template <typename Base>
+  using json_reverse_iterator = ::nlohmann::detail::json_reverse_iterator<Base>;
 
-    template<typename CharType>
-    using output_adapter_t = ::nlohmann::detail::output_adapter_t<CharType>;
+  template <typename CharType>
+  using output_adapter_t = ::nlohmann::detail::output_adapter_t<CharType>;
 
-    using binary_reader = ::nlohmann::detail::binary_reader<basic_json>;
-    template<typename CharType> using binary_writer = ::nlohmann::detail::binary_writer<basic_json, CharType>;
+  using binary_reader = ::nlohmann::detail::binary_reader<basic_json>;
+  template <typename CharType>
+  using binary_writer = ::nlohmann::detail::binary_writer<basic_json, CharType>;
 
-    using serializer = ::nlohmann::detail::serializer<basic_json>;
+  using serializer = ::nlohmann::detail::serializer<basic_json>;
 
-  public:
-    using value_t = detail::value_t;
-    /// JSON Pointer, see @ref nlohmann::json_pointer
-    using json_pointer = ::nlohmann::json_pointer<basic_json>;
-    template<typename T, typename SFINAE>
-    using json_serializer = JSONSerializer<T, SFINAE>;
-    /// how to treat decoding errors
-    using error_handler_t = detail::error_handler_t;
-    /// helper type for initializer lists of basic_json values
-    using initializer_list_t = std::initializer_list<detail::json_ref<basic_json>>;
+public:
+  using value_t = detail::value_t;
+  /// JSON Pointer, see @ref nlohmann::json_pointer
+  using json_pointer = ::nlohmann::json_pointer<basic_json>;
+  template <typename T, typename SFINAE>
+  using json_serializer = JSONSerializer<T, SFINAE>;
+  /// how to treat decoding errors
+  using error_handler_t = detail::error_handler_t;
+  /// helper type for initializer lists of basic_json values
+  using initializer_list_t = std::initializer_list<detail::json_ref<basic_json>>;
 
-    using input_format_t = detail::input_format_t;
-    /// SAX interface type, see @ref nlohmann::json_sax
-    using json_sax_t = json_sax<basic_json>;
+  using input_format_t = detail::input_format_t;
+  /// SAX interface type, see @ref nlohmann::json_sax
+  using json_sax_t = json_sax<basic_json>;
 
-    ////////////////
-    // exceptions //
-    ////////////////
+  ////////////////
+  // exceptions //
+  ////////////////
 
-    /// @name exceptions
-    /// Classes to implement user-defined exceptions.
-    /// @{
+  /// @name exceptions
+  /// Classes to implement user-defined exceptions.
+  /// @{
 
-    /// @copydoc detail::exception
-    using exception = detail::exception;
-    /// @copydoc detail::parse_error
-    using parse_error = detail::parse_error;
-    /// @copydoc detail::invalid_iterator
-    using invalid_iterator = detail::invalid_iterator;
-    /// @copydoc detail::type_error
-    using type_error = detail::type_error;
-    /// @copydoc detail::out_of_range
-    using out_of_range = detail::out_of_range;
-    /// @copydoc detail::other_error
-    using other_error = detail::other_error;
+  /// @copydoc detail::exception
+  using exception = detail::exception;
+  /// @copydoc detail::parse_error
+  using parse_error = detail::parse_error;
+  /// @copydoc detail::invalid_iterator
+  using invalid_iterator = detail::invalid_iterator;
+  /// @copydoc detail::type_error
+  using type_error = detail::type_error;
+  /// @copydoc detail::out_of_range
+  using out_of_range = detail::out_of_range;
+  /// @copydoc detail::other_error
+  using other_error = detail::other_error;
 
-    /// @}
+  /// @}
 
+  /////////////////////
+  // container types //
+  /////////////////////
 
-    /////////////////////
-    // container types //
-    /////////////////////
+  /// @name container types
+  /// The canonic container types to use @ref basic_json like any other STL
+  /// container.
+  /// @{
 
-    /// @name container types
-    /// The canonic container types to use @ref basic_json like any other STL
-    /// container.
-    /// @{
+  /// the type of elements in a basic_json container
+  using value_type = basic_json;
 
-    /// the type of elements in a basic_json container
-    using value_type = basic_json;
+  /// the type of an element reference
+  using reference = value_type &;
+  /// the type of an element const reference
+  using const_reference = const value_type &;
 
-    /// the type of an element reference
-    using reference = value_type&;
-    /// the type of an element const reference
-    using const_reference = const value_type&;
+  /// a type to represent differences between iterators
+  using difference_type = std::ptrdiff_t;
+  /// a type to represent container sizes
+  using size_type = std::size_t;
 
-    /// a type to represent differences between iterators
-    using difference_type = std::ptrdiff_t;
-    /// a type to represent container sizes
-    using size_type = std::size_t;
+  /// the allocator type
+  using allocator_type = AllocatorType<basic_json>;
 
-    /// the allocator type
-    using allocator_type = AllocatorType<basic_json>;
+  /// the type of an element pointer
+  using pointer = typename std::allocator_traits<allocator_type>::pointer;
+  /// the type of an element const pointer
+  using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
 
-    /// the type of an element pointer
-    using pointer = typename std::allocator_traits<allocator_type>::pointer;
-    /// the type of an element const pointer
-    using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+  /// an iterator for a basic_json container
+  using iterator = iter_impl<basic_json>;
+  /// a const iterator for a basic_json container
+  using const_iterator = iter_impl<const basic_json>;
+  /// a reverse iterator for a basic_json container
+  using reverse_iterator = json_reverse_iterator<typename basic_json::iterator>;
+  /// a const reverse iterator for a basic_json container
+  using const_reverse_iterator = json_reverse_iterator<typename basic_json::const_iterator>;
 
-    /// an iterator for a basic_json container
-    using iterator = iter_impl<basic_json>;
-    /// a const iterator for a basic_json container
-    using const_iterator = iter_impl<const basic_json>;
-    /// a reverse iterator for a basic_json container
-    using reverse_iterator = json_reverse_iterator<typename basic_json::iterator>;
-    /// a const reverse iterator for a basic_json container
-    using const_reverse_iterator = json_reverse_iterator<typename basic_json::const_iterator>;
+  /// @}
 
-    /// @}
-
-
-    /*!
+  /*!
     @brief returns the allocator associated with the container
     */
-    static allocator_type get_allocator()
-    {
-        return allocator_type();
-    }
+  static allocator_type get_allocator()
+  {
+    return allocator_type();
+  }
 
-    /*!
+  /*!
     @brief returns version information on the library
 
     This function returns a JSON object with information about the library,
@@ -12697,80 +11694,79 @@ class basic_json
 
     @since 2.1.0
     */
-    static basic_json meta()
-    {
-        basic_json result;
+  static basic_json meta()
+  {
+    basic_json result;
 
-        result["copyright"] = "(C) 2013-2017 Niels Lohmann";
-        result["name"] = "JSON for Modern C++";
-        result["url"] = "https://github.com/nlohmann/json";
-        result["version"]["string"] =
-            std::to_string(NLOHMANN_JSON_VERSION_MAJOR) + "." +
-            std::to_string(NLOHMANN_JSON_VERSION_MINOR) + "." +
-            std::to_string(NLOHMANN_JSON_VERSION_PATCH);
-        result["version"]["major"] = NLOHMANN_JSON_VERSION_MAJOR;
-        result["version"]["minor"] = NLOHMANN_JSON_VERSION_MINOR;
-        result["version"]["patch"] = NLOHMANN_JSON_VERSION_PATCH;
+    result["copyright"] = "(C) 2013-2017 Niels Lohmann";
+    result["name"]      = "JSON for Modern C++";
+    result["url"]       = "https://github.com/nlohmann/json";
+    result["version"]["string"] =
+        std::to_string(NLOHMANN_JSON_VERSION_MAJOR) + "." +
+        std::to_string(NLOHMANN_JSON_VERSION_MINOR) + "." +
+        std::to_string(NLOHMANN_JSON_VERSION_PATCH);
+    result["version"]["major"] = NLOHMANN_JSON_VERSION_MAJOR;
+    result["version"]["minor"] = NLOHMANN_JSON_VERSION_MINOR;
+    result["version"]["patch"] = NLOHMANN_JSON_VERSION_PATCH;
 
 #ifdef _WIN32
-        result["platform"] = "win32";
+    result["platform"] = "win32";
 #elif defined __linux__
-        result["platform"] = "linux";
+    result["platform"]        = "linux";
 #elif defined __APPLE__
-        result["platform"] = "apple";
+    result["platform"] = "apple";
 #elif defined __unix__
-        result["platform"] = "unix";
+    result["platform"] = "unix";
 #else
-        result["platform"] = "unknown";
+    result["platform"] = "unknown";
 #endif
 
 #if defined(__ICC) || defined(__INTEL_COMPILER)
-        result["compiler"] = {{"family", "icc"}, {"version", __INTEL_COMPILER}};
+    result["compiler"] = {{"family", "icc"}, {"version", __INTEL_COMPILER}};
 #elif defined(__clang__)
-        result["compiler"] = {{"family", "clang"}, {"version", __clang_version__}};
+    result["compiler"]        = {{"family", "clang"}, {"version", __clang_version__}};
 #elif defined(__GNUC__) || defined(__GNUG__)
-        result["compiler"] = {{"family", "gcc"}, {"version", std::to_string(__GNUC__) + "." + std::to_string(__GNUC_MINOR__) + "." + std::to_string(__GNUC_PATCHLEVEL__)}};
+    result["compiler"] = {{"family", "gcc"}, {"version", std::to_string(__GNUC__) + "." + std::to_string(__GNUC_MINOR__) + "." + std::to_string(__GNUC_PATCHLEVEL__)}};
 #elif defined(__HP_cc) || defined(__HP_aCC)
-        result["compiler"] = "hp"
+    result["compiler"] = "hp"
 #elif defined(__IBMCPP__)
-        result["compiler"] = {{"family", "ilecpp"}, {"version", __IBMCPP__}};
+    result["compiler"] = {{"family", "ilecpp"}, {"version", __IBMCPP__}};
 #elif defined(_MSC_VER)
-        result["compiler"] = {{"family", "msvc"}, {"version", _MSC_VER}};
+    result["compiler"] = {{"family", "msvc"}, {"version", _MSC_VER}};
 #elif defined(__PGI)
-        result["compiler"] = {{"family", "pgcpp"}, {"version", __PGI}};
+    result["compiler"] = {{"family", "pgcpp"}, {"version", __PGI}};
 #elif defined(__SUNPRO_CC)
-        result["compiler"] = {{"family", "sunpro"}, {"version", __SUNPRO_CC}};
+    result["compiler"] = {{"family", "sunpro"}, {"version", __SUNPRO_CC}};
 #else
-        result["compiler"] = {{"family", "unknown"}, {"version", "unknown"}};
+    result["compiler"] = {{"family", "unknown"}, {"version", "unknown"}};
 #endif
 
 #ifdef __cplusplus
-        result["compiler"]["c++"] = std::to_string(__cplusplus);
+    result["compiler"]["c++"] = std::to_string(__cplusplus);
 #else
-        result["compiler"]["c++"] = "unknown";
+    result["compiler"]["c++"] = "unknown";
 #endif
-        return result;
-    }
+    return result;
+  }
 
+  ///////////////////////////
+  // JSON value data types //
+  ///////////////////////////
 
-    ///////////////////////////
-    // JSON value data types //
-    ///////////////////////////
-
-    /// @name JSON value data types
-    /// The data types to store a JSON value. These types are derived from
-    /// the template arguments passed to class @ref basic_json.
-    /// @{
+  /// @name JSON value data types
+  /// The data types to store a JSON value. These types are derived from
+  /// the template arguments passed to class @ref basic_json.
+  /// @{
 
 #if defined(JSON_HAS_CPP_14)
-    // Use transparent comparator if possible, combined with perfect forwarding
-    // on find() and count() calls prevents unnecessary string construction.
-    using object_comparator_t = std::less<>;
+  // Use transparent comparator if possible, combined with perfect forwarding
+  // on find() and count() calls prevents unnecessary string construction.
+  using object_comparator_t = std::less<>;
 #else
-    using object_comparator_t = std::less<StringType>;
+  using object_comparator_t = std::less<StringType>;
 #endif
 
-    /*!
+  /*!
     @brief a type for an object
 
     [RFC 7159](http://rfc7159.net/rfc7159) describes JSON objects as follows:
@@ -12853,13 +11849,13 @@ class basic_json
     7159](http://rfc7159.net/rfc7159), because any order implements the
     specified "unordered" nature of JSON objects.
     */
-    using object_t = ObjectType<StringType,
-          basic_json,
-          object_comparator_t,
-          AllocatorType<std::pair<const StringType,
-          basic_json>>>;
+  using object_t = ObjectType<StringType,
+                              basic_json,
+                              object_comparator_t,
+                              AllocatorType<std::pair<const StringType,
+                                                      basic_json>>>;
 
-    /*!
+  /*!
     @brief a type for an array
 
     [RFC 7159](http://rfc7159.net/rfc7159) describes JSON arrays as follows:
@@ -12903,9 +11899,9 @@ class basic_json
 
     @since version 1.0.0
     */
-    using array_t = ArrayType<basic_json, AllocatorType<basic_json>>;
+  using array_t = ArrayType<basic_json, AllocatorType<basic_json>>;
 
-    /*!
+  /*!
     @brief a type for a string
 
     [RFC 7159](http://rfc7159.net/rfc7159) describes JSON strings as follows:
@@ -12956,9 +11952,9 @@ class basic_json
 
     @since version 1.0.0
     */
-    using string_t = StringType;
+  using string_t = StringType;
 
-    /*!
+  /*!
     @brief a type for a boolean
 
     [RFC 7159](http://rfc7159.net/rfc7159) implicitly describes a boolean as a
@@ -12982,9 +11978,9 @@ class basic_json
 
     @since version 1.0.0
     */
-    using boolean_t = BooleanType;
+  using boolean_t = BooleanType;
 
-    /*!
+  /*!
     @brief a type for a number (integer)
 
     [RFC 7159](http://rfc7159.net/rfc7159) describes numbers as follows:
@@ -13054,9 +12050,9 @@ class basic_json
 
     @since version 1.0.0
     */
-    using number_integer_t = NumberIntegerType;
+  using number_integer_t = NumberIntegerType;
 
-    /*!
+  /*!
     @brief a type for a number (unsigned)
 
     [RFC 7159](http://rfc7159.net/rfc7159) describes numbers as follows:
@@ -13125,9 +12121,9 @@ class basic_json
 
     @since version 2.0.0
     */
-    using number_unsigned_t = NumberUnsignedType;
+  using number_unsigned_t = NumberUnsignedType;
 
-    /*!
+  /*!
     @brief a type for a number (floating-point)
 
     [RFC 7159](http://rfc7159.net/rfc7159) describes numbers as follows:
@@ -13193,34 +12189,32 @@ class basic_json
 
     @since version 1.0.0
     */
-    using number_float_t = NumberFloatType;
+  using number_float_t = NumberFloatType;
 
-    /// @}
+  /// @}
 
-  private:
+private:
+  /// helper for exception-safe object creation
+  template <typename T, typename... Args>
+  static T *create(Args &&... args)
+  {
+    AllocatorType<T> alloc;
+    using AllocatorTraits = std::allocator_traits<AllocatorType<T>>;
 
-    /// helper for exception-safe object creation
-    template<typename T, typename... Args>
-    static T* create(Args&& ... args)
-    {
-        AllocatorType<T> alloc;
-        using AllocatorTraits = std::allocator_traits<AllocatorType<T>>;
+    auto deleter = [&](T *object) {
+      AllocatorTraits::deallocate(alloc, object, 1);
+    };
+    std::unique_ptr<T, decltype(deleter)> object(AllocatorTraits::allocate(alloc, 1), deleter);
+    AllocatorTraits::construct(alloc, object.get(), std::forward<Args>(args)...);
+    assert(object != nullptr);
+    return object.release();
+  }
 
-        auto deleter = [&](T * object)
-        {
-            AllocatorTraits::deallocate(alloc, object, 1);
-        };
-        std::unique_ptr<T, decltype(deleter)> object(AllocatorTraits::allocate(alloc, 1), deleter);
-        AllocatorTraits::construct(alloc, object.get(), std::forward<Args>(args)...);
-        assert(object != nullptr);
-        return object.release();
-    }
+  ////////////////////////
+  // JSON value storage //
+  ////////////////////////
 
-    ////////////////////////
-    // JSON value storage //
-    ////////////////////////
-
-    /*!
+  /*!
     @brief a JSON value
 
     The actual storage for a JSON value of the @ref basic_json class. This
@@ -13244,171 +12238,158 @@ class basic_json
 
     @since version 1.0.0
     */
-    union json_value
+  union json_value {
+    /// object (stored with pointer to save storage)
+    object_t *object;
+    /// array (stored with pointer to save storage)
+    array_t *array;
+    /// string (stored with pointer to save storage)
+    string_t *string;
+    /// boolean
+    boolean_t boolean;
+    /// number (integer)
+    number_integer_t number_integer;
+    /// number (unsigned integer)
+    number_unsigned_t number_unsigned;
+    /// number (floating-point)
+    number_float_t number_float;
+
+    /// default constructor (for null values)
+    json_value() = default;
+    /// constructor for booleans
+    json_value(boolean_t v) noexcept
+        : boolean(v) {}
+    /// constructor for numbers (integer)
+    json_value(number_integer_t v) noexcept
+        : number_integer(v) {}
+    /// constructor for numbers (unsigned)
+    json_value(number_unsigned_t v) noexcept
+        : number_unsigned(v) {}
+    /// constructor for numbers (floating-point)
+    json_value(number_float_t v) noexcept
+        : number_float(v) {}
+    /// constructor for empty values of a given type
+    json_value(value_t t)
     {
-        /// object (stored with pointer to save storage)
-        object_t* object;
-        /// array (stored with pointer to save storage)
-        array_t* array;
-        /// string (stored with pointer to save storage)
-        string_t* string;
-        /// boolean
-        boolean_t boolean;
-        /// number (integer)
-        number_integer_t number_integer;
-        /// number (unsigned integer)
-        number_unsigned_t number_unsigned;
-        /// number (floating-point)
-        number_float_t number_float;
+      switch (t) {
+      case value_t::object: {
+        object = create<object_t>();
+        break;
+      }
 
-        /// default constructor (for null values)
-        json_value() = default;
-        /// constructor for booleans
-        json_value(boolean_t v) noexcept : boolean(v) {}
-        /// constructor for numbers (integer)
-        json_value(number_integer_t v) noexcept : number_integer(v) {}
-        /// constructor for numbers (unsigned)
-        json_value(number_unsigned_t v) noexcept : number_unsigned(v) {}
-        /// constructor for numbers (floating-point)
-        json_value(number_float_t v) noexcept : number_float(v) {}
-        /// constructor for empty values of a given type
-        json_value(value_t t)
-        {
-            switch (t)
-            {
-                case value_t::object:
-                {
-                    object = create<object_t>();
-                    break;
-                }
+      case value_t::array: {
+        array = create<array_t>();
+        break;
+      }
 
-                case value_t::array:
-                {
-                    array = create<array_t>();
-                    break;
-                }
+      case value_t::string: {
+        string = create<string_t>("");
+        break;
+      }
 
-                case value_t::string:
-                {
-                    string = create<string_t>("");
-                    break;
-                }
+      case value_t::boolean: {
+        boolean = boolean_t(false);
+        break;
+      }
 
-                case value_t::boolean:
-                {
-                    boolean = boolean_t(false);
-                    break;
-                }
+      case value_t::number_integer: {
+        number_integer = number_integer_t(0);
+        break;
+      }
 
-                case value_t::number_integer:
-                {
-                    number_integer = number_integer_t(0);
-                    break;
-                }
+      case value_t::number_unsigned: {
+        number_unsigned = number_unsigned_t(0);
+        break;
+      }
 
-                case value_t::number_unsigned:
-                {
-                    number_unsigned = number_unsigned_t(0);
-                    break;
-                }
+      case value_t::number_float: {
+        number_float = number_float_t(0.0);
+        break;
+      }
 
-                case value_t::number_float:
-                {
-                    number_float = number_float_t(0.0);
-                    break;
-                }
+      case value_t::null: {
+        object = nullptr; // silence warning, see #821
+        break;
+      }
 
-                case value_t::null:
-                {
-                    object = nullptr;  // silence warning, see #821
-                    break;
-                }
-
-                default:
-                {
-                    object = nullptr;  // silence warning, see #821
-                    if (JSON_UNLIKELY(t == value_t::null))
-                    {
-                        JSON_THROW(other_error::create(500, "961c151d2e87f2686a955a9be24d316f1362bf21 3.5.0")); // LCOV_EXCL_LINE
-                    }
-                    break;
-                }
-            }
+      default: {
+        object = nullptr; // silence warning, see #821
+        if (JSON_UNLIKELY(t == value_t::null)) {
+          JSON_THROW(other_error::create(500, "961c151d2e87f2686a955a9be24d316f1362bf21 3.5.0")); // LCOV_EXCL_LINE
         }
+        break;
+      }
+      }
+    }
 
-        /// constructor for strings
-        json_value(const string_t& value)
-        {
-            string = create<string_t>(value);
-        }
+    /// constructor for strings
+    json_value(const string_t &value)
+    {
+      string = create<string_t>(value);
+    }
 
-        /// constructor for rvalue strings
-        json_value(string_t&& value)
-        {
-            string = create<string_t>(std::move(value));
-        }
+    /// constructor for rvalue strings
+    json_value(string_t &&value)
+    {
+      string = create<string_t>(std::move(value));
+    }
 
-        /// constructor for objects
-        json_value(const object_t& value)
-        {
-            object = create<object_t>(value);
-        }
+    /// constructor for objects
+    json_value(const object_t &value)
+    {
+      object = create<object_t>(value);
+    }
 
-        /// constructor for rvalue objects
-        json_value(object_t&& value)
-        {
-            object = create<object_t>(std::move(value));
-        }
+    /// constructor for rvalue objects
+    json_value(object_t &&value)
+    {
+      object = create<object_t>(std::move(value));
+    }
 
-        /// constructor for arrays
-        json_value(const array_t& value)
-        {
-            array = create<array_t>(value);
-        }
+    /// constructor for arrays
+    json_value(const array_t &value)
+    {
+      array = create<array_t>(value);
+    }
 
-        /// constructor for rvalue arrays
-        json_value(array_t&& value)
-        {
-            array = create<array_t>(std::move(value));
-        }
+    /// constructor for rvalue arrays
+    json_value(array_t &&value)
+    {
+      array = create<array_t>(std::move(value));
+    }
 
-        void destroy(value_t t) noexcept
-        {
-            switch (t)
-            {
-                case value_t::object:
-                {
-                    AllocatorType<object_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
-                    break;
-                }
+    void destroy(value_t t) noexcept
+    {
+      switch (t) {
+      case value_t::object: {
+        AllocatorType<object_t> alloc;
+        std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
+        std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
+        break;
+      }
 
-                case value_t::array:
-                {
-                    AllocatorType<array_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
-                    break;
-                }
+      case value_t::array: {
+        AllocatorType<array_t> alloc;
+        std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
+        std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
+        break;
+      }
 
-                case value_t::string:
-                {
-                    AllocatorType<string_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, string);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, string, 1);
-                    break;
-                }
+      case value_t::string: {
+        AllocatorType<string_t> alloc;
+        std::allocator_traits<decltype(alloc)>::destroy(alloc, string);
+        std::allocator_traits<decltype(alloc)>::deallocate(alloc, string, 1);
+        break;
+      }
 
-                default:
-                {
-                    break;
-                }
-            }
-        }
-    };
+      default: {
+        break;
+      }
+      }
+    }
+  };
 
-    /*!
+  /*!
     @brief checks the class invariants
 
     This function asserts the class invariants. It needs to be called at the
@@ -13417,19 +12398,19 @@ class basic_json
     value is changed, because the invariant expresses a relationship between
     @a m_type and @a m_value.
     */
-    void assert_invariant() const noexcept
-    {
-        assert(m_type != value_t::object or m_value.object != nullptr);
-        assert(m_type != value_t::array or m_value.array != nullptr);
-        assert(m_type != value_t::string or m_value.string != nullptr);
-    }
+  void assert_invariant() const noexcept
+  {
+    assert(m_type != value_t::object or m_value.object != nullptr);
+    assert(m_type != value_t::array or m_value.array != nullptr);
+    assert(m_type != value_t::string or m_value.string != nullptr);
+  }
 
-  public:
-    //////////////////////////
-    // JSON parser callback //
-    //////////////////////////
+public:
+  //////////////////////////
+  // JSON parser callback //
+  //////////////////////////
 
-    /*!
+  /*!
     @brief parser event types
 
     The parser callback distinguishes the following events:
@@ -13444,9 +12425,9 @@ class basic_json
 
     @sa @ref parser_callback_t for more information and examples
     */
-    using parse_event_t = typename parser::parse_event_t;
+  using parse_event_t = typename parser::parse_event_t;
 
-    /*!
+  /*!
     @brief per-element parser callback type
 
     With a parser callback function, the result of parsing a JSON text can be
@@ -13495,18 +12476,18 @@ class basic_json
 
     @since version 1.0.0
     */
-    using parser_callback_t = typename parser::parser_callback_t;
+  using parser_callback_t = typename parser::parser_callback_t;
 
-    //////////////////
-    // constructors //
-    //////////////////
+  //////////////////
+  // constructors //
+  //////////////////
 
-    /// @name constructors and destructors
-    /// Constructors of class @ref basic_json, copy/move constructor, copy
-    /// assignment, static functions creating objects, and the destructor.
-    /// @{
+  /// @name constructors and destructors
+  /// Constructors of class @ref basic_json, copy/move constructor, copy
+  /// assignment, static functions creating objects, and the destructor.
+  /// @{
 
-    /*!
+  /*!
     @brief create an empty value with a given type
 
     Create an empty JSON value with a given type. The value will be default
@@ -13535,13 +12516,13 @@ class basic_json
 
     @since version 1.0.0
     */
-    basic_json(const value_t v)
-        : m_type(v), m_value(v)
-    {
-        assert_invariant();
-    }
+  basic_json(const value_t v)
+      : m_type(v), m_value(v)
+  {
+    assert_invariant();
+  }
 
-    /*!
+  /*!
     @brief create a null object
 
     Create a `null` JSON value. It either takes a null pointer as parameter
@@ -13559,13 +12540,13 @@ class basic_json
 
     @since version 1.0.0
     */
-    basic_json(std::nullptr_t = nullptr) noexcept
-        : basic_json(value_t::null)
-    {
-        assert_invariant();
-    }
+  basic_json(std::nullptr_t = nullptr) noexcept
+      : basic_json(value_t::null)
+  {
+    assert_invariant();
+  }
 
-    /*!
+  /*!
     @brief create a JSON value
 
     This is a "catch all" constructor for all compatible JSON types; that is,
@@ -13622,19 +12603,19 @@ class basic_json
 
     @since version 2.1.0
     */
-    template <typename CompatibleType,
-              typename U = detail::uncvref_t<CompatibleType>,
-              detail::enable_if_t<
-                  not detail::is_basic_json<U>::value and detail::is_compatible_type<basic_json_t, U>::value, int> = 0>
-    basic_json(CompatibleType && val) noexcept(noexcept(
-                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
-                                           std::forward<CompatibleType>(val))))
-    {
-        JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
-        assert_invariant();
-    }
+  template <typename CompatibleType,
+            typename U = detail::uncvref_t<CompatibleType>,
+            detail::enable_if_t<
+                not detail::is_basic_json<U>::value and detail::is_compatible_type<basic_json_t, U>::value, int> = 0>
+  basic_json(CompatibleType &&val) noexcept(noexcept(
+      JSONSerializer<U>::to_json(std::declval<basic_json_t &>(),
+                                 std::forward<CompatibleType>(val))))
+  {
+    JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
+    assert_invariant();
+  }
 
-    /*!
+  /*!
     @brief create a JSON value from an existing one
 
     This is a constructor for existing @ref basic_json types.
@@ -13660,53 +12641,52 @@ class basic_json
 
     @since version 3.2.0
     */
-    template <typename BasicJsonType,
-              detail::enable_if_t<
-                  detail::is_basic_json<BasicJsonType>::value and not std::is_same<basic_json, BasicJsonType>::value, int> = 0>
-    basic_json(const BasicJsonType& val)
-    {
-        using other_boolean_t = typename BasicJsonType::boolean_t;
-        using other_number_float_t = typename BasicJsonType::number_float_t;
-        using other_number_integer_t = typename BasicJsonType::number_integer_t;
-        using other_number_unsigned_t = typename BasicJsonType::number_unsigned_t;
-        using other_string_t = typename BasicJsonType::string_t;
-        using other_object_t = typename BasicJsonType::object_t;
-        using other_array_t = typename BasicJsonType::array_t;
+  template <typename BasicJsonType,
+            detail::enable_if_t<
+                detail::is_basic_json<BasicJsonType>::value and not std::is_same<basic_json, BasicJsonType>::value, int> = 0>
+  basic_json(const BasicJsonType &val)
+  {
+    using other_boolean_t         = typename BasicJsonType::boolean_t;
+    using other_number_float_t    = typename BasicJsonType::number_float_t;
+    using other_number_integer_t  = typename BasicJsonType::number_integer_t;
+    using other_number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using other_string_t          = typename BasicJsonType::string_t;
+    using other_object_t          = typename BasicJsonType::object_t;
+    using other_array_t           = typename BasicJsonType::array_t;
 
-        switch (val.type())
-        {
-            case value_t::boolean:
-                JSONSerializer<other_boolean_t>::to_json(*this, val.template get<other_boolean_t>());
-                break;
-            case value_t::number_float:
-                JSONSerializer<other_number_float_t>::to_json(*this, val.template get<other_number_float_t>());
-                break;
-            case value_t::number_integer:
-                JSONSerializer<other_number_integer_t>::to_json(*this, val.template get<other_number_integer_t>());
-                break;
-            case value_t::number_unsigned:
-                JSONSerializer<other_number_unsigned_t>::to_json(*this, val.template get<other_number_unsigned_t>());
-                break;
-            case value_t::string:
-                JSONSerializer<other_string_t>::to_json(*this, val.template get_ref<const other_string_t&>());
-                break;
-            case value_t::object:
-                JSONSerializer<other_object_t>::to_json(*this, val.template get_ref<const other_object_t&>());
-                break;
-            case value_t::array:
-                JSONSerializer<other_array_t>::to_json(*this, val.template get_ref<const other_array_t&>());
-                break;
-            case value_t::null:
-                *this = nullptr;
-                break;
-            case value_t::discarded:
-                m_type = value_t::discarded;
-                break;
-        }
-        assert_invariant();
+    switch (val.type()) {
+    case value_t::boolean:
+      JSONSerializer<other_boolean_t>::to_json(*this, val.template get<other_boolean_t>());
+      break;
+    case value_t::number_float:
+      JSONSerializer<other_number_float_t>::to_json(*this, val.template get<other_number_float_t>());
+      break;
+    case value_t::number_integer:
+      JSONSerializer<other_number_integer_t>::to_json(*this, val.template get<other_number_integer_t>());
+      break;
+    case value_t::number_unsigned:
+      JSONSerializer<other_number_unsigned_t>::to_json(*this, val.template get<other_number_unsigned_t>());
+      break;
+    case value_t::string:
+      JSONSerializer<other_string_t>::to_json(*this, val.template get_ref<const other_string_t &>());
+      break;
+    case value_t::object:
+      JSONSerializer<other_object_t>::to_json(*this, val.template get_ref<const other_object_t &>());
+      break;
+    case value_t::array:
+      JSONSerializer<other_array_t>::to_json(*this, val.template get_ref<const other_array_t &>());
+      break;
+    case value_t::null:
+      *this = nullptr;
+      break;
+    case value_t::discarded:
+      m_type = value_t::discarded;
+      break;
     }
+    assert_invariant();
+  }
 
-    /*!
+  /*!
     @brief create a container (array or object) from an initializer list
 
     Creates a JSON value of type array or object from the passed initializer
@@ -13780,59 +12760,51 @@ class basic_json
 
     @since version 1.0.0
     */
-    basic_json(initializer_list_t init,
-               bool type_deduction = true,
-               value_t manual_type = value_t::array)
-    {
-        // check if each element is an array with two elements whose first
-        // element is a string
-        bool is_an_object = std::all_of(init.begin(), init.end(),
-                                        [](const detail::json_ref<basic_json>& element_ref)
-        {
-            return (element_ref->is_array() and element_ref->size() == 2 and (*element_ref)[0].is_string());
-        });
+  basic_json(initializer_list_t init,
+             bool               type_deduction = true,
+             value_t            manual_type    = value_t::array)
+  {
+    // check if each element is an array with two elements whose first
+    // element is a string
+    bool is_an_object = std::all_of(init.begin(), init.end(),
+                                    [](const detail::json_ref<basic_json> &element_ref) {
+                                      return (element_ref->is_array() and element_ref->size() == 2 and (*element_ref)[0].is_string());
+                                    });
 
-        // adjust type if type deduction is not wanted
-        if (not type_deduction)
-        {
-            // if array is wanted, do not create an object though possible
-            if (manual_type == value_t::array)
-            {
-                is_an_object = false;
-            }
+    // adjust type if type deduction is not wanted
+    if (not type_deduction) {
+      // if array is wanted, do not create an object though possible
+      if (manual_type == value_t::array) {
+        is_an_object = false;
+      }
 
-            // if object is wanted but impossible, throw an exception
-            if (JSON_UNLIKELY(manual_type == value_t::object and not is_an_object))
-            {
-                JSON_THROW(type_error::create(301, "cannot create object from initializer list"));
-            }
-        }
-
-        if (is_an_object)
-        {
-            // the initializer list is a list of pairs -> create object
-            m_type = value_t::object;
-            m_value = value_t::object;
-
-            std::for_each(init.begin(), init.end(), [this](const detail::json_ref<basic_json>& element_ref)
-            {
-                auto element = element_ref.moved_or_copied();
-                m_value.object->emplace(
-                    std::move(*((*element.m_value.array)[0].m_value.string)),
-                    std::move((*element.m_value.array)[1]));
-            });
-        }
-        else
-        {
-            // the initializer list describes an array -> create array
-            m_type = value_t::array;
-            m_value.array = create<array_t>(init.begin(), init.end());
-        }
-
-        assert_invariant();
+      // if object is wanted but impossible, throw an exception
+      if (JSON_UNLIKELY(manual_type == value_t::object and not is_an_object)) {
+        JSON_THROW(type_error::create(301, "cannot create object from initializer list"));
+      }
     }
 
-    /*!
+    if (is_an_object) {
+      // the initializer list is a list of pairs -> create object
+      m_type  = value_t::object;
+      m_value = value_t::object;
+
+      std::for_each(init.begin(), init.end(), [this](const detail::json_ref<basic_json> &element_ref) {
+        auto element = element_ref.moved_or_copied();
+        m_value.object->emplace(
+            std::move(*((*element.m_value.array)[0].m_value.string)),
+            std::move((*element.m_value.array)[1]));
+      });
+    } else {
+      // the initializer list describes an array -> create array
+      m_type        = value_t::array;
+      m_value.array = create<array_t>(init.begin(), init.end());
+    }
+
+    assert_invariant();
+  }
+
+  /*!
     @brief explicitly create an array from an initializer list
 
     Creates a JSON array value from a given initializer list. That is, given a
@@ -13869,12 +12841,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    static basic_json array(initializer_list_t init = {})
-    {
-        return basic_json(init, false, value_t::array);
-    }
+  static basic_json array(initializer_list_t init = {})
+  {
+    return basic_json(init, false, value_t::array);
+  }
 
-    /*!
+  /*!
     @brief explicitly create an object from an initializer list
 
     Creates a JSON object value from a given initializer list. The initializer
@@ -13912,12 +12884,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    static basic_json object(initializer_list_t init = {})
-    {
-        return basic_json(init, false, value_t::object);
-    }
+  static basic_json object(initializer_list_t init = {})
+  {
+    return basic_json(init, false, value_t::object);
+  }
 
-    /*!
+  /*!
     @brief construct an array with count copies of given value
 
     Constructs a JSON array value by creating @a cnt copies of a passed value.
@@ -13939,14 +12911,14 @@ class basic_json
 
     @since version 1.0.0
     */
-    basic_json(size_type cnt, const basic_json& val)
-        : m_type(value_t::array)
-    {
-        m_value.array = create<array_t>(cnt, val);
-        assert_invariant();
-    }
+  basic_json(size_type cnt, const basic_json &val)
+      : m_type(value_t::array)
+  {
+    m_value.array = create<array_t>(cnt, val);
+    assert_invariant();
+  }
 
-    /*!
+  /*!
     @brief construct a JSON container given an iterator range
 
     Constructs the JSON value with the contents of the range `[first, last)`.
@@ -14001,109 +12973,97 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<class InputIT, typename std::enable_if<
-                 std::is_same<InputIT, typename basic_json_t::iterator>::value or
-                 std::is_same<InputIT, typename basic_json_t::const_iterator>::value, int>::type = 0>
-    basic_json(InputIT first, InputIT last)
-    {
-        assert(first.m_object != nullptr);
-        assert(last.m_object != nullptr);
+  template <class InputIT, typename std::enable_if<
+                               std::is_same<InputIT, typename basic_json_t::iterator>::value or
+                                   std::is_same<InputIT, typename basic_json_t::const_iterator>::value,
+                               int>::type = 0>
+  basic_json(InputIT first, InputIT last)
+  {
+    assert(first.m_object != nullptr);
+    assert(last.m_object != nullptr);
 
-        // make sure iterator fits the current value
-        if (JSON_UNLIKELY(first.m_object != last.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(201, "iterators are not compatible"));
-        }
-
-        // copy type from first iterator
-        m_type = first.m_object->m_type;
-
-        // check if iterator range is complete for primitive values
-        switch (m_type)
-        {
-            case value_t::boolean:
-            case value_t::number_float:
-            case value_t::number_integer:
-            case value_t::number_unsigned:
-            case value_t::string:
-            {
-                if (JSON_UNLIKELY(not first.m_it.primitive_iterator.is_begin()
-                                  or not last.m_it.primitive_iterator.is_end()))
-                {
-                    JSON_THROW(invalid_iterator::create(204, "iterators out of range"));
-                }
-                break;
-            }
-
-            default:
-                break;
-        }
-
-        switch (m_type)
-        {
-            case value_t::number_integer:
-            {
-                m_value.number_integer = first.m_object->m_value.number_integer;
-                break;
-            }
-
-            case value_t::number_unsigned:
-            {
-                m_value.number_unsigned = first.m_object->m_value.number_unsigned;
-                break;
-            }
-
-            case value_t::number_float:
-            {
-                m_value.number_float = first.m_object->m_value.number_float;
-                break;
-            }
-
-            case value_t::boolean:
-            {
-                m_value.boolean = first.m_object->m_value.boolean;
-                break;
-            }
-
-            case value_t::string:
-            {
-                m_value = *first.m_object->m_value.string;
-                break;
-            }
-
-            case value_t::object:
-            {
-                m_value.object = create<object_t>(first.m_it.object_iterator,
-                                                  last.m_it.object_iterator);
-                break;
-            }
-
-            case value_t::array:
-            {
-                m_value.array = create<array_t>(first.m_it.array_iterator,
-                                                last.m_it.array_iterator);
-                break;
-            }
-
-            default:
-                JSON_THROW(invalid_iterator::create(206, "cannot construct with iterators from " +
-                                                    std::string(first.m_object->type_name())));
-        }
-
-        assert_invariant();
+    // make sure iterator fits the current value
+    if (JSON_UNLIKELY(first.m_object != last.m_object)) {
+      JSON_THROW(invalid_iterator::create(201, "iterators are not compatible"));
     }
 
+    // copy type from first iterator
+    m_type = first.m_object->m_type;
 
-    ///////////////////////////////////////
-    // other constructors and destructor //
-    ///////////////////////////////////////
+    // check if iterator range is complete for primitive values
+    switch (m_type) {
+    case value_t::boolean:
+    case value_t::number_float:
+    case value_t::number_integer:
+    case value_t::number_unsigned:
+    case value_t::string: {
+      if (JSON_UNLIKELY(not first.m_it.primitive_iterator.is_begin() or not last.m_it.primitive_iterator.is_end())) {
+        JSON_THROW(invalid_iterator::create(204, "iterators out of range"));
+      }
+      break;
+    }
 
-    /// @private
-    basic_json(const detail::json_ref<basic_json>& ref)
-        : basic_json(ref.moved_or_copied())
-    {}
+    default:
+      break;
+    }
 
-    /*!
+    switch (m_type) {
+    case value_t::number_integer: {
+      m_value.number_integer = first.m_object->m_value.number_integer;
+      break;
+    }
+
+    case value_t::number_unsigned: {
+      m_value.number_unsigned = first.m_object->m_value.number_unsigned;
+      break;
+    }
+
+    case value_t::number_float: {
+      m_value.number_float = first.m_object->m_value.number_float;
+      break;
+    }
+
+    case value_t::boolean: {
+      m_value.boolean = first.m_object->m_value.boolean;
+      break;
+    }
+
+    case value_t::string: {
+      m_value = *first.m_object->m_value.string;
+      break;
+    }
+
+    case value_t::object: {
+      m_value.object = create<object_t>(first.m_it.object_iterator,
+                                        last.m_it.object_iterator);
+      break;
+    }
+
+    case value_t::array: {
+      m_value.array = create<array_t>(first.m_it.array_iterator,
+                                      last.m_it.array_iterator);
+      break;
+    }
+
+    default:
+      JSON_THROW(invalid_iterator::create(206, "cannot construct with iterators from " +
+                                                   std::string(first.m_object->type_name())));
+    }
+
+    assert_invariant();
+  }
+
+  ///////////////////////////////////////
+  // other constructors and destructor //
+  ///////////////////////////////////////
+
+  /// @private
+  basic_json(const detail::json_ref<basic_json> &ref)
+      : basic_json(ref.moved_or_copied())
+  {
+  }
+
+  /*!
     @brief copy constructor
 
     Creates a copy of a given JSON value.
@@ -14128,64 +13088,56 @@ class basic_json
 
     @since version 1.0.0
     */
-    basic_json(const basic_json& other)
-        : m_type(other.m_type)
-    {
-        // check of passed value is valid
-        other.assert_invariant();
+  basic_json(const basic_json &other)
+      : m_type(other.m_type)
+  {
+    // check of passed value is valid
+    other.assert_invariant();
 
-        switch (m_type)
-        {
-            case value_t::object:
-            {
-                m_value = *other.m_value.object;
-                break;
-            }
-
-            case value_t::array:
-            {
-                m_value = *other.m_value.array;
-                break;
-            }
-
-            case value_t::string:
-            {
-                m_value = *other.m_value.string;
-                break;
-            }
-
-            case value_t::boolean:
-            {
-                m_value = other.m_value.boolean;
-                break;
-            }
-
-            case value_t::number_integer:
-            {
-                m_value = other.m_value.number_integer;
-                break;
-            }
-
-            case value_t::number_unsigned:
-            {
-                m_value = other.m_value.number_unsigned;
-                break;
-            }
-
-            case value_t::number_float:
-            {
-                m_value = other.m_value.number_float;
-                break;
-            }
-
-            default:
-                break;
-        }
-
-        assert_invariant();
+    switch (m_type) {
+    case value_t::object: {
+      m_value = *other.m_value.object;
+      break;
     }
 
-    /*!
+    case value_t::array: {
+      m_value = *other.m_value.array;
+      break;
+    }
+
+    case value_t::string: {
+      m_value = *other.m_value.string;
+      break;
+    }
+
+    case value_t::boolean: {
+      m_value = other.m_value.boolean;
+      break;
+    }
+
+    case value_t::number_integer: {
+      m_value = other.m_value.number_integer;
+      break;
+    }
+
+    case value_t::number_unsigned: {
+      m_value = other.m_value.number_unsigned;
+      break;
+    }
+
+    case value_t::number_float: {
+      m_value = other.m_value.number_float;
+      break;
+    }
+
+    default:
+      break;
+    }
+
+    assert_invariant();
+  }
+
+  /*!
     @brief move constructor
 
     Move constructor. Constructs a JSON value with the contents of the given
@@ -14211,21 +13163,21 @@ class basic_json
 
     @since version 1.0.0
     */
-    basic_json(basic_json&& other) noexcept
-        : m_type(std::move(other.m_type)),
-          m_value(std::move(other.m_value))
-    {
-        // check that passed value is valid
-        other.assert_invariant();
+  basic_json(basic_json &&other) noexcept
+      : m_type(std::move(other.m_type)),
+        m_value(std::move(other.m_value))
+  {
+    // check that passed value is valid
+    other.assert_invariant();
 
-        // invalidate payload
-        other.m_type = value_t::null;
-        other.m_value = {};
+    // invalidate payload
+    other.m_type  = value_t::null;
+    other.m_value = {};
 
-        assert_invariant();
-    }
+    assert_invariant();
+  }
 
-    /*!
+  /*!
     @brief copy assignment
 
     Copy assignment operator. Copies a JSON value via the "copy and swap"
@@ -14248,25 +13200,24 @@ class basic_json
 
     @since version 1.0.0
     */
-    basic_json& operator=(basic_json other) noexcept (
-        std::is_nothrow_move_constructible<value_t>::value and
-        std::is_nothrow_move_assignable<value_t>::value and
-        std::is_nothrow_move_constructible<json_value>::value and
-        std::is_nothrow_move_assignable<json_value>::value
-    )
-    {
-        // check that passed value is valid
-        other.assert_invariant();
+  basic_json &operator=(basic_json other) noexcept(
+      std::is_nothrow_move_constructible<value_t>::value and
+          std::is_nothrow_move_assignable<value_t>::value and
+              std::is_nothrow_move_constructible<json_value>::value and
+                  std::is_nothrow_move_assignable<json_value>::value)
+  {
+    // check that passed value is valid
+    other.assert_invariant();
 
-        using std::swap;
-        swap(m_type, other.m_type);
-        swap(m_value, other.m_value);
+    using std::swap;
+    swap(m_type, other.m_type);
+    swap(m_value, other.m_value);
 
-        assert_invariant();
-        return *this;
-    }
+    assert_invariant();
+    return *this;
+  }
 
-    /*!
+  /*!
     @brief destructor
 
     Destroys the JSON value and frees all allocated memory.
@@ -14281,24 +13232,24 @@ class basic_json
 
     @since version 1.0.0
     */
-    ~basic_json() noexcept
-    {
-        assert_invariant();
-        m_value.destroy(m_type);
-    }
+  ~basic_json() noexcept
+  {
+    assert_invariant();
+    m_value.destroy(m_type);
+  }
 
-    /// @}
+  /// @}
 
-  public:
-    ///////////////////////
-    // object inspection //
-    ///////////////////////
+public:
+  ///////////////////////
+  // object inspection //
+  ///////////////////////
 
-    /// @name object inspection
-    /// Functions to inspect the type of a JSON value.
-    /// @{
+  /// @name object inspection
+  /// Functions to inspect the type of a JSON value.
+  /// @{
 
-    /*!
+  /*!
     @brief serialization
 
     Serialization function for JSON values. The function tries to mimic
@@ -14339,27 +13290,24 @@ class basic_json
            @a ensure_ascii and exceptions added in version 3.0.0; error
            handlers added in version 3.4.0.
     */
-    string_t dump(const int indent = -1,
-                  const char indent_char = ' ',
-                  const bool ensure_ascii = false,
-                  const error_handler_t error_handler = error_handler_t::strict) const
-    {
-        string_t result;
-        serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
+  string_t dump(const int             indent        = -1,
+                const char            indent_char   = ' ',
+                const bool            ensure_ascii  = false,
+                const error_handler_t error_handler = error_handler_t::strict) const
+  {
+    string_t   result;
+    serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
 
-        if (indent >= 0)
-        {
-            s.dump(*this, true, ensure_ascii, static_cast<unsigned int>(indent));
-        }
-        else
-        {
-            s.dump(*this, false, ensure_ascii, 0);
-        }
-
-        return result;
+    if (indent >= 0) {
+      s.dump(*this, true, ensure_ascii, static_cast<unsigned int>(indent));
+    } else {
+      s.dump(*this, false, ensure_ascii, 0);
     }
 
-    /*!
+    return result;
+  }
+
+  /*!
     @brief return the type of the JSON value (explicit)
 
     Return the type of the JSON value as a value from the @ref value_t
@@ -14391,12 +13339,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr value_t type() const noexcept
-    {
-        return m_type;
-    }
+  constexpr value_t type() const noexcept
+  {
+    return m_type;
+  }
 
-    /*!
+  /*!
     @brief return whether type is primitive
 
     This function returns true if and only if the JSON type is primitive
@@ -14421,12 +13369,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_primitive() const noexcept
-    {
-        return is_null() or is_string() or is_boolean() or is_number();
-    }
+  constexpr bool is_primitive() const noexcept
+  {
+    return is_null() or is_string() or is_boolean() or is_number();
+  }
 
-    /*!
+  /*!
     @brief return whether type is structured
 
     This function returns true if and only if the JSON type is structured
@@ -14448,12 +13396,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_structured() const noexcept
-    {
-        return is_array() or is_object();
-    }
+  constexpr bool is_structured() const noexcept
+  {
+    return is_array() or is_object();
+  }
 
-    /*!
+  /*!
     @brief return whether value is null
 
     This function returns true if and only if the JSON value is null.
@@ -14470,12 +13418,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_null() const noexcept
-    {
-        return (m_type == value_t::null);
-    }
+  constexpr bool is_null() const noexcept
+  {
+    return (m_type == value_t::null);
+  }
 
-    /*!
+  /*!
     @brief return whether value is a boolean
 
     This function returns true if and only if the JSON value is a boolean.
@@ -14492,12 +13440,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_boolean() const noexcept
-    {
-        return (m_type == value_t::boolean);
-    }
+  constexpr bool is_boolean() const noexcept
+  {
+    return (m_type == value_t::boolean);
+  }
 
-    /*!
+  /*!
     @brief return whether value is a number
 
     This function returns true if and only if the JSON value is a number. This
@@ -14522,12 +13470,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_number() const noexcept
-    {
-        return is_number_integer() or is_number_float();
-    }
+  constexpr bool is_number() const noexcept
+  {
+    return is_number_integer() or is_number_float();
+  }
 
-    /*!
+  /*!
     @brief return whether value is an integer number
 
     This function returns true if and only if the JSON value is a signed or
@@ -14551,12 +13499,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_number_integer() const noexcept
-    {
-        return (m_type == value_t::number_integer or m_type == value_t::number_unsigned);
-    }
+  constexpr bool is_number_integer() const noexcept
+  {
+    return (m_type == value_t::number_integer or m_type == value_t::number_unsigned);
+  }
 
-    /*!
+  /*!
     @brief return whether value is an unsigned integer number
 
     This function returns true if and only if the JSON value is an unsigned
@@ -14579,12 +13527,12 @@ class basic_json
 
     @since version 2.0.0
     */
-    constexpr bool is_number_unsigned() const noexcept
-    {
-        return (m_type == value_t::number_unsigned);
-    }
+  constexpr bool is_number_unsigned() const noexcept
+  {
+    return (m_type == value_t::number_unsigned);
+  }
 
-    /*!
+  /*!
     @brief return whether value is a floating-point number
 
     This function returns true if and only if the JSON value is a
@@ -14607,12 +13555,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_number_float() const noexcept
-    {
-        return (m_type == value_t::number_float);
-    }
+  constexpr bool is_number_float() const noexcept
+  {
+    return (m_type == value_t::number_float);
+  }
 
-    /*!
+  /*!
     @brief return whether value is an object
 
     This function returns true if and only if the JSON value is an object.
@@ -14629,12 +13577,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_object() const noexcept
-    {
-        return (m_type == value_t::object);
-    }
+  constexpr bool is_object() const noexcept
+  {
+    return (m_type == value_t::object);
+  }
 
-    /*!
+  /*!
     @brief return whether value is an array
 
     This function returns true if and only if the JSON value is an array.
@@ -14651,12 +13599,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_array() const noexcept
-    {
-        return (m_type == value_t::array);
-    }
+  constexpr bool is_array() const noexcept
+  {
+    return (m_type == value_t::array);
+  }
 
-    /*!
+  /*!
     @brief return whether value is a string
 
     This function returns true if and only if the JSON value is a string.
@@ -14673,12 +13621,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_string() const noexcept
-    {
-        return (m_type == value_t::string);
-    }
+  constexpr bool is_string() const noexcept
+  {
+    return (m_type == value_t::string);
+  }
 
-    /*!
+  /*!
     @brief return whether value is discarded
 
     This function returns true if and only if the JSON value was discarded
@@ -14700,12 +13648,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr bool is_discarded() const noexcept
-    {
-        return (m_type == value_t::discarded);
-    }
+  constexpr bool is_discarded() const noexcept
+  {
+    return (m_type == value_t::discarded);
+  }
 
-    /*!
+  /*!
     @brief return the type of the JSON value (implicit)
 
     Implicitly return the type of the JSON value as a value from the @ref
@@ -14726,114 +13674,113 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr operator value_t() const noexcept
-    {
-        return m_type;
+  constexpr operator value_t() const noexcept
+  {
+    return m_type;
+  }
+
+  /// @}
+
+private:
+  //////////////////
+  // value access //
+  //////////////////
+
+  /// get a boolean (explicit)
+  boolean_t get_impl(boolean_t * /*unused*/) const
+  {
+    if (JSON_LIKELY(is_boolean())) {
+      return m_value.boolean;
     }
 
-    /// @}
+    JSON_THROW(type_error::create(302, "type must be boolean, but is " + std::string(type_name())));
+  }
 
-  private:
-    //////////////////
-    // value access //
-    //////////////////
+  /// get a pointer to the value (object)
+  object_t *get_impl_ptr(object_t * /*unused*/) noexcept
+  {
+    return is_object() ? m_value.object : nullptr;
+  }
 
-    /// get a boolean (explicit)
-    boolean_t get_impl(boolean_t* /*unused*/) const
-    {
-        if (JSON_LIKELY(is_boolean()))
-        {
-            return m_value.boolean;
-        }
+  /// get a pointer to the value (object)
+  constexpr const object_t *get_impl_ptr(const object_t * /*unused*/) const noexcept
+  {
+    return is_object() ? m_value.object : nullptr;
+  }
 
-        JSON_THROW(type_error::create(302, "type must be boolean, but is " + std::string(type_name())));
-    }
+  /// get a pointer to the value (array)
+  array_t *get_impl_ptr(array_t * /*unused*/) noexcept
+  {
+    return is_array() ? m_value.array : nullptr;
+  }
 
-    /// get a pointer to the value (object)
-    object_t* get_impl_ptr(object_t* /*unused*/) noexcept
-    {
-        return is_object() ? m_value.object : nullptr;
-    }
+  /// get a pointer to the value (array)
+  constexpr const array_t *get_impl_ptr(const array_t * /*unused*/) const noexcept
+  {
+    return is_array() ? m_value.array : nullptr;
+  }
 
-    /// get a pointer to the value (object)
-    constexpr const object_t* get_impl_ptr(const object_t* /*unused*/) const noexcept
-    {
-        return is_object() ? m_value.object : nullptr;
-    }
+  /// get a pointer to the value (string)
+  string_t *get_impl_ptr(string_t * /*unused*/) noexcept
+  {
+    return is_string() ? m_value.string : nullptr;
+  }
 
-    /// get a pointer to the value (array)
-    array_t* get_impl_ptr(array_t* /*unused*/) noexcept
-    {
-        return is_array() ? m_value.array : nullptr;
-    }
+  /// get a pointer to the value (string)
+  constexpr const string_t *get_impl_ptr(const string_t * /*unused*/) const noexcept
+  {
+    return is_string() ? m_value.string : nullptr;
+  }
 
-    /// get a pointer to the value (array)
-    constexpr const array_t* get_impl_ptr(const array_t* /*unused*/) const noexcept
-    {
-        return is_array() ? m_value.array : nullptr;
-    }
+  /// get a pointer to the value (boolean)
+  boolean_t *get_impl_ptr(boolean_t * /*unused*/) noexcept
+  {
+    return is_boolean() ? &m_value.boolean : nullptr;
+  }
 
-    /// get a pointer to the value (string)
-    string_t* get_impl_ptr(string_t* /*unused*/) noexcept
-    {
-        return is_string() ? m_value.string : nullptr;
-    }
+  /// get a pointer to the value (boolean)
+  constexpr const boolean_t *get_impl_ptr(const boolean_t * /*unused*/) const noexcept
+  {
+    return is_boolean() ? &m_value.boolean : nullptr;
+  }
 
-    /// get a pointer to the value (string)
-    constexpr const string_t* get_impl_ptr(const string_t* /*unused*/) const noexcept
-    {
-        return is_string() ? m_value.string : nullptr;
-    }
+  /// get a pointer to the value (integer number)
+  number_integer_t *get_impl_ptr(number_integer_t * /*unused*/) noexcept
+  {
+    return is_number_integer() ? &m_value.number_integer : nullptr;
+  }
 
-    /// get a pointer to the value (boolean)
-    boolean_t* get_impl_ptr(boolean_t* /*unused*/) noexcept
-    {
-        return is_boolean() ? &m_value.boolean : nullptr;
-    }
+  /// get a pointer to the value (integer number)
+  constexpr const number_integer_t *get_impl_ptr(const number_integer_t * /*unused*/) const noexcept
+  {
+    return is_number_integer() ? &m_value.number_integer : nullptr;
+  }
 
-    /// get a pointer to the value (boolean)
-    constexpr const boolean_t* get_impl_ptr(const boolean_t* /*unused*/) const noexcept
-    {
-        return is_boolean() ? &m_value.boolean : nullptr;
-    }
+  /// get a pointer to the value (unsigned number)
+  number_unsigned_t *get_impl_ptr(number_unsigned_t * /*unused*/) noexcept
+  {
+    return is_number_unsigned() ? &m_value.number_unsigned : nullptr;
+  }
 
-    /// get a pointer to the value (integer number)
-    number_integer_t* get_impl_ptr(number_integer_t* /*unused*/) noexcept
-    {
-        return is_number_integer() ? &m_value.number_integer : nullptr;
-    }
+  /// get a pointer to the value (unsigned number)
+  constexpr const number_unsigned_t *get_impl_ptr(const number_unsigned_t * /*unused*/) const noexcept
+  {
+    return is_number_unsigned() ? &m_value.number_unsigned : nullptr;
+  }
 
-    /// get a pointer to the value (integer number)
-    constexpr const number_integer_t* get_impl_ptr(const number_integer_t* /*unused*/) const noexcept
-    {
-        return is_number_integer() ? &m_value.number_integer : nullptr;
-    }
+  /// get a pointer to the value (floating-point number)
+  number_float_t *get_impl_ptr(number_float_t * /*unused*/) noexcept
+  {
+    return is_number_float() ? &m_value.number_float : nullptr;
+  }
 
-    /// get a pointer to the value (unsigned number)
-    number_unsigned_t* get_impl_ptr(number_unsigned_t* /*unused*/) noexcept
-    {
-        return is_number_unsigned() ? &m_value.number_unsigned : nullptr;
-    }
+  /// get a pointer to the value (floating-point number)
+  constexpr const number_float_t *get_impl_ptr(const number_float_t * /*unused*/) const noexcept
+  {
+    return is_number_float() ? &m_value.number_float : nullptr;
+  }
 
-    /// get a pointer to the value (unsigned number)
-    constexpr const number_unsigned_t* get_impl_ptr(const number_unsigned_t* /*unused*/) const noexcept
-    {
-        return is_number_unsigned() ? &m_value.number_unsigned : nullptr;
-    }
-
-    /// get a pointer to the value (floating-point number)
-    number_float_t* get_impl_ptr(number_float_t* /*unused*/) noexcept
-    {
-        return is_number_float() ? &m_value.number_float : nullptr;
-    }
-
-    /// get a pointer to the value (floating-point number)
-    constexpr const number_float_t* get_impl_ptr(const number_float_t* /*unused*/) const noexcept
-    {
-        return is_number_float() ? &m_value.number_float : nullptr;
-    }
-
-    /*!
+  /*!
     @brief helper function to implement get_ref()
 
     This function helps to implement get_ref() without code duplication for
@@ -14844,26 +13791,25 @@ class basic_json
     @throw type_error.303 if ReferenceType does not match underlying value
     type of the current JSON
     */
-    template<typename ReferenceType, typename ThisType>
-    static ReferenceType get_ref_impl(ThisType& obj)
-    {
-        // delegate the call to get_ptr<>()
-        auto ptr = obj.template get_ptr<typename std::add_pointer<ReferenceType>::type>();
+  template <typename ReferenceType, typename ThisType>
+  static ReferenceType get_ref_impl(ThisType &obj)
+  {
+    // delegate the call to get_ptr<>()
+    auto ptr = obj.template get_ptr<typename std::add_pointer<ReferenceType>::type>();
 
-        if (JSON_LIKELY(ptr != nullptr))
-        {
-            return *ptr;
-        }
-
-        JSON_THROW(type_error::create(303, "incompatible ReferenceType for get_ref, actual type is " + std::string(obj.type_name())));
+    if (JSON_LIKELY(ptr != nullptr)) {
+      return *ptr;
     }
 
-  public:
-    /// @name value access
-    /// Direct access to the stored value of a JSON value.
-    /// @{
+    JSON_THROW(type_error::create(303, "incompatible ReferenceType for get_ref, actual type is " + std::string(obj.type_name())));
+  }
 
-    /*!
+public:
+  /// @name value access
+  /// Direct access to the stored value of a JSON value.
+  /// @{
+
+  /*!
     @brief get special-case overload
 
     This overloads avoids a lot of template boilerplate, it can be seen as the
@@ -14877,15 +13823,15 @@ class basic_json
 
     @since version 2.1.0
     */
-    template<typename BasicJsonType, detail::enable_if_t<
-                 std::is_same<typename std::remove_const<BasicJsonType>::type, basic_json_t>::value,
-                 int> = 0>
-    basic_json get() const
-    {
-        return *this;
-    }
+  template <typename BasicJsonType, detail::enable_if_t<
+                                        std::is_same<typename std::remove_const<BasicJsonType>::type, basic_json_t>::value,
+                                        int> = 0>
+  basic_json get() const
+  {
+    return *this;
+  }
 
-    /*!
+  /*!
     @brief get special-case overload
 
     This overloads converts the current @ref basic_json in a different
@@ -14900,15 +13846,16 @@ class basic_json
 
     @since version 3.2.0
     */
-    template<typename BasicJsonType, detail::enable_if_t<
-                 not std::is_same<BasicJsonType, basic_json>::value and
-                 detail::is_basic_json<BasicJsonType>::value, int> = 0>
-    BasicJsonType get() const
-    {
-        return *this;
-    }
+  template <typename BasicJsonType, detail::enable_if_t<
+                                        not std::is_same<BasicJsonType, basic_json>::value and
+                                            detail::is_basic_json<BasicJsonType>::value,
+                                        int> = 0>
+  BasicJsonType get() const
+  {
+    return *this;
+  }
 
-    /*!
+  /*!
     @brief get a value (explicit)
 
     Explicit type conversion between the JSON value and a compatible value
@@ -14947,29 +13894,29 @@ class basic_json
 
     @since version 2.1.0
     */
-    template<typename ValueTypeCV, typename ValueType = detail::uncvref_t<ValueTypeCV>,
-             detail::enable_if_t <
-                 not detail::is_basic_json<ValueType>::value and
-                 detail::has_from_json<basic_json_t, ValueType>::value and
-                 not detail::has_non_default_from_json<basic_json_t, ValueType>::value,
-                 int> = 0>
-    ValueType get() const noexcept(noexcept(
-                                       JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
-    {
-        // we cannot static_assert on ValueTypeCV being non-const, because
-        // there is support for get<const basic_json_t>(), which is why we
-        // still need the uncvref
-        static_assert(not std::is_reference<ValueTypeCV>::value,
-                      "get() cannot be used with reference types, you might want to use get_ref()");
-        static_assert(std::is_default_constructible<ValueType>::value,
-                      "types must be DefaultConstructible when used with get()");
+  template <typename ValueTypeCV, typename ValueType = detail::uncvref_t<ValueTypeCV>,
+            detail::enable_if_t<
+                not detail::is_basic_json<ValueType>::value and
+                    detail::has_from_json<basic_json_t, ValueType>::value and
+                    not detail::has_non_default_from_json<basic_json_t, ValueType>::value,
+                int> = 0>
+  ValueType get() const noexcept(noexcept(
+      JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t &>(), std::declval<ValueType &>())))
+  {
+    // we cannot static_assert on ValueTypeCV being non-const, because
+    // there is support for get<const basic_json_t>(), which is why we
+    // still need the uncvref
+    static_assert(not std::is_reference<ValueTypeCV>::value,
+                  "get() cannot be used with reference types, you might want to use get_ref()");
+    static_assert(std::is_default_constructible<ValueType>::value,
+                  "types must be DefaultConstructible when used with get()");
 
-        ValueType ret;
-        JSONSerializer<ValueType>::from_json(*this, ret);
-        return ret;
-    }
+    ValueType ret;
+    JSONSerializer<ValueType>::from_json(*this, ret);
+    return ret;
+  }
 
-    /*!
+  /*!
     @brief get a value (explicit); special case
 
     Explicit type conversion between the JSON value and a compatible value
@@ -15000,19 +13947,19 @@ class basic_json
 
     @since version 2.1.0
     */
-    template<typename ValueTypeCV, typename ValueType = detail::uncvref_t<ValueTypeCV>,
-             detail::enable_if_t<not std::is_same<basic_json_t, ValueType>::value and
-                                 detail::has_non_default_from_json<basic_json_t, ValueType>::value,
-                                 int> = 0>
-    ValueType get() const noexcept(noexcept(
-                                       JSONSerializer<ValueTypeCV>::from_json(std::declval<const basic_json_t&>())))
-    {
-        static_assert(not std::is_reference<ValueTypeCV>::value,
-                      "get() cannot be used with reference types, you might want to use get_ref()");
-        return JSONSerializer<ValueTypeCV>::from_json(*this);
-    }
+  template <typename ValueTypeCV, typename ValueType = detail::uncvref_t<ValueTypeCV>,
+            detail::enable_if_t<not std::is_same<basic_json_t, ValueType>::value and
+                                    detail::has_non_default_from_json<basic_json_t, ValueType>::value,
+                                int> = 0>
+  ValueType get() const noexcept(noexcept(
+      JSONSerializer<ValueTypeCV>::from_json(std::declval<const basic_json_t &>())))
+  {
+    static_assert(not std::is_reference<ValueTypeCV>::value,
+                  "get() cannot be used with reference types, you might want to use get_ref()");
+    return JSONSerializer<ValueTypeCV>::from_json(*this);
+  }
 
-    /*!
+  /*!
     @brief get a value (explicit)
 
     Explicit type conversion between the JSON value and a compatible value.
@@ -15045,20 +13992,19 @@ class basic_json
 
     @since version 3.3.0
     */
-    template<typename ValueType,
-             detail::enable_if_t <
-                 not detail::is_basic_json<ValueType>::value and
-                 detail::has_from_json<basic_json_t, ValueType>::value,
-                 int> = 0>
-    ValueType & get_to(ValueType& v) const noexcept(noexcept(
-                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
-    {
-        JSONSerializer<ValueType>::from_json(*this, v);
-        return v;
-    }
+  template <typename ValueType,
+            detail::enable_if_t<
+                not detail::is_basic_json<ValueType>::value and
+                    detail::has_from_json<basic_json_t, ValueType>::value,
+                int> = 0>
+  ValueType &get_to(ValueType &v) const noexcept(noexcept(
+      JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t &>(), v)))
+  {
+    JSONSerializer<ValueType>::from_json(*this, v);
+    return v;
+  }
 
-
-    /*!
+  /*!
     @brief get a pointer value (implicit)
 
     Implicit pointer access to the internally stored JSON value. No copies are
@@ -15084,28 +14030,29 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<typename PointerType, typename std::enable_if<
-                 std::is_pointer<PointerType>::value, int>::type = 0>
-    auto get_ptr() noexcept -> decltype(std::declval<basic_json_t&>().get_impl_ptr(std::declval<PointerType>()))
-    {
-        // delegate the call to get_impl_ptr<>()
-        return get_impl_ptr(static_cast<PointerType>(nullptr));
-    }
+  template <typename PointerType, typename std::enable_if<
+                                      std::is_pointer<PointerType>::value, int>::type = 0>
+  auto get_ptr() noexcept -> decltype(std::declval<basic_json_t &>().get_impl_ptr(std::declval<PointerType>()))
+  {
+    // delegate the call to get_impl_ptr<>()
+    return get_impl_ptr(static_cast<PointerType>(nullptr));
+  }
 
-    /*!
+  /*!
     @brief get a pointer value (implicit)
     @copydoc get_ptr()
     */
-    template<typename PointerType, typename std::enable_if<
-                 std::is_pointer<PointerType>::value and
-                 std::is_const<typename std::remove_pointer<PointerType>::type>::value, int>::type = 0>
-    constexpr auto get_ptr() const noexcept -> decltype(std::declval<const basic_json_t&>().get_impl_ptr(std::declval<PointerType>()))
-    {
-        // delegate the call to get_impl_ptr<>() const
-        return get_impl_ptr(static_cast<PointerType>(nullptr));
-    }
+  template <typename PointerType, typename std::enable_if<
+                                      std::is_pointer<PointerType>::value and
+                                          std::is_const<typename std::remove_pointer<PointerType>::type>::value,
+                                      int>::type = 0>
+  constexpr auto get_ptr() const noexcept -> decltype(std::declval<const basic_json_t &>().get_impl_ptr(std::declval<PointerType>()))
+  {
+    // delegate the call to get_impl_ptr<>() const
+    return get_impl_ptr(static_cast<PointerType>(nullptr));
+  }
 
-    /*!
+  /*!
     @brief get a pointer value (explicit)
 
     Explicit pointer access to the internally stored JSON value. No copies are
@@ -15132,27 +14079,27 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<typename PointerType, typename std::enable_if<
-                 std::is_pointer<PointerType>::value, int>::type = 0>
-    auto get() noexcept -> decltype(std::declval<basic_json_t&>().template get_ptr<PointerType>())
-    {
-        // delegate the call to get_ptr
-        return get_ptr<PointerType>();
-    }
+  template <typename PointerType, typename std::enable_if<
+                                      std::is_pointer<PointerType>::value, int>::type = 0>
+  auto get() noexcept -> decltype(std::declval<basic_json_t &>().template get_ptr<PointerType>())
+  {
+    // delegate the call to get_ptr
+    return get_ptr<PointerType>();
+  }
 
-    /*!
+  /*!
     @brief get a pointer value (explicit)
     @copydoc get()
     */
-    template<typename PointerType, typename std::enable_if<
-                 std::is_pointer<PointerType>::value, int>::type = 0>
-    constexpr auto get() const noexcept -> decltype(std::declval<const basic_json_t&>().template get_ptr<PointerType>())
-    {
-        // delegate the call to get_ptr
-        return get_ptr<PointerType>();
-    }
+  template <typename PointerType, typename std::enable_if<
+                                      std::is_pointer<PointerType>::value, int>::type = 0>
+  constexpr auto get() const noexcept -> decltype(std::declval<const basic_json_t &>().template get_ptr<PointerType>())
+  {
+    // delegate the call to get_ptr
+    return get_ptr<PointerType>();
+  }
 
-    /*!
+  /*!
     @brief get a reference value (implicit)
 
     Implicit reference access to the internally stored JSON value. No copies
@@ -15178,28 +14125,29 @@ class basic_json
 
     @since version 1.1.0
     */
-    template<typename ReferenceType, typename std::enable_if<
-                 std::is_reference<ReferenceType>::value, int>::type = 0>
-    ReferenceType get_ref()
-    {
-        // delegate call to get_ref_impl
-        return get_ref_impl<ReferenceType>(*this);
-    }
+  template <typename ReferenceType, typename std::enable_if<
+                                        std::is_reference<ReferenceType>::value, int>::type = 0>
+  ReferenceType get_ref()
+  {
+    // delegate call to get_ref_impl
+    return get_ref_impl<ReferenceType>(*this);
+  }
 
-    /*!
+  /*!
     @brief get a reference value (implicit)
     @copydoc get_ref()
     */
-    template<typename ReferenceType, typename std::enable_if<
-                 std::is_reference<ReferenceType>::value and
-                 std::is_const<typename std::remove_reference<ReferenceType>::type>::value, int>::type = 0>
-    ReferenceType get_ref() const
-    {
-        // delegate call to get_ref_impl
-        return get_ref_impl<ReferenceType>(*this);
-    }
+  template <typename ReferenceType, typename std::enable_if<
+                                        std::is_reference<ReferenceType>::value and
+                                            std::is_const<typename std::remove_reference<ReferenceType>::type>::value,
+                                        int>::type = 0>
+  ReferenceType get_ref() const
+  {
+    // delegate call to get_ref_impl
+    return get_ref_impl<ReferenceType>(*this);
+  }
 
-    /*!
+  /*!
     @brief get a value (implicit)
 
     Implicit type conversion between the JSON value and a compatible value.
@@ -15228,38 +14176,37 @@ class basic_json
 
     @since version 1.0.0
     */
-    template < typename ValueType, typename std::enable_if <
-                   not std::is_pointer<ValueType>::value and
-                   not std::is_same<ValueType, detail::json_ref<basic_json>>::value and
-                   not std::is_same<ValueType, typename string_t::value_type>::value and
-                   not detail::is_basic_json<ValueType>::value
+  template <typename ValueType, typename std::enable_if<
+                                    not std::is_pointer<ValueType>::value and
+                                        not std::is_same<ValueType, detail::json_ref<basic_json>>::value and
+                                        not std::is_same<ValueType, typename string_t::value_type>::value and
+                                        not detail::is_basic_json<ValueType>::value
 
-#ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
-                   and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
+#ifndef _MSC_VER // fix for issue #167 operator<< ambiguity under VS2015
+                                        and not std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>::value
 #if defined(JSON_HAS_CPP_17) && defined(_MSC_VER) and _MSC_VER <= 1914
-                   and not std::is_same<ValueType, typename std::string_view>::value
+                                        and not std::is_same<ValueType, typename std::string_view>::value
 #endif
 #endif
-                   and detail::is_detected<detail::get_template_function, const basic_json_t&, ValueType>::value
-                   , int >::type = 0 >
-    operator ValueType() const
-    {
-        // delegate the call to get<>() const
-        return get<ValueType>();
-    }
+                                        and detail::is_detected<detail::get_template_function, const basic_json_t &, ValueType>::value,
+                                    int>::type = 0>
+  operator ValueType() const
+  {
+    // delegate the call to get<>() const
+    return get<ValueType>();
+  }
 
-    /// @}
+  /// @}
 
+  ////////////////////
+  // element access //
+  ////////////////////
 
-    ////////////////////
-    // element access //
-    ////////////////////
+  /// @name element access
+  /// Access to the JSON value.
+  /// @{
 
-    /// @name element access
-    /// Access to the JSON value.
-    /// @{
-
-    /*!
+  /*!
     @brief access specified array element with bounds checking
 
     Returns a reference to the element at specified location @a idx, with
@@ -15285,28 +14232,25 @@ class basic_json
     written using `at()`. It also demonstrates the different exceptions that
     can be thrown.,at__size_type}
     */
-    reference at(size_type idx)
-    {
-        // at only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            JSON_TRY
-            {
-                return m_value.array->at(idx);
-            }
-            JSON_CATCH (std::out_of_range&)
-            {
-                // create better exception explanation
-                JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
-            }
-        }
-        else
-        {
-            JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
-        }
+  reference at(size_type idx)
+  {
+    // at only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      JSON_TRY
+      {
+        return m_value.array->at(idx);
+      }
+      JSON_CATCH(std::out_of_range &)
+      {
+        // create better exception explanation
+        JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
+      }
+    } else {
+      JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
     }
+  }
 
-    /*!
+  /*!
     @brief access specified array element with bounds checking
 
     Returns a const reference to the element at specified location @a idx,
@@ -15332,28 +14276,25 @@ class basic_json
     `at()`. It also demonstrates the different exceptions that can be thrown.,
     at__size_type_const}
     */
-    const_reference at(size_type idx) const
-    {
-        // at only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            JSON_TRY
-            {
-                return m_value.array->at(idx);
-            }
-            JSON_CATCH (std::out_of_range&)
-            {
-                // create better exception explanation
-                JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
-            }
-        }
-        else
-        {
-            JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
-        }
+  const_reference at(size_type idx) const
+  {
+    // at only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      JSON_TRY
+      {
+        return m_value.array->at(idx);
+      }
+      JSON_CATCH(std::out_of_range &)
+      {
+        // create better exception explanation
+        JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
+      }
+    } else {
+      JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
     }
+  }
 
-    /*!
+  /*!
     @brief access specified object element with bounds checking
 
     Returns a reference to the element at with specified key @a key, with
@@ -15383,28 +14324,25 @@ class basic_json
     written using `at()`. It also demonstrates the different exceptions that
     can be thrown.,at__object_t_key_type}
     */
-    reference at(const typename object_t::key_type& key)
-    {
-        // at only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            JSON_TRY
-            {
-                return m_value.object->at(key);
-            }
-            JSON_CATCH (std::out_of_range&)
-            {
-                // create better exception explanation
-                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found"));
-            }
-        }
-        else
-        {
-            JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
-        }
+  reference at(const typename object_t::key_type &key)
+  {
+    // at only works for objects
+    if (JSON_LIKELY(is_object())) {
+      JSON_TRY
+      {
+        return m_value.object->at(key);
+      }
+      JSON_CATCH(std::out_of_range &)
+      {
+        // create better exception explanation
+        JSON_THROW(out_of_range::create(403, "key '" + key + "' not found"));
+      }
+    } else {
+      JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
     }
+  }
 
-    /*!
+  /*!
     @brief access specified object element with bounds checking
 
     Returns a const reference to the element at with specified key @a key,
@@ -15434,28 +14372,25 @@ class basic_json
     `at()`. It also demonstrates the different exceptions that can be thrown.,
     at__object_t_key_type_const}
     */
-    const_reference at(const typename object_t::key_type& key) const
-    {
-        // at only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            JSON_TRY
-            {
-                return m_value.object->at(key);
-            }
-            JSON_CATCH (std::out_of_range&)
-            {
-                // create better exception explanation
-                JSON_THROW(out_of_range::create(403, "key '" + key + "' not found"));
-            }
-        }
-        else
-        {
-            JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
-        }
+  const_reference at(const typename object_t::key_type &key) const
+  {
+    // at only works for objects
+    if (JSON_LIKELY(is_object())) {
+      JSON_TRY
+      {
+        return m_value.object->at(key);
+      }
+      JSON_CATCH(std::out_of_range &)
+      {
+        // create better exception explanation
+        JSON_THROW(out_of_range::create(403, "key '" + key + "' not found"));
+      }
+    } else {
+      JSON_THROW(type_error::create(304, "cannot use at() with " + std::string(type_name())));
     }
+  }
 
-    /*!
+  /*!
     @brief access specified array element
 
     Returns a reference to the element at specified location @a idx.
@@ -15480,34 +14415,31 @@ class basic_json
 
     @since version 1.0.0
     */
-    reference operator[](size_type idx)
-    {
-        // implicitly convert null value to an empty array
-        if (is_null())
-        {
-            m_type = value_t::array;
-            m_value.array = create<array_t>();
-            assert_invariant();
-        }
-
-        // operator[] only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            // fill up array with null values if given idx is outside range
-            if (idx >= m_value.array->size())
-            {
-                m_value.array->insert(m_value.array->end(),
-                                      idx - m_value.array->size() + 1,
-                                      basic_json());
-            }
-
-            return m_value.array->operator[](idx);
-        }
-
-        JSON_THROW(type_error::create(305, "cannot use operator[] with a numeric argument with " + std::string(type_name())));
+  reference operator[](size_type idx)
+  {
+    // implicitly convert null value to an empty array
+    if (is_null()) {
+      m_type        = value_t::array;
+      m_value.array = create<array_t>();
+      assert_invariant();
     }
 
-    /*!
+    // operator[] only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      // fill up array with null values if given idx is outside range
+      if (idx >= m_value.array->size()) {
+        m_value.array->insert(m_value.array->end(),
+                              idx - m_value.array->size() + 1,
+                              basic_json());
+      }
+
+      return m_value.array->operator[](idx);
+    }
+
+    JSON_THROW(type_error::create(305, "cannot use operator[] with a numeric argument with " + std::string(type_name())));
+  }
+
+  /*!
     @brief access specified array element
 
     Returns a const reference to the element at specified location @a idx.
@@ -15526,18 +14458,17 @@ class basic_json
 
     @since version 1.0.0
     */
-    const_reference operator[](size_type idx) const
-    {
-        // const operator[] only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            return m_value.array->operator[](idx);
-        }
-
-        JSON_THROW(type_error::create(305, "cannot use operator[] with a numeric argument with " + std::string(type_name())));
+  const_reference operator[](size_type idx) const
+  {
+    // const operator[] only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      return m_value.array->operator[](idx);
     }
 
-    /*!
+    JSON_THROW(type_error::create(305, "cannot use operator[] with a numeric argument with " + std::string(type_name())));
+  }
+
+  /*!
     @brief access specified object element
 
     Returns a reference to the element at with specified key @a key.
@@ -15564,26 +14495,24 @@ class basic_json
 
     @since version 1.0.0
     */
-    reference operator[](const typename object_t::key_type& key)
-    {
-        // implicitly convert null value to an empty object
-        if (is_null())
-        {
-            m_type = value_t::object;
-            m_value.object = create<object_t>();
-            assert_invariant();
-        }
-
-        // operator[] only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            return m_value.object->operator[](key);
-        }
-
-        JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  reference operator[](const typename object_t::key_type &key)
+  {
+    // implicitly convert null value to an empty object
+    if (is_null()) {
+      m_type         = value_t::object;
+      m_value.object = create<object_t>();
+      assert_invariant();
     }
 
-    /*!
+    // operator[] only works for objects
+    if (JSON_LIKELY(is_object())) {
+      return m_value.object->operator[](key);
+    }
+
+    JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  }
+
+  /*!
     @brief read-only access specified object element
 
     Returns a const reference to the element at with specified key @a key. No
@@ -15613,19 +14542,18 @@ class basic_json
 
     @since version 1.0.0
     */
-    const_reference operator[](const typename object_t::key_type& key) const
-    {
-        // const operator[] only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            assert(m_value.object->find(key) != m_value.object->end());
-            return m_value.object->find(key)->second;
-        }
-
-        JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  const_reference operator[](const typename object_t::key_type &key) const
+  {
+    // const operator[] only works for objects
+    if (JSON_LIKELY(is_object())) {
+      assert(m_value.object->find(key) != m_value.object->end());
+      return m_value.object->find(key)->second;
     }
 
-    /*!
+    JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  }
+
+  /*!
     @brief access specified object element
 
     Returns a reference to the element at with specified key @a key.
@@ -15652,27 +14580,25 @@ class basic_json
 
     @since version 1.1.0
     */
-    template<typename T>
-    reference operator[](T* key)
-    {
-        // implicitly convert null to object
-        if (is_null())
-        {
-            m_type = value_t::object;
-            m_value = value_t::object;
-            assert_invariant();
-        }
-
-        // at only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            return m_value.object->operator[](key);
-        }
-
-        JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  template <typename T>
+  reference operator[](T *key)
+  {
+    // implicitly convert null to object
+    if (is_null()) {
+      m_type  = value_t::object;
+      m_value = value_t::object;
+      assert_invariant();
     }
 
-    /*!
+    // at only works for objects
+    if (JSON_LIKELY(is_object())) {
+      return m_value.object->operator[](key);
+    }
+
+    JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  }
+
+  /*!
     @brief read-only access specified object element
 
     Returns a const reference to the element at with specified key @a key. No
@@ -15702,20 +14628,19 @@ class basic_json
 
     @since version 1.1.0
     */
-    template<typename T>
-    const_reference operator[](T* key) const
-    {
-        // at only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            assert(m_value.object->find(key) != m_value.object->end());
-            return m_value.object->find(key)->second;
-        }
-
-        JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  template <typename T>
+  const_reference operator[](T *key) const
+  {
+    // at only works for objects
+    if (JSON_LIKELY(is_object())) {
+      assert(m_value.object->find(key) != m_value.object->end());
+      return m_value.object->find(key)->second;
     }
 
-    /*!
+    JSON_THROW(type_error::create(305, "cannot use operator[] with a string argument with " + std::string(type_name())));
+  }
+
+  /*!
     @brief access specified object element with default value
 
     Returns either a copy of an object's element at the specified key @a key
@@ -15763,36 +14688,34 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<class ValueType, typename std::enable_if<
-                 std::is_convertible<basic_json_t, ValueType>::value, int>::type = 0>
-    ValueType value(const typename object_t::key_type& key, const ValueType& default_value) const
-    {
-        // at only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            // if key is found, return value and given default value otherwise
-            const auto it = find(key);
-            if (it != end())
-            {
-                return *it;
-            }
+  template <class ValueType, typename std::enable_if<
+                                 std::is_convertible<basic_json_t, ValueType>::value, int>::type = 0>
+  ValueType value(const typename object_t::key_type &key, const ValueType &default_value) const
+  {
+    // at only works for objects
+    if (JSON_LIKELY(is_object())) {
+      // if key is found, return value and given default value otherwise
+      const auto it = find(key);
+      if (it != end()) {
+        return *it;
+      }
 
-            return default_value;
-        }
-
-        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+      return default_value;
     }
 
-    /*!
+    JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+  }
+
+  /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const typename object_t::key_type&, const ValueType&) const
     */
-    string_t value(const typename object_t::key_type& key, const char* default_value) const
-    {
-        return value(key, string_t(default_value));
-    }
+  string_t value(const typename object_t::key_type &key, const char *default_value) const
+  {
+    return value(key, string_t(default_value));
+  }
 
-    /*!
+  /*!
     @brief access specified object element via JSON Pointer with default value
 
     Returns either a copy of an object's element at the specified key @a key
@@ -15833,37 +14756,36 @@ class basic_json
 
     @since version 2.0.2
     */
-    template<class ValueType, typename std::enable_if<
-                 std::is_convertible<basic_json_t, ValueType>::value, int>::type = 0>
-    ValueType value(const json_pointer& ptr, const ValueType& default_value) const
-    {
-        // at only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            // if pointer resolves a value, return it or use default value
-            JSON_TRY
-            {
-                return ptr.get_checked(this);
-            }
-            JSON_INTERNAL_CATCH (out_of_range&)
-            {
-                return default_value;
-            }
-        }
-
-        JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+  template <class ValueType, typename std::enable_if<
+                                 std::is_convertible<basic_json_t, ValueType>::value, int>::type = 0>
+  ValueType value(const json_pointer &ptr, const ValueType &default_value) const
+  {
+    // at only works for objects
+    if (JSON_LIKELY(is_object())) {
+      // if pointer resolves a value, return it or use default value
+      JSON_TRY
+      {
+        return ptr.get_checked(this);
+      }
+      JSON_INTERNAL_CATCH(out_of_range &)
+      {
+        return default_value;
+      }
     }
 
-    /*!
+    JSON_THROW(type_error::create(306, "cannot use value() with " + std::string(type_name())));
+  }
+
+  /*!
     @brief overload for a default value of type const char*
     @copydoc basic_json::value(const json_pointer&, ValueType) const
     */
-    string_t value(const json_pointer& ptr, const char* default_value) const
-    {
-        return value(ptr, string_t(default_value));
-    }
+  string_t value(const json_pointer &ptr, const char *default_value) const
+  {
+    return value(ptr, string_t(default_value));
+  }
 
-    /*!
+  /*!
     @brief access the first element
 
     Returns a reference to the first element in the container. For a JSON
@@ -15888,20 +14810,20 @@ class basic_json
 
     @since version 1.0.0
     */
-    reference front()
-    {
-        return *begin();
-    }
+  reference front()
+  {
+    return *begin();
+  }
 
-    /*!
+  /*!
     @copydoc basic_json::front()
     */
-    const_reference front() const
-    {
-        return *cbegin();
-    }
+  const_reference front() const
+  {
+    return *cbegin();
+  }
 
-    /*!
+  /*!
     @brief access the last element
 
     Returns a reference to the last element in the container. For a JSON
@@ -15932,24 +14854,24 @@ class basic_json
 
     @since version 1.0.0
     */
-    reference back()
-    {
-        auto tmp = end();
-        --tmp;
-        return *tmp;
-    }
+  reference back()
+  {
+    auto tmp = end();
+    --tmp;
+    return *tmp;
+  }
 
-    /*!
+  /*!
     @copydoc basic_json::back()
     */
-    const_reference back() const
-    {
-        auto tmp = cend();
-        --tmp;
-        return *tmp;
-    }
+  const_reference back() const
+  {
+    auto tmp = cend();
+    --tmp;
+    return *tmp;
+  }
 
-    /*!
+  /*!
     @brief remove element given an iterator
 
     Removes the element specified by iterator @a pos. The iterator @a pos must
@@ -15995,66 +14917,59 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<class IteratorType, typename std::enable_if<
-                 std::is_same<IteratorType, typename basic_json_t::iterator>::value or
-                 std::is_same<IteratorType, typename basic_json_t::const_iterator>::value, int>::type
-             = 0>
-    IteratorType erase(IteratorType pos)
-    {
-        // make sure iterator fits the current value
-        if (JSON_UNLIKELY(this != pos.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
-        }
-
-        IteratorType result = end();
-
-        switch (m_type)
-        {
-            case value_t::boolean:
-            case value_t::number_float:
-            case value_t::number_integer:
-            case value_t::number_unsigned:
-            case value_t::string:
-            {
-                if (JSON_UNLIKELY(not pos.m_it.primitive_iterator.is_begin()))
-                {
-                    JSON_THROW(invalid_iterator::create(205, "iterator out of range"));
-                }
-
-                if (is_string())
-                {
-                    AllocatorType<string_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.string);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.string, 1);
-                    m_value.string = nullptr;
-                }
-
-                m_type = value_t::null;
-                assert_invariant();
-                break;
-            }
-
-            case value_t::object:
-            {
-                result.m_it.object_iterator = m_value.object->erase(pos.m_it.object_iterator);
-                break;
-            }
-
-            case value_t::array:
-            {
-                result.m_it.array_iterator = m_value.array->erase(pos.m_it.array_iterator);
-                break;
-            }
-
-            default:
-                JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
-        }
-
-        return result;
+  template <class IteratorType, typename std::enable_if<
+                                    std::is_same<IteratorType, typename basic_json_t::iterator>::value or
+                                        std::is_same<IteratorType, typename basic_json_t::const_iterator>::value,
+                                    int>::type = 0>
+  IteratorType erase(IteratorType pos)
+  {
+    // make sure iterator fits the current value
+    if (JSON_UNLIKELY(this != pos.m_object)) {
+      JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
     }
 
-    /*!
+    IteratorType result = end();
+
+    switch (m_type) {
+    case value_t::boolean:
+    case value_t::number_float:
+    case value_t::number_integer:
+    case value_t::number_unsigned:
+    case value_t::string: {
+      if (JSON_UNLIKELY(not pos.m_it.primitive_iterator.is_begin())) {
+        JSON_THROW(invalid_iterator::create(205, "iterator out of range"));
+      }
+
+      if (is_string()) {
+        AllocatorType<string_t> alloc;
+        std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.string);
+        std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.string, 1);
+        m_value.string = nullptr;
+      }
+
+      m_type = value_t::null;
+      assert_invariant();
+      break;
+    }
+
+    case value_t::object: {
+      result.m_it.object_iterator = m_value.object->erase(pos.m_it.object_iterator);
+      break;
+    }
+
+    case value_t::array: {
+      result.m_it.array_iterator = m_value.array->erase(pos.m_it.array_iterator);
+      break;
+    }
+
+    default:
+      JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
+    }
+
+    return result;
+  }
+
+  /*!
     @brief remove elements given an iterator range
 
     Removes the element specified by the range `[first; last)`. The iterator
@@ -16100,69 +15015,61 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<class IteratorType, typename std::enable_if<
-                 std::is_same<IteratorType, typename basic_json_t::iterator>::value or
-                 std::is_same<IteratorType, typename basic_json_t::const_iterator>::value, int>::type
-             = 0>
-    IteratorType erase(IteratorType first, IteratorType last)
-    {
-        // make sure iterator fits the current value
-        if (JSON_UNLIKELY(this != first.m_object or this != last.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(203, "iterators do not fit current value"));
-        }
-
-        IteratorType result = end();
-
-        switch (m_type)
-        {
-            case value_t::boolean:
-            case value_t::number_float:
-            case value_t::number_integer:
-            case value_t::number_unsigned:
-            case value_t::string:
-            {
-                if (JSON_LIKELY(not first.m_it.primitive_iterator.is_begin()
-                                or not last.m_it.primitive_iterator.is_end()))
-                {
-                    JSON_THROW(invalid_iterator::create(204, "iterators out of range"));
-                }
-
-                if (is_string())
-                {
-                    AllocatorType<string_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.string);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.string, 1);
-                    m_value.string = nullptr;
-                }
-
-                m_type = value_t::null;
-                assert_invariant();
-                break;
-            }
-
-            case value_t::object:
-            {
-                result.m_it.object_iterator = m_value.object->erase(first.m_it.object_iterator,
-                                              last.m_it.object_iterator);
-                break;
-            }
-
-            case value_t::array:
-            {
-                result.m_it.array_iterator = m_value.array->erase(first.m_it.array_iterator,
-                                             last.m_it.array_iterator);
-                break;
-            }
-
-            default:
-                JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
-        }
-
-        return result;
+  template <class IteratorType, typename std::enable_if<
+                                    std::is_same<IteratorType, typename basic_json_t::iterator>::value or
+                                        std::is_same<IteratorType, typename basic_json_t::const_iterator>::value,
+                                    int>::type = 0>
+  IteratorType erase(IteratorType first, IteratorType last)
+  {
+    // make sure iterator fits the current value
+    if (JSON_UNLIKELY(this != first.m_object or this != last.m_object)) {
+      JSON_THROW(invalid_iterator::create(203, "iterators do not fit current value"));
     }
 
-    /*!
+    IteratorType result = end();
+
+    switch (m_type) {
+    case value_t::boolean:
+    case value_t::number_float:
+    case value_t::number_integer:
+    case value_t::number_unsigned:
+    case value_t::string: {
+      if (JSON_LIKELY(not first.m_it.primitive_iterator.is_begin() or not last.m_it.primitive_iterator.is_end())) {
+        JSON_THROW(invalid_iterator::create(204, "iterators out of range"));
+      }
+
+      if (is_string()) {
+        AllocatorType<string_t> alloc;
+        std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.string);
+        std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.string, 1);
+        m_value.string = nullptr;
+      }
+
+      m_type = value_t::null;
+      assert_invariant();
+      break;
+    }
+
+    case value_t::object: {
+      result.m_it.object_iterator = m_value.object->erase(first.m_it.object_iterator,
+                                                          last.m_it.object_iterator);
+      break;
+    }
+
+    case value_t::array: {
+      result.m_it.array_iterator = m_value.array->erase(first.m_it.array_iterator,
+                                                        last.m_it.array_iterator);
+      break;
+    }
+
+    default:
+      JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
+    }
+
+    return result;
+  }
+
+  /*!
     @brief remove element from a JSON object given a key
 
     Removes elements from a JSON object with the key value @a key.
@@ -16191,18 +15098,17 @@ class basic_json
 
     @since version 1.0.0
     */
-    size_type erase(const typename object_t::key_type& key)
-    {
-        // this erase only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            return m_value.object->erase(key);
-        }
-
-        JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
+  size_type erase(const typename object_t::key_type &key)
+  {
+    // this erase only works for objects
+    if (JSON_LIKELY(is_object())) {
+      return m_value.object->erase(key);
     }
 
-    /*!
+    JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
+  }
+
+  /*!
     @brief remove element from a JSON array given an index
 
     Removes element from a JSON array at the index @a idx.
@@ -16226,35 +15132,30 @@ class basic_json
 
     @since version 1.0.0
     */
-    void erase(const size_type idx)
-    {
-        // this erase only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            if (JSON_UNLIKELY(idx >= size()))
-            {
-                JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
-            }
+  void erase(const size_type idx)
+  {
+    // this erase only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      if (JSON_UNLIKELY(idx >= size())) {
+        JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
+      }
 
-            m_value.array->erase(m_value.array->begin() + static_cast<difference_type>(idx));
-        }
-        else
-        {
-            JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
-        }
+      m_value.array->erase(m_value.array->begin() + static_cast<difference_type>(idx));
+    } else {
+      JSON_THROW(type_error::create(307, "cannot use erase() with " + std::string(type_name())));
     }
+  }
 
-    /// @}
+  /// @}
 
+  ////////////
+  // lookup //
+  ////////////
 
-    ////////////
-    // lookup //
-    ////////////
+  /// @name lookup
+  /// @{
 
-    /// @name lookup
-    /// @{
-
-    /*!
+  /*!
     @brief find an element in a JSON object
 
     Finds an element in a JSON object with key equivalent to @a key. If the
@@ -16276,37 +15177,35 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<typename KeyT>
-    iterator find(KeyT&& key)
-    {
-        auto result = end();
+  template <typename KeyT>
+  iterator find(KeyT &&key)
+  {
+    auto result = end();
 
-        if (is_object())
-        {
-            result.m_it.object_iterator = m_value.object->find(std::forward<KeyT>(key));
-        }
-
-        return result;
+    if (is_object()) {
+      result.m_it.object_iterator = m_value.object->find(std::forward<KeyT>(key));
     }
 
-    /*!
+    return result;
+  }
+
+  /*!
     @brief find an element in a JSON object
     @copydoc find(KeyT&&)
     */
-    template<typename KeyT>
-    const_iterator find(KeyT&& key) const
-    {
-        auto result = cend();
+  template <typename KeyT>
+  const_iterator find(KeyT &&key) const
+  {
+    auto result = cend();
 
-        if (is_object())
-        {
-            result.m_it.object_iterator = m_value.object->find(std::forward<KeyT>(key));
-        }
-
-        return result;
+    if (is_object()) {
+      result.m_it.object_iterator = m_value.object->find(std::forward<KeyT>(key));
     }
 
-    /*!
+    return result;
+  }
+
+  /*!
     @brief returns the number of occurrences of a key in a JSON object
 
     Returns the number of elements with key @a key. If ObjectType is the
@@ -16327,24 +15226,23 @@ class basic_json
 
     @since version 1.0.0
     */
-    template<typename KeyT>
-    size_type count(KeyT&& key) const
-    {
-        // return 0 for all nonobject types
-        return is_object() ? m_value.object->count(std::forward<KeyT>(key)) : 0;
-    }
+  template <typename KeyT>
+  size_type count(KeyT &&key) const
+  {
+    // return 0 for all nonobject types
+    return is_object() ? m_value.object->count(std::forward<KeyT>(key)) : 0;
+  }
 
-    /// @}
+  /// @}
 
+  ///////////////
+  // iterators //
+  ///////////////
 
-    ///////////////
-    // iterators //
-    ///////////////
+  /// @name iterators
+  /// @{
 
-    /// @name iterators
-    /// @{
-
-    /*!
+  /*!
     @brief returns an iterator to the first element
 
     Returns an iterator to the first element.
@@ -16368,22 +15266,22 @@ class basic_json
 
     @since version 1.0.0
     */
-    iterator begin() noexcept
-    {
-        iterator result(this);
-        result.set_begin();
-        return result;
-    }
+  iterator begin() noexcept
+  {
+    iterator result(this);
+    result.set_begin();
+    return result;
+  }
 
-    /*!
+  /*!
     @copydoc basic_json::cbegin()
     */
-    const_iterator begin() const noexcept
-    {
-        return cbegin();
-    }
+  const_iterator begin() const noexcept
+  {
+    return cbegin();
+  }
 
-    /*!
+  /*!
     @brief returns a const iterator to the first element
 
     Returns a const iterator to the first element.
@@ -16408,14 +15306,14 @@ class basic_json
 
     @since version 1.0.0
     */
-    const_iterator cbegin() const noexcept
-    {
-        const_iterator result(this);
-        result.set_begin();
-        return result;
-    }
+  const_iterator cbegin() const noexcept
+  {
+    const_iterator result(this);
+    result.set_begin();
+    return result;
+  }
 
-    /*!
+  /*!
     @brief returns an iterator to one past the last element
 
     Returns an iterator to one past the last element.
@@ -16439,22 +15337,22 @@ class basic_json
 
     @since version 1.0.0
     */
-    iterator end() noexcept
-    {
-        iterator result(this);
-        result.set_end();
-        return result;
-    }
+  iterator end() noexcept
+  {
+    iterator result(this);
+    result.set_end();
+    return result;
+  }
 
-    /*!
+  /*!
     @copydoc basic_json::cend()
     */
-    const_iterator end() const noexcept
-    {
-        return cend();
-    }
+  const_iterator end() const noexcept
+  {
+    return cend();
+  }
 
-    /*!
+  /*!
     @brief returns a const iterator to one past the last element
 
     Returns a const iterator to one past the last element.
@@ -16479,14 +15377,14 @@ class basic_json
 
     @since version 1.0.0
     */
-    const_iterator cend() const noexcept
-    {
-        const_iterator result(this);
-        result.set_end();
-        return result;
-    }
+  const_iterator cend() const noexcept
+  {
+    const_iterator result(this);
+    result.set_end();
+    return result;
+  }
 
-    /*!
+  /*!
     @brief returns an iterator to the reverse-beginning
 
     Returns an iterator to the reverse-beginning; that is, the last element.
@@ -16509,20 +15407,20 @@ class basic_json
 
     @since version 1.0.0
     */
-    reverse_iterator rbegin() noexcept
-    {
-        return reverse_iterator(end());
-    }
+  reverse_iterator rbegin() noexcept
+  {
+    return reverse_iterator(end());
+  }
 
-    /*!
+  /*!
     @copydoc basic_json::crbegin()
     */
-    const_reverse_iterator rbegin() const noexcept
-    {
-        return crbegin();
-    }
+  const_reverse_iterator rbegin() const noexcept
+  {
+    return crbegin();
+  }
 
-    /*!
+  /*!
     @brief returns an iterator to the reverse-end
 
     Returns an iterator to the reverse-end; that is, one before the first
@@ -16546,20 +15444,20 @@ class basic_json
 
     @since version 1.0.0
     */
-    reverse_iterator rend() noexcept
-    {
-        return reverse_iterator(begin());
-    }
+  reverse_iterator rend() noexcept
+  {
+    return reverse_iterator(begin());
+  }
 
-    /*!
+  /*!
     @copydoc basic_json::crend()
     */
-    const_reverse_iterator rend() const noexcept
-    {
-        return crend();
-    }
+  const_reverse_iterator rend() const noexcept
+  {
+    return crend();
+  }
 
-    /*!
+  /*!
     @brief returns a const reverse iterator to the last element
 
     Returns a const iterator to the reverse-beginning; that is, the last
@@ -16583,12 +15481,12 @@ class basic_json
 
     @since version 1.0.0
     */
-    const_reverse_iterator crbegin() const noexcept
-    {
-        return const_reverse_iterator(cend());
-    }
+  const_reverse_iterator crbegin() const noexcept
+  {
+    return const_reverse_iterator(cend());
+  }
 
-    /*!
+  /*!
     @brief returns a const reverse iterator to one before the first
 
     Returns a const reverse iterator to the reverse-end; that is, one before
@@ -16612,13 +15510,13 @@ class basic_json
 
     @since version 1.0.0
     */
-    const_reverse_iterator crend() const noexcept
-    {
-        return const_reverse_iterator(cbegin());
-    }
+  const_reverse_iterator crend() const noexcept
+  {
+    return const_reverse_iterator(cbegin());
+  }
 
-  public:
-    /*!
+public:
+  /*!
     @brief wrapper to access iterator member functions in range-based for
 
     This function allows to access @ref iterator::key() and @ref
@@ -16675,22 +15573,22 @@ class basic_json
                 future 4.0.0 of the library. Please use @ref items() instead;
                 that is, replace `json::iterator_wrapper(j)` with `j.items()`.
     */
-    JSON_DEPRECATED
-    static iteration_proxy<iterator> iterator_wrapper(reference ref) noexcept
-    {
-        return ref.items();
-    }
+  JSON_DEPRECATED
+  static iteration_proxy<iterator> iterator_wrapper(reference ref) noexcept
+  {
+    return ref.items();
+  }
 
-    /*!
+  /*!
     @copydoc iterator_wrapper(reference)
     */
-    JSON_DEPRECATED
-    static iteration_proxy<const_iterator> iterator_wrapper(const_reference ref) noexcept
-    {
-        return ref.items();
-    }
+  JSON_DEPRECATED
+  static iteration_proxy<const_iterator> iterator_wrapper(const_reference ref) noexcept
+  {
+    return ref.items();
+  }
 
-    /*!
+  /*!
     @brief helper to access iterator member functions in range-based for
 
     This function allows to access @ref iterator::key() and @ref
@@ -16753,30 +15651,29 @@ class basic_json
 
     @since version 3.1.0, structured bindings support since 3.5.0.
     */
-    iteration_proxy<iterator> items() noexcept
-    {
-        return iteration_proxy<iterator>(*this);
-    }
+  iteration_proxy<iterator> items() noexcept
+  {
+    return iteration_proxy<iterator>(*this);
+  }
 
-    /*!
+  /*!
     @copydoc items()
     */
-    iteration_proxy<const_iterator> items() const noexcept
-    {
-        return iteration_proxy<const_iterator>(*this);
-    }
+  iteration_proxy<const_iterator> items() const noexcept
+  {
+    return iteration_proxy<const_iterator>(*this);
+  }
 
-    /// @}
+  /// @}
 
+  //////////////
+  // capacity //
+  //////////////
 
-    //////////////
-    // capacity //
-    //////////////
+  /// @name capacity
+  /// @{
 
-    /// @name capacity
-    /// @{
-
-    /*!
+  /*!
     @brief checks whether the container is empty.
 
     Checks if a JSON value has no elements (i.e. whether its @ref size is `0`).
@@ -16817,37 +15714,32 @@ class basic_json
 
     @since version 1.0.0
     */
-    bool empty() const noexcept
-    {
-        switch (m_type)
-        {
-            case value_t::null:
-            {
-                // null values are empty
-                return true;
-            }
-
-            case value_t::array:
-            {
-                // delegate call to array_t::empty()
-                return m_value.array->empty();
-            }
-
-            case value_t::object:
-            {
-                // delegate call to object_t::empty()
-                return m_value.object->empty();
-            }
-
-            default:
-            {
-                // all other types are nonempty
-                return false;
-            }
-        }
+  bool empty() const noexcept
+  {
+    switch (m_type) {
+    case value_t::null: {
+      // null values are empty
+      return true;
     }
 
-    /*!
+    case value_t::array: {
+      // delegate call to array_t::empty()
+      return m_value.array->empty();
+    }
+
+    case value_t::object: {
+      // delegate call to object_t::empty()
+      return m_value.object->empty();
+    }
+
+    default: {
+      // all other types are nonempty
+      return false;
+    }
+    }
+  }
+
+  /*!
     @brief returns the number of elements
 
     Returns the number of elements in a JSON value.
@@ -16889,37 +15781,32 @@ class basic_json
 
     @since version 1.0.0
     */
-    size_type size() const noexcept
-    {
-        switch (m_type)
-        {
-            case value_t::null:
-            {
-                // null values are empty
-                return 0;
-            }
-
-            case value_t::array:
-            {
-                // delegate call to array_t::size()
-                return m_value.array->size();
-            }
-
-            case value_t::object:
-            {
-                // delegate call to object_t::size()
-                return m_value.object->size();
-            }
-
-            default:
-            {
-                // all other types have size 1
-                return 1;
-            }
-        }
+  size_type size() const noexcept
+  {
+    switch (m_type) {
+    case value_t::null: {
+      // null values are empty
+      return 0;
     }
 
-    /*!
+    case value_t::array: {
+      // delegate call to array_t::size()
+      return m_value.array->size();
+    }
+
+    case value_t::object: {
+      // delegate call to object_t::size()
+      return m_value.object->size();
+    }
+
+    default: {
+      // all other types have size 1
+      return 1;
+    }
+    }
+  }
+
+  /*!
     @brief returns the maximum possible number of elements
 
     Returns the maximum number of elements a JSON value is able to hold due to
@@ -16959,41 +15846,36 @@ class basic_json
 
     @since version 1.0.0
     */
-    size_type max_size() const noexcept
-    {
-        switch (m_type)
-        {
-            case value_t::array:
-            {
-                // delegate call to array_t::max_size()
-                return m_value.array->max_size();
-            }
-
-            case value_t::object:
-            {
-                // delegate call to object_t::max_size()
-                return m_value.object->max_size();
-            }
-
-            default:
-            {
-                // all other types have max_size() == size()
-                return size();
-            }
-        }
+  size_type max_size() const noexcept
+  {
+    switch (m_type) {
+    case value_t::array: {
+      // delegate call to array_t::max_size()
+      return m_value.array->max_size();
     }
 
-    /// @}
+    case value_t::object: {
+      // delegate call to object_t::max_size()
+      return m_value.object->max_size();
+    }
 
+    default: {
+      // all other types have max_size() == size()
+      return size();
+    }
+    }
+  }
 
-    ///////////////
-    // modifiers //
-    ///////////////
+  /// @}
 
-    /// @name modifiers
-    /// @{
+  ///////////////
+  // modifiers //
+  ///////////////
 
-    /*!
+  /// @name modifiers
+  /// @{
+
+  /*!
     @brief clears the contents
 
     Clears the content of a JSON value and resets it to the default value as
@@ -17029,58 +15911,50 @@ class basic_json
 
     @since version 1.0.0
     */
-    void clear() noexcept
-    {
-        switch (m_type)
-        {
-            case value_t::number_integer:
-            {
-                m_value.number_integer = 0;
-                break;
-            }
-
-            case value_t::number_unsigned:
-            {
-                m_value.number_unsigned = 0;
-                break;
-            }
-
-            case value_t::number_float:
-            {
-                m_value.number_float = 0.0;
-                break;
-            }
-
-            case value_t::boolean:
-            {
-                m_value.boolean = false;
-                break;
-            }
-
-            case value_t::string:
-            {
-                m_value.string->clear();
-                break;
-            }
-
-            case value_t::array:
-            {
-                m_value.array->clear();
-                break;
-            }
-
-            case value_t::object:
-            {
-                m_value.object->clear();
-                break;
-            }
-
-            default:
-                break;
-        }
+  void clear() noexcept
+  {
+    switch (m_type) {
+    case value_t::number_integer: {
+      m_value.number_integer = 0;
+      break;
     }
 
-    /*!
+    case value_t::number_unsigned: {
+      m_value.number_unsigned = 0;
+      break;
+    }
+
+    case value_t::number_float: {
+      m_value.number_float = 0.0;
+      break;
+    }
+
+    case value_t::boolean: {
+      m_value.boolean = false;
+      break;
+    }
+
+    case value_t::string: {
+      m_value.string->clear();
+      break;
+    }
+
+    case value_t::array: {
+      m_value.array->clear();
+      break;
+    }
+
+    case value_t::object: {
+      m_value.object->clear();
+      break;
+    }
+
+    default:
+      break;
+    }
+  }
+
+  /*!
     @brief add an object to an array
 
     Appends the given element @a val to the end of the JSON value. If the
@@ -17100,73 +15974,69 @@ class basic_json
 
     @since version 1.0.0
     */
-    void push_back(basic_json&& val)
-    {
-        // push_back only works for null objects or arrays
-        if (JSON_UNLIKELY(not(is_null() or is_array())))
-        {
-            JSON_THROW(type_error::create(308, "cannot use push_back() with " + std::string(type_name())));
-        }
-
-        // transform null object into an array
-        if (is_null())
-        {
-            m_type = value_t::array;
-            m_value = value_t::array;
-            assert_invariant();
-        }
-
-        // add element to array (move semantics)
-        m_value.array->push_back(std::move(val));
-        // invalidate object
-        val.m_type = value_t::null;
+  void push_back(basic_json &&val)
+  {
+    // push_back only works for null objects or arrays
+    if (JSON_UNLIKELY(not(is_null() or is_array()))) {
+      JSON_THROW(type_error::create(308, "cannot use push_back() with " + std::string(type_name())));
     }
 
-    /*!
+    // transform null object into an array
+    if (is_null()) {
+      m_type  = value_t::array;
+      m_value = value_t::array;
+      assert_invariant();
+    }
+
+    // add element to array (move semantics)
+    m_value.array->push_back(std::move(val));
+    // invalidate object
+    val.m_type = value_t::null;
+  }
+
+  /*!
     @brief add an object to an array
     @copydoc push_back(basic_json&&)
     */
-    reference operator+=(basic_json&& val)
-    {
-        push_back(std::move(val));
-        return *this;
-    }
+  reference operator+=(basic_json &&val)
+  {
+    push_back(std::move(val));
+    return *this;
+  }
 
-    /*!
+  /*!
     @brief add an object to an array
     @copydoc push_back(basic_json&&)
     */
-    void push_back(const basic_json& val)
-    {
-        // push_back only works for null objects or arrays
-        if (JSON_UNLIKELY(not(is_null() or is_array())))
-        {
-            JSON_THROW(type_error::create(308, "cannot use push_back() with " + std::string(type_name())));
-        }
-
-        // transform null object into an array
-        if (is_null())
-        {
-            m_type = value_t::array;
-            m_value = value_t::array;
-            assert_invariant();
-        }
-
-        // add element to array
-        m_value.array->push_back(val);
+  void push_back(const basic_json &val)
+  {
+    // push_back only works for null objects or arrays
+    if (JSON_UNLIKELY(not(is_null() or is_array()))) {
+      JSON_THROW(type_error::create(308, "cannot use push_back() with " + std::string(type_name())));
     }
 
-    /*!
+    // transform null object into an array
+    if (is_null()) {
+      m_type  = value_t::array;
+      m_value = value_t::array;
+      assert_invariant();
+    }
+
+    // add element to array
+    m_value.array->push_back(val);
+  }
+
+  /*!
     @brief add an object to an array
     @copydoc push_back(basic_json&&)
     */
-    reference operator+=(const basic_json& val)
-    {
-        push_back(val);
-        return *this;
-    }
+  reference operator+=(const basic_json &val)
+  {
+    push_back(val);
+    return *this;
+  }
 
-    /*!
+  /*!
     @brief add an object to an object
 
     Inserts the given element @a val to the JSON object. If the function is
@@ -17186,37 +16056,35 @@ class basic_json
 
     @since version 1.0.0
     */
-    void push_back(const typename object_t::value_type& val)
-    {
-        // push_back only works for null objects or objects
-        if (JSON_UNLIKELY(not(is_null() or is_object())))
-        {
-            JSON_THROW(type_error::create(308, "cannot use push_back() with " + std::string(type_name())));
-        }
-
-        // transform null object into an object
-        if (is_null())
-        {
-            m_type = value_t::object;
-            m_value = value_t::object;
-            assert_invariant();
-        }
-
-        // add element to array
-        m_value.object->insert(val);
+  void push_back(const typename object_t::value_type &val)
+  {
+    // push_back only works for null objects or objects
+    if (JSON_UNLIKELY(not(is_null() or is_object()))) {
+      JSON_THROW(type_error::create(308, "cannot use push_back() with " + std::string(type_name())));
     }
 
-    /*!
+    // transform null object into an object
+    if (is_null()) {
+      m_type  = value_t::object;
+      m_value = value_t::object;
+      assert_invariant();
+    }
+
+    // add element to array
+    m_value.object->insert(val);
+  }
+
+  /*!
     @brief add an object to an object
     @copydoc push_back(const typename object_t::value_type&)
     */
-    reference operator+=(const typename object_t::value_type& val)
-    {
-        push_back(val);
-        return *this;
-    }
+  reference operator+=(const typename object_t::value_type &val)
+  {
+    push_back(val);
+    return *this;
+  }
 
-    /*!
+  /*!
     @brief add an object to an object
 
     This function allows to use `push_back` with an initializer list. In case
@@ -17241,31 +16109,28 @@ class basic_json
     @liveexample{The example shows how initializer lists are treated as
     objects when possible.,push_back__initializer_list}
     */
-    void push_back(initializer_list_t init)
-    {
-        if (is_object() and init.size() == 2 and (*init.begin())->is_string())
-        {
-            basic_json&& key = init.begin()->moved_or_copied();
-            push_back(typename object_t::value_type(
-                          std::move(key.get_ref<string_t&>()), (init.begin() + 1)->moved_or_copied()));
-        }
-        else
-        {
-            push_back(basic_json(init));
-        }
+  void push_back(initializer_list_t init)
+  {
+    if (is_object() and init.size() == 2 and (*init.begin())->is_string()) {
+      basic_json &&key = init.begin()->moved_or_copied();
+      push_back(typename object_t::value_type(
+          std::move(key.get_ref<string_t &>()), (init.begin() + 1)->moved_or_copied()));
+    } else {
+      push_back(basic_json(init));
     }
+  }
 
-    /*!
+  /*!
     @brief add an object to an object
     @copydoc push_back(initializer_list_t)
     */
-    reference operator+=(initializer_list_t init)
-    {
-        push_back(init);
-        return *this;
-    }
+  reference operator+=(initializer_list_t init)
+  {
+    push_back(init);
+    return *this;
+  }
 
-    /*!
+  /*!
     @brief add an object to an array
 
     Creates a JSON value from the passed parameters @a args to the end of the
@@ -17286,28 +16151,26 @@ class basic_json
 
     @since version 2.0.8
     */
-    template<class... Args>
-    void emplace_back(Args&& ... args)
-    {
-        // emplace_back only works for null objects or arrays
-        if (JSON_UNLIKELY(not(is_null() or is_array())))
-        {
-            JSON_THROW(type_error::create(311, "cannot use emplace_back() with " + std::string(type_name())));
-        }
-
-        // transform null object into an array
-        if (is_null())
-        {
-            m_type = value_t::array;
-            m_value = value_t::array;
-            assert_invariant();
-        }
-
-        // add element to array (perfect forwarding)
-        m_value.array->emplace_back(std::forward<Args>(args)...);
+  template <class... Args>
+  void emplace_back(Args &&... args)
+  {
+    // emplace_back only works for null objects or arrays
+    if (JSON_UNLIKELY(not(is_null() or is_array()))) {
+      JSON_THROW(type_error::create(311, "cannot use emplace_back() with " + std::string(type_name())));
     }
 
-    /*!
+    // transform null object into an array
+    if (is_null()) {
+      m_type  = value_t::array;
+      m_value = value_t::array;
+      assert_invariant();
+    }
+
+    // add element to array (perfect forwarding)
+    m_value.array->emplace_back(std::forward<Args>(args)...);
+  }
+
+  /*!
     @brief add an object to an object if key does not exist
 
     Inserts a new element into a JSON object constructed in-place with the
@@ -17334,54 +16197,52 @@ class basic_json
 
     @since version 2.0.8
     */
-    template<class... Args>
-    std::pair<iterator, bool> emplace(Args&& ... args)
-    {
-        // emplace only works for null objects or arrays
-        if (JSON_UNLIKELY(not(is_null() or is_object())))
-        {
-            JSON_THROW(type_error::create(311, "cannot use emplace() with " + std::string(type_name())));
-        }
-
-        // transform null object into an object
-        if (is_null())
-        {
-            m_type = value_t::object;
-            m_value = value_t::object;
-            assert_invariant();
-        }
-
-        // add element to array (perfect forwarding)
-        auto res = m_value.object->emplace(std::forward<Args>(args)...);
-        // create result iterator and set iterator to the result of emplace
-        auto it = begin();
-        it.m_it.object_iterator = res.first;
-
-        // return pair of iterator and boolean
-        return {it, res.second};
+  template <class... Args>
+  std::pair<iterator, bool> emplace(Args &&... args)
+  {
+    // emplace only works for null objects or arrays
+    if (JSON_UNLIKELY(not(is_null() or is_object()))) {
+      JSON_THROW(type_error::create(311, "cannot use emplace() with " + std::string(type_name())));
     }
 
-    /// Helper for insertion of an iterator
-    /// @note: This uses std::distance to support GCC 4.8,
-    ///        see https://github.com/nlohmann/json/pull/1257
-    template<typename... Args>
-    iterator insert_iterator(const_iterator pos, Args&& ... args)
-    {
-        iterator result(this);
-        assert(m_value.array != nullptr);
-
-        auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
-        m_value.array->insert(pos.m_it.array_iterator, std::forward<Args>(args)...);
-        result.m_it.array_iterator = m_value.array->begin() + insert_pos;
-
-        // This could have been written as:
-        // result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
-        // but the return value of insert is missing in GCC 4.8, so it is written this way instead.
-
-        return result;
+    // transform null object into an object
+    if (is_null()) {
+      m_type  = value_t::object;
+      m_value = value_t::object;
+      assert_invariant();
     }
 
-    /*!
+    // add element to array (perfect forwarding)
+    auto res = m_value.object->emplace(std::forward<Args>(args)...);
+    // create result iterator and set iterator to the result of emplace
+    auto it                 = begin();
+    it.m_it.object_iterator = res.first;
+
+    // return pair of iterator and boolean
+    return {it, res.second};
+  }
+
+  /// Helper for insertion of an iterator
+  /// @note: This uses std::distance to support GCC 4.8,
+  ///        see https://github.com/nlohmann/json/pull/1257
+  template <typename... Args>
+  iterator insert_iterator(const_iterator pos, Args &&... args)
+  {
+    iterator result(this);
+    assert(m_value.array != nullptr);
+
+    auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+    m_value.array->insert(pos.m_it.array_iterator, std::forward<Args>(args)...);
+    result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+
+    // This could have been written as:
+    // result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+    // but the return value of insert is missing in GCC 4.8, so it is written this way instead.
+
+    return result;
+  }
+
+  /*!
     @brief inserts element
 
     Inserts element @a val before iterator @a pos.
@@ -17403,34 +16264,32 @@ class basic_json
 
     @since version 1.0.0
     */
-    iterator insert(const_iterator pos, const basic_json& val)
-    {
-        // insert only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            // check if iterator pos fits to this JSON value
-            if (JSON_UNLIKELY(pos.m_object != this))
-            {
-                JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
-            }
+  iterator insert(const_iterator pos, const basic_json &val)
+  {
+    // insert only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      // check if iterator pos fits to this JSON value
+      if (JSON_UNLIKELY(pos.m_object != this)) {
+        JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
+      }
 
-            // insert to array and return iterator
-            return insert_iterator(pos, val);
-        }
-
-        JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
+      // insert to array and return iterator
+      return insert_iterator(pos, val);
     }
 
-    /*!
+    JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
+  }
+
+  /*!
     @brief inserts element
     @copydoc insert(const_iterator, const basic_json&)
     */
-    iterator insert(const_iterator pos, basic_json&& val)
-    {
-        return insert(pos, val);
-    }
+  iterator insert(const_iterator pos, basic_json &&val)
+  {
+    return insert(pos, val);
+  }
 
-    /*!
+  /*!
     @brief inserts elements
 
     Inserts @a cnt copies of @a val before iterator @a pos.
@@ -17454,25 +16313,23 @@ class basic_json
 
     @since version 1.0.0
     */
-    iterator insert(const_iterator pos, size_type cnt, const basic_json& val)
-    {
-        // insert only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            // check if iterator pos fits to this JSON value
-            if (JSON_UNLIKELY(pos.m_object != this))
-            {
-                JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
-            }
+  iterator insert(const_iterator pos, size_type cnt, const basic_json &val)
+  {
+    // insert only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      // check if iterator pos fits to this JSON value
+      if (JSON_UNLIKELY(pos.m_object != this)) {
+        JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
+      }
 
-            // insert to array and return iterator
-            return insert_iterator(pos, cnt, val);
-        }
-
-        JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
+      // insert to array and return iterator
+      return insert_iterator(pos, cnt, val);
     }
 
-    /*!
+    JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
+  }
+
+  /*!
     @brief inserts elements
 
     Inserts elements from range `[first, last)` before iterator @a pos.
@@ -17502,36 +16359,32 @@ class basic_json
 
     @since version 1.0.0
     */
-    iterator insert(const_iterator pos, const_iterator first, const_iterator last)
-    {
-        // insert only works for arrays
-        if (JSON_UNLIKELY(not is_array()))
-        {
-            JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
-        }
-
-        // check if iterator pos fits to this JSON value
-        if (JSON_UNLIKELY(pos.m_object != this))
-        {
-            JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
-        }
-
-        // check if range iterators belong to the same JSON object
-        if (JSON_UNLIKELY(first.m_object != last.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(210, "iterators do not fit"));
-        }
-
-        if (JSON_UNLIKELY(first.m_object == this))
-        {
-            JSON_THROW(invalid_iterator::create(211, "passed iterators may not belong to container"));
-        }
-
-        // insert to array and return iterator
-        return insert_iterator(pos, first.m_it.array_iterator, last.m_it.array_iterator);
+  iterator insert(const_iterator pos, const_iterator first, const_iterator last)
+  {
+    // insert only works for arrays
+    if (JSON_UNLIKELY(not is_array())) {
+      JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
     }
 
-    /*!
+    // check if iterator pos fits to this JSON value
+    if (JSON_UNLIKELY(pos.m_object != this)) {
+      JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
+    }
+
+    // check if range iterators belong to the same JSON object
+    if (JSON_UNLIKELY(first.m_object != last.m_object)) {
+      JSON_THROW(invalid_iterator::create(210, "iterators do not fit"));
+    }
+
+    if (JSON_UNLIKELY(first.m_object == this)) {
+      JSON_THROW(invalid_iterator::create(211, "passed iterators may not belong to container"));
+    }
+
+    // insert to array and return iterator
+    return insert_iterator(pos, first.m_it.array_iterator, last.m_it.array_iterator);
+  }
+
+  /*!
     @brief inserts elements
 
     Inserts elements from initializer list @a ilist before iterator @a pos.
@@ -17555,25 +16408,23 @@ class basic_json
 
     @since version 1.0.0
     */
-    iterator insert(const_iterator pos, initializer_list_t ilist)
-    {
-        // insert only works for arrays
-        if (JSON_UNLIKELY(not is_array()))
-        {
-            JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
-        }
-
-        // check if iterator pos fits to this JSON value
-        if (JSON_UNLIKELY(pos.m_object != this))
-        {
-            JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
-        }
-
-        // insert to array and return iterator
-        return insert_iterator(pos, ilist.begin(), ilist.end());
+  iterator insert(const_iterator pos, initializer_list_t ilist)
+  {
+    // insert only works for arrays
+    if (JSON_UNLIKELY(not is_array())) {
+      JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
     }
 
-    /*!
+    // check if iterator pos fits to this JSON value
+    if (JSON_UNLIKELY(pos.m_object != this)) {
+      JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value"));
+    }
+
+    // insert to array and return iterator
+    return insert_iterator(pos, ilist.begin(), ilist.end());
+  }
+
+  /*!
     @brief inserts elements
 
     Inserts elements from range `[first, last)`.
@@ -17596,30 +16447,27 @@ class basic_json
 
     @since version 3.0.0
     */
-    void insert(const_iterator first, const_iterator last)
-    {
-        // insert only works for objects
-        if (JSON_UNLIKELY(not is_object()))
-        {
-            JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
-        }
-
-        // check if range iterators belong to the same JSON object
-        if (JSON_UNLIKELY(first.m_object != last.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(210, "iterators do not fit"));
-        }
-
-        // passed iterators must belong to objects
-        if (JSON_UNLIKELY(not first.m_object->is_object()))
-        {
-            JSON_THROW(invalid_iterator::create(202, "iterators first and last must point to objects"));
-        }
-
-        m_value.object->insert(first.m_it.object_iterator, last.m_it.object_iterator);
+  void insert(const_iterator first, const_iterator last)
+  {
+    // insert only works for objects
+    if (JSON_UNLIKELY(not is_object())) {
+      JSON_THROW(type_error::create(309, "cannot use insert() with " + std::string(type_name())));
     }
 
-    /*!
+    // check if range iterators belong to the same JSON object
+    if (JSON_UNLIKELY(first.m_object != last.m_object)) {
+      JSON_THROW(invalid_iterator::create(210, "iterators do not fit"));
+    }
+
+    // passed iterators must belong to objects
+    if (JSON_UNLIKELY(not first.m_object->is_object())) {
+      JSON_THROW(invalid_iterator::create(202, "iterators first and last must point to objects"));
+    }
+
+    m_value.object->insert(first.m_it.object_iterator, last.m_it.object_iterator);
+  }
+
+  /*!
     @brief updates a JSON object from another object, overwriting existing keys
 
     Inserts all values from JSON object @a j and overwrites existing keys.
@@ -17638,32 +16486,28 @@ class basic_json
 
     @since version 3.0.0
     */
-    void update(const_reference j)
-    {
-        // implicitly convert null value to an empty object
-        if (is_null())
-        {
-            m_type = value_t::object;
-            m_value.object = create<object_t>();
-            assert_invariant();
-        }
-
-        if (JSON_UNLIKELY(not is_object()))
-        {
-            JSON_THROW(type_error::create(312, "cannot use update() with " + std::string(type_name())));
-        }
-        if (JSON_UNLIKELY(not j.is_object()))
-        {
-            JSON_THROW(type_error::create(312, "cannot use update() with " + std::string(j.type_name())));
-        }
-
-        for (auto it = j.cbegin(); it != j.cend(); ++it)
-        {
-            m_value.object->operator[](it.key()) = it.value();
-        }
+  void update(const_reference j)
+  {
+    // implicitly convert null value to an empty object
+    if (is_null()) {
+      m_type         = value_t::object;
+      m_value.object = create<object_t>();
+      assert_invariant();
     }
 
-    /*!
+    if (JSON_UNLIKELY(not is_object())) {
+      JSON_THROW(type_error::create(312, "cannot use update() with " + std::string(type_name())));
+    }
+    if (JSON_UNLIKELY(not j.is_object())) {
+      JSON_THROW(type_error::create(312, "cannot use update() with " + std::string(j.type_name())));
+    }
+
+    for (auto it = j.cbegin(); it != j.cend(); ++it) {
+      m_value.object->operator[](it.key()) = it.value();
+    }
+  }
+
+  /*!
     @brief updates a JSON object from another object, overwriting existing keys
 
     Inserts all values from from range `[first, last)` and overwrites existing
@@ -17689,41 +16533,35 @@ class basic_json
 
     @since version 3.0.0
     */
-    void update(const_iterator first, const_iterator last)
-    {
-        // implicitly convert null value to an empty object
-        if (is_null())
-        {
-            m_type = value_t::object;
-            m_value.object = create<object_t>();
-            assert_invariant();
-        }
-
-        if (JSON_UNLIKELY(not is_object()))
-        {
-            JSON_THROW(type_error::create(312, "cannot use update() with " + std::string(type_name())));
-        }
-
-        // check if range iterators belong to the same JSON object
-        if (JSON_UNLIKELY(first.m_object != last.m_object))
-        {
-            JSON_THROW(invalid_iterator::create(210, "iterators do not fit"));
-        }
-
-        // passed iterators must belong to objects
-        if (JSON_UNLIKELY(not first.m_object->is_object()
-                          or not last.m_object->is_object()))
-        {
-            JSON_THROW(invalid_iterator::create(202, "iterators first and last must point to objects"));
-        }
-
-        for (auto it = first; it != last; ++it)
-        {
-            m_value.object->operator[](it.key()) = it.value();
-        }
+  void update(const_iterator first, const_iterator last)
+  {
+    // implicitly convert null value to an empty object
+    if (is_null()) {
+      m_type         = value_t::object;
+      m_value.object = create<object_t>();
+      assert_invariant();
     }
 
-    /*!
+    if (JSON_UNLIKELY(not is_object())) {
+      JSON_THROW(type_error::create(312, "cannot use update() with " + std::string(type_name())));
+    }
+
+    // check if range iterators belong to the same JSON object
+    if (JSON_UNLIKELY(first.m_object != last.m_object)) {
+      JSON_THROW(invalid_iterator::create(210, "iterators do not fit"));
+    }
+
+    // passed iterators must belong to objects
+    if (JSON_UNLIKELY(not first.m_object->is_object() or not last.m_object->is_object())) {
+      JSON_THROW(invalid_iterator::create(202, "iterators first and last must point to objects"));
+    }
+
+    for (auto it = first; it != last; ++it) {
+      m_value.object->operator[](it.key()) = it.value();
+    }
+  }
+
+  /*!
     @brief exchanges the values
 
     Exchanges the contents of the JSON value with those of @a other. Does not
@@ -17740,19 +16578,18 @@ class basic_json
 
     @since version 1.0.0
     */
-    void swap(reference other) noexcept (
-        std::is_nothrow_move_constructible<value_t>::value and
-        std::is_nothrow_move_assignable<value_t>::value and
-        std::is_nothrow_move_constructible<json_value>::value and
-        std::is_nothrow_move_assignable<json_value>::value
-    )
-    {
-        std::swap(m_type, other.m_type);
-        std::swap(m_value, other.m_value);
-        assert_invariant();
-    }
+  void swap(reference other) noexcept(
+      std::is_nothrow_move_constructible<value_t>::value and
+          std::is_nothrow_move_assignable<value_t>::value and
+              std::is_nothrow_move_constructible<json_value>::value and
+                  std::is_nothrow_move_assignable<json_value>::value)
+  {
+    std::swap(m_type, other.m_type);
+    std::swap(m_value, other.m_value);
+    assert_invariant();
+  }
 
-    /*!
+  /*!
     @brief exchanges the values
 
     Exchanges the contents of a JSON array with those of @a other. Does not
@@ -17772,20 +16609,17 @@ class basic_json
 
     @since version 1.0.0
     */
-    void swap(array_t& other)
-    {
-        // swap only works for arrays
-        if (JSON_LIKELY(is_array()))
-        {
-            std::swap(*(m_value.array), other);
-        }
-        else
-        {
-            JSON_THROW(type_error::create(310, "cannot use swap() with " + std::string(type_name())));
-        }
+  void swap(array_t &other)
+  {
+    // swap only works for arrays
+    if (JSON_LIKELY(is_array())) {
+      std::swap(*(m_value.array), other);
+    } else {
+      JSON_THROW(type_error::create(310, "cannot use swap() with " + std::string(type_name())));
     }
+  }
 
-    /*!
+  /*!
     @brief exchanges the values
 
     Exchanges the contents of a JSON object with those of @a other. Does not
@@ -17805,20 +16639,17 @@ class basic_json
 
     @since version 1.0.0
     */
-    void swap(object_t& other)
-    {
-        // swap only works for objects
-        if (JSON_LIKELY(is_object()))
-        {
-            std::swap(*(m_value.object), other);
-        }
-        else
-        {
-            JSON_THROW(type_error::create(310, "cannot use swap() with " + std::string(type_name())));
-        }
+  void swap(object_t &other)
+  {
+    // swap only works for objects
+    if (JSON_LIKELY(is_object())) {
+      std::swap(*(m_value.object), other);
+    } else {
+      JSON_THROW(type_error::create(310, "cannot use swap() with " + std::string(type_name())));
     }
+  }
 
-    /*!
+  /*!
     @brief exchanges the values
 
     Exchanges the contents of a JSON string with those of @a other. Does not
@@ -17838,30 +16669,27 @@ class basic_json
 
     @since version 1.0.0
     */
-    void swap(string_t& other)
-    {
-        // swap only works for strings
-        if (JSON_LIKELY(is_string()))
-        {
-            std::swap(*(m_value.string), other);
-        }
-        else
-        {
-            JSON_THROW(type_error::create(310, "cannot use swap() with " + std::string(type_name())));
-        }
+  void swap(string_t &other)
+  {
+    // swap only works for strings
+    if (JSON_LIKELY(is_string())) {
+      std::swap(*(m_value.string), other);
+    } else {
+      JSON_THROW(type_error::create(310, "cannot use swap() with " + std::string(type_name())));
     }
+  }
 
-    /// @}
+  /// @}
 
-  public:
-    //////////////////////////////////////////
-    // lexicographical comparison operators //
-    //////////////////////////////////////////
+public:
+  //////////////////////////////////////////
+  // lexicographical comparison operators //
+  //////////////////////////////////////////
 
-    /// @name lexicographical comparison operators
-    /// @{
+  /// @name lexicographical comparison operators
+  /// @{
 
-    /*!
+  /*!
     @brief comparison: equal
 
     Compares two JSON values for equality according to the following rules:
@@ -17900,94 +16728,80 @@ class basic_json
 
     @since version 1.0.0
     */
-    friend bool operator==(const_reference lhs, const_reference rhs) noexcept
-    {
-        const auto lhs_type = lhs.type();
-        const auto rhs_type = rhs.type();
+  friend bool operator==(const_reference lhs, const_reference rhs) noexcept
+  {
+    const auto lhs_type = lhs.type();
+    const auto rhs_type = rhs.type();
 
-        if (lhs_type == rhs_type)
-        {
-            switch (lhs_type)
-            {
-                case value_t::array:
-                    return (*lhs.m_value.array == *rhs.m_value.array);
+    if (lhs_type == rhs_type) {
+      switch (lhs_type) {
+      case value_t::array:
+        return (*lhs.m_value.array == *rhs.m_value.array);
 
-                case value_t::object:
-                    return (*lhs.m_value.object == *rhs.m_value.object);
+      case value_t::object:
+        return (*lhs.m_value.object == *rhs.m_value.object);
 
-                case value_t::null:
-                    return true;
+      case value_t::null:
+        return true;
 
-                case value_t::string:
-                    return (*lhs.m_value.string == *rhs.m_value.string);
+      case value_t::string:
+        return (*lhs.m_value.string == *rhs.m_value.string);
 
-                case value_t::boolean:
-                    return (lhs.m_value.boolean == rhs.m_value.boolean);
+      case value_t::boolean:
+        return (lhs.m_value.boolean == rhs.m_value.boolean);
 
-                case value_t::number_integer:
-                    return (lhs.m_value.number_integer == rhs.m_value.number_integer);
+      case value_t::number_integer:
+        return (lhs.m_value.number_integer == rhs.m_value.number_integer);
 
-                case value_t::number_unsigned:
-                    return (lhs.m_value.number_unsigned == rhs.m_value.number_unsigned);
+      case value_t::number_unsigned:
+        return (lhs.m_value.number_unsigned == rhs.m_value.number_unsigned);
 
-                case value_t::number_float:
-                    return (lhs.m_value.number_float == rhs.m_value.number_float);
+      case value_t::number_float:
+        return (lhs.m_value.number_float == rhs.m_value.number_float);
 
-                default:
-                    return false;
-            }
-        }
-        else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_float)
-        {
-            return (static_cast<number_float_t>(lhs.m_value.number_integer) == rhs.m_value.number_float);
-        }
-        else if (lhs_type == value_t::number_float and rhs_type == value_t::number_integer)
-        {
-            return (lhs.m_value.number_float == static_cast<number_float_t>(rhs.m_value.number_integer));
-        }
-        else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_float)
-        {
-            return (static_cast<number_float_t>(lhs.m_value.number_unsigned) == rhs.m_value.number_float);
-        }
-        else if (lhs_type == value_t::number_float and rhs_type == value_t::number_unsigned)
-        {
-            return (lhs.m_value.number_float == static_cast<number_float_t>(rhs.m_value.number_unsigned));
-        }
-        else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_integer)
-        {
-            return (static_cast<number_integer_t>(lhs.m_value.number_unsigned) == rhs.m_value.number_integer);
-        }
-        else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_unsigned)
-        {
-            return (lhs.m_value.number_integer == static_cast<number_integer_t>(rhs.m_value.number_unsigned));
-        }
-
+      default:
         return false;
+      }
+    } else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_float) {
+      return (static_cast<number_float_t>(lhs.m_value.number_integer) == rhs.m_value.number_float);
+    } else if (lhs_type == value_t::number_float and rhs_type == value_t::number_integer) {
+      return (lhs.m_value.number_float == static_cast<number_float_t>(rhs.m_value.number_integer));
+    } else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_float) {
+      return (static_cast<number_float_t>(lhs.m_value.number_unsigned) == rhs.m_value.number_float);
+    } else if (lhs_type == value_t::number_float and rhs_type == value_t::number_unsigned) {
+      return (lhs.m_value.number_float == static_cast<number_float_t>(rhs.m_value.number_unsigned));
+    } else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_integer) {
+      return (static_cast<number_integer_t>(lhs.m_value.number_unsigned) == rhs.m_value.number_integer);
+    } else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_unsigned) {
+      return (lhs.m_value.number_integer == static_cast<number_integer_t>(rhs.m_value.number_unsigned));
     }
 
-    /*!
+    return false;
+  }
+
+  /*!
     @brief comparison: equal
     @copydoc operator==(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator==(const_reference lhs, const ScalarType rhs) noexcept
-    {
-        return (lhs == basic_json(rhs));
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator==(const_reference lhs, const ScalarType rhs) noexcept
+  {
+    return (lhs == basic_json(rhs));
+  }
 
-    /*!
+  /*!
     @brief comparison: equal
     @copydoc operator==(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator==(const ScalarType lhs, const_reference rhs) noexcept
-    {
-        return (basic_json(lhs) == rhs);
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator==(const ScalarType lhs, const_reference rhs) noexcept
+  {
+    return (basic_json(lhs) == rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: not equal
 
     Compares two JSON values for inequality by calculating `not (lhs == rhs)`.
@@ -18005,34 +16819,34 @@ class basic_json
 
     @since version 1.0.0
     */
-    friend bool operator!=(const_reference lhs, const_reference rhs) noexcept
-    {
-        return not (lhs == rhs);
-    }
+  friend bool operator!=(const_reference lhs, const_reference rhs) noexcept
+  {
+    return not(lhs == rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: not equal
     @copydoc operator!=(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator!=(const_reference lhs, const ScalarType rhs) noexcept
-    {
-        return (lhs != basic_json(rhs));
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator!=(const_reference lhs, const ScalarType rhs) noexcept
+  {
+    return (lhs != basic_json(rhs));
+  }
 
-    /*!
+  /*!
     @brief comparison: not equal
     @copydoc operator!=(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator!=(const ScalarType lhs, const_reference rhs) noexcept
-    {
-        return (basic_json(lhs) != rhs);
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator!=(const ScalarType lhs, const_reference rhs) noexcept
+  {
+    return (basic_json(lhs) != rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: less than
 
     Compares whether one JSON value @a lhs is less than another JSON value @a
@@ -18058,97 +16872,83 @@ class basic_json
 
     @since version 1.0.0
     */
-    friend bool operator<(const_reference lhs, const_reference rhs) noexcept
-    {
-        const auto lhs_type = lhs.type();
-        const auto rhs_type = rhs.type();
+  friend bool operator<(const_reference lhs, const_reference rhs) noexcept
+  {
+    const auto lhs_type = lhs.type();
+    const auto rhs_type = rhs.type();
 
-        if (lhs_type == rhs_type)
-        {
-            switch (lhs_type)
-            {
-                case value_t::array:
-                    return (*lhs.m_value.array) < (*rhs.m_value.array);
+    if (lhs_type == rhs_type) {
+      switch (lhs_type) {
+      case value_t::array:
+        return (*lhs.m_value.array) < (*rhs.m_value.array);
 
-                case value_t::object:
-                    return *lhs.m_value.object < *rhs.m_value.object;
+      case value_t::object:
+        return *lhs.m_value.object < *rhs.m_value.object;
 
-                case value_t::null:
-                    return false;
+      case value_t::null:
+        return false;
 
-                case value_t::string:
-                    return *lhs.m_value.string < *rhs.m_value.string;
+      case value_t::string:
+        return *lhs.m_value.string < *rhs.m_value.string;
 
-                case value_t::boolean:
-                    return lhs.m_value.boolean < rhs.m_value.boolean;
+      case value_t::boolean:
+        return lhs.m_value.boolean < rhs.m_value.boolean;
 
-                case value_t::number_integer:
-                    return lhs.m_value.number_integer < rhs.m_value.number_integer;
+      case value_t::number_integer:
+        return lhs.m_value.number_integer < rhs.m_value.number_integer;
 
-                case value_t::number_unsigned:
-                    return lhs.m_value.number_unsigned < rhs.m_value.number_unsigned;
+      case value_t::number_unsigned:
+        return lhs.m_value.number_unsigned < rhs.m_value.number_unsigned;
 
-                case value_t::number_float:
-                    return lhs.m_value.number_float < rhs.m_value.number_float;
+      case value_t::number_float:
+        return lhs.m_value.number_float < rhs.m_value.number_float;
 
-                default:
-                    return false;
-            }
-        }
-        else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_float)
-        {
-            return static_cast<number_float_t>(lhs.m_value.number_integer) < rhs.m_value.number_float;
-        }
-        else if (lhs_type == value_t::number_float and rhs_type == value_t::number_integer)
-        {
-            return lhs.m_value.number_float < static_cast<number_float_t>(rhs.m_value.number_integer);
-        }
-        else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_float)
-        {
-            return static_cast<number_float_t>(lhs.m_value.number_unsigned) < rhs.m_value.number_float;
-        }
-        else if (lhs_type == value_t::number_float and rhs_type == value_t::number_unsigned)
-        {
-            return lhs.m_value.number_float < static_cast<number_float_t>(rhs.m_value.number_unsigned);
-        }
-        else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_unsigned)
-        {
-            return lhs.m_value.number_integer < static_cast<number_integer_t>(rhs.m_value.number_unsigned);
-        }
-        else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_integer)
-        {
-            return static_cast<number_integer_t>(lhs.m_value.number_unsigned) < rhs.m_value.number_integer;
-        }
-
-        // We only reach this line if we cannot compare values. In that case,
-        // we compare types. Note we have to call the operator explicitly,
-        // because MSVC has problems otherwise.
-        return operator<(lhs_type, rhs_type);
+      default:
+        return false;
+      }
+    } else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_float) {
+      return static_cast<number_float_t>(lhs.m_value.number_integer) < rhs.m_value.number_float;
+    } else if (lhs_type == value_t::number_float and rhs_type == value_t::number_integer) {
+      return lhs.m_value.number_float < static_cast<number_float_t>(rhs.m_value.number_integer);
+    } else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_float) {
+      return static_cast<number_float_t>(lhs.m_value.number_unsigned) < rhs.m_value.number_float;
+    } else if (lhs_type == value_t::number_float and rhs_type == value_t::number_unsigned) {
+      return lhs.m_value.number_float < static_cast<number_float_t>(rhs.m_value.number_unsigned);
+    } else if (lhs_type == value_t::number_integer and rhs_type == value_t::number_unsigned) {
+      return lhs.m_value.number_integer < static_cast<number_integer_t>(rhs.m_value.number_unsigned);
+    } else if (lhs_type == value_t::number_unsigned and rhs_type == value_t::number_integer) {
+      return static_cast<number_integer_t>(lhs.m_value.number_unsigned) < rhs.m_value.number_integer;
     }
 
-    /*!
+    // We only reach this line if we cannot compare values. In that case,
+    // we compare types. Note we have to call the operator explicitly,
+    // because MSVC has problems otherwise.
+    return operator<(lhs_type, rhs_type);
+  }
+
+  /*!
     @brief comparison: less than
     @copydoc operator<(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator<(const_reference lhs, const ScalarType rhs) noexcept
-    {
-        return (lhs < basic_json(rhs));
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator<(const_reference lhs, const ScalarType rhs) noexcept
+  {
+    return (lhs < basic_json(rhs));
+  }
 
-    /*!
+  /*!
     @brief comparison: less than
     @copydoc operator<(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator<(const ScalarType lhs, const_reference rhs) noexcept
-    {
-        return (basic_json(lhs) < rhs);
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator<(const ScalarType lhs, const_reference rhs) noexcept
+  {
+    return (basic_json(lhs) < rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: less than or equal
 
     Compares whether one JSON value @a lhs is less than or equal to another
@@ -18167,34 +16967,34 @@ class basic_json
 
     @since version 1.0.0
     */
-    friend bool operator<=(const_reference lhs, const_reference rhs) noexcept
-    {
-        return not (rhs < lhs);
-    }
+  friend bool operator<=(const_reference lhs, const_reference rhs) noexcept
+  {
+    return not(rhs < lhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: less than or equal
     @copydoc operator<=(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator<=(const_reference lhs, const ScalarType rhs) noexcept
-    {
-        return (lhs <= basic_json(rhs));
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator<=(const_reference lhs, const ScalarType rhs) noexcept
+  {
+    return (lhs <= basic_json(rhs));
+  }
 
-    /*!
+  /*!
     @brief comparison: less than or equal
     @copydoc operator<=(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator<=(const ScalarType lhs, const_reference rhs) noexcept
-    {
-        return (basic_json(lhs) <= rhs);
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator<=(const ScalarType lhs, const_reference rhs) noexcept
+  {
+    return (basic_json(lhs) <= rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: greater than
 
     Compares whether one JSON value @a lhs is greater than another
@@ -18213,34 +17013,34 @@ class basic_json
 
     @since version 1.0.0
     */
-    friend bool operator>(const_reference lhs, const_reference rhs) noexcept
-    {
-        return not (lhs <= rhs);
-    }
+  friend bool operator>(const_reference lhs, const_reference rhs) noexcept
+  {
+    return not(lhs <= rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: greater than
     @copydoc operator>(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator>(const_reference lhs, const ScalarType rhs) noexcept
-    {
-        return (lhs > basic_json(rhs));
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator>(const_reference lhs, const ScalarType rhs) noexcept
+  {
+    return (lhs > basic_json(rhs));
+  }
 
-    /*!
+  /*!
     @brief comparison: greater than
     @copydoc operator>(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator>(const ScalarType lhs, const_reference rhs) noexcept
-    {
-        return (basic_json(lhs) > rhs);
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator>(const ScalarType lhs, const_reference rhs) noexcept
+  {
+    return (basic_json(lhs) > rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: greater than or equal
 
     Compares whether one JSON value @a lhs is greater than or equal to another
@@ -18259,43 +17059,43 @@ class basic_json
 
     @since version 1.0.0
     */
-    friend bool operator>=(const_reference lhs, const_reference rhs) noexcept
-    {
-        return not (lhs < rhs);
-    }
+  friend bool operator>=(const_reference lhs, const_reference rhs) noexcept
+  {
+    return not(lhs < rhs);
+  }
 
-    /*!
+  /*!
     @brief comparison: greater than or equal
     @copydoc operator>=(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator>=(const_reference lhs, const ScalarType rhs) noexcept
-    {
-        return (lhs >= basic_json(rhs));
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator>=(const_reference lhs, const ScalarType rhs) noexcept
+  {
+    return (lhs >= basic_json(rhs));
+  }
 
-    /*!
+  /*!
     @brief comparison: greater than or equal
     @copydoc operator>=(const_reference, const_reference)
     */
-    template<typename ScalarType, typename std::enable_if<
-                 std::is_scalar<ScalarType>::value, int>::type = 0>
-    friend bool operator>=(const ScalarType lhs, const_reference rhs) noexcept
-    {
-        return (basic_json(lhs) >= rhs);
-    }
+  template <typename ScalarType, typename std::enable_if<
+                                     std::is_scalar<ScalarType>::value, int>::type = 0>
+  friend bool operator>=(const ScalarType lhs, const_reference rhs) noexcept
+  {
+    return (basic_json(lhs) >= rhs);
+  }
 
-    /// @}
+  /// @}
 
-    ///////////////////
-    // serialization //
-    ///////////////////
+  ///////////////////
+  // serialization //
+  ///////////////////
 
-    /// @name serialization
-    /// @{
+  /// @name serialization
+  /// @{
 
-    /*!
+  /*!
     @brief serialize to stream
 
     Serialize the given JSON value @a j to the output stream @a o. The JSON
@@ -18326,22 +17126,22 @@ class basic_json
 
     @since version 1.0.0; indentation character added in version 3.0.0
     */
-    friend std::ostream& operator<<(std::ostream& o, const basic_json& j)
-    {
-        // read width member and use it as indentation parameter if nonzero
-        const bool pretty_print = (o.width() > 0);
-        const auto indentation = (pretty_print ? o.width() : 0);
+  friend std::ostream &operator<<(std::ostream &o, const basic_json &j)
+  {
+    // read width member and use it as indentation parameter if nonzero
+    const bool pretty_print = (o.width() > 0);
+    const auto indentation  = (pretty_print ? o.width() : 0);
 
-        // reset width to 0 for subsequent calls to this stream
-        o.width(0);
+    // reset width to 0 for subsequent calls to this stream
+    o.width(0);
 
-        // do the actual serialization
-        serializer s(detail::output_adapter<char>(o), o.fill());
-        s.dump(j, pretty_print, false, static_cast<unsigned int>(indentation));
-        return o;
-    }
+    // do the actual serialization
+    serializer s(detail::output_adapter<char>(o), o.fill());
+    s.dump(j, pretty_print, false, static_cast<unsigned int>(indentation));
+    return o;
+  }
 
-    /*!
+  /*!
     @brief serialize to stream
     @deprecated This stream operator is deprecated and will be removed in
                 future 4.0.0 of the library. Please use
@@ -18349,23 +17149,22 @@ class basic_json
                 instead; that is, replace calls like `j >> o;` with `o << j;`.
     @since version 1.0.0; deprecated since version 3.0.0
     */
-    JSON_DEPRECATED
-    friend std::ostream& operator>>(const basic_json& j, std::ostream& o)
-    {
-        return o << j;
-    }
+  JSON_DEPRECATED
+  friend std::ostream &operator>>(const basic_json &j, std::ostream &o)
+  {
+    return o << j;
+  }
 
-    /// @}
+  /// @}
 
+  /////////////////////
+  // deserialization //
+  /////////////////////
 
-    /////////////////////
-    // deserialization //
-    /////////////////////
+  /// @name deserialization
+  /// @{
 
-    /// @name deserialization
-    /// @{
-
-    /*!
+  /*!
     @brief deserialize from a compatible input
 
     This function reads from a compatible input. Examples are:
@@ -18429,21 +17228,21 @@ class basic_json
 
     @since version 2.0.3 (contiguous containers)
     */
-    static basic_json parse(detail::input_adapter&& i,
-                            const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
-    {
-        basic_json result;
-        parser(i, cb, allow_exceptions).parse(true, result);
-        return result;
-    }
+  static basic_json parse(detail::input_adapter &&i,
+                          const parser_callback_t cb               = nullptr,
+                          const bool              allow_exceptions = true)
+  {
+    basic_json result;
+    parser(i, cb, allow_exceptions).parse(true, result);
+    return result;
+  }
 
-    static bool accept(detail::input_adapter&& i)
-    {
-        return parser(i).accept(true);
-    }
+  static bool accept(detail::input_adapter &&i)
+  {
+    return parser(i).accept(true);
+  }
 
-    /*!
+  /*!
     @brief generate SAX events
 
     The SAX event lister must follow the interface of @ref json_sax.
@@ -18499,22 +17298,21 @@ class basic_json
 
     @since version 3.2.0
     */
-    template <typename SAX>
-    static bool sax_parse(detail::input_adapter&& i, SAX* sax,
-                          input_format_t format = input_format_t::json,
-                          const bool strict = true)
-    {
-        assert(sax);
-        switch (format)
-        {
-            case input_format_t::json:
-                return parser(std::move(i)).sax_parse(sax, strict);
-            default:
-                return detail::binary_reader<basic_json, SAX>(std::move(i)).sax_parse(format, sax, strict);
-        }
+  template <typename SAX>
+  static bool sax_parse(detail::input_adapter &&i, SAX *sax,
+                        input_format_t format = input_format_t::json,
+                        const bool     strict = true)
+  {
+    assert(sax);
+    switch (format) {
+    case input_format_t::json:
+      return parser(std::move(i)).sax_parse(sax, strict);
+    default:
+      return detail::binary_reader<basic_json, SAX>(std::move(i)).sax_parse(format, sax, strict);
     }
+  }
 
-    /*!
+  /*!
     @brief deserialize from an iterator range with contiguous storage
 
     This function reads from an iterator range of a container with contiguous
@@ -18561,38 +17359,37 @@ class basic_json
 
     @since version 2.0.3
     */
-    template<class IteratorType, typename std::enable_if<
-                 std::is_base_of<
-                     std::random_access_iterator_tag,
-                     typename std::iterator_traits<IteratorType>::iterator_category>::value, int>::type = 0>
-    static basic_json parse(IteratorType first, IteratorType last,
-                            const parser_callback_t cb = nullptr,
-                            const bool allow_exceptions = true)
-    {
-        basic_json result;
-        parser(detail::input_adapter(first, last), cb, allow_exceptions).parse(true, result);
-        return result;
-    }
+  template <class IteratorType, typename std::enable_if<
+                                    std::is_base_of<
+                                        std::random_access_iterator_tag,
+                                        typename std::iterator_traits<IteratorType>::iterator_category>::value,
+                                    int>::type = 0>
+  static basic_json parse(IteratorType first, IteratorType last,
+                          const parser_callback_t cb               = nullptr,
+                          const bool              allow_exceptions = true)
+  {
+    basic_json result;
+    parser(detail::input_adapter(first, last), cb, allow_exceptions).parse(true, result);
+    return result;
+  }
 
-    template<class IteratorType, typename std::enable_if<
-                 std::is_base_of<
-                     std::random_access_iterator_tag,
-                     typename std::iterator_traits<IteratorType>::iterator_category>::value, int>::type = 0>
-    static bool accept(IteratorType first, IteratorType last)
-    {
-        return parser(detail::input_adapter(first, last)).accept(true);
-    }
+  template <class IteratorType, typename std::enable_if<
+                                    std::is_base_of<
+                                        std::random_access_iterator_tag,
+                                        typename std::iterator_traits<IteratorType>::iterator_category>::value,
+                                    int>::type = 0>
+  static bool accept(IteratorType first, IteratorType last)
+  {
+    return parser(detail::input_adapter(first, last)).accept(true);
+  }
 
-    template<class IteratorType, class SAX, typename std::enable_if<
-                 std::is_base_of<
-                     std::random_access_iterator_tag,
-                     typename std::iterator_traits<IteratorType>::iterator_category>::value, int>::type = 0>
-    static bool sax_parse(IteratorType first, IteratorType last, SAX* sax)
-    {
-        return parser(detail::input_adapter(first, last)).sax_parse(sax);
-    }
+  template <class IteratorType, class SAX, typename std::enable_if<std::is_base_of<std::random_access_iterator_tag, typename std::iterator_traits<IteratorType>::iterator_category>::value, int>::type = 0>
+  static bool sax_parse(IteratorType first, IteratorType last, SAX *sax)
+  {
+    return parser(detail::input_adapter(first, last)).sax_parse(sax);
+  }
 
-    /*!
+  /*!
     @brief deserialize from stream
     @deprecated This stream operator is deprecated and will be removed in
                 version 4.0.0 of the library. Please use
@@ -18600,13 +17397,13 @@ class basic_json
                 instead; that is, replace calls like `j << i;` with `i >> j;`.
     @since version 1.0.0; deprecated since version 3.0.0
     */
-    JSON_DEPRECATED
-    friend std::istream& operator<<(basic_json& j, std::istream& i)
-    {
-        return operator>>(i, j);
-    }
+  JSON_DEPRECATED
+  friend std::istream &operator<<(basic_json &j, std::istream &i)
+  {
+    return operator>>(i, j);
+  }
 
-    /*!
+  /*!
     @brief deserialize from stream
 
     Deserializes an input stream to a JSON value.
@@ -18631,19 +17428,19 @@ class basic_json
 
     @since version 1.0.0
     */
-    friend std::istream& operator>>(std::istream& i, basic_json& j)
-    {
-        parser(detail::input_adapter(i)).parse(false, j);
-        return i;
-    }
+  friend std::istream &operator>>(std::istream &i, basic_json &j)
+  {
+    parser(detail::input_adapter(i)).parse(false, j);
+    return i;
+  }
 
-    /// @}
+  /// @}
 
-    ///////////////////////////
-    // convenience functions //
-    ///////////////////////////
+  ///////////////////////////
+  // convenience functions //
+  ///////////////////////////
 
-    /*!
+  /*!
     @brief return the type as string
 
     Returns the type name as string to be used in error messages - usually to
@@ -18673,50 +17470,48 @@ class basic_json
     @since version 1.0.0, public since 2.1.0, `const char*` and `noexcept`
     since 3.0.0
     */
-    const char* type_name() const noexcept
+  const char *type_name() const noexcept
+  {
     {
-        {
-            switch (m_type)
-            {
-                case value_t::null:
-                    return "null";
-                case value_t::object:
-                    return "object";
-                case value_t::array:
-                    return "array";
-                case value_t::string:
-                    return "string";
-                case value_t::boolean:
-                    return "boolean";
-                case value_t::discarded:
-                    return "discarded";
-                default:
-                    return "number";
-            }
-        }
+      switch (m_type) {
+      case value_t::null:
+        return "null";
+      case value_t::object:
+        return "object";
+      case value_t::array:
+        return "array";
+      case value_t::string:
+        return "string";
+      case value_t::boolean:
+        return "boolean";
+      case value_t::discarded:
+        return "discarded";
+      default:
+        return "number";
+      }
     }
+  }
 
+private:
+  //////////////////////
+  // member variables //
+  //////////////////////
 
-  private:
-    //////////////////////
-    // member variables //
-    //////////////////////
+  /// the type of the current element
+  value_t m_type = value_t::null;
 
-    /// the type of the current element
-    value_t m_type = value_t::null;
+  /// the value of the current element
+  json_value m_value = {};
 
-    /// the value of the current element
-    json_value m_value = {};
+  //////////////////////////////////////////
+  // binary serialization/deserialization //
+  //////////////////////////////////////////
 
-    //////////////////////////////////////////
-    // binary serialization/deserialization //
-    //////////////////////////////////////////
+  /// @name binary serialization/deserialization support
+  /// @{
 
-    /// @name binary serialization/deserialization support
-    /// @{
-
-  public:
-    /*!
+public:
+  /*!
     @brief create a CBOR serialization of a given JSON value
 
     Serializes a given JSON value @a j to a byte vector using the CBOR (Concise
@@ -18804,24 +17599,24 @@ class basic_json
 
     @since version 2.0.9
     */
-    static std::vector<uint8_t> to_cbor(const basic_json& j)
-    {
-        std::vector<uint8_t> result;
-        to_cbor(j, result);
-        return result;
-    }
+  static std::vector<uint8_t> to_cbor(const basic_json &j)
+  {
+    std::vector<uint8_t> result;
+    to_cbor(j, result);
+    return result;
+  }
 
-    static void to_cbor(const basic_json& j, detail::output_adapter<uint8_t> o)
-    {
-        binary_writer<uint8_t>(o).write_cbor(j);
-    }
+  static void to_cbor(const basic_json &j, detail::output_adapter<uint8_t> o)
+  {
+    binary_writer<uint8_t>(o).write_cbor(j);
+  }
 
-    static void to_cbor(const basic_json& j, detail::output_adapter<char> o)
-    {
-        binary_writer<char>(o).write_cbor(j);
-    }
+  static void to_cbor(const basic_json &j, detail::output_adapter<char> o)
+  {
+    binary_writer<char>(o).write_cbor(j);
+  }
 
-    /*!
+  /*!
     @brief create a MessagePack serialization of a given JSON value
 
     Serializes a given JSON value @a j to a byte vector using the MessagePack
@@ -18900,24 +17695,24 @@ class basic_json
 
     @since version 2.0.9
     */
-    static std::vector<uint8_t> to_msgpack(const basic_json& j)
-    {
-        std::vector<uint8_t> result;
-        to_msgpack(j, result);
-        return result;
-    }
+  static std::vector<uint8_t> to_msgpack(const basic_json &j)
+  {
+    std::vector<uint8_t> result;
+    to_msgpack(j, result);
+    return result;
+  }
 
-    static void to_msgpack(const basic_json& j, detail::output_adapter<uint8_t> o)
-    {
-        binary_writer<uint8_t>(o).write_msgpack(j);
-    }
+  static void to_msgpack(const basic_json &j, detail::output_adapter<uint8_t> o)
+  {
+    binary_writer<uint8_t>(o).write_msgpack(j);
+  }
 
-    static void to_msgpack(const basic_json& j, detail::output_adapter<char> o)
-    {
-        binary_writer<char>(o).write_msgpack(j);
-    }
+  static void to_msgpack(const basic_json &j, detail::output_adapter<char> o)
+  {
+    binary_writer<char>(o).write_msgpack(j);
+  }
 
-    /*!
+  /*!
     @brief create a UBJSON serialization of a given JSON value
 
     Serializes a given JSON value @a j to a byte vector using the UBJSON
@@ -18997,29 +17792,28 @@ class basic_json
 
     @since version 3.1.0
     */
-    static std::vector<uint8_t> to_ubjson(const basic_json& j,
-                                          const bool use_size = false,
-                                          const bool use_type = false)
-    {
-        std::vector<uint8_t> result;
-        to_ubjson(j, result, use_size, use_type);
-        return result;
-    }
+  static std::vector<uint8_t> to_ubjson(const basic_json &j,
+                                        const bool        use_size = false,
+                                        const bool        use_type = false)
+  {
+    std::vector<uint8_t> result;
+    to_ubjson(j, result, use_size, use_type);
+    return result;
+  }
 
-    static void to_ubjson(const basic_json& j, detail::output_adapter<uint8_t> o,
-                          const bool use_size = false, const bool use_type = false)
-    {
-        binary_writer<uint8_t>(o).write_ubjson(j, use_size, use_type);
-    }
+  static void to_ubjson(const basic_json &j, detail::output_adapter<uint8_t> o,
+                        const bool use_size = false, const bool use_type = false)
+  {
+    binary_writer<uint8_t>(o).write_ubjson(j, use_size, use_type);
+  }
 
-    static void to_ubjson(const basic_json& j, detail::output_adapter<char> o,
-                          const bool use_size = false, const bool use_type = false)
-    {
-        binary_writer<char>(o).write_ubjson(j, use_size, use_type);
-    }
+  static void to_ubjson(const basic_json &j, detail::output_adapter<char> o,
+                        const bool use_size = false, const bool use_type = false)
+  {
+    binary_writer<char>(o).write_ubjson(j, use_size, use_type);
+  }
 
-
-    /*!
+  /*!
     @brief Serializes the given JSON object `j` to BSON and returns a vector
            containing the corresponding BSON-representation.
 
@@ -19074,14 +17868,14 @@ class basic_json
     @sa @ref to_cbor(const basic_json&) for the related CBOR format
     @sa @ref to_msgpack(const basic_json&) for the related MessagePack format
     */
-    static std::vector<uint8_t> to_bson(const basic_json& j)
-    {
-        std::vector<uint8_t> result;
-        to_bson(j, result);
-        return result;
-    }
+  static std::vector<uint8_t> to_bson(const basic_json &j)
+  {
+    std::vector<uint8_t> result;
+    to_bson(j, result);
+    return result;
+  }
 
-    /*!
+  /*!
     @brief Serializes the given JSON object `j` to BSON and forwards the
            corresponding BSON-representation to the given output_adapter `o`.
     @param j The JSON object to convert to BSON.
@@ -19089,21 +17883,20 @@ class basic_json
     @pre The input `j` shall be an object: `j.is_object() == true`
     @sa @ref to_bson(const basic_json&)
     */
-    static void to_bson(const basic_json& j, detail::output_adapter<uint8_t> o)
-    {
-        binary_writer<uint8_t>(o).write_bson(j);
-    }
+  static void to_bson(const basic_json &j, detail::output_adapter<uint8_t> o)
+  {
+    binary_writer<uint8_t>(o).write_bson(j);
+  }
 
-    /*!
+  /*!
     @copydoc to_bson(const basic_json&, detail::output_adapter<uint8_t>)
     */
-    static void to_bson(const basic_json& j, detail::output_adapter<char> o)
-    {
-        binary_writer<char>(o).write_bson(j);
-    }
+  static void to_bson(const basic_json &j, detail::output_adapter<char> o)
+  {
+    binary_writer<char>(o).write_bson(j);
+  }
 
-
-    /*!
+  /*!
     @brief create a JSON value from an input in CBOR format
 
     Deserializes a given input @a i to a JSON value using the CBOR (Concise
@@ -19200,32 +17993,32 @@ class basic_json
            @a strict parameter since 3.0.0; added @a allow_exceptions parameter
            since 3.2.0
     */
-    static basic_json from_cbor(detail::input_adapter&& i,
-                                const bool strict = true,
-                                const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::cbor, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  static basic_json from_cbor(detail::input_adapter &&i,
+                              const bool              strict           = true,
+                              const bool              allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::cbor, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
-    /*!
+  /*!
     @copydoc from_cbor(detail::input_adapter&&, const bool, const bool)
     */
-    template<typename A1, typename A2,
-             detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
-    static basic_json from_cbor(A1 && a1, A2 && a2,
-                                const bool strict = true,
-                                const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::cbor, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  template <typename A1, typename A2,
+            detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
+  static basic_json from_cbor(A1 &&a1, A2 &&a2,
+                              const bool strict           = true,
+                              const bool allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::cbor, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
-    /*!
+  /*!
     @brief create a JSON value from an input in MessagePack format
 
     Deserializes a given input @a i to a JSON value using the MessagePack
@@ -19305,32 +18098,32 @@ class basic_json
            @a strict parameter since 3.0.0; added @a allow_exceptions parameter
            since 3.2.0
     */
-    static basic_json from_msgpack(detail::input_adapter&& i,
-                                   const bool strict = true,
-                                   const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::msgpack, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  static basic_json from_msgpack(detail::input_adapter &&i,
+                                 const bool              strict           = true,
+                                 const bool              allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::msgpack, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
-    /*!
+  /*!
     @copydoc from_msgpack(detail::input_adapter&&, const bool, const bool)
     */
-    template<typename A1, typename A2,
-             detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
-    static basic_json from_msgpack(A1 && a1, A2 && a2,
-                                   const bool strict = true,
-                                   const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::msgpack, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  template <typename A1, typename A2,
+            detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
+  static basic_json from_msgpack(A1 &&a1, A2 &&a2,
+                                 const bool strict           = true,
+                                 const bool allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::msgpack, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
-    /*!
+  /*!
     @brief create a JSON value from an input in UBJSON format
 
     Deserializes a given input @a i to a JSON value using the UBJSON (Universal
@@ -19389,32 +18182,32 @@ class basic_json
 
     @since version 3.1.0; added @a allow_exceptions parameter since 3.2.0
     */
-    static basic_json from_ubjson(detail::input_adapter&& i,
-                                  const bool strict = true,
-                                  const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::ubjson, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  static basic_json from_ubjson(detail::input_adapter &&i,
+                                const bool              strict           = true,
+                                const bool              allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::ubjson, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
-    /*!
+  /*!
     @copydoc from_ubjson(detail::input_adapter&&, const bool, const bool)
     */
-    template<typename A1, typename A2,
-             detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
-    static basic_json from_ubjson(A1 && a1, A2 && a2,
-                                  const bool strict = true,
-                                  const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::ubjson, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  template <typename A1, typename A2,
+            detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
+  static basic_json from_ubjson(A1 &&a1, A2 &&a2,
+                                const bool strict           = true,
+                                const bool allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::ubjson, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
-    /*!
+  /*!
     @brief Create a JSON value from an input in BSON format
 
     Deserializes a given input @a i to a JSON value using the BSON (Binary JSON)
@@ -19472,43 +18265,41 @@ class basic_json
     @sa @ref from_ubjson(detail::input_adapter&&, const bool, const bool) for the
         related UBJSON format
     */
-    static basic_json from_bson(detail::input_adapter&& i,
-                                const bool strict = true,
-                                const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::bson, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  static basic_json from_bson(detail::input_adapter &&i,
+                              const bool              strict           = true,
+                              const bool              allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(i)).sax_parse(input_format_t::bson, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
-    /*!
+  /*!
     @copydoc from_bson(detail::input_adapter&&, const bool, const bool)
     */
-    template<typename A1, typename A2,
-             detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
-    static basic_json from_bson(A1 && a1, A2 && a2,
-                                const bool strict = true,
-                                const bool allow_exceptions = true)
-    {
-        basic_json result;
-        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
-        const bool res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::bson, &sdp, strict);
-        return res ? result : basic_json(value_t::discarded);
-    }
+  template <typename A1, typename A2,
+            detail::enable_if_t<std::is_constructible<detail::input_adapter, A1, A2>::value, int> = 0>
+  static basic_json from_bson(A1 &&a1, A2 &&a2,
+                              const bool strict           = true,
+                              const bool allow_exceptions = true)
+  {
+    basic_json                              result;
+    detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+    const bool                              res = binary_reader(detail::input_adapter(std::forward<A1>(a1), std::forward<A2>(a2))).sax_parse(input_format_t::bson, &sdp, strict);
+    return res ? result : basic_json(value_t::discarded);
+  }
 
+  /// @}
 
+  //////////////////////////
+  // JSON Pointer support //
+  //////////////////////////
 
-    /// @}
+  /// @name JSON Pointer functions
+  /// @{
 
-    //////////////////////////
-    // JSON Pointer support //
-    //////////////////////////
-
-    /// @name JSON Pointer functions
-    /// @{
-
-    /*!
+  /*!
     @brief access specified element via JSON Pointer
 
     Uses a JSON pointer to retrieve a reference to the respective JSON value.
@@ -19541,12 +18332,12 @@ class basic_json
 
     @since version 2.0.0
     */
-    reference operator[](const json_pointer& ptr)
-    {
-        return ptr.get_unchecked(this);
-    }
+  reference operator[](const json_pointer &ptr)
+  {
+    return ptr.get_unchecked(this);
+  }
 
-    /*!
+  /*!
     @brief access specified element via JSON Pointer
 
     Uses a JSON pointer to retrieve a reference to the respective JSON value.
@@ -19569,12 +18360,12 @@ class basic_json
 
     @since version 2.0.0
     */
-    const_reference operator[](const json_pointer& ptr) const
-    {
-        return ptr.get_unchecked(this);
-    }
+  const_reference operator[](const json_pointer &ptr) const
+  {
+    return ptr.get_unchecked(this);
+  }
 
-    /*!
+  /*!
     @brief access specified element via JSON Pointer
 
     Returns a reference to the element at with specified JSON pointer @a ptr,
@@ -19612,12 +18403,12 @@ class basic_json
 
     @liveexample{The behavior is shown in the example.,at_json_pointer}
     */
-    reference at(const json_pointer& ptr)
-    {
-        return ptr.get_checked(this);
-    }
+  reference at(const json_pointer &ptr)
+  {
+    return ptr.get_checked(this);
+  }
 
-    /*!
+  /*!
     @brief access specified element via JSON Pointer
 
     Returns a const reference to the element at with specified JSON pointer @a
@@ -19655,12 +18446,12 @@ class basic_json
 
     @liveexample{The behavior is shown in the example.,at_json_pointer_const}
     */
-    const_reference at(const json_pointer& ptr) const
-    {
-        return ptr.get_checked(this);
-    }
+  const_reference at(const json_pointer &ptr) const
+  {
+    return ptr.get_checked(this);
+  }
 
-    /*!
+  /*!
     @brief return flattened JSON value
 
     The function creates a JSON object whose keys are JSON pointers (see [RFC
@@ -19682,14 +18473,14 @@ class basic_json
 
     @since version 2.0.0
     */
-    basic_json flatten() const
-    {
-        basic_json result(value_t::object);
-        json_pointer::flatten("", *this, result);
-        return result;
-    }
+  basic_json flatten() const
+  {
+    basic_json result(value_t::object);
+    json_pointer::flatten("", *this, result);
+    return result;
+  }
 
-    /*!
+  /*!
     @brief unflatten a previously flattened JSON value
 
     The function restores the arbitrary nesting of a JSON value that has been
@@ -19719,21 +18510,21 @@ class basic_json
 
     @since version 2.0.0
     */
-    basic_json unflatten() const
-    {
-        return json_pointer::unflatten(*this);
-    }
+  basic_json unflatten() const
+  {
+    return json_pointer::unflatten(*this);
+  }
 
-    /// @}
+  /// @}
 
-    //////////////////////////
-    // JSON Patch functions //
-    //////////////////////////
+  //////////////////////////
+  // JSON Patch functions //
+  //////////////////////////
 
-    /// @name JSON Patch functions
-    /// @{
+  /// @name JSON Patch functions
+  /// @{
 
-    /*!
+  /*!
     @brief applies a JSON patch
 
     [JSON Patch](http://jsonpatch.com) defines a JSON document structure for
@@ -19780,272 +18571,236 @@ class basic_json
 
     @since version 2.0.0
     */
-    basic_json patch(const basic_json& json_patch) const
-    {
-        // make a working copy to apply the patch to
-        basic_json result = *this;
+  basic_json patch(const basic_json &json_patch) const
+  {
+    // make a working copy to apply the patch to
+    basic_json result = *this;
 
-        // the valid JSON Patch operations
-        enum class patch_operations {add, remove, replace, move, copy, test, invalid};
+    // the valid JSON Patch operations
+    enum class patch_operations { add,
+                                  remove,
+                                  replace,
+                                  move,
+                                  copy,
+                                  test,
+                                  invalid };
 
-        const auto get_op = [](const std::string & op)
-        {
-            if (op == "add")
-            {
-                return patch_operations::add;
-            }
-            if (op == "remove")
-            {
-                return patch_operations::remove;
-            }
-            if (op == "replace")
-            {
-                return patch_operations::replace;
-            }
-            if (op == "move")
-            {
-                return patch_operations::move;
-            }
-            if (op == "copy")
-            {
-                return patch_operations::copy;
-            }
-            if (op == "test")
-            {
-                return patch_operations::test;
-            }
+    const auto get_op = [](const std::string &op) {
+      if (op == "add") {
+        return patch_operations::add;
+      }
+      if (op == "remove") {
+        return patch_operations::remove;
+      }
+      if (op == "replace") {
+        return patch_operations::replace;
+      }
+      if (op == "move") {
+        return patch_operations::move;
+      }
+      if (op == "copy") {
+        return patch_operations::copy;
+      }
+      if (op == "test") {
+        return patch_operations::test;
+      }
 
-            return patch_operations::invalid;
-        };
+      return patch_operations::invalid;
+    };
 
-        // wrapper for "add" operation; add value at ptr
-        const auto operation_add = [&result](json_pointer & ptr, basic_json val)
-        {
-            // adding to the root of the target document means replacing it
-            if (ptr.is_root())
-            {
-                result = val;
-            }
-            else
-            {
-                // make sure the top element of the pointer exists
-                json_pointer top_pointer = ptr.top();
-                if (top_pointer != ptr)
-                {
-                    result.at(top_pointer);
-                }
-
-                // get reference to parent of JSON pointer ptr
-                const auto last_path = ptr.pop_back();
-                basic_json& parent = result[ptr];
-
-                switch (parent.m_type)
-                {
-                    case value_t::null:
-                    case value_t::object:
-                    {
-                        // use operator[] to add value
-                        parent[last_path] = val;
-                        break;
-                    }
-
-                    case value_t::array:
-                    {
-                        if (last_path == "-")
-                        {
-                            // special case: append to back
-                            parent.push_back(val);
-                        }
-                        else
-                        {
-                            const auto idx = json_pointer::array_index(last_path);
-                            if (JSON_UNLIKELY(static_cast<size_type>(idx) > parent.size()))
-                            {
-                                // avoid undefined behavior
-                                JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
-                            }
-
-                            // default case: insert add offset
-                            parent.insert(parent.begin() + static_cast<difference_type>(idx), val);
-                        }
-                        break;
-                    }
-
-                    // LCOV_EXCL_START
-                    default:
-                    {
-                        // if there exists a parent it cannot be primitive
-                        assert(false);
-                    }
-                        // LCOV_EXCL_STOP
-                }
-            }
-        };
-
-        // wrapper for "remove" operation; remove value at ptr
-        const auto operation_remove = [&result](json_pointer & ptr)
-        {
-            // get reference to parent of JSON pointer ptr
-            const auto last_path = ptr.pop_back();
-            basic_json& parent = result.at(ptr);
-
-            // remove child
-            if (parent.is_object())
-            {
-                // perform range check
-                auto it = parent.find(last_path);
-                if (JSON_LIKELY(it != parent.end()))
-                {
-                    parent.erase(it);
-                }
-                else
-                {
-                    JSON_THROW(out_of_range::create(403, "key '" + last_path + "' not found"));
-                }
-            }
-            else if (parent.is_array())
-            {
-                // note erase performs range check
-                parent.erase(static_cast<size_type>(json_pointer::array_index(last_path)));
-            }
-        };
-
-        // type check: top level value must be an array
-        if (JSON_UNLIKELY(not json_patch.is_array()))
-        {
-            JSON_THROW(parse_error::create(104, 0, "JSON patch must be an array of objects"));
+    // wrapper for "add" operation; add value at ptr
+    const auto operation_add = [&result](json_pointer &ptr, basic_json val) {
+      // adding to the root of the target document means replacing it
+      if (ptr.is_root()) {
+        result = val;
+      } else {
+        // make sure the top element of the pointer exists
+        json_pointer top_pointer = ptr.top();
+        if (top_pointer != ptr) {
+          result.at(top_pointer);
         }
 
-        // iterate and apply the operations
-        for (const auto& val : json_patch)
-        {
-            // wrapper to get a value for an operation
-            const auto get_value = [&val](const std::string & op,
-                                          const std::string & member,
-                                          bool string_type) -> basic_json &
-            {
-                // find value
-                auto it = val.m_value.object->find(member);
+        // get reference to parent of JSON pointer ptr
+        const auto  last_path = ptr.pop_back();
+        basic_json &parent    = result[ptr];
 
-                // context-sensitive error message
-                const auto error_msg = (op == "op") ? "operation" : "operation '" + op + "'";
-
-                // check if desired value is present
-                if (JSON_UNLIKELY(it == val.m_value.object->end()))
-                {
-                    JSON_THROW(parse_error::create(105, 0, error_msg + " must have member '" + member + "'"));
-                }
-
-                // check if result is of type string
-                if (JSON_UNLIKELY(string_type and not it->second.is_string()))
-                {
-                    JSON_THROW(parse_error::create(105, 0, error_msg + " must have string member '" + member + "'"));
-                }
-
-                // no error: return value
-                return it->second;
-            };
-
-            // type check: every element of the array must be an object
-            if (JSON_UNLIKELY(not val.is_object()))
-            {
-                JSON_THROW(parse_error::create(104, 0, "JSON patch must be an array of objects"));
-            }
-
-            // collect mandatory members
-            const std::string op = get_value("op", "op", true);
-            const std::string path = get_value(op, "path", true);
-            json_pointer ptr(path);
-
-            switch (get_op(op))
-            {
-                case patch_operations::add:
-                {
-                    operation_add(ptr, get_value("add", "value", false));
-                    break;
-                }
-
-                case patch_operations::remove:
-                {
-                    operation_remove(ptr);
-                    break;
-                }
-
-                case patch_operations::replace:
-                {
-                    // the "path" location must exist - use at()
-                    result.at(ptr) = get_value("replace", "value", false);
-                    break;
-                }
-
-                case patch_operations::move:
-                {
-                    const std::string from_path = get_value("move", "from", true);
-                    json_pointer from_ptr(from_path);
-
-                    // the "from" location must exist - use at()
-                    basic_json v = result.at(from_ptr);
-
-                    // The move operation is functionally identical to a
-                    // "remove" operation on the "from" location, followed
-                    // immediately by an "add" operation at the target
-                    // location with the value that was just removed.
-                    operation_remove(from_ptr);
-                    operation_add(ptr, v);
-                    break;
-                }
-
-                case patch_operations::copy:
-                {
-                    const std::string from_path = get_value("copy", "from", true);
-                    const json_pointer from_ptr(from_path);
-
-                    // the "from" location must exist - use at()
-                    basic_json v = result.at(from_ptr);
-
-                    // The copy is functionally identical to an "add"
-                    // operation at the target location using the value
-                    // specified in the "from" member.
-                    operation_add(ptr, v);
-                    break;
-                }
-
-                case patch_operations::test:
-                {
-                    bool success = false;
-                    JSON_TRY
-                    {
-                        // check if "value" matches the one at "path"
-                        // the "path" location must exist - use at()
-                        success = (result.at(ptr) == get_value("test", "value", false));
-                    }
-                    JSON_INTERNAL_CATCH (out_of_range&)
-                    {
-                        // ignore out of range errors: success remains false
-                    }
-
-                    // throw an exception if test fails
-                    if (JSON_UNLIKELY(not success))
-                    {
-                        JSON_THROW(other_error::create(501, "unsuccessful: " + val.dump()));
-                    }
-
-                    break;
-                }
-
-                case patch_operations::invalid:
-                {
-                    // op must be "add", "remove", "replace", "move", "copy", or
-                    // "test"
-                    JSON_THROW(parse_error::create(105, 0, "operation value '" + op + "' is invalid"));
-                }
-            }
+        switch (parent.m_type) {
+        case value_t::null:
+        case value_t::object: {
+          // use operator[] to add value
+          parent[last_path] = val;
+          break;
         }
 
-        return result;
+        case value_t::array: {
+          if (last_path == "-") {
+            // special case: append to back
+            parent.push_back(val);
+          } else {
+            const auto idx = json_pointer::array_index(last_path);
+            if (JSON_UNLIKELY(static_cast<size_type>(idx) > parent.size())) {
+              // avoid undefined behavior
+              JSON_THROW(out_of_range::create(401, "array index " + std::to_string(idx) + " is out of range"));
+            }
+
+            // default case: insert add offset
+            parent.insert(parent.begin() + static_cast<difference_type>(idx), val);
+          }
+          break;
+        }
+
+        // LCOV_EXCL_START
+        default: {
+          // if there exists a parent it cannot be primitive
+          assert(false);
+        }
+          // LCOV_EXCL_STOP
+        }
+      }
+    };
+
+    // wrapper for "remove" operation; remove value at ptr
+    const auto operation_remove = [&result](json_pointer &ptr) {
+      // get reference to parent of JSON pointer ptr
+      const auto  last_path = ptr.pop_back();
+      basic_json &parent    = result.at(ptr);
+
+      // remove child
+      if (parent.is_object()) {
+        // perform range check
+        auto it = parent.find(last_path);
+        if (JSON_LIKELY(it != parent.end())) {
+          parent.erase(it);
+        } else {
+          JSON_THROW(out_of_range::create(403, "key '" + last_path + "' not found"));
+        }
+      } else if (parent.is_array()) {
+        // note erase performs range check
+        parent.erase(static_cast<size_type>(json_pointer::array_index(last_path)));
+      }
+    };
+
+    // type check: top level value must be an array
+    if (JSON_UNLIKELY(not json_patch.is_array())) {
+      JSON_THROW(parse_error::create(104, 0, "JSON patch must be an array of objects"));
     }
 
-    /*!
+    // iterate and apply the operations
+    for (const auto &val : json_patch) {
+      // wrapper to get a value for an operation
+      const auto get_value = [&val](const std::string &op,
+                                    const std::string &member,
+                                    bool               string_type) -> basic_json & {
+        // find value
+        auto it = val.m_value.object->find(member);
+
+        // context-sensitive error message
+        const auto error_msg = (op == "op") ? "operation" : "operation '" + op + "'";
+
+        // check if desired value is present
+        if (JSON_UNLIKELY(it == val.m_value.object->end())) {
+          JSON_THROW(parse_error::create(105, 0, error_msg + " must have member '" + member + "'"));
+        }
+
+        // check if result is of type string
+        if (JSON_UNLIKELY(string_type and not it->second.is_string())) {
+          JSON_THROW(parse_error::create(105, 0, error_msg + " must have string member '" + member + "'"));
+        }
+
+        // no error: return value
+        return it->second;
+      };
+
+      // type check: every element of the array must be an object
+      if (JSON_UNLIKELY(not val.is_object())) {
+        JSON_THROW(parse_error::create(104, 0, "JSON patch must be an array of objects"));
+      }
+
+      // collect mandatory members
+      const std::string op   = get_value("op", "op", true);
+      const std::string path = get_value(op, "path", true);
+      json_pointer      ptr(path);
+
+      switch (get_op(op)) {
+      case patch_operations::add: {
+        operation_add(ptr, get_value("add", "value", false));
+        break;
+      }
+
+      case patch_operations::remove: {
+        operation_remove(ptr);
+        break;
+      }
+
+      case patch_operations::replace: {
+        // the "path" location must exist - use at()
+        result.at(ptr) = get_value("replace", "value", false);
+        break;
+      }
+
+      case patch_operations::move: {
+        const std::string from_path = get_value("move", "from", true);
+        json_pointer      from_ptr(from_path);
+
+        // the "from" location must exist - use at()
+        basic_json v = result.at(from_ptr);
+
+        // The move operation is functionally identical to a
+        // "remove" operation on the "from" location, followed
+        // immediately by an "add" operation at the target
+        // location with the value that was just removed.
+        operation_remove(from_ptr);
+        operation_add(ptr, v);
+        break;
+      }
+
+      case patch_operations::copy: {
+        const std::string  from_path = get_value("copy", "from", true);
+        const json_pointer from_ptr(from_path);
+
+        // the "from" location must exist - use at()
+        basic_json v = result.at(from_ptr);
+
+        // The copy is functionally identical to an "add"
+        // operation at the target location using the value
+        // specified in the "from" member.
+        operation_add(ptr, v);
+        break;
+      }
+
+      case patch_operations::test: {
+        bool success = false;
+        JSON_TRY
+        {
+          // check if "value" matches the one at "path"
+          // the "path" location must exist - use at()
+          success = (result.at(ptr) == get_value("test", "value", false));
+        }
+        JSON_INTERNAL_CATCH(out_of_range &)
+        {
+          // ignore out of range errors: success remains false
+        }
+
+        // throw an exception if test fails
+        if (JSON_UNLIKELY(not success)) {
+          JSON_THROW(other_error::create(501, "unsuccessful: " + val.dump()));
+        }
+
+        break;
+      }
+
+      case patch_operations::invalid: {
+        // op must be "add", "remove", "replace", "move", "copy", or
+        // "test"
+        JSON_THROW(parse_error::create(105, 0, "operation value '" + op + "' is invalid"));
+      }
+      }
+    }
+
+    return result;
+  }
+
+  /*!
     @brief creates a diff as a JSON patch
 
     Creates a [JSON Patch](http://jsonpatch.com) so that value @a source can
@@ -20078,141 +18833,111 @@ class basic_json
 
     @since version 2.0.0
     */
-    static basic_json diff(const basic_json& source, const basic_json& target,
-                           const std::string& path = "")
-    {
-        // the patch
-        basic_json result(value_t::array);
+  static basic_json diff(const basic_json &source, const basic_json &target,
+                         const std::string &path = "")
+  {
+    // the patch
+    basic_json result(value_t::array);
 
-        // if the values are the same, return empty patch
-        if (source == target)
-        {
-            return result;
-        }
-
-        if (source.type() != target.type())
-        {
-            // different types: replace value
-            result.push_back(
-            {
-                {"op", "replace"}, {"path", path}, {"value", target}
-            });
-        }
-        else
-        {
-            switch (source.type())
-            {
-                case value_t::array:
-                {
-                    // first pass: traverse common elements
-                    std::size_t i = 0;
-                    while (i < source.size() and i < target.size())
-                    {
-                        // recursive call to compare array values at index i
-                        auto temp_diff = diff(source[i], target[i], path + "/" + std::to_string(i));
-                        result.insert(result.end(), temp_diff.begin(), temp_diff.end());
-                        ++i;
-                    }
-
-                    // i now reached the end of at least one array
-                    // in a second pass, traverse the remaining elements
-
-                    // remove my remaining elements
-                    const auto end_index = static_cast<difference_type>(result.size());
-                    while (i < source.size())
-                    {
-                        // add operations in reverse order to avoid invalid
-                        // indices
-                        result.insert(result.begin() + end_index, object(
-                        {
-                            {"op", "remove"},
-                            {"path", path + "/" + std::to_string(i)}
-                        }));
-                        ++i;
-                    }
-
-                    // add other remaining elements
-                    while (i < target.size())
-                    {
-                        result.push_back(
-                        {
-                            {"op", "add"},
-                            {"path", path + "/" + std::to_string(i)},
-                            {"value", target[i]}
-                        });
-                        ++i;
-                    }
-
-                    break;
-                }
-
-                case value_t::object:
-                {
-                    // first pass: traverse this object's elements
-                    for (auto it = source.cbegin(); it != source.cend(); ++it)
-                    {
-                        // escape the key name to be used in a JSON patch
-                        const auto key = json_pointer::escape(it.key());
-
-                        if (target.find(it.key()) != target.end())
-                        {
-                            // recursive call to compare object values at key it
-                            auto temp_diff = diff(it.value(), target[it.key()], path + "/" + key);
-                            result.insert(result.end(), temp_diff.begin(), temp_diff.end());
-                        }
-                        else
-                        {
-                            // found a key that is not in o -> remove it
-                            result.push_back(object(
-                            {
-                                {"op", "remove"}, {"path", path + "/" + key}
-                            }));
-                        }
-                    }
-
-                    // second pass: traverse other object's elements
-                    for (auto it = target.cbegin(); it != target.cend(); ++it)
-                    {
-                        if (source.find(it.key()) == source.end())
-                        {
-                            // found a key that is not in this -> add it
-                            const auto key = json_pointer::escape(it.key());
-                            result.push_back(
-                            {
-                                {"op", "add"}, {"path", path + "/" + key},
-                                {"value", it.value()}
-                            });
-                        }
-                    }
-
-                    break;
-                }
-
-                default:
-                {
-                    // both primitive type: replace value
-                    result.push_back(
-                    {
-                        {"op", "replace"}, {"path", path}, {"value", target}
-                    });
-                    break;
-                }
-            }
-        }
-
-        return result;
+    // if the values are the same, return empty patch
+    if (source == target) {
+      return result;
     }
 
-    /// @}
+    if (source.type() != target.type()) {
+      // different types: replace value
+      result.push_back(
+          {{"op", "replace"}, {"path", path}, {"value", target}});
+    } else {
+      switch (source.type()) {
+      case value_t::array: {
+        // first pass: traverse common elements
+        std::size_t i = 0;
+        while (i < source.size() and i < target.size()) {
+          // recursive call to compare array values at index i
+          auto temp_diff = diff(source[i], target[i], path + "/" + std::to_string(i));
+          result.insert(result.end(), temp_diff.begin(), temp_diff.end());
+          ++i;
+        }
 
-    ////////////////////////////////
-    // JSON Merge Patch functions //
-    ////////////////////////////////
+        // i now reached the end of at least one array
+        // in a second pass, traverse the remaining elements
 
-    /// @name JSON Merge Patch functions
-    /// @{
+        // remove my remaining elements
+        const auto end_index = static_cast<difference_type>(result.size());
+        while (i < source.size()) {
+          // add operations in reverse order to avoid invalid
+          // indices
+          result.insert(result.begin() + end_index, object(
+                                                        {{"op", "remove"},
+                                                         {"path", path + "/" + std::to_string(i)}}));
+          ++i;
+        }
 
-    /*!
+        // add other remaining elements
+        while (i < target.size()) {
+          result.push_back(
+              {{"op", "add"},
+               {"path", path + "/" + std::to_string(i)},
+               {"value", target[i]}});
+          ++i;
+        }
+
+        break;
+      }
+
+      case value_t::object: {
+        // first pass: traverse this object's elements
+        for (auto it = source.cbegin(); it != source.cend(); ++it) {
+          // escape the key name to be used in a JSON patch
+          const auto key = json_pointer::escape(it.key());
+
+          if (target.find(it.key()) != target.end()) {
+            // recursive call to compare object values at key it
+            auto temp_diff = diff(it.value(), target[it.key()], path + "/" + key);
+            result.insert(result.end(), temp_diff.begin(), temp_diff.end());
+          } else {
+            // found a key that is not in o -> remove it
+            result.push_back(object(
+                {{"op", "remove"}, {"path", path + "/" + key}}));
+          }
+        }
+
+        // second pass: traverse other object's elements
+        for (auto it = target.cbegin(); it != target.cend(); ++it) {
+          if (source.find(it.key()) == source.end()) {
+            // found a key that is not in this -> add it
+            const auto key = json_pointer::escape(it.key());
+            result.push_back(
+                {{"op", "add"}, {"path", path + "/" + key}, {"value", it.value()}});
+          }
+        }
+
+        break;
+      }
+
+      default: {
+        // both primitive type: replace value
+        result.push_back(
+            {{"op", "replace"}, {"path", path}, {"value", target}});
+        break;
+      }
+      }
+    }
+
+    return result;
+  }
+
+  /// @}
+
+  ////////////////////////////////
+  // JSON Merge Patch functions //
+  ////////////////////////////////
+
+  /// @name JSON Merge Patch functions
+  /// @{
+
+  /*!
     @brief applies a JSON Merge Patch
 
     The merge patch format is primarily intended for use with the HTTP PATCH
@@ -20254,33 +18979,25 @@ class basic_json
 
     @since version 3.0.0
     */
-    void merge_patch(const basic_json& apply_patch)
-    {
-        if (apply_patch.is_object())
-        {
-            if (not is_object())
-            {
-                *this = object();
-            }
-            for (auto it = apply_patch.begin(); it != apply_patch.end(); ++it)
-            {
-                if (it.value().is_null())
-                {
-                    erase(it.key());
-                }
-                else
-                {
-                    operator[](it.key()).merge_patch(it.value());
-                }
-            }
+  void merge_patch(const basic_json &apply_patch)
+  {
+    if (apply_patch.is_object()) {
+      if (not is_object()) {
+        *this = object();
+      }
+      for (auto it = apply_patch.begin(); it != apply_patch.end(); ++it) {
+        if (it.value().is_null()) {
+          erase(it.key());
+        } else {
+          operator[](it.key()).merge_patch(it.value());
         }
-        else
-        {
-            *this = apply_patch;
-        }
+      }
+    } else {
+      *this = apply_patch;
     }
+  }
 
-    /// @}
+  /// @}
 };
 } // namespace nlohmann
 
@@ -20289,41 +19006,38 @@ class basic_json
 ///////////////////////
 
 // specialization of std::swap, and std::hash
-namespace std
-{
+namespace std {
 
 /// hash value for JSON objects
-template<>
-struct hash<nlohmann::json>
-{
-    /*!
+template <>
+struct hash<nlohmann::json> {
+  /*!
     @brief return a hash value for a JSON object
 
     @since version 1.0.0
     */
-    std::size_t operator()(const nlohmann::json& j) const
-    {
-        // a naive hashing via the string representation
-        const auto& h = hash<nlohmann::json::string_t>();
-        return h(j.dump());
-    }
+  std::size_t operator()(const nlohmann::json &j) const
+  {
+    // a naive hashing via the string representation
+    const auto &h = hash<nlohmann::json::string_t>();
+    return h(j.dump());
+  }
 };
 
 /// specialization for std::less<value_t>
 /// @note: do not remove the space after '<',
 ///        see https://github.com/nlohmann/json/pull/679
-template<>
-struct less< ::nlohmann::detail::value_t>
-{
-    /*!
+template <>
+struct less<::nlohmann::detail::value_t> {
+  /*!
     @brief compare two value_t enum values
     @since version 3.0.0
     */
-    bool operator()(nlohmann::detail::value_t lhs,
-                    nlohmann::detail::value_t rhs) const noexcept
-    {
-        return nlohmann::detail::operator<(lhs, rhs);
-    }
+  bool operator()(nlohmann::detail::value_t lhs,
+                  nlohmann::detail::value_t rhs) const noexcept
+  {
+    return nlohmann::detail::operator<(lhs, rhs);
+  }
 };
 
 /*!
@@ -20331,13 +19045,12 @@ struct less< ::nlohmann::detail::value_t>
 
 @since version 1.0.0
 */
-template<>
-inline void swap<nlohmann::json>(nlohmann::json& j1, nlohmann::json& j2) noexcept(
+template <>
+inline void swap<nlohmann::json>(nlohmann::json &j1, nlohmann::json &j2) noexcept(
     is_nothrow_move_constructible<nlohmann::json>::value and
-    is_nothrow_move_assignable<nlohmann::json>::value
-)
+        is_nothrow_move_assignable<nlohmann::json>::value)
 {
-    j1.swap(j2);
+  j1.swap(j2);
 }
 
 } // namespace std
@@ -20355,9 +19068,9 @@ if no parse error occurred.
 
 @since version 1.0.0
 */
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+inline nlohmann::json operator"" _json(const char *s, std::size_t n)
 {
-    return nlohmann::json::parse(s, s + n);
+  return nlohmann::json::parse(s, s + n);
 }
 
 /*!
@@ -20373,20 +19086,19 @@ object if no parse error occurred.
 
 @since version 2.0.0
 */
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+inline nlohmann::json::json_pointer operator"" _json_pointer(const char *s, std::size_t n)
 {
-    return nlohmann::json::json_pointer(std::string(s, n));
+  return nlohmann::json::json_pointer(std::string(s, n));
 }
 
 // #include <nlohmann/detail/macro_unscope.hpp>
 
-
 // restore GCC/clang diagnostic settings
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 #if defined(__clang__)
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
 // clean up
@@ -20401,6 +19113,5 @@ inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std
 #undef JSON_HAS_CPP_17
 #undef NLOHMANN_BASIC_JSON_TPL_DECLARATION
 #undef NLOHMANN_BASIC_JSON_TPL
-
 
 #endif

--- a/thirdparty/prettyprint/include/prettyprint/prettyprint.hpp
+++ b/thirdparty/prettyprint/include/prettyprint/prettyprint.hpp
@@ -22,425 +22,458 @@
 #include <utility>
 #include <valarray>
 
-namespace pretty_print
+namespace pretty_print {
+namespace detail {
+// SFINAE type trait to detect whether T::const_iterator exists.
+
+struct sfinae_base {
+  using yes = char;
+  using no  = yes[2];
+};
+
+template <typename T>
+struct has_const_iterator : private sfinae_base {
+private:
+  template <typename C>
+  static typename std::enable_if<!std::is_void<typename std::iterator_traits<typename C::const_iterator>::value_type>::value, yes &>::type test(typename C::const_iterator *);
+  template <typename C>
+  static no &test(...);
+
+public:
+  static const bool value = sizeof(test<T>(nullptr)) == sizeof(yes);
+  using type              = T;
+};
+
+template <typename T>
+struct has_begin_end : private sfinae_base {
+private:
+  template <typename C>
+  static yes &f(typename std::enable_if<
+                std::is_same<decltype(static_cast<typename C::const_iterator (C::*)() const>(&C::begin)),
+                             typename C::const_iterator (C::*)() const>::value>::type *);
+
+  template <typename C>
+  static no &f(...);
+
+  template <typename C>
+  static yes &g(typename std::enable_if<
+                std::is_same<decltype(static_cast<typename C::const_iterator (C::*)() const>(&C::end)),
+                             typename C::const_iterator (C::*)() const>::value,
+                void>::type *);
+
+  template <typename C>
+  static no &g(...);
+
+public:
+  static bool const beg_value = sizeof(f<T>(nullptr)) == sizeof(yes);
+  static bool const end_value = sizeof(g<T>(nullptr)) == sizeof(yes);
+};
+
+} // namespace detail
+
+// Holds the delimiter values for a specific character type
+
+template <typename TChar>
+struct delimiters_values {
+  using char_type = TChar;
+  const char_type *prefix;
+  const char_type *delimiter;
+  const char_type *postfix;
+};
+
+// Defines the delimiter values for a specific container and character type
+
+template <typename T, typename TChar>
+struct delimiters {
+  using type = delimiters_values<TChar>;
+  static const type values;
+};
+
+// Functor to print containers. You can use this directly if you want
+// to specificy a non-default delimiters type. The printing logic can
+// be customized by specializing the nested template.
+
+template <typename T,
+          typename TChar       = char,
+          typename TCharTraits = ::std::char_traits<TChar>,
+          typename TDelimiters = delimiters<T, TChar>>
+struct print_container_helper {
+  using delimiters_type = TDelimiters;
+  using ostream_type    = std::basic_ostream<TChar, TCharTraits>;
+
+  template <typename U>
+  struct printer {
+    static void print_body(const U &c, ostream_type &stream)
+    {
+      using std::begin;
+      using std::end;
+
+      auto       it      = begin(c);
+      const auto the_end = end(c);
+
+      if (it != the_end) {
+        for (;;) {
+          stream << *it;
+
+          if (++it == the_end)
+            break;
+
+          if (delimiters_type::values.delimiter != NULL)
+            stream << delimiters_type::values.delimiter;
+        }
+      }
+    }
+  };
+
+  print_container_helper(const T &container)
+      : container_(container)
+  {
+  }
+
+  inline void operator()(ostream_type &stream) const
+  {
+    if (delimiters_type::values.prefix != NULL)
+      stream << delimiters_type::values.prefix;
+
+    printer<T>::print_body(container_, stream);
+
+    if (delimiters_type::values.postfix != NULL)
+      stream << delimiters_type::values.postfix;
+  }
+
+private:
+  const T &container_;
+};
+
+// Specialization for pairs
+
+template <typename T, typename TChar, typename TCharTraits, typename TDelimiters>
+template <typename T1, typename T2>
+struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::pair<T1, T2>> {
+  using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
+
+  static void print_body(const std::pair<T1, T2> &c, ostream_type &stream)
+  {
+    stream << c.first;
+    if (print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter != NULL)
+      stream << print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter;
+    stream << c.second;
+  }
+};
+
+// Specialization for tuples
+
+template <typename T, typename TChar, typename TCharTraits, typename TDelimiters>
+template <typename... Args>
+struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::tuple<Args...>> {
+  using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
+  using element_type = std::tuple<Args...>;
+
+  template <std::size_t I>
+  struct Int {
+  };
+
+  static void print_body(const element_type &c, ostream_type &stream)
+  {
+    tuple_print(c, stream, Int<0>());
+  }
+
+  static void tuple_print(const element_type &, ostream_type &, Int<sizeof...(Args)>)
+  {
+  }
+
+  static void tuple_print(const element_type &c, ostream_type &stream,
+                          typename std::conditional<sizeof...(Args) != 0, Int<0>, std::nullptr_t>::type)
+  {
+    stream << std::get<0>(c);
+    tuple_print(c, stream, Int<1>());
+  }
+
+  template <std::size_t N>
+  static void tuple_print(const element_type &c, ostream_type &stream, Int<N>)
+  {
+    if (print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter != NULL)
+      stream << print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter;
+
+    stream << std::get<N>(c);
+
+    tuple_print(c, stream, Int<N + 1>());
+  }
+};
+
+// Prints a print_container_helper to the specified stream.
+
+template <typename T, typename TChar, typename TCharTraits, typename TDelimiters>
+inline std::basic_ostream<TChar, TCharTraits> &operator<<(
+    std::basic_ostream<TChar, TCharTraits> &                          stream,
+    const print_container_helper<T, TChar, TCharTraits, TDelimiters> &helper)
 {
-    namespace detail
-    {
-        // SFINAE type trait to detect whether T::const_iterator exists.
-
-        struct sfinae_base
-        {
-            using yes = char;
-            using no  = yes[2];
-        };
-
-        template <typename T>
-        struct has_const_iterator : private sfinae_base
-        {
-        private:
-            template <typename C>
-            static typename std::enable_if<!std::is_void<typename std::iterator_traits<typename C::const_iterator>::value_type>::value, yes &>::type test(typename C::const_iterator*);
-            template <typename C> static no  & test(...);
-        public:
-            static const bool value = sizeof(test<T>(nullptr)) == sizeof(yes);
-            using type =  T;
-        };
-
-        template <typename T>
-        struct has_begin_end : private sfinae_base
-        {
-        private:
-            template <typename C>
-            static yes & f(typename std::enable_if<
-                std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::begin)),
-                             typename C::const_iterator(C::*)() const>::value>::type *);
-
-            template <typename C> static no & f(...);
-
-            template <typename C>
-            static yes & g(typename std::enable_if<
-                std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::end)),
-                             typename C::const_iterator(C::*)() const>::value, void>::type*);
-
-            template <typename C> static no & g(...);
-
-        public:
-            static bool const beg_value = sizeof(f<T>(nullptr)) == sizeof(yes);
-            static bool const end_value = sizeof(g<T>(nullptr)) == sizeof(yes);
-        };
-
-    }  // namespace detail
-
-
-    // Holds the delimiter values for a specific character type
-
-    template <typename TChar>
-    struct delimiters_values
-    {
-        using char_type = TChar;
-        const char_type * prefix;
-        const char_type * delimiter;
-        const char_type * postfix;
-    };
-
-
-    // Defines the delimiter values for a specific container and character type
-
-    template <typename T, typename TChar>
-    struct delimiters
-    {
-        using type = delimiters_values<TChar>;
-        static const type values; 
-    };
-
-
-    // Functor to print containers. You can use this directly if you want
-    // to specificy a non-default delimiters type. The printing logic can
-    // be customized by specializing the nested template.
-
-    template <typename T,
-              typename TChar = char,
-              typename TCharTraits = ::std::char_traits<TChar>,
-              typename TDelimiters = delimiters<T, TChar>>
-    struct print_container_helper
-    {
-        using delimiters_type = TDelimiters;
-        using ostream_type = std::basic_ostream<TChar, TCharTraits>;
-
-        template <typename U>
-        struct printer
-        {
-            static void print_body(const U & c, ostream_type & stream)
-            {
-                using std::begin;
-                using std::end;
-
-                auto it = begin(c);
-                const auto the_end = end(c);
-
-                if (it != the_end)
-                {
-                    for ( ; ; )
-                    {
-                        stream << *it;
-
-                    if (++it == the_end) break;
-
-                    if (delimiters_type::values.delimiter != NULL)
-                        stream << delimiters_type::values.delimiter;
-                    }
-                }
-            }
-        };
-
-        print_container_helper(const T & container)
-        : container_(container)
-        { }
-
-        inline void operator()(ostream_type & stream) const
-        {
-            if (delimiters_type::values.prefix != NULL)
-                stream << delimiters_type::values.prefix;
-
-            printer<T>::print_body(container_, stream);
-
-            if (delimiters_type::values.postfix != NULL)
-                stream << delimiters_type::values.postfix;
-        }
-
-    private:
-        const T & container_;
-    };
-
-    // Specialization for pairs
-
-    template <typename T, typename TChar, typename TCharTraits, typename TDelimiters>
-    template <typename T1, typename T2>
-    struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::pair<T1, T2>>
-    {
-        using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
-
-        static void print_body(const std::pair<T1, T2> & c, ostream_type & stream)
-        {
-            stream << c.first;
-            if (print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter != NULL)
-                stream << print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter;
-            stream << c.second;
-        }
-    };
-
-    // Specialization for tuples
-
-    template <typename T, typename TChar, typename TCharTraits, typename TDelimiters>
-    template <typename ...Args>
-    struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::tuple<Args...>>
-    {
-        using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
-        using element_type = std::tuple<Args...>;
-
-        template <std::size_t I> struct Int { };
-
-        static void print_body(const element_type & c, ostream_type & stream)
-        {
-            tuple_print(c, stream, Int<0>());
-        }
-
-        static void tuple_print(const element_type &, ostream_type &, Int<sizeof...(Args)>)
-        {
-        }
-
-        static void tuple_print(const element_type & c, ostream_type & stream,
-                                typename std::conditional<sizeof...(Args) != 0, Int<0>, std::nullptr_t>::type)
-        {
-            stream << std::get<0>(c);
-            tuple_print(c, stream, Int<1>());
-        }
-
-        template <std::size_t N>
-        static void tuple_print(const element_type & c, ostream_type & stream, Int<N>)
-        {
-            if (print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter != NULL)
-                stream << print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter;
-
-            stream << std::get<N>(c);
-
-            tuple_print(c, stream, Int<N + 1>());
-        }
-    };
-
-    // Prints a print_container_helper to the specified stream.
-
-    template<typename T, typename TChar, typename TCharTraits, typename TDelimiters>
-    inline std::basic_ostream<TChar, TCharTraits> & operator<<(
-        std::basic_ostream<TChar, TCharTraits> & stream,
-        const print_container_helper<T, TChar, TCharTraits, TDelimiters> & helper)
-    {
-        helper(stream);
-        return stream;
-    }
-
-
-    // Basic is_container template; specialize to derive from std::true_type for all desired container types
-
-    template <typename T>
-    struct is_container : public std::integral_constant<bool,
-                                                        detail::has_const_iterator<T>::value &&
-                                                        detail::has_begin_end<T>::beg_value  &&
-                                                        detail::has_begin_end<T>::end_value> { };
-
-    template <typename T, std::size_t N>
-    struct is_container<T[N]> : std::true_type { };
-
-    template <std::size_t N>
-    struct is_container<char[N]> : std::false_type { };
-
-    template <typename T>
-    struct is_container<std::valarray<T>> : std::true_type { };
-
-    template <typename T1, typename T2>
-    struct is_container<std::pair<T1, T2>> : std::true_type { };
-
-    template <typename ...Args>
-    struct is_container<std::tuple<Args...>> : std::true_type { };
-
-
-    // Default delimiters
-
-    template <typename T> struct delimiters<T, char> { static const delimiters_values<char> values; };
-    template <typename T> const delimiters_values<char> delimiters<T, char>::values = { "[", ", ", "]" };
-    template <typename T> struct delimiters<T, wchar_t> { static const delimiters_values<wchar_t> values; };
-    template <typename T> const delimiters_values<wchar_t> delimiters<T, wchar_t>::values = { L"[", L", ", L"]" };
-
-
-    // Delimiters for (multi)set and unordered_(multi)set
-
-    template <typename T, typename TComp, typename TAllocator>
-    struct delimiters< ::std::set<T, TComp, TAllocator>, char> { static const delimiters_values<char> values; };
-
-    template <typename T, typename TComp, typename TAllocator>
-    const delimiters_values<char> delimiters< ::std::set<T, TComp, TAllocator>, char>::values = { "{", ", ", "}" };
-
-    template <typename T, typename TComp, typename TAllocator>
-    struct delimiters< ::std::set<T, TComp, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
-
-    template <typename T, typename TComp, typename TAllocator>
-    const delimiters_values<wchar_t> delimiters< ::std::set<T, TComp, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
-
-    template <typename T, typename TComp, typename TAllocator>
-    struct delimiters< ::std::multiset<T, TComp, TAllocator>, char> { static const delimiters_values<char> values; };
-
-    template <typename T, typename TComp, typename TAllocator>
-    const delimiters_values<char> delimiters< ::std::multiset<T, TComp, TAllocator>, char>::values = { "{", ", ", "}" };
-
-    template <typename T, typename TComp, typename TAllocator>
-    struct delimiters< ::std::multiset<T, TComp, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
-
-    template <typename T, typename TComp, typename TAllocator>
-    const delimiters_values<wchar_t> delimiters< ::std::multiset<T, TComp, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    struct delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, char> { static const delimiters_values<char> values; };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    const delimiters_values<char> delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, char>::values = { "{", ", ", "}" };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    struct delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    const delimiters_values<wchar_t> delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    struct delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, char> { static const delimiters_values<char> values; };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    const delimiters_values<char> delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, char>::values = { "{", ", ", "}" };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    struct delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
-
-    template <typename T, typename THash, typename TEqual, typename TAllocator>
-    const delimiters_values<wchar_t> delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
-
-
-    // Delimiters for pair and tuple
-
-    template <typename T1, typename T2> struct delimiters<std::pair<T1, T2>, char> { static const delimiters_values<char> values; };
-    template <typename T1, typename T2> const delimiters_values<char> delimiters<std::pair<T1, T2>, char>::values = { "(", ", ", ")" };
-    template <typename T1, typename T2> struct delimiters< ::std::pair<T1, T2>, wchar_t> { static const delimiters_values<wchar_t> values; };
-    template <typename T1, typename T2> const delimiters_values<wchar_t> delimiters< ::std::pair<T1, T2>, wchar_t>::values = { L"(", L", ", L")" };
-
-    template <typename ...Args> struct delimiters<std::tuple<Args...>, char> { static const delimiters_values<char> values; };
-    template <typename ...Args> const delimiters_values<char> delimiters<std::tuple<Args...>, char>::values = { "(", ", ", ")" };
-    template <typename ...Args> struct delimiters< ::std::tuple<Args...>, wchar_t> { static const delimiters_values<wchar_t> values; };
-    template <typename ...Args> const delimiters_values<wchar_t> delimiters< ::std::tuple<Args...>, wchar_t>::values = { L"(", L", ", L")" };
-
-
-    // Type-erasing helper class for easy use of custom delimiters.
-    // Requires TCharTraits = std::char_traits<TChar> and TChar = char or wchar_t, and MyDelims needs to be defined for TChar.
-    // Usage: "cout << pretty_print::custom_delims<MyDelims>(x)".
-
-    struct custom_delims_base
-    {
-        virtual ~custom_delims_base() { }
-        virtual std::ostream & stream(::std::ostream &) = 0;
-        virtual std::wostream & stream(::std::wostream &) = 0;
-    };
-
-    template <typename T, typename Delims>
-    struct custom_delims_wrapper : custom_delims_base
-    {
-        custom_delims_wrapper(const T & t_) : t(t_) { }
-
-        std::ostream & stream(std::ostream & s)
-        {
-            return s << print_container_helper<T, char, std::char_traits<char>, Delims>(t);
-        }
-
-        std::wostream & stream(std::wostream & s)
-        {
-            return s << print_container_helper<T, wchar_t, std::char_traits<wchar_t>, Delims>(t);
-        }
-
-    private:
-        const T & t;
-    };
-
-    template <typename Delims>
-    struct custom_delims
-    {
-        template <typename Container>
-        custom_delims(const Container & c) : base(new custom_delims_wrapper<Container, Delims>(c)) { }
-
-        std::unique_ptr<custom_delims_base> base;
-    };
-
-    template <typename TChar, typename TCharTraits, typename Delims>
-    inline std::basic_ostream<TChar, TCharTraits> & operator<<(std::basic_ostream<TChar, TCharTraits> & s, const custom_delims<Delims> & p)
-    {
-        return p.base->stream(s);
-    }
-
-
-    // A wrapper for a C-style array given as pointer-plus-size.
-    // Usage: std::cout << pretty_print_array(arr, n) << std::endl;
-
-    template<typename T>
-    struct array_wrapper_n
-    {
-        typedef const T * const_iterator;
-        typedef T value_type;
-
-        array_wrapper_n(const T * const a, size_t n) : _array(a), _n(n) { }
-        inline const_iterator begin() const { return _array; }
-        inline const_iterator end() const { return _array + _n; }
-
-    private:
-        const T * const _array;
-        size_t _n;
-    };
-
-
-    // A wrapper for hash-table based containers that offer local iterators to each bucket.
-    // Usage: std::cout << bucket_print(m, 4) << std::endl;  (Prints bucket 5 of container m.)
-
-    template <typename T>
-    struct bucket_print_wrapper
-    {
-        typedef typename T::const_local_iterator const_iterator;
-        typedef typename T::size_type size_type;
-
-        const_iterator begin() const
-        {
-            return m_map.cbegin(n);
-        }
-
-        const_iterator end() const
-        {
-            return m_map.cend(n);
-        }
-
-        bucket_print_wrapper(const T & m, size_type bucket) : m_map(m), n(bucket) { }
-
-    private:
-        const T & m_map;
-        const size_type n;
-    };
-
-}   // namespace pretty_print
-
+  helper(stream);
+  return stream;
+}
+
+// Basic is_container template; specialize to derive from std::true_type for all desired container types
+
+template <typename T>
+struct is_container : public std::integral_constant<bool,
+                                                    detail::has_const_iterator<T>::value &&
+                                                        detail::has_begin_end<T>::beg_value &&
+                                                        detail::has_begin_end<T>::end_value> {
+};
+
+template <typename T, std::size_t N>
+struct is_container<T[N]> : std::true_type {
+};
+
+template <std::size_t N>
+struct is_container<char[N]> : std::false_type {
+};
+
+template <typename T>
+struct is_container<std::valarray<T>> : std::true_type {
+};
+
+template <typename T1, typename T2>
+struct is_container<std::pair<T1, T2>> : std::true_type {
+};
+
+template <typename... Args>
+struct is_container<std::tuple<Args...>> : std::true_type {
+};
+
+// Default delimiters
+
+template <typename T>
+struct delimiters<T, char> {
+  static const delimiters_values<char> values;
+};
+template <typename T>
+const delimiters_values<char> delimiters<T, char>::values = {"[", ", ", "]"};
+template <typename T>
+struct delimiters<T, wchar_t> {
+  static const delimiters_values<wchar_t> values;
+};
+template <typename T>
+const delimiters_values<wchar_t> delimiters<T, wchar_t>::values = {L"[", L", ", L"]"};
+
+// Delimiters for (multi)set and unordered_(multi)set
+
+template <typename T, typename TComp, typename TAllocator>
+struct delimiters<::std::set<T, TComp, TAllocator>, char> {
+  static const delimiters_values<char> values;
+};
+
+template <typename T, typename TComp, typename TAllocator>
+const delimiters_values<char> delimiters<::std::set<T, TComp, TAllocator>, char>::values = {"{", ", ", "}"};
+
+template <typename T, typename TComp, typename TAllocator>
+struct delimiters<::std::set<T, TComp, TAllocator>, wchar_t> {
+  static const delimiters_values<wchar_t> values;
+};
+
+template <typename T, typename TComp, typename TAllocator>
+const delimiters_values<wchar_t> delimiters<::std::set<T, TComp, TAllocator>, wchar_t>::values = {L"{", L", ", L"}"};
+
+template <typename T, typename TComp, typename TAllocator>
+struct delimiters<::std::multiset<T, TComp, TAllocator>, char> {
+  static const delimiters_values<char> values;
+};
+
+template <typename T, typename TComp, typename TAllocator>
+const delimiters_values<char> delimiters<::std::multiset<T, TComp, TAllocator>, char>::values = {"{", ", ", "}"};
+
+template <typename T, typename TComp, typename TAllocator>
+struct delimiters<::std::multiset<T, TComp, TAllocator>, wchar_t> {
+  static const delimiters_values<wchar_t> values;
+};
+
+template <typename T, typename TComp, typename TAllocator>
+const delimiters_values<wchar_t> delimiters<::std::multiset<T, TComp, TAllocator>, wchar_t>::values = {L"{", L", ", L"}"};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+struct delimiters<::std::unordered_set<T, THash, TEqual, TAllocator>, char> {
+  static const delimiters_values<char> values;
+};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+const delimiters_values<char> delimiters<::std::unordered_set<T, THash, TEqual, TAllocator>, char>::values = {"{", ", ", "}"};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+struct delimiters<::std::unordered_set<T, THash, TEqual, TAllocator>, wchar_t> {
+  static const delimiters_values<wchar_t> values;
+};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+const delimiters_values<wchar_t> delimiters<::std::unordered_set<T, THash, TEqual, TAllocator>, wchar_t>::values = {L"{", L", ", L"}"};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+struct delimiters<::std::unordered_multiset<T, THash, TEqual, TAllocator>, char> {
+  static const delimiters_values<char> values;
+};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+const delimiters_values<char> delimiters<::std::unordered_multiset<T, THash, TEqual, TAllocator>, char>::values = {"{", ", ", "}"};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+struct delimiters<::std::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t> {
+  static const delimiters_values<wchar_t> values;
+};
+
+template <typename T, typename THash, typename TEqual, typename TAllocator>
+const delimiters_values<wchar_t> delimiters<::std::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t>::values = {L"{", L", ", L"}"};
+
+// Delimiters for pair and tuple
+
+template <typename T1, typename T2>
+struct delimiters<std::pair<T1, T2>, char> {
+  static const delimiters_values<char> values;
+};
+template <typename T1, typename T2>
+const delimiters_values<char> delimiters<std::pair<T1, T2>, char>::values = {"(", ", ", ")"};
+template <typename T1, typename T2>
+struct delimiters<::std::pair<T1, T2>, wchar_t> {
+  static const delimiters_values<wchar_t> values;
+};
+template <typename T1, typename T2>
+const delimiters_values<wchar_t> delimiters<::std::pair<T1, T2>, wchar_t>::values = {L"(", L", ", L")"};
+
+template <typename... Args>
+struct delimiters<std::tuple<Args...>, char> {
+  static const delimiters_values<char> values;
+};
+template <typename... Args>
+const delimiters_values<char> delimiters<std::tuple<Args...>, char>::values = {"(", ", ", ")"};
+template <typename... Args>
+struct delimiters<::std::tuple<Args...>, wchar_t> {
+  static const delimiters_values<wchar_t> values;
+};
+template <typename... Args>
+const delimiters_values<wchar_t> delimiters<::std::tuple<Args...>, wchar_t>::values = {L"(", L", ", L")"};
+
+// Type-erasing helper class for easy use of custom delimiters.
+// Requires TCharTraits = std::char_traits<TChar> and TChar = char or wchar_t, and MyDelims needs to be defined for TChar.
+// Usage: "cout << pretty_print::custom_delims<MyDelims>(x)".
+
+struct custom_delims_base {
+  virtual ~custom_delims_base() {}
+  virtual std::ostream & stream(::std::ostream &)  = 0;
+  virtual std::wostream &stream(::std::wostream &) = 0;
+};
+
+template <typename T, typename Delims>
+struct custom_delims_wrapper : custom_delims_base {
+  custom_delims_wrapper(const T &t_)
+      : t(t_) {}
+
+  std::ostream &stream(std::ostream &s)
+  {
+    return s << print_container_helper<T, char, std::char_traits<char>, Delims>(t);
+  }
+
+  std::wostream &stream(std::wostream &s)
+  {
+    return s << print_container_helper<T, wchar_t, std::char_traits<wchar_t>, Delims>(t);
+  }
+
+private:
+  const T &t;
+};
+
+template <typename Delims>
+struct custom_delims {
+  template <typename Container>
+  custom_delims(const Container &c)
+      : base(new custom_delims_wrapper<Container, Delims>(c)) {}
+
+  std::unique_ptr<custom_delims_base> base;
+};
+
+template <typename TChar, typename TCharTraits, typename Delims>
+inline std::basic_ostream<TChar, TCharTraits> &operator<<(std::basic_ostream<TChar, TCharTraits> &s, const custom_delims<Delims> &p)
+{
+  return p.base->stream(s);
+}
+
+// A wrapper for a C-style array given as pointer-plus-size.
+// Usage: std::cout << pretty_print_array(arr, n) << std::endl;
+
+template <typename T>
+struct array_wrapper_n {
+  typedef const T *const_iterator;
+  typedef T        value_type;
+
+  array_wrapper_n(const T *const a, size_t n)
+      : _array(a), _n(n) {}
+  inline const_iterator begin() const
+  {
+    return _array;
+  }
+  inline const_iterator end() const
+  {
+    return _array + _n;
+  }
+
+private:
+  const T *const _array;
+  size_t         _n;
+};
+
+// A wrapper for hash-table based containers that offer local iterators to each bucket.
+// Usage: std::cout << bucket_print(m, 4) << std::endl;  (Prints bucket 5 of container m.)
+
+template <typename T>
+struct bucket_print_wrapper {
+  typedef typename T::const_local_iterator const_iterator;
+  typedef typename T::size_type            size_type;
+
+  const_iterator begin() const
+  {
+    return m_map.cbegin(n);
+  }
+
+  const_iterator end() const
+  {
+    return m_map.cend(n);
+  }
+
+  bucket_print_wrapper(const T &m, size_type bucket)
+      : m_map(m), n(bucket) {}
+
+private:
+  const T &       m_map;
+  const size_type n;
+};
+
+} // namespace pretty_print
 
 // Global accessor functions for the convenience wrappers
 
-template<typename T>
-inline pretty_print::array_wrapper_n<T> pretty_print_array(const T * const a, size_t n)
+template <typename T>
+inline pretty_print::array_wrapper_n<T> pretty_print_array(const T *const a, size_t n)
 {
-    return pretty_print::array_wrapper_n<T>(a, n);
+  return pretty_print::array_wrapper_n<T>(a, n);
 }
 
-template <typename T> pretty_print::bucket_print_wrapper<T>
-bucket_print(const T & m, typename T::size_type n)
+template <typename T>
+pretty_print::bucket_print_wrapper<T>
+bucket_print(const T &m, typename T::size_type n)
 {
-    return pretty_print::bucket_print_wrapper<T>(m, n);
+  return pretty_print::bucket_print_wrapper<T>(m, n);
 }
-
 
 // Main magic entry point: An overload snuck into namespace std.
 // Can we do better?
 
-namespace std
+namespace std {
+// Prints a container to the stream using default delimiters
+
+template <typename T, typename TChar, typename TCharTraits>
+inline typename enable_if<::pretty_print::is_container<T>::value,
+                          basic_ostream<TChar, TCharTraits> &>::type
+operator<<(basic_ostream<TChar, TCharTraits> &stream, const T &container)
 {
-    // Prints a container to the stream using default delimiters
-
-    template<typename T, typename TChar, typename TCharTraits>
-    inline typename enable_if< ::pretty_print::is_container<T>::value,
-                              basic_ostream<TChar, TCharTraits> &>::type
-    operator<<(basic_ostream<TChar, TCharTraits> & stream, const T & container)
-    {
-        return stream << ::pretty_print::print_container_helper<T, TChar, TCharTraits>(container);
-    }
+  return stream << ::pretty_print::print_container_helper<T, TChar, TCharTraits>(container);
 }
+} // namespace std
 
-
-
-#endif  // H_PRETTY_PRINT
+#endif // H_PRETTY_PRINT

--- a/tools/cad_converter/DataConverter.cpp
+++ b/tools/cad_converter/DataConverter.cpp
@@ -1,39 +1,35 @@
 #include "TransformToVRML.hpp"
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <vector>
 
 #include "IGES2Vrml.hpp"
 #include "STEP2Vrml.hpp"
 
-#include  "TransformToVRML.hpp"
+#include "TransformToVRML.hpp"
 
-int main ( int argc, char** argv )
+int main(int argc, char **argv)
 {
-  if ( argc != 3 ) {
+  if (argc != 3) {
     std::cout << " Usage: ./DataConverter inputFileName outputFilename\n";
-    abort ();
+    abort();
   }
 
-  std::string inputFileName ( argv[1] );
-  std::string outputFileName ( argv[2] );
+  std::string inputFileName(argv[1]);
+  std::string outputFileName(argv[2]);
 
-  TransformToVRML myTransformer( inputFileName, outputFileName );
+  TransformToVRML myTransformer(inputFileName, outputFileName);
 
-  if ( myTransformer.parseFileType () ) {
-    if ( myTransformer.doTransform() ) {
+  if (myTransformer.parseFileType()) {
+    if (myTransformer.doTransform()) {
       std::cout << " Transform to VRML succeed!\n";
-    }
-    else {
+    } else {
       std::cout << " Transform to VRML failed!\n";
     }
-  }
-  else {
+  } else {
     std::cout << "Input file type must be one of: .stp .step .igs .iges\n";
     return 0;
   }
   return 1;
 }
-
-

--- a/tools/cad_converter/IGES2Vrml.cpp
+++ b/tools/cad_converter/IGES2Vrml.cpp
@@ -1,73 +1,70 @@
 #include "IGES2Vrml.hpp"
 
-IGES2Vrml:: IGES2Vrml ( void )
+IGES2Vrml::IGES2Vrml(void)
 {
-   myIGESFileName = "";
+  myIGESFileName = "";
 }
 
-IGES2Vrml:: ~IGES2Vrml ( void )
+IGES2Vrml::~IGES2Vrml(void)
 {
 }
 
-bool IGES2Vrml:: readFile (  const std::string & inputFileName )
+bool IGES2Vrml::readFile(const std::string &inputFileName)
 {
-   myIGESFileName = inputFileName.c_str ();
-   if ( !myIGESFileName || ( myIGESFileName[0] == '\0' ) ) {
-      return false;
-   }
+  myIGESFileName = inputFileName.c_str();
+  if (!myIGESFileName || (myIGESFileName[0] == '\0')) {
+    return false;
+  }
 
-   IFSelect_ReturnStatus stat = myReader.ReadFile( myIGESFileName );
+  IFSelect_ReturnStatus stat = myReader.ReadFile(myIGESFileName);
 
-   if ( stat != IFSelect_RetDone)  {
-      return false;
-   }
+  if (stat != IFSelect_RetDone) {
+    return false;
+  }
 
-   return true;
-
+  return true;
 }
 
-void IGES2Vrml:: loadReport ( void )
+void IGES2Vrml::loadReport(void)
 {
-   if ( !myIGESFileName || ( myIGESFileName [0] == '\0' ) ) {
-      std::cout << "no input file" << '\n';
-      return;
-   }
+  if (!myIGESFileName || (myIGESFileName[0] == '\0')) {
+    std::cout << "no input file" << '\n';
+    return;
+  }
 
-   // get list of all entities
-   Handle ( TColStd_HSequenceOfTransient ) myList =
-         myReader.GiveList( "xst-transferrable-all" );
+  // get list of all entities
+  Handle(TColStd_HSequenceOfTransient) myList =
+      myReader.GiveList("xst-transferrable-all");
 
-   myReader.TransferList ( myList );
+  myReader.TransferList(myList);
 
-   myReader.PrintTransferInfo ( IFSelect_FailAndWarn, IFSelect_Mapping );
+  myReader.PrintTransferInfo(IFSelect_FailAndWarn, IFSelect_Mapping);
 
-   myReader.ClearShapes ();
-
+  myReader.ClearShapes();
 }
 
-bool IGES2Vrml:: transfer( const std::string & outputFileName )
+bool IGES2Vrml::transfer(const std::string &outputFileName)
 {
-   // get list of all entities
-   Handle ( TColStd_HSequenceOfTransient ) myList =
-         myReader.GiveList ( "xst-transferrable-all" );
+  // get list of all entities
+  Handle(TColStd_HSequenceOfTransient) myList =
+      myReader.GiveList("xst-transferrable-all");
 
-   myReader.TransferList ( myList );
+  myReader.TransferList(myList);
 
-   VrmlAPI_Writer myWriter;
-   TopoDS_Shape   myOneShape;
+  VrmlAPI_Writer myWriter;
+  TopoDS_Shape   myOneShape;
 
-   for ( int i =  1; i < myList-> Length (); i++ ) {
+  for (int i = 1; i < myList->Length(); i++) {
 
-      myOneShape =  myReader.Shape ( i );
-      if ( myOneShape.ShapeType () == TopAbs_COMPOUND ) {
-         break;
-      }
-   }
+    myOneShape = myReader.Shape(i);
+    if (myOneShape.ShapeType() == TopAbs_COMPOUND) {
+      break;
+    }
+  }
 
-   Standard_CString vrmlOutputFile = outputFileName.c_str ();
+  Standard_CString vrmlOutputFile = outputFileName.c_str();
 
-   myWriter.SetRepresentation ( VrmlAPI_ShadedRepresentation );
-   myWriter.Write ( myOneShape, vrmlOutputFile );
-   return true;
+  myWriter.SetRepresentation(VrmlAPI_ShadedRepresentation);
+  myWriter.Write(myOneShape, vrmlOutputFile);
+  return true;
 }
-

--- a/tools/cad_converter/IGES2Vrml.hpp
+++ b/tools/cad_converter/IGES2Vrml.hpp
@@ -1,13 +1,13 @@
 #ifndef PRECICE_DATACONVERTER_IGES2VRML_H_
 #define PRECICE_DATACONVERTER_IGES2VRML_H_
 
-#include <config.h>                 // occ variable for precompiler
-#include <IGESControl_Reader.hxx>   // Import -Tools
-#include <VrmlAPI_Writer.hxx>       // export -Tools
+#include <IGESControl_Reader.hxx> // Import -Tools
 #include <Standard_TypeDef.hxx>
 #include <TColStd_HSequenceOfTransient.hxx>
-#include <TopoDS_Shape.hxx>
 #include <TopTools_HSequenceOfShape.hxx>
+#include <TopoDS_Shape.hxx>
+#include <VrmlAPI_Writer.hxx> // export -Tools
+#include <config.h>           // occ variable for precompiler
 #include <string>
 
 /**
@@ -20,43 +20,39 @@
  *
  * @author Yuan Fei, Beteuer: Bernhard Gatzhammer
  */
-class IGES2Vrml
-{
+class IGES2Vrml {
 public:
-
-   /**
+  /**
     * @brief Constructor
     */
-   IGES2Vrml ( void );
+  IGES2Vrml(void);
 
-   /**
+  /**
     * @brief Destructor
     */
-   virtual ~IGES2Vrml ( void );
+  virtual ~IGES2Vrml(void);
 
-   /**
+  /**
     * @brief setting input file
     */
-   bool readFile ( const std::string & inputFileName );
+  bool readFile(const std::string &inputFileName);
 
-
-   /**
+  /**
     * @brief prints Statistics of input file
     */
-   void loadReport( void );
+  void loadReport(void);
 
-   /**
+  /**
     * @brief transform to VRML
     */
-   bool transfer( const std::string & outputFileName );
+  bool transfer(const std::string &outputFileName);
 
 private:
+  // @brief reader for IGES file
+  IGESControl_Reader myReader;
 
-   // @brief reader for IGES file
-   IGESControl_Reader myReader;
-
-   // @brief path and name of input file, must be set before transform
-   Standard_CString myIGESFileName;
+  // @brief path and name of input file, must be set before transform
+  Standard_CString myIGESFileName;
 };
 
 #endif /* IGES2VRML_H_ */

--- a/tools/cad_converter/STEP2Vrml.cpp
+++ b/tools/cad_converter/STEP2Vrml.cpp
@@ -1,67 +1,66 @@
 #include "STEP2Vrml.hpp"
 
-STEP2Vrml:: STEP2Vrml ( void )
+STEP2Vrml::STEP2Vrml(void)
 {
 
-   mySTEPFileName = "";
+  mySTEPFileName = "";
 }
 
-STEP2Vrml:: ~STEP2Vrml ( void )
+STEP2Vrml::~STEP2Vrml(void)
 {
 }
 
-bool STEP2Vrml:: readFile ( const std::string & inputFileName )
+bool STEP2Vrml::readFile(const std::string &inputFileName)
 {
-   mySTEPFileName = inputFileName.c_str ();
-   if ( !mySTEPFileName || ( mySTEPFileName[0] == '\0' ) ) {
-     return false;
-   }
-   IFSelect_ReturnStatus stat = myReader.ReadFile ( mySTEPFileName );
-   if ( stat != IFSelect_RetDone )  {
-      return false;
-   }
-   return true;
+  mySTEPFileName = inputFileName.c_str();
+  if (!mySTEPFileName || (mySTEPFileName[0] == '\0')) {
+    return false;
+  }
+  IFSelect_ReturnStatus stat = myReader.ReadFile(mySTEPFileName);
+  if (stat != IFSelect_RetDone) {
+    return false;
+  }
+  return true;
 }
 
-void STEP2Vrml:: loadReport ( void )
+void STEP2Vrml::loadReport(void)
 {
-   if ( !mySTEPFileName || ( mySTEPFileName [0] == '\0' ) ) {
-      cout << "no input Filename" << '\n';
-      return;
-   }
+  if (!mySTEPFileName || (mySTEPFileName[0] == '\0')) {
+    cout << "no input Filename" << '\n';
+    return;
+  }
 
-   // get list of all entities
-   Handle( TColStd_HSequenceOfTransient ) myList =
-         myReader.GiveList ( "xst-transferrable-all" );
+  // get list of all entities
+  Handle(TColStd_HSequenceOfTransient) myList =
+      myReader.GiveList("xst-transferrable-all");
 
-   myReader.TransferList ( myList );
+  myReader.TransferList(myList);
 
-   myReader.PrintStatsTransfer ( true, 3 );
-   myReader.ClearShapes ();
+  myReader.PrintStatsTransfer(true, 3);
+  myReader.ClearShapes();
 }
 
-
-bool STEP2Vrml:: transfer ( const std::string & outputFileName )
+bool STEP2Vrml::transfer(const std::string &outputFileName)
 {
-   // get list of all entities
-   Handle ( TColStd_HSequenceOfTransient ) myList =
-         myReader.GiveList ( "xst-transferrable-all" );
+  // get list of all entities
+  Handle(TColStd_HSequenceOfTransient) myList =
+      myReader.GiveList("xst-transferrable-all");
 
-   myReader.TransferList ( myList );
+  myReader.TransferList(myList);
 
-   VrmlAPI_Writer myWriter;
-   TopoDS_Shape   myOneShape;
+  VrmlAPI_Writer myWriter;
+  TopoDS_Shape   myOneShape;
 
-   Standard_CString vrmlOutputFile = outputFileName.c_str ();
+  Standard_CString vrmlOutputFile = outputFileName.c_str();
 
-   for ( int i =  1; i <= myList->Length (); i++ ) {
-      myOneShape =  myReader.Shape ( i );
-      if ( myOneShape.ShapeType () == TopAbs_SOLID )
-         break;
-   }
+  for (int i = 1; i <= myList->Length(); i++) {
+    myOneShape = myReader.Shape(i);
+    if (myOneShape.ShapeType() == TopAbs_SOLID)
+      break;
+  }
 
-   myWriter.SetRepresentation ( VrmlAPI_ShadedRepresentation );
-   myWriter.Write ( myOneShape,vrmlOutputFile );
+  myWriter.SetRepresentation(VrmlAPI_ShadedRepresentation);
+  myWriter.Write(myOneShape, vrmlOutputFile);
 
-   return true;
+  return true;
 }

--- a/tools/cad_converter/STEP2Vrml.hpp
+++ b/tools/cad_converter/STEP2Vrml.hpp
@@ -1,13 +1,13 @@
 #ifndef PRECICE_DATACONVERTER_STEP2VRML_HPP_
 #define PRECICE_DATACONVERTER_STEP2VRML_HPP_
 
-#include <config.h>     // occ variable for precompiler
-#include <STEPControl_Reader.hxx>   // Import -Tools
-#include <VrmlAPI_Writer.hxx>       // export -Tools
-#include <Standard_TypeDef.hxx>     //standard data type in Opencascade
-#include <TColStd_HSequenceOfTransient.hxx>  //save list of shapes for transfer
-#include <TopoDS_Shape.hxx>
+#include <STEPControl_Reader.hxx>           // Import -Tools
+#include <Standard_TypeDef.hxx>             //standard data type in Opencascade
+#include <TColStd_HSequenceOfTransient.hxx> //save list of shapes for transfer
 #include <TopTools_HSequenceOfShape.hxx>
+#include <TopoDS_Shape.hxx>
+#include <VrmlAPI_Writer.hxx> // export -Tools
+#include <config.h>           // occ variable for precompiler
 #include <string>
 
 /**
@@ -21,44 +21,39 @@
  * @author Yuan Fei, Beteuer: Bernhard Gatzhammer
  */
 
-class STEP2Vrml
-{
+class STEP2Vrml {
 public:
-
-   /**
+  /**
     * @brief Constructor
     */
-   STEP2Vrml ( void );
+  STEP2Vrml(void);
 
-   /**
+  /**
     * @brief Destructor
     */
-   virtual ~STEP2Vrml ( void );
+  virtual ~STEP2Vrml(void);
 
-   /**
+  /**
     * @brief setting input file
     */
-   bool readFile ( const std::string & inputFileName );
+  bool readFile(const std::string &inputFileName);
 
-   /**
+  /**
     * @brief prints Statistics of input file
     */
-   void loadReport ( void );
+  void loadReport(void);
 
-   /**
+  /**
     * @brief transform to VRML
     */
-   bool transfer ( const std::string & outputFileName );
+  bool transfer(const std::string &outputFileName);
 
 private:
+  // @brief reader for IGES file
+  STEPControl_Reader myReader;
 
-   // @brief reader for IGES file
-   STEPControl_Reader myReader;
-
-   // @brief path and name of input file, must be set before transform
-   Standard_CString mySTEPFileName;
-
+  // @brief path and name of input file, must be set before transform
+  Standard_CString mySTEPFileName;
 };
-
 
 #endif /* STEP2VRML_H_ */

--- a/tools/cad_converter/TransformToVRML.cpp
+++ b/tools/cad_converter/TransformToVRML.cpp
@@ -1,199 +1,189 @@
 #include "TransformToVRML.hpp"
 
+#include <boost/unordered_map.hpp>
 #include <iostream>
+#include <vector>
 #include "IGES2Vrml.hpp"
 #include "STEP2Vrml.hpp"
 #include "boost/algorithm/string.hpp"
-#include <vector>
-#include <boost/unordered_map.hpp>
 
 using namespace boost;
 
-TransformToVRML:: TransformToVRML
-(
-  const std::string & inputFileName,
-  const std::string & outputFileName )
-:
-  _inputFileName ( inputFileName ),
-  _outputFileName ( outputFileName ),
-  _inputFileType ( UNDEFINED )
-{}
-
-bool TransformToVRML:: parseFileType ()
+TransformToVRML::TransformToVRML(
+    const std::string &inputFileName,
+    const std::string &outputFileName)
+    : _inputFileName(inputFileName),
+      _outputFileName(outputFileName),
+      _inputFileType(UNDEFINED)
 {
-  if ( (_inputFileName.length() < 1) || (_outputFileName.length() < 1) ) {
+}
+
+bool TransformToVRML::parseFileType()
+{
+  if ((_inputFileName.length() < 1) || (_outputFileName.length() < 1)) {
     return false;
   }
 
   std::string suffix; // file type:  .igs .iges .stp .step
 
-  suffix = _inputFileName.substr ( _inputFileName.length() - 4 );
-  boost::to_lower( suffix );
-  if ( suffix == ".igs") {
+  suffix = _inputFileName.substr(_inputFileName.length() - 4);
+  boost::to_lower(suffix);
+  if (suffix == ".igs") {
     _inputFileType = IGES;
-  }
-  else if ( suffix == ".stp") {
+  } else if (suffix == ".stp") {
     _inputFileType = STEP;
-  }
-  else if ( suffix == ".wrl" ) {
+  } else if (suffix == ".wrl") {
     _inputFileType = VRML;
-  }
-  else {
-    suffix = _inputFileName.substr ( _inputFileName.length() - 5 );
-    boost::to_lower( suffix );
-    if ( suffix == ".iges") {
+  } else {
+    suffix = _inputFileName.substr(_inputFileName.length() - 5);
+    boost::to_lower(suffix);
+    if (suffix == ".iges") {
       _inputFileType = IGES;
-    }
-    else if ( suffix == ".step") {
+    } else if (suffix == ".step") {
       _inputFileType = STEP;
     }
   }
   return _inputFileType != UNDEFINED;
 }
 
-bool TransformToVRML:: doTransform ()
+bool TransformToVRML::doTransform()
 {
-  if ( _inputFileType == IGES ) {
-    transformIGES ();
-  }
-  else if ( _inputFileType == STEP ) {
-    transformSTEP ();
-  }
-  else if ( _inputFileType == VRML ) {
+  if (_inputFileType == IGES) {
+    transformIGES();
+  } else if (_inputFileType == STEP) {
+    transformSTEP();
+  } else if (_inputFileType == VRML) {
     // do nothing
-  }
-  else {
+  } else {
     return false;
   }
-  eliminateRedundancy ();
+  eliminateRedundancy();
   return true;
 }
 
-bool TransformToVRML:: transformIGES ()
+bool TransformToVRML::transformIGES()
 {
   IGES2Vrml convertIGES;
-  if ( ! convertIGES.readFile(_inputFileName) ) {
+  if (!convertIGES.readFile(_inputFileName)) {
     return false;
   }
-  convertIGES.loadReport ();
-  return convertIGES.transfer ( _outputFileName );
+  convertIGES.loadReport();
+  return convertIGES.transfer(_outputFileName);
 }
 
-bool TransformToVRML:: transformSTEP ()
+bool TransformToVRML::transformSTEP()
 {
   STEP2Vrml convertSTEP;
-  if ( convertSTEP.readFile(_inputFileName) ) {
+  if (convertSTEP.readFile(_inputFileName)) {
     return false;
   }
-  convertSTEP.loadReport ();
-  return convertSTEP.transfer ( _outputFileName );
+  convertSTEP.loadReport();
+  return convertSTEP.transfer(_outputFileName);
 }
 
-void TransformToVRML:: eliminateRedundancy ()
+void TransformToVRML::eliminateRedundancy()
 {
-  std::fstream fp;
-  char buf[1024] = {0};
+  std::fstream             fp;
+  char                     buf[1024] = {0};
   std::vector<std::string> stringCoordinate3;
   std::vector<std::string> vrmlText;
 
-  fp.open( _outputFileName.c_str(), std::ios_base::in );
+  fp.open(_outputFileName.c_str(), std::ios_base::in);
 
-  while ( fp.getline(buf, sizeof(buf)) ) {
+  while (fp.getline(buf, sizeof(buf))) {
     std::string str = buf;
-    vrmlText.push_back ( str );
-    if ( str.find("point [") != std::string::npos ) {
+    vrmlText.push_back(str);
+    if (str.find("point [") != std::string::npos) {
       break;
     }
   }
 
-  while ( fp.getline ( buf, sizeof ( buf ) ) ) {
+  while (fp.getline(buf, sizeof(buf))) {
     std::string str = buf;
     // not last line
-    if ( str.find(']') == std::string::npos ) {
-      str.erase ( str.length()-1 );
-      stringCoordinate3.push_back ( str );
+    if (str.find(']') == std::string::npos) {
+      str.erase(str.length() - 1);
+      stringCoordinate3.push_back(str);
     }
     // last line
     else {
-      str.erase( str.length()-1 );
-      str.erase( str.length()-1 );
-      stringCoordinate3.push_back( str );
+      str.erase(str.length() - 1);
+      str.erase(str.length() - 1);
+      stringCoordinate3.push_back(str);
       break;
     }
   }
 
   // count redundancy
-  typedef boost::unordered_map<std::string,int> Map;
-  Map oneMap;
-  std::vector<int> newOrder;
-  std::vector<int> deleteList;
+  typedef boost::unordered_map<std::string, int> Map;
+  Map                                            oneMap;
+  std::vector<int>                               newOrder;
+  std::vector<int>                               deleteList;
 
   std::cout << "before elemination: " << stringCoordinate3.size() << " points "
             << '\n';
 
   size_t j = 0;
-  for ( size_t i=0; i < stringCoordinate3.size (); i++ ) {
+  for (size_t i = 0; i < stringCoordinate3.size(); i++) {
     Map::iterator iter;
-    iter = oneMap.find ( stringCoordinate3 [ i ] );
-    if ( iter == oneMap.end() ) {
-      oneMap.insert ( Map::value_type(stringCoordinate3[i], j) );
-      newOrder.push_back ( j++ );
-    }
-    else {
-      newOrder.push_back ( iter->second );
-      deleteList.push_back ( i );
+    iter = oneMap.find(stringCoordinate3[i]);
+    if (iter == oneMap.end()) {
+      oneMap.insert(Map::value_type(stringCoordinate3[i], j));
+      newOrder.push_back(j++);
+    } else {
+      newOrder.push_back(iter->second);
+      deleteList.push_back(i);
     }
   }
 
   std::cout << "after elemination: " << oneMap.size() << " points \n";
 
   // eliminate redundancy
-  for ( size_t i=deleteList.size ()-1; i >= 0; i-- ) {
-    stringCoordinate3.erase ( stringCoordinate3.begin() + deleteList[i] );
+  for (size_t i = deleteList.size() - 1; i >= 0; i--) {
+    stringCoordinate3.erase(stringCoordinate3.begin() + deleteList[i]);
   }
 
-  while ( fp.getline(buf, sizeof(buf)) ) {
+  while (fp.getline(buf, sizeof(buf))) {
     std::string str = buf;
-    if ( str.find("IndexedFaceSet") != std::string::npos ) {
-      fp.getline ( buf, sizeof(buf) );
+    if (str.find("IndexedFaceSet") != std::string::npos) {
+      fp.getline(buf, sizeof(buf));
       break;
     }
   }
 
-  int s0, s1, s2;
+  int              s0, s1, s2;
   std::vector<int> vectorFaceIndices;
-  char kommer;
-  std::string str;
+  char             kommer;
+  std::string      str;
 
   do {
-    fp >> s0 >> kommer >> s1 >> kommer >> s2 ;
+    fp >> s0 >> kommer >> s1 >> kommer >> s2;
 
-    vectorFaceIndices.push_back( s0 );
-    vectorFaceIndices.push_back( s1 );
-    vectorFaceIndices.push_back( s2 );
+    vectorFaceIndices.push_back(s0);
+    vectorFaceIndices.push_back(s1);
+    vectorFaceIndices.push_back(s2);
 
-    fp.getline ( buf, sizeof ( buf ) );
+    fp.getline(buf, sizeof(buf));
     str = buf;
 
-  } while ( str.compare(",-1,") == 0  );
+  } while (str.compare(",-1,") == 0);
 
-
-  for ( size_t i=0; i < vectorFaceIndices.size(); i++ ) {
+  for (size_t i = 0; i < vectorFaceIndices.size(); i++) {
     vectorFaceIndices[i] = newOrder[vectorFaceIndices[i]];
   }
-  fp.close ();
+  fp.close();
 
-  fp.open ( _outputFileName.c_str(), std::ios_base::out );
+  fp.open(_outputFileName.c_str(), std::ios_base::out);
 
-  for ( size_t i=0; i < vrmlText.size(); i++ ) {
-    fp << vrmlText [ i ] << '\n';
+  for (size_t i = 0; i < vrmlText.size(); i++) {
+    fp << vrmlText[i] << '\n';
   }
 
-  for ( size_t i=0; i < stringCoordinate3.size()-1; i++ ) {
+  for (size_t i = 0; i < stringCoordinate3.size() - 1; i++) {
     fp << stringCoordinate3[i] << ",\n";
   }
 
-  fp << stringCoordinate3[stringCoordinate3.size()-1] << " ]\n";
+  fp << stringCoordinate3[stringCoordinate3.size() - 1] << " ]\n";
 
   fp << "}\n";
   fp << "ShapeHints {\n";
@@ -201,17 +191,17 @@ void TransformToVRML:: eliminateRedundancy ()
   fp << "IndexedFaceSet {\n";
   fp << "coordIndex [\n";
 
-  for ( size_t i=0; i < vectorFaceIndices.size() - 1; i += 3 ) {
-    fp << vectorFaceIndices [ i + 0 ] << ","
-    << vectorFaceIndices [ i + 1 ] << ","
-    << vectorFaceIndices [ i + 2 ] << ","
-    << "-1,\n";
+  for (size_t i = 0; i < vectorFaceIndices.size() - 1; i += 3) {
+    fp << vectorFaceIndices[i + 0] << ","
+       << vectorFaceIndices[i + 1] << ","
+       << vectorFaceIndices[i + 2] << ","
+       << "-1,\n";
   }
 
-  fp << vectorFaceIndices [ vectorFaceIndices.size() - 3 ] << ","
-  << vectorFaceIndices [ vectorFaceIndices.size() - 2 ] << ","
-  << vectorFaceIndices [ vectorFaceIndices.size() - 1 ] << ","
-  << "-1\n";
+  fp << vectorFaceIndices[vectorFaceIndices.size() - 3] << ","
+     << vectorFaceIndices[vectorFaceIndices.size() - 2] << ","
+     << vectorFaceIndices[vectorFaceIndices.size() - 1] << ","
+     << "-1\n";
 
   fp << "]\n";
   fp << "}\n";
@@ -222,14 +212,3 @@ void TransformToVRML:: eliminateRedundancy ()
 
   return;
 }
-
-
-
-
-
-
-
-
-
-
-

--- a/tools/cad_converter/TransformToVRML.hpp
+++ b/tools/cad_converter/TransformToVRML.hpp
@@ -2,10 +2,8 @@
 #define TOOLS_DATACONVERTER_HPP_
 #include <string>
 
-class TransformToVRML
-{
+class TransformToVRML {
 public:
-
   enum FileType {
     UNDEFINED,
     IGES,
@@ -13,29 +11,28 @@ public:
     VRML
   };
 
-  TransformToVRML (
-    const std::string & inputFileName,
-    const std::string & outputFileName );
+  TransformToVRML(
+      const std::string &inputFileName,
+      const std::string &outputFileName);
 
-  virtual ~TransformToVRML() {};
+  virtual ~TransformToVRML(){};
 
-  bool parseFileType ();
+  bool parseFileType();
 
-  bool doTransform ();
+  bool doTransform();
 
 private:
-
   std::string _inputFileName;
 
   std::string _outputFileName;
 
   FileType _inputFileType;
 
-  void eliminateRedundancy ();
+  void eliminateRedundancy();
 
-  bool transformIGES ();
+  bool transformIGES();
 
-  bool transformSTEP ();
+  bool transformSTEP();
 };
 
 #endif /* TOOLS_DATACONVERTER_HPP_ */

--- a/tools/communication_dummies/mainA.cpp
+++ b/tools/communication_dummies/mainA.cpp
@@ -1,7 +1,7 @@
-#include <m2n/PointToPointCommunication.hpp>
 #include <com/MPIDirectCommunication.hpp>
-#include <com/SocketCommunicationFactory.hpp>
 #include <com/MPIPortsCommunicationFactory.hpp>
+#include <com/SocketCommunicationFactory.hpp>
+#include <m2n/PointToPointCommunication.hpp>
 #include <mesh/Mesh.hpp>
 #include <utils/MasterSlave.hpp>
 
@@ -16,15 +16,16 @@ using std::cout;
 using std::vector;
 
 vector<double>
-getData() {
+getData()
+{
   int rank = utils::MasterSlave::getRank();
 
   static double data_0[] = {10.0, 20.0, 40.0, 80.0};
   static double data_1[] = {30.0, 50.0, 60.0, 90.0};
   static double data_2[] = {70.0, 100.0};
 
-  static double* data[] = {data_0, data_1, data_2};
-  static int size[] = {sizeof(data_0) / sizeof(*data_0),
+  static double *data[] = {data_0, data_1, data_2};
+  static int     size[] = {sizeof(data_0) / sizeof(*data_0),
                        sizeof(data_1) / sizeof(*data_1),
                        sizeof(data_2) / sizeof(*data_2)};
 
@@ -32,23 +33,24 @@ getData() {
 }
 
 vector<double>
-getExpectedData() {
+getExpectedData()
+{
   int rank = utils::MasterSlave::getRank();
 
   static double data_0[] = {10.0 + 2, 20.0 + 1, 40.0 + 2, 80.0 + 5};
   static double data_1[] = {30.0 + 2, 50.0 + 1, 60.0 + 3, 90.0 + 5};
   static double data_2[] = {70.0 + 3, 100.0 + 5};
 
-  static double* data[] = {data_0, data_1, data_2};
-  static int size[] = {sizeof(data_0) / sizeof(*data_0),
+  static double *data[] = {data_0, data_1, data_2};
+  static int     size[] = {sizeof(data_0) / sizeof(*data_0),
                        sizeof(data_1) / sizeof(*data_1),
                        sizeof(data_2) / sizeof(*data_2)};
 
   return std::move(vector<double>(data[rank], data[rank] + size[rank]));
 }
 
-bool
-validate(vector<double> const& data) {
+bool validate(vector<double> const &data)
+{
   bool valid = true;
 
   vector<double> expectedData = getExpectedData();
@@ -63,8 +65,8 @@ validate(vector<double> const& data) {
   return valid;
 }
 
-int
-main(int argc, char** argv) {
+int main(int argc, char **argv)
+{
   std::cout << "Running communication dummy\n";
 
   int provided;
@@ -81,10 +83,10 @@ main(int argc, char** argv) {
 
   if (utils::MasterSlave::getRank() == 0) {
     utils::MasterSlave::isMaster() = true;
-    utils::MasterSlave::isSlave() = false;
+    utils::MasterSlave::isSlave()  = false;
   } else {
     utils::MasterSlave::isMaster() = false;
-    utils::MasterSlave::isSlave() = true;
+    utils::MasterSlave::isSlave()  = true;
   }
 
   if (utils::MasterSlave::isMaster()) {
@@ -92,7 +94,7 @@ main(int argc, char** argv) {
     utils::Parallel::splitCommunicator("Master");
   } else {
     assertion(utils::MasterSlave::isSlave());
-    utils::Parallel::initializeMPI(NULL, NULL);    
+    utils::Parallel::initializeMPI(NULL, NULL);
     utils::Parallel::splitCommunicator("Slave");
   }
 
@@ -136,18 +138,17 @@ main(int argc, char** argv) {
   std::vector<com::PtrCommunicationFactory> cfs(
       {com::PtrCommunicationFactory(new com::SocketCommunicationFactory)});
 
- //std::vector<com::PtrCommunicationFactory> cfs(
- //     {com::PtrCommunicationFactory(new com::SocketCommunicationFactory),
- //      com::PtrCommunicationFactory(new com::MPIPortsCommunicationFactory)});
-
-
+  //std::vector<com::PtrCommunicationFactory> cfs(
+  //     {com::PtrCommunicationFactory(new com::SocketCommunicationFactory),
+  //      com::PtrCommunicationFactory(new com::MPIPortsCommunicationFactory)});
 
   for (auto cf : cfs) {
     m2n::PointToPointCommunication c(cf, mesh);
 
     c.requestConnection("B", "A");
 
-    cout << utils::MasterSlave::getRank() << ": " << "Connected!\n";
+    cout << utils::MasterSlave::getRank() << ": "
+         << "Connected!\n";
 
     std::vector<double> data = getData();
 
@@ -156,9 +157,11 @@ main(int argc, char** argv) {
     c.receive(data.data(), data.size());
 
     if (validate(data))
-      cout << utils::MasterSlave::getRank() << ": " << "Success!\n";
+      cout << utils::MasterSlave::getRank() << ": "
+           << "Success!\n";
     else
-      cout << utils::MasterSlave::getRank() << ": " << "Failure!\n";
+      cout << utils::MasterSlave::getRank() << ": "
+           << "Failure!\n";
 
     cout << "----------\n";
   }

--- a/tools/communication_dummies/mainB.cpp
+++ b/tools/communication_dummies/mainB.cpp
@@ -1,7 +1,7 @@
-#include <m2n/PointToPointCommunication.hpp>
 #include <com/MPIDirectCommunication.hpp>
-#include <com/SocketCommunicationFactory.hpp>
 #include <com/MPIPortsCommunicationFactory.hpp>
+#include <com/SocketCommunicationFactory.hpp>
+#include <m2n/PointToPointCommunication.hpp>
 #include <mesh/Mesh.hpp>
 #include <utils/MasterSlave.hpp>
 
@@ -13,21 +13,22 @@
 using namespace precice;
 
 using std::cout;
-using std::vector;
 using std::rand;
+using std::vector;
 
 vector<double>
-getData() {
+getData()
+{
   int rank = utils::MasterSlave::getRank();
 
-  static double data_0[] = {rand(), rand()};
-  static double data_1[] = {rand(), rand(), rand()};
-  static double data_2[] = {rand(), rand()};
-  static double* data_3;
-  static double data_4[] = {rand(), rand(), rand()};
+  static double  data_0[] = {rand(), rand()};
+  static double  data_1[] = {rand(), rand(), rand()};
+  static double  data_2[] = {rand(), rand()};
+  static double *data_3;
+  static double  data_4[] = {rand(), rand(), rand()};
 
-  static double* data[] = {data_0, data_1, data_2, data_3, data_4};
-  static int size[] = {sizeof(data_0) / sizeof(*data_0),
+  static double *data[] = {data_0, data_1, data_2, data_3, data_4};
+  static int     size[] = {sizeof(data_0) / sizeof(*data_0),
                        sizeof(data_1) / sizeof(*data_1),
                        sizeof(data_2) / sizeof(*data_2),
                        0,
@@ -37,17 +38,18 @@ getData() {
 }
 
 vector<double>
-getExpectedData() {
+getExpectedData()
+{
   int rank = utils::MasterSlave::getRank();
 
-  static double data_0[] = {20.0, 50.0};
-  static double data_1[] = {10.0, 30.0, 40.0};
-  static double data_2[] = {60.0, 70.0};
-  static double* data_3;
-  static double data_4[] = {80.0, 90.0, 100.0};
+  static double  data_0[] = {20.0, 50.0};
+  static double  data_1[] = {10.0, 30.0, 40.0};
+  static double  data_2[] = {60.0, 70.0};
+  static double *data_3;
+  static double  data_4[] = {80.0, 90.0, 100.0};
 
-  static double* data[] = {data_0, data_1, data_2, data_3, data_4};
-  static int size[] = {sizeof(data_0) / sizeof(*data_0),
+  static double *data[] = {data_0, data_1, data_2, data_3, data_4};
+  static int     size[] = {sizeof(data_0) / sizeof(*data_0),
                        sizeof(data_1) / sizeof(*data_1),
                        sizeof(data_2) / sizeof(*data_2),
                        0,
@@ -56,8 +58,8 @@ getExpectedData() {
   return std::move(vector<double>(data[rank], data[rank] + size[rank]));
 }
 
-bool
-validate(vector<double> const& data) {
+bool validate(vector<double> const &data)
+{
   bool valid = true;
 
   vector<double> expectedData = getExpectedData();
@@ -72,15 +74,15 @@ validate(vector<double> const& data) {
   return valid;
 }
 
-void
-process(vector<double>& data) {
+void process(vector<double> &data)
+{
   for (int i = 0; i < data.size(); ++i) {
     data[i] += utils::MasterSlave::getRank() + 1;
   }
 }
 
-int
-main(int argc, char** argv) {
+int main(int argc, char **argv)
+{
   std::cout << "Running communication dummy\n";
 
   int provided;
@@ -97,10 +99,10 @@ main(int argc, char** argv) {
 
   if (utils::MasterSlave::getRank() == 0) {
     utils::MasterSlave::isMaster() = true;
-    utils::MasterSlave::isSlave() = false;
+    utils::MasterSlave::isSlave()  = false;
   } else {
     utils::MasterSlave::isMaster() = false;
-    utils::MasterSlave::isSlave() = true;
+    utils::MasterSlave::isSlave()  = true;
   }
 
   if (utils::MasterSlave::isMaster()) {
@@ -155,11 +157,9 @@ main(int argc, char** argv) {
   std::vector<com::PtrCommunicationFactory> cfs(
       {com::PtrCommunicationFactory(new com::SocketCommunicationFactory)});
 
- //std::vector<com::PtrCommunicationFactory> cfs(
- //     {com::PtrCommunicationFactory(new com::SocketCommunicationFactory),
- //      com::PtrCommunicationFactory(new com::MPIPortsCommunicationFactory)});
-
-
+  //std::vector<com::PtrCommunicationFactory> cfs(
+  //     {com::PtrCommunicationFactory(new com::SocketCommunicationFactory),
+  //      com::PtrCommunicationFactory(new com::MPIPortsCommunicationFactory)});
 
   for (auto cf : cfs) {
     m2n::PointToPointCommunication c(cf, mesh);

--- a/tools/formatting/check-format
+++ b/tools/formatting/check-format
@@ -8,7 +8,7 @@ FILES="$(find . -type f -name \*.hpp -or -name \*.h -or -name \*.cpp -or -name \
 
 DIFFS=""
 for cfile in $FILES; do
-    DIFF=$(diff "$cfile" <(clang-format -style=file $cfile))
+    DIFF=$(diff "$cfile" <(clang-format-8 -style=file $cfile))
     if [[ -n "$DIFF" ]]; then
         DIFFS="$DIFFS $cfile"
     fi

--- a/tools/formatting/format-all
+++ b/tools/formatting/format-all
@@ -7,7 +7,7 @@ SPIN=0
 echo "Formatting files"
 for cfile in $FILES
 do
-    clang-format -style=file -i $cfile
+    clang-format-8 -style=file -i $cfile
     echo -n "."
 done
 echo -e "\nDone"

--- a/tools/mpi/acceptor/main.cpp
+++ b/tools/mpi/acceptor/main.cpp
@@ -39,14 +39,16 @@ using std::string;
 
 int size = 0;
 int rank = -1;
-int ack = 0;
+int ack  = 0;
 
 struct Sentinel {
-  Sentinel() {
+  Sentinel()
+  {
     ::ack = 1;
   }
 
-  ~Sentinel() {
+  ~Sentinel()
+  {
     if (::rank != 0)
       return;
 
@@ -54,8 +56,8 @@ struct Sentinel {
   }
 } sentinel;
 
-int
-main(int argc, char** argv) {
+int main(int argc, char **argv)
+{
   MPI_Init(&argc, &argv);
 
   MPI_Comm_size(MPI_COMM_WORLD, &::size);

--- a/tools/mpi/requester/main.cpp
+++ b/tools/mpi/requester/main.cpp
@@ -39,14 +39,16 @@ using std::string;
 
 int size = 0;
 int rank = -1;
-int ack = 0;
+int ack  = 0;
 
 struct Sentinel {
-  Sentinel() {
+  Sentinel()
+  {
     ::ack = 1;
   }
 
-  ~Sentinel() {
+  ~Sentinel()
+  {
     if (::rank != 0)
       return;
 
@@ -54,8 +56,8 @@ struct Sentinel {
   }
 } sentinel;
 
-int
-main(int argc, char** argv) {
+int main(int argc, char **argv)
+{
   MPI_Init(&argc, &argv);
 
   MPI_Comm_size(MPI_COMM_WORLD, &::size);

--- a/tools/solverdummies/c/solverdummy.c
+++ b/tools/solverdummies/c/solverdummy.c
@@ -5,60 +5,59 @@
 
 int main(int argc, char **argv)
 {
-  double dt = 0.0;
-  int solverProcessIndex = 0;
-  int solverProcessSize = 1;
-  int dimensions = -1;
-  double* vertex;
-  int meshID = -1;
-  int dataID = -1;
-  int vertexID = -1;
+  double  dt                 = 0.0;
+  int     solverProcessIndex = 0;
+  int     solverProcessSize  = 1;
+  int     dimensions         = -1;
+  double *vertex;
+  int     meshID   = -1;
+  int     dataID   = -1;
+  int     vertexID = -1;
 
-  if(argc != 4){
-    printf ("Usage: ./exec precice-config participant-name mesh-name \n");
+  if (argc != 4) {
+    printf("Usage: ./exec precice-config participant-name mesh-name \n");
     return 1;
   }
-         
-  const char* configFileName = argv[1]; 
-  const char* participantName = argv[2]; 
-  const char* meshName = argv[3];        
+
+  const char *configFileName  = argv[1];
+  const char *participantName = argv[2];
+  const char *meshName        = argv[3];
 
   printf("DUMMY: Running solver dummy with preCICE config file \"%s\", participant name \"%s\", and mesh name \"%s\".\n",
          configFileName, participantName, meshName);
 
-  const char* writeItCheckp = precicec_actionWriteIterationCheckpoint();
-  const char* readItCheckp = precicec_actionReadIterationCheckpoint();
+  const char *writeItCheckp = precicec_actionWriteIterationCheckpoint();
+  const char *readItCheckp  = precicec_actionReadIterationCheckpoint();
 
   precicec_createSolverInterface(participantName, configFileName, solverProcessIndex, solverProcessSize);
 
   meshID = precicec_getMeshID(meshName);
 
   dimensions = precicec_getDimensions();
-  vertex = malloc(dimensions * sizeof(double));    
+  vertex     = malloc(dimensions * sizeof(double));
 
-  for(int i=0; i<dimensions; i++){
+  for (int i = 0; i < dimensions; i++) {
     vertex[i] = 0.0;
   }
 
   vertexID = precicec_setMeshVertex(meshID, vertex);
-  free(vertex);    
+  free(vertex);
 
   dt = precicec_initialize();
 
-  while(precicec_isCouplingOngoing()){
-  
-    if(precicec_isActionRequired(writeItCheckp)){
+  while (precicec_isCouplingOngoing()) {
+
+    if (precicec_isActionRequired(writeItCheckp)) {
       printf("DUMMY: Writing iteration checkpoint");
       precicec_fulfilledAction(writeItCheckp);
     }
-  
+
     dt = precicec_advance(dt);
-    
-    if(precicec_isActionRequired(readItCheckp)){
+
+    if (precicec_isActionRequired(readItCheckp)) {
       precicec_fulfilledAction(readItCheckp);
       printf("DUMMY: Reading iteration checkpoint");
-    }
-    else{
+    } else {
       printf("DUMMY: Advancing in time");
     }
   }

--- a/tools/solverdummies/cpp/solverdummy.cpp
+++ b/tools/solverdummies/cpp/solverdummy.cpp
@@ -5,7 +5,7 @@
 #include <sstream>
 #include "precice/SolverInterface.hpp"
 
-int main (int argc, char **argv)
+int main(int argc, char **argv)
 {
   std::cout << "Starting SolverDummy...\n";
   int commRank = 0;
@@ -14,7 +14,7 @@ int main (int argc, char **argv)
   using namespace precice;
   using namespace precice::constants;
 
-  if (argc != 4){
+  if (argc != 4) {
     std::cout << "Usage: ./solverdummy configFile solverName meshName\n";
     std::cout << '\n';
     std::cout << "Parameter description\n";
@@ -22,41 +22,40 @@ int main (int argc, char **argv)
     std::cout << "  solverName:        SolverDummy participant name in preCICE configuration\n";
     std::cout << "  meshName:          Mesh in preCICE configuration that carries read and write data\n";
     return 1;
-}
+  }
 
   std::string configFileName(argv[1]);
   std::string solverName(argv[2]);
   std::string meshName(argv[3]);
-  int N = 1;
+  int         N = 1;
 
   SolverInterface interface(solverName, commRank, commSize);
   interface.configure(configFileName);
 
-  int meshID = interface.getMeshID(meshName);
-  int dimensions = interface.getDimensions();
-  std::vector<std::vector<double>> vertices(N, std::vector<double>(dimensions, 0)); 
-  std::vector<int> dataIndices(N,0);
+  int                              meshID     = interface.getMeshID(meshName);
+  int                              dimensions = interface.getDimensions();
+  std::vector<std::vector<double>> vertices(N, std::vector<double>(dimensions, 0));
+  std::vector<int>                 dataIndices(N, 0);
 
-  for(int i=0; i<N; i++){
+  for (int i = 0; i < N; i++) {
     dataIndices[i] = interface.setMeshVertex(meshID, vertices[i].data());
   }
 
   double dt = interface.initialize();
 
-  while (interface.isCouplingOngoing()){
+  while (interface.isCouplingOngoing()) {
 
-    if (interface.isActionRequired(actionWriteIterationCheckpoint())){
+    if (interface.isActionRequired(actionWriteIterationCheckpoint())) {
       std::cout << "DUMMY: Writing iteration checkpoint\n";
       interface.fulfilledAction(actionWriteIterationCheckpoint());
     }
 
     dt = interface.advance(dt);
 
-    if (interface.isActionRequired(actionReadIterationCheckpoint())){
+    if (interface.isActionRequired(actionReadIterationCheckpoint())) {
       std::cout << "DUMMY: Writing iteration checkpoint\n";
       interface.fulfilledAction(actionReadIterationCheckpoint());
-    }
-    else{
+    } else {
       std::cout << "DUMMY: Advancing in time\n";
     }
   }

--- a/tools/structure0815/Globals.hpp
+++ b/tools/structure0815/Globals.hpp
@@ -7,21 +7,21 @@
  * @param message  An input stream such as: "Blabla = " << variable << ", ..."
  */
 #ifdef STRUCTURE_DEBUG_MODE
-#define STRUCTURE_DEBUG(message) \
-   { \
-      std::ostringstream conv; \
-      conv << message; \
-      std::cout << conv.str() << '\n'; \
-   }
+#define STRUCTURE_DEBUG(message)     \
+  {                                  \
+    std::ostringstream conv;         \
+    conv << message;                 \
+    std::cout << conv.str() << '\n'; \
+  }
 #else
 #define STRUCTURE_DEBUG(message)
 #endif
 
-#define STRUCTURE_INFO(message) \
-   { \
-      std::ostringstream conv; \
-      conv << message; \
-      std::cout << conv.str() << '\n'; \
-   }
+#define STRUCTURE_INFO(message)      \
+  {                                  \
+    std::ostringstream conv;         \
+    conv << message;                 \
+    std::cout << conv.str() << '\n'; \
+  }
 
 #endif /* GLOBALS_HPP_ */

--- a/tools/structure0815/Structure0815.cpp
+++ b/tools/structure0815/Structure0815.cpp
@@ -1,45 +1,43 @@
 #include "Structure0815.hpp"
 
-#include "math/math.hpp"
 #include "math/geometry.hpp"
+#include "math/math.hpp"
 
-using Eigen::VectorXd;
 using Eigen::Vector3d;
+using Eigen::VectorXd;
 
-Structure0815:: Structure0815
-(
-  int              dim,
-  double           density,
-  const VectorXd& gravity,
-  const VectorXd& vertices,
-  const Eigen::VectorXi faces )
-:
-  TIMESTEPS("Timesteps"),
-  TIME("Time"),
-  CENTEROFGRAVITY("Center-of-gravity"),
-  TOTALMASS("Total mass"),
-  TOTALVOLUME("Total volume"),
-  _dim(dim),
-  _density(density),
-  _gravity(gravity),
-  _centerOfGravity(VectorXd::Constant(dim, 0.0)),
-  _totalMass(0.0),
-  _time(0.0),
-  _timesteps(0),
-  _vertices(vertices),
-  _faces(faces),
-  _forces(VectorXd::Zero(vertices.size())),
-  _velocities(VectorXd::Zero(vertices.size())),
-  _oldVelocities(VectorXd::Zero(vertices.size())),
-  _velocityDeltas(VectorXd::Zero(vertices.size())),
-  _displacements(VectorXd::Zero(vertices.size())),
-  _oldDisplacements(VectorXd::Zero(vertices.size())),
-  _displacementDeltas(VectorXd::Zero(vertices.size())),
-  _fixedTranslationDirections(Eigen::Matrix<bool, Eigen::Dynamic, 1>::Constant(dim, false)),
-  _fixed(false),
-  _fixture(VectorXd::Constant(dim, 0.0)),
-  _fixedCharacteristics(false),
-  _statisticsWriter("structure0815-statistics.txt")
+Structure0815::Structure0815(
+    int                   dim,
+    double                density,
+    const VectorXd &      gravity,
+    const VectorXd &      vertices,
+    const Eigen::VectorXi faces)
+    : TIMESTEPS("Timesteps"),
+      TIME("Time"),
+      CENTEROFGRAVITY("Center-of-gravity"),
+      TOTALMASS("Total mass"),
+      TOTALVOLUME("Total volume"),
+      _dim(dim),
+      _density(density),
+      _gravity(gravity),
+      _centerOfGravity(VectorXd::Constant(dim, 0.0)),
+      _totalMass(0.0),
+      _time(0.0),
+      _timesteps(0),
+      _vertices(vertices),
+      _faces(faces),
+      _forces(VectorXd::Zero(vertices.size())),
+      _velocities(VectorXd::Zero(vertices.size())),
+      _oldVelocities(VectorXd::Zero(vertices.size())),
+      _velocityDeltas(VectorXd::Zero(vertices.size())),
+      _displacements(VectorXd::Zero(vertices.size())),
+      _oldDisplacements(VectorXd::Zero(vertices.size())),
+      _displacementDeltas(VectorXd::Zero(vertices.size())),
+      _fixedTranslationDirections(Eigen::Matrix<bool, Eigen::Dynamic, 1>::Constant(dim, false)),
+      _fixed(false),
+      _fixture(VectorXd::Constant(dim, 0.0)),
+      _fixedCharacteristics(false),
+      _statisticsWriter("structure0815-statistics.txt")
 {
   double totalVolume = 0.0;
   computeCharacteristics(_centerOfGravity, _totalMass, totalVolume);
@@ -47,12 +45,11 @@ Structure0815:: Structure0815
   STRUCTURE_INFO("Total mass: " << _totalMass);
   STRUCTURE_INFO("Total volume: " << totalVolume);
 
-  _statisticsWriter.addData(TIMESTEPS, precice::io::TXTTableWriter::INT );
-  _statisticsWriter.addData(TIME, precice::io::TXTTableWriter::DOUBLE );
-  if (dim == 2){
+  _statisticsWriter.addData(TIMESTEPS, precice::io::TXTTableWriter::INT);
+  _statisticsWriter.addData(TIME, precice::io::TXTTableWriter::DOUBLE);
+  if (dim == 2) {
     _statisticsWriter.addData(CENTEROFGRAVITY, precice::io::TXTTableWriter::VECTOR2D);
-  }
-  else {
+  } else {
     _statisticsWriter.addData(CENTEROFGRAVITY, precice::io::TXTTableWriter::VECTOR3D);
   }
   _statisticsWriter.addData(TOTALMASS, precice::io::TXTTableWriter::DOUBLE);
@@ -60,11 +57,10 @@ Structure0815:: Structure0815
 
   _statisticsWriter.writeData(TIMESTEPS, _timesteps);
   _statisticsWriter.writeData(TIME, _time);
-  if (dim == 2){
+  if (dim == 2) {
     Eigen::Vector2d centerOfGravity(_centerOfGravity);
     _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity);
-  }
-  else {
+  } else {
     assertion(_dim == 3, _dim);
     Eigen::Vector3d centerOfGravity(_centerOfGravity);
     _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity);
@@ -73,59 +69,55 @@ Structure0815:: Structure0815
   _statisticsWriter.writeData(TOTALVOLUME, totalVolume);
 }
 
-void Structure0815:: fixPoint
-(
-  const VectorXd& fixture )
+void Structure0815::fixPoint(
+    const VectorXd &fixture)
 {
-  _fixed = true;
+  _fixed   = true;
   _fixture = fixture;
   STRUCTURE_INFO("Fixed point at: " << fixture << " (only rotations possible)");
 }
 
-void Structure0815:: fixTranslations
-(
-  const Eigen::Matrix<bool, Eigen::Dynamic, 1>& fixedDirections )
+void Structure0815::fixTranslations(
+    const Eigen::Matrix<bool, Eigen::Dynamic, 1> &fixedDirections)
 {
   _fixedTranslationDirections = fixedDirections;
   STRUCTURE_INFO("Fixed translations: " << fixedDirections);
 }
 
-void Structure0815:: fixCharacteristics
-(
-  const VectorXd& centerOfGravity,
-  double           totalVolume )
+void Structure0815::fixCharacteristics(
+    const VectorXd &centerOfGravity,
+    double          totalVolume)
 {
   _fixedCharacteristics = true;
-  _centerOfGravity = centerOfGravity;
-  _totalMass = totalVolume * _density;
+  _centerOfGravity      = centerOfGravity;
+  _totalMass            = totalVolume * _density;
   STRUCTURE_INFO("Fixed characteristics!");
   STRUCTURE_INFO("Center of gravity: " << _centerOfGravity);
   STRUCTURE_INFO("Total mass: " << _totalMass);
   STRUCTURE_INFO("Total volume: " << totalVolume);
 }
 
-void Structure0815:: iterate
-(
-  double dt )
+void Structure0815::iterate(
+    double dt)
 {
-  VectorXd zero = VectorXd::Zero(_dim);
+  VectorXd zero  = VectorXd::Zero(_dim);
   Vector3d force = Vector3d::Zero();
   VectorXd totalForce(_gravity);
-  totalForce *= _totalMass; // Makes gravity acceleration a force
-  Vector3d r = Vector3d::Zero(); // Distance vector from center of gravity
+  totalForce *= _totalMass;                // Makes gravity acceleration a force
+  Vector3d r           = Vector3d::Zero(); // Distance vector from center of gravity
   Vector3d totalTorque = Vector3d::Zero(); // Always init with three components
-  Vector3d torque = Vector3d::Zero();
+  Vector3d torque      = Vector3d::Zero();
 
   int verticesSize = _vertices.size() / _dim;
-  for (int iVertex=0; iVertex < verticesSize; iVertex++){
+  for (int iVertex = 0; iVertex < verticesSize; iVertex++) {
 
-    for (int i=0; i < _dim; i++){
-      force[i] = _forces[iVertex*_dim + i];
+    for (int i = 0; i < _dim; i++) {
+      force[i] = _forces[iVertex * _dim + i];
       totalForce[i] += force[i];
     }
 
-    for (int i=0; i<_dim; i++){
-      r[i] = _vertices[iVertex*_dim + i] - _centerOfGravity[i];
+    for (int i = 0; i < _dim; i++) {
+      r[i] = _vertices[iVertex * _dim + i] - _centerOfGravity[i];
     }
     torque = r.cross(force);
     totalTorque += torque;
@@ -137,13 +129,13 @@ void Structure0815:: iterate
   STRUCTURE_DEBUG("Total torque = " << totalTorque);
 
   VectorXd translVelocityDelta(zero);
-  if (not _fixed){
+  if (not _fixed) {
     // Compute values of next timestep
     translVelocityDelta = (totalForce / _totalMass) * dt;
     STRUCTURE_DEBUG("translVelocityDelta = " << translVelocityDelta);
   }
-  for (int i=0; i < _dim; i++){
-    if (_fixedTranslationDirections[i]){
+  for (int i = 0; i < _dim; i++) {
+    if (_fixedTranslationDirections[i]) {
       translVelocityDelta[i] = 0.0;
     }
   }
@@ -154,11 +146,11 @@ void Structure0815:: iterate
   VectorXd writeVelocity(zero);
   VectorXd writeDisplacement(zero);
   VectorXd velocityDelta(zero);
-  double normR = 0.0;
-  for (int iVertex=0; iVertex < verticesSize; iVertex++){
-    int index = iVertex *_dim;
+  double   normR = 0.0;
+  for (int iVertex = 0; iVertex < verticesSize; iVertex++) {
+    int index = iVertex * _dim;
     // Compute and write velocity
-    for (int i=0; i<_dim; i++){
+    for (int i = 0; i < _dim; i++) {
       r[i] = _vertices[index + i] - _centerOfGravity[i];
     }
     normR = r.norm();
@@ -166,49 +158,48 @@ void Structure0815:: iterate
     rotForce = totalTorque.cross(r);
     //rotForce[0] = torque * -1.0 * r[1]; /// @todo
     //rotForce[1] = torque * r[0]; /// @todo
-    for (int i=0; i < _dim; i++){
+    for (int i = 0; i < _dim; i++) {
       rotVelocityDelta[i] = (rotForce[i] / _totalMass) * dt;
     }
     velocityDelta = rotVelocityDelta + translVelocityDelta;
-    for (int i=0; i < _dim; i++){
-      _velocityDeltas[index+i] = velocityDelta[i];
-      _velocities[index+i] = _oldVelocities[index+i] + _velocityDeltas[index+i];
-      _displacementDeltas[index+i] =
-          (_oldVelocities[index+i] + _velocityDeltas[index+i])*dt;
-      _displacements[index+i] =
-          _oldDisplacements[index+i] + _displacementDeltas[index+i];
+    for (int i = 0; i < _dim; i++) {
+      _velocityDeltas[index + i] = velocityDelta[i];
+      _velocities[index + i]     = _oldVelocities[index + i] + _velocityDeltas[index + i];
+      _displacementDeltas[index + i] =
+          (_oldVelocities[index + i] + _velocityDeltas[index + i]) * dt;
+      _displacements[index + i] =
+          _oldDisplacements[index + i] + _displacementDeltas[index + i];
     }
   }
 
   STRUCTURE_DEBUG("Computed time = " << _time
-                  << ", computed timesteps = " << _timesteps);
+                                     << ", computed timesteps = " << _timesteps);
 }
 
-void Structure0815:: timestep(double dt)
+void Structure0815::timestep(double dt)
 {
   STRUCTURE_DEBUG("Adding value changes to values.");
-  _oldVelocities = _velocities;
+  _oldVelocities    = _velocities;
   _oldDisplacements = _displacements;
   _time += dt;
   _timesteps++;
 
   VectorXd centerOfGravity = VectorXd::Zero(_dim);
-  double totalMass = 0.0;
-  double totalVolume = 0.0;
-  if (not _fixedCharacteristics){
+  double   totalMass       = 0.0;
+  double   totalVolume     = 0.0;
+  if (not _fixedCharacteristics) {
     computeCharacteristics(centerOfGravity, totalMass, totalVolume);
     STRUCTURE_INFO("Center of gravity delta: " << _centerOfGravity - centerOfGravity);
     STRUCTURE_INFO("Total mass delta: " << _totalMass - totalMass);
-    STRUCTURE_INFO("Total volume delta: " << _totalMass/_density - totalVolume);
+    STRUCTURE_INFO("Total volume delta: " << _totalMass / _density - totalVolume);
   }
 
   _statisticsWriter.writeData(TIMESTEPS, _timesteps);
   _statisticsWriter.writeData(TIME, _time);
-  if (_dim == 2){
+  if (_dim == 2) {
     Eigen::Vector2d centerOfGravity2D(centerOfGravity);
     _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity2D);
-  }
-  else {
+  } else {
     assertion(_dim == 3, _dim);
     Eigen::Vector3d centerOfGravity3D(centerOfGravity);
     _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity3D);
@@ -217,37 +208,35 @@ void Structure0815:: timestep(double dt)
   _statisticsWriter.writeData(TOTALVOLUME, totalVolume);
 }
 
-void Structure0815:: computeCharacteristics
-(
-  VectorXd& centerOfGravity,
-  double&    totalMass,
-  double&    totalVolume )
+void Structure0815::computeCharacteristics(
+    VectorXd &centerOfGravity,
+    double &  totalMass,
+    double &  totalVolume)
 {
-  VectorXd zero = VectorXd::Zero(_dim);
+  VectorXd zero   = VectorXd::Zero(_dim);
   centerOfGravity = zero;
-  totalMass = 0.0;
-  totalVolume = 0.0;
+  totalMass       = 0.0;
+  totalVolume     = 0.0;
 
-  if (_dim == 2){
+  if (_dim == 2) {
     VectorXd coords0(zero);
     VectorXd coords1(zero);
-    for (int iEdge=0; iEdge < _faces.size()/2; iEdge++){
+    for (int iEdge = 0; iEdge < _faces.size() / 2; iEdge++) {
       int index = iEdge * 2;
-      for (int i=0; i<_dim; i++){
+      for (int i = 0; i < _dim; i++) {
         coords0[i] = _vertices[_faces[index] * _dim + i];
         coords0[i] += _displacements[_faces[index] * _dim + i];
-        coords1[i] = _vertices[_faces[index+1] * _dim + i];
-        coords1[i] += _displacements[_faces[index+1] * _dim + i];
+        coords1[i] = _vertices[_faces[index + 1] * _dim + i];
+        coords1[i] += _displacements[_faces[index + 1] * _dim + i];
       }
       double area = geometry::triangleArea(zero, coords0, coords1);
-      area = std::abs(area); // since it comes out signed from cross-prod
+      area        = std::abs(area); // since it comes out signed from cross-prod
       totalVolume += area;
-      if (not precice::math::equals(area, 0.0)){
+      if (not precice::math::equals(area, 0.0)) {
         centerOfGravity += (coords0 + coords1) * area / 3.0;
       }
     }
-  }
-  else {
+  } else {
     assertion(_dim == 3, _dim);
     VectorXd coords0(zero);
     VectorXd coords1(zero);
@@ -256,15 +245,15 @@ void Structure0815:: computeCharacteristics
     Vector3d vec02(zero);
     VectorXd vec03(zero);
     Vector3d crossVec(zero);
-    for (int iTriangle=0; iTriangle < _faces.size()/3; iTriangle++){
+    for (int iTriangle = 0; iTriangle < _faces.size() / 3; iTriangle++) {
       int index = iTriangle * 3;
-      for (int i=0; i<_dim; i++){
+      for (int i = 0; i < _dim; i++) {
         coords0[i] = _vertices[_faces[index] * _dim + i];
         coords0[i] += _displacements[_faces[index] * _dim + i];
-        coords1[i] = _vertices[_faces[index+1] * _dim + i];
-        coords1[i] += _displacements[_faces[index+1] * _dim + i];
-        coords2[i] = _vertices[_faces[index+2] * _dim + i];
-        coords2[i] += _displacements[_faces[index+2] * _dim + i];
+        coords1[i] = _vertices[_faces[index + 1] * _dim + i];
+        coords1[i] += _displacements[_faces[index + 1] * _dim + i];
+        coords2[i] = _vertices[_faces[index + 2] * _dim + i];
+        coords2[i] += _displacements[_faces[index + 2] * _dim + i];
       }
       vec01 = coords1;
       vec01 -= coords0;
@@ -272,11 +261,11 @@ void Structure0815:: computeCharacteristics
       vec02 -= coords0;
       vec03 = zero;
       vec03 -= coords0;
-      crossVec = vec01.cross(vec02);
+      crossVec      = vec01.cross(vec02);
       double volume = crossVec.dot(vec03) / 6.0;
-      volume = std::abs(volume);
+      volume        = std::abs(volume);
       totalVolume += volume;
-      if (not precice::math::equals(volume, 0.0)){
+      if (not precice::math::equals(volume, 0.0)) {
         centerOfGravity += (coords0 + coords1 + coords2) * volume / 4.0;
       }
     }
@@ -284,4 +273,3 @@ void Structure0815:: computeCharacteristics
   totalMass = totalVolume * _density;
   centerOfGravity /= totalVolume;
 }
-

--- a/tools/structure0815/Structure0815.hpp
+++ b/tools/structure0815/Structure0815.hpp
@@ -2,9 +2,9 @@
 #define STRUCTURE0815_HPP_
 
 #include "Globals.hpp"
+#include "io/TXTTableWriter.hpp"
 #include "precice/SolverInterface.hpp"
 #include "utils/Dimensions.hpp"
-#include "io/TXTTableWriter.hpp"
 
 using Eigen::VectorXd;
 
@@ -26,22 +26,20 @@ using Eigen::VectorXd;
  * Statistical data is written each timestep into a file
  * "structure0815-statistics.txt".
  */
-class Structure0815
-{
+class Structure0815 {
 public:
-
   Structure0815(
-    int              dim,
-    double           density,
-    const VectorXd& gravity,
-    const VectorXd& vertices,
-    const Eigen::VectorXi faces );
+      int                   dim,
+      double                density,
+      const VectorXd &      gravity,
+      const VectorXd &      vertices,
+      const Eigen::VectorXi faces);
 
   /// Only allows rotations around the point of fixture.
-  void fixPoint(const VectorXd& fixture);
+  void fixPoint(const VectorXd &fixture);
 
   /// Fixes translations in given directions.
-  void fixTranslations(const Eigen::Matrix<bool, Eigen::Dynamic, 1>& fixedDirections);
+  void fixTranslations(const Eigen::Matrix<bool, Eigen::Dynamic, 1> &fixedDirections);
 
   /**
    * @brief Sets the centerOfGravity and totalVolume manually.
@@ -50,18 +48,33 @@ public:
    * every node is visible from the origin.
    */
   void fixCharacteristics(
-    const VectorXd& centerOfGravity,
-    double           totalVolume);
+      const VectorXd &centerOfGravity,
+      double          totalVolume);
 
-  VectorXd& forces() { return _forces; }
+  VectorXd &forces()
+  {
+    return _forces;
+  }
 
-  VectorXd& displacements() { return _displacements; }
+  VectorXd &displacements()
+  {
+    return _displacements;
+  }
 
-  VectorXd& velocities() { return _velocities; }
+  VectorXd &velocities()
+  {
+    return _velocities;
+  }
 
-  VectorXd& displacementDeltas() { return _displacementDeltas; }
+  VectorXd &displacementDeltas()
+  {
+    return _displacementDeltas;
+  }
 
-  VectorXd& velocityDeltas() { return _velocityDeltas; }
+  VectorXd &velocityDeltas()
+  {
+    return _velocityDeltas;
+  }
 
   /// Performs an iteration from the last timestep.
   void iterate(double dt);
@@ -69,12 +82,17 @@ public:
   /// Overwrites old timestep values with the current iteration.
   void timestep(double dt);
 
-  const VectorXd& getCenterOfGravity() const { return _centerOfGravity; }
+  const VectorXd &getCenterOfGravity() const
+  {
+    return _centerOfGravity;
+  }
 
-  double getMass() const { return _totalMass; }
+  double getMass() const
+  {
+    return _totalMass;
+  }
 
 private:
-
   // String constants for statistics writer entries
   const std::string TIMESTEPS;
   const std::string TIME;
@@ -82,37 +100,37 @@ private:
   const std::string TOTALMASS;
   const std::string TOTALVOLUME;
 
-  int _dim;
-  double _density;
-  VectorXd _gravity;
-  VectorXd _centerOfGravity;
-  double _totalMass;
-  double _time;
-  int _timesteps;
-  VectorXd _vertices;
-  Eigen::VectorXi _faces;
-  VectorXd _forces;
-  VectorXd _velocities;
-  VectorXd _oldVelocities;
-  VectorXd _velocityDeltas;
-  VectorXd _displacements;
-  VectorXd _oldDisplacements;
-  VectorXd _displacementDeltas;
+  int                                    _dim;
+  double                                 _density;
+  VectorXd                               _gravity;
+  VectorXd                               _centerOfGravity;
+  double                                 _totalMass;
+  double                                 _time;
+  int                                    _timesteps;
+  VectorXd                               _vertices;
+  Eigen::VectorXi                        _faces;
+  VectorXd                               _forces;
+  VectorXd                               _velocities;
+  VectorXd                               _oldVelocities;
+  VectorXd                               _velocityDeltas;
+  VectorXd                               _displacements;
+  VectorXd                               _oldDisplacements;
+  VectorXd                               _displacementDeltas;
   Eigen::Matrix<bool, Eigen::Dynamic, 1> _fixedTranslationDirections;
-  bool _fixed;
-  VectorXd _fixture;
-  bool _fixedCharacteristics;
-  precice::io::TXTTableWriter _statisticsWriter;
+  bool                                   _fixed;
+  VectorXd                               _fixture;
+  bool                                   _fixedCharacteristics;
+  precice::io::TXTTableWriter            _statisticsWriter;
 
   /**
    * @brief Computes the center of gravity, total mass and total volume.
    *
    * Does not store the values in the member variables.
    */
-  void computeCharacteristics (
-    VectorXd&  centerOfGravity,
-    double&    totalMass,
-    double&    totalVolume );
+  void computeCharacteristics(
+      VectorXd &centerOfGravity,
+      double &  totalMass,
+      double &  totalVolume);
 };
 
 #endif /* STRUCTURE0815_HPP_ */

--- a/tools/structure0815/Tests.cpp
+++ b/tools/structure0815/Tests.cpp
@@ -5,16 +5,17 @@
 
 using precice::math::equals;
 
-#define validate(booleanExpr, msg) if (!(booleanExpr)) { \
-    std::cerr << "  boolean test failed \n" \
+#define validate(booleanExpr, msg)                                          \
+  if (!(booleanExpr)) {                                                     \
+    std::cerr << "  boolean test failed \n"                                 \
               << "  file: " << __FILE__ << " \t line: " << __LINE__ << '\n' \
-              << "  statement: " << #booleanExpr \
-              << "  msg: " << msg \
-              << '\n'; \
-    return;\
+              << "  statement: " << #booleanExpr                            \
+              << "  msg: " << msg                                           \
+              << '\n';                                                      \
+    return;                                                                 \
   }
 
-void Tests:: run()
+void Tests::run()
 {
   STRUCTURE_DEBUG("Running tests...");
   test2D();
@@ -22,31 +23,31 @@ void Tests:: run()
   STRUCTURE_DEBUG("...done running tests.");
 }
 
-void Tests:: test2D()
+void Tests::test2D()
 {
   STRUCTURE_DEBUG("  test2D()...");
-  using Eigen::VectorXd;
   using Eigen::Vector2d;
-  int dim = 2;
-  double density = 1;
-  Vector2d gravity = Vector2d::Zero();
-  VectorXd vertices = Eigen::VectorXd::Zero(4*dim);
-  Eigen::VectorXi faces = Eigen::VectorXi::Zero(4*dim);
+  using Eigen::VectorXd;
+  int             dim      = 2;
+  double          density  = 1;
+  Vector2d        gravity  = Vector2d::Zero();
+  VectorXd        vertices = Eigen::VectorXd::Zero(4 * dim);
+  Eigen::VectorXi faces    = Eigen::VectorXi::Zero(4 * dim);
 
   vertices << 0.0, 0.0,
-    1.0, 0.0,
-    1.0, 1.0,
-    0.0, 1.0;
+      1.0, 0.0,
+      1.0, 1.0,
+      0.0, 1.0;
   faces << 0, 1, 1, 2, 2, 3, 3, 0;
 
   Structure0815 structure(dim, density, gravity, vertices, faces);
 
-  VectorXd expected = VectorXd::Zero(4*dim);
-  VectorXd& forces = structure.forces();
-  const VectorXd& displacements = structure.displacements();
-  const VectorXd& displDeltas = structure.displacementDeltas();
-  const VectorXd& velocities = structure.velocities();
-  const VectorXd& velDeltas = structure.velocityDeltas();
+  VectorXd        expected      = VectorXd::Zero(4 * dim);
+  VectorXd &      forces        = structure.forces();
+  const VectorXd &displacements = structure.displacements();
+  const VectorXd &displDeltas   = structure.displacementDeltas();
+  const VectorXd &velocities    = structure.velocities();
+  const VectorXd &velDeltas     = structure.velocityDeltas();
 
   validate(forces.size() == 8, forces.size());
   validate(displacements.size() == 8, displacements.size());
@@ -75,9 +76,9 @@ void Tests:: test2D()
   validate(equals(velDeltas, expected), velDeltas);
 
   forces << 1.0, 0.0,
-           1.0, 0.0,
-           1.0, 0.0,
-           1.0, 0.0;
+      1.0, 0.0,
+      1.0, 0.0,
+      1.0, 0.0;
 
   dt = 1.0;
   structure.iterate(dt);
@@ -85,9 +86,9 @@ void Tests:: test2D()
   expected = forces;
   validate(equals(forces, expected), forces);
   expected << 4.0, 0.0,
-             4.0, 0.0,
-             4.0, 0.0,
-             4.0, 0.0;
+      4.0, 0.0,
+      4.0, 0.0,
+      4.0, 0.0;
   validate(equals(displacements, expected), displacements);
   validate(equals(velocities, expected), velocities);
   validate(equals(displDeltas, expected), displDeltas);
@@ -101,173 +102,173 @@ void Tests:: test2D()
   validate(equals(velDeltas, expected), velDeltas);
 
   forces << 0.0, 1.0,
-           0.0, 1.0,
-           0.0, 1.0,
-           0.0, 1.0;
+      0.0, 1.0,
+      0.0, 1.0,
+      0.0, 1.0;
 
   structure.iterate(dt);
   expected << 8.0, 4.0,
-             8.0, 4.0,
-             8.0, 4.0,
-             8.0, 4.0;
+      8.0, 4.0,
+      8.0, 4.0,
+      8.0, 4.0;
   validate(equals(displacements, expected), displacements);
   expected << 4.0, 4.0,
-             4.0, 4.0,
-             4.0, 4.0,
-             4.0, 4.0;
+      4.0, 4.0,
+      4.0, 4.0,
+      4.0, 4.0;
   validate(equals(velocities, expected), velocities);
   expected << 4.0, 4.0,
-             4.0, 4.0,
-             4.0, 4.0,
-             4.0, 4.0;
+      4.0, 4.0,
+      4.0, 4.0,
+      4.0, 4.0;
   validate(equals(displDeltas, expected), displDeltas);
   expected << 0.0, 4.0,
-             0.0, 4.0,
-             0.0, 4.0,
-             0.0, 4.0;
+      0.0, 4.0,
+      0.0, 4.0,
+      0.0, 4.0;
   validate(equals(velDeltas, expected), velDeltas);
 
   forces << -1.0, 0.0,
-           -1.0, 0.0,
-           -1.0, 0.0,
-           -1.0, 0.0;
+      -1.0, 0.0,
+      -1.0, 0.0,
+      -1.0, 0.0;
 
   structure.iterate(dt);
   expected << 4.0, 0.0,
-             4.0, 0.0,
-             4.0, 0.0,
-             4.0, 0.0;
+      4.0, 0.0,
+      4.0, 0.0,
+      4.0, 0.0;
   validate(equals(displacements, expected), displacements);
   expected << 0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0;
+      0.0, 0.0,
+      0.0, 0.0,
+      0.0, 0.0;
   validate(equals(velocities, expected), velocities);
   expected << 0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0;
+      0.0, 0.0,
+      0.0, 0.0,
+      0.0, 0.0;
   validate(equals(displDeltas, expected), displDeltas);
   expected << -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0;
+      -4.0, 0.0,
+      -4.0, 0.0,
+      -4.0, 0.0;
   validate(equals(velDeltas, expected), velDeltas);
 
   structure.timestep(dt);
   structure.iterate(dt);
 
   expected << 0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0;
+      0.0, 0.0,
+      0.0, 0.0,
+      0.0, 0.0;
   validate(equals(displacements, expected), displacements);
   expected << -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0;
+      -4.0, 0.0,
+      -4.0, 0.0,
+      -4.0, 0.0;
   validate(equals(velocities, expected), velocities);
   expected << -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0;
+      -4.0, 0.0,
+      -4.0, 0.0,
+      -4.0, 0.0;
   validate(equals(displDeltas, expected), displDeltas);
   expected << -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0,
-             -4.0, 0.0;
+      -4.0, 0.0,
+      -4.0, 0.0,
+      -4.0, 0.0;
   validate(equals(velDeltas, expected), velDeltas);
 
   structure.timestep(dt);
 
   forces << 1.0, 0.0,
-           1.0, 0.0,
-           1.0, 0.0,
-           1.0, 0.0;
+      1.0, 0.0,
+      1.0, 0.0,
+      1.0, 0.0;
 
   structure.iterate(dt);
 
   expected << 0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0;
+      0.0, 0.0,
+      0.0, 0.0,
+      0.0, 0.0;
   validate(equals(displacements, expected), displacements);
   expected << 0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0;
+      0.0, 0.0,
+      0.0, 0.0,
+      0.0, 0.0;
   validate(equals(velocities, expected), velocities);
   expected << 0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0,
-             0.0, 0.0;
+      0.0, 0.0,
+      0.0, 0.0,
+      0.0, 0.0;
   validate(equals(displDeltas, expected), displDeltas);
   expected << 4.0, 0.0,
-             4.0, 0.0,
-             4.0, 0.0,
-             4.0, 0.0;
+      4.0, 0.0,
+      4.0, 0.0,
+      4.0, 0.0;
   validate(equals(velDeltas, expected), velDeltas);
 
   structure.timestep(dt);
 
   forces << 1.0, 0.0,
-           0.0, 0.0,
-           -1.0, 0.0,
-           0.0, 0.0;
+      0.0, 0.0,
+      -1.0, 0.0,
+      0.0, 0.0;
 
   structure.iterate(dt);
 
   double rot = 0.5;
   expected << rot, -rot,
-             rot, rot,
-             -rot, rot,
-             -rot, -rot;
+      rot, rot,
+      -rot, rot,
+      -rot, -rot;
   validate(equals(displacements, expected), displacements);
 
   STRUCTURE_DEBUG("  ...done test2D()");
 }
 
-void Tests:: test3D()
+void Tests::test3D()
 {
   STRUCTURE_DEBUG("  test3D()...");
-  using Eigen::VectorXd;
   using Eigen::Vector3d;
-  int dim = 3;
-  double density = 1;
-  Vector3d gravity = Vector3d::Zero();
-  VectorXd vertices = VectorXd::Zero(8*dim); // Cube vertex coordinates
-  Eigen::VectorXi faces = Eigen::VectorXi::Zero(6*2*dim); // Triangle vertex indices
-  double eps = 1e-13;
+  using Eigen::VectorXd;
+  int             dim      = 3;
+  double          density  = 1;
+  Vector3d        gravity  = Vector3d::Zero();
+  VectorXd        vertices = VectorXd::Zero(8 * dim);            // Cube vertex coordinates
+  Eigen::VectorXi faces    = Eigen::VectorXi::Zero(6 * 2 * dim); // Triangle vertex indices
+  double          eps      = 1e-13;
 
   vertices << 0.0, 0.0, 0.0, // 0
-             1.0, 0.0, 0.0, // 1
-             1.0, 1.0, 0.0, // 2
-             0.0, 1.0, 0.0, // 3
-             0.0, 0.0, 1.0, // 4
-             1.0, 0.0, 1.0, // 5
-             1.0, 1.0, 1.0, // 6
-             0.0, 1.0, 1.0; // 7
-  faces << 0, 1, 2, // z=0
-          0, 2, 3,
-          4, 5, 6, // z=1
-          4, 6, 7,
-          0, 3, 7, // x=0
-          0, 7, 4,
-          1, 2, 6, // x=1
-          1, 6, 5,
-          0, 5, 4, // y=0
-          0, 1, 5,
-          3, 6, 7, // y=1
-          3, 2, 6;
+      1.0, 0.0, 0.0,         // 1
+      1.0, 1.0, 0.0,         // 2
+      0.0, 1.0, 0.0,         // 3
+      0.0, 0.0, 1.0,         // 4
+      1.0, 0.0, 1.0,         // 5
+      1.0, 1.0, 1.0,         // 6
+      0.0, 1.0, 1.0;         // 7
+  faces << 0, 1, 2,          // z=0
+      0, 2, 3,
+      4, 5, 6, // z=1
+      4, 6, 7,
+      0, 3, 7, // x=0
+      0, 7, 4,
+      1, 2, 6, // x=1
+      1, 6, 5,
+      0, 5, 4, // y=0
+      0, 1, 5,
+      3, 6, 7, // y=1
+      3, 2, 6;
 
   Structure0815 structure(dim, density, gravity, vertices, faces);
 
-  VectorXd expected = VectorXd::Zero(8*dim);
-  VectorXd& forces = structure.forces();
-  const VectorXd& displacements = structure.displacements();
-  const VectorXd& displDeltas = structure.displacementDeltas();
-  const VectorXd& velocities = structure.velocities();
-  const VectorXd& velDeltas = structure.velocityDeltas();
+  VectorXd        expected      = VectorXd::Zero(8 * dim);
+  VectorXd &      forces        = structure.forces();
+  const VectorXd &displacements = structure.displacements();
+  const VectorXd &displDeltas   = structure.displacementDeltas();
+  const VectorXd &velocities    = structure.velocities();
+  const VectorXd &velDeltas     = structure.velocityDeltas();
 
   validate(forces.size() == 24, forces.size());
   validate(displacements.size() == 24, displacements.size());
@@ -296,148 +297,147 @@ void Tests:: test3D()
   validate(equals(velDeltas, expected), velDeltas);
 
   forces << 0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0;
+      0.0, 0.0, 1.0,
+      0.0, 0.0, 1.0,
+      0.0, 0.0, 1.0,
+      0.0, 0.0, 1.0,
+      0.0, 0.0, 1.0,
+      0.0, 0.0, 1.0,
+      0.0, 0.0, 1.0;
   dt = 2.0;
   structure.iterate(dt);
 
   expected << 0.0, 0.0, 32.0,
-             0.0, 0.0, 32.0,
-             0.0, 0.0, 32.0,
-             0.0, 0.0, 32.0,
-             0.0, 0.0, 32.0,
-             0.0, 0.0, 32.0,
-             0.0, 0.0, 32.0,
-             0.0, 0.0, 32.0;
+      0.0, 0.0, 32.0,
+      0.0, 0.0, 32.0,
+      0.0, 0.0, 32.0,
+      0.0, 0.0, 32.0,
+      0.0, 0.0, 32.0,
+      0.0, 0.0, 32.0,
+      0.0, 0.0, 32.0;
   validate(equals(displacements, expected, eps), displacements);
   validate(equals(displDeltas, expected, eps), displDeltas);
   expected << 0.0, 0.0, 16.0,
-             0.0, 0.0, 16.0,
-             0.0, 0.0, 16.0,
-             0.0, 0.0, 16.0,
-             0.0, 0.0, 16.0,
-             0.0, 0.0, 16.0,
-             0.0, 0.0, 16.0,
-             0.0, 0.0, 16.0;
+      0.0, 0.0, 16.0,
+      0.0, 0.0, 16.0,
+      0.0, 0.0, 16.0,
+      0.0, 0.0, 16.0,
+      0.0, 0.0, 16.0,
+      0.0, 0.0, 16.0,
+      0.0, 0.0, 16.0;
   validate(equals(velocities, expected, eps), velocities);
   validate(equals(velDeltas, expected, eps), velDeltas);
 
   forces << 0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0;
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0;
   dt = 1.0;
   structure.iterate(dt);
 
   expected << 0.0, 8.0, 0.0,
-             0.0, 8.0, 0.0,
-             0.0, 8.0, 0.0,
-             0.0, 8.0, 0.0,
-             0.0, 8.0, 0.0,
-             0.0, 8.0, 0.0,
-             0.0, 8.0, 0.0,
-             0.0, 8.0, 0.0;
+      0.0, 8.0, 0.0,
+      0.0, 8.0, 0.0,
+      0.0, 8.0, 0.0,
+      0.0, 8.0, 0.0,
+      0.0, 8.0, 0.0,
+      0.0, 8.0, 0.0,
+      0.0, 8.0, 0.0;
   validate(equals(displacements, expected, eps), displacements);
   validate(equals(displDeltas, expected, eps), displDeltas);
   validate(equals(velocities, expected, eps), velocities);
   validate(equals(velDeltas, expected, eps), velDeltas);
 
   forces << 1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0;
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0;
   dt = 1.0;
   structure.iterate(dt);
 
   expected << 8.0, 0.0, 0.0,
-             8.0, 0.0, 0.0,
-             8.0, 0.0, 0.0,
-             8.0, 0.0, 0.0,
-             8.0, 0.0, 0.0,
-             8.0, 0.0, 0.0,
-             8.0, 0.0, 0.0,
-             8.0, 0.0, 0.0;
+      8.0, 0.0, 0.0,
+      8.0, 0.0, 0.0,
+      8.0, 0.0, 0.0,
+      8.0, 0.0, 0.0,
+      8.0, 0.0, 0.0,
+      8.0, 0.0, 0.0,
+      8.0, 0.0, 0.0;
   validate(equals(displacements, expected, eps), displacements);
   validate(equals(displDeltas, expected, eps), displDeltas);
   validate(equals(velocities, expected, eps), velocities);
   validate(equals(velDeltas, expected, eps), velDeltas);
 
   forces << 1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           1.0, 0.0, 0.0,
-           -1.0, 0.0, 0.0,
-           -1.0, 0.0, 0.0,
-           -1.0, 0.0, 0.0,
-           -1.0, 0.0, 0.0;
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0,
+      1.0, 0.0, 0.0,
+      -1.0, 0.0, 0.0,
+      -1.0, 0.0, 0.0,
+      -1.0, 0.0, 0.0,
+      -1.0, 0.0, 0.0;
   dt = 1.0;
   structure.iterate(dt);
 
   expected << 2.0, 0.0, -2.0,
-             2.0, 0.0, 2.0,
-             2.0, 0.0, 2.0,
-             2.0, 0.0, -2.0,
-             -2.0, 0.0, -2.0,
-             -2.0, 0.0, 2.0,
-             -2.0, 0.0, 2.0,
-             -2.0, 0.0, -2.0;
+      2.0, 0.0, 2.0,
+      2.0, 0.0, 2.0,
+      2.0, 0.0, -2.0,
+      -2.0, 0.0, -2.0,
+      -2.0, 0.0, 2.0,
+      -2.0, 0.0, 2.0,
+      -2.0, 0.0, -2.0;
   validate(equals(displacements, expected, eps), displacements);
 
   forces << 0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, 1.0, 0.0,
-           0.0, -1.0, 0.0,
-           0.0, -1.0, 0.0,
-           0.0, -1.0, 0.0,
-           0.0, -1.0, 0.0;
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0,
+      0.0, 1.0, 0.0,
+      0.0, -1.0, 0.0,
+      0.0, -1.0, 0.0,
+      0.0, -1.0, 0.0,
+      0.0, -1.0, 0.0;
   dt = 1.0;
   structure.iterate(dt);
 
   expected << 0.0, 2.0, -2.0,
-             0.0, 2.0, -2.0,
-             0.0, 2.0, 2.0,
-             0.0, 2.0, 2.0,
-             0.0, -2.0, -2.0,
-             0.0, -2.0, -2.0,
-             0.0, -2.0, 2.0,
-             0.0, -2.0, 2.0;
+      0.0, 2.0, -2.0,
+      0.0, 2.0, 2.0,
+      0.0, 2.0, 2.0,
+      0.0, -2.0, -2.0,
+      0.0, -2.0, -2.0,
+      0.0, -2.0, 2.0,
+      0.0, -2.0, 2.0;
   validate(equals(displacements, expected, eps), displacements);
 
   forces << 0.0, 0.0, 1.0,
-           0.0, 0.0, -1.0,
-           0.0, 0.0, -1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, 1.0,
-           0.0, 0.0, -1.0,
-           0.0, 0.0, -1.0,
-           0.0, 0.0, 1.0;
+      0.0, 0.0, -1.0,
+      0.0, 0.0, -1.0,
+      0.0, 0.0, 1.0,
+      0.0, 0.0, 1.0,
+      0.0, 0.0, -1.0,
+      0.0, 0.0, -1.0,
+      0.0, 0.0, 1.0;
   dt = 1.0;
   structure.iterate(dt);
 
   expected << -2.0, 0.0, 2.0,
-             -2.0, 0.0, -2.0,
-             -2.0, 0.0, -2.0,
-             -2.0, 0.0, 2.0,
-             2.0, 0.0, 2.0,
-             2.0, 0.0, -2.0,
-             2.0, 0.0, -2.0,
-             2.0, 0.0, 2.0;
+      -2.0, 0.0, -2.0,
+      -2.0, 0.0, -2.0,
+      -2.0, 0.0, 2.0,
+      2.0, 0.0, 2.0,
+      2.0, 0.0, -2.0,
+      2.0, 0.0, -2.0,
+      2.0, 0.0, 2.0;
   validate(equals(displacements, expected, eps), displacements);
 
   STRUCTURE_DEBUG("  ...done test3D()");
 }
-

--- a/tools/structure0815/Tests.hpp
+++ b/tools/structure0815/Tests.hpp
@@ -1,18 +1,14 @@
 #ifndef TESTS_HPP_
 #define TESTS_HPP_
 
-class Tests
-{
+class Tests {
 public:
-
   void run();
 
 private:
-
   void test2D();
 
   void test3D();
-
 };
 
 #endif /* TESTS_HPP_ */

--- a/tools/structure0815/main.cpp
+++ b/tools/structure0815/main.cpp
@@ -1,15 +1,14 @@
 #include <iostream>
 #include <sstream>
+#include "Globals.hpp"
 #include "Structure0815.hpp"
 #include "Tests.hpp"
-#include "Globals.hpp"
 #include "precice/SolverInterface.hpp"
 #include "utils/Dimensions.hpp"
 #include "utils/Globals.hpp"
 
-
-using Eigen::VectorXd;
 using Eigen::Vector2d;
+using Eigen::VectorXd;
 
 using namespace precice;
 
@@ -17,13 +16,13 @@ int main(int argc, char **argv)
 {
   STRUCTURE_INFO("Starting Structure0815");
 
-  if (argc != 2){
+  if (argc != 2) {
     STRUCTURE_INFO("Usage: ./structure0815 configurationFileName/tests");
     abort();
   }
   std::string configFileName(argv[1]);
 
-  if (configFileName == std::string("tests")){
+  if (configFileName == std::string("tests")) {
     Tests tests;
     tests.run();
     return 1;
@@ -38,25 +37,25 @@ int main(int argc, char **argv)
   std::string writeCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readCheckpoint(constants::actionReadIterationCheckpoint());
 
-  int dimensions = cplInterface.getDimensions();
-  int meshID = cplInterface.getMeshID(meshName);
-  double density = 500.0;
-  VectorXd gravity (dimensions, 0.0); //-9.81;
+  int      dimensions = cplInterface.getDimensions();
+  int      meshID     = cplInterface.getMeshID(meshName);
+  double   density    = 500.0;
+  VectorXd gravity(dimensions, 0.0); //-9.81;
   gravity(1) = -9.81;
 
   STRUCTURE_INFO("Density = " << density);
   STRUCTURE_INFO("Gravity = " << gravity);
 
-  if ( not cplInterface.hasMesh(meshName) ){
+  if (not cplInterface.hasMesh(meshName)) {
     STRUCTURE_INFO("Mesh \"" << meshName << "\" required for coupling!");
     exit(-1);
   }
   MeshHandle handle = cplInterface.getMeshHandle(meshName);
 
-  int velocitiesID = -1;
-  int forcesID = -1;
-  int displacementsID = -1;
-  int displDeltasID = -1;
+  int velocitiesID     = -1;
+  int forcesID         = -1;
+  int displacementsID  = -1;
+  int displDeltasID    = -1;
   int velocityDeltasID = -1;
 
   if (not cplInterface.hasData(constants::dataForces(), meshID)) {
@@ -77,117 +76,116 @@ int main(int argc, char **argv)
     velocityDeltasID = cplInterface.getDataID("VelocityDeltas", meshID);
   }
 
-  VectorXd nodes(handle.vertices().size()*dimensions);
+  VectorXd        nodes(handle.vertices().size() * dimensions);
   Eigen::VectorXi faces;
-  size_t iVertex = 0;
-  VertexHandle vertices = handle.vertices();
-  for (VertexIterator it : vertices){
-    for (int i=0; i < dimensions; i++){
-      nodes[iVertex*dimensions+i] = it.vertexCoords()[i];
+  size_t          iVertex  = 0;
+  VertexHandle    vertices = handle.vertices();
+  for (VertexIterator it : vertices) {
+    for (int i = 0; i < dimensions; i++) {
+      nodes[iVertex * dimensions + i] = it.vertexCoords()[i];
     }
     iVertex++;
   }
-  if (dimensions == 2){
+  if (dimensions == 2) {
     // faces.append(handle.edges().size()*2, 0);
-    faces = Eigen::VectorXi::Zero(handle.edges().size()*2);
+    faces            = Eigen::VectorXi::Zero(handle.edges().size() * 2);
     EdgeHandle edges = handle.edges();
-    int iEdge = 0;
-    for (EdgeIterator it : edges){
-      for (int i=0; i < 2; i++){
-        faces[iEdge*2+i] = it.vertexID(i);
+    int        iEdge = 0;
+    for (EdgeIterator it : edges) {
+      for (int i = 0; i < 2; i++) {
+        faces[iEdge * 2 + i] = it.vertexID(i);
       }
       iEdge++;
     }
-  }
-  else {
+  } else {
     assertion(dimensions == 3, dimensions);
     // faces.append(handle.triangles().size()*3, 0);
-    faces = Eigen::VectorXi::Zero(handle.triangles().size()*3);
+    faces                    = Eigen::VectorXi::Zero(handle.triangles().size() * 3);
     TriangleHandle triangles = handle.triangles();
-    int iTriangle = 0;
-    for (TriangleIterator it : triangles){
-      for (int i=0; i < 3; i++){
-        faces[iTriangle*3+i] = it.vertexID(i);
+    int            iTriangle = 0;
+    for (TriangleIterator it : triangles) {
+      for (int i = 0; i < 3; i++) {
+        faces[iTriangle * 3 + i] = it.vertexID(i);
       }
       iTriangle++;
     }
   }
 
   Eigen::VectorXi vertexIDs(handle.vertices().size());
-  for (int i=0; i < handle.vertices().size(); i++){
+  for (int i = 0; i < handle.vertices().size(); i++) {
     vertexIDs[i] = i;
   }
 
   Structure0815 structure(dimensions, density, gravity, nodes, faces);
 
   bool fixStructure = false;
-  if (fixStructure){ // Fix the structure (only rotations possible)
+  if (fixStructure) { // Fix the structure (only rotations possible)
     VectorXd fixture = VectorXd::Zero(dimensions);
     structure.fixPoint(fixture);
   }
 
   bool fixTranslations = true;
-  if (fixTranslations){
+  if (fixTranslations) {
     Eigen::Matrix<bool, Eigen::Dynamic, 1> fixedDirections = Eigen::Matrix<bool, Eigen::Dynamic, 1>::Constant(dimensions, false);
-    fixedDirections[0] = true;
+    fixedDirections[0]                                     = true;
     structure.fixTranslations(fixedDirections);
   }
 
   bool fixCharacteristics = false;
-  if (fixCharacteristics){
+  if (fixCharacteristics) {
     // Floating structure with anti-motion device scenario
 
-//    // Anti-motion devices are rotated by 45 degree downwards
-//    DynVector centerOfGravity(2, 0.0);
-//    double volumeLeftLeg = 0.000107;
-//    double volumeRightLeg = 0.000107;
-//    double volumeTrunkUpper = 0.048232;
-//    double volumeTrunkLower = 0.001743;
-//    double volumeTrunkLowerLeftTriangle = 0.000006;
-//    double volumeTrunkLowerRightTriangle = 0.000006;
-//    double totalVolume = volumeLeftLeg + volumeRightLeg + volumeTrunkUpper
-//                         + volumeTrunkLower + volumeTrunkLowerLeftTriangle
-//                         + volumeTrunkLowerRightTriangle;
-//
-//    Vector2D cogLeftLeg(4.74418, 0.44418);
-//    Vector2D cogRightLeg(5.25582, 0.44418);
-//    Vector2D cogTrunkUpper(5.0,0.50177);
-//    Vector2D cogTrunkLower(5.0,0.45177);
-//
-//    Vector2D triangleA(4.75,0.45354);
-//    Vector2D triangleB(4.75354,0.45354);
-//    Vector2D triangleC(4.75354,0.45);
-//    Vector2D cogTrunkLowerRightTriangle = triangleA;
-//    cogTrunkLowerRightTriangle += triangleB;
-//    cogTrunkLowerRightTriangle += triangleC;
-//    cogTrunkLowerRightTriangle /= 3.0;
-//
-//    triangleA = 5.25,    0.45354;
-//    triangleB = 5.24646, 0.45354;
-//    triangleC = 5.24646, 0.45;
-//    Vector2D cogTrunkLowerLeftTriangle = triangleA;
-//    cogTrunkLowerLeftTriangle += triangleB;
-//    cogTrunkLowerLeftTriangle += triangleC;
-//    cogTrunkLowerLeftTriangle /= 3.0;
-//
-//    centerOfGravity = cogLeftLeg * volumeLeftLeg;
-//    centerOfGravity += cogRightLeg * volumeRightLeg;
-//    centerOfGravity += cogTrunkUpper * volumeTrunkUpper;
-//    centerOfGravity += cogTrunkLower * volumeTrunkLower;
-//    centerOfGravity += cogTrunkLowerRightTriangle * volumeTrunkLowerRightTriangle;
-//    centerOfGravity += cogTrunkLowerLeftTriangle * volumeTrunkLowerLeftTriangle;
-//    centerOfGravity /= totalVolume;
+    //    // Anti-motion devices are rotated by 45 degree downwards
+    //    DynVector centerOfGravity(2, 0.0);
+    //    double volumeLeftLeg = 0.000107;
+    //    double volumeRightLeg = 0.000107;
+    //    double volumeTrunkUpper = 0.048232;
+    //    double volumeTrunkLower = 0.001743;
+    //    double volumeTrunkLowerLeftTriangle = 0.000006;
+    //    double volumeTrunkLowerRightTriangle = 0.000006;
+    //    double totalVolume = volumeLeftLeg + volumeRightLeg + volumeTrunkUpper
+    //                         + volumeTrunkLower + volumeTrunkLowerLeftTriangle
+    //                         + volumeTrunkLowerRightTriangle;
+    //
+    //    Vector2D cogLeftLeg(4.74418, 0.44418);
+    //    Vector2D cogRightLeg(5.25582, 0.44418);
+    //    Vector2D cogTrunkUpper(5.0,0.50177);
+    //    Vector2D cogTrunkLower(5.0,0.45177);
+    //
+    //    Vector2D triangleA(4.75,0.45354);
+    //    Vector2D triangleB(4.75354,0.45354);
+    //    Vector2D triangleC(4.75354,0.45);
+    //    Vector2D cogTrunkLowerRightTriangle = triangleA;
+    //    cogTrunkLowerRightTriangle += triangleB;
+    //    cogTrunkLowerRightTriangle += triangleC;
+    //    cogTrunkLowerRightTriangle /= 3.0;
+    //
+    //    triangleA = 5.25,    0.45354;
+    //    triangleB = 5.24646, 0.45354;
+    //    triangleC = 5.24646, 0.45;
+    //    Vector2D cogTrunkLowerLeftTriangle = triangleA;
+    //    cogTrunkLowerLeftTriangle += triangleB;
+    //    cogTrunkLowerLeftTriangle += triangleC;
+    //    cogTrunkLowerLeftTriangle /= 3.0;
+    //
+    //    centerOfGravity = cogLeftLeg * volumeLeftLeg;
+    //    centerOfGravity += cogRightLeg * volumeRightLeg;
+    //    centerOfGravity += cogTrunkUpper * volumeTrunkUpper;
+    //    centerOfGravity += cogTrunkLower * volumeTrunkLower;
+    //    centerOfGravity += cogTrunkLowerRightTriangle * volumeTrunkLowerRightTriangle;
+    //    centerOfGravity += cogTrunkLowerLeftTriangle * volumeTrunkLowerLeftTriangle;
+    //    centerOfGravity /= totalVolume;
 
     // Anti-motion devices are facing downwards (rotated by 90 degrees)
     Vector2d centerOfGravity = Vector2d::Zero();
-    double volumeLeftLeg = 0.0001;
-    double volumeRightLeg = 0.0001;
-    double volumeTrunk = 0.05;
-    double totalVolume = volumeLeftLeg + volumeRightLeg + volumeTrunk;
+    double   volumeLeftLeg   = 0.0001;
+    double   volumeRightLeg  = 0.0001;
+    double   volumeTrunk     = 0.05;
+    double   totalVolume     = volumeLeftLeg + volumeRightLeg + volumeTrunk;
 
     Vector2d cogLeftLeg(-0.2475, -0.01);
     Vector2d cogRightLeg(0.2475, -0.01);
-    Vector2d cogTrunk(0.0,0.05);
+    Vector2d cogTrunk(0.0, 0.05);
 
     centerOfGravity = cogLeftLeg * volumeLeftLeg;
     centerOfGravity += cogRightLeg * volumeRightLeg;
@@ -197,10 +195,9 @@ int main(int argc, char **argv)
     structure.fixCharacteristics(centerOfGravity, totalVolume);
   }
 
-
   // Main timestepping/iteration loop
-  while (cplInterface.isCouplingOngoing()){
-    if (cplInterface.isActionRequired(writeCheckpoint)){
+  while (cplInterface.isCouplingOngoing()) {
+    if (cplInterface.isActionRequired(writeCheckpoint)) {
       cplInterface.fulfilledAction(writeCheckpoint);
     }
 
@@ -208,26 +205,25 @@ int main(int argc, char **argv)
 
     structure.iterate(dt);
 
-    if (velocitiesID != -1){
+    if (velocitiesID != -1) {
       cplInterface.writeBlockVectorData(velocitiesID, vertexIDs.size(), vertexIDs.data(), structure.velocities().data());
     }
-    if (displacementsID != -1){
+    if (displacementsID != -1) {
       cplInterface.writeBlockVectorData(displacementsID, vertexIDs.size(), vertexIDs.data(), structure.displacements().data());
     }
-    if (displDeltasID != -1){
+    if (displDeltasID != -1) {
       cplInterface.writeBlockVectorData(displDeltasID, vertexIDs.size(), vertexIDs.data(), structure.displacementDeltas().data()));
     }
-    if (velocityDeltasID != -1){
+    if (velocityDeltasID != -1) {
       cplInterface.writeBlockVectorData(velocityDeltasID, vertexIDs.size(), vertexIDs.data(), structure.velocityDeltas().data());
     }
 
     dt = cplInterface.advance(dt);
 
-    if (cplInterface.isActionRequired(readCheckpoint)){
+    if (cplInterface.isActionRequired(readCheckpoint)) {
       STRUCTURE_DEBUG("Loading checkpoint");
       cplInterface.fulfilledAction(readCheckpoint);
-    }
-    else {
+    } else {
       structure.timestep(dt);
     }
   }


### PR DESCRIPTION
This PR finally reformats the code-base using the `clang-format` version `8.0.0`.
The `.clang-format` config was re-dumped using the correct version and should contain all relevant options.

Please comment ASAP if you have objections to the style.

This PR will be merged once the CI succeeds.

The enforcement of the style turns out to be a bit more difficult as #391 due to the fixed verision requirement. I'll comment there.