### PR TITLE
CPack: Remove runtime dependencies on libeigen3-dev and libxml2-dev

### DIFF
--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -61,7 +61,7 @@ set(CPACK_SOURCE_IGNORE_FILES
 
 # Build dependecy set
 unset(CPACK_DEBIAN_PACKAGE_DEPENDS)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libboost-dev (>= 1.65), libboost-log-dev (>= 1.65), libboost-thread-dev (>= 1.65), libboost-system-dev (>= 1.65), libboost-filesystem-dev (>= 1.65), libboost-program-options-dev (>= 1.65), libboost-test-dev (>= 1.65), libeigen3-dev, libxml2-dev")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libboost-dev (>= 1.65), libboost-log-dev (>= 1.65), libboost-thread-dev (>= 1.65), libboost-system-dev (>= 1.65), libboost-filesystem-dev (>= 1.65), libboost-program-options-dev (>= 1.65), libboost-test-dev (>= 1.65), libxml2")
 if(PRECICE_PythonActions)
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, python3-dev, python3-numpy")
 endif()


### PR DESCRIPTION
- libeigen3-dev is completely removed, as header-only
- libxml2-dev is replaced by libxml2

As discussed, we keep Boost as development packages, since the name of the runtime packages depends on the available Boost version, which depends on the distribution we are building packages for.

Closes #678.

I tested this on Ubuntu 20.04, uninstalling the packages `libeigen3-dev` and `libxml2-dev`, installing the produced `libprecice2.0.1-focal.deb` and building/running the C++ solverdummy.