### PR TITLE
Update timestep to timewindow in cplscheme

### DIFF
--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -15,11 +15,11 @@ void CompositionalCouplingScheme::addCouplingScheme(
 
 void CompositionalCouplingScheme::initialize(
     double startTime,
-    int    startTimestep)
+    int    startTimeWindow)
 {
-  PRECICE_TRACE(startTime, startTimestep);
+  PRECICE_TRACE(startTime, startTimeWindow);
   for (Scheme scheme : _couplingSchemes) {
-    scheme.scheme->initialize(startTime, startTimestep);
+    scheme.scheme->initialize(startTime, startTimeWindow);
   }
   determineActiveCouplingSchemes();
 }
@@ -83,28 +83,6 @@ void CompositionalCouplingScheme::finalize()
   }
 }
 
-//bool CompositionalCouplingScheme:: isDataUsed
-//(
-//  int dataID )
-//{
-//  PRECICE_TRACE(dataID);
-//  bool isUsed = false;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    isUsed |= couplingScheme->isDataUsed(dataID);
-//  }
-//  return isUsed;
-//}
-//
-//bool CompositionalCouplingScheme:: isDataUsed()
-//{
-//  PRECICE_TRACE();
-//  bool isUsed = false;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    isUsed |= couplingScheme->isDataUsed();
-//  }
-//  return isUsed;
-//}
-
 std::vector<std::string> CompositionalCouplingScheme::getCouplingPartners() const
 {
   PRECICE_TRACE();
@@ -157,17 +135,17 @@ double CompositionalCouplingScheme::getTime() const
   return time;
 }
 
-int CompositionalCouplingScheme::getTimesteps() const
+int CompositionalCouplingScheme::getTimeWindows() const
 {
   PRECICE_TRACE();
-  int timesteps = std::numeric_limits<int>::max();
+  int timeWindows = std::numeric_limits<int>::max();
   for (Scheme scheme : _couplingSchemes) {
     if (not scheme.onHold) {
-      timesteps = std::min(timesteps, scheme.scheme->getTimesteps());
+      timeWindows = std::min(timeWindows, scheme.scheme->getTimeWindows());
     }
   }
-  PRECICE_DEBUG("return " << timesteps);
-  return timesteps;
+  PRECICE_DEBUG("return " << timeWindows);
+  return timeWindows;
 }
 
 double CompositionalCouplingScheme::getMaxTime() const
@@ -181,59 +159,49 @@ double CompositionalCouplingScheme::getMaxTime() const
   return maxTime;
 }
 
-int CompositionalCouplingScheme::getMaxTimesteps() const
+int CompositionalCouplingScheme::getMaxTimeWindows() const
 {
   PRECICE_TRACE();
-  int maxTimesteps = 0;
+  int maxTimeWindows = 0;
   for (Scheme scheme : _couplingSchemes) {
-    maxTimesteps = std::max(maxTimesteps, scheme.scheme->getMaxTimesteps());
+    maxTimeWindows = std::max(maxTimeWindows, scheme.scheme->getMaxTimeWindows());
   }
-  PRECICE_DEBUG("return " << maxTimesteps);
-  return maxTimesteps;
+  PRECICE_DEBUG("return " << maxTimeWindows);
+  return maxTimeWindows;
 }
 
-//int CompositionalCouplingScheme:: getSubIteration() const
-//{
-//  PRECICE_TRACE();
-//  int subiteration = false;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    isSubiterating |= couplingScheme->getSubIteration();
-//  }
-//  return isSubiterating;
-//}
-
-bool CompositionalCouplingScheme::hasTimestepLength() const
+bool CompositionalCouplingScheme::hasTimeWindowSize() const
 {
   PRECICE_TRACE();
   bool hasIt = false;
   for (Scheme scheme : _couplingSchemes) {
-    hasIt |= scheme.scheme->hasTimestepLength();
+    hasIt |= scheme.scheme->hasTimeWindowSize();
   }
   PRECICE_DEBUG("return " << hasIt);
   return hasIt;
 }
 
-double CompositionalCouplingScheme::getTimestepLength() const
+double CompositionalCouplingScheme::getTimeWindowSize() const
 {
   PRECICE_TRACE();
-  double timestepLength = std::numeric_limits<double>::max();
+  double timeWindowSize = std::numeric_limits<double>::max();
   for (Scheme scheme : _couplingSchemes) {
-    if (scheme.scheme->getTimestepLength() < timestepLength) {
-      timestepLength = scheme.scheme->getTimestepLength();
+    if (scheme.scheme->getTimeWindowSize() < timeWindowSize) {
+      timeWindowSize = scheme.scheme->getTimeWindowSize();
     }
   }
-  PRECICE_DEBUG("return " << timestepLength);
-  return timestepLength;
+  PRECICE_DEBUG("return " << timeWindowSize);
+  return timeWindowSize;
 }
 
-double CompositionalCouplingScheme::getThisTimestepRemainder() const
+double CompositionalCouplingScheme::getThisTimeWindowRemainder() const
 {
   PRECICE_TRACE();
   double maxRemainder = 0.0;
   for (Scheme scheme : _couplingSchemes) {
     if (not scheme.onHold) {
-      if (scheme.scheme->getThisTimestepRemainder() > maxRemainder) {
-        maxRemainder = scheme.scheme->getThisTimestepRemainder();
+      if (scheme.scheme->getThisTimeWindowRemainder() > maxRemainder) {
+        maxRemainder = scheme.scheme->getThisTimeWindowRemainder();
       }
     }
   }
@@ -241,17 +209,17 @@ double CompositionalCouplingScheme::getThisTimestepRemainder() const
   return maxRemainder;
 }
 
-double CompositionalCouplingScheme::getComputedTimestepPart() const
+double CompositionalCouplingScheme::getComputedTimeWindowPart() const
 {
   PRECICE_TRACE();
-  double timestepPart = std::numeric_limits<double>::max();
+  double timeWindowPart = std::numeric_limits<double>::max();
   for (Scheme scheme : _couplingSchemes) {
     if (not scheme.onHold) {
-      timestepPart = std::min(timestepPart, scheme.scheme->getComputedTimestepPart());
+      timeWindowPart = std::min(timeWindowPart, scheme.scheme->getComputedTimeWindowPart());
     }
   }
-  PRECICE_DEBUG("return " << timestepPart);
-  return timestepPart;
+  PRECICE_DEBUG("return " << timeWindowPart);
+  return timeWindowPart;
 }
 
 double CompositionalCouplingScheme::getNextTimestepMaxLength() const
@@ -436,536 +404,3 @@ void CompositionalCouplingScheme::advanceActiveCouplingSchemes()
 
 } // namespace cplscheme
 } // namespace precice
