### PR TITLE
Initial implementation of split patches

### DIFF
--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -47,14 +47,14 @@ void NearestNeighborMapping::computeMapping()
       PRECICE_INFO("outputID = " << outputPatchID);
       // Search for the output vertex inside the input mesh and add index to _vertexIndices
       // rtree will only have vertices with a specific patch number
-      rtree->query(boost::geometry::index::nearest(coords, 1) and boost::geometry::index::satisfies([&](size_t const i) { return (outputPatchID - input()->vertices()[i].getPatchID()) < 1 ;}),
+      rtree->query(boost::geometry::index::nearest(coords, 1),
                    boost::make_function_output_iterator([&](size_t const &val) {
                      const auto &match = input()->vertices()[val];
                      _vertexIndices[i] = match.getID();
                      distanceStatistics(bg::distance(match, coords));
                    }));
                    
-      /*rtree->query(boost::geometry::index::nearest(coords, 1) && boost::geometry::index::satisfies([&](size_t const i) {return outputPatchID == input()->vertices()[i].getPatchID();}),
+      /*rtree->query(boost::geometry::index::nearest(coords, 1) and boost::geometry::index::satisfies([&](size_t const i) { return (outputPatchID - input()->vertices()[i].getPatchID()) < 1 ;}),
                    boost::make_function_output_iterator([&](size_t const &val) {
                      const auto &match = input()->vertices()[val];
                      _vertexIndices[i] = match.getID();
@@ -78,19 +78,20 @@ void NearestNeighborMapping::computeMapping()
       const Eigen::VectorXd &coords = inputVertices[i].getCoords();
       int inputPatchID = inputVertices[i].getPatchID();
       // Search for the input vertex inside the output mesh and add index to _vertexIndices
-      /*rtree->query(boost::geometry::index::nearest(coords, 1),
+      rtree->query(boost::geometry::index::nearest(coords, 1),
                    boost::make_function_output_iterator([&](size_t const &val) {
                      const auto &match = output()->vertices()[val];
                      _vertexIndices[i] = match.getID();
                      distanceStatistics(bg::distance(match, coords));
                    }));
-                   */
-      rtree->query(boost::geometry::index::nearest(coords, 1) && boost::geometry::index::satisfies([&](size_t const i) {return inputPatchID == outputVertices[i].getPatchID();}),
+                   
+      /*rtree->query(boost::geometry::index::nearest(coords, 1) && boost::geometry::index::satisfies([&](size_t const i) {return inputPatchID == outputVertices[i].getPatchID();}),
                    boost::make_function_output_iterator([&](size_t const &val) {
                      const auto &match = input()->vertices()[val];
                      _vertexIndices[i] = match.getID();
                      distanceStatistics(bg::distance(match, coords));
-                   }));   
+                   }));  
+                   */ 
     }
     PRECICE_INFO("Mapping distance " << distanceStatistics);
   }

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -46,6 +46,7 @@ void NearestNeighborMapping::computeMapping()
       int outputPatchID = outputVertices[i].getPatchID();
       PRECICE_INFO("outputID = " << outputPatchID);
       // Search for the output vertex inside the input mesh and add index to _vertexIndices
