### PR TITLE
Add option to pass custom MPI communicator to Fortran bindings

### DIFF
--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -33,6 +33,23 @@ void precicec_createSolverInterface(
     int         solverProcessIndex,
     int         solverProcessSize);
 
+/**
+ * @param[in] participantName Name of the participant using the interface. Has to
+ *        match the name given for a participant in the xml configuration file.
+ * @param[in] configurationFileName Name (with path) of the xml configuration file.
+ * @param[in] solverProcessIndex If the solver code runs with several processes,
+ *        each process using preCICE has to specify its index, which has to start
+ *        from 0 and end with solverProcessSize - 1.
+ * @param[in] solverProcessSize The number of solver processes using preCICE.
+ * @param[in] communicator A pointer to an MPI_Comm to use as MPI_COMM_WORLD.
+ */
+void precicec_createSolverInterface_withCommunicator(
+    const char *participantName,
+    const char *configFileName,
+    int         solverProcessIndex,
+    int         solverProcessSize,
+    void *      communicator);
+
 ///@}
 
 /// @name Steering Methods

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -22,6 +22,22 @@ void precicec_createSolverInterface(
                                            solverProcessSize);
 }
 
+void precicec_createSolverInterface_withCommunicator(
+    const char *participantName,
+    const char *configFileName,
+    int         solverProcessIndex,
+    int         solverProcessSize,
+    void *      communicator)
+{
+  std::string stringAccessorName(participantName);
+  std::string stringConfigFileName(configFileName);
+  interface = new precice::SolverInterface(stringAccessorName,
+                                           stringConfigFileName,
+                                           solverProcessIndex,
+                                           solverProcessSize,
+                                           communicator);
+}
+
 double precicec_initialize()
 {
   PRECICE_ASSERT(interface != nullptr);

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -35,6 +35,29 @@ void precicef_create_(
     int         lengthConfigFileName);
 
 /**
+ * @brief See precice::SolverInterface::SolverInterface() and ...::configure().
+ *
+ * Fortran syntax:
+ * precicef_create(
+ *   CHARACTER participantName(*),
+ *   CHARACTER configFileName(*),
+ *   INTEGER   solverProcessIndex,
+ *   INTEGER   solverProcessSize,
+ *   INTEGER   communicator )
+ *
+ * IN:  participantName, configFileName, solverProcessIndex, solverProcessSize, communicator
+ * OUT: -
+ */
+void precicef_create_with_communicator_(
+    const char *participantName,
+    const char *configFileName,
+    const int * solverProcessIndex,
+    const int * solverProcessSize,
+    int       * communicator,
+    int         lengthAccessorName,
+    int         lengthConfigFileName);
+
+/**
  * @brief See precice::SolverInterface::initialize().
  *
  * Fortran syntax:

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -46,6 +46,31 @@ void precicef_create_(
                                       *solverProcessIndex, *solverProcessSize);
 }
 
+void precicef_create_with_communicator_(
+    const char *participantName,
+    const char *configFileName,
+    const int * solverProcessIndex,
+    const int * solverProcessSize,
+    int       * communicator,
+    int         lengthAccessorName,
+    int         lengthConfigFileName)
+{
+  //cout << "lengthAccessorName: " << lengthAccessorName << '\n';
+  //cout << "lengthConfigFileName: " << lengthConfigFileName << '\n';
+  //cout << "solverProcessIndex: " << *solverProcessIndex << '\n';
+  //cout << "solverProcessSize: " << *solverProcessSize << '\n';
+  //cout << "communicator: " << *communicator << '\n';
+  int    strippedLength = precice::impl::strippedLength(participantName, lengthAccessorName);
+  string stringAccessorName(participantName, strippedLength);
+  strippedLength = precice::impl::strippedLength(configFileName, lengthConfigFileName);
+  string stringConfigFileName(configFileName, strippedLength);
+  //cout << "Accessor: " << stringAccessorName << "!" << '\n';
+  //cout << "Config  : " << stringConfigFileName << "!" << '\n';
+  impl = new precice::SolverInterface(stringAccessorName,
+                                      stringConfigFileName,
+                                      *solverProcessIndex, *solverProcessSize, &communicator);
+}
+
 void precicef_initialize_(
     double *timestepLengthLimit)
 {


### PR DESCRIPTION
In #382 we introduced (in the C++ API) the option to pass an MPI communicator. In #649 we extended this for C and tested it with the C solver dummy.

I implement the same for the Fortran bindings here, however this method is untested (and maybe wrong). I was not able to make it work with the Fortran solverdummy and I am unsure how to pass the communicator correctly through the differenet layers and languages.

I tried the following in the solver dummy (built with mpifort):
```fortran
Program main
    use mpi
   ! ... more declarations ...

   integer :: ierror, comm
   call MPI_INIT(ierror)
   call MPI_COMM_SIZE(MPI_COMM_WORLD, commsize, ierror)
   call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierror)

   ! ... more stuff

   call precicef_create_with_communicator(participantName, config, rank, commsize, MPI_COMM_WORLD)
```

This leads to the following error:

```
preCICE: No coupling scheme exists for the participant
preCICE: No coupling scheme exists for the participant
[Magdalena:9519] *** An error occurred in MPI_Comm_rank
[Magdalena:9519] *** reported by process [1268056065,0]
[Magdalena:9519] *** on communicator MPI_COMM_WORLD
[Magdalena:9519] *** MPI_ERR_COMM: invalid communicator
```

Notice here that in the C solver dummy we cannot directly pass `MPI_COMM_WORLD`, so there I defined another communicator, copied `MPI_COMM_WORLD` to that and passed its reference as `&comm`.

In Fortran, I also tried defining another integer as a copy and use that one instead of `MPI_COMM_WORLD`, but I got the same error. I still need deeper understanding of the situation.

Related to #649, #520, #382.