-
-//#include "CompositionalCouplingScheme.hpp"
-//#include "Constants.hpp"
-//#include "utils/Globals.hpp"
-//#include <limits>
-//
-//namespace precice {
-//namespace cplscheme {
-//
-//logging::Logger CompositionalCouplingScheme::
-//   _log("cplscheme::CompositionalCouplingScheme");
-//
-//CompositionalCouplingScheme:: CompositionalCouplingScheme()
-//:
-//  _couplingSchemes(),
-//  _activeCouplingSchemes(),
-//  //_activeSchemesBegin(_couplingSchemes.end()),
-//  _activeSchemesEnd(_couplingSchemes.end()),
-//  _lastAddedTime(0.0)
-//{}
-//
-//void CompositionalCouplingScheme:: addCouplingScheme
-//(
-//  PtrCouplingScheme couplingScheme )
-//{
-//  PRECICE_TRACE();
-//  _couplingSchemes.push_back(couplingScheme);
-//}
-//
-//void CompositionalCouplingScheme:: initialize
-//(
-//  double startTime,
-//  int    startTimestep )
-//{
-//  PRECICE_TRACE(startTime, startTimestep);
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    couplingScheme->initialize(startTime, startTimestep);
-//  }
-//  determineActiveCouplingSchemes();
-//}
-//
-//bool CompositionalCouplingScheme:: isInitialized() const
-//{
-//  PRECICE_TRACE();
-//  bool isInitialized = true;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    isInitialized &= couplingScheme->isInitialized();
-//  }
-//  PRECICE_DEBUG("return " << isInitialized);
-//  return isInitialized;
-//}
-//
-//void CompositionalCouplingScheme:: initializeData()
-//{
-//  PRECICE_TRACE();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->isActionRequired(constants::actionWriteInitialData())){
-//      couplingScheme->initializeData();
-//    }
-//  }
-//}
-//
-//void CompositionalCouplingScheme:: addComputedTime
-//(
-//  double timeToAdd )
-//{
-//  PRECICE_TRACE(timeToAdd);
-//  foriter(SchemesIt, it, _activeCouplingSchemes){
-//  //for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
-//    (*it)->addComputedTime(timeToAdd);
-//  }
-//  _lastAddedTime += timeToAdd;
-//}
-//
-//void CompositionalCouplingScheme:: advance()
-//{
-//  PRECICE_TRACE();
-//  bool moreSchemesToHandle = false;
-//  do {
-//    //for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
-//    foriter(SchemesIt, it, _activeCouplingSchemes){
-//      (*it)->advance();
-//    }
-//    moreSchemesToHandle = determineActiveCouplingSchemes();
-//    if (moreSchemesToHandle){
-//      // The new schemes to be handled in this advance also need the time that
-//      // has been computed so far. This time can't be added in the solver call
-//      // to addComputedTime(), since there the schemes are not active yet.
-//      addComputedTime(_lastAddedTime);
-//    }
-//  } while (moreSchemesToHandle);
-//  _lastAddedTime = 0.0;
-//}
-//
-//void CompositionalCouplingScheme:: finalize()
-//{
-//  PRECICE_TRACE();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    couplingScheme->finalize();
-//  }
-//}
-//
-////bool CompositionalCouplingScheme:: isDataUsed
-////(
-////  int dataID )
-////{
-////  PRECICE_TRACE(dataID);
-////  bool isUsed = false;
-////  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-////    isUsed |= couplingScheme->isDataUsed(dataID);
-////  }
-////  return isUsed;
-////}
-////
-////bool CompositionalCouplingScheme:: isDataUsed()
-////{
-////  PRECICE_TRACE();
-////  bool isUsed = false;
-////  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-////    isUsed |= couplingScheme->isDataUsed();
-////  }
-////  return isUsed;
-////}
-//
-//std::vector<std::string> CompositionalCouplingScheme:: getCouplingPartners() const
-//{
-//  PRECICE_TRACE();
-//  std::vector<std::string> partners;
-//  std::vector<std::string> subpartners;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    subpartners = couplingScheme->getCouplingPartners();
-//    partners.insert(partners.end(), subpartners.begin(), subpartners.end());
-//  }
-//  return partners;
-//}
-//
-//bool CompositionalCouplingScheme:: willDataBeExchanged
-//(
-//  double lastSolverTimestepLength ) const
-//{
-//  PRECICE_TRACE(lastSolverTimestepLength);
-//  bool willBeExchanged = false;
-//  //for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
-//  foriter(ConstSchemesIt, it, _activeCouplingSchemes){
-//    willBeExchanged |= (*it)->willDataBeExchanged(lastSolverTimestepLength);
-//  }
-//  PRECICE_DEBUG("return " << willBeExchanged);
-//  return willBeExchanged;
-//}
-//
-//bool CompositionalCouplingScheme:: hasDataBeenExchanged() const
-//{
-//  PRECICE_TRACE();
-//  bool hasBeenExchanged = false;
-//  // Question: Does it suffice to only check the active ones?
-//  //for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++){
-//  foriter(ConstSchemesIt, it, _activeCouplingSchemes){
-//    hasBeenExchanged |= (*it)->hasDataBeenExchanged();
-//  }
-//  PRECICE_DEBUG("return " << hasBeenExchanged);
-//  return hasBeenExchanged;
-//}
-//
-//double CompositionalCouplingScheme:: getTime() const
-//{
-//  PRECICE_TRACE();
-//  double time = std::numeric_limits<double>::max();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getTime() < time){
-//      time = couplingScheme->getTime();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << time);
-//  return time;
-//}
-//
-//int CompositionalCouplingScheme:: getTimesteps() const
-//{
-//  PRECICE_TRACE();
-//  int timesteps = std::numeric_limits<int>::max();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getTimesteps() < timesteps){
-//      timesteps = couplingScheme->getTimesteps();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << timesteps);
-//  return timesteps;
-//}
-//
-//double CompositionalCouplingScheme:: getMaxTime() const
-//{
-//  PRECICE_TRACE();
-//  double maxTime = 0.0;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getMaxTime() > maxTime){
-//      maxTime = couplingScheme->getMaxTime();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << maxTime);
-//  return maxTime;
-//}
-//
-//int CompositionalCouplingScheme:: getMaxTimesteps() const
-//{
-//  PRECICE_TRACE();
-//  int maxTimesteps = 0;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getMaxTimesteps() > maxTimesteps){
-//      maxTimesteps = couplingScheme->getMaxTimesteps();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << maxTimesteps);
-//  return maxTimesteps;
-//}
-//
-////int CompositionalCouplingScheme:: getSubIteration() const
-////{
-////  PRECICE_TRACE();
-////  int subiteration = false;
-////  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-////    isSubiterating |= couplingScheme->getSubIteration();
-////  }
-////  return isSubiterating;
-////}
-//
-//bool CompositionalCouplingScheme:: hasTimestepLength() const
-//{
-//  PRECICE_TRACE();
-//  bool hasIt = false;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    hasIt |= couplingScheme->hasTimestepLength();
-//  }
-//  PRECICE_DEBUG("return " << hasIt);
-//  return hasIt;
-//}
-//
-//double CompositionalCouplingScheme:: getTimestepLength() const
-//{
-//  PRECICE_TRACE();
-//  double timestepLength = std::numeric_limits<double>::max();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getTimestepLength() < timestepLength){
-//      timestepLength = couplingScheme->getTimestepLength();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << timestepLength);
-//  return timestepLength;
-//}
-//
-//double CompositionalCouplingScheme:: getThisTimestepRemainder() const
-//{
-//  PRECICE_TRACE();
-//  double maxRemainder = 0.0;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getThisTimestepRemainder() > maxRemainder){
-//      maxRemainder = couplingScheme->getThisTimestepRemainder();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << maxRemainder);
-//  return maxRemainder;
-//}
-//
-//double CompositionalCouplingScheme:: getComputedTimestepPart() const
-//{
-//  PRECICE_TRACE();
-//  double timestepPart = std::numeric_limits<double>::max();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getComputedTimestepPart() < timestepPart){
-//      timestepPart = couplingScheme->getComputedTimestepPart();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << timestepPart);
-//  return timestepPart;
-//}
-//
-//double CompositionalCouplingScheme:: getNextTimestepMaxLength() const
-//{
-//  PRECICE_TRACE();
-//  double maxLength = std::numeric_limits<double>::max();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getNextTimestepMaxLength() < maxLength){
-//      maxLength = couplingScheme->getNextTimestepMaxLength();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << maxLength);
-//  return maxLength;
-//}
-//
-//bool CompositionalCouplingScheme:: isCouplingOngoing() const
-//{
-//  PRECICE_TRACE();
-//  bool isOngoing = false;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    isOngoing |= couplingScheme->isCouplingOngoing();
-//  }
-//  PRECICE_DEBUG("return " << isOngoing);
-//  return isOngoing;
-//}
-//
-//bool CompositionalCouplingScheme:: isCouplingTimestepComplete() const
-//{
-//  PRECICE_TRACE();
-//  bool isComplete = true;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    isComplete &= couplingScheme->isCouplingTimestepComplete();
-//  }
-//  PRECICE_DEBUG("return " << isComplete);
-//  return isComplete;
-//}
-//
-//bool CompositionalCouplingScheme:: isActionRequired
-//(
-//  const std::string& actionName) const
-//{
-//  PRECICE_TRACE(actionName);
-//  bool isRequired = false;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    isRequired |= couplingScheme->isActionRequired(actionName);
-//  }
-//  PRECICE_DEBUG("return " << isRequired);
-//  return isRequired;
-//}
-//
-//void CompositionalCouplingScheme:: markActionFulfilled
-//(
-//  const std::string& actionName)
-//{
-//  PRECICE_TRACE(actionName);
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    couplingScheme->markActionFulfilled(actionName);
-//  }
-//}
-//
-//int CompositionalCouplingScheme:: getCheckpointTimestepInterval() const
-//{
-//  PRECICE_TRACE();
-//  int interval = std::numeric_limits<int>::max();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (couplingScheme->getCheckpointTimestepInterval() < interval){
-//      interval = couplingScheme->getCheckpointTimestepInterval();
-//    }
-//  }
-//  PRECICE_DEBUG("return " << interval);
-//  return interval;
-//}
-//
-//void CompositionalCouplingScheme:: requireAction
-//(
-//  const std::string& actionName )
-//{
-//  PRECICE_TRACE(actionName);
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    couplingScheme->requireAction(actionName);
-//  }
-//}
-//
-//std::string CompositionalCouplingScheme:: printCouplingState() const
-//{
-//  std::string state;
-//  std::vector<std::string> partners;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    if (not state.empty()){
-//      state += "\n";
-//    }
-//    partners = couplingScheme->getCouplingPartners();
-//    PRECICE_ASSERT(partners.size() == 1, partners.size());
-//    state += "Coupling to ";
-//    state += partners[0];
-//    state += ":\n";
-//    state += couplingScheme->printCouplingState();
-//  }
-//  return state;
-//}
-//
-//void CompositionalCouplingScheme:: exportState
-//(
-//  const std::string& filenamePrefix ) const
-//{
-//  PRECICE_TRACE();
-//  int enumerator = 0;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    std::ostringstream stream;
-//    stream << filenamePrefix << "_" << enumerator;
-//    couplingScheme->exportState(stream.str());
-//    enumerator++;
-//  }
-//}
-//
-//void CompositionalCouplingScheme:: importState
-//(
-//  const std::string& filenamePrefix )
-//{
-//  PRECICE_TRACE();
-//  int enumerator = 0;
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    std::ostringstream stream;
-//    stream << filenamePrefix << "_" << enumerator;
-//    couplingScheme->importState(stream.str());
-//    enumerator++;
-//  }
-//}
-//
-//void CompositionalCouplingScheme:: sendState
-//(
-//  com::Communication::SharedPointer communication,
-//  int                   rankReceiver )
-//{
-//  PRECICE_TRACE();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    couplingScheme->sendState(communication, rankReceiver);
-//  }
-//}
-//
-//void CompositionalCouplingScheme:: receiveState
-//(
-//  com::Communication::SharedPointer communication,
-//  int                   rankSender )
-//{
-//  PRECICE_TRACE();
-//  for (PtrCouplingScheme couplingScheme : _couplingSchemes){
-//    couplingScheme->receiveState(communication, rankSender);
-//  }
-//}
-//
-//bool CompositionalCouplingScheme:: determineActiveCouplingSchemes()
-//{
-//  PRECICE_TRACE();
-//  bool newActiveSchemes = false;
-//  std::string writeCheckpoint = constants::actionWriteIterationCheckpoint();
-//  std::string readCheckpoint = constants::actionReadIterationCheckpoint();
-//  if (_activeCouplingSchemes.empty()){
-//    PRECICE_DEBUG("Case After Init");
-//    // First call after initialization of all coupling schemes. All coupling
-//    // schemes are set active up to (but not including) the first explicit
-//    // scheme after an implicit scheme.
-//    //_activeSchemesBegin = _couplingSchemes.begin();
-//    _activeSchemesEnd = _couplingSchemes.begin();
-//    advanceActiveCouplingSchemes();
-//    newActiveSchemes = true;
-//  }
-//  else {
-//    PRECICE_DEBUG("Normal Case");
-//    // Redetermine active schemes. First, all preceding explicit schemes are
-//    // removed. Then, all remaining implicit schemes are checked for the
-//    // convergence of iterations (this is given when an iteration checkpoint
-//    // should be created). If all are converged, a next set of active schemes
-//    // is determined.
-//
-//    // Remove preceding explicit schemes
-//    //while (_activeSchemesBegin != _activeSchemesEnd){
-//    while (not _activeCouplingSchemes.empty()){
-//      bool explicitScheme = true;
-//      SchemesIt it = _activeCouplingSchemes.begin();
-//      explicitScheme &= not (*it)->isActionRequired(writeCheckpoint);
-//      explicitScheme &= not (*it)->isActionRequired(readCheckpoint);
-//      if (explicitScheme) {
-//        //_activeSchemesBegin++;
-//        _activeCouplingSchemes.pop_front();
-//        PRECICE_DEBUG("Remove preceding explicit scheme");
-//      }
-//      else {
-//        break;
-//      }
-//    }
-//
-//    // Check implicit schemes for convergence and remove if converged
-//    if (not _activeCouplingSchemes.empty()){
-//      bool converged = true;
-//      //for (SchemesIt it=_activeSchemesBegin; it != _activeSchemesEnd; it++){
-//      SchemesIt it = _activeCouplingSchemes.begin();
-//      while (it != _activeCouplingSchemes.end()){
-//        if ((*it)->isActionRequired(readCheckpoint)){
-//          converged = false;
-//          it++; // Advance it to the next scheme
-//          PRECICE_DEBUG("Non converged implicit scheme");
-//        }
-//        else if ((*it)->isActionRequired(writeCheckpoint)){
-//          it = _activeCouplingSchemes.erase(it); // Automatically advances to next scheme
-//          PRECICE_DEBUG("Remove converged implicit scheme");
-//        }
-//      }
-//      if (converged) {
-//        PRECICE_DEBUG("Active implicit schemes converged");
-//        _activeCouplingSchemes.clear();
-//        //_activeSchemesBegin = _activeSchemesEnd;
-//      }
-//    }
-//
-//    // Determine next set of active schemes if current is empty
-//    //if (_activeSchemesBegin == _activeSchemesEnd){
-//    if (_activeCouplingSchemes.empty()){
-//      if (_activeSchemesEnd == _couplingSchemes.end()){
-//        PRECICE_DEBUG("Through with all coupling schemes");
-//        // All coupling schemes are through
-//        //_activeSchemesBegin = _couplingSchemes.begin();
-//        _activeSchemesEnd = _couplingSchemes.begin();
-//        advanceActiveCouplingSchemes();
-//        // newActiveSchemes stays false, since the current it/dt is complete
-//      }
-//      else {
-//        PRECICE_DEBUG("Coupling schemes remaining");
-//        advanceActiveCouplingSchemes();
-//        newActiveSchemes = true;
-//      }
-//    }
-//  }
-//  PRECICE_DEBUG("return newActiveSchemes=" << newActiveSchemes);
-//  return newActiveSchemes;
-//}
-//
-//void CompositionalCouplingScheme:: advanceActiveCouplingSchemes()
-//{
-//  PRECICE_TRACE();
-//  std::string writeCheckpoint = constants::actionWriteIterationCheckpoint();
-//  bool iterating = false;
-//  while (_activeSchemesEnd != _couplingSchemes.end()){
-//    if ((*_activeSchemesEnd)->isActionRequired(writeCheckpoint)){
-//      PRECICE_DEBUG("Found implicit scheme");
-//      iterating = true;
-//    }
-//    if (iterating && (not (*_activeSchemesEnd)->isActionRequired(writeCheckpoint))){
-//      PRECICE_DEBUG("Found explicit scheme after implicit scheme");
-//      break;
-//    }
-//    _activeCouplingSchemes.push_back(*_activeSchemesEnd);
-//    _activeSchemesEnd++;
-//    PRECICE_DEBUG("Advanced active schemes by one new scheme");
-//  }
-//  PRECICE_ASSERT(not _activeCouplingSchemes.empty());
-//  //PRECICE_ASSERT(_activeSchemesBegin != _activeSchemesEnd);
-//}
-//
-//}} // namespace precice, cplscheme

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -72,12 +72,14 @@ public:
   void addCouplingScheme(PtrCouplingScheme scheme);
 
   /**
-   * @brief Initializes the coupling scheme and establishes a communiation
+   * @brief Initializes the coupling scheme and establishes a communication
    *        connection to the coupling partner.
-   */
+* @param[in] startTime TODO
+* @param[in] startTimeWindow TODO
+*/
   virtual void initialize(
       double startTime,
-      int    startTimesteps);
+      int    startTimeWindow);
 
   /// Returns true, if initialize has been called.
   virtual bool isInitialized() const;
