### PR TITLE
Add Directional folder level and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file. For future 
   - Renamed `acceleration` configuration option `timesteps-reused` to `time-windows-reused`
   - Renamed `acceleration` configuration option `reused-timesteps-at-restart` to `reused-time-windows-at-restart`
   - Renamed `export` configuration option `timestep-interval` to `every-n-time-windows`
+- Added directional directory level for file-based connection exchange. For each connection, there is now a directory in `precice-run` of the form `Accepter-Requestor`.
+- Added step to remove the connection directories after connecting the slaves. `precice-run` will be empty after a successful run.
 - Restructure tools and bindings
   - Moved developer tools to `tools/`
   - Moved user tools to `extras/`

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -120,6 +120,7 @@ void MVQNAcceleration::initialize(
         _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::MasterSlave::getRank()), "", "", 0, 1);
         _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "", utils::MasterSlave::getRank());
       }
+      _cyclicCommLeft->cleanupEstablishment("cyclicComm-" + std::to_string(prevProc), "");
     }
   }
 

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -167,6 +167,7 @@ BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp, *boost::unit_test::fixture<testing:
     _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::Parallel::getProcessRank()), "", "Test", 0, 1);
     _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "Test", utils::Parallel::getProcessRank());
   }
+  _cyclicCommLeft->cleanupEstablishment("cyclicComm-" + std::to_string(prevProc), "");
 
   int              n_global = 10, m_global = 5;
   int              n_local;

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -155,13 +155,19 @@ public:
 
   /**
    * @brief Prepare environment used to establish the communication.
+   *
+   * @todo doc
    */
-  virtual void prepareEstablishment() {}
+  virtual void prepareEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) {}
 
   /**
    * @brief Clean-up environment used to establish the communication.
+   *
+   * @todo doc
    */
-  virtual void cleanupEstablishment() {}
+  virtual void cleanupEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) {}
 
   /// @}
 

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -156,7 +156,8 @@ public:
   /**
    * @brief Prepare environment used to establish the communication.
    *
-   * @todo doc
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
    */
   virtual void prepareEstablishment(std::string const &acceptorName,
                                     std::string const &requesterName) {}
