### PR TITLE
Add Mesh Name to Connection Info Publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. For future 
 ## develop
 
 - Remove `MeshHandle` from API and replace use in integration tests by `SolverInterfaceImpl::mesh()`.
+- Added the mesh name to the information used to generate connection information files, which is required for the two-level initialization.
 - Completely remove server mode. Now, the only supported parallelization concept is the peer-to-peer master-slave mode.
 - Added support for python 3 in python actions
 - Simplify parallel configuration

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -114,11 +114,11 @@ void MVQNAcceleration::initialize(
       // initialize cyclic communication between successive slaves
       int prevProc = (utils::MasterSlave::getRank() - 1 < 0) ? utils::MasterSlave::getSize() - 1 : utils::MasterSlave::getRank() - 1;
       if ((utils::MasterSlave::getRank() % 2) == 0) {
-        _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", utils::MasterSlave::getRank());
-        _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::MasterSlave::getRank()), "", 0, 1);
+        _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "", utils::MasterSlave::getRank());
+        _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::MasterSlave::getRank()), "", "", 0, 1);
       } else {
-        _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::MasterSlave::getRank()), "", 0, 1);
-        _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", utils::MasterSlave::getRank());
+        _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::MasterSlave::getRank()), "", "", 0, 1);
+        _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "", utils::MasterSlave::getRank());
       }
     }
   }

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -161,11 +161,11 @@ BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp, *boost::unit_test::fixture<testing:
   // initialize cyclic communication between successive slaves
   int prevProc = (utils::Parallel::getProcessRank() - 1 < 0) ? utils::Parallel::getCommunicatorSize() - 1 : utils::Parallel::getProcessRank() - 1;
   if ((utils::Parallel::getProcessRank() % 2) == 0) {
-    _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", utils::Parallel::getProcessRank());
-    _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::Parallel::getProcessRank()), "", 0, 1);
+    _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "Test", utils::Parallel::getProcessRank());
+    _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::Parallel::getProcessRank()), "", "Test", 0, 1);
   } else {
-    _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::Parallel::getProcessRank()), "", 0, 1);
-    _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", utils::Parallel::getProcessRank());
+    _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::Parallel::getProcessRank()), "", "Test", 0, 1);
+    _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "Test", utils::Parallel::getProcessRank());
   }
 
   int              n_global = 10, m_global = 5;

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -76,10 +76,12 @@ public:
    *
    * @param[in] acceptorName Name of calling participant.
    * @param[in] requesterName Name of remote participant to connect to.
+   * @param[in] tag Tag for establishing this connection
    * @param[in] acceptorRank Rank of the accpeting process, usually the calling one.
    */
   virtual void acceptConnection(std::string const &acceptorName,
                                 std::string const &requesterName,
+                                std::string const &tag,
                                 int                acceptorRank) = 0;
 
   /**
@@ -93,11 +95,13 @@ public:
    *
    * @param[in] acceptorName Name of calling participant.
    * @param[in] requesterName Name of remote participant to connect to.
+   * @param[in] tag Tag for establishing this connection
    * @param[in] acceptorRank Rank of accepting server, usually the rank of the current process.
    * @param[in] requesterCommunicatorSize Size of the requester (N)
    */
   virtual void acceptConnectionAsServer(std::string const &acceptorName,
                                         std::string const &requesterName,
+                                        std::string const &tag,
                                         int                acceptorRank,
                                         int                requesterCommunicatorSize) = 0;
 
@@ -112,11 +116,13 @@ public:
    *
    * @param[in] acceptorName Name of remote participant to connect to.
    * @param[in] requesterName Name of calling participant.
+   * @param[in] tag Tag for establishing this connection
    * @param[in] requesterRank Rank of the requester (has to go from 0 to N-1)
    * @param[in] requesterCommunicatorSize Size of the requester (N)
    */
   virtual void requestConnection(std::string const &acceptorName,
                                  std::string const &requesterName,
+                                 std::string const &tag,
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) = 0;
 
@@ -130,11 +136,13 @@ public:
    *
    * @param[in] acceptorName Name of calling participant.
    * @param[in] requesterName Name of remote participant to connect to
+   * @param[in] tag Tag for establishing this connection
    * @param[in] acceptorRanks Set of ranks that accept a connection
    * @param[in] requesterRank Rank that requests the connection, usually the caller's rank
    */
   virtual void requestConnectionAsClient(std::string const &  acceptorName,
                                          std::string const &  requesterName,
+                                         std::string const &  tag,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) = 0;
 

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -18,7 +18,7 @@ std::string ConnectionInfoPublisher::getFilename() const
   auto                           ns = ns_gen("af7ce8f2-a9ee-46cb-38ee-71c318aa3580"); // md5 hash of precice.org as namespace
 
   boost::uuids::name_generator gen{ns};
-  std::string const            s    = acceptorName + requesterName + std::to_string(rank);
+  std::string const            s    = acceptorName + tag + requesterName + std::to_string(rank);
   std::string                  hash = boost::uuids::to_string(gen(s));
   hash.erase(std::remove(hash.begin(), hash.end(), '-'), hash.end());
 
@@ -61,7 +61,7 @@ void ConnectionInfoWriter::write(std::string const &info) const
   {
     std::ofstream ofs(tmp.string(), std::ofstream::out);
     ofs << info << "\n";
-    ofs << "Acceptor: " << acceptorName << ", Requester: " << requesterName << ", Rank: " << rank << "\n";
+    ofs << "Acceptor: " << acceptorName << ", Requester: " << requesterName << ", Tag: " << tag << ", Rank: " << rank << "\n";
   }
   fs::rename(tmp, path);
 }