@@ -127,7 +129,7 @@ public:
    *
    * The timestep is the minimum timestep in any coupling scheme in the composition.
    */
-  virtual int getTimesteps() const;
+  virtual int getTimeWindows() const;
 
   /**
    * @brief Returns the maximal time to be computed.
@@ -137,10 +139,7 @@ public:
   virtual double getMaxTime() const;
 
   /// Returns the maximal timesteps to be computed.
-  virtual int getMaxTimesteps() const;
-
-  /// Returns current subiteration number in timestep.
-  //virtual int getSubIteration() const;
+  virtual int getMaxTimeWindows() const;
 
   /**
    * @brief Returns true, if timestep length is prescribed by the cpl scheme.
@@ -148,18 +147,18 @@ public:
    * If any of the solvers in the composition has a timestep length limit, this
    * counts as limit.
    */
-  virtual bool hasTimestepLength() const;
+  virtual bool hasTimeWindowSize() const;
 
   /**
    * @brief Returns the timestep length, if one is given by the coupling scheme.
    *
    * An assertion is thrown, if no valid timestep is given. Check with
-   * hasTimestepLength().
+   * hasTimeWindowSize().
    *
    * The smallest timestep length limit in the coupling scheme composition has
    * to be obeyed.
    */
-  virtual double getTimestepLength() const;
+  virtual double getTimeWindowSize() const;
 
   /**
    * @brief Returns the remaining timestep length of the current time step.
@@ -172,7 +171,7 @@ public:
    *
    * The maximum remainer of all composed coupling schemes is returned.
    */
-  virtual double getThisTimestepRemainder() const;
+  virtual double getThisTimeWindowRemainder() const;
 
   /**
    * @brief Returns part of the current timestep that has been computed already.
@@ -180,7 +179,7 @@ public:
    * This is the minimum of all computed timestep parts of the composed coupling
    * schemes.
    */
-  virtual double getComputedTimestepPart() const;
+  virtual double getComputedTimeWindowPart() const;
 
   /**
    * @brief Returns the maximal length of the next timestep to be computed.

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -14,7 +14,7 @@ struct CouplingData {
   /// Data values of current iteration.
   Eigen::VectorXd *values;
 
-  /// Data values of previous iteration (1st col) and previous timesteps.
+  /// Data values of previous iteration (1st col) and previous time windows.
   DataMatrix oldValues;
 
   mesh::PtrMesh mesh;

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -31,7 +31,7 @@ namespace cplscheme {
  * -# compute data to be sent (possibly taking into account received data from
  *    initialize())
  * -# advance the coupling scheme with advance(); where the maximum timestep
- *    length needs to be obeyed
+ *    length (= time window size) needs to be obeyed
  * -# ....
  * -# when the method isCouplingOngoing() returns false, call finalize() to
  *    stop the coupling scheme
@@ -52,12 +52,15 @@ public:
   virtual ~CouplingScheme() {}
 
   /**
-   * @brief Initializes the coupling scheme and establishes a communiation
+   * @brief Initializes the coupling scheme and establishes a communication
    *        connection to the coupling partner.
+   *
+   * @param[in] startTime starting time for coupling @BU correct?
+   * @param[in] startTimeWindow counter of time window for coupling @BU correct?
    */
   virtual void initialize(
       double startTime,
-      int    startTimesteps) = 0;
+      int    startTimeWindow) = 0;
 
   /// Returns true, if initialize has been called.
   virtual bool isInitialized() const = 0;
@@ -95,7 +98,7 @@ public:
   /// Returns list of all coupling partners.
   virtual std::vector<std::string> getCouplingPartners() const = 0;
 
-  /*
+  /**
    * @brief Returns true, if data will be exchanged when calling advance().
    *
    * Also returns true after the last call of advance() at the end of the
@@ -113,30 +116,25 @@ public:
   /// Returns the currently computed time of the coupling scheme.
   virtual double getTime() const = 0;
 
-  /// Returns the currently computed timesteps of the coupling scheme.
-  virtual int getTimesteps() const = 0;
+  /// Returns the currently computed time windows of the coupling scheme.
+  virtual int getTimeWindows() const = 0;
 
   /// Returns the maximal time to be computed.
   virtual double getMaxTime() const = 0;
 
-  /// Returns the maximal timesteps to be computed.
-  virtual int getMaxTimesteps() const = 0;
+  /// Returns the maximal time windows to be computed.
+  virtual int getMaxTimeWindows() const = 0;
 
-  //
-  // @brief Returns current subiteration number in timestep.
-  //
-  //virtual int getSubIteration() const =0;
-
-  /// Returns true, if timestep length is prescribed by the cpl scheme.
-  virtual bool hasTimestepLength() const = 0;
+  /// Returns true, if time window size is prescribed by the cpl scheme.
+  virtual bool hasTimeWindowSize() const = 0;
 
   /**
-   * @brief Returns the timestep length, if one is given by the coupling scheme.
+   * @brief Returns the time window size, if one is given by the coupling scheme.
    *
-   * An assertion is thrown, if no valid timestep is given. Check with
-   * hasTimestepLength().
+   * An assertion is thrown, if no valid time window size is given. Check with
+   * hasTimeWindowSize().
    */
-  virtual double getTimestepLength() const = 0;
+  virtual double getTimeWindowSize() const = 0;
 
   /// Defaults to false, i.e., no multilevel PP
   virtual bool isCoarseModelOptimizationActive()
@@ -145,31 +143,26 @@ public:
   }
 
   /**
-   * @brief Returns the remaining timestep length of the current time step.
+   * @brief Returns the remaining time within the current time window.
    *
-   * This is not necessarily the timestep length limit the solver has to obeye
-   * which is returned by getNextTimestepMaxLength().
+   * This is not necessarily the time window size limit the solver has to obey
+   * which is returned by getNextTimestepMaxLength().  // TODO explain this better
    *
-   * If no timestep length is precribed by the coupling scheme, always 0.0 is
+   * If no time window size is prescribed by the coupling scheme, always 0.0 is
    * returned.
    */
