### PR TITLE
Add connectMasterSlaves to Communication

### DIFF
--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -3,6 +3,31 @@
 
 namespace precice {
 namespace com {
+
+void Communication::connectMasterSlaves(std::string const &participantName,
+                                        std::string const &tag,
+                                        int                rank,
+                                        int                size)
+{
+  if (size == 1) return;
+
+  std::string masterName = participantName + "Master";
+  std::string slaveName  = participantName + "Slave";
+
+  constexpr int rankOffset = 1;
+  int slavesSize = size - rankOffset;
+  if (rank == 0) {
+    PRECICE_INFO("Connecting Master to " << slavesSize << " Slaves");
+    prepareEstablishment(masterName, slaveName);
+    acceptConnection(masterName, slaveName, tag, rank, rankOffset);
+    cleanupEstablishment(masterName, slaveName);
+  } else {
+    int slaveRank = rank - rankOffset;
+    PRECICE_INFO("Connecting Slave #" << slaveRank << " to Master");
+    requestConnection(masterName, slaveName, tag, slaveRank, slavesSize);
+  }
+}
+
 /**
  * @attention This method modifies the input buffer.
  */

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -147,6 +147,19 @@ public:
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) = 0;
 
+  /** Establishes the Master-Slave connection.
+   *
+   * @param[in] participantName Name of the calling participant.
+   * @param[in] tag Tag for establishing this connection
+   * @param[in] rank The current rank in the participant 
+   * @param[in] size Total size of the participant
+   *
+   */
+  void connectMasterSlaves(std::string const &participantName,
+                           std::string const &tag,
+                           int                rank,
+                           int                size);
+
   /**
    * @brief Disconnects from communication space, i.e. participant.
    *

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1416,20 +1416,9 @@ void SolverInterfaceImpl::initializeMasterSlaveCommunication()
   PRECICE_TRACE();
 
   Event e("com.initializeMasterSlaveCom", precice::syncMode);
-  //slaves create new communicator with ranks 0 to size-2
-  //therefore, the master uses a rankOffset and the slaves have to call request
-  // with that offset
-  int rankOffset = 1;
-  if (utils::MasterSlave::isMaster()) {
-    PRECICE_INFO("Setting up communication to slaves");
-    utils::MasterSlave::_communication->prepareEstablishment(_accessorName + "Master", _accessorName);
-    utils::MasterSlave::_communication->acceptConnection(_accessorName + "Master", _accessorName, "MasterSlave", utils::MasterSlave::getRank(), rankOffset);
-    utils::MasterSlave::_communication->cleanupEstablishment(_accessorName + "Master", _accessorName);
-  } else {
-    PRECICE_ASSERT(utils::MasterSlave::isSlave());
-    utils::MasterSlave::_communication->requestConnection(_accessorName + "Master", _accessorName, "MasterSlave",
-                                                          _accessorProcessRank - rankOffset, _accessorCommunicatorSize - rankOffset);
-  }
+  utils::MasterSlave::_communication->connectMasterSlaves(
+      _accessorName, "MasterSlaves",
+      _accessorProcessRank, _accessorCommunicatorSize);
 }
 
 void SolverInterfaceImpl::syncTimestep(double computedTimestepLength)

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -180,13 +180,7 @@ void TestContext::initializeMasterSlave()
   precice::com::PtrCommunication masterSlaveCom = precice::com::PtrCommunication(new precice::com::SocketCommunication());
 #endif
 
-  const auto masterName = name + "Master";
-  const auto slavesName = name + "Slaves";
-  if (isMaster()) {
-    masterSlaveCom->acceptConnection(masterName, slavesName, "", rank, 1);
-  } else {
-    masterSlaveCom->requestConnection(masterName, slavesName, "", rank - 1, size - 1);
-  }
+  masterSlaveCom->connectMasterSlaves(name, "", rank, size);
 
   utils::MasterSlave::_communication = std::move(masterSlaveCom);
 }


### PR DESCRIPTION
This PR adds `connectMasterSlaves()` to `com::Communication`.

The participant name, size and current rank are all known at the when establishing the MS connection.
Thus it is safer to pass everything to the communication class which then performs the required calls.
The current class design allows a single implementation for all Comunication classes.