### PR TITLE
Pkg-config now uses GNUInstallDirs

### DIFF
--- a/tools/releasing/packaging/debian/precice.pc.in
+++ b/tools/releasing/packaging/debian/precice.pc.in
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${prefix}/lib
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 Name: preCICE
 Description: preCICE coupling library


### PR DESCRIPTION
This PR fixes the generated pkg-config files for preCICE for the case where `GNUInstallDirs` points to anything but `lib` and `include`.

Closes #673 