-  virtual double getThisTimestepRemainder() const = 0;
+  virtual double getThisTimeWindowRemainder() const = 0;
 
   /// Returns part of the current timestep that has been computed already.
-  virtual double getComputedTimestepPart() const = 0;
+  virtual double getComputedTimeWindowPart() const = 0;
 
   /**
    * @brief Returns the maximal length of the next timestep to be computed.
    *
-   * If no timestep length is prescribed by the coupling scheme, always the
+   * If no time window size is prescribed by the coupling scheme, always the
    * maximal double accuracy floating point number value is returned.
    */
   virtual double getNextTimestepMaxLength() const = 0;
-
-  //
-  // @brief Returns the number of valid digits when compare times.
-  //
-  //virtual int getValidDigits() const =0;
 
   /// Returns true, when the coupled simulation is still ongoing.
   virtual bool isCouplingOngoing() const = 0;

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -6,21 +6,41 @@
 namespace precice {
 namespace cplscheme {
 
+/**
+ * @brief TODO
+ */
 class MultiCouplingScheme : public BaseCouplingScheme {
 public:
+  /**
+ * @brief Constructor.
+ *
+ * @param[in] maxTime Simulation time limit, or UNDEFINED_TIME.
+ * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIMEWINDOWS.
+ * @param[in] timeWindowSize Simulation time window size.
+ * @param[in] validDigits TODO
+ * @param[in] localParticipant Name of participant using this coupling scheme.
+ * @param[in] m2n Communication object for com. between participants. TODO?
+ * TODO add dtMethod, maxIterations
+ */
   MultiCouplingScheme(
       double                        maxTime,
-      int                           maxTimesteps,
-      double                        timestepLength,
+      int                           maxTimeWindows,
+      double                        timeWindowSize,
       int                           validDigits,
       const std::string &           localParticipant,
-      std::vector<m2n::PtrM2N>      communications,
+      std::vector<m2n::PtrM2N>      m2n,
       constants::TimesteppingMethod dtMethod,
       int                           maxIterations = 1);
 
   logging::Logger _log{"cplscheme::MultiCouplingScheme"};
 
-  virtual void initialize(double startTime, int startTimestep);
+  /**
+ * @brief TODO
+ *
+ * @param[in] startTime TODO
+ * @param[in] startTimeWindow TODO
+ */
+  virtual void initialize(double startTime, int startTimeWindow);
 
   virtual void initializeData();
 

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -10,8 +10,8 @@ namespace cplscheme {
 
 ParallelCouplingScheme::ParallelCouplingScheme(
     double                        maxTime,
-    int                           maxTimesteps,
-    double                        timestepLength,
+    int                           maxTimeWindows,
+    double                        timeWindowsSize,
     int                           validDigits,
     const std::string &           firstParticipant,
     const std::string &           secondParticipant,
@@ -20,7 +20,7 @@ ParallelCouplingScheme::ParallelCouplingScheme(
     constants::TimesteppingMethod dtMethod,
     CouplingMode                  cplMode,
     int                           maxIterations)
-    : BaseCouplingScheme(maxTime, maxTimesteps, timestepLength, validDigits, firstParticipant,
+    : BaseCouplingScheme(maxTime, maxTimeWindows, timeWindowsSize, validDigits, firstParticipant,
                          secondParticipant, localParticipant, m2n, maxIterations, dtMethod)
 {
   _couplingMode = cplMode;
@@ -33,14 +33,14 @@ ParallelCouplingScheme::ParallelCouplingScheme(
 
 void ParallelCouplingScheme::initialize(
     double startTime,
-    int    startTimestep)
+    int    startTimeWindow)
 {
-  PRECICE_TRACE(startTime, startTimestep);
+  PRECICE_TRACE(startTime, startTimeWindow);
   PRECICE_ASSERT(not isInitialized());
   PRECICE_ASSERT(math::greaterEquals(startTime, 0.0), startTime);
-  PRECICE_ASSERT(startTimestep >= 0, startTimestep);
+  PRECICE_ASSERT(startTimeWindow >= 0, startTimeWindow);
   setTime(startTime);
-  setTimesteps(startTimestep);
+  setTimeWindows(startTimeWindow);
   if (_couplingMode == Implicit) {
     PRECICE_CHECK(not getSendData().empty(), "No send data configured! Use explicit scheme for one-way coupling.");
     if (not doesFirstStep()) {         // second participant
@@ -113,7 +113,7 @@ void ParallelCouplingScheme::initializeData()
           if (pair.second->oldValues.cols() == 0)
             break;
           pair.second->oldValues.col(0) = *pair.second->values;
-          // For extrapolation, treat the initial value as old timestep value
+          // For extrapolation, treat the initial value as old time windows value
           utils::shiftSetFirst(pair.second->oldValues, *pair.second->values);
         }
       }
@@ -124,7 +124,7 @@ void ParallelCouplingScheme::initializeData()
           if (pair.second->oldValues.cols() == 0)
             break;
           pair.second->oldValues.col(0) = *pair.second->values;
-          // For extrapolation, treat the initial value as old timestep value
+          // For extrapolation, treat the initial value as old time windows value
           utils::shiftSetFirst(pair.second->oldValues, *pair.second->values);
         }
       }
@@ -139,182 +139,174 @@ void ParallelCouplingScheme::initializeData()
 
 void ParallelCouplingScheme::advance()
 {
-  if (_couplingMode == Explicit) {
-    explicitAdvance();
-  } else if (_couplingMode == Implicit) {
-    implicitAdvance();
-  }
+  PRECICE_TRACE(getTimeWindows(), getTime());
+  checkCompletenessRequiredActions();
+
+  PRECICE_CHECK(!hasToReceiveInitData() && !hasToSendInitData(),
+                "initializeData() needs to be called before advance if data has to be initialized!");
+
+  setHasDataBeenExchanged(false);
+  setIsTimeWindowComplete(false);
+
+  if (math::equals(getThisTimeWindowRemainder(), 0.0, _eps)) {
+    if (_couplingMode == Explicit) {
+      explicitAdvance();
+    } else if (_couplingMode == Implicit) {
+      implicitAdvance();
+    }
+  } // subcycling complete
 }
 
 void ParallelCouplingScheme::explicitAdvance()
 {
-  PRECICE_TRACE();
-  checkCompletenessRequiredActions();
-  PRECICE_CHECK(!hasToReceiveInitData() && !hasToSendInitData(),
-                "initializeData() needs to be called before advance if data has to be initialized!");
-  setHasDataBeenExchanged(false);
-  setIsTimeWindowComplete(false);
+  setIsTimeWindowComplete(true);
+  setTimeWindows(getTimeWindows() + 1);
 
-  if (math::equals(getThisTimestepRemainder(), 0.0, _eps)) {
-    setIsTimeWindowComplete(true);
-    setTimesteps(getTimesteps() + 1);
+  if (doesFirstStep()) {
+    PRECICE_DEBUG("Sending data...");
+    sendDt();
+    sendData(getM2N());
 
-    if (doesFirstStep()) {
-      PRECICE_DEBUG("Sending data...");
-      sendDt();
-      sendData(getM2N());
+    PRECICE_DEBUG("Receiving data...");
+    receiveAndSetDt();
+    receiveData(getM2N());
+    setHasDataBeenExchanged(true);
+  } else { //second participant
+    PRECICE_DEBUG("Receiving data...");
+    receiveAndSetDt();
+    receiveData(getM2N());
+    setHasDataBeenExchanged(true);
 
-      PRECICE_DEBUG("Receiving data...");
-      receiveAndSetDt();
-      receiveData(getM2N());
-      setHasDataBeenExchanged(true);
-    } else { //second participant
-      PRECICE_DEBUG("Receiving data...");
-      receiveAndSetDt();
-      receiveData(getM2N());
-      setHasDataBeenExchanged(true);
-
-      PRECICE_DEBUG("Sending data...");
-      sendDt();
-      sendData(getM2N());
-    }
-
-    //both participants
-    setComputedTimestepPart(0.0);
+    PRECICE_DEBUG("Sending data...");
+    sendDt();
+    sendData(getM2N());
   }
+
+  //both participants
+  setComputedTimeWindowPart(0.0);
 }
 
 void ParallelCouplingScheme::implicitAdvance()
 {
-  PRECICE_TRACE(getTimesteps(), getTime());
-  checkCompletenessRequiredActions();
-
-  PRECICE_CHECK(!hasToReceiveInitData() && !hasToSendInitData(),
-                "initializeData() needs to be called before advance if data has to be initialized!");
-
-  setHasDataBeenExchanged(false);
-  setIsTimeWindowComplete(false);
+  PRECICE_DEBUG("Computed full length of iteration");
   bool convergence                   = false;
   bool convergenceCoarseOptimization = true;
   bool doOnlySolverEvaluation        = false;
-  if (math::equals(getThisTimestepRemainder(), 0.0, _eps)) {
-    PRECICE_DEBUG("Computed full length of iteration");
-    if (doesFirstStep()) { //First participant
-      sendData(getM2N());
-      getM2N()->receive(convergence);
-      getM2N()->receive(_isCoarseModelOptimizationActive);
-      if (convergence) {
-        timeWindowCompleted();
-      }
-      receiveData(getM2N());
-    } else { // second participant
-      receiveData(getM2N());
+  if (doesFirstStep()) { //First participant
+    sendData(getM2N());
+    getM2N()->receive(convergence);
+    getM2N()->receive(_isCoarseModelOptimizationActive);
+    if (convergence) {
+      timeWindowCompleted();
+    }
+    receiveData(getM2N());
+  } else { // second participant
+    receiveData(getM2N());
 
-      // get the current design specifications from the acceleration (for convergence measure)
-      std::map<int, Eigen::VectorXd> designSpecifications;
-      if (getAcceleration().get() != nullptr) {
-        designSpecifications = getAcceleration()->getDesignSpecification(getAllData());
-      }
+    // get the current design specifications from the acceleration (for convergence measure)
+    std::map<int, Eigen::VectorXd> designSpecifications;
+    if (getAcceleration().get() != nullptr) {
+      designSpecifications = getAcceleration()->getDesignSpecification(getAllData());
+    }
 
-      // measure convergence for coarse model optimization
-      if (_isCoarseModelOptimizationActive) {
-        PRECICE_DEBUG("measure convergence of coarse model optimization.");
-        // in case of multilevel acceleration only: measure the convergence of the coarse model optimization
-        convergenceCoarseOptimization = measureConvergenceCoarseModelOptimization(designSpecifications);
-        // Stop, when maximal iteration count (given in config) is reached
-        if (maxIterationsReached())
-          convergenceCoarseOptimization = true;
+    // measure convergence for coarse model optimization
+    if (_isCoarseModelOptimizationActive) {
+      PRECICE_DEBUG("measure convergence of coarse model optimization.");
+      // in case of multilevel acceleration only: measure the convergence of the coarse model optimization
+      convergenceCoarseOptimization = measureConvergenceCoarseModelOptimization(designSpecifications);
+      // Stop, when maximal iteration count (given in config) is reached
+      if (maxIterationsReached())
+        convergenceCoarseOptimization = true;
 
-        convergence = false;
-        // in case of multilevel PP only: if coarse model optimization converged
-        // steering the requests for evaluation of coarse and fine model, respectively
-        if (convergenceCoarseOptimization) {
-          _isCoarseModelOptimizationActive = false;
-          doOnlySolverEvaluation           = true;
-        } else {
-          _isCoarseModelOptimizationActive = true;
-        }
-      }
-      // measure convergence of coupling iteration
-      else {
-        PRECICE_DEBUG("measure convergence.");
-        doOnlySolverEvaluation = false;
-
-        // measure convergence of the coupling iteration,
-        convergence = measureConvergence(designSpecifications);
-        // Stop, when maximal iteration count (given in config) is reached
-        if (maxIterationsReached())
-          convergence = true;
-      }
-
-      // passed by reference, modified in MM acceleration. No-op for all other accelerations
-      if (getAcceleration().get() != nullptr) {
-        getAcceleration()->setCoarseModelOptimizationActive(&_isCoarseModelOptimizationActive);
-      }
-
-      // for multi-level case, i.e., manifold mapping: after convergence of coarse problem
-      // we only want to evaluate the fine model for the new input, no acceleration etc..
-      if (not doOnlySolverEvaluation) {
-        if (convergence) {
-          if (getAcceleration().get() != nullptr) {
-            _deletedColumnsPPFiltering = getAcceleration()->getDeletedColumns();
-            getAcceleration()->iterationsConverged(getAllData());
-          }
-          newConvergenceMeasurements();
-          timeWindowCompleted();
-        } else if (getAcceleration().get() != nullptr) {
-          getAcceleration()->performAcceleration(getAllData());
-        }
-
-        // extrapolate new input data for the solver evaluation in time.
-        if (convergence && (getExtrapolationOrder() > 0)) {
-          extrapolateData(getAllData()); // Also stores data
-        } else {                         // Store data for conv. measurement, acceleration, or extrapolation
-          for (DataMap::value_type &pair : getSendData()) {
-            if (pair.second->oldValues.size() > 0) {
-              pair.second->oldValues.col(0) = *pair.second->values;
-            }
-          }
-          for (DataMap::value_type &pair : getReceiveData()) {
-            if (pair.second->oldValues.size() > 0) {
-              pair.second->oldValues.col(0) = *pair.second->values;
-            }
-          }
-        }
+      convergence = false;
+      // in case of multilevel PP only: if coarse model optimization converged
+      // steering the requests for evaluation of coarse and fine model, respectively
+      if (convergenceCoarseOptimization) {
+        _isCoarseModelOptimizationActive = false;
+        doOnlySolverEvaluation           = true;
       } else {
+        _isCoarseModelOptimizationActive = true;
+      }
+    }
+    // measure convergence of coupling iteration
+    else {
+      PRECICE_DEBUG("measure convergence.");
+      doOnlySolverEvaluation = false;
 
-        // if the coarse model problem converged within the first iteration, i.e., no acceleration at all
-        // we need to register the coarse initialized data again on the fine input data,
-        // otherwise the fine input data would be zero in this case, neither anything has been computed so far for the fine
-        // model nor the acceleration did any data registration
-        // ATTENTION: assumes that coarse data is defined after fine data in same ordering.
-        if (_iterationsCoarseOptimization == 1 && getAcceleration().get() != nullptr) {
-          auto  fineIDs = getAcceleration()->getDataIDs();
-          auto &allData = getAllData();
-          for (auto &fineID : fineIDs) {
-            *allData.at(fineID)->values = allData.at(fineID + fineIDs.size())->oldValues.col(0);
+      // measure convergence of the coupling iteration,
+      convergence = measureConvergence(designSpecifications);
+      // Stop, when maximal iteration count (given in config) is reached
+      if (maxIterationsReached())
+        convergence = true;
+    }
+
+    // passed by reference, modified in MM acceleration. No-op for all other accelerations
+    if (getAcceleration().get() != nullptr) {
+      getAcceleration()->setCoarseModelOptimizationActive(&_isCoarseModelOptimizationActive);
+    }
+
+    // for multi-level case, i.e., manifold mapping: after convergence of coarse problem
+    // we only want to evaluate the fine model for the new input, no acceleration etc..
+    if (not doOnlySolverEvaluation) {
+      if (convergence) {
+        if (getAcceleration().get() != nullptr) {
+          _deletedColumnsPPFiltering = getAcceleration()->getDeletedColumns();
+          getAcceleration()->iterationsConverged(getAllData());
+        }
+        newConvergenceMeasurements();
+        timeWindowCompleted();
+      } else if (getAcceleration().get() != nullptr) {
+        getAcceleration()->performAcceleration(getAllData());
+      }
+
+      // extrapolate new input data for the solver evaluation in time.
+      if (convergence && (getExtrapolationOrder() > 0)) {
+        extrapolateData(getAllData()); // Also stores data
+      } else {                         // Store data for conv. measurement, acceleration, or extrapolation
+        for (DataMap::value_type &pair : getSendData()) {
+          if (pair.second->oldValues.size() > 0) {
+            pair.second->oldValues.col(0) = *pair.second->values;
+          }
+        }
+        for (DataMap::value_type &pair : getReceiveData()) {
+          if (pair.second->oldValues.size() > 0) {
+            pair.second->oldValues.col(0) = *pair.second->values;
           }
         }
       }
-
-      getM2N()->send(convergence);
-      getM2N()->send(_isCoarseModelOptimizationActive);
-
-      sendData(getM2N());
-    }
-
-    // both participants
-    if (not convergence) {
-      PRECICE_DEBUG("No convergence achieved");
-      requireAction(constants::actionReadIterationCheckpoint());
     } else {
-      PRECICE_DEBUG("Convergence achieved");
-      advanceTXTWriters();
+
+      // if the coarse model problem converged within the first iteration, i.e., no acceleration at all
+      // we need to register the coarse initialized data again on the fine input data,
+      // otherwise the fine input data would be zero in this case, neither anything has been computed so far for the fine
+      // model nor the acceleration did any data registration
+      // ATTENTION: assumes that coarse data is defined after fine data in same ordering.
+      if (_iterationsCoarseOptimization == 1 && getAcceleration().get() != nullptr) {
+        auto  fineIDs = getAcceleration()->getDataIDs();
+        auto &allData = getAllData();
+        for (auto &fineID : fineIDs) {
+          *allData.at(fineID)->values = allData.at(fineID + fineIDs.size())->oldValues.col(0);
+        }
+      }
     }
-    updateTimeAndIterations(convergence, convergenceCoarseOptimization);
-    setHasDataBeenExchanged(true);
-    setComputedTimestepPart(0.0);
-  } // subcycling complete
+
+    getM2N()->send(convergence);
+    getM2N()->send(_isCoarseModelOptimizationActive);
+
+    sendData(getM2N());
+  }
+
+  // both participants
+  if (not convergence) {
+    PRECICE_DEBUG("No convergence achieved");
+    requireAction(constants::actionReadIterationCheckpoint());
+  } else {
+    PRECICE_DEBUG("Convergence achieved");
+    advanceTXTWriters();
+  }
+  updateTimeAndIterations(convergence, convergenceCoarseOptimization);
+  setHasDataBeenExchanged(true);
+  setComputedTimeWindowPart(0.0);
 }
 
 void ParallelCouplingScheme::mergeData()

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -14,10 +14,23 @@ namespace cplscheme {
  */
 class ParallelCouplingScheme : public BaseCouplingScheme {
 public:
+  /**
+ * @brief Constructor.
+ *
+ * @param[in] maxTime Simulation time limit, or UNDEFINED_TIME.
+ * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIMEWINDOWS.
+ * @param[in] timeWindowSize Simulation time window size.
+ * @param[in] validDigits TODO
+ * @param[in] firstParticipant Name of participant starting simulation.
+ * @param[in] secondParticipant Name of second participant in coupling.
+ * @param[in] localParticipant Name of participant using this coupling scheme.
+ * @param[in] m2n Communication object for com. between participants. TODO?
+ * TODO add dtMethod, cplMode, maxIterations
+ */
   ParallelCouplingScheme(
       double                        maxTime,
-      int                           maxTimesteps,
-      double                        timestepLength,
+      int                           maxTimeWindows,
+      double                        timeWindowsSize,
       int                           validDigits,
       const std::string &           firstParticipant,
       const std::string &           secondParticipant,
@@ -27,7 +40,13 @@ public:
       CouplingMode                  cplMode,
       int                           maxIterations = 1);
 
-  virtual void initialize(double startTime, int startTimestep);
+  /**
+ * @brief TODO
+ *
+ * @param[in] startTime TODO
+ * @param[in] startTimeWindow TODO
+ */
+  virtual void initialize(double startTime, int startTimeWindow);
 
   virtual void initializeData();
 

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -10,8 +10,8 @@ namespace cplscheme {
 
 SerialCouplingScheme::SerialCouplingScheme(
     double                        maxTime,
-    int                           maxTimesteps,
-    double                        timestepLength,
+    int                           maxTimeWindows,
+    double                        timeWindowSize,
     int                           validDigits,
     const std::string &           firstParticipant,
     const std::string &           secondParticipant,
@@ -20,7 +20,7 @@ SerialCouplingScheme::SerialCouplingScheme(
     constants::TimesteppingMethod dtMethod,
     CouplingMode                  cplMode,
     int                           maxIterations)
-    : BaseCouplingScheme(maxTime, maxTimesteps, timestepLength, validDigits, firstParticipant,
+    : BaseCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, validDigits, firstParticipant,
                          secondParticipant, localParticipant, m2n, maxIterations, dtMethod)
 {
   _couplingMode = cplMode;
@@ -33,14 +33,14 @@ SerialCouplingScheme::SerialCouplingScheme(
 
 void SerialCouplingScheme::initialize(
     double startTime,
-    int    startTimestep)
+    int    startTimeWindow)
 {
-  PRECICE_TRACE(startTime, startTimestep);
+  PRECICE_TRACE(startTime, startTimeWindow);
   PRECICE_ASSERT(not isInitialized());
   PRECICE_ASSERT(math::greaterEquals(startTime, 0.0), startTime);
-  PRECICE_ASSERT(startTimestep >= 0, startTimestep);
+  PRECICE_ASSERT(startTimeWindow >= 0, startTimeWindow);
   setTime(startTime);
-  setTimesteps(startTimestep);
+  setTimeWindows(startTimeWindow);
 
   if (_couplingMode == Implicit) {
     PRECICE_CHECK(not getSendData().empty(), "No send data configured! Use explicit scheme for one-way coupling.");
@@ -125,11 +125,11 @@ void SerialCouplingScheme::initializeData()
       if (pair.second->oldValues.cols() == 0)
         break;
       pair.second->oldValues.col(0) = *pair.second->values;
-      // For extrapolation, treat the initial value as old timestep value
+      // For extrapolation, treat the initial value as old time window value
       utils::shiftSetFirst(pair.second->oldValues, *pair.second->values);
     }
 
-    // The second participant sends the initialized data to the first particpant
+    // The second participant sends the initialized data to the first participant
     // here, which receives the data on call of initialize().
     sendData(getM2N());
     receiveAndSetDt();
@@ -145,7 +145,7 @@ void SerialCouplingScheme::initializeData()
 
 void SerialCouplingScheme::advance()
 {
-  PRECICE_TRACE(getTimesteps(), getTime());
+  PRECICE_TRACE(getTimeWindows(), getTime());
 #ifndef NDEBUG
   for (const DataMap::value_type &pair : getReceiveData()) {
     Eigen::VectorXd &  values = *pair.second->values;
@@ -165,170 +165,177 @@ void SerialCouplingScheme::advance()
   setHasDataBeenExchanged(false);
   setIsTimeWindowComplete(false);
 
-  if (_couplingMode == Explicit) {
-    if (math::equals(getThisTimestepRemainder(), 0.0, _eps)) {
-      setIsTimeWindowComplete(true);
-      setTimesteps(getTimesteps() + 1);
-      PRECICE_DEBUG("Sending data...");
-      sendDt();
-      sendData(getM2N());
-
-      if (isCouplingOngoing() || doesFirstStep()) {
-        PRECICE_DEBUG("Receiving data...");
-        receiveAndSetDt();
-        receiveData(getM2N());
-        setHasDataBeenExchanged(true);
-      }
-      setComputedTimestepPart(0.0);
+  if (math::equals(getThisTimeWindowRemainder(), 0.0, _eps)) {
+    if (_couplingMode == Explicit) {
+      explicitAdvance();
+    } else if (_couplingMode == Implicit) {
+      implicitAdvance();
     }
-  } else if (_couplingMode == Implicit) {
-    bool convergence                   = true;
-    bool convergenceCoarseOptimization = true;
-    bool doOnlySolverEvaluation        = false;
+  } //subcycling completed
+}
 
-    if (math::equals(getThisTimestepRemainder(), 0.0, _eps)) {
-      PRECICE_DEBUG("Computed full length of iteration");
-      if (doesFirstStep()) {
-        sendDt();
-        sendData(getM2N());
-        getM2N()->receive(convergence);
-        getM2N()->receive(_isCoarseModelOptimizationActive);
-        if (convergence) {
-          timeWindowCompleted();
-        }
-        //if (isCouplingOngoing()) {
-        receiveData(getM2N());
-        //}
-        setHasDataBeenExchanged(true);
-      } else {
+void SerialCouplingScheme::explicitAdvance()
+{
+  setIsTimeWindowComplete(true);
+  setTimeWindows(getTimeWindows() + 1);
+  PRECICE_DEBUG("Sending data...");
+  sendDt();
+  sendData(getM2N());
 
-        // get the current design specifications from the acceleration (for convergence measure)
-        std::map<int, Eigen::VectorXd> designSpecifications;
-        if (getAcceleration().get() != nullptr) {
-          designSpecifications = getAcceleration()->getDesignSpecification(getSendData());
-        }
-        // measure convergence of coupling iteration
-        // measure convergence for coarse model optimization
-        if (_isCoarseModelOptimizationActive) {
-          PRECICE_DEBUG("measure convergence of coarse model optimization.");
-          // in case of multilevel acceleration only: measure the convergence of the coarse model optimization
-          convergenceCoarseOptimization = measureConvergenceCoarseModelOptimization(designSpecifications);
-          // Stop, when maximal iteration count (given in config) is reached
-          if (maxIterationsReached())
-            convergenceCoarseOptimization = true;
-
-          convergence = false;
-          // in case of multilevel PP only: if coarse model optimization converged
-          // steering the requests for evaluation of coarse and fine model, respectively
-          if (convergenceCoarseOptimization) {
-            _isCoarseModelOptimizationActive = false;
-            doOnlySolverEvaluation           = true;
-          } else {
-            _isCoarseModelOptimizationActive = true;
-          }
-        }
-        // measure convergence of coupling iteration
-        else {
-          PRECICE_DEBUG("measure convergence.");
-          doOnlySolverEvaluation = false;
-
-          // measure convergence of the coupling iteration,
-          convergence = measureConvergence(designSpecifications);
-          // Stop, when maximal iteration count (given in config) is reached
-          if (maxIterationsReached())
-            convergence = true;
-        }
-
-        // passed by reference, modified in MM acceleration. No-op for all other accelerations
-        if (getAcceleration().get() != nullptr) {
-          getAcceleration()->setCoarseModelOptimizationActive(&_isCoarseModelOptimizationActive);
-        }
-
-        // for multi-level case, i.e., manifold mapping: after convergence of coarse problem
-        // we only want to evaluate the fine model for the new input, no acceleration etc..
-        if (not doOnlySolverEvaluation) {
-          // coupling iteration converged for current time step. Advance in time.
-          if (convergence) {
-            if (getAcceleration().get() != nullptr) {
-              _deletedColumnsPPFiltering = getAcceleration()->getDeletedColumns();
-              getAcceleration()->iterationsConverged(getSendData());
-            }
-            newConvergenceMeasurements();
-            timeWindowCompleted();
-
-            // no convergence achieved for the coupling iteration within the current time step
-          } else if (getAcceleration().get() != nullptr) {
-            getAcceleration()->performAcceleration(getSendData());
-          }
-
-          // extrapolate new input data for the solver evaluation in time.
-          if (convergence && (getExtrapolationOrder() > 0)) {
-            extrapolateData(getSendData()); // Also stores data
-          } else {                          // Store data for conv. measurement, acceleration, or extrapolation
-            for (DataMap::value_type &pair : getSendData()) {
-              if (pair.second->oldValues.size() > 0) {
-                pair.second->oldValues.col(0) = *pair.second->values;
-              }
-            }
-            for (DataMap::value_type &pair : getReceiveData()) {
-              if (pair.second->oldValues.size() > 0) {
-                pair.second->oldValues.col(0) = *pair.second->values;
-              }
-            }
-          }
-
-          /*
-          /// @todo: (Edit: Done in the solver now) need to copy coarse old values to fine old values, as first solver always sends zeros to the second solver (as pressure vals)
-          //       in the serial scheme, only the sendData is registered in MM PP, we also need to register the pressure values, i.e.
-          //       old fine pressure vals = old coarse pressure vals TODO: find better solution,
-          //auto fineIDs = getAcceleration()->getDataIDs();
-          //for(auto id: fineIDs){
-          //  std::cout<<"id: "<<id<<", fineIds.size(): "<<fineIDs.size()<<'\n';
-          //  getReceiveData(id)->oldValues.column(0) = getReceiveData(id+fineIDs.size())->oldValues.column(0);
-          //}
-           */
-
-          // only fine model solver evaluation is done, no PP
-        } else {
-
-          // if the coarse model problem converged within the first iteration, i.e., no acceleration at all
-          // we need to register the coarse initialized data again on the fine input data,
-          // otherwise the fine input data would be zero in this case, neither anything has been computed so far for the fine
-          // model nor the acceleration did any data registration
-          // ATTENTION: assumes that coarse data is defined after fine data in same ordering.
-          if (_iterationsCoarseOptimization == 1 && getAcceleration().get() != nullptr) {
-            auto fineIDs = getAcceleration()->getDataIDs();
-            for (auto &fineID : fineIDs) {
-              (*getSendData(fineID)->values) = getSendData(fineID + fineIDs.size() + 1)->oldValues.col(0);
-            }
-          }
-        }
-
-        getM2N()->send(convergence);
-
-        getM2N()->send(_isCoarseModelOptimizationActive);
-
-        sendData(getM2N());
-
-        // the second participant does not want new data in the last iteration of the last timestep
-        if (isCouplingOngoing() || not convergence) {
-          receiveAndSetDt();
-          receiveData(getM2N());
-          setHasDataBeenExchanged(true);
-        }
-      }
-
-      if (not convergence) {
-        PRECICE_DEBUG("No convergence achieved");
-        requireAction(constants::actionReadIterationCheckpoint());
-      } else {
-        PRECICE_DEBUG("Convergence achieved");
-        advanceTXTWriters();
-      }
-      updateTimeAndIterations(convergence, convergenceCoarseOptimization);
-      setComputedTimestepPart(0.0);
-    } //subcycling completed
+  if (isCouplingOngoing() || doesFirstStep()) {
+    PRECICE_DEBUG("Receiving data...");
+    receiveAndSetDt();
+    receiveData(getM2N());
+    setHasDataBeenExchanged(true);
   }
+  setComputedTimeWindowPart(0.0);
+}
+
+void SerialCouplingScheme::implicitAdvance()
+{
+  bool convergence                   = true;
+  bool convergenceCoarseOptimization = true;
+  bool doOnlySolverEvaluation        = false;
+
+  PRECICE_DEBUG("Computed full length of iteration");
+  if (doesFirstStep()) {
+    sendDt();
+    sendData(getM2N());
+    getM2N()->receive(convergence);
+    getM2N()->receive(_isCoarseModelOptimizationActive);
+    if (convergence) {
+      timeWindowCompleted();
+    }
+    receiveData(getM2N());
+    setHasDataBeenExchanged(true);
+  } else {
+
+    // get the current design specifications from the acceleration (for convergence measure)
+    std::map<int, Eigen::VectorXd> designSpecifications;
+    if (getAcceleration().get() != nullptr) {
+      designSpecifications = getAcceleration()->getDesignSpecification(getSendData());
+    }
+    // measure convergence of coupling iteration
+    // measure convergence for coarse model optimization
+    if (_isCoarseModelOptimizationActive) {
+      PRECICE_DEBUG("measure convergence of coarse model optimization.");
+      // in case of multilevel acceleration only: measure the convergence of the coarse model optimization
+      convergenceCoarseOptimization = measureConvergenceCoarseModelOptimization(designSpecifications);
+      // Stop, when maximal iteration count (given in config) is reached
+      if (maxIterationsReached())
+        convergenceCoarseOptimization = true;
+
+      convergence = false;
+      // in case of multilevel PP only: if coarse model optimization converged
+      // steering the requests for evaluation of coarse and fine model, respectively
+      if (convergenceCoarseOptimization) {
+        _isCoarseModelOptimizationActive = false;
+        doOnlySolverEvaluation           = true;
+      } else {
+        _isCoarseModelOptimizationActive = true;
+      }
+    }
+    // measure convergence of coupling iteration
+    else {
+      PRECICE_DEBUG("measure convergence.");
+      doOnlySolverEvaluation = false;
+
+      // measure convergence of the coupling iteration,
+      convergence = measureConvergence(designSpecifications);
+      // Stop, when maximal iteration count (given in config) is reached
+      if (maxIterationsReached())
+        convergence = true;
+    }
+
+    // passed by reference, modified in MM acceleration. No-op for all other accelerations
+    if (getAcceleration().get() != nullptr) {
+      getAcceleration()->setCoarseModelOptimizationActive(&_isCoarseModelOptimizationActive);
+    }
+
+    // for multi-level case, i.e., manifold mapping: after convergence of coarse problem
+    // we only want to evaluate the fine model for the new input, no acceleration etc..
+    if (not doOnlySolverEvaluation) {
+      // coupling iteration converged for current time step. Advance in time.
+      if (convergence) {
+        if (getAcceleration().get() != nullptr) {
+          _deletedColumnsPPFiltering = getAcceleration()->getDeletedColumns();
+          getAcceleration()->iterationsConverged(getSendData());
+        }
+        newConvergenceMeasurements();
+        timeWindowCompleted();
+
+        // no convergence achieved for the coupling iteration within the current time step
+      } else if (getAcceleration().get() != nullptr) {
+        getAcceleration()->performAcceleration(getSendData());
+      }
+
+      // extrapolate new input data for the solver evaluation in time.
+      if (convergence && (getExtrapolationOrder() > 0)) {
+        extrapolateData(getSendData()); // Also stores data
+      } else {                          // Store data for conv. measurement, acceleration, or extrapolation
+        for (DataMap::value_type &pair : getSendData()) {
+          if (pair.second->oldValues.size() > 0) {
+            pair.second->oldValues.col(0) = *pair.second->values;
+          }
+        }
+        for (DataMap::value_type &pair : getReceiveData()) {
+          if (pair.second->oldValues.size() > 0) {
+            pair.second->oldValues.col(0) = *pair.second->values;
+          }
+        }
+      }
+
+      /*
+      /// @todo: (Edit: Done in the solver now) need to copy coarse old values to fine old values, as first solver always sends zeros to the second solver (as pressure vals)
+      //       in the serial scheme, only the sendData is registered in MM PP, we also need to register the pressure values, i.e.
+      //       old fine pressure vals = old coarse pressure vals TODO: find better solution,
+      //auto fineIDs = getAcceleration()->getDataIDs();
+      //for(auto id: fineIDs){
+      //  std::cout<<"id: "<<id<<", fineIds.size(): "<<fineIDs.size()<<'\n';
+      //  getReceiveData(id)->oldValues.column(0) = getReceiveData(id+fineIDs.size())->oldValues.column(0);
+      //}
+       */
+
+      // only fine model solver evaluation is done, no PP
+    } else {
+
+      // if the coarse model problem converged within the first iteration, i.e., no acceleration at all
+      // we need to register the coarse initialized data again on the fine input data,
+      // otherwise the fine input data would be zero in this case, neither anything has been computed so far for the fine
+      // model nor the acceleration did any data registration
+      // ATTENTION: assumes that coarse data is defined after fine data in same ordering.
+      if (_iterationsCoarseOptimization == 1 && getAcceleration().get() != nullptr) {
+        auto fineIDs = getAcceleration()->getDataIDs();
+        for (auto &fineID : fineIDs) {
+          (*getSendData(fineID)->values) = getSendData(fineID + fineIDs.size() + 1)->oldValues.col(0);
+        }
+      }
+    }
+
+    getM2N()->send(convergence);
+
+    getM2N()->send(_isCoarseModelOptimizationActive);
+
+    sendData(getM2N());
+
+    // the second participant does not want new data in the last iteration of the last time window
+    if (isCouplingOngoing() || not convergence) {
+      receiveAndSetDt();
+      receiveData(getM2N());
+      setHasDataBeenExchanged(true);
+    }
+  }
+
+  if (not convergence) {
+    PRECICE_DEBUG("No convergence achieved");
+    requireAction(constants::actionReadIterationCheckpoint());
+  } else {
+    PRECICE_DEBUG("Convergence achieved");
+    advanceTXTWriters();
+  }
+
+  updateTimeAndIterations(convergence, convergenceCoarseOptimization);
+  setComputedTimeWindowPart(0.0);
 }
 
 } // namespace cplscheme

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -255,7 +255,7 @@ void SerialCouplingScheme::implicitAdvance()
     // for multi-level case, i.e., manifold mapping: after convergence of coarse problem
     // we only want to evaluate the fine model for the new input, no acceleration etc..
     if (not doOnlySolverEvaluation) {
-      // coupling iteration converged for current time step. Advance in time.
+      // coupling iteration converged for current time window. Advance in time.
       if (convergence) {
         if (getAcceleration().get() != nullptr) {
           _deletedColumnsPPFiltering = getAcceleration()->getDeletedColumns();

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -25,18 +25,19 @@ public:
  * @brief Constructor.
  *
  * @param[in] maxTime Simulation time limit, or UNDEFINED_TIME.
- * @param[in] maxTimesteps Simulation timestep limit, or UNDEFINED_TIMESTEPS.
- * @param[in] timestepLength Simulation timestep length.
+ * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIMEWINDOWS.
+ * @param[in] timeWindowSize Simulation time window size.
+ * @param[in] validDigits TODO
  * @param[in] firstParticipant Name of participant starting simulation.
  * @param[in] secondParticipant Name of second participant in coupling.
  * @param[in] localParticipant Name of participant using this coupling scheme.
- * @param[in] communication Communication object for com. between participants.
- * @param[in] monitorIterations If true, a txt file monitoring iterations is written.
+ * @param[in] m2n Communication object for com. between participants. TODO?
+ * TODO add dtMethod, cplMode, maxIterations
  */
   SerialCouplingScheme(
       double                        maxTime,
-      int                           maxTimesteps,
-      double                        timestepLength,
+      int                           maxTimeWindows,
+      double                        timeWindowSize,
       int                           validDigits,
       const std::string &           firstParticipant,
       const std::string &           secondParticipant,
@@ -46,7 +47,13 @@ public:
       CouplingMode                  cplMode,
       int                           maxIterations = 1);
 
-  virtual void initialize(double startTime, int startTimestep);
+  /**
+   * @brief TODO
+   *
+   * @param[in] startTime TODO
+   * @param[in] startTimeWindow TODO
+   */
+  virtual void initialize(double startTime, int startTimeWindow);
 
   virtual void initializeData();
 
@@ -55,6 +62,11 @@ public:
   logging::Logger _log{"cplschemes::SerialCouplingSchemes"};
 
   friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testExtrapolateData; // For whitebox tests
+
+private:
+  virtual void explicitAdvance();
+
+  virtual void implicitAdvance();
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -123,7 +123,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
-        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps() - 1);
+        BOOST_TEST(computedTimesteps == cplScheme->getTimeWindows() - 1);
         BOOST_TEST(cplScheme->hasDataBeenExchanged());
       }
       cplScheme->finalize();
@@ -151,7 +151,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
-        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps() - 1);
+        BOOST_TEST(computedTimesteps == cplScheme->getTimeWindows() - 1);
         BOOST_TEST(cplScheme->hasDataBeenExchanged());
       }
       cplScheme->finalize();
@@ -180,7 +180,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
-        BOOST_TEST(computedTimesteps == cplScheme->getTimesteps() - 1);
+        BOOST_TEST(computedTimesteps == cplScheme->getTimeWindows() - 1);
         if (cplScheme->isCouplingOngoing())
           BOOST_TEST(cplScheme->hasDataBeenExchanged());
       }
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1)
   }
   composition.finalize();
   BOOST_TEST(advances == 10);
-  BOOST_TEST(scheme->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme->getTimeWindows() - 1 == 10);
 }
 
 // Test one implicit dummy coupling scheme
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit1)
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme->getTimeWindows() - 1 == 10);
 }
 
 // Test two explicit dummy coupling schemes
@@ -278,8 +278,8 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
   }
   composition.finalize();
   BOOST_TEST(advances == 10);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
 }
 
 // Test three explicit dummy coupling schemes
@@ -308,9 +308,9 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
   }
   composition.finalize();
   BOOST_TEST(advances == 10);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 // Test two implicit dummy coupling schemes
@@ -343,8 +343,8 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2)
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
 }
 
 // Test two implicit dummy coupling schemes with different iteration number
@@ -379,8 +379,8 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2DiffIteration)
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
 }
 
 // Test three implicit dummy coupling schemes
@@ -415,9 +415,9 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3)
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 // Test three implicit dummy coupling schemes with different iteration number
@@ -462,9 +462,9 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3DiffIteration)
   }
   composition.finalize();
   BOOST_TEST(advances == 40);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 // Test E, I(2)
@@ -488,16 +488,16 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
     advances++;
     if (advances % 2 == 0) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 2);
     } else {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 1) / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances + 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
 }
 
 // Test I(2), E
