### PR TITLE
Fix and Reword the Main Doxygen Page

### DIFF
--- a/docs/documents/000_main.dox
+++ b/docs/documents/000_main.dox
@@ -16,10 +16,10 @@ Please refer to the github wiki and the documentation of the \ref precice::Solve
 - \ref tooling
 - \ref releases
 
-The directory `src` contains the sources of preCICE. The library API of preCICE
-is contained in the directory $precice$, which brings together the functionalities
-contained in the other components of preCICE. Every component has its own
-directory and namespace.
+The directory \ref src contains the sources of preCICE.
+Every component has its own directory and namespace. The namespaces of internal components are all rooted in the project namespace \ref precice.
+The library API of preCICE is contained in the directory and namespace \ref precice, which brings together the functionalities of all components.
+
 The following components currently exist:
 
 - \ref precice::acceleration "acceleration" provides various acceleration schemes.
@@ -44,6 +44,5 @@ The components of preCICE have some common subdirectory/namespace structure. Som
 - ```tests``` holds classes for automated testing of the corresponding component.
 - ```config``` provides functionality to configure the classes of a component from xml files.
 - ```impl``` contains implementation of a component which is not part of its interface and used only internally.
-
 
 */


### PR DESCRIPTION
This PR fixes the small problem pointed out by @renefritze.
I also reworded the first paragraph a bit and added some directory reference.

![image](https://user-images.githubusercontent.com/13552216/73839211-ba940f80-4815-11ea-8467-a04697b2ffef.png)
