### PR TITLE
Change default mpi com in m2n to MPISinglePortsCom

### DIFF
--- a/docs/changelog/624.md
+++ b/docs/changelog/624.md
@@ -1,0 +1,1 @@
+- Change `m2n:mpi` to use the more efficient single-ports implementation. To use the old implementation, use `m2n:mpi-mulitple-ports`.

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -162,7 +162,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
     } else if (tag.getName() == "mpi-multiple-ports") {
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
-      PRECICE_ERROR("Communication type \"mpi\" can only be used if preCICE was compiled with MPI support enabled. "
+      PRECICE_ERROR("Communication type \"mpi-multiple-ports\" can only be used if preCICE was compiled with MPI support enabled. "
                     "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
 #ifdef OMPI_MAJOR_VERSION
@@ -174,7 +174,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
     } else if (tag.getName() == "mpi") {
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
-      PRECICE_ERROR("Communication type \"mpi-singleports\" can only be used if preCICE was compiled with MPI support enabled. "
+      PRECICE_ERROR("Communication type \"mpi\" can only be used if preCICE was compiled with MPI support enabled. "
                     "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
 #ifdef OMPI_MAJOR_VERSION

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -85,6 +85,20 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     tag.addAttribute(attrExchangeDirectory);
     tags.push_back(tag);
   }
+  {
+    /// @TODO Remove in Version 3.0
+    XMLTag tag(*this, "mpi-singleports", occ, TAG);
+    doc = "Communication via MPI with startup in separated communication spaces, using a single communicator";
+    tag.setDocumentation(doc);
+
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+                                     .setDocumentation(
+                                         "Directory where connection information is exchanged. By default, the "
+                                         "directory of startup is chosen, and both solvers have to be started "
+                                         "in the same directory.");
+    tag.addAttribute(attrExchangeDirectory);
+    tags.push_back(tag);
+  }
 
   XMLAttribute<bool> attrEnforce(ATTR_ENFORCE_GATHER_SCATTER, false);
   attrEnforce.setDocumentation("Enforce the distributed communication to a gather-scatter scheme. "
@@ -149,7 +163,8 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
 
     com::PtrCommunicationFactory comFactory;
     com::PtrCommunication        com;
-    if (tag.getName() == "sockets") {
+    const std::string            tagName = tag.getName();
+    if (tagName == "sockets") {
       std::string network = tag.getStringAttributeValue("network");
       int         port    = tag.getIntAttributeValue("port");
 
@@ -159,26 +174,30 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
       comFactory      = std::make_shared<com::SocketCommunicationFactory>(port, false, network, dir);
       com             = comFactory->newCommunication();
-    } else if (tag.getName() == "mpi-multiple-ports") {
+    } else if (tagName == "mpi-multiple-ports") {
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
       PRECICE_ERROR("Communication type \"mpi-multiple-ports\" can only be used if preCICE was compiled with MPI support enabled. "
                     "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
 #ifdef OMPI_MAJOR_VERSION
-      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:mpi />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.");
+      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:mpi-multiple-ports />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.");
 #endif
       comFactory = std::make_shared<com::MPIPortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
 #endif
-    } else if (tag.getName() == "mpi") {
+    } else if (tagName == "mpi" || tagName == "mpi-singleports") {
+      if (tagName == "mpi-singleports") {
+        PRECICE_WARN("You used <m2n:mpi-singleports />, which is deprecated. Please use <m2n:mpi /> instead.");
+      }
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
-      PRECICE_ERROR("Communication type \"mpi\" can only be used if preCICE was compiled with MPI support enabled. "
-                    "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
+      PRECICE_ERROR("Communication type \"{}\" can only be used if preCICE was compiled with MPI support enabled. "
+                    "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".",
+                    tagName);
 #else
 #ifdef OMPI_MAJOR_VERSION
-      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:mpi-singleports />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.");
+      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:{} />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.", tagName);
 #endif
       comFactory = std::make_shared<com::MPISinglePortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -60,7 +60,7 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     tags.push_back(tag);
   }
   {
-    XMLTag tag(*this, "mpi", occ, TAG);
+    XMLTag tag(*this, "mpi-multiple-ports", occ, TAG);
     doc = "Communication via MPI with startup in separated communication spaces, using multiple communicators.";
     tag.setDocumentation(doc);
 
@@ -73,7 +73,7 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     tags.push_back(tag);
   }
   {
-    XMLTag tag(*this, "mpi-singleports", occ, TAG);
+    XMLTag tag(*this, "mpi", occ, TAG);
     doc = "Communication via MPI with startup in separated communication spaces, using a single communicator";
     tag.setDocumentation(doc);
 
@@ -159,7 +159,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
       comFactory      = std::make_shared<com::SocketCommunicationFactory>(port, false, network, dir);
       com             = comFactory->newCommunication();
-    } else if (tag.getName() == "mpi") {
+    } else if (tag.getName() == "mpi-multiple-ports") {
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
       PRECICE_ERROR("Communication type \"mpi\" can only be used if preCICE was compiled with MPI support enabled. "
@@ -171,7 +171,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
       comFactory = std::make_shared<com::MPIPortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
 #endif
-    } else if (tag.getName() == "mpi-singleports") {
+    } else if (tag.getName() == "mpi") {
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
       PRECICE_ERROR("Communication type \"mpi-singleports\" can only be used if preCICE was compiled with MPI support enabled. "

--- a/src/precice/tests/explicit-mpi-single-non-inc.xml
+++ b/src/precice/tests/explicit-mpi-single-non-inc.xml
@@ -49,7 +49,7 @@
       <read-data name="Pressures" mesh="Test-Square" />
     </participant>
 
-    <m2n:sockets from="SolverOne" to="SolverTwo" />
+    <m2n:mpi from="SolverOne" to="SolverTwo" />
 
     <coupling-scheme:serial-explicit>
       <participants first="SolverOne" second="SolverTwo" />

--- a/src/precice/tests/explicit-mpi-single.xml
+++ b/src/precice/tests/explicit-mpi-single.xml
@@ -39,7 +39,7 @@
       <read-data name="Forces" mesh="Test-Square" />
     </participant>
 
-    <m2n:sockets from="SolverOne" to="SolverTwo" />
+    <m2n:mpi from="SolverOne" to="SolverTwo" />
 
     <coupling-scheme:serial-explicit>
       <participants first="SolverOne" second="SolverTwo" />

--- a/src/precice/tests/explicit-mpi.xml
+++ b/src/precice/tests/explicit-mpi.xml
@@ -38,7 +38,7 @@
       <read-data name="Forces" mesh="Test-Square" />
     </participant>
 
-    <m2n:mpi from="SolverOne" to="SolverTwo" />
+    <m2n:mpi-multiple-ports from="SolverOne" to="SolverTwo" />
 
     <coupling-scheme:serial-explicit>
       <participants first="SolverOne" second="SolverTwo" />


### PR DESCRIPTION
`MPISinglePortsCom` is the more efficient variant developed by @floli. `MPIPortsCom` is the old, now kind of deprecated, variant. This PR changes the default setting. `"mpi"` now points to the new implementation and the old variant is accessible via `"mpi-multiple-ports"`. 
In my opinion it is still too early to completely remove the old implementation. 