@@ -521,16 +521,16 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
     advances++;
     if (advances % 2 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 2);
     } else {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 1) / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
 }
 
 // Test E, I(3)
@@ -556,16 +556,16 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
     advances++;
     if (advances % 3 == 0) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 3);
     } else {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + (3 - advances % 3)) / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances + (3 - advances % 3)) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
 }
 
 // Test I(3), E
@@ -589,16 +589,16 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3Explicit1)
     advances++;
     if (advances % 3 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 3);
     } else {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - (advances % 3)) / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - (advances % 3)) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
 }
 
 // Test E, I(2), I(2)
@@ -625,18 +625,18 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2Implicit2)
     if (advances % 2 == 0) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 2);
     } else {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 1) / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances + 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 // Test E, I(2), I(3)
@@ -662,24 +662,24 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2Implicit3)
     composition.advance();
     advances++;
     if (advances % 3 == 0) {
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 3);
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(writeIterationCheckpoint));
     } else if (advances % 3 == 1) {
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 2) / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances + 2) / 3);
     } else if (advances % 3 == 2) {
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme3->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances + 1) / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances + 1) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 // Test I(2), I(2), E
@@ -706,22 +706,22 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Implicit2Explicit1)
     if (advances % 2 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 2);
-      BOOST_TEST(scheme2->getTimesteps() - 1 == advances / 2);
-      BOOST_TEST(scheme3->getTimesteps() - 1 == advances / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 2);
+      BOOST_TEST(scheme2->getTimeWindows() - 1 == advances / 2);
+      BOOST_TEST(scheme3->getTimeWindows() - 1 == advances / 2);
     } else {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 1) / 2);
