### PR TITLE
Simplify FindNumPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://github.com/precice/precice/wiki/Roadmap).
 
-
+- Change the CMake FindNumPy module to only consider information based on the selected python interpreter.
 - Implemented a new action to sum up data values, `action:summation`.
 
 ## 2.0.2

--- a/cmake/modules/FindNumPy.cmake
+++ b/cmake/modules/FindNumPy.cmake
@@ -1,7 +1,7 @@
 #.rst:
 #
-# Find the include directory for ``numpy/arrayobject.h`` as well as other NumPy tools like ``conv-template`` and
-# ``from-template``.
+# Find the include directory for ``numpy/arrayobject.h``.
+# This module exclusively uses the information from the numpy python module.
 #
 # This module sets the following variables:
 #
@@ -11,25 +11,10 @@
 #   The include directories needed to use NumpPy.
 # ``NumPy_VERSION``
 #   The version of NumPy found.
-# ``NumPy_CONV_TEMPLATE_EXECUTABLE``
-#   Path to conv-template executable.
-# ``NumPy_FROM_TEMPLATE_EXECUTABLE``
-#   Path to from-template executable.
 #
 # The module will also explicitly define one cache variable:
 #
 # ``NumPy_INCLUDE_DIR``
-#
-# .. note::
-#
-#     To support NumPy < v0.15.0 where ``from-template`` and ``conv-template`` are not declared as entry points,
-#     the module emulates the behavior of standalone executables by setting the corresponding variables with the
-#     path the the python interpreter and the path to the associated script. For example:
-#     ::
-#
-#         set(NumPy_CONV_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/conv_template.py CACHE STRING "Command executing conv-template program" FORCE)
-#
-#         set(NumPy_FROM_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/from_template.py CACHE STRING "Command executing from-template program" FORCE)
 #
 
 if(NOT NumPy_FOUND)
@@ -43,10 +28,8 @@ if(NOT NumPy_FOUND)
   find_package(PythonInterp ${_find_extra_args})
   find_package(PythonLibs ${_find_extra_args})
 
-  find_program(NumPy_CONV_TEMPLATE_EXECUTABLE NAMES conv-template)
-  find_program(NumPy_FROM_TEMPLATE_EXECUTABLE NAMES from-template)
-
   if(PYTHON_EXECUTABLE)
+    unset(_numpy_include_dir)
     execute_process(COMMAND "${PYTHON_EXECUTABLE}"
       -c "import numpy; print(numpy.get_include())"
       OUTPUT_VARIABLE _numpy_include_dir
@@ -59,45 +42,22 @@ if(NOT NumPy_FOUND)
       OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_QUIET
       )
-
-    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
-    if(NOT NumPy_CONV_TEMPLATE_EXECUTABLE)
-      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
-        -c "from numpy.distutils import conv_template; print(conv_template.__file__)"
-        OUTPUT_VARIABLE _numpy_conv_template_file
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-        )
-      set(NumPy_CONV_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_conv_template_file}" CACHE STRING "Command executing conv-template program" FORCE)
-    endif()
-
-    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
-    if(NOT NumPy_FROM_TEMPLATE_EXECUTABLE)
-      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
-        -c "from numpy.distutils import from_template; print(from_template.__file__)"
-        OUTPUT_VARIABLE _numpy_from_template_file
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-        )
-      set(NumPy_FROM_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_from_template_file}" CACHE STRING "Command executing from-template program" FORCE)
-    endif()
+    find_path(NumPy_INCLUDE_DIR
+      numpy/arrayobject.h
+      PATH "${_numpy_include_dir}"
+      NO_DEFAULT_PATH
+      )
+    unset(_numpy_include_dir)
   endif()
 endif()
-
-find_path(NumPy_INCLUDE_DIR
-  numpy/arrayobject.h
-  HINTS "${_numpy_include_dir}" "${PYTHON_INCLUDE_DIR}"
-  PATH_SUFFIXES numpy/core/include
-  )
 
 # handle the QUIETLY and REQUIRED arguments and set NumPy_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args( NumPy
-    REQUIRED_VARS NumPy_INCLUDE_DIR NumPy_CONV_TEMPLATE_EXECUTABLE NumPy_FROM_TEMPLATE_EXECUTABLE
+    REQUIRED_VARS NumPy_INCLUDE_DIR
     VERSION_VAR NumPy_VERSION
     )
-
 
 if(NumPy_FOUND)
     set(NumPy_INCLUDE_DIRS ${NumPy_INCLUDE_DIR})


### PR DESCRIPTION
This PR simplifies the CMake module for finding NumPy.

It now **exclusively** uses the information from the python module:
* `numpy.__version__` for the version, and
* `numpy.get_include()` for the include directory.

The latter is verified via a the `find_path` CMake command using `NO_DEFAULT_PATH`.

This point of this PR is to keep numpy in sync with the detected python interpreter. This is crucial to support virtual environments reliably.