### PR TITLE
Documentation: Add clarifications for clang-format

### DIFF
--- a/docs/documents/070_tooling.dox
+++ b/docs/documents/070_tooling.dox
@@ -13,6 +13,7 @@ The tool [clang-format](https://clang.llvm.org/docs/ClangFormat.html) applies a 
 It checks parent directories for a `.clang-format` file and applies the style to a given source file.
 To keep the code-base consistent, please use `clang-format` version 8.
 Scripts will explicitly use `clang-format-8` to prevent any problems.
+Looking for precompiled binaries? Here is the [official APT repository](http://apt.llvm.org/).
 
 To use the tool form the shell, run:
 ```
@@ -25,7 +26,6 @@ Editor integration is available for:
 - [Emacs](https://clang.llvm.org/docs/ClangFormat.html#emacs-integration)
 - [Vim](https://clang.llvm.org/docs/ClangFormat.html#vim-integration)
 - [Visual Studio](https://clang.llvm.org/docs/ClangFormat.html#visual-studio-integration)
-
 
 To [disable formatting](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code) for a section of code use comments:
 ```

--- a/tools/formatting/README.md
+++ b/tools/formatting/README.md
@@ -8,6 +8,6 @@ Otherwise, it displays the list of files that do not match the format and return
 
 ## format-all
 
-This bash-script applies the format of a parent `.clang-format` to every c(pp) & h(pp) file in the current and parent directories.
+This bash-script applies the format of a parent `.clang-format` to every c(pp) & h(pp) file in the current and child directories. To format the complete codebase, run the script from the root directory.
 
 This script returns 0 on success.


### PR DESCRIPTION
This adds a couple of hints for clang-format:
- Where to find Debian/Ubuntu packages
- Execute `format-all` from the root directory (highlights the "and child directories", which before was wrongly "parent directories")