-      BOOST_TEST(scheme2->getTimesteps() - 1 == (advances - 1) / 2);
-      BOOST_TEST(scheme3->getTimesteps() - 1 == (advances - 1) / 2);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - 1) / 2);
+      BOOST_TEST(scheme2->getTimeWindows() - 1 == (advances - 1) / 2);
+      BOOST_TEST(scheme3->getTimeWindows() - 1 == (advances - 1) / 2);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 20);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 // Test I(2), I(2), E
@@ -749,28 +749,28 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Implicit2Explicit1DiffIt
     if (advances % 3 == 0) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == advances / 3);
-      BOOST_TEST(scheme2->getTimesteps() - 1 == advances / 3);
-      BOOST_TEST(scheme3->getTimesteps() - 1 == advances / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 3);
+      BOOST_TEST(scheme2->getTimeWindows() - 1 == advances / 3);
+      BOOST_TEST(scheme3->getTimeWindows() - 1 == advances / 3);
     } else if (advances % 3 == 1) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 1) / 3);
-      BOOST_TEST(scheme2->getTimesteps() - 1 == (advances - 1) / 3);
-      BOOST_TEST(scheme3->getTimesteps() - 1 == (advances - 1) / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - 1) / 3);
+      BOOST_TEST(scheme2->getTimeWindows() - 1 == (advances - 1) / 3);
+      BOOST_TEST(scheme3->getTimeWindows() - 1 == (advances - 1) / 3);
     } else if (advances % 3 == 2) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
       BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - 2) / 3);
