### PR TITLE
Single-step setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. For future 
 
 - Remove `MeshHandle` from API and replace use in integration tests by `SolverInterfaceImpl::mesh()`.
 - Added the mesh name to the information used to generate connection information files, which is required for the two-level initialization.
+- Merged the `SolverInterface::configure()` into the `SolverInterface` constructors. They now have a second parameter for the configuration file.
 - Completely remove server mode. Now, the only supported parallelization concept is the peer-to-peer master-slave mode.
 - Added support for python 3 in python actions
 - Simplify parallel configuration

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -7,28 +7,24 @@ namespace precice {
 
 SolverInterface::SolverInterface(
     const std::string &participantName,
+    const std::string &configurationFileName,
     int                solverProcessIndex,
     int                solverProcessSize)
-    : _impl(new impl::SolverInterfaceImpl(participantName, solverProcessIndex, solverProcessSize))
+    : _impl(new impl::SolverInterfaceImpl(participantName, configurationFileName, solverProcessIndex, solverProcessSize))
 {
 }
 
 SolverInterface::SolverInterface(
     const std::string &participantName,
+    const std::string &configurationFileName,
     int                solverProcessIndex,
     int                solverProcessSize,
     void *             communicator)
-    : _impl(new impl::SolverInterfaceImpl(participantName, solverProcessIndex, solverProcessSize, communicator))
+    : _impl(new impl::SolverInterfaceImpl(participantName, configurationFileName, solverProcessIndex, solverProcessSize, communicator))
 {
 }
 
 SolverInterface::~SolverInterface() = default;
-
-void SolverInterface::configure(
-    const std::string &configurationFileName)
-{
-  _impl->configure(configurationFileName);
-}
 
 double SolverInterface::initialize()
 {

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -27,7 +27,6 @@ namespace precice {
  * To adapt a solver to preCICE, follow the following main structure:
  *
  * -# Create an object of SolverInterface with SolverInterface()
- * -# Configure the object with SolverInterface::configure()
  * -# Initialize preCICE with SolverInterface::initialize()
  * -# Advance to the next (time)step with SolverInterface::advance()
  * -# Finalize preCICE with SolverInterface::finalize()
@@ -44,6 +43,7 @@ public:
   /**
    * @param[in] participantName Name of the participant using the interface. Has to
    *        match the name given for a participant in the xml configuration file.
+   * @param[in] configurationFileName Name (with path) of the xml configuration file.
    * @param[in] solverProcessIndex If the solver code runs with several processes,
    *        each process using preCICE has to specify its index, which has to start
    *        from 0 and end with solverProcessSize - 1.
@@ -51,12 +51,14 @@ public:
    */
   SolverInterface(
       const std::string &participantName,
+      const std::string &configurationFileName,
       int                solverProcessIndex,
       int                solverProcessSize);
 
   /**
    * @param[in] participantName Name of the participant using the interface. Has to
    *        match the name given for a participant in the xml configuration file.
+   * @param[in] configurationFileName Name (with path) of the xml configuration file.
    * @param[in] solverProcessIndex If the solver code runs with several processes,
    *        each process using preCICE has to specify its index, which has to start
    *        from 0 and end with solverProcessSize - 1.
@@ -65,30 +67,12 @@ public:
    */
   SolverInterface(
       const std::string &participantName,
+      const std::string &configurationFileName,
       int                solverProcessIndex,
       int                solverProcessSize,
       void *             communicator);
 
   ~SolverInterface();
-
-  /**
-   * @brief Configures preCICE from the given xml file.
-   *
-   * Only after the configuration a usable state of a SolverInterface
-   * object is achieved. However, most of the functionalities in preCICE can be
-   * used only after initialize() has been called. Some actions, e.g. specifying
-   * the solvers interface mesh, have to be done before initialize is called.
-   *
-   * In configure, the following is done:
-   * - The XML configuration for preCICE is parsed and all objects containing
-   *   data are created, but not necessarily filled with data.
-   * - Communication between master and slaves is established.
-   *
-   * @pre configure() has not yet been called
-   *
-   * @param[in] configurationFileName Name (with path) of the xml configuration file to be read.
-   */
-  void configure(const std::string &configurationFileName);
 
   ///@}
 
@@ -98,7 +82,6 @@ public:
   /**
    * @brief Fully initializes preCICE
    *
-   * @pre configure() has been called successfully.
    * @pre initialize() has not yet bee called.
    *
    * @post Parallel communication to the coupling partner/s is setup.
@@ -183,8 +166,6 @@ public:
    *
    * Currently, two and three dimensional problems can be solved using preCICE.
    * The dimension is specified in the XML configuration.
-   *
-   * @pre configure() has been called successfully.
    */
   int getDimensions() const;
 

--- a/src/precice/bindings/c/SolverInterfaceC.cpp
+++ b/src/precice/bindings/c/SolverInterfaceC.cpp
@@ -14,10 +14,10 @@ void precicec_createSolverInterface(
     int         solverProcessSize)
 {
   std::string stringAccessorName(participantName);
-  impl = new precice::impl::SolverInterfaceImpl(stringAccessorName,
-                                                solverProcessIndex, solverProcessSize);
   std::string stringConfigFileName(configFileName);
-  impl->configure(stringConfigFileName);
+  impl = new precice::impl::SolverInterfaceImpl(stringAccessorName,
+                                                stringConfigFileName,
+                                                solverProcessIndex, solverProcessSize);
 }
 
 double precicec_initialize()

--- a/src/precice/bindings/fortran/SolverInterfaceFASTEST.cpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFASTEST.cpp
@@ -44,13 +44,13 @@ void precice_fastest_create_(
   //cout << "Config  : " << stringConfigFileName << "!" << '\n';
   if (isAcousticUsed) {
     implAcoustic = new precice::SolverInterface(stringAccessorNameAcoustic,
+                                                stringConfigFileName,
                                                 *solverProcessIndex, *solverProcessSize);
-    implAcoustic->configure(stringConfigFileName);
   }
   if (isFluidUsed) {
     implFluid = new precice::SolverInterface(stringAccessorNameFluid,
+                                             stringConfigFileName,
                                              *solverProcessIndex, *solverProcessSize);
-    implFluid->configure(stringConfigFileName);
   }
   PRECICE_CHECK(implAcoustic != nullptr || implFluid != nullptr, "Either the Fluid interface or the Acoustic"
                                                                  " interface or both need to be used");

--- a/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
+++ b/src/precice/bindings/fortran/SolverInterfaceFortran.cpp
@@ -41,8 +41,8 @@ void precicef_create_(
   //cout << "Accessor: " << stringAccessorName << "!" << '\n';
   //cout << "Config  : " << stringConfigFileName << "!" << '\n';
   impl = new precice::SolverInterface(stringAccessorName,
+                                      stringConfigFileName,
                                       *solverProcessIndex, *solverProcessSize);
-  impl->configure(stringConfigFileName);
 }
 
 void precicef_initialize_(

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -51,10 +51,11 @@ bool syncMode = false;
 namespace impl {
 
 SolverInterfaceImpl::SolverInterfaceImpl(
-    std::string participantName,
-    int         accessorProcessRank,
-    int         accessorCommunicatorSize,
-    void *      communicator)
+    std::string        participantName,
+    const std::string &configurationFileName,
+    int                accessorProcessRank,
+    int                accessorCommunicatorSize,
+    void *             communicator)
     : _accessorName(std::move(participantName)),
       _accessorProcessRank(accessorProcessRank),
       _accessorCommunicatorSize(accessorCommunicatorSize)
@@ -77,6 +78,8 @@ SolverInterfaceImpl::SolverInterfaceImpl(
 #endif
 
   logging::setParticipant(_accessorName);
+
+  configure(configurationFileName);
 }
 
 SolverInterfaceImpl::SolverInterfaceImpl(

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -83,10 +83,11 @@ SolverInterfaceImpl::SolverInterfaceImpl(
 }
 
 SolverInterfaceImpl::SolverInterfaceImpl(
-    std::string participantName,
-    int         accessorProcessRank,
-    int         accessorCommunicatorSize)
-    : SolverInterfaceImpl::SolverInterfaceImpl(std::move(participantName), accessorProcessRank, accessorCommunicatorSize, nullptr)
+    std::string        participantName,
+    const std::string &configurationFileName,
+    int                accessorProcessRank,
+    int                accessorCommunicatorSize)
+    : SolverInterfaceImpl::SolverInterfaceImpl(std::move(participantName), configurationFileName, accessorProcessRank, accessorCommunicatorSize, nullptr)
 {
 }
 

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -78,10 +78,11 @@ public:
    * @param[in] communicator    A pointer to the MPI_Comm to use.
    */
   SolverInterfaceImpl(
-      std::string participantName,
-      int         accessorProcessRank,
-      int         accessorCommunicatorSize,
-      void *      communicator);
+      std::string        participantName,
+      const std::string &configurationFileName,
+      int                accessorProcessRank,
+      int                accessorCommunicatorSize,
+      void *             communicator);
 
   /**
    * @brief Configures the coupling interface from the given xml file.

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -41,14 +41,16 @@ public:
    * of this class. The object has to be configured by one of the configure
    * methods before it has a reasonable state and can be used.
    *
+   * @param[in] configurationFileName Name (with path) of the xml config file.
    * @param[in] participantName Name of the participant using the interface. Has to
    *                            match the name given for a participant in the
    *                            xml configuration file.
    */
   SolverInterfaceImpl(
-      std::string participantName,
-      int         accessorProcessRank,
-      int         accessorCommunicatorSize);
+      std::string        participantName,
+      const std::string &configurationFileName,
+      int                accessorProcessRank,
+      int                accessorCommunicatorSize);
 
   /// Deleted copy constructor
   SolverInterfaceImpl(SolverInterfaceImpl const &) = delete;
@@ -75,6 +77,7 @@ public:
    * @param[in] participantName Name of the participant using the interface. Has to
    *                            match the name given for a participant in the
    *                            xml configuration file.
+   * @param[in] configurationFileName Name (with path) of the xml config file.
    * @param[in] communicator    A pointer to the MPI_Comm to use.
    */
   SolverInterfaceImpl(

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -20,7 +20,7 @@ void reset()
   utils::MasterSlave::reset();
 }
 
-struct ParallelTestFixture : testing::SlimConfigurator {
+struct ParallelTestFixture : testing::WhiteboxAccessor {
 
   std::string _pathToTests;
 
@@ -44,9 +44,8 @@ BOOST_FIXTURE_TEST_SUITE(Parallel, ParallelTestFixture)
 
 BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup, *testing::OnSize(4))
 {
-  SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 4);
   std::string     configFilename = _pathToTests + "config1.xml";
-  slimConfigure(interface, configFilename);
+  SolverInterface interface("SolverOne", configFilename, utils::Parallel::getProcessRank(), 4);
   BOOST_TEST(interface.getDimensions() == 3);
 
   if (utils::Parallel::getProcessRank() == 0) {
@@ -71,20 +70,18 @@ BOOST_AUTO_TEST_CASE(TestFinalize, *testing::OnSize(4))
 {
   std::string configFilename = _pathToTests + "config1.xml";
   if (utils::Parallel::getProcessRank() <= 1) {
-    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 2);
-    slimConfigure(interface, configFilename);
-    int    meshID = interface.getMeshID("MeshOne");
-    double xCoord = 0.0 + utils::Parallel::getProcessRank();
+    SolverInterface interface("SolverOne", configFilename, utils::Parallel::getProcessRank(), 2);
+    int             meshID = interface.getMeshID("MeshOne");
+    double          xCoord = 0.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord, 0.0, 0.0).data());
     interface.initialize();
     BOOST_TEST(impl(interface).mesh("MeshOne").vertices().size() == 1);
     BOOST_TEST(impl(interface).mesh("MeshTwo").vertices().size() == 1);
     interface.finalize();
   } else {
-    SolverInterface interface("SolverTwo", utils::Parallel::getProcessRank() - 2, 2);
-    slimConfigure(interface, configFilename);
-    int    meshID = interface.getMeshID("MeshTwo");
-    double xCoord = -2.0 + utils::Parallel::getProcessRank();
+    SolverInterface interface("SolverTwo", configFilename, utils::Parallel::getProcessRank() - 2, 2);
+    int             meshID = interface.getMeshID("MeshTwo");
+    double          xCoord = -2.0 + utils::Parallel::getProcessRank();
     interface.setMeshVertex(meshID, Eigen::Vector3d(xCoord, 0.0, 0.0).data());
     interface.initialize();
     BOOST_TEST(impl(interface).mesh("MeshTwo").vertices().size() == 1);
@@ -103,10 +100,9 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, *testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3);
-    slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshOne");
-    int dataID = interface.getDataID("Data2", meshID);
+    SolverInterface interface("SolverOne", configFilename, utils::Parallel::getProcessRank(), 3);
+    int             meshID = interface.getMeshID("MeshOne");
+    int             dataID = interface.getDataID("Data2", meshID);
 
     int    vertexIDs[2];
     double xCoord       = utils::Parallel::getProcessRank() * 0.4;
@@ -124,11 +120,10 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning, *testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverTwo", 0, 1);
-    slimConfigure(interface, configFilename);
-    int    meshID = interface.getMeshID("MeshTwo");
-    int    vertexIDs[6];
-    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
+    SolverInterface interface("SolverTwo", configFilename, 0, 1);
+    int             meshID = interface.getMeshID("MeshTwo");
+    int             vertexIDs[6];
+    double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
     int    dataID    = interface.getDataID("Data2", meshID);
@@ -149,10 +144,9 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, *testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3);
-    slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshOne");
-    int dataID = interface.getDataID("Data2", meshID);
+    SolverInterface interface("SolverOne", configFilename, utils::Parallel::getProcessRank(), 3);
+    int             meshID = interface.getMeshID("MeshOne");
+    int             dataID = interface.getDataID("Data2", meshID);
 
     int    vertexIDs[2];
     double xCoord       = utils::Parallel::getProcessRank() * 0.4;
@@ -169,11 +163,10 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning, *testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverTwo", 0, 1);
-    slimConfigure(interface, configFilename);
-    int    meshID = interface.getMeshID("MeshTwo");
-    int    vertexIDs[6];
-    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
+    SolverInterface interface("SolverTwo", configFilename, 0, 1);
+    int             meshID = interface.getMeshID("MeshTwo");
+    int             vertexIDs[6];
+    double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
     int    dataID    = interface.getDataID("Data2", meshID);
@@ -196,9 +189,8 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, *testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    SolverInterface interface("Ateles", utils::Parallel::getProcessRank(), 3);
-    slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("Ateles_Mesh");
+    SolverInterface interface("Ateles", configFilename, utils::Parallel::getProcessRank(), 3);
+    int             meshID = interface.getMeshID("Ateles_Mesh");
 
     int    vertexIDs[4];
     double offset        = utils::Parallel::getProcessRank() * 0.4;
@@ -217,13 +209,12 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine, *testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    SolverInterface interface("FASTEST", 0, 1);
-    slimConfigure(interface, configFilename);
-    int    meshID = interface.getMeshID("FASTEST_Mesh");
-    int    vertexIDs[10];
-    double xCoord        = -0.0001;
-    double yCoord        = 1.00001;
-    double positions[30] = {xCoord, yCoord, 0.12,
+    SolverInterface interface("FASTEST", configFilename, 0, 1);
+    int             meshID = interface.getMeshID("FASTEST_Mesh");
+    int             vertexIDs[10];
+    double          xCoord        = -0.0001;
+    double          yCoord        = 1.00001;
+    double          positions[30] = {xCoord, yCoord, 0.12,
                             xCoord, yCoord, 0.24,
                             xCoord, yCoord, 0.36,
                             xCoord, yCoord, 0.48,
@@ -279,11 +270,10 @@ BOOST_AUTO_TEST_CASE(TestQN, *testing::OnSize(4))
   for (int k = 0; k < numberOfTests; k++) {
     reset();
 
-    SolverInterface interface(solverName, rank, size);
-    slimConfigure(interface, configs[k]);
-    int meshID      = interface.getMeshID(meshName);
-    int writeDataID = interface.getDataID(writeDataName, meshID);
-    int readDataID  = interface.getDataID(readDataName, meshID);
+    SolverInterface interface(solverName, configs[k], rank, size);
+    int             meshID      = interface.getMeshID(meshName);
+    int             writeDataID = interface.getDataID(writeDataName, meshID);
+    int             readDataID  = interface.getDataID(readDataName, meshID);
 
     int vertexIDs[4];
 
@@ -406,11 +396,10 @@ BOOST_AUTO_TEST_CASE(testDistributedCommunications, *testing::OnSize(4))
       i2         = 4;
     }
 
-    SolverInterface precice(solverName, rank, size);
-    slimConfigure(precice, _pathToTests + fileName);
-    int meshID   = precice.getMeshID(meshName);
-    int forcesID = precice.getDataID("Forces", meshID);
-    int velocID  = precice.getDataID("Velocities", meshID);
+    SolverInterface precice(solverName, _pathToTests + fileName, rank, size);
+    int             meshID   = precice.getMeshID(meshName);
+    int             forcesID = precice.getDataID("Forces", meshID);
+    int             velocID  = precice.getDataID("Velocities", meshID);
 
     std::vector<int> vertexIDs;
     for (int i = i1; i < i2; i++) {
@@ -457,8 +446,7 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, *testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 3);
     utils::Parallel::clearGroups();
-    SolverInterface interface("FluidSolver", utils::Parallel::getProcessRank(), 3);
-    slimConfigure(interface, configFilename);
+    SolverInterface interface("FluidSolver", configFilename, utils::Parallel::getProcessRank(), 3);
 
     if (utils::Parallel::getProcessRank() == 1) {
 
@@ -552,10 +540,9 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning, *testing::OnSize(4))
     utils::Parallel::setGlobalCommunicator(utils::Parallel::getLocalCommunicator());
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
-    SolverInterface interface("SolidSolver", 0, 1);
-    slimConfigure(interface, configFilename);
-    const int meshID     = interface.getMeshID("Nodes");
-    const int dimensions = 3;
+    SolverInterface interface("SolidSolver", configFilename, 0, 1);
+    const int       meshID     = interface.getMeshID("Nodes");
+    const int       dimensions = 3;
     BOOST_TEST(interface.getDimensions() == dimensions);
     const int                 numberOfVertices = 34;
     const double              yCoord           = 0.0;
@@ -639,10 +626,9 @@ BOOST_AUTO_TEST_CASE(MasterSockets, *testing::OnSize(4))
     mySize     = 1;
     myMeshName = "SerialMesh";
   }
-  SolverInterface interface(myName, myRank, mySize);
-  slimConfigure(interface, configFilename);
-  int    meshID      = interface.getMeshID(myMeshName);
-  double position[2] = {0, 0};
+  SolverInterface interface(myName, configFilename, myRank, mySize);
+  int             meshID      = interface.getMeshID(myMeshName);
+  double          position[2] = {0, 0};
   interface.setMeshVertex(meshID, position);
   interface.initialize();
   interface.advance(1.0);
@@ -662,9 +648,8 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, *testing::OnSize(4))
     BOOST_TEST(myCommSize == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3, &myComm);
-    slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshOne");
+    SolverInterface interface("SolverOne", configFilename, utils::Parallel::getProcessRank(), 3, &myComm);
+    int             meshID = interface.getMeshID("MeshOne");
 
     int    vertexIDs[2];
     double xCoord       = utils::Parallel::getProcessRank() * 0.4;
@@ -678,11 +663,10 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator, *testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverTwo", 0, 1);
-    slimConfigure(interface, configFilename);
-    int    meshID = interface.getMeshID("MeshTwo");
-    int    vertexIDs[6];
-    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
+    SolverInterface interface("SolverTwo", configFilename, 0, 1);
+    int             meshID = interface.getMeshID("MeshTwo");
+    int             vertexIDs[6];
+    double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
@@ -705,9 +689,8 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, *testing::OnSize(4))
     BOOST_TEST(myCommSize == 3);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverOne", utils::Parallel::getProcessRank(), 3, &myComm);
-    slimConfigure(interface, configFilename);
-    int meshID = interface.getMeshID("MeshOne");
+    SolverInterface interface("SolverOne", configFilename, utils::Parallel::getProcessRank(), 3, &myComm);
+    int             meshID = interface.getMeshID("MeshOne");
 
     int    vertexIDs[2];
     double xCoord       = utils::Parallel::getProcessRank() * 0.4;
@@ -721,11 +704,10 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF, *testing::OnSize(4))
     BOOST_TEST(utils::Parallel::getCommunicatorSize() == 1);
     utils::Parallel::clearGroups();
 
