### PR TITLE
Reorder Logging Setup and MPI Initalisation

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -233,8 +233,6 @@ double SolverInterfaceImpl::initialize()
     m2nPair.second.cleanupEstablishment();
   }
 
-  PRECICE_INFO("Slaves are connected");
-
   PRECICE_DEBUG("Initialize watchpoints");
   for (PtrWatchPoint &watchPoint : _accessor->watchPoints()) {
     watchPoint->initialize();

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -109,8 +109,9 @@ SolverInterfaceImpl::SolverInterfaceImpl(
 void SolverInterfaceImpl::configure(
     const std::string &configurationFileName)
 {
+  config::Configuration config;
   utils::Parallel::initializeMPI(nullptr, nullptr);
-  config::Configuration     config;
+  logging::setMPIRank(utils::Parallel::getProcessRank());
   xml::ConfigurationContext context{
       _accessorName,
       _accessorProcessRank,
@@ -178,7 +179,6 @@ void SolverInterfaceImpl::configure(
     _meshLock.add(meshID.second, false);
   }
 
-  logging::setMPIRank(utils::Parallel::getProcessRank());
   utils::EventRegistry::instance().initialize("precice-" + _accessorName, "", utils::Parallel::getGlobalCommunicator());
 
   PRECICE_DEBUG("Initialize master-slave communication");

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -88,24 +88,6 @@ public:
       void *             communicator);
 
   /**
-   * @brief Configures the coupling interface from the given xml file.
-   *
-   * Only after the configuration a reasonable state of a SolverInterfaceImpl
-   * object is achieved.
-   *
-   * @param configurationFileName [IN] Name (with path) of the xml config. file.
-   */
-  void configure(const std::string &configurationFileName);
-
-  /**
-   * @brief Configures the coupling interface with a prepared configuration.
-   *
-   * Can be used to configure the SolverInterfaceImpl without xml file. Requires
-   * to manually setup the configuration object.
-   */
-  void configure(const config::SolverInterfaceConfiguration &configuration);
-
-  /**
    * @brief Initializes all coupling data and starts (coupled) simulation.
    *
    * - Initiates MPI communication, if not done yet.
@@ -537,6 +519,25 @@ private:
   /// Counts calls to advance for plotting.
   long int _numberAdvanceCalls = 0;
 
+  /**
+   * @brief Configures the coupling interface from the given xml file.
+   *
+   * Only after the configuration a reasonable state of a SolverInterfaceImpl
+   * object is achieved.
+   *
+   * @param configurationFileName [IN] Name (with path) of the xml config. file.
+   */
+  void configure(const std::string &configurationFileName);
+
+  /**
+   * @brief Configures the coupling interface with a prepared configuration.
+   *
+   * Can be used to configure the SolverInterfaceImpl without xml file. Requires
+   * to manually setup the configuration object.
+   */
+  void configure(const config::SolverInterfaceConfiguration &configuration);
+
+
   void configureM2Ns(const m2n::M2NConfiguration::SharedPointer &config);
 
   /// Exports meshes with data and watch point data.
@@ -625,6 +626,7 @@ private:
 
   /// To allow white box tests.
   friend struct PreciceTests::Serial::TestConfiguration;
+
 };
 
 } // namespace impl


### PR DESCRIPTION
Currently, MPI will be initialized prior to creating the `Configuration`, which configures the logger.
`utils::Parallel::initializeMPI` uses `PRECICE_TRACE` which results in weird output #660.

We initialise the logger during the construction of the `Configuration`:
https://github.com/precice/precice/blob/65a67b4df88151d50baec8c7cd462abecc8d34bb/src/logging/config/LogConfiguration.cpp#L6-L11

Thus we can reorder the call-site from:
https://github.com/precice/precice/blob/910feb378cc7fc2b8275f7b664b48d2db76d172e/src/precice/impl/SolverInterfaceImpl.cpp#L109-L113
to:
https://github.com/precice/precice/blob/b7523a78f7374fd9e63bbd85f817972e513b00b0/src/precice/impl/SolverInterfaceImpl.cpp#L109-L114


Note: this reordering will lead to `getProcessRank()` being called during `PRECICE_ASSERT` prior to the call to `utils::Parallel::initializeMPI`, which is save as it always returns `0`.
This change now requires calling the `string` version of configure. I make both versions private as they are not required to be public since #614 

@uekerman Does this solve your problem?


Closes #660