-      BOOST_TEST(scheme2->getTimesteps() - 1 == (advances + 1) / 3);
-      BOOST_TEST(scheme3->getTimesteps() - 1 == (advances - 2) / 3);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - 2) / 3);
+      BOOST_TEST(scheme2->getTimeWindows() - 1 == (advances + 1) / 3);
+      BOOST_TEST(scheme3->getTimeWindows() - 1 == (advances - 2) / 3);
     }
   }
   composition.finalize();
   BOOST_TEST(advances == 30);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionUntitled) /// @todo give a better name, what is this test doing?
@@ -796,18 +796,18 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionUntitled) /// @todo give a better
     advances++;
     if (advances % 4 >= 3) {
       BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(scheme1->getTimesteps() - 1 == (advances - (advances % 4) + 4) / 4);
+      BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - (advances % 4) + 4) / 4);
     } else if (advances % 4 != 0) {
       BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
     }
-    BOOST_TEST(scheme2->getTimesteps() - 1 == (advances + 1) / 4);
-    BOOST_TEST(scheme2->getTimesteps() - 1 == (advances + 1) / 4);
+    BOOST_TEST(scheme2->getTimeWindows() - 1 == (advances + 1) / 4);
+    BOOST_TEST(scheme2->getTimeWindows() - 1 == (advances + 1) / 4);
   }
   composition.finalize();
   BOOST_TEST(advances == 40);