+      // rtree will only have vertices with a specific patch number
       rtree->query(boost::geometry::index::nearest(coords, 1) and boost::geometry::index::satisfies([&](size_t const i) { return (outputPatchID - input()->vertices()[i].getPatchID()) < 1 ;}),
                    boost::make_function_output_iterator([&](size_t const &val) {
                      const auto &match = input()->vertices()[val];

--- a/src/mapping/NearestNeighborMapping.hpp
+++ b/src/mapping/NearestNeighborMapping.hpp
@@ -16,7 +16,7 @@ public:
    * @param[in] constraint Specifies mapping to be consistent or conservative.
    * @param[in] dimensions Dimensionality of the meshes
    */
-  NearestNeighborMapping(Constraint constraint, int dimensions);
+  NearestNeighborMapping(Constraint constraint, int fromPatchID, int toPatchID, int dimensions);
 
   /// Destructor, empty.
   virtual ~NearestNeighborMapping() {}
@@ -29,6 +29,16 @@ public:
 
   /// Removes a computed mapping.
   virtual void clear() override;
+
+  int getFromPatchID() const
+  {
+    return _fromPatchID;
+  }
+
+  int getToPatchID() const
+  {
+    return _toPatchID;
+  }
 
   /// Maps input data to output data from input mesh to output mesh.
   virtual void map(
@@ -43,6 +53,10 @@ private:
 
   /// Flag to indicate whether computeMapping() has been called.
   bool _hasComputedMapping = false;
+
+  int _fromPatchID;
+
+  int _toPatchID;
 
   /// Computed output vertex indices to map data from input vertices to.
   std::vector<int> _vertexIndices;

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -113,7 +113,8 @@ void NearestProjectionMapping::computeMapping()
       if (not found) {
         if (!indexVertices) {
           precice::utils::Event e3(baseEvent + ".getIndexOnVertices", precice::syncMode);
-          indexVertices = mesh::rtree::getVertexRTree(search_space);
+          int z = 0;
+          indexVertices = mesh::rtree::getVertexRTree(search_space, z);
         }
         // Search for the origin inside the destination meshes vertices
         indexVertices->query(bg::index::nearest(coords, 1),
@@ -190,7 +191,8 @@ void NearestProjectionMapping::computeMapping()
       if (not found) {
         if (!indexVertices) {
           precice::utils::Event e4(baseEvent + ".getIndexOnVertices", precice::syncMode);
-          indexVertices = mesh::rtree::getVertexRTree(search_space);
+          int z = 0;
+          indexVertices = mesh::rtree::getVertexRTree(search_space,z);
         }
         // Search for the vertex inside the destination meshes vertices
         indexVertices->query(bg::index::nearest(coords, 1),

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -71,6 +71,7 @@ public:
       bool                           xDead,
       bool                           yDead,
       bool                           zDead,
+      int                            fromPatchID,
       double                         solverRtol    = 1e-9,
       Polynomial                     polynomial    = Polynomial::SEPARATE,
       Preallocation                  preallocation = Preallocation::TREE);
@@ -193,6 +194,7 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping(
     bool                           xDead,
     bool                           yDead,
     bool                           zDead,
+    int                            fromPatchID,
     double                         solverRtol,
     Polynomial                     polynomial,
     Preallocation                  preallocation)
@@ -824,7 +826,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
       preCICE is fully functional, but performance for large cases is degraded."
 #endif
   ) {
-    auto rtree    = mesh::rtree::getVertexRTree(filterMesh);
+    int z = 0;
+    auto rtree    = mesh::rtree::getVertexRTree(filterMesh,z);
     namespace bgi = boost::geometry::index;
     auto bb       = otherMesh->getBoundingBox();
     // Enlarge by support radius
@@ -881,7 +884,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshSecondRound()
     bb[d].first -= _basisFunction.getSupportRadius();
     bb[d].second += _basisFunction.getSupportRadius();
   }
-  auto rtree = mesh::rtree::getVertexRTree(mesh);
+  int z = 0;
+  auto rtree = mesh::rtree::getVertexRTree(mesh,z);
   rtree->query(boost::geometry::index::within(bb),
                boost::make_function_output_iterator([&mesh](size_t idx) {
                  mesh->vertices()[idx].tag();
@@ -1346,7 +1350,8 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixC(mesh::
   std::tie(n, std::ignore) = _matrixC.getLocalSize();
   std::vector<PetscInt> d_nnz(n), o_nnz(n);
 
-  auto tree = mesh::rtree::getVertexRTree(inMesh);
+  int z = 0;
+  auto tree = mesh::rtree::getVertexRTree(inMesh,z);
 
   double const supportRadius = _basisFunction.getSupportRadius();
 
@@ -1444,7 +1449,8 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixA(mesh::
 
   PetscInt       ownerRangeABegin, ownerRangeAEnd, colOwnerRangeABegin, colOwnerRangeAEnd;
   PetscInt const outputSize    = _matrixA.getLocalSize().first;
-  auto           tree          = mesh::rtree::getVertexRTree(inMesh);
+  int z = 0;
+  auto           tree          = mesh::rtree::getVertexRTree(inMesh,z);
   double const   supportRadius = _basisFunction.getSupportRadius();
 
   std::tie(ownerRangeABegin, ownerRangeAEnd)       = _matrixA.ownerRange();

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -368,9 +368,6 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     if (not inVertex.isOwner())
       continue;
 
-    // Need the patch ID for the vertex of interest here
-    // int inVertexPatchID = inVertex.getPatchID();
-
     PetscInt colNum = 0; // holds the number of non-zero columns in current row
 
     // -- SETS THE POLYNOMIAL PART OF THE MATRIX --
@@ -406,9 +403,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       ++preallocRow;
     } else {
       for (const mesh::Vertex &vj : inMesh->vertices()) {
-        // If patch ID of vj vertex, then skip all computations
-        //int vjPatchID = vj.getPatchID();
-        //if (vjPatchID == inVertexPatchID) {
+
           int const col = vj.getGlobalIndex() + polyparams;
           if (row > col)
             continue; // matrix is symmetric
@@ -423,9 +418,6 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
             rowVals[colNum]  = _basisFunction.evaluate(norm);
             colIdx[colNum++] = col; // column of entry is the globalIndex
           }
-        //}else{
-        //  PRECICE_INFO("Skip due to patch ID difference");
-        //}
       }
     }
     ierr = AOApplicationToPetsc(_AOmapping, colNum, colIdx.data());
@@ -473,7 +465,6 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
 
   for (PetscInt row = ownerRangeABegin; row < ownerRangeAEnd; ++row) {
     mesh::Vertex const &oVertex = outMesh->vertices()[row - _matrixA.ownerRange().first];
-    //int oVertexPatchID = oVertex.getPatchID();
 
     // -- SET THE POLYNOMIAL PART OF THE MATRIX --
     if (_polynomial == Polynomial::ON or _polynomial == Polynomial::SEPARATE) {
@@ -504,8 +495,6 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       }
     } else {
       for (const mesh::Vertex &inVertex : inMesh->vertices()) {
-        //int inVertexPatchID = inVertex.getPatchID();
-        //if (inVertexPatchID == oVertexPatchID){
         distance = oVertex.getCoords() - inVertex.getCoords();
         for (int d = 0; d < dimensions; d++) {
           if (_deadAxis[d])
@@ -516,9 +505,6 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
           rowVals[colNum]  = _basisFunction.evaluate(norm);
           colIdx[colNum++] = inVertex.getGlobalIndex() + polyparams;
         }
-        //}else {
-        //PRECICE_INFO("Skip due to patch ID difference");
-      //}
       } 
     }
     ierr = AOApplicationToPetsc(_AOmapping, colNum, colIdx.data());

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -1028,12 +1028,18 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computePreallocationMatr
           distance[d] = 0;
         }
       }
-
-      if (_basisFunction.getSupportRadius() > distance.norm() or col == global_row) {
-        if (mappedCol >= colOwnerRangeCBegin and mappedCol < colOwnerRangeCEnd)
-          d_nnz[local_row]++;
-        else
-          o_nnz[local_row]++;
+      if ( inVertex.getPatchID() == vj.getPatchID() ){
+        PRECICE_INFO("Matrix C: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+        PRECICE_INFO("Matrix C: Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
+        if (_basisFunction.getSupportRadius() > distance.norm() or col == global_row) {
+          if (mappedCol >= colOwnerRangeCBegin and mappedCol < colOwnerRangeCEnd)
+            d_nnz[local_row]++;
+          else
+            o_nnz[local_row]++;
+      }
+      }else{
+        PRECICE_INFO("Matrix C: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+        PRECICE_INFO("Matrix C: Skip due to patch ID difference: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
       }
     }
     local_row++;
@@ -1106,14 +1112,21 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computePreallocationMatr
         if (_deadAxis[d])
           distance[d] = 0;
       }
+      if ( inVertex.getPatchID() == oVertex.getPatchID() ){
+        PRECICE_INFO("Matrix A: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << oVertex.getID() );
+        PRECICE_INFO("Matrix A: Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << oVertex.getPatchID() );
 
-      if (_basisFunction.getSupportRadius() > distance.norm()) {
-        col = inVertex.getGlobalIndex() + polyparams;
-        AOApplicationToPetsc(_AOmapping, 1, &col);
-        if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-          d_nnz[localRow]++;
-        else
-          o_nnz[localRow]++;
+        if (_basisFunction.getSupportRadius() > distance.norm()) {
+          col = inVertex.getGlobalIndex() + polyparams;
+          AOApplicationToPetsc(_AOmapping, 1, &col);
+          if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
+            d_nnz[localRow]++;
+          else
+            o_nnz[localRow]++;
+        }
+        }else{
+          PRECICE_INFO("Matrix A: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+          PRECICE_INFO("Matrix A: Skip due to patch ID difference: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
       }
     }
   }
@@ -1183,13 +1196,21 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::savedPreallocationMatrixC(mes
         if (_deadAxis[d])
           distance[d] = 0;
 
-      double const norm = distance.norm();
-      if (_basisFunction.getSupportRadius() > norm or col == global_row) {
-        vertexData[local_row - localPolyparams].emplace_back(vj.getGlobalIndex() + polyparams, norm);
-        if (mappedCol >= colOwnerRangeCBegin and mappedCol < colOwnerRangeCEnd)
-          d_nnz[local_row]++;
-        else
-          o_nnz[local_row]++;
+      if ( inVertex.getPatchID() == vj.getPatchID() ){
+        PRECICE_INFO("Matrix C: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+        PRECICE_INFO("Matrix C: Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
+        double const norm = distance.norm();
+        if (_basisFunction.getSupportRadius() > norm or col == global_row) {
+          vertexData[local_row - localPolyparams].emplace_back(vj.getGlobalIndex() + polyparams, norm);
+          if (mappedCol >= colOwnerRangeCBegin and mappedCol < colOwnerRangeCEnd)
+            d_nnz[local_row]++;
+          else
+            o_nnz[local_row]++;
+        }
+        }else{
+          PRECICE_INFO("Matrix C: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+          PRECICE_INFO("Matrix C: Skip due to patch ID difference: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
+        
       }
     }
     local_row++;
@@ -1264,19 +1285,28 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::savedPreallocationMatrixA(mes
         if (_deadAxis[d])
           distance[d] = 0;
 
-      double const norm = distance.norm();
-      if (_basisFunction.getSupportRadius() > norm) {
-        col = inVertex.getGlobalIndex() + polyparams;
-        vertexData[localRow].emplace_back(col, norm);
+      if ( inVertex.getPatchID() == oVertex.getPatchID() ){
+        PRECICE_INFO("Matrix A: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << oVertex.getID() );
+        PRECICE_INFO("Matrix A: Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << oVertex.getPatchID() );
 
-        AOApplicationToPetsc(_AOmapping, 1, &col);
-        if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-          d_nnz[localRow]++;
-        else
-          o_nnz[localRow]++;
+        double const norm = distance.norm();
+        if (_basisFunction.getSupportRadius() > norm) {
+          col = inVertex.getGlobalIndex() + polyparams;
+          vertexData[localRow].emplace_back(col, norm);
+
+          AOApplicationToPetsc(_AOmapping, 1, &col);
+          if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
+            d_nnz[localRow]++;
+          else
+           o_nnz[localRow]++;
+        }
+      }else{
+        PRECICE_INFO("Matrix A: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+        PRECICE_INFO("Matrix A: Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
       }
     }
   }
+  
   if (utils::Parallel::getCommunicatorSize() == 1) {
     // std::cout << "Preallocation A Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
     MatSeqAIJSetPreallocation(_matrixA, 0, d_nnz.data());
@@ -1355,11 +1385,14 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixC(mesh::
       for (int d = 0; d < dimensions; d++)
         if (_deadAxis[d])
           distance[d] = 0;
+      
+      int inVertexPatchID = inVertex.getPatchID();
+      int vjPatchID = vj.getPatchID();
 
       double const norm = distance.norm();
-      if (inVertex.getPatchID() == vj.getPatchID()){
-        PRECICE_INFO("ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
-        PRECICE_INFO("Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
+      if ( inVertexPatchID == vjPatchID ){
+        PRECICE_INFO("Matrix C: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+        PRECICE_INFO("Matrix C: Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
       if (supportRadius > norm or col == global_row) {
         vertexData[local_row - localPolyparams].emplace_back(vj.getGlobalIndex() + polyparams, norm);
         if (mappedCol >= colOwnerRangeCBegin and mappedCol < colOwnerRangeCEnd)
@@ -1368,8 +1401,8 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixC(mesh::
           o_nnz[local_row]++;
       }
       } else{
-        PRECICE_INFO("ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
-        PRECICE_INFO("Skip due to patch ID difference: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
+        PRECICE_INFO("Matrix C: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << vj.getID() );
+        PRECICE_INFO("Matrix C: Skip due to patch ID difference: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << vj.getPatchID() );
       }
       col++;
     }
@@ -1438,6 +1471,8 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixA(mesh::
       }
     }
 
+    int oVertexPatchID = oVertex.getPatchID();
+
     // -- PREALLOCATE THE COEFFICIENTS --
     results.clear();
     auto search_box = mesh::getEnclosingBox(oVertex, supportRadius);
@@ -1448,6 +1483,8 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixA(mesh::
     for (auto i : results) {
       const mesh::Vertex &inVertex = inMesh->vertices()[i];
       distance                     = oVertex.getCoords() - inVertex.getCoords();
+      
+      int inVertexPatchID = inVertex.getPatchID();
 
       for (int d = 0; d < dimensions; d++)
         if (_deadAxis[d])
@@ -1455,14 +1492,21 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixA(mesh::
 
       double const norm = distance.norm();
       if (supportRadius > norm) {
-        col = inVertex.getGlobalIndex() + polyparams;
-        vertexData[localRow].emplace_back(col, norm);
+        if ( inVertexPatchID == oVertexPatchID ){
+          PRECICE_INFO("Matrix A: D numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << oVertex.getID() );
+          PRECICE_INFO("Matrix A: Patch ID matches: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << oVertex.getPatchID() );
+          col = inVertex.getGlobalIndex() + polyparams;
+          vertexData[localRow].emplace_back(col, norm);
 
-        AOApplicationToPetsc(_AOmapping, 1, &col);
-        if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-          d_nnz[localRow]++;
-        else
-          o_nnz[localRow]++;
+          AOApplicationToPetsc(_AOmapping, 1, &col);
+          if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
+            d_nnz[localRow]++;
+          else
+            o_nnz[localRow]++;
+        }else{
+          PRECICE_INFO("Matrix A: ID numbers of vertices: inVertexID = " << inVertex.getID() << " and vjID = " << oVertex.getID() );
+          PRECICE_INFO("Matrix A: Skip due to patch ID difference: inVertexPatchID = " << inVertex.getPatchID() << " and vjPatchID = " << oVertex.getPatchID() );
+        }
       }
     }
   }

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -139,8 +139,21 @@ void MappingConfiguration::xmlTagCallback(
     double        solverRtol     = 1e-9;
     bool          xDead = false, yDead = false, zDead = false;
     bool          useLU         = false;
+    int           fromPatchID = -1;
+    int           toPatchID = -1;
     Polynomial    polynomial    = Polynomial::ON;
     Preallocation preallocation = Preallocation::TREE;
+
+    mesh::PtrMesh     fromMeshName(_meshConfig->getMesh(fromMesh));
+    mesh::PtrMesh     toMeshName(_meshConfig->getMesh(toMesh));
+    std::vector<std::string>  totalFromPatches = fromMeshName->getTotalPatches();   // How many patches to create a mapping for
+    std::vector<std::string>  totalToPatches = toMeshName->getTotalPatches();   // How many patches to create a mapping for
+
+    PRECICE_INFO("All from patches: " << totalFromPatches);
+    PRECICE_INFO("All to patches: " << totalToPatches);
+    PRECICE_INFO("Number of patches: " << totalFromPatches.size());
+
+    
 
     if (tag.hasAttribute(ATTR_SHAPE_PARAM)) {
       shapeParameter = tag.getDoubleAttributeValue(ATTR_SHAPE_PARAM);
@@ -190,7 +203,8 @@ void MappingConfiguration::xmlTagCallback(
                                                         dir, type, constraint,
                                                         fromMesh, toMesh, timing,
                                                         shapeParameter, supportRadius, solverRtol,
-                                                        xDead, yDead, zDead,
+                                                        xDead, yDead, zDead, 
+                                                        fromPatchID, toPatchID,
                                                         useLU,
                                                         polynomial, preallocation);
     checkDuplicates(configuredMapping);
@@ -223,6 +237,8 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
     bool                             yDead,
     bool                             zDead,
     bool                             useLU,
+    int                              fromPatchID,
+    int                              toPatchID,
     Polynomial                       polynomial,
     Preallocation                    preallocation) const
 {
@@ -231,7 +247,12 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
   ConfiguredMapping configuredMapping;
   mesh::PtrMesh     fromMesh(_meshConfig->getMesh(fromMeshName));
   mesh::PtrMesh     toMesh(_meshConfig->getMesh(toMeshName));
-  int               totalPatches = fromMesh->getTotalPatches();   // How many patches to create a mapping for
+  std::vector<std::string>  totalFromPatches = fromMesh->getTotalPatches();   // How many patches to create a mapping for
+  std::vector<std::string>  totalToPatches = toMesh->getTotalPatches();   // How many patches to create a mapping for
+  PRECICE_INFO("All from patches: " << totalFromPatches);
+  PRECICE_INFO("All to patches: " << totalToPatches);
+  PRECICE_INFO("Number of patches: " << totalFromPatches.size());
+  
   PRECICE_CHECK(fromMesh.get() != nullptr, "Mesh \"" << fromMeshName << "\" not defined at creation of mapping!");
   PRECICE_CHECK(toMesh.get() != nullptr, "Mesh \"" << toMeshName << "\" not defined at creation of mapping!");
   // Having a list of the patches associated with the mesh, and configure a mapping per patch.

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -231,8 +231,20 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
   ConfiguredMapping configuredMapping;
   mesh::PtrMesh     fromMesh(_meshConfig->getMesh(fromMeshName));
   mesh::PtrMesh     toMesh(_meshConfig->getMesh(toMeshName));
+  int               totalPatches = fromMesh->getTotalPatches();   // How many patches to create a mapping for
   PRECICE_CHECK(fromMesh.get() != nullptr, "Mesh \"" << fromMeshName << "\" not defined at creation of mapping!");
   PRECICE_CHECK(toMesh.get() != nullptr, "Mesh \"" << toMeshName << "\" not defined at creation of mapping!");
+  // Having a list of the patches associated with the mesh, and configure a mapping per patch.
+  /*
+  for (i = patch Start; i < patch End; i++)
+    configuredMapping.fromPatch = fromPatch;
+    configuredMapping.toPatch   = toPatch;
+    configuredMapping.timing   = timing;
+    int dimensions             = fromMesh->getDimensions();
+    ...
+    ...
+    ...
+  */
   configuredMapping.fromMesh = fromMesh;
   configuredMapping.toMesh   = toMesh;
   configuredMapping.timing   = timing;
@@ -382,6 +394,7 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
 void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
 {
   for (const ConfiguredMapping &configuredMapping : _mappings) {
+    // Check same patch as well
     bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
     bool sameToMesh   = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
     PRECICE_CHECK(!sameFromMesh, "There cannot be two mappings from mesh \""

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -59,6 +59,10 @@ public:
     Timing timing;
     /// true for RBF mapping
     bool isRBF;
+
+    int fromPatchID;
+
+    int toPatchID;
   };
 
   MappingConfiguration(

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -149,6 +149,8 @@ private:
       bool                             yDead,
       bool                             zDead,
       bool                             useLU,
+      int                              fromPatchID,
+      int                              toPatchID,
       Polynomial                       polynomial,
       Preallocation                    preallocation) const;
 

--- a/src/math/geometry.hpp
+++ b/src/math/geometry.hpp
@@ -42,6 +42,7 @@ bool segmentsIntersect(
     const Eigen::Ref<const Eigen::Vector2d> &d,
     bool                                     countTouchingAsIntersection);
 
+
 /**
  * @brief Determines the intersection point of two lines, if one exists.
  *

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -23,6 +23,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
     if (p(vertex)) {
       Vertex &v = destination.createVertex(vertex.getCoords());
       v.setGlobalIndex(vertex.getGlobalIndex());
+      v.setPatchID(vertex.getPatchID());
       if (vertex.isTagged())
         v.tag();
       v.setOwner(vertex.isOwner());

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -92,9 +92,9 @@ int Mesh::getDimensions() const
   return _dimensions;
 }
 
-int Mesh::getTotalPatches()
+std::vector<std::string> Mesh::getTotalPatches()
 {
-  return 1;
+  return _patchNames;
 }
 
 Edge &Mesh::createEdge(
@@ -161,6 +161,11 @@ PtrData &Mesh::createData(
   PtrData data(new Data(name, id, dimension));
   _data.push_back(data);
   return _data.back();
+}
+
+void Mesh::createPatch(const std::string &name)
+{
+  _patchNames.push_back(name);
 }
 
 const Mesh::DataContainer &Mesh::data() const

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <boost/container/flat_map.hpp>
 #include "Edge.hpp"
+#include "Patch.hpp"
 #include "Quad.hpp"
 #include "RTree.hpp"
 #include "Triangle.hpp"
@@ -76,9 +77,24 @@ const Mesh::QuadContainer &Mesh::quads() const
   return _quads;
 }
 
+Mesh::PatchContainer &Mesh::patches()
+{
+  return _patches;
+}
+
+const Mesh::PatchContainer &Mesh::patches() const
+{
+  return _patches;
+}
+
 int Mesh::getDimensions() const
 {
   return _dimensions;
+}
+
+int Mesh::getTotalPatches()
+{
+  return 1;
 }
 
 Edge &Mesh::createEdge(

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -162,6 +162,8 @@ public:
       const std::string &name,
       int                dimension);
 
+  void createPatch(const std::string &name);
+
   const DataContainer &data() const;
 
   const PtrData &data(int dataID) const;
@@ -177,7 +179,7 @@ public:
   int getID() const;
 
   /// Returns the base ID of the mesh.
-  int getTotalPatches();
+  std::vector<std::string> getTotalPatches();
 
   /// Returns true if the given vertexID is valid
   bool isValidVertexID(int vertexID) const;
@@ -276,6 +278,9 @@ private:
 
   /// The ID of this mesh.
   int _id;
+
+  // Vector of patchNames for the mesh
+  std::vector<std::string> _patchNames; 
 
   /// Holds vertices, edges, and triangles.
   VertexContainer   _vertices;

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -8,6 +8,7 @@
 #include "mesh/Data.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Quad.hpp"
+#include "mesh/Patch.hpp"
 #include "mesh/SharedPointer.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
@@ -34,6 +35,7 @@ public:
   using EdgeContainer     = std::deque<Edge>;
   using TriangleContainer = std::deque<Triangle>;
   using QuadContainer     = std::deque<Quad>;
+  using PatchContainer    = std::deque<Patch>;
   using DataContainer     = std::vector<PtrData>;
   using BoundingBox       = std::vector<std::pair<double, double>>;
   using BoundingBoxMap    = std::map<int, BoundingBox>;
@@ -93,6 +95,12 @@ public:
 
   /// Returns const container holding all quads.
   const QuadContainer &quads() const;
+
+  /// Returns modifiable container holding all quads.
+  PatchContainer &patches();
+
+  /// Returns const container holding all quads.
+  const PatchContainer &patches() const;
 
   int getDimensions() const;
 
@@ -167,6 +175,9 @@ public:
 
   /// Returns the base ID of the mesh.
   int getID() const;
+
+  /// Returns the base ID of the mesh.
+  int getTotalPatches();
 
   /// Returns true if the given vertexID is valid
   bool isValidVertexID(int vertexID) const;
@@ -271,6 +282,7 @@ private:
   EdgeContainer     _edges;
   TriangleContainer _triangles;
   QuadContainer     _quads;
+  PatchContainer   _patches;
 
   /// Data hold by the vertices of the mesh.
   DataContainer _data;

--- a/src/mesh/Patch.cpp
+++ b/src/mesh/Patch.cpp
@@ -1,0 +1,45 @@
+#include "Patch.hpp"
+#include "Vertex.hpp"
+#include "utils/EigenIO.hpp"
+
+namespace precice {
+namespace mesh {
+
+//void Patch::setPatchID(int patchID)
+//{
+//  _patchid = patchID;
+//}
+
+Patch::Patch(
+    const std::string &name,
+    int                id)
+    : _name(name),
+      _id(id)
+{
+
+}
+
+Patch::patchVertexContainer &Patch::patchVertices()
+{
+  return _vertices;
+}
+
+const Patch::patchVertexContainer &Patch::patchVertices() const
+{
+  return _vertices;
+}
+
+const std::string &Patch::getName() const
+{
+  return _name;
+}
+
+int Patch::getID() const
+{
+  return _id;
+}
+
+
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Patch.hpp
+++ b/src/mesh/Patch.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <iostream>
+
+#include "math/differences.hpp"
+
+namespace precice {
+namespace mesh {
+
+/// Patch of a vertex for a mesh.
+class Patch {
+public:
+  using patchVertexContainer   = std::deque<Vertex>;
+
+  /**
+   * @brief Constructor.
+   *
+   * @param[in] name Unique name of the mesh.
+   * @param[in] dimensions Dimensionalty of the mesh.
+   * @param[in] flipNormals Inverts the standard direction of normals.
+   * @param[in] id The id of this mesh
+   */
+  Patch(
+      const std::string &name,
+      int                id);
+      
+  /// Returns modifieable container holding all vertices.
+  patchVertexContainer &patchVertices();
+
+  /// Returns const container holding all vertices.
+  const patchVertexContainer &patchVertices() const;
+
+  /// Returns the name of the mesh, as set in the config file.
+  const std::string &getName() const;
+
+  /// Returns the base ID of the mesh.
+  int getID() const;
+
+
+private:
+
+  /// Patch id that a vertex belongs to
+  //int _patchid;
+
+  /// Coordinates of the vertex.
+  //Eigen::VectorXd _coords;
+
+  /// Normal of the vertex.
+  //Eigen::VectorXd _normal;
+
+  /// global (unique) index for parallel simulations
+  //int _globalIndex = -1;
+
+  /// true if this processors is the owner of the vertex (for parallel simulations)
+  //bool _owner = true;
+
+  /// true if this vertex is tagged for partition
+  //bool _tagged = false;
+};
+
+// ------------------------------------------------------ HEADER IMPLEMENTATION
+/*template <typename VECTOR_T>
+Patch::Patch(
+    int             id,
+    int             patchid)
+    : _id(id),
+      _patchid(patchid)
+{
+}
+
+
+inline int Patch::getPatchID() const
+{
+  return _patchid;
+
+*/
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -19,11 +19,11 @@ rtree::MeshIndices &rtree::cacheEntry(int meshID)
   return result.first->second;
 }
 
-rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh &mesh)
+rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh &mesh, int toPatchID)
 {
   PRECICE_ASSERT(mesh);
   auto &cache = cacheEntry(mesh->getID());
-  int patchID = mesh->getTotalPatches();      //This actually needs to be the patch number, but totalPatches will suffice for intial testing
+  //int patchID = mesh->getTotalPatches();      //This actually needs to be the patch number, but totalPatches will suffice for intial testing
   if (cache.vertices) {
     return cache.vertices;
   }
@@ -36,7 +36,6 @@ rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh &mesh)
 
   for (int i = 0; i < mesh->vertices().size(); i++){
     int vertexPatchID = mesh->vertices()[i].getPatchID();
-    PRECICE_INFO("PatchID: " << vertexPatchID);
   }
   // If not using a patchVertexContainer, then check if patchID matches, then add the vertex if it does.
   // This slows down this process, but NN with boost remains O(NlogN). This is a larger savings.

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -33,10 +33,15 @@ rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh &mesh)
   // tree->insert repeatedly is about 10x faster.
   RTreeParameters            params;
   // If adding a patch class, mesh->patch()->vertices();
+
   for (int i = 0; i < mesh->vertices().size(); i++){
     int vertexPatchID = mesh->vertices()[i].getPatchID();
-    //PRECICE_INFO("PatchID: " << vertexPatchID);
+    PRECICE_INFO("PatchID: " << vertexPatchID);
   }
+  // If not using a patchVertexContainer, then check if patchID matches, then add the vertex if it does.
+  // This slows down this process, but NN with boost remains O(NlogN). This is a larger savings.
+  // This can also be used for NP mapping. RBF does not matter. It runs through both. Maybe include this for RBF
+  // and use boost to find points N nearest points or within a radius? Speed up building RBF function.
   
 
   vertex_traits::IndexGetter ind(mesh->vertices());

--- a/src/mesh/RTree.cpp
+++ b/src/mesh/RTree.cpp
@@ -23,6 +23,7 @@ rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh &mesh)
 {
   PRECICE_ASSERT(mesh);
   auto &cache = cacheEntry(mesh->getID());
+  int patchID = mesh->getTotalPatches();      //This actually needs to be the patch number, but totalPatches will suffice for intial testing
   if (cache.vertices) {
     return cache.vertices;
   }
@@ -31,6 +32,13 @@ rtree::vertex_traits::Ptr rtree::getVertexRTree(const PtrMesh &mesh)
   // the best we can do. Even passing an index range instead of calling
   // tree->insert repeatedly is about 10x faster.
   RTreeParameters            params;
+  // If adding a patch class, mesh->patch()->vertices();
+  for (int i = 0; i < mesh->vertices().size(); i++){
+    int vertexPatchID = mesh->vertices()[i].getPatchID();
+    //PRECICE_INFO("PatchID: " << vertexPatchID);
+  }
+  
+
   vertex_traits::IndexGetter ind(mesh->vertices());
   auto                       tree = std::make_shared<vertex_traits::RTree>(
       boost::irange<std::size_t>(0lu, mesh->vertices().size()), params, ind);

--- a/src/mesh/RTree.hpp
+++ b/src/mesh/RTree.hpp
@@ -185,7 +185,7 @@ public:
   /*
    * Creates and fills the tree, if it wasn't requested before, otherwise it returns the cached tree.
    */
-  static vertex_traits::Ptr getVertexRTree(const PtrMesh &mesh);
+  static vertex_traits::Ptr getVertexRTree(const PtrMesh &mesh, int toPatchID);
 
   static edge_traits::Ptr getEdgeRTree(const PtrMesh &mesh);
 

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -49,6 +49,11 @@ void Vertex::setPatchID(int patchid)
   _patchid = patchid;
 }
 
+void Vertex::setPatchName(std::string patchname)
+{
+  _patchname = patchname;
+}
+
 std::ostream &operator<<(std::ostream &os, Vertex const &v)
 {
   return os << "POINT (" << v.getCoords().transpose().format(utils::eigenio::wkt()) << ')';

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -44,6 +44,11 @@ void Vertex::tag()
   _tagged = true;
 }
 
+void Vertex::setPatchID(int patchid)
+{
+  _patchid = patchid;
+}
+
 std::ostream &operator<<(std::ostream &os, Vertex const &v)
 {
   return os << "POINT (" << v.getCoords().transpose().format(utils::eigenio::wkt()) << ')';

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -45,6 +45,12 @@ public:
   /// Sets the patchID of a vertex
   void setPatchID(int patchid);
 
+  /// Sets the name of the patch of that vertex
+  void setPatchName(std::string patchName);
+
+  /// Returns the name of the patch of the vertex
+  void getPatchName() const;
+
   /// Returns the coordinates of the vertex.
   const Eigen::VectorXd &getCoords() const;
 
@@ -76,6 +82,8 @@ private:
 
   /// Patch id that a vertex belongs to
   int _patchid = 0;
+
+  std::string _patchname;
 
   /// Coordinates of the vertex.
   Eigen::VectorXd _coords;
@@ -145,6 +153,11 @@ inline int Vertex::getID() const
 inline int Vertex::getPatchID() const
 {
  return _patchid;
+}
+
+inline int Vertex::getPatchName() const
+{
+ return _patchname;
 }
 
 inline const Eigen::VectorXd &Vertex::getCoords() const

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -49,7 +49,7 @@ public:
   void setPatchName(std::string patchName);
 
   /// Returns the name of the patch of the vertex
-  void getPatchName() const;
+  std::string getPatchName() const;
 
   /// Returns the coordinates of the vertex.
   const Eigen::VectorXd &getCoords() const;
@@ -155,7 +155,7 @@ inline int Vertex::getPatchID() const
  return _patchid;
 }
 
-inline int Vertex::getPatchName() const
+inline std::string Vertex::getPatchName() const
 {
  return _patchname;
 }

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -15,9 +15,9 @@ public:
   template <typename VECTOR_T>
   Vertex(
       const VECTOR_T &coordinates,
-      int             id);     // This indicates which patch a vertex is a part of
+      int             id);
 
-  /// Returns spatial dimensionality of vsetMeshVerticesertex.
+  /// Returns spatial dimensionality of vertex
   int getDimensions() const;
 
   /// Sets the coordinates of the vertex.

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -15,9 +15,9 @@ public:
   template <typename VECTOR_T>
   Vertex(
       const VECTOR_T &coordinates,
-      int             id);
+      int             id);     // This indicates which patch a vertex is a part of
 
-  /// Returns spatial dimensionality of vertex.
+  /// Returns spatial dimensionality of vsetMeshVerticesertex.
   int getDimensions() const;
 
   /// Sets the coordinates of the vertex.
@@ -38,6 +38,12 @@ public:
 
   /// Returns the unique (among vertices of one mesh on one processor) ID of the vertex.
   int getID() const;
+
+  /// Returns the patchID that a vertex belongs to
+  int getPatchID() const;
+
+  /// Sets the patchID of a vertex
+  void setPatchID(int patchid);
 
   /// Returns the coordinates of the vertex.
   const Eigen::VectorXd &getCoords() const;
@@ -62,9 +68,14 @@ public:
 
   inline bool operator!=(const Vertex &rhs) const;
 
+  
+
 private:
   /// Unique (among vertices in one mesh) ID of the vertex.
   int _id;
+
+  /// Patch id that a vertex belongs to
+  int _patchid = 0;
 
   /// Coordinates of the vertex.
   Eigen::VectorXd _coords;
@@ -129,6 +140,11 @@ void Vertex::setNormal(
 inline int Vertex::getID() const
 {
   return _id;
+}
+
+inline int Vertex::getPatchID() const
+{
+ return _patchid;
 }
 
 inline const Eigen::VectorXd &Vertex::getCoords() const

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -96,7 +96,6 @@ void MeshConfiguration::xmlTagCallback(
   } else if (tag.getName() == TAG_PATCH) {
     std::string name  = tag.getStringAttributeValue(ATTR_NAME);
     bool        found = false;
-    PRECICE_INFO("Found patch name: " << _patchNames);
         _meshes.back()->createPatch(name);    //No check for if the name already exists.
         found = true;
   }

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -15,10 +15,12 @@ MeshConfiguration::MeshConfiguration(
       ATTR_NAME("name"),
       ATTR_FLIP_NORMALS("flip-normals"),
       TAG_DATA("use-data"),
+      TAG_PATCH("use-patch"),
       ATTR_SIDE_INDEX("side"),
       _dimensions(0),
       _dataConfig(config),
       _meshes(),
+      _patchNames(),
       _neededMeshes(),
       _meshIdManager(new utils::ManageUniqueIDs())
 {
@@ -45,6 +47,13 @@ MeshConfiguration::MeshConfiguration(
   attrName.setDocumentation("Name of the data set.");
   subtagData.addAttribute(attrName);
   tag.addSubtag(subtagData);
+
+  XMLTag subtagPatch(*this, TAG_PATCH, XMLTag::OCCUR_ARBITRARY);
+  doc = "Assigns a patch name that is used by the mesh.";
+  subtagPatch.setDocumentation(doc);
+  attrName.setDocumentation("Name of the patch.");
+  subtagPatch.addAttribute(attrName);
+  tag.addSubtag(subtagPatch);
 
   parent.addSubtag(tag);
 }
@@ -84,6 +93,12 @@ void MeshConfiguration::xmlTagCallback(
              << "configuration of mesh \"" << _meshes.back()->getName() << "\"";
       throw std::runtime_error{stream.str()};
     }
+  } else if (tag.getName() == TAG_PATCH) {
+    std::string name  = tag.getStringAttributeValue(ATTR_NAME);
+    bool        found = false;
+    PRECICE_INFO("Found patch name: " << _patchNames);
+        _meshes.back()->createPatch(name);    //No check for if the name already exists.
+        found = true;
   }
 }
 

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -69,6 +69,7 @@ private:
   const std::string ATTR_NAME;
   const std::string ATTR_FLIP_NORMALS;
   const std::string TAG_DATA;
+  const std::string TAG_PATCH;
   const std::string ATTR_SIDE_INDEX;
 
   int _dimensions;
@@ -78,6 +79,9 @@ private:
 
   /// Configured meshes.
   std::vector<PtrMesh> _meshes;
+
+  /// patchName of mesh.
+  std::vector<std::string> _patchNames;
 
   /// to check later if all meshes that any coupling scheme needs are actually used by the participants
   std::map<std::string, std::vector<std::string>> _neededMeshes;

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -153,6 +153,21 @@ void SolverInterface::setMeshVertices(
   _impl->setMeshVertices(meshID, size, positions, ids);
 }
 
+void SolverInterface::setMeshVertexPatch(
+    int           meshID,
+    int           VertexID, 
+    int           patchID)
+{
+  _impl->setMeshVertexPatch(meshID, VertexID, patchID);
+}
+
+int SolverInterface::getMeshVertexPatch(
+    int           meshID,
+    int           vertexID)
+{
+  _impl->getMeshVertexPatch(meshID, vertexID);
+}
+
 void SolverInterface::getMeshVertices(
     int        meshID,
     int        size,

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -391,6 +391,16 @@ public:
       const double *positions,
       int *         ids);
 
+
+  void setMeshVertexPatch(
+      int           meshID, 
+      int           VertexID, 
+      int           patchID);
+
+  int getMeshVertexPatch(
+    int           meshID,
+    int           vertexID);
+
   /**
    * @brief Get vertex positions for multiple vertex ids from a given mesh
    *

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -648,7 +648,7 @@ void SolverInterfaceImpl::setMeshVertexPatch(
 void SolverInterfaceImpl::setMeshVertexPatchName(
       int           meshID, 
       int           VertexID, 
-      std::string           patchName)
+      std::string   patchName)
 {
     PRECICE_TRACE(meshID);
     PRECICE_REQUIRE_MESH_MODIFY(meshID);

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -645,6 +645,19 @@ void SolverInterfaceImpl::setMeshVertexPatch(
     vertices[VertexID].setPatchID(patchID);
 }
 
+void SolverInterfaceImpl::setMeshVertexPatchName(
+      int           meshID, 
+      int           VertexID, 
+      std::string           patchName)
+{
+    PRECICE_TRACE(meshID);
+    PRECICE_REQUIRE_MESH_MODIFY(meshID);
+    MeshContext & context = _accessor->meshContext(meshID);
+    mesh::PtrMesh mesh(context.mesh);
+    auto &vertices = mesh->vertices();
+    vertices[VertexID].setPatchName(patchName);
+}
+
 int SolverInterfaceImpl::getMeshVertexPatch(
     int           meshID,
     int           vertexID)

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -631,6 +631,33 @@ void SolverInterfaceImpl::setMeshVertices(
   mesh->allocateDataValues();
 }
 
+void SolverInterfaceImpl::setMeshVertexPatch(
+      int           meshID, 
+      int           VertexID, 
+      int           patchID)
+{
+    PRECICE_TRACE(meshID);
+    PRECICE_REQUIRE_MESH_MODIFY(meshID);
+    MeshContext & context = _accessor->meshContext(meshID);
+    mesh::PtrMesh mesh(context.mesh);
+    auto &vertices = mesh->vertices();
+    vertices[VertexID].setPatchID(patchID);
+}
+
+int SolverInterfaceImpl::getMeshVertexPatch(
+    int           meshID,
+    int           vertexID)
+{
+    PRECICE_TRACE(meshID);
+    int index = -1;
+    PRECICE_REQUIRE_MESH_USE(meshID);
+    MeshContext & context = _accessor->meshContext(meshID);
+    mesh::PtrMesh mesh(context.mesh);
+    auto &vertices = mesh->vertices();
+    index = vertices[vertexID].getPatchID();
+    return index;
+}
+
 void SolverInterfaceImpl::getMeshVertices(
     int        meshID,
     size_t     size,

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -9,6 +9,7 @@
 #include "m2n/config/M2NConfiguration.hpp"
 #include "mapping/Mapping.hpp"
 #include "mesh/Edge.hpp"
+#include "mesh/Patch.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -255,6 +255,11 @@ public:
       int           meshID,
       int           vertexID);
 
+  void setMeshVertexPatchName(
+      int           meshID, 
+      int           VertexID, 
+      std::string   patchName);
+
   /**
    * @brief Gets spatial positions of vertices for given IDs.
    *

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -237,7 +237,7 @@ public:
   /**
    * @brief Sets several spatial positions for a mesh.
    *
-   * @param[out] ids IDs fo r data from given positions.
+   * @param[out] ids IDs for data from given positions.
    */
   void setMeshVertices(
       int           meshID,

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -237,13 +237,26 @@ public:
   /**
    * @brief Sets several spatial positions for a mesh.
    *
-   * @param[out] ids IDs for data from given positions.
+   * @param[out] ids IDs fo r data from given positions.
    */
   void setMeshVertices(
       int           meshID,
       int           size,
       const double *positions,
       int *         ids);
+
+
+  void setMeshVertexPatch(
+      int           meshID, 
+      int           VertexID, 
+      int           patchID);
+
+  /**
+   * @brief Leave as int for now for trouble shooting
+   */
+  int getMeshVertexPatch(
+      int           meshID,
+      int           vertexID);
 
   /**
    * @brief Gets spatial positions of vertices for given IDs.

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -251,9 +251,6 @@ public:
       int           VertexID, 
       int           patchID);
 
-  /**
-   * @brief Leave as int for now for trouble shooting
-   */
   int getMeshVertexPatch(
       int           meshID,
       int           vertexID);


### PR DESCRIPTION
This PR aims to implement the changes required for the split patching issue from https://github.com/precice/precice/issues/374. The initial idea is to add a `patchID` variable for each vertex. During the mapping, a vertex on mesh A is only used in the mapping of a vertex in mesh B, if it has the same patch ID of a vertex on the corresponding mesh in the other solver. 

As an example, consider the yellow, blue and red surfaces in https://github.com/precice/precice/issues/374, both solvers need the meshes split into the patches accordingly. Each colour will receive a patch ID of 1, 2 and 3 respectively. For a vertex in the yellow patch, with a patchID of 1, it can only be mapped to a point on the yellow patch of the other solver (also with a patch ID of 1). Any vertex that is not assigned a patchID automatically has a value of 0, making it fair game for any other vertex with a partchID of 0. Therefore if no patchID is set, then mapping functions as normal. 

The adapters would need to be changed to allow multiple surfaces to make up a mesh, but use each surface to define the patch. That is not the purpose of this PR, but only to implement how to use the patchID. 

Note that this does not create a meshing for each patch, but only influences which vertices are used (i.e. still one mesh with one RBF matrix). it has also only been added to the `tree-based preallocation for matrix C` of `PetRadialBasisFctMapping.hpp`. The RBF mapping functions as normal by getting the distance between 2 vertices

```
distance = inVertex.getCoords() - vj.getCoords();
double const norm = distance.norm();
```
For any compact support RBF, this norm must be within the support radius
```
if (supportRadius > norm or col == global_row) {
```
The patchID can then be checked to see if the vertices on both meshes belong to the same patch ID
```
if (inVertex.getPatchID() == vj.getPatchID()) {
```
This is probably not the most efficient implementation, and the patchID check can probably be moved up to avoid doing unnecessary computations, such as determining the distance between vertices.

# Open Todos

- [x] Implement function to set the patchID of a vertex
- [ ] Implement setting block variant `setMeshVerticesPatch`
- [ ] Implement `getPatchID(meshID, patchName)` that can be used with patch names in the config
- [ ] Add patch functions for C
- [ ] Add patch functions for python
- [ ] Add patch functions for fortran
- [ ] Integration tests