### PR TITLE
Extend accumulator to handle no samples.

### DIFF
--- a/src/utils/Statistics.hpp
+++ b/src/utils/Statistics.hpp
@@ -27,19 +27,25 @@ public:
   /// Returns the minimum of all accumulated values
   double min() const
   {
-    return boost::accumulators::extract::min(_acc);
+    return empty() ? std::nan("") : boost::accumulators::extract::min(_acc);
   }
 
   /// Returns the maximum of all accumulated values
   double max() const
   {
-    return boost::accumulators::extract::max(_acc);
+    return empty() ? std::nan("") : boost::accumulators::extract::max(_acc);
   }
 
   /// Returns the mean of all accumulated values
   double mean() const
   {
-    return boost::accumulators::extract::mean(_acc);
+    return empty() ? std::nan("") : boost::accumulators::extract::mean(_acc);
+  }
+
+  /// Returns the sample variance based on all accumulated values
+  double variance() const
+  {
+    return empty() ? std::nan("") : boost::accumulators::extract::variance(_acc);
   }
 
   /// Returns how many values have been accumulated
@@ -48,10 +54,10 @@ public:
     return boost::accumulators::extract::count(_acc);
   }
 
-  /// Returns the sample variance based on all accumulated values
-  double variance() const
+  /// Returns count == 0
+  bool empty() const
   {
-    return boost::accumulators::extract::variance(_acc);
+    return count() == 0;
   }
 
 private:

--- a/src/utils/Statistics.hpp
+++ b/src/utils/Statistics.hpp
@@ -71,11 +71,15 @@ private:
 
 inline std::ostream &operator<<(std::ostream &out, const DistanceAccumulator &accumulator)
 {
-  out << "min:" << accumulator.min()
-      << " max:" << accumulator.max()
-      << " avg: " << accumulator.mean()
-      << " var: " << accumulator.variance()
-      << " cnt: " << accumulator.count();
+  if (accumulator.empty()) {
+    out << "empty";
+  } else {
+    out << "min:" << accumulator.min()
+        << " max:" << accumulator.max()
+        << " avg: " << accumulator.mean()
+        << " var: " << accumulator.variance()
+        << " cnt: " << accumulator.count();
+  }
   return out;
 };
 

--- a/src/utils/tests/StatisticsTest.cpp
+++ b/src/utils/tests/StatisticsTest.cpp
@@ -10,9 +10,13 @@ BOOST_AUTO_TEST_SUITE(UtilsTests)
 BOOST_AUTO_TEST_CASE(DistanceAccumulator, *testing::OnMaster())
 {
   pu::statistics::DistanceAccumulator acc;
-  acc(0);
-  BOOST_TEST(acc.min() == 0);
-  BOOST_TEST(acc.max() == 0);
+  acc(0.01);
+  BOOST_TEST(!acc.empty());
+  BOOST_TEST(acc.count() == 1);
+  BOOST_TEST(acc.min() == 0.01);
+  BOOST_TEST(acc.max() == 0.01);
+  BOOST_TEST(acc.mean() == 0.01);
+  BOOST_TEST(acc.variance() == 0);
 
   acc(1);
   acc(-1);
@@ -21,6 +25,17 @@ BOOST_AUTO_TEST_CASE(DistanceAccumulator, *testing::OnMaster())
   BOOST_TEST(acc.min() == -1);
   BOOST_TEST(acc.min() != 0);
   BOOST_TEST(acc.max() == 23);
+}
+
+BOOST_AUTO_TEST_CASE(DistanceAccumulatorOnEmptyMesh, *testing::OnMaster())
+{
+  pu::statistics::DistanceAccumulator acc;
+  BOOST_TEST(acc.empty());
+  BOOST_TEST(acc.count() == 0);
+  BOOST_TEST(std::isnan(acc.min()));
+  BOOST_TEST(std::isnan(acc.mean()));
+  BOOST_TEST(std::isnan(acc.max()));
+  BOOST_TEST(std::isnan(acc.variance()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tools/ci/travis-install-dependencies.sh
+++ b/tools/ci/travis-install-dependencies.sh
@@ -52,7 +52,7 @@ if [ ! -f $CACHE_PETSC_TOKEN ]; then
     # Configure and compile
     cd $LOCAL_INSTALL/petsc
     export PETSC_ARCH=arch-linux2-c-debug
-    python2 configure --with-debugging=1 --with-64-bit-indices > ~/petsc.configure
+    python configure --with-debugging=1 --with-64-bit-indices > ~/petsc.configure
     make > ~/petsc.make
     cd $LOCAL_INSTALL
     # Create token


### PR DESCRIPTION
This PR
* forces the statistics accumulator to return nan when it does not contain any values.
* adds an `empty()` check.
* prints `empty` if there was nothing accumulated.

Closes #679