### PR TITLE
Fix critical bug in testing framework

### DIFF
--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -13,7 +13,6 @@
 namespace precice {
 extern bool testMode;
 extern bool syncMode;
-static int  testCount{0};
 } // namespace precice
 
 /// Boost test Initialization function
@@ -43,12 +42,6 @@ bool init_unit_test()
 
   auto &master_suite        = framework::master_test_suite();
   master_suite.p_name.value = "preCICE Tests";
-
-  {
-    test_case_counter tcc;
-    traverse_test_tree(master_suite.p_id, tcc);
-    precice::testCount = tcc.p_count;
-  }
 
   auto logConfigs = logging::readLogConfFile("log.conf");
 
@@ -91,6 +84,14 @@ bool init_unit_test()
   return true;
 }
 
+int countEnabledTests()
+{
+  using namespace boost::unit_test;
+  test_case_counter tcc;
+  traverse_test_tree(framework::master_test_suite(), tcc, true);
+  return tcc.p_count;
+}
+
 /// Entry point for the boost test executable
 int main(int argc, char *argv[])
 {
@@ -104,19 +105,24 @@ int main(int argc, char *argv[])
   utils::Petsc::initialize(&argc, &argv);
   utils::EventRegistry::instance().initialize("precice-Tests", "", utils::Parallel::getGlobalCommunicator());
 
-  if (utils::Parallel::getCommunicatorSize() < 4) {
-    if (utils::Parallel::getProcessRank() == 0)
+  const int rank = utils::Parallel::getProcessRank();
+  const int size = utils::Parallel::getCommunicatorSize();
+
+  if (size < 4) {
+    if (rank == 0)
       std::cerr << "Running tests on less than four processors. Not all tests are executed.\n";
   }
-  if (utils::Parallel::getCommunicatorSize() > 4) {
-    if (utils::Parallel::getProcessRank() == 0)
+  if (size > 4) {
+    if (rank == 0)
       std::cerr << "Running tests on more than 4 processors is not supported. Aborting.\n";
     std::exit(-1);
   }
 
-  int retCode = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
+  int       retCode  = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
+  const int testsRan = countEnabledTests();
+
   // Override the return code if the slaves have nothing to test
-  if ((precice::testCount == 0) && (utils::Parallel::getProcessRank() != 0)) {
+  if ((testsRan == 0) && (rank != 0)) {
     retCode = EXIT_SUCCESS;
   }
 


### PR DESCRIPTION
Test cases are unfiltered and disabled in init_unit_test().
We have to count them after the tests ran.

**This means that the tests always returned 0 since a5bc1e76!**
Hanging tests will be terminated by CTest, thus this affects mostly unit tests.