### PR TITLE
Improve errors: Data and mesh config

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -146,7 +146,7 @@ PtrData &Mesh::createData(
   for (const PtrData data : _data) {
     PRECICE_CHECK(data->getName() != name,
                   "Data \"" << name << "\" cannot be created twice for "
-                            << "mesh \"" << _name << "\"!");
+                            << "mesh \"" << _name << "\". Please rename or remove one of the use-data tags with name \""<< name << "\".");
   }
   int     id = Data::getDataCount();
   PtrData data(new Data(name, id, dimension));

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -79,9 +79,9 @@ void DataConfiguration::addData(
 {
   ConfiguredData data(name, dataDimensions);
 
-  // Check, if data with same name has been added already
+  // Check if data with same name has been added already
   for (auto &elem : _data) {
-    PRECICE_CHECK(elem.name != data.name, "Data \"" << data.name << "\" uses non-unique name!");
+    PRECICE_CHECK(elem.name != data.name, "Data \"" << data.name << "\" has already been defined. Please rename or remove one of the data tags with name=\"" << data.name << "\".");
   }
   _data.push_back(data);
 }
@@ -94,7 +94,7 @@ int DataConfiguration::getDataDimensions(
   } else if (typeName == VALUE_SCALAR) {
     return 1;
   }
-  PRECICE_ERROR("Unknown data type!");
+  PRECICE_ERROR("Unknown data type \"" << typeName << "\". Known data types: " << VALUE_SCALAR << ", " << VALUE_VECTOR << ".");
 }
 
 } // namespace mesh

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -94,7 +94,7 @@ int DataConfiguration::getDataDimensions(
   } else if (typeName == VALUE_SCALAR) {
     return 1;
   }
-  PRECICE_ERROR("Unknown data type \"" << typeName << "\". Known data types: " << VALUE_SCALAR << ", " << VALUE_VECTOR << ".");
+  PRECICE_ASSERT(false, "Unknown data type \"" << typeName << "\". Known data types: " << VALUE_SCALAR << ", " << VALUE_VECTOR << ".");
 }
 
 } // namespace mesh

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -85,8 +85,9 @@ void MeshConfiguration::xmlTagCallback(
     }
     if (not found) {
       std::ostringstream stream;
-      stream << "Data with name \"" << name << "\" is not available during "
-             << "configuration of mesh \"" << _meshes.back()->getName() << "\"";
+      stream << "Data with name \"" << name << "\" used by "
+             << "mesh \"" << _meshes.back()->getName() << "\" is not defined. "
+             << "Please define a data tag with name=\"" << name << "\".";
       throw std::runtime_error{stream.str()};
     }
   }
@@ -114,7 +115,7 @@ void MeshConfiguration::addMesh(
         break;
       }
     }
-    PRECICE_CHECK(found, "Data " << dataNewMesh->getName() << " is not available in data configuration!");
+    PRECICE_CHECK(found, "Data " << dataNewMesh->getName() << " is not defined. Please define a data tag with name=\""<< dataNewMesh->getName() << "\".");
   }
   _meshes.push_back(mesh);
 }

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -84,11 +84,9 @@ void MeshConfiguration::xmlTagCallback(
       }
     }
     if (not found) {
-      std::ostringstream stream;
-      stream << "Data with name \"" << name << "\" used by "
+      PRECICE_ERROR("Data with name \"" << name << "\" used by "
              << "mesh \"" << _meshes.back()->getName() << "\" is not defined. "
-             << "Please define a data tag with name=\"" << name << "\".";
-      throw std::runtime_error{stream.str()};
+             << "Please define a data tag with name=\"" << name << "\".");
     }
   }
 }
@@ -115,7 +113,7 @@ void MeshConfiguration::addMesh(
         break;
       }
     }
-    PRECICE_CHECK(found, "Data " << dataNewMesh->getName() << " is not defined. Please define a data tag with name=\""<< dataNewMesh->getName() << "\".");
+    PRECICE_ASSERT(found, "Data " << dataNewMesh->getName() << " is not defined. Please define a data tag with name=\""<< dataNewMesh->getName() << "\".");
   }
   _meshes.push_back(mesh);
 }


### PR DESCRIPTION
```diff
- Data "MyData" cannot be created twice for mesh "MyMesh"!
+ Data "MyData" cannot be created twice for mesh "MyMesh". Please rename or remove one of the use-data tags with name "MyData".
```
```diff
- Data "MyData" uses non-unique name!
+ Data "MyData" has already been defined. Please rename or remove one of the data tags with name="MyData".
```
```diff
- Data "MyData" is not available in data configuration!
+ Data "MyData" is not defined. Please define a data tag with name="MyData".
```
```diff
- Unknown data type!
+ Unknown data type "typeName". Known data types: "scalar", "vector".
```

```diff
- Data with name "MyData" is not available during configuration of mesh "MyMesh"
+ Data with name "MyData" used by mesh "MyMesh" is not defined. Please define a data tag with name="MyData"
```

Related to #698.