### PR TITLE
Give details for develop and master branch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,12 +23,12 @@
 </a>
 
 ``precice/master``  
-[![MasterBuild](https://travis-ci.org/precice/precice.svg?branch=master)](https://travis-ci.org/precice/precice)
-[![MasterSystemtests](https://img.shields.io/travis/precice/systemtests/master.svg?label=system%20tests&style=flat)](https://travis-ci.org/precice/systemtests)
+[![MasterBuild](https://travis-ci.org/precice/precice.svg?branch=master)](https://travis-ci.org/precice/precice/branches)
+[![MasterSystemtests](https://img.shields.io/travis/precice/systemtests/master.svg?label=system%20tests&style=flat)](https://travis-ci.org/precice/systemtests/branches)
 
 ``precice/develop``  
-[![DevelopBuild](https://travis-ci.org/precice/precice.svg?branch=develop)](https://travis-ci.org/precice/precice)
-[![DevelopSystemtests](https://img.shields.io/travis/precice/systemtests/develop.svg?label=system%20tests&style=flat)](https://travis-ci.org/precice/systemtests)
+[![DevelopBuild](https://travis-ci.org/precice/precice.svg?branch=develop)](https://travis-ci.org/precice/precice/branches)
+[![DevelopSystemtests](https://img.shields.io/travis/precice/systemtests/develop.svg?label=system%20tests&style=flat)](https://travis-ci.org/precice/systemtests/branches)
 
 **Code Quality**  
 [![CodeFactor](https://www.codefactor.io/repository/github/precice/precice/badge)](https://www.codefactor.io/repository/github/precice/precice)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,13 +25,13 @@
 ``master`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=master" alt="Build status">
 </a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">    
-    <img src="https://travis-ci.org/precice/systemtests.svg?branch=master" alt="Build status">
+    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat&branch=master" alt="Build status">
 </a>
 
 ``develop`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
 </a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">    
-    <img src="https://travis-ci.org/precice/systemtests.svg?branch=develop" alt="Build status">
+    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat&branch=develop" alt="Build status">
 </a>
 
 **Code Quality**  

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,13 +22,15 @@
     <img src="https://img.shields.io/github/release/precice/precice.svg" alt="Release">
 </a>
 
-``master`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
+``master`` branch: 
+<a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=master" alt="Build status">
 </a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=master" target="_blank">    
     <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
 </a>
 
-``develop`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
+``develop`` branch: 
+<a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
 </a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=develop" target="_blank">    
     <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,14 +24,14 @@
 
 ``master`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=master" alt="Build status">
-</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">    
-    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat&branch=master" alt="Build status">
+</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=master" target="_blank">    
+    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
 </a>
 
 ``develop`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
-</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">    
-    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat&branch=develop" alt="Build status">
+</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=develop" target="_blank">    
+    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
 </a>
 
 **Code Quality**  

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,17 +22,13 @@
     <img src="https://img.shields.io/github/release/precice/precice.svg" alt="Release">
 </a>
 
-``master`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
-    <img src="https://travis-ci.org/precice/precice.svg?branch=master" alt="Build status">
-</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=master" target="_blank">    
-    <img src="https://img.shields.io/travis/precice/systemtests/master.svg?label=system%20tests&style=flat" alt="Build status">
-</a>
+``precice/master``  
+[![MasterBuild](https://travis-ci.org/precice/precice.svg?branch=master)](https://travis-ci.org/precice/precice)
+[![MasterSystemtests](https://img.shields.io/travis/precice/systemtests/master.svg?label=system%20tests&style=flat)](https://travis-ci.org/precice/systemtests)
 
-``develop`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
-    <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
-</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=develop" target="_blank">    
-    <img src="https://img.shields.io/travis/precice/systemtests/develop.svg?label=system%20tests&style=flat" alt="Build status">
-</a>
+``precice/develop``  
+[![DevelopBuild](https://travis-ci.org/precice/precice.svg?branch=develop)](https://travis-ci.org/precice/precice)
+[![DevelopSystemtests](https://img.shields.io/travis/precice/systemtests/develop.svg?label=system%20tests&style=flat)](https://travis-ci.org/precice/systemtests)
 
 **Code Quality**  
 [![CodeFactor](https://www.codefactor.io/repository/github/precice/precice/badge)](https://www.codefactor.io/repository/github/precice/precice)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,11 +21,17 @@
 <a style="text-decoration: none" href="https://github.com/precice/precice/releases/latest" target="_blank">
     <img src="https://img.shields.io/github/release/precice/precice.svg" alt="Release">
 </a>
-<a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">
-    <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
+
+``master`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
+    <img src="https://travis-ci.org/precice/precice.svg?branch=master" alt="Build status">
+</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">    
+    <img src="https://travis-ci.org/precice/systemtests.svg?branch=master" alt="Build status">
 </a>
-<a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">
-    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
+
+``develop`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
+    <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
+</a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">    
+    <img src="https://travis-ci.org/precice/systemtests.svg?branch=develop" alt="Build status">
 </a>
 
 **Code Quality**  

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,18 +22,16 @@
     <img src="https://img.shields.io/github/release/precice/precice.svg" alt="Release">
 </a>
 
-``master`` branch: 
-<a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
+``master`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=master" alt="Build status">
 </a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=master" target="_blank">    
-    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
+    <img src="https://img.shields.io/travis/precice/systemtests/master.svg?label=system%20tests&style=flat" alt="Build status">
 </a>
 
-``develop`` branch: 
-<a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
+``develop`` branch: <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">    
     <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
 </a> <a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests.svg?branch=develop" target="_blank">    
-    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
+    <img src="https://img.shields.io/travis/precice/systemtests/develop.svg?label=system%20tests&style=flat" alt="Build status">
 </a>
 
 **Code Quality**  


### PR DESCRIPTION
The project status part in our `README.md` file often looks much worse than it acutally is:

![Screenshot from 2020-02-05 10-16-32](https://user-images.githubusercontent.com/5740604/73827909-a85ba680-4800-11ea-9b29-59b3003528bd.png)

Often the system tests are shown as failing. However, this is often only the case for the develop branch and for master everything should be fine. But the way we are presenting the project status currently suggests that our tests are failing for the actual release.