### PR TITLE
Add Examples to Installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ All notable changes to this project will be documented in this file. For future 
 - Added information to the log of the first written Data values.
 - Changed unit tests to run only on MPI Rank 0.
 - Removed deprecated SCons.
-
+- Added `examples/` to installation and package
 
 ## 1.6.1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,12 @@ if(PRECICE_InstallTest)
     )
 endif()
 
+# Install examples
+install(DIRECTORY examples
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/precice
+  PATTERN ".gitignore" EXCLUDE
+  )
+
 # Export the Targets to install
 install(EXPORT preciceTargets
   FILE preciceTargets.cmake


### PR DESCRIPTION
This PR adds the directory `examples/` to the installation and thus to the packages.