### PR TITLE
Add error when participant uses mesh from itself

### DIFF
--- a/docs/changelog/724.md
+++ b/docs/changelog/724.md
@@ -1,0 +1,1 @@
+* Add check to prevent `<use-mesh>` from the same participant.

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -234,8 +234,11 @@ void ParticipantConfiguration::xmlTagCallback(
       stream << "Safety Factor must be positive or 0";
       throw std::runtime_error{stream.str()};
     }
-    bool          provide = tag.getBooleanAttributeValue(ATTR_PROVIDE);
-    mesh::PtrMesh mesh    = _meshConfig->getMesh(name);
+    bool provide = tag.getBooleanAttributeValue(ATTR_PROVIDE);
+    if (_participants.back()->getName() == from) {
+      PRECICE_CHECK(provide, "Participant \"" << context.name << "\" cannot use mesh \"" << name << "\" from itself. Use the \"from\"-field to specify which participant has to communicate the mesh to \"" << context.name << "\".");
+    }
+    mesh::PtrMesh mesh = _meshConfig->getMesh(name);
     if (mesh.get() == nullptr) {
       std::ostringstream stream;
       stream << "Participant \"" << _participants.back()->getName()


### PR DESCRIPTION
This PR adds a check to the `<use-mesh>` tag which verifies that a participant does not use a mesh `from=` itself.

Closes #488