### PR TITLE
Print participant name to INFO at configuration

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -120,8 +120,8 @@ void SolverInterfaceImpl::configure(
   if (_accessorProcessRank == 0) {
     PRECICE_INFO("This is preCICE version " << PRECICE_VERSION);
     PRECICE_INFO("Revision info: " << precice::preciceRevision);
-    PRECICE_INFO("Configuring preCICE with configuration: \"" << configurationFileName << "\"");
-    PRECICE_INFO("I am participant: \"" << _accessorName << "\"");
+    PRECICE_INFO("Configuring preCICE with configuration \"" << configurationFileName << "\"");
+    PRECICE_INFO("I am participant \"" << _accessorName << "\"");
   }
   configure(config.getSolverInterfaceConfiguration());
 }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -121,6 +121,7 @@ void SolverInterfaceImpl::configure(
     PRECICE_INFO("This is preCICE version " << PRECICE_VERSION);
     PRECICE_INFO("Revision info: " << precice::preciceRevision);
     PRECICE_INFO("Configuring preCICE with configuration: \"" << configurationFileName << "\"");
+    PRECICE_INFO("I am participant: \"" << _accessorName << "\"");
   }
   configure(config.getSolverInterfaceConfiguration());
 }


### PR DESCRIPTION
Sometimes, it is helpful to get a very early feedback on which participant I am. We saw with the `Generator-Propagator` tutorial that many people copy the setup lines from one participant to the others and then have the wrong participant's name there. 

With this PR, we now get e.g.
```
(0) 11:52:58 [impl::SolverInterfaceImpl]:121 in configure: This is preCICE version 2.0.1
(0) 11:52:58 [impl::SolverInterfaceImpl]:122 in configure: Revision info: v2.0.0-28-g78b266f3-dirty
(0) 11:52:58 [impl::SolverInterfaceImpl]:123 in configure: Configuring preCICE with configuration: "../precice-config.xml"
(0) 11:52:58 [impl::SolverInterfaceImpl]:124 in configure: I am participant: "NASTIN"
(0) 11:52:58 [impl::SolverInterfaceImpl]:1422 in initializeMasterSlaveCommunication: Setting up communication 
```

Reviewers: Just FYI, no need to test. If there are no complaints I will merge later today.