-  BOOST_TEST(scheme1->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme2->getTimesteps() - 1 == 10);
-  BOOST_TEST(scheme3->getTimesteps() - 1 == 10);
+  BOOST_TEST(scheme1->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme2->getTimeWindows() - 1 == 10);
+  BOOST_TEST(scheme3->getTimeWindows() - 1 == 10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -108,7 +108,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  virtual int getTimesteps() const
+  virtual int getTimeWindows() const
   {
     return _timesteps;
     return 0;
@@ -126,7 +126,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  virtual int getMaxTimesteps() const
+  virtual int getMaxTimeWindows() const
   {
     PRECICE_ASSERT(false);
     return 0;
@@ -135,7 +135,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  virtual bool hasTimestepLength() const
+  virtual bool hasTimeWindowSize() const
   {
     PRECICE_ASSERT(false);
     return false;
@@ -144,7 +144,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  virtual double getTimestepLength() const
+  virtual double getTimeWindowSize() const
   {
     PRECICE_ASSERT(false);
     return 0;
@@ -153,7 +153,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  virtual double getThisTimestepRemainder() const
+  virtual double getThisTimeWindowRemainder() const
   {
     PRECICE_ASSERT(false);
     return 0;
@@ -162,7 +162,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  virtual double getComputedTimestepPart() const
+  virtual double getComputedTimeWindowPart() const
   {
     PRECICE_ASSERT(false);
     return 0;

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -58,7 +58,7 @@ void runSimpleExplicitCoupling(
       cplScheme.advance();
       BOOST_TEST(cplScheme.isTimeWindowComplete());
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
       BOOST_TEST(not cplScheme.isActionRequired("WriteIterationCheckpoint"));
       BOOST_TEST(not cplScheme.isActionRequired("ReadIterationCheckpoint"));
       BOOST_TEST(cplScheme.isTimeWindowComplete());
@@ -100,7 +100,7 @@ void runSimpleExplicitCoupling(
       cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
       cplScheme.advance();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
       BOOST_TEST(cplScheme.isTimeWindowComplete());
@@ -214,7 +214,7 @@ void runExplicitCouplingWithSubcycling(
       cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
       cplScheme.advance();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
       BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
       BOOST_TEST(cplScheme.isTimeWindowComplete());
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
       cplScheme.advance();
       BOOST_TEST(cplScheme.isTimeWindowComplete());
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
       if (cplScheme.isCouplingOngoing()) {
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
       }
@@ -430,13 +430,13 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt,
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
-      computedTime += cplScheme.getTimestepLength();
+      computedTime += cplScheme.getTimeWindowSize();
       computedTimesteps++;
-      cplScheme.addComputedTime(cplScheme.getTimestepLength());
+      cplScheme.addComputedTime(cplScheme.getTimeWindowSize());
       cplScheme.advance();
       BOOST_TEST(cplScheme.isTimeWindowComplete());
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(computedTimesteps == cplScheme.getTimesteps() - 1);
+      BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
       if (cplScheme.isCouplingOngoing()) {
         BOOST_TEST(cplScheme.hasDataBeenExchanged());
       }

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -79,7 +79,7 @@ void runCoupling(
         computedTime += maxLengthTimestep;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
@@ -146,7 +146,7 @@ void runCoupling(
         computedTime += maxLengthTimestep;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
         // The iterations are enforced by the controlled decrease of the
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
@@ -241,7 +241,7 @@ void runCouplingWithSubcycling(
         computedTime += maxTimestepLength;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
@@ -325,7 +325,7 @@ void runCouplingWithSubcycling(
         computedTime += maxTimestepLength;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimesteps() - 1));
+        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
@@ -445,14 +445,14 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 0.0));
 
   (*cplData->values)[0] = 1.0;
-  scheme.setTimesteps(scheme.getTimesteps() + 1);
+  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
   scheme.extrapolateData(scheme.getSendData());
   BOOST_TEST(testing::equals((*cplData->values)[0], 2.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 2.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 1.0));
 
   (*cplData->values)[0] = 4.0;
-  scheme.setTimesteps(scheme.getTimesteps() + 1);
+  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
   scheme.extrapolateData(scheme.getSendData());
   BOOST_TEST(testing::equals((*cplData->values)[0], 7.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 7.0));
@@ -479,7 +479,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 0.0));
 
   (*cplData->values)[0] = 1.0;
-  scheme2.setTimesteps(scheme2.getTimesteps() + 1);
+  scheme2.setTimeWindows(scheme2.getTimeWindows() + 1);
   scheme2.extrapolateData(scheme2.getSendData());
   BOOST_TEST(testing::equals((*cplData->values)[0], 2.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 2.0));
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 0.0));
 
   (*cplData->values)[0] = 4.0;
-  scheme2.setTimesteps(scheme2.getTimesteps() + 1);
+  scheme2.setTimeWindows(scheme2.getTimeWindows() + 1);
   scheme2.extrapolateData(scheme2.getSendData());
   BOOST_TEST(testing::equals((*cplData->values)[0], 8.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 8.0));


### PR DESCRIPTION
`cplscheme` needs an update in naming due to #639.

Other minor changes:

* Update/Add documentation
* Create functions `explicitAdvance` and `implicitAdvance` in `SerialCouplingScheme`, following `ParallelCouplingScheme`
* Factor out subcycling check (`if (math::equals(getThisTimestepRemainder(), 0.0, _eps))`)