### PR TITLE
C bindings: Rename isCouplingTimeWindowComplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. For future 
 - Replaced geometric filter option "filter-first" and "broadcast-filter" by "on-master" and "on-slaves", respectively, to generalize to two-level initialization.
 - Sorted out the different meaning of timestep and time window:
   - Renamed API function `isTimestepComplete` to `isTimeWindowComplete`.
+  - Renamed C bindings function `precicec_isCouplingTimestepComplete` to `precicec_isTimeWindowComplete`.
   - Renamed `cplscheme` configuration option `timestep-length` to `time-window-size`.
   - Renamed `cplscheme` configuration option `max-timesteps` to `max-time-windows`.
   - Renamed `acceleration` configuration option `timesteps-reused` to `time-windows-reused`.

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -95,7 +95,7 @@ int precicec_isWriteDataRequired(double computedTimestepLength);
 /**
  * @brief Returns true (->1), if the coupling time window is completed.
  */
-int precicec_isCouplingTimeWindowComplete();
+int precicec_isTimeWindowComplete();
 
 /**
  * @brief Returns whether the solver has to evaluate the surrogate model representation.

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -61,7 +61,7 @@ int precicec_isCouplingOngoing()
   return 0;
 }
 
-int precicec_isCouplingTimeWindowComplete()
+int precicec_isTimeWindowComplete()
 {
   PRECICE_ASSERT(interface != nullptr);
   if (interface->isTimeWindowComplete()) {


### PR DESCRIPTION
to isTimeWindowComplete for consistency.

Related to #520.