### PR TITLE
Improve and sync RBF error messages

### DIFF
--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -214,7 +214,8 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping(
   if (getDimensions() == 2) {
     _deadAxis = {xDead, yDead};
     PRECICE_CHECK(not(xDead and yDead), "You cannot choose all axes to be dead for a RBF mapping");
-    PRECICE_CHECK(not zDead, "You cannot dead out the z-axis if dimension is set to 2");
+    if (zDead)
+      PRECICE_WARN("Setting the z-axis to dead on a 2 dimensional problem has not effect.");
   } else if (getDimensions() == 3) {
     _deadAxis = {xDead, yDead, zDead};
     PRECICE_CHECK(not(xDead and yDead and zDead), "You cannot choose all axes to be dead for a RBF mapping");
@@ -672,7 +673,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
         auto sigma = petsc::Vector::allocate(_matrixQ, "sigma", petsc::Vector::LEFT);
         if (not _QRsolver.solveTranspose(tau, sigma)) {
           KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
-          PRECICE_ERROR("RBF Polynomial linear system has not converged.");
+          PRECICE_ERROR("RBF Polynomial linear system has not converged. "
+                        "Try to fix axis-aligned mapping setups by marking perpendicular axis as dead.");
         }
         VecWAXPY(out, -1, sigma, mu);
       } else {
@@ -681,7 +683,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
         utils::Event eSolve("map.pet.solveConservative.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
         if (not _solver.solve(au, out)) {
           KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
-          PRECICE_ERROR("RBF linear system has not converged.");
+          PRECICE_ERROR("RBF linear system has not converged. "
+                        "Try to fix axis-aligned mapping setups by marking perpendicular axis as dead.");
         }
         eSolve.addData("Iterations", _solver.getIterationNumber());
         eSolve.stop();
@@ -733,7 +736,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
       if (_polynomial == Polynomial::SEPARATE) {
         if (not _QRsolver.solve(in, a)) {
           KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
-          PRECICE_ERROR("Polynomial QR linear system has not converged.");
+          PRECICE_ERROR("Polynomial QR linear system has not converged. "
+                        "Try to fix axis-aligned mapping setups by marking perpendicular axis as dead.");
         }
         VecScale(a, -1);
         MatMultAdd(_matrixQ, a, in, in); // Subtract the polynomial from the input values
@@ -748,7 +752,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
       utils::Event eSolve("map.pet.solveConsistent.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
       if (not _solver.solve(in, p)) {
         KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
-        PRECICE_ERROR("RBF linear system has not converged.");
+        PRECICE_ERROR("RBF linear system has not converged. "
+                      "Try to fix axis-aligned mapping setups by marking perpendicular axis as dead.");
       }
       eSolve.addData("Iterations", _solver.getIterationNumber());
       eSolve.stop();

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -85,7 +85,7 @@ private:
       _deadAxis[1] = yDead;
       PRECICE_CHECK(not(xDead && yDead), "You cannot choose all axis to be dead for a RBF mapping");
       if (zDead)
-        PRECICE_WARN("Setting the z-axis to dead on a 2 dimensional problem has not effect and will be ignored.");
+        PRECICE_WARN("Setting the z-axis to dead on a 2 dimensional problem has not effect.");
     } else if (getDimensions() == 3) {
       _deadAxis[0] = xDead;
       _deadAxis[1] = yDead;
@@ -194,8 +194,10 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   }
 
   _qr = matrixCLU.colPivHouseholderQr();
-  if (not _qr.isInvertible())
-    PRECICE_ERROR("Interpolation matrix C is not invertible.");
+  if (not _qr.isInvertible()) {
+    PRECICE_ERROR("RBF interpolation matrix is not invertible! "
+                  "Try to fix axis-aligned mapping setups by marking perpendicular axis as dead.");
+  }
 
   _hasComputedMapping = true;
 }


### PR DESCRIPTION
This PR improves RBF-related error messages by giving a hint on how to resolve them.
```
RBF interpolation matrix is not invertible! Try to fix axis-aligned mapping setups by marking perpendicular axis as dead.
```

Its also makes the handling of setting the z-axis to dead in a 2d case. Both mapping now warn that this has no effect.