-    SolverInterface interface("SolverTwo", 0, 1);
-    slimConfigure(interface, configFilename);
-    int    meshID = interface.getMeshID("MeshTwo");
-    int    vertexIDs[6];
-    double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
+    SolverInterface interface("SolverTwo", configFilename, 0, 1);
+    int             meshID = interface.getMeshID("MeshTwo");
+    int             vertexIDs[6];
+    double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
     interface.finalize();

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -12,7 +12,7 @@
 
 using namespace precice;
 
-struct SerialTestFixture : testing::SlimConfigurator {
+struct SerialTestFixture : testing::WhiteboxAccessor {
 
   std::string _pathToTests;
 
@@ -38,8 +38,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
 {
   std::string filename = _pathToTests + "/configuration.xml";
   // Test configuration for accessor "Peano"
-  SolverInterface interfacePeano("Peano", 0, 1);
-  slimConfigure(interfacePeano, filename);
+  SolverInterface interfacePeano("Peano", filename, 0, 1);
 
   BOOST_TEST(impl(interfacePeano)._participants.size() == 2);
   BOOST_TEST(interfacePeano.getDimensions() == 2);
@@ -57,8 +56,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   BOOST_TEST(meshContexts[1]->mesh->getName() == std::string("ComsolNodes"));
 
   // Test configuration for accessor "Comsol"
-  SolverInterface interfaceComsol("Comsol", 0, 1);
-  slimConfigure(interfaceComsol, filename);
+  SolverInterface interfaceComsol("Comsol", filename, 0, 1);
   BOOST_TEST(impl(interfaceComsol)._participants.size() == 2);
   BOOST_TEST(interfaceComsol.getDimensions() == 2);
 
@@ -103,8 +101,7 @@ BOOST_AUTO_TEST_CASE(TestExplicit,
       solverName = "SolverTwo";
     }
 
-    SolverInterface couplingInterface(solverName, 0, 1);
-    slimConfigure(couplingInterface, configurationFileName);
+    SolverInterface couplingInterface(solverName, configurationFileName, 0, 1);
 
     //was necessary to replace pre-defined geometries
     if (solverName == "SolverOne" && couplingInterface.hasMesh("MeshOne")) {
@@ -140,8 +137,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
     return;
 
   if (utils::Parallel::getProcessRank() == 0) {
-    SolverInterface precice("SolverOne", 0, 1);
-    slimConfigure(precice, _pathToTests + "explicit-mpi-single.xml");
+    SolverInterface precice("SolverOne", _pathToTests + "explicit-mpi-single.xml", 0, 1);
 
     double maxDt     = precice.initialize();
     int    timestep  = 0;
@@ -155,9 +151,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling,
     precice.finalize();
     BOOST_TEST(timestep == 20);
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface precice("SolverTwo", 0, 1);
-    slimConfigure(precice, _pathToTests + "explicit-mpi-single.xml");
-    int meshID = precice.getMeshID("Test-Square");
+    SolverInterface precice("SolverTwo", _pathToTests + "explicit-mpi-single.xml", 0, 1);
+    int             meshID = precice.getMeshID("Test-Square");
     precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     precice.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     double maxDt     = precice.initialize();
@@ -185,8 +180,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
   using Eigen::Vector3d;
 
   if (utils::Parallel::getProcessRank() == 0) {
-    SolverInterface cplInterface("SolverOne", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single.xml");
+    SolverInterface cplInterface("SolverOne", _pathToTests + "explicit-mpi-single.xml", 0, 1);
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     /* int squareID = */ cplInterface.getMeshID("Test-Square");
@@ -230,8 +224,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange,
     }
     cplInterface.finalize();
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface cplInterface("SolverTwo", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single.xml");
+    SolverInterface cplInterface("SolverTwo", _pathToTests + "explicit-mpi-single.xml", 0, 1);
 
     int meshID = cplInterface.getMeshID("Test-Square");
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
@@ -285,8 +278,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
   using Eigen::Vector3d;
 
   if (utils::Parallel::getProcessRank() == 0) {
-    SolverInterface cplInterface("SolverOne", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-data-init.xml");
+    SolverInterface cplInterface("SolverOne", _pathToTests + "explicit-data-init.xml", 0, 1);
 
     int meshOneID = cplInterface.getMeshID("MeshOne");
     cplInterface.setMeshVertex(meshOneID, Vector3d(1.0, 2.0, 3.0).data());
@@ -306,8 +298,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization,
     }
     cplInterface.finalize();
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface cplInterface("SolverTwo", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-data-init.xml");
+    SolverInterface cplInterface("SolverTwo", _pathToTests + "explicit-data-init.xml", 0, 1);
 
     int      meshTwoID = cplInterface.getMeshID("MeshTwo");
     Vector3d pos       = Vector3d::Zero();
@@ -344,8 +335,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
   using Eigen::Vector3d;
 
   if (utils::Parallel::getProcessRank() == 0) {
-    SolverInterface cplInterface("SolverOne", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
+    SolverInterface cplInterface("SolverOne", _pathToTests + "explicit-mpi-single-non-inc.xml", 0, 1);
 
     int             meshOneID      = cplInterface.getMeshID("MeshOne");
     double          maxDt          = cplInterface.initialize();
@@ -422,8 +412,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange,
     }
     cplInterface.finalize();
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface cplInterface("SolverTwo", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-mpi-single-non-inc.xml");
+    SolverInterface cplInterface("SolverTwo", _pathToTests + "explicit-mpi-single-non-inc.xml", 0, 1);
 
     int squareID       = cplInterface.getMeshID("Test-Square");
     int forcesID       = cplInterface.getDataID("Forces", squareID);
@@ -491,8 +480,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
 
   if (utils::Parallel::getProcessRank() == 0) {
 
-    SolverInterface couplingInterface("SolverOne", 0, 1);
-    slimConfigure(couplingInterface, _pathToTests + "explicit-solvergeometry.xml");
+    SolverInterface couplingInterface("SolverOne", _pathToTests + "explicit-solvergeometry.xml", 0, 1);
 
     //was necessary to replace pre-defined geometries
     int meshID = couplingInterface.getMeshID("MeshOne");
@@ -508,8 +496,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry,
     }
     couplingInterface.finalize();
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface cplInterface("SolverTwo", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-solvergeometry.xml");
+    SolverInterface cplInterface("SolverTwo", _pathToTests + "explicit-solvergeometry.xml", 0, 1);
 
     BOOST_TEST(cplInterface.getDimensions() == 3);
     int meshID = cplInterface.getMeshID("SolverGeometry");
@@ -549,8 +536,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
 
   double dt;
   if (utils::Parallel::getProcessRank() == 0) { // SolverOne part
-    SolverInterface cplInterface("SolverOne", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-datascaling.xml");
+    SolverInterface cplInterface("SolverOne", _pathToTests + "explicit-datascaling.xml", 0, 1);
 
     BOOST_TEST(cplInterface.getDimensions() == 2);
 
@@ -574,8 +560,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling,
     cplInterface.finalize();
 
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface cplInterface("SolverTwo", 0, 1);
-    slimConfigure(cplInterface, _pathToTests + "explicit-datascaling.xml");
+    SolverInterface cplInterface("SolverTwo", _pathToTests + "explicit-datascaling.xml", 0, 1);
 
     BOOST_TEST(cplInterface.getDimensions() == 2);
     dt               = cplInterface.initialize();
@@ -611,8 +596,7 @@ BOOST_AUTO_TEST_CASE(testImplicit,
   using namespace precice::constants;
 
   if (utils::Parallel::getProcessRank() == 0) {
-    SolverInterface couplingInterface("SolverOne", 0, 1);
-    slimConfigure(couplingInterface, _pathToTests + "implicit.xml");
+    SolverInterface couplingInterface("SolverOne", _pathToTests + "implicit.xml", 0, 1);
 
     int    meshID = couplingInterface.getMeshID("Square");
     double pos[3];
@@ -656,8 +640,7 @@ BOOST_AUTO_TEST_CASE(testImplicit,
     couplingInterface.finalize();
     BOOST_TEST(computedTimesteps == 4);
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface couplingInterface("SolverTwo", 0, 1);
-    slimConfigure(couplingInterface, _pathToTests + "implicit.xml");
+    SolverInterface couplingInterface("SolverTwo", _pathToTests + "implicit.xml", 0, 1);
 
     double maxDt = couplingInterface.initialize();
     while (couplingInterface.isCouplingOngoing()) {
@@ -707,8 +690,7 @@ BOOST_AUTO_TEST_CASE(testStationaryMappingWithSolverMesh,
     // @todo this should normally happen in finalize and should not be necessary
     mesh::Data::resetDataCount();
     impl::Participant::resetParticipantCount();
-    SolverInterface interface(solverName, 0, 1);
-    slimConfigure(interface, (dim == 2 ? config2D : config3D));
+    SolverInterface interface(solverName, (dim == 2 ? config2D : config3D), 0, 1);
     BOOST_TEST(interface.getDimensions() == dim);
 
     std::vector<Eigen::VectorXd> positions;
@@ -867,8 +849,7 @@ BOOST_AUTO_TEST_CASE(testBug,
   BOOST_TEST(((rank == 0) || (rank == 1)), rank);
   std::string solverName = rank == 0 ? "Flite" : "Calculix";
   if (solverName == std::string("Flite")) {
-    SolverInterface precice("Flite", 0, 1);
-    slimConfigure(precice, configName);
+    SolverInterface precice("Flite", configName, 0, 1);
 
     int meshID             = precice.getMeshID("FliteNodes");
     int forcesID           = precice.getDataID("Forces", meshID);
@@ -898,8 +879,7 @@ BOOST_AUTO_TEST_CASE(testBug,
     precice.finalize();
   } else {
     BOOST_TEST(solverName == std::string("Calculix"), solverName);
-    SolverInterface precice("Calculix", 0, 1);
-    slimConfigure(precice, configName);
+    SolverInterface precice("Calculix", configName, 0, 1);
 
     int meshID = precice.getMeshID("CalculixNodes");
     for (Vector3d &coord : coords) {
@@ -973,8 +953,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
     int callsOfAdvance = 0;
 
     if (solverName == std::string("SolverOne")) {
-      SolverInterface precice(solverName, 0, 1);
-      slimConfigure(precice, configs[k]);
+      SolverInterface precice(solverName, configs[k], 0, 1);
 
       int meshAID = precice.getMeshID("MeshA");
       int meshBID = precice.getMeshID("MeshB");
@@ -1000,8 +979,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       precice.finalize();
       BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[k][0]);
     } else if (solverName == std::string("SolverTwo")) {
-      SolverInterface precice(solverName, 0, 1);
-      slimConfigure(precice, configs[k]);
+      SolverInterface precice(solverName, configs[k], 0, 1);
 
       int meshID = precice.getMeshID("MeshC");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
@@ -1026,8 +1004,7 @@ BOOST_AUTO_TEST_CASE(testThreeSolvers,
       BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[k][1]);
     } else {
       BOOST_TEST(solverName == std::string("SolverThree"), solverName);
-      SolverInterface precice(solverName, 0, 1);
-      slimConfigure(precice, configs[k]);
+      SolverInterface precice(solverName, configs[k], 0, 1);
 
       int meshID = precice.getMeshID("MeshD");
       precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
@@ -1097,8 +1074,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, *testing::OnSize(4))
       participant = "SOLIDZ3";
     }
 
-    SolverInterface precice(participant, 0, 1);
-    slimConfigure(precice, _pathToTests + "/multi.xml");
+    SolverInterface precice(participant, _pathToTests + "/multi.xml", 0, 1);
     BOOST_TEST(precice.getDimensions() == 2);
 
     if (utils::Parallel::getProcessRank() == 0) {
@@ -1153,8 +1129,7 @@ BOOST_AUTO_TEST_CASE(testMultiCoupling, *testing::OnSize(4))
 
   } else {
     BOOST_TEST(utils::Parallel::getProcessRank() == 3);
-    SolverInterface precice("NASTIN", 0, 1);
-    slimConfigure(precice, _pathToTests + "/multi.xml");
+    SolverInterface precice("NASTIN", _pathToTests + "/multi.xml", 0, 1);
     BOOST_TEST(precice.getDimensions() == 2);
     int meshID1      = precice.getMeshID("NASTIN_Mesh1");
     int meshID2      = precice.getMeshID("NASTIN_Mesh2");
@@ -1227,9 +1202,8 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
   double   expectedValTwoC = Vector3d{valOneA, valOneB, valOneC}.dot(barycenterABC);
 
   if (utils::Parallel::getProcessRank() == 0) {
-    SolverInterface cplInterface("SolverOne", 0, 1);
+    SolverInterface cplInterface("SolverOne", configFile, 0, 1);
     // namespace is required because we are outside the fixture
-    testing::SlimConfigurator::slimConfigure(cplInterface, configFile);
     const int meshOneID = cplInterface.getMeshID("MeshOne");
 
     // Setup mesh one.
@@ -1270,9 +1244,8 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
     BOOST_TEST(!cplInterface.isCouplingOngoing(), "Sending participant should have to advance once!");
     cplInterface.finalize();
   } else if (utils::Parallel::getProcessRank() == 1) {
-    SolverInterface cplInterface("SolverTwo", 0, 1);
+    SolverInterface cplInterface("SolverTwo", configFile, 0, 1);
     // namespace is required because we are outside the fixture
-    testing::SlimConfigurator::slimConfigure(cplInterface, configFile);
     int meshTwoID = cplInterface.getMeshID("MeshTwo");
 
     // Setup receiving mesh.
@@ -1359,8 +1332,7 @@ BOOST_AUTO_TEST_CASE(testSendMeshToMultipleParticipants,
     meshName   = "MeshC";
   }
 
-  SolverInterface cplInterface(solverName, 0, 1);
-  slimConfigure(cplInterface, configFile);
+  SolverInterface cplInterface(solverName, configFile, 0, 1);
 
   const int meshID = cplInterface.getMeshID(meshName);
 
@@ -1400,9 +1372,8 @@ BOOST_AUTO_TEST_CASE(testPreconditionerBug,
   std::string participantName = utils::Parallel::getProcessRank() == 0 ? "SolverOne" : "SolverTwo";
   std::string meshName        = utils::Parallel::getProcessRank() == 0 ? "MeshOne" : "MeshTwo";
 
-  SolverInterface cplInterface(participantName, 0, 1);
-  slimConfigure(cplInterface, configFile);
-  const int meshID = cplInterface.getMeshID(meshName);
+  SolverInterface cplInterface(participantName, configFile, 0, 1);
+  const int       meshID = cplInterface.getMeshID(meshName);
 
   Vector2d vertex{0.0, 0.0};
 

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -199,31 +199,6 @@ struct WhiteboxAccessor {
   }
 };
 
-/// struct extending WhiteboxAccessor by a slim configuration call.
-struct SlimConfigurator : WhiteboxAccessor {
-  /** Configures the interface given a fileName in a slim and quiet manner.
-     *
-     * This first generates a ConfigurationContext from the SolverInterface.
-     * It then configures a config::Configuration using the context and the given file.
-     * Finally, it calls SolverInterface::configure with the configuration.
-     * 
-     * @param[in] interface The SolverInterface to configure.
-     * @param[in] configFilename The filename of the configuration file.
-     */
-  template <typename T>
-  static void slimConfigure(T &interface, const std::string &configFilename)
-  {
-    auto &                             interfaceImpl = impl(interface);
-    precice::xml::ConfigurationContext context{
-        interfaceImpl.getAccessorName(),
-        interfaceImpl.getAccessorProcessRank(),
-        interfaceImpl.getAccessorCommunicatorSize()};
-    precice::config::Configuration config;
-    precice::xml::configure(config.getXMLTag(), context, configFilename);
-    interfaceImpl.configure(config.getSolverInterfaceConfiguration());
-  }
-};
-
 /// equals to be used in tests. Prints both operatorans on failure
 template <class DerivedA, class DerivedB>
 boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,

--- a/tools/solverdummies/cpp/solverdummy.cpp
+++ b/tools/solverdummies/cpp/solverdummy.cpp
@@ -29,8 +29,7 @@ int main(int argc, char **argv)
   std::string meshName(argv[3]);
   int         N = 1;
 
-  SolverInterface interface(solverName, commRank, commSize);
-  interface.configure(configFileName);
+  SolverInterface interface(solverName, configFileName, commRank, commSize);
 
   int                              meshID     = interface.getMeshID(meshName);
   int                              dimensions = interface.getDimensions();


### PR DESCRIPTION
This PR changes the two-step setup of the `SolverInterface` to a single-step setup by:
* Removing `SolverInterface::configure()`
* Making `SolverInterfaceImpl::configure()`s private
* Extending the `SolverInterface` constructors with the parameter `const std::string& configurationFileName`.
* Migrating the C and Fortran bindings
* Migrating the C++ Solverdummy to the new interface.
* Removing `testing::SlimConfigurator`
* Migrating the tests to directly use the `SolverInterface` constructor.

## Adapter developers

Please merge the initialization with the configuration of preCICE as such:
```diff
-  SolverInterface interface(solverName, commRank, commSize);
-  interface.configure(configFileName);
+  SolverInterface interface(solverName, configFileName, commRank, commSize);
```

**TO-Update**

* [ ] openfoam https://github.com/precice/openfoam-adapter
* [ ] dealii https://github.com/precice/dealii-adapter
* [ ] su2 https://github.com/precice/su2-adapter

* [ ] elastictube1d https://github.com/precice/elastictube1d
* [ ] ASTE https://github.com/precice/aste
* [ ] fem-shell https://github.com/precice/fem-shell
* [ ] python bindings https://github.com/precice/python-bindings/pull/18
* [ ] matlab bindings https://github.com/precice/matlab-bindings/issues/8


Related to #366 