--- a/src/com/ConnectionInfoPublisher.hpp
+++ b/src/com/ConnectionInfoPublisher.hpp
@@ -9,10 +9,12 @@ class ConnectionInfoPublisher {
 public:
   ConnectionInfoPublisher(std::string acceptorName,
                           std::string requesterName,
+                          std::string tag,
                           int         rank,
                           std::string addressDirectory) noexcept
       : acceptorName(std::move(acceptorName)),
         requesterName(std::move(requesterName)),
+        tag(std::move(tag)),
         rank(rank),
         addressDirectory(std::move(addressDirectory))
   {
@@ -20,9 +22,11 @@ public:
 
   ConnectionInfoPublisher(std::string acceptorName,
                           std::string requesterName,
+                          std::string tag,
                           std::string addressDirectory) noexcept
       : acceptorName(std::move(acceptorName)),
         requesterName(std::move(requesterName)),
+        tag(std::move(tag)),
         addressDirectory(std::move(addressDirectory))
   {
   }
@@ -30,6 +34,7 @@ public:
 protected:
   std::string const acceptorName;
   std::string const requesterName;
+  std::string const tag;
   int const         rank = -1;
   std::string const addressDirectory;
 
@@ -48,16 +53,18 @@ class ConnectionInfoReader : public ConnectionInfoPublisher {
 public:
   ConnectionInfoReader(std::string acceptorName,
                        std::string requesterName,
+                       std::string tag,
                        int         rank,
                        std::string addressDirectory) noexcept
-      : ConnectionInfoPublisher(acceptorName, requesterName, rank, addressDirectory)
+      : ConnectionInfoPublisher(acceptorName, requesterName, tag, rank, addressDirectory)
   {
   }
 
   ConnectionInfoReader(std::string acceptorName,
                        std::string requesterName,
+                       std::string tag,
                        std::string addressDirectory) noexcept
-      : ConnectionInfoPublisher(acceptorName, requesterName, addressDirectory)
+      : ConnectionInfoPublisher(acceptorName, requesterName, tag, addressDirectory)
   {
   }
 
@@ -73,16 +80,18 @@ class ConnectionInfoWriter : public ConnectionInfoPublisher {
 public:
   ConnectionInfoWriter(std::string acceptorName,
                        std::string requesterName,
+                       std::string tag,
                        int         rank,
                        std::string addressDirectory) noexcept
-      : ConnectionInfoPublisher(acceptorName, requesterName, rank, addressDirectory)
+      : ConnectionInfoPublisher(acceptorName, requesterName, tag, rank, addressDirectory)
   {
   }
 
   ConnectionInfoWriter(std::string acceptorName,
                        std::string requesterName,
+                       std::string tag,
                        std::string addressDirectory) noexcept
-      : ConnectionInfoPublisher(acceptorName, requesterName, addressDirectory)
+      : ConnectionInfoPublisher(acceptorName, requesterName, tag, addressDirectory)
   {
   }
 

--- a/src/com/MPIDirectCommunication.cpp
+++ b/src/com/MPIDirectCommunication.cpp
@@ -30,6 +30,7 @@ size_t MPIDirectCommunication::getRemoteCommunicatorSize()
 
 void MPIDirectCommunication::acceptConnection(std::string const &acceptorName,
                                               std::string const &requesterName,
+                                              std::string const &tag,
                                               int                acceptorRank)
 {
   PRECICE_TRACE(acceptorName, requesterName);
@@ -65,6 +66,7 @@ void MPIDirectCommunication::closeConnection()
 
 void MPIDirectCommunication::requestConnection(std::string const &acceptorName,
                                                std::string const &requesterName,
+                                               std::string const &tag,
                                                int                requesterRank,
                                                int                requesterCommunicatorSize)
 {

--- a/src/com/MPIDirectCommunication.hpp
+++ b/src/com/MPIDirectCommunication.hpp
@@ -36,10 +36,12 @@ public:
   /// See precice::com::Communication::acceptConnection().
   virtual void acceptConnection(std::string const &acceptorName,
                                 std::string const &requesterName,
+                                std::string const &tag,
                                 int                acceptorRank) override;
 
   virtual void acceptConnectionAsServer(std::string const &acceptorName,
                                         std::string const &requesterName,
+                                        std::string const &tag,
                                         int                acceptorRank,
                                         int                requesterCommunicatorSize) override
   {
@@ -49,11 +51,13 @@ public:
   /// See precice::com::Communication::requestConnection().
   virtual void requestConnection(std::string const &acceptorName,
                                  std::string const &requesterName,
+                                 std::string const &tag,
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
   virtual void requestConnectionAsClient(std::string const &  acceptorName,
                                          std::string const &  requesterName,
+                                         std::string const &  tag,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) override
   {

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -30,6 +30,7 @@ size_t MPIPortsCommunication::getRemoteCommunicatorSize()
 
 void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
                                              std::string const &requesterName,
+                                             std::string const &tag,
                                              int                acceptorRank)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank);
@@ -39,7 +40,7 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
   MPI_Open_port(MPI_INFO_NULL, const_cast<char *>(_portName.data()));
 
-  ConnectionInfoWriter conInfo(acceptorName, requesterName, _addressDirectory);
+  ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
   conInfo.write(_portName);
   PRECICE_DEBUG("Accept connection at " << _portName);
 
@@ -80,6 +81,7 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
 void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptorName,
                                                      std::string const &requesterName,
+                                                     std::string const &tag,
                                                      int                acceptorRank,
                                                      int                requesterCommunicatorSize)
 {
@@ -91,7 +93,7 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
 
   MPI_Open_port(MPI_INFO_NULL, const_cast<char *>(_portName.data()));
 
-  ConnectionInfoWriter conInfo(acceptorName, requesterName, acceptorRank, _addressDirectory);
+  ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
   conInfo.write(_portName);
   PRECICE_DEBUG("Accept connection at " << _portName);
 
@@ -110,6 +112,7 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
 
 void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
                                               std::string const &requesterName,
+                                              std::string const &tag,
                                               int                requesterRank,
                                               int                requesterCommunicatorSize)
 {
@@ -117,7 +120,7 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
   PRECICE_ASSERT(not isConnected());
   _isAcceptor = false;
 
-  ConnectionInfoReader conInfo(acceptorName, requesterName, _addressDirectory);
+  ConnectionInfoReader conInfo(acceptorName, requesterName, tag, _addressDirectory);
   _portName = conInfo.read();
 
   PRECICE_DEBUG("Request connection to " << _portName);
@@ -137,6 +140,7 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
 
 void MPIPortsCommunication::requestConnectionAsClient(std::string const &  acceptorName,
                                                       std::string const &  requesterName,
+                                                      std::string const &  tag,
                                                       std::set<int> const &acceptorRanks,
                                                       int                  requesterRank)
 
@@ -147,7 +151,7 @@ void MPIPortsCommunication::requestConnectionAsClient(std::string const &  accep
   _isAcceptor = false;
 
   for (auto const &acceptorRank : acceptorRanks) {
-    ConnectionInfoReader conInfo(acceptorName, requesterName, acceptorRank, _addressDirectory);
+    ConnectionInfoReader conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     _portName = conInfo.read();
     PRECICE_DEBUG("Request connection to " << _portName);
 

--- a/src/com/MPIPortsCommunication.hpp
+++ b/src/com/MPIPortsCommunication.hpp
@@ -23,20 +23,24 @@ public:
 
   virtual void acceptConnection(std::string const &acceptorName,
                                 std::string const &requesterName,
+                                std::string const &tag,
                                 int                acceptorRank) override;
 
   virtual void acceptConnectionAsServer(std::string const &acceptorName,
                                         std::string const &requesterName,
+                                        std::string const &tag,
                                         int                acceptorRank,
                                         int                requesterCommunicatorSize) override;
 
   virtual void requestConnection(std::string const &acceptorName,
                                  std::string const &requesterName,
+                                 std::string const &tag,
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
   virtual void requestConnectionAsClient(std::string const &  acceptorName,
                                          std::string const &  requesterName,
+                                         std::string const &  tag,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) override;
 

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -33,6 +33,7 @@ size_t MPISinglePortsCommunication::getRemoteCommunicatorSize()
 
 void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorName,
                                                    std::string const &requesterName,
+                                                   std::string const &tag,
                                                    int                acceptorRank)
 {
   PRECICE_TRACE(acceptorName, requesterName);
@@ -42,7 +43,7 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
 
   MPI_Open_port(MPI_INFO_NULL, const_cast<char *>(_portName.data()));
 
-  ConnectionInfoWriter conPub(acceptorName, requesterName, _addressDirectory);
+  ConnectionInfoWriter conPub(acceptorName, requesterName, tag, _addressDirectory);
   conPub.write(_portName);
 
   size_t peerCurrent               = 0; // current peer to connect to
@@ -84,13 +85,14 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
 void MPISinglePortsCommunication::acceptConnectionAsServer(
     std::string const &acceptorName,
     std::string const &requesterName,
+    std::string const &tag,
     int                acceptorRank,
     int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
   PRECICE_ASSERT(not isConnected());
 
-  ConnectionInfoWriter conInfo(acceptorName, requesterName, _addressDirectory);
+  ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
 
   _isAcceptor = true;
 
@@ -111,6 +113,7 @@ void MPISinglePortsCommunication::acceptConnectionAsServer(
 
 void MPISinglePortsCommunication::requestConnection(std::string const &acceptorName,
                                                     std::string const &requesterName,
+                                                    std::string const &tag,
                                                     int                requesterRank,
                                                     int                requesterCommunicatorSize)
 {
@@ -118,7 +121,7 @@ void MPISinglePortsCommunication::requestConnection(std::string const &acceptorN
   PRECICE_ASSERT(not isConnected());
   _isAcceptor = false;
 
-  ConnectionInfoReader conInfo(acceptorName, requesterName, _addressDirectory);
+  ConnectionInfoReader conInfo(acceptorName, requesterName, tag, _addressDirectory);
   _portName = conInfo.read();
   PRECICE_DEBUG("Request connection to " << _portName);
 
@@ -137,16 +140,16 @@ void MPISinglePortsCommunication::requestConnection(std::string const &acceptorN
 
 void MPISinglePortsCommunication::requestConnectionAsClient(std::string const &  acceptorName,
                                                             std::string const &  requesterName,
+                                                            std::string const &  tag,
                                                             std::set<int> const &acceptorRanks,
                                                             int                  requesterRank)
-
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected());
 
   _isAcceptor = false;
 
-  ConnectionInfoReader conInfo(acceptorName, requesterName, _addressDirectory);
+  ConnectionInfoReader conInfo(acceptorName, requesterName, tag, _addressDirectory);
   _portName = conInfo.read();
   PRECICE_DEBUG("Request connection to " << _portName);
 

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -37,20 +37,24 @@ public:
 
   virtual void acceptConnection(std::string const &acceptorName,
                                 std::string const &requesterName,
+                                std::string const &tag,
                                 int                acceptorRank) override;
 
   virtual void acceptConnectionAsServer(std::string const &acceptorName,
                                         std::string const &requesterName,
+                                        std::string const &tag,
                                         int                acceptorRank,
                                         int                requesterCommunicatorSize) override;
 
   virtual void requestConnection(std::string const &acceptorName,
                                  std::string const &requesterName,
+                                 std::string const &tag,
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
   virtual void requestConnectionAsClient(std::string const &  acceptorName,
                                          std::string const &  requesterName,
+                                         std::string const &  tag,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) override;
 

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -46,6 +46,7 @@ size_t SocketCommunication::getRemoteCommunicatorSize()
 
 void SocketCommunication::acceptConnection(std::string const &acceptorName,
                                            std::string const &requesterName,
+                                           std::string const &tag,
                                            int                acceptorRank)
 {
   PRECICE_TRACE(acceptorName, requesterName);
@@ -70,7 +71,7 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
 
     _portNumber = acceptor.local_endpoint().port();
     address     = ipAddress + ":" + std::to_string(_portNumber);
-    ConnectionInfoWriter conInfo(acceptorName, requesterName, _addressDirectory);
+    ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
     conInfo.write(address);
     PRECICE_DEBUG("Accept connection at " << address);
 
@@ -120,6 +121,7 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
 
 void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorName,
                                                    std::string const &requesterName,
+                                                   std::string const &tag,
                                                    int                acceptorRank,
                                                    int                requesterCommunicatorSize)
 {
@@ -148,7 +150,7 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
     }
 
     address = ipAddress + ":" + std::to_string(_portNumber);
-    ConnectionInfoWriter conInfo(acceptorName, requesterName, acceptorRank, _addressDirectory);
+    ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     conInfo.write(address);
 
     PRECICE_DEBUG("Accepting connection at " << address);
@@ -176,13 +178,14 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
 
 void SocketCommunication::requestConnection(std::string const &acceptorName,
                                             std::string const &requesterName,
+                                            std::string const &tag,
                                             int                requesterRank,
                                             int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected());
 
-  ConnectionInfoReader conInfo(acceptorName, requesterName, _addressDirectory);
+  ConnectionInfoReader conInfo(acceptorName, requesterName, tag, _addressDirectory);
   std::string const    address = conInfo.read();
   PRECICE_DEBUG("Request connection to " << address);
   auto const        sepidx     = address.find(':');
@@ -234,6 +237,7 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
 
 void SocketCommunication::requestConnectionAsClient(std::string const &  acceptorName,
                                                     std::string const &  requesterName,
+                                                    std::string const &  tag,
                                                     std::set<int> const &acceptorRanks,
                                                     int                  requesterRank)
 
@@ -243,7 +247,7 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
 
   for (auto const &acceptorRank : acceptorRanks) {
     _isConnected = false;
-    ConnectionInfoReader conInfo(acceptorName, requesterName, acceptorRank, _addressDirectory);
+    ConnectionInfoReader conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     std::string const    address    = conInfo.read();
     auto const           sepidx     = address.find(':');
     std::string const    ipAddress  = address.substr(0, sepidx);

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -26,20 +26,24 @@ public:
 
   virtual void acceptConnection(std::string const &acceptorName,
                                 std::string const &requesterName,
+                                std::string const &tag,
                                 int                acceptorRank) override;
 
   virtual void acceptConnectionAsServer(std::string const &acceptorName,
                                         std::string const &requesterName,
+                                        std::string const &tag,
                                         int                acceptorRank,
                                         int                requesterCommunicatorSize) override;
 
   virtual void requestConnection(std::string const &acceptorName,
                                  std::string const &requesterName,
+                                 std::string const &tag,
                                  int                requesterRank,
                                  int                requesterCommunicatorSize) override;
 
   virtual void requestConnectionAsClient(std::string const &  acceptorName,
                                          std::string const &  requesterName,
+                                         std::string const &  tag,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) override;
 

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -45,14 +45,14 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh,
 
       if (utils::Parallel::getProcessRank() == 0) {
         utils::Parallel::splitCommunicator(participant0);
-        com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
+        com->acceptConnection(participant0, participant1, "", utils::Parallel::getProcessRank());
         comMesh.sendMesh(sendMesh, 0);
       } else if (utils::Parallel::getProcessRank() == 1) {
         // receiveMesh can also deal with delta meshes
         mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
         recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
         utils::Parallel::splitCommunicator(participant1);
-        com->requestConnection(participant0, participant1, 0, 1);
+        com->requestConnection(participant0, participant1, "", 0, 1);
         comMesh.receiveMesh(recvMesh, 0);
         BOOST_TEST(recvMesh.vertices().size() == 4);
         BOOST_TEST(testing::equals(recvMesh.vertices()[0].getCoords(), Eigen::VectorXd::Constant(dim, 9)));
@@ -101,14 +101,14 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh,
 
     if (utils::Parallel::getProcessRank() == 0) {
       utils::Parallel::splitCommunicator(participant0);
-      com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
+      com->acceptConnection(participant0, participant1, "", utils::Parallel::getProcessRank());
       comMesh.sendMesh(sendMesh, 0);
     } else if (utils::Parallel::getProcessRank() == 1) {
       mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
       // receiveMesh can also deal with delta meshes
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       utils::Parallel::splitCommunicator(participant1);
-      com->requestConnection(participant0, participant1, 0, 1);
+      com->requestConnection(participant0, participant1, "", 0, 1);
       comMesh.receiveMesh(recvMesh, 0);
       BOOST_TEST(recvMesh.vertices().size() == 4);
       BOOST_TEST(testing::equals(recvMesh.vertices()[0].getCoords(), Eigen::VectorXd::Constant(dim, 9)));
@@ -158,14 +158,14 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh,
 
     if (utils::Parallel::getProcessRank() == 0) {
       utils::Parallel::splitCommunicator(participant0);
-      com->acceptConnection(participant0, participant1, utils::Parallel::getProcessRank());
+      com->acceptConnection(participant0, participant1, "", utils::Parallel::getProcessRank());
       comMesh.broadcastSendMesh(sendMesh);
     } else if (utils::Parallel::getProcessRank() == 1) {
       mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
       // receiveMesh can also deal with delta meshes
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       utils::Parallel::splitCommunicator(participant1);
-      com->requestConnection(participant0, participant1, 0, 1);
+      com->requestConnection(participant0, participant1, "", 0, 1);
       comMesh.broadcastReceiveMesh(recvMesh);
       BOOST_TEST(recvMesh.vertices().size() == 4);
       BOOST_TEST(testing::equals(recvMesh.vertices()[0].getCoords(), Eigen::VectorXd::Constant(dim, 9)));

--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -20,7 +20,7 @@ void TestSendAndReceivePrimitiveTypes()
   const int rank = utils::Parallel::getProcessRank();
 
   if (rank == 0) {
-    com.acceptConnection("process0", "process1", rank);
+    com.acceptConnection("process0", "process1", "", rank);
     {
       std::string msg("testOne");
       com.send(msg, 0);
@@ -47,7 +47,7 @@ void TestSendAndReceivePrimitiveTypes()
     }
     com.closeConnection();
   } else if (rank == 1) {
-    com.requestConnection("process0", "process1", 0, 1);
+    com.requestConnection("process0", "process1", "", 0, 1);
     {
       std::string msg;
       com.receive(msg, 0);
@@ -88,7 +88,7 @@ void TestSendAndReceiveVectors()
   const int rank = utils::Parallel::getProcessRank();
 
   if (rank == 0) {
-    com.acceptConnection("process0", "process1", rank);
+    com.acceptConnection("process0", "process1", "", rank);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
       com.receive(msg.data(), msg.size(), 0);
@@ -118,7 +118,7 @@ void TestSendAndReceiveVectors()
     }
     com.closeConnection();
   } else if (rank == 1) {
-    com.requestConnection("process0", "process1", 0, 1);
+    com.requestConnection("process0", "process1", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(1);
       com.send(msg.data(), msg.size(), 0);
@@ -157,7 +157,7 @@ void TestSendReceiveFourProcesses()
 
   switch (rank) {
   case 0: {
-    communication.acceptConnection("A", "B", rank);
+    communication.acceptConnection("A", "B", "", rank);
 
     communication.send(10, 2);
     communication.receive(message, 2);
@@ -175,7 +175,7 @@ void TestSendReceiveFourProcesses()
     break;
   }
   case 2: {
-    communication.requestConnection("A", "B", rank, 2);
+    communication.requestConnection("A", "B", "", rank, 2);
 
     communication.receive(message, 0);
     BOOST_TEST(message == 10);
@@ -186,7 +186,7 @@ void TestSendReceiveFourProcesses()
     break;
   }
   case 3: {
-    communication.requestConnection("A", "B", rank, 2);
+    communication.requestConnection("A", "B", "", rank, 2);
 
     communication.receive(message, 0);
     BOOST_TEST(message == 20);
@@ -216,7 +216,7 @@ void TestSendReceiveTwoProcessesServerClient()
 
   switch (rank) {
   case 0: {
-    communication.acceptConnectionAsServer("A", "B", rank, 1);
+    communication.acceptConnectionAsServer("A", "B", "", rank, 1);
     communication.send(message, 1);
     communication.receive(message, 1);
     BOOST_TEST(message == 2);
@@ -224,7 +224,7 @@ void TestSendReceiveTwoProcessesServerClient()
     break;
   }
   case 1: {
-    communication.requestConnectionAsClient("A", "B", {0}, rank);
+    communication.requestConnectionAsClient("A", "B", "", {0}, rank);
     communication.receive(message, 0);
     BOOST_TEST(message == 1);
     message = 2;
@@ -244,7 +244,7 @@ void TestSendReceiveFourProcessesServerClient()
 
   switch (rank) {
   case 0: {
-    communication.acceptConnectionAsServer("A", "B", rank, 2);
+    communication.acceptConnectionAsServer("A", "B", "", rank, 2);
 
     communication.send(10, 2);
     communication.receive(message, 2);
@@ -262,7 +262,7 @@ void TestSendReceiveFourProcessesServerClient()
     break;
   }
   case 2: {
-    communication.requestConnectionAsClient("A", "B", {0}, rank);
+    communication.requestConnectionAsClient("A", "B", "", {0}, rank);
 
     communication.receive(message, 0);
     BOOST_TEST(message == 10);
@@ -273,7 +273,7 @@ void TestSendReceiveFourProcessesServerClient()
     break;
   }
   case 3: {
-    communication.requestConnectionAsClient("A", "B", {0}, rank);
+    communication.requestConnectionAsClient("A", "B", "", {0}, rank);
 
     communication.receive(message, 0);
     BOOST_TEST(message == 20);
@@ -295,7 +295,7 @@ void TestSendReceiveFourProcessesServerClientV2()
 
   switch (rank) {
   case 0: {
-    communication.acceptConnectionAsServer("A", "B", rank, 2);
+    communication.acceptConnectionAsServer("A", "B", "", rank, 2);
 
     communication.send(10, 2);
     communication.receive(message, 2);
@@ -309,7 +309,7 @@ void TestSendReceiveFourProcessesServerClientV2()
     break;
   }
   case 1: {
-    communication.acceptConnectionAsServer("A", "B", rank, 2);
+    communication.acceptConnectionAsServer("A", "B", "", rank, 2);
 
     communication.send(20, 2);
     communication.receive(message, 2);
@@ -323,7 +323,7 @@ void TestSendReceiveFourProcessesServerClientV2()
     break;
   }
   case 2: {
-    communication.requestConnectionAsClient("A", "B", {0, 1}, rank);
+    communication.requestConnectionAsClient("A", "B", "", {0, 1}, rank);
 
     communication.receive(message, 0);
     BOOST_TEST(message == 10);
@@ -337,7 +337,7 @@ void TestSendReceiveFourProcessesServerClientV2()
     break;
   }
   case 3: {
-    communication.requestConnectionAsClient("A", "B", {0, 1}, rank);
+    communication.requestConnectionAsClient("A", "B", "", {0, 1}, rank);
 
     communication.receive(message, 0);
     BOOST_TEST(message == 100);

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -43,20 +43,20 @@ struct SetupMasterSlaveFixture {
 
     if (utils::Parallel::getProcessRank() == 0) {
       utils::Parallel::splitCommunicator("Master");
-      masterSlaveCom->acceptConnection("Master", "Slaves", utils::Parallel::getProcessRank());
+      masterSlaveCom->acceptConnection("Master", "Slaves", "Test", utils::Parallel::getProcessRank());
       masterSlaveCom->setRankOffset(1);
       utils::MasterSlave::configure(0, 4);
     } else if (utils::Parallel::getProcessRank() == 1) {
       utils::Parallel::splitCommunicator("Slaves");
-      masterSlaveCom->requestConnection("Master", "Slaves", 0, 3);
+      masterSlaveCom->requestConnection("Master", "Slaves", "Test", 0, 3);
       utils::MasterSlave::configure(1, 4);
     } else if (utils::Parallel::getProcessRank() == 2) {
       utils::Parallel::splitCommunicator("Slaves");
-      masterSlaveCom->requestConnection("Master", "Slaves", 1, 3);
+      masterSlaveCom->requestConnection("Master", "Slaves", "Test", 1, 3);
       utils::MasterSlave::configure(2, 4);
     } else if (utils::Parallel::getProcessRank() == 3) {
       utils::Parallel::splitCommunicator("Slaves");
-      masterSlaveCom->requestConnection("Master", "Slaves", 2, 3);
+      masterSlaveCom->requestConnection("Master", "Slaves", "Test", 2, 3);
       utils::MasterSlave::configure(3, 4);
     }
   }

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -43,7 +43,7 @@ void M2N::acceptMasterConnection(
   if (not utils::MasterSlave::isSlave()) {
     PRECICE_DEBUG("Accept master-master connection");
     PRECICE_ASSERT(_masterCom);
-    _masterCom->acceptConnection(acceptorName, requesterName, utils::MasterSlave::getRank());
+    _masterCom->acceptConnection(acceptorName, requesterName, "MASTERCOM", utils::MasterSlave::getRank());
     _isMasterConnected = _masterCom->isConnected();
   }
 
@@ -61,7 +61,7 @@ void M2N::requestMasterConnection(
   if (not utils::MasterSlave::isSlave()) {
     PRECICE_ASSERT(_masterCom);
     PRECICE_DEBUG("Request master-master connection");
-    _masterCom->requestConnection(acceptorName, requesterName, 0, 1);
+    _masterCom->requestConnection(acceptorName, requesterName, "MASTERCOM", 0, 1);
     _isMasterConnected = _masterCom->isConnected();
   }
 

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -300,7 +300,7 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
     // Establish connection between participants' master processes.
     auto c = _communicationFactory->newCommunication();
 
-    c->acceptConnection(acceptorName, requesterName, utils::MasterSlave::getRank());
+    c->acceptConnection(acceptorName, requesterName, "TMP-MASTERCOM-" + _mesh->getName(), utils::MasterSlave::getRank());
 
     // Exchange vertex distributions.
     m2n::send(vertexDistribution, 0, c);
@@ -363,6 +363,7 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
   // and (multiple) requester processes (in the requester participant).
   _communication->acceptConnectionAsServer(acceptorName,
                                            requesterName,
+                                           _mesh->getName(),
                                            utils::MasterSlave::getRank(),
                                            communicationMap.size());
 
@@ -398,6 +399,7 @@ void PointToPointCommunication::acceptPreConnection(std::string const &acceptorN
   c->acceptConnectionAsServer(
       acceptorName,
       requesterName,
+      _mesh->getName(),
       utils::MasterSlave::getRank(),
       localConnectedRanks.size());
 
@@ -424,7 +426,9 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
     Event e0("m2n.exchangeVertexDistribution");
     // Establish connection between participants' master processes.
     auto c = _communicationFactory->newCommunication();
-    c->requestConnection(acceptorName, requesterName, 0, 1);
+    c->requestConnection(acceptorName, requesterName,
+                         "TMP-MASTERCOM-" + _mesh->getName(),
+                         0, 1);
 
     // Exchange vertex distributions.
     m2n::receive(acceptorVertexDistribution, 0, c);
@@ -493,6 +497,7 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
   // processes (in the acceptor participant) to ranks `accceptingRanks'
   // according to `communicationMap`.
   _communication->requestConnectionAsClient(acceptorName, requesterName,
+                                            _mesh->getName(),
                                             acceptingRanks, utils::MasterSlave::getRank());
 
   PRECICE_DEBUG("Store communication map");
@@ -530,6 +535,7 @@ void PointToPointCommunication::requestPreConnection(std::string const &acceptor
 
   auto c = _communicationFactory->newCommunication();
   c->requestConnectionAsClient(acceptorName, requesterName,
+                               _mesh->getName(),
                                acceptingRanks, utils::MasterSlave::getRank());
 
   for (auto &connectedRank : localConnectedRanks) {

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -37,16 +37,16 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest, *testing::OnSize(4))
   } else if (utils::Parallel::getProcessRank() == 1) { // Participant 2 - Master
     utils::Parallel::splitCommunicator("Part2Master");
     utils::MasterSlave::configure(0, 3);
-    masterSlaveCom->acceptConnection("Part2Master", "Part2Slaves", utils::Parallel::getProcessRank());
+    masterSlaveCom->acceptConnection("Part2Master", "Part2Slaves", "Test", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { // Participant 2 - Slave1
     utils::Parallel::splitCommunicator("Part2Slaves");
     utils::MasterSlave::configure(1, 3);
-    masterSlaveCom->requestConnection("Part2Master", "Part2Slaves", 0, 2);
+    masterSlaveCom->requestConnection("Part2Master", "Part2Slaves", "Test", 0, 2);
   } else if (utils::Parallel::getProcessRank() == 3) { // Participant 2 - Slave2
     utils::Parallel::splitCommunicator("Part2Slaves");
     utils::MasterSlave::configure(2, 3);
-    masterSlaveCom->requestConnection("Part2Master", "Part2Slaves", 1, 2);
+    masterSlaveCom->requestConnection("Part2Master", "Part2Slaves", "Test", 1, 2);
   }
 
   utils::Parallel::synchronizeProcesses();

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -45,7 +45,7 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
 
     utils::MasterSlave::configure(0, 2);
 
-    MasterSlave::_communication->acceptConnection("A.Master", "A.Slave", 0);
+    MasterSlave::_communication->acceptConnection("A.Master", "A.Slave", "Test", 0);
     MasterSlave::_communication->setRankOffset(1);
 
     mesh->setGlobalNumberOfVertices(10);
@@ -71,7 +71,7 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
     Parallel::splitCommunicator("A.Slave");
     MasterSlave::configure(1, 2);
 
-    MasterSlave::_communication->requestConnection("A.Master", "A.Slave", 1, 1);
+    MasterSlave::_communication->requestConnection("A.Master", "A.Slave", "Test", 1, 1);
 
     data         = {20, 30, 50, 60, 70};
     expectedData = {4 * 20 + 3, 30 + 1, 50 + 2, 4 * 60 + 3, 70 + 1};
@@ -82,7 +82,7 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
     Parallel::splitCommunicator("B.Master");
     MasterSlave::configure(0, 2);
 
-    MasterSlave::_communication->acceptConnection("B.Master", "B.Slave", 0);
+    MasterSlave::_communication->acceptConnection("B.Master", "B.Slave", "Test", 0);
     MasterSlave::_communication->setRankOffset(1);
 
     mesh->setGlobalNumberOfVertices(10);
@@ -108,7 +108,7 @@ void P2PComTest1(com::PtrCommunicationFactory cf)
     Parallel::splitCommunicator("B.Slave");
     MasterSlave::configure(1, 2);
 
-    MasterSlave::_communication->requestConnection("B.Master", "B.Slave", 1, 1);
+    MasterSlave::_communication->requestConnection("B.Master", "B.Slave", "Test", 1, 1);
 
     data.assign(6, -1);
     expectedData = {10, 2 * 20, 40, 50, 2 * 60, 80};
@@ -159,7 +159,7 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
     Parallel::splitCommunicator("A.Master");
     MasterSlave::configure(0, 2);
 
-    MasterSlave::_communication->acceptConnection("A.Master", "A.Slave", utils::Parallel::getProcessRank());
+    MasterSlave::_communication->acceptConnection("A.Master", "A.Slave", "Test", utils::Parallel::getProcessRank());
     MasterSlave::_communication->setRankOffset(1);
 
     mesh->setGlobalNumberOfVertices(10);
@@ -185,7 +185,7 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
     Parallel::splitCommunicator("A.Slave");
     utils::MasterSlave::configure(1, 2);
 
-    MasterSlave::_communication->requestConnection("A.Master", "A.Slave", 0, 1);
+    MasterSlave::_communication->requestConnection("A.Master", "A.Slave", "Test", 0, 1);
 
     data         = {20, 30, 50, 60, 70};
     expectedData = {4 * 20 + 3, 0, 50 + 2, 4 * 60 + 3, 70 + 1};
@@ -196,7 +196,7 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
     Parallel::splitCommunicator("B.Master");
     utils::MasterSlave::configure(0, 2);
 
-    MasterSlave::_communication->acceptConnection("B.Master", "B.Slave", utils::Parallel::getProcessRank());
+    MasterSlave::_communication->acceptConnection("B.Master", "B.Slave", "Test", utils::Parallel::getProcessRank());
     MasterSlave::_communication->setRankOffset(1);
 
     mesh->setGlobalNumberOfVertices(10);
@@ -221,7 +221,7 @@ void P2PComTest2(com::PtrCommunicationFactory cf)
   case 3: {
     Parallel::splitCommunicator("B.Slave");
     MasterSlave::configure(1, 2);
-    MasterSlave::_communication->requestConnection("B.Master", "B.Slave", 0, 1);
+    MasterSlave::_communication->requestConnection("B.Master", "B.Slave", "Test", 0, 1);
 
     data.assign(6, -1);
     expectedData = {10, 2 * 20, 40, 50, 2 * 60, 80};
@@ -270,7 +270,7 @@ void connectionTest(com::PtrCommunicationFactory cf)
     case 0: {
       utils::Parallel::splitCommunicator("Fluid.Master");
       utils::MasterSlave::configure(0, 2);
-      utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
+      utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", "Test", utils::Parallel::getProcessRank());
       utils::MasterSlave::_communication->setRankOffset(1);
 
       if (connectionType == "same") {
@@ -283,7 +283,7 @@ void connectionTest(com::PtrCommunicationFactory cf)
     case 1: {
       utils::Parallel::splitCommunicator("Fluid.Slave");
       utils::MasterSlave::configure(1, 2);
-      utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
+      utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", "Test", 0, 1);
 
       if (connectionType == "same") {
         mesh->getConnectedRanks().push_back(1);
@@ -295,7 +295,7 @@ void connectionTest(com::PtrCommunicationFactory cf)
     case 2: {
       utils::Parallel::splitCommunicator("Solid.Master");
       utils::MasterSlave::configure(0, 2);
-      utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
+      utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", "Test", utils::Parallel::getProcessRank());
       utils::MasterSlave::_communication->setRankOffset(1);
 
       if (connectionType == "same") {
@@ -308,7 +308,7 @@ void connectionTest(com::PtrCommunicationFactory cf)
     case 3: {
       utils::Parallel::splitCommunicator("Solid.Slave");
       utils::MasterSlave::configure(1, 2);
-      utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
+      utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", "Test", 0, 1);
 
       if (connectionType == "same") {
         mesh->getConnectedRanks().push_back(1);
@@ -379,7 +379,7 @@ void emptyConnectionTest(com::PtrCommunicationFactory cf)
   case 0: {
     utils::Parallel::splitCommunicator("Fluid.Master");
     utils::MasterSlave::configure(0, 2);
-    utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
 
     mesh->getConnectedRanks().push_back(0);
@@ -389,14 +389,14 @@ void emptyConnectionTest(com::PtrCommunicationFactory cf)
   case 1: {
     utils::Parallel::splitCommunicator("Fluid.Slave");
     utils::MasterSlave::configure(1, 2);
-    utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", "Test", 0, 1);
 
     break;
   }
   case 2: {
     utils::Parallel::splitCommunicator("Solid.Master");
     utils::MasterSlave::configure(0, 2);
-    utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
 
     mesh->getConnectedRanks().push_back(0);
@@ -406,7 +406,7 @@ void emptyConnectionTest(com::PtrCommunicationFactory cf)
   case 3: {
     utils::Parallel::splitCommunicator("Solid.Slave");
     utils::MasterSlave::configure(1, 2);
-    utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", "Test", 0, 1);
 
     break;
   }
@@ -455,7 +455,7 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   case 0: {
     utils::Parallel::splitCommunicator("Fluid.Master");
     utils::MasterSlave::configure(0, 2);
-    utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
 
     Eigen::VectorXd position(dimensions);
@@ -472,7 +472,7 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   case 1: {
     utils::Parallel::splitCommunicator("Fluid.Slave");
     utils::MasterSlave::configure(1, 2);
-    utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", "Test", 0, 1);
 
     Eigen::VectorXd position(dimensions);
     position << 1.5, 0.0;
@@ -488,7 +488,7 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   case 2: {
     utils::Parallel::splitCommunicator("Solid.Master");
     utils::MasterSlave::configure(0, 2);
-    utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
 
     mesh->getConnectedRanks().push_back(0);
@@ -498,7 +498,7 @@ void P2PMeshBroadcastTest(com::PtrCommunicationFactory cf)
   case 3: {
     utils::Parallel::splitCommunicator("Solid.Slave");
     utils::MasterSlave::configure(1, 2);
-    utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", "Test", 0, 1);
 
     mesh->getConnectedRanks().push_back(1);
 
@@ -559,7 +559,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   case 0: {
     utils::Parallel::splitCommunicator("Fluid.Master");
     utils::MasterSlave::configure(0, 2);
-    utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("Fluid.Master", "Fluid.Slave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
 
     // The numbers are chosen in this way to make it easy to test weather
@@ -577,7 +577,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   case 1: {
     utils::Parallel::splitCommunicator("Fluid.Slave");
     utils::MasterSlave::configure(1, 2);
-    utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("Fluid.Master", "Fluid.Slave", "Test", 0, 1);
 
     // The numbers are chosen in this way to make it easy to test weather
     // correct values are communicated or not!
@@ -594,7 +594,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   case 2: {
     utils::Parallel::splitCommunicator("Solid.Master");
     utils::MasterSlave::configure(0, 2);
-    utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("Solid.Master", "Solid.Slave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
 
     mesh->getConnectedRanks().push_back(0);
@@ -604,7 +604,7 @@ void P2PComLCMTest(com::PtrCommunicationFactory cf)
   case 3: {
     utils::Parallel::splitCommunicator("Solid.Slave");
     utils::MasterSlave::configure(1, 2);
-    utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("Solid.Master", "Solid.Slave", "Test", 0, 1);
 
     mesh->getConnectedRanks().push_back(1);
 

--- a/src/partition/tests/ProvidedBoundingBoxTest.cpp
+++ b/src/partition/tests/ProvidedBoundingBoxTest.cpp
@@ -47,12 +47,12 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
   }
 
   if (utils::Parallel::getProcessRank() == 1) { //Master
-    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
+    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", "Test", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
-    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 0, 2);
+    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", "Test", 0, 2);
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
-    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 1, 2);
+    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", "Test", 1, 2);
   }
 }
 
@@ -85,15 +85,15 @@ void setupM2NBaseEnvironment(m2n::PtrM2N p2p)
   }
 
   if (utils::Parallel::getProcessRank() == 0) { //Master Fluid
-    utils::MasterSlave::_communication->acceptConnection("FluidMaster", "FluidSlave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("FluidMaster", "FluidSlave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 1) { //Slave Fluid
-    utils::MasterSlave::_communication->requestConnection("FluidMaster", "FluidSlave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("FluidMaster", "FluidSlave", "Test", 0, 1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Master Solid
-    utils::MasterSlave::_communication->acceptConnection("SolidMaster", "SolidSlave", utils::Parallel::getProcessRank());
+    utils::MasterSlave::_communication->acceptConnection("SolidMaster", "SolidSlave", "Test", utils::Parallel::getProcessRank());
     utils::MasterSlave::_communication->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave Solis
-    utils::MasterSlave::_communication->requestConnection("SolidMaster", "SolidSlave", 0, 1);
+    utils::MasterSlave::_communication->requestConnection("SolidMaster", "SolidSlave", "Test", 0, 1);
   }
 }
 

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -42,12 +42,12 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
   }
 
   if (utils::Parallel::getProcessRank() == 1) { //Master
-    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
+    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", "Test", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
-    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 0, 2);
+    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", "Test", 0, 2);
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
-    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 1, 2);
+    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", "Test", 1, 2);
   }
 }
 

--- a/src/partition/tests/ReceivedBoundingBoxTest.cpp
+++ b/src/partition/tests/ReceivedBoundingBoxTest.cpp
@@ -47,12 +47,12 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
   }
 
   if (utils::Parallel::getProcessRank() == 1) { //Master
-    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", utils::Parallel::getProcessRank());
+    masterSlaveCom->acceptConnection("SolidMaster", "SolidSlaves", "Test", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
-    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 0, 2);
+    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", "Test", 0, 2);
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
-    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", 1, 2);
+    masterSlaveCom->requestConnection("SolidMaster", "SolidSlaves", "Test", 1, 2);
   }
 }
 

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -46,12 +46,12 @@ void setupParallelEnvironment(m2n::PtrM2N m2n)
   }
 
   if (utils::Parallel::getProcessRank() == 1) { //Master
-    masterSlaveCom->acceptConnection("FluidMaster", "FluidSlaves", utils::Parallel::getProcessRank());
+    masterSlaveCom->acceptConnection("FluidMaster", "FluidSlaves", "Test", utils::Parallel::getProcessRank());
     masterSlaveCom->setRankOffset(1);
   } else if (utils::Parallel::getProcessRank() == 2) { //Slave1
-    masterSlaveCom->requestConnection("FluidMaster", "FluidSlaves", 0, 2);
+    masterSlaveCom->requestConnection("FluidMaster", "FluidSlaves", "Test", 0, 2);
   } else if (utils::Parallel::getProcessRank() == 3) { //Slave2
-    masterSlaveCom->requestConnection("FluidMaster", "FluidSlaves", 1, 2);
+    masterSlaveCom->requestConnection("FluidMaster", "FluidSlaves", "Test", 1, 2);
   }
 }
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1355,11 +1355,11 @@ void SolverInterfaceImpl::initializeMasterSlaveCommunication()
   int rankOffset = 1;
   if (utils::MasterSlave::isMaster()) {
     PRECICE_INFO("Setting up communication to slaves");
-    utils::MasterSlave::_communication->acceptConnection(_accessorName + "Master", _accessorName, utils::MasterSlave::getRank());
+    utils::MasterSlave::_communication->acceptConnection(_accessorName + "Master", _accessorName, "MasterSlave", utils::MasterSlave::getRank());
     utils::MasterSlave::_communication->setRankOffset(rankOffset);
   } else {
     PRECICE_ASSERT(utils::MasterSlave::isSlave());
-    utils::MasterSlave::_communication->requestConnection(_accessorName + "Master", _accessorName,
+    utils::MasterSlave::_communication->requestConnection(_accessorName + "Master", _accessorName, "MasterSlave",
                                                           _accessorProcessRank - rankOffset, _accessorCommunicatorSize - rankOffset);
   }
 }

--- a/src/testing/Fixtures.hpp
+++ b/src/testing/Fixtures.hpp
@@ -27,13 +27,13 @@ struct MasterComFixture {
     if (utils::Parallel::getProcessRank() == 0) { //Master
       utils::Parallel::splitCommunicator("Master");
       utils::MasterSlave::configure(0, size);
-      utils::MasterSlave::_communication->acceptConnection("Master", "Slaves", utils::Parallel::getProcessRank());
+      utils::MasterSlave::_communication->acceptConnection("Master", "Slaves", "Test", utils::Parallel::getProcessRank());
       utils::MasterSlave::_communication->setRankOffset(1);
     } else { //Slaves
       PRECICE_ASSERT(utils::Parallel::getProcessRank() > 0 && utils::Parallel::getProcessRank() < size);
       utils::Parallel::splitCommunicator("Slaves");
       utils::MasterSlave::configure(utils::Parallel::getProcessRank(), size);
-      utils::MasterSlave::_communication->requestConnection("Master", "Slaves", utils::Parallel::getProcessRank() - 1, size - 1);
+      utils::MasterSlave::_communication->requestConnection("Master", "Slaves", "Test", utils::Parallel::getProcessRank() - 1, size - 1);
     }
   }
 


### PR DESCRIPTION
This PR adds the mesh-name to the context used in the connection info publisher.

This required passing the name of the mesh from the distributed communication down to:
1. the `m2n::M2N`
2. the `com::Communication::accept/requestConnection`
3. the `com::ConnectionInfoWriter`

Resolves #570 