@@ -164,7 +165,8 @@ public:
   /**
    * @brief Clean-up environment used to establish the communication.
    *
-   * @todo doc
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
    */
   virtual void cleanupEstablishment(std::string const &acceptorName,
                                     std::string const &requesterName) {}

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -9,7 +9,7 @@
 namespace precice {
 namespace com {
 
-std::string ConnectionInfoPublisher::getFilename() const
+std::string impl::hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &tag, int rank)
 {
   using namespace boost::filesystem;
 
@@ -22,7 +22,33 @@ std::string ConnectionInfoPublisher::getFilename() const
   std::string                  hash = boost::uuids::to_string(gen(s));
   hash.erase(std::remove(hash.begin(), hash.end(), '-'), hash.end());
 
-  path p = path(addressDirectory) / path("precice-run") / path(hash.substr(0, firstLevelLen)) / hash.substr(firstLevelLen);
+  path p = path(hash.substr(0, firstLevelLen)) / hash.substr(firstLevelLen);
+
+  return p.string();
+}
+
+std::string impl::localDirectory(const std::string &acceptorName, const std::string &requesterName, const std::string &addressDirectory)
+{
+  using namespace boost::filesystem;
+  std::string directional = acceptorName + "-" + requesterName;
+
+  path p = path(addressDirectory) / path("precice-run") / path(directional);
+
+  return p.string();
+}
+
+std::string ConnectionInfoPublisher::getLocalDirectory() const
+{
+  return impl::localDirectory(acceptorName, requesterName, addressDirectory);
+}
+
+std::string ConnectionInfoPublisher::getFilename() const
+{
+  using namespace boost::filesystem;
+
+  auto local  = getLocalDirectory();
+  auto hashed = impl::hashedFilePath(acceptorName, requesterName, tag, rank);
+  path p      = path(getLocalDirectory()) / path(hashed);
 
   return p.string();
 }

--- a/src/com/ConnectionInfoPublisher.hpp
+++ b/src/com/ConnectionInfoPublisher.hpp
@@ -5,6 +5,20 @@
 namespace precice {
 namespace com {
 
+namespace impl {
+/// Returns the file name for the connection information.
+/**
+   * It has the form first two letters from hash of 
+   * (acceptorName, requesterName, mesh, rank)/rest of hash.
+   */
+std::string hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &meshName, int rank);
+
+/** Returns the local directory which is the root for storing connection information.
+   * It has the form addressDirectory/precice-run/acceptorName-requesterName
+   */
+std::string localDirectory(const std::string &acceptorName, const std::string &requesterName, const std::string &addressDirectory);
+} // namespace impl
+
 class ConnectionInfoPublisher {
 public:
   ConnectionInfoPublisher(std::string acceptorName,
@@ -38,11 +52,10 @@ protected:
   int const         rank = -1;
   std::string const addressDirectory;
 
-  /// Returns the file name for the connection information.
-  /**
-   * It has the form addressDirectory/precice-run/first two letters from hash of 
-   * (acceptorName, requesterName, rank)/rest of hash.
-   */
+  /// Returns the local directory which is used to store the hashed part.
+  std::string getLocalDirectory() const;
+
+  /// Returns the full path to the hashed filename
   std::string getFilename() const;
 
   mutable logging::Logger _log{"com::ConnectionInfoPublisher"};

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -4,6 +4,7 @@
 #include "ConnectionInfoPublisher.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
+#include <boost/filesystem.hpp>
 
 namespace precice {
 namespace com {
@@ -185,6 +186,32 @@ void MPIPortsCommunication::closeConnection()
   }
 
   _isConnected = false;
+}
+
+void MPIPortsCommunication::prepareEstablishment(std::string const &acceptorName,
+                                                 std::string const &requesterName)
+{
+  using namespace boost::filesystem;
+  path dir = com::impl::localDirectory(acceptorName, requesterName, _addressDirectory);
+  PRECICE_DEBUG("Creating connection exchange directory " << dir);
+  try {
+    create_directories(dir);
+  } catch (const boost::filesystem::filesystem_error &e) {
+    PRECICE_WARN("Creating directory for connection info failed with: " << e.what());
+  }
+}
+
+void MPIPortsCommunication::cleanupEstablishment(std::string const &acceptorName,
+                                                 std::string const &requesterName)
+{
+  using namespace boost::filesystem;
+  path dir = com::impl::localDirectory(acceptorName, requesterName, _addressDirectory);
+  PRECICE_DEBUG("Removing connection exchange directory " << dir);
+  try {
+    remove_all(dir);
+  } catch (const boost::filesystem::filesystem_error &e) {
+    PRECICE_WARN("Cleaning up connection info failed with: " << e.what());
+  }
 }
 
 MPI_Comm &MPIPortsCommunication::communicator(int rank)

--- a/src/com/MPIPortsCommunication.hpp
+++ b/src/com/MPIPortsCommunication.hpp
@@ -46,6 +46,12 @@ public:
 
   virtual void closeConnection() override;
 
+  virtual void prepareEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) override;
+
+  virtual void cleanupEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) override;
+
 private:
   virtual MPI_Comm &communicator(int rank) override;
 

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -5,6 +5,7 @@
 #include "utils/MasterSlave.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
+#include <boost/filesystem.hpp>
 
 namespace precice {
 namespace com {
@@ -82,8 +83,7 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
 }
 
 /// requesterCommunicatorSize is not used, since connection is always made on the entire communicator
-void MPISinglePortsCommunication::acceptConnectionAsServer(
-    std::string const &acceptorName,
+void MPISinglePortsCommunication::acceptConnectionAsServer( std::string const &acceptorName,
     std::string const &requesterName,
     std::string const &tag,
     int                acceptorRank,

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -1,11 +1,11 @@
 #ifndef PRECICE_NO_MPI
 
 #include "MPISinglePortsCommunication.hpp"
+#include <boost/filesystem.hpp>
 #include "ConnectionInfoPublisher.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
-#include <boost/filesystem.hpp>
 
 namespace precice {
 namespace com {
@@ -83,11 +83,11 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
 }
 
 /// requesterCommunicatorSize is not used, since connection is always made on the entire communicator
-void MPISinglePortsCommunication::acceptConnectionAsServer( std::string const &acceptorName,
-    std::string const &requesterName,
-    std::string const &tag,
-    int                acceptorRank,
-    int                requesterCommunicatorSize)
+void MPISinglePortsCommunication::acceptConnectionAsServer(std::string const &acceptorName,
+                                                           std::string const &requesterName,
+                                                           std::string const &tag,
+                                                           int                acceptorRank,
+                                                           int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
   PRECICE_ASSERT(not isConnected());
@@ -190,6 +190,32 @@ MPI_Comm &MPISinglePortsCommunication::communicator(int rank)
 int MPISinglePortsCommunication::rank(int rank)
 {
   return rank;
+}
+
+void MPISinglePortsCommunication::prepareEstablishment(std::string const &acceptorName,
+                                                       std::string const &requesterName)
+{
+  using namespace boost::filesystem;
+  path dir = com::impl::localDirectory(acceptorName, requesterName, _addressDirectory);
+  PRECICE_DEBUG("Creating connection exchange directory " << dir);
+  try {
+    create_directories(dir);
+  } catch (const boost::filesystem::filesystem_error &e) {
+    PRECICE_WARN("Creating directory for connection info failed with: " << e.what());
+  }
+}
+
+void MPISinglePortsCommunication::cleanupEstablishment(std::string const &acceptorName,
+                                                       std::string const &requesterName)
+{
+  using namespace boost::filesystem;
+  path dir = com::impl::localDirectory(acceptorName, requesterName, _addressDirectory);
+  PRECICE_DEBUG("Removing connection exchange directory " << dir);
+  try {
+    remove_all(dir);
+  } catch (const boost::filesystem::filesystem_error &e) {
+    PRECICE_WARN("Cleaning up connection info failed with: " << e.what());
+  }
 }
 
 } // namespace com

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -58,6 +58,12 @@ public:
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) override;
 
+  virtual void prepareEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) override;
+
+  virtual void cleanupEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) override;
+
   virtual void closeConnection() override;
 
 private:

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -1,6 +1,7 @@
 #include "SocketCommunication.hpp"
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
+#include <boost/filesystem.hpp>
 #include <sstream>
 #include "ConnectionInfoPublisher.hpp"
 #include "SocketRequest.hpp"
@@ -345,6 +346,32 @@ void SocketCommunication::send(const int *itemsToSend, int size, int rankReceive
     asio::write(*_sockets[rankReceiver], asio::buffer(itemsToSend, size * sizeof(int)));
   } catch (std::exception &e) {
     PRECICE_ERROR("Send failed: " << e.what());
+  }
+}
+
+void SocketCommunication::prepareEstablishment(std::string const &acceptorName,
+                                               std::string const &requesterName)
+{
+  using namespace boost::filesystem;
+  path dir = com::impl::localDirectory(acceptorName, requesterName, _addressDirectory);
+  PRECICE_DEBUG("Creating connection exchange directory " << dir);
+  try {
+    create_directories(dir);
+  } catch (const boost::filesystem::filesystem_error &e) {
+    PRECICE_WARN("Creating directory for connection info failed with: " << e.what());
+  }
+}
+
+void SocketCommunication::cleanupEstablishment(std::string const &acceptorName,
+                                               std::string const &requesterName)
+{
+  using namespace boost::filesystem;
+  path dir = com::impl::localDirectory(acceptorName, requesterName, _addressDirectory);
+  PRECICE_DEBUG("Removing connection exchange directory " << dir);
+  try {
+    remove_all(dir);
+  } catch (const boost::filesystem::filesystem_error &e) {
+    PRECICE_WARN("Cleaning up connection info failed with: " << e.what());
   }
 }
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -124,6 +124,12 @@ public:
   void send(std::vector<double> const &v, int rankReceiver) override;
   void receive(std::vector<double> &v, int rankSender) override;
 
+  virtual void prepareEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) override;
+
+  virtual void cleanupEstablishment(std::string const &acceptorName,
+                                    std::string const &requesterName) override;
+
 private:
   logging::Logger _log{"com::SocketCommunication"};
 

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -9,7 +9,11 @@ namespace m2n {
 
 void BoundM2N::prepareEstablishment()
 {
-  m2n->prepareEstablishment();
+  if (isRequesting) {
+    m2n->prepareEstablishment(remoteName, localName);
+  } else {
+    m2n->prepareEstablishment(localName, remoteName);
+  }
 }
 
 void BoundM2N::connectMasters()
@@ -61,7 +65,11 @@ void BoundM2N::preConnectSlaves()
 
 void BoundM2N::cleanupEstablishment()
 {
-  m2n->cleanupEstablishment();
+  if (isRequesting) {
+    m2n->cleanupEstablishment(remoteName, localName);
+  } else {
+    m2n->cleanupEstablishment(localName, remoteName);
+  }
 }
 
 } // namespace m2n

--- a/src/m2n/BoundM2N.hpp
+++ b/src/m2n/BoundM2N.hpp
@@ -8,7 +8,8 @@ namespace precice {
 namespace m2n {
 
 /// An M2N between participants with a configured direction
-struct BoundM2N {
+class BoundM2N {
+public:
   /// Prepare to establish the connection
   void prepareEstablishment();
 
@@ -31,6 +32,14 @@ struct BoundM2N {
 
 private:
   mutable logging::Logger _log{"impl::SolverInterfaceImpl"};
+
+  /** Instructs the Master wait for Slaves.
+   *
+   * Performs a collective operation which forces every slave to sync with the Master.
+   * 
+   * @note this does nothing if the participant is running serially.
+   */
+  void waitForSlaves();
 };
 
 } // namespace m2n

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -103,16 +103,18 @@ void M2N::requestSlavesConnection(
   PRECICE_ASSERT(_areSlavesConnected);
 }
 
-void M2N::prepareEstablishment()
+void M2N::prepareEstablishment(const std::string &acceptorName,
+                               const std::string &requesterName)
 {
   PRECICE_TRACE();
-  _masterCom->prepareEstablishment();
+  _masterCom->prepareEstablishment(acceptorName, requesterName);
 }
 
-void M2N::cleanupEstablishment()
+void M2N::cleanupEstablishment(const std::string &acceptorName,
+                               const std::string &requesterName)
 {
   PRECICE_TRACE();
-  _masterCom->cleanupEstablishment();
+  _masterCom->cleanupEstablishment(acceptorName, requesterName);
 }
 
 void M2N::acceptSlavesPreConnection(

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -95,8 +95,11 @@ public:
    *
    * @see com::Communication::prepareEstablishment()
    * @see cleanupEstablishment()
+   *
+   * @todo doc
    */
-  void prepareEstablishment();
+  void prepareEstablishment(const std::string &acceptorName,
+                            const std::string &requesterName);
 
   /**
    * @brief cleans-up to establish the connections
@@ -106,8 +109,11 @@ public:
    *
    * @see com::Communication::cleanupEstablishment()
    * @see prepareEstablishment()
+   *
+   * @todo doc
    */
-  void cleanupEstablishment();
+  void cleanupEstablishment(const std::string &acceptorName,
+                            const std::string &requesterName);
 
   /**
    * @brief Disconnects from communication space, i.e. participant.

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -93,10 +93,11 @@ public:
    * This should be called before calling the accept and request methods.
    * Calling this function forwards the call to the configured master communication.
    *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
+   *
    * @see com::Communication::prepareEstablishment()
    * @see cleanupEstablishment()
-   *
-   * @todo doc
    */
   void prepareEstablishment(const std::string &acceptorName,
                             const std::string &requesterName);
@@ -107,10 +108,11 @@ public:
    * This should be called after calling the accept and request methods.
    * Calling this function forwards the call to the configured master communication.
    *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
+   *
    * @see com::Communication::cleanupEstablishment()
    * @see prepareEstablishment()
-   *
-   * @todo doc
    */
   void cleanupEstablishment(const std::string &acceptorName,
                             const std::string &requesterName);

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -210,7 +210,12 @@ double SolverInterfaceImpl::initialize()
   for (auto &m2nPair : _m2ns) {
     auto &bm2n = m2nPair.second;
     bm2n.connectSlaves();
-    bm2n.cleanupEstablishment();
+    PRECICE_DEBUG("Established slaves connection " << (bm2n.isRequesting ? "from " : "to ") << bm2n.remoteName);
+  }
+  PRECICE_INFO("Slaves are connected");
+  
+  for (auto &m2nPair : _m2ns) {
+    m2nPair.second.cleanupEstablishment();
   }
 
   PRECICE_INFO("Slaves are connected");
@@ -1402,8 +1407,10 @@ void SolverInterfaceImpl::initializeMasterSlaveCommunication()
   int rankOffset = 1;
   if (utils::MasterSlave::isMaster()) {
     PRECICE_INFO("Setting up communication to slaves");
+    utils::MasterSlave::_communication->prepareEstablishment(_accessorName + "Master", _accessorName);
     utils::MasterSlave::_communication->acceptConnection(_accessorName + "Master", _accessorName, "MasterSlave", utils::MasterSlave::getRank());
     utils::MasterSlave::_communication->setRankOffset(rankOffset);
+    utils::MasterSlave::_communication->cleanupEstablishment(_accessorName + "Master", _accessorName);
   } else {
     PRECICE_ASSERT(utils::MasterSlave::isSlave());
     utils::MasterSlave::_communication->requestConnection(_accessorName + "Master", _accessorName, "MasterSlave",

--- a/src/testing/Fixtures.hpp
+++ b/src/testing/Fixtures.hpp
@@ -29,6 +29,7 @@ struct MasterComFixture {
       utils::MasterSlave::configure(0, size);
       utils::MasterSlave::_communication->acceptConnection("Master", "Slaves", "Test", utils::Parallel::getProcessRank());
       utils::MasterSlave::_communication->setRankOffset(1);
+      utils::MasterSlave::_communication->cleanupEstablishment("Master", "Slaves");
     } else { //Slaves
       PRECICE_ASSERT(utils::Parallel::getProcessRank() > 0 && utils::Parallel::getProcessRank() < size);
       utils::Parallel::splitCommunicator("Slaves");


### PR DESCRIPTION
This PR:
* Adds a an additional folder level in the `precice-run` directory of the form `Acceptor-Requestor`.
* Adds a step that cleans up the above folder after successfully connecting all slaves.
  Consequentially, the `precice-run` folder will be empty if everything worked as expected. 

Closes #430 