### PR TITLE
Add changelog dir

### DIFF
--- a/docs/changelog/722.md
+++ b/docs/changelog/722.md
@@ -1,0 +1,1 @@
+* Add tooling to prevent changelog conflicts

--- a/tools/releasing/bumpversion.sh
+++ b/tools/releasing/bumpversion.sh
@@ -48,7 +48,7 @@ VERSIONREGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
 echo " - CMake"
 sed "s/\(project(preCICE\s\+VERSION\s\+\)$VERSIONREGEX/\1$VERSION/" -i CMakeLists.txt
 echo " - Changelog"
-CL_FILES=`find docs/changelog -type f -not -name ".*"`
+CL_FILES=`find docs/changelog -type f -name "*.md"`
 echo "   compressing"
 echo -e "$(head -n4 CHANGELOG.md)\n\n## $VERSION\n\n$(cat $CL_FILES)\n$(tail +6 CHANGELOG.md)" > CHANGELOG.md
 echo "   cleaning"

--- a/tools/releasing/bumpversion.sh
+++ b/tools/releasing/bumpversion.sh
@@ -28,6 +28,10 @@ else
     exit 1
 fi
 
+REPO=`git rev-parse --show-toplevel`
+cd $REPO
+echo "Root at $REPO"
+
 echo -n "Checking location ... "
 DEBLOC="tools/releasing/packaging/debian/changelog"
 if [ -f "CMakeLists.txt" ] && [ -f "CHANGELOG.md" ] && [ -f "$DEBLOC" ]; then
@@ -44,7 +48,11 @@ VERSIONREGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
 echo " - CMake"
 sed "s/\(project(preCICE\s\+VERSION\s\+\)$VERSIONREGEX/\1$VERSION/" -i CMakeLists.txt
 echo " - Changelog"
-sed "s/## develop/&\n\n## $VERSION/" -i CHANGELOG.md
+CL_FILES=`find docs/changelog -type f -not -name ".*"`
+echo "   compressing"
+echo -e "$(head -n4 CHANGELOG.md)\n\n## $VERSION\n\n$(cat $CL_FILES)\n$(tail +6 CHANGELOG.md)" > CHANGELOG.md
+echo "   cleaning"
+rm $CL_FILES
 echo " - Debian Changelog"
 
 DEBENTRY="


### PR DESCRIPTION
This PR adds a changelog dir which should contain pr-wide changelogs.
The bumpversion script also automatically updates the changelog by merging the files in `docs/changelog/`.

Closes #621 
