### PR TITLE
Improve Errors in Interface Validation

### DIFF
--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -1,0 +1,13 @@
+#include "precice/impl/DataContext.hpp"
+#include "mesh/Data.hpp"
+
+namespace precice {
+namespace impl {
+
+std::string DataContext::getName() const
+{
+  return fromData->getName();
+}
+
+} // namespace impl
+} // namespace precice

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -13,6 +13,8 @@ namespace impl {
 struct DataContext {
   bool used = false;
 
+  std::string getName() const;
+
   mesh::PtrData fromData;
 
   mesh::PtrData toData;

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -84,25 +84,27 @@
                     return datakv.second == id;                                                                                                     \
                   });                                                                                                                               \
                 }),                                                                                                                                 \
-                "There is no Data with ID " << id);
+                "The given Data ID \"" << id << "\" is not known to preCICE!");
 
 /** Implementation of PRECICE_REQUIRE_DATA_READ()
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_REQUIRE_DATA_READ_IMPL(id)                                                  \
-  PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                         \
-  PRECICE_CHECK(_accessor->isDataUsed(id), "Data is not used by this participant! " << id); \
-  PRECICE_CHECK(_accessor->isDataRead(id), "Data is not marked as read! " << id);
+#define PRECICE_REQUIRE_DATA_READ_IMPL(id)                                                                                          \
+  PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                                 \
+  DataContext &context = _accessor->dataContext(id);                                                                                \
+  PRECICE_CHECK(_accessor->isDataUsed(id), "This participant does not use Data \"" << context.getName() << "\" [" << id << "] !"); \
+  PRECICE_CHECK(_accessor->isDataRead(id), "This participant uses Data \"" << context.getName() << "\" [" << id << "], but does not request read access!");
 
 /** Implementation of PRECICE_REQUIRE_DATA_WRITE()
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_REQUIRE_DATA_WRITE_IMPL(id)                                                 \
-  PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                         \
-  PRECICE_CHECK(_accessor->isDataUsed(id), "Data is not used by this participant! " << id); \
-  PRECICE_CHECK(_accessor->isDataWrite(id), "Data is not marked as write! " << id);
+#define PRECICE_REQUIRE_DATA_WRITE_IMPL(id)                                                                                         \
+  PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                                 \
+  DataContext &context = _accessor->dataContext(id);                                                                                \
+  PRECICE_CHECK(_accessor->isDataUsed(id), "This participant does not use Data \"" << context.getName() << "\" [" << id << "] !"); \
+  PRECICE_CHECK(_accessor->isDataWrite(id), "This participant uses Data \"" << context.getName() << "\" [" << id << "], but does not request write access!");
 
 /// Validates a given dataID
 #define PRECICE_VALIDATE_DATA_ID(dataID) \

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -24,7 +24,7 @@
 #define PRECICE_REQUIRE_MESH_USE_IMPL(id)            \
   PRECICE_VALIDATE_MESH_ID_IMPL(id)                  \
   MeshContext &context = _accessor->meshContext(id); \
-  PRECICE_CHECK(_accessor->isMeshUsed(id), "This participant does not use the mesh \"" << context.mesh->getName() << "\", but attempted to access it. Please define <use-mesh name=\"" << context.mesh->getName() << "\" /> in the configuration of paritipant \"" << _accessorName << '"');
+  PRECICE_CHECK(_accessor->isMeshUsed(id), "This participant does not use the mesh \"" << context.mesh->getName() << "\", but attempted to access it. Please define <use-mesh name=\"" << context.mesh->getName() << "\" /> in the configuration of participant \"" << _accessorName << '"');
 
 /** Implementation of PRECICE_REQUIRE_MESH_PROVIDE()
  *
@@ -32,7 +32,7 @@
  */
 #define PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id) \
   PRECICE_REQUIRE_MESH_USE_IMPL(id)           \
-  PRECICE_CHECK(context.provideMesh, "This participant does not provide Mesh \"" << context.mesh->getName() << "\", but attempted to modify it. Please extend the use-mesh tag as follows <use-mesh name=\"" << context.mesh->getName() << "\" provide=\"1\" >.");
+  PRECICE_CHECK(context.provideMesh, "This participant does not provide Mesh \"" << context.mesh->getName() << "\", but attempted to modify it. Please extend the use-mesh tag as follows <use-mesh name=\"" << context.mesh->getName() << "\" provide=\"yes\" />.");
 
 /** Implementation of PRECICE_REQUIRE_MESH_MODIFY()
  *
@@ -94,7 +94,7 @@
   PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                                                                 \
   DataContext &context = _accessor->dataContext(id);                                                                                                                \
   PRECICE_CHECK((_accessor->isDataUsed(id) && _accessor->isDataRead(id)),                                                                                           \
-                "This participant does not use Data \"" << context.getName() << "\", but attempted to access it. Please extend the configuarion of partiticpant \"" \
+                "This participant does not use Data \"" << context.getName() << "\", but attempted to read it. Please extend the configuarion of partiticpant \"" \
                                                         << _accessorName << "\" by defining <read-data mesh=\"" << context.mesh->getName() << "\" name=\"" << context.getName() << "\" />.");
 
 /** Implementation of PRECICE_REQUIRE_DATA_WRITE()
@@ -105,7 +105,7 @@
   PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                                                                 \
   DataContext &context = _accessor->dataContext(id);                                                                                                                \
   PRECICE_CHECK((_accessor->isDataUsed(id) && _accessor->isDataWrite(id)),                                                                                          \
-                "This participant does not use Data \"" << context.getName() << "\", but attempted to access it. Please extend the configuarion of partiticpant \"" \
+                "This participant does not use Data \"" << context.getName() << "\", but attempted to write it. Please extend the configuarion of partiticpant \"" \
                                                         << _accessorName << "\" by defining <write-data mesh=\"" << context.mesh->getName() << "\" name=\"" << context.getName() << "\" />.");
 
 /// Validates a given dataID

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -219,6 +219,7 @@ target_sources(precice
     src/precice/config/SharedPointer.hpp
     src/precice/config/SolverInterfaceConfiguration.cpp
     src/precice/config/SolverInterfaceConfiguration.hpp
+    src/precice/impl/DataContext.cpp
     src/precice/impl/DataContext.hpp
     src/precice/impl/MappingContext.hpp
     src/precice/impl/MeshContext.hpp


### PR DESCRIPTION
This PR increases the verbosity of the error messages thrown in the API sanitization.
The messages uses names where they can and suggest to add potentially missing tags.

Reviewers: please check the wording

Closes #680 
