### PR TITLE
Platform Specific Default for Loopback Name

### DIFF
--- a/docs/changelog/736.md
+++ b/docs/changelog/736.md
@@ -1,0 +1,1 @@
+* Add platform-specific defaults of the loopback interface name to the `network` attribute of socket connections.

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -6,6 +6,7 @@
 #include "ConnectionInfoPublisher.hpp"
 #include "SocketRequest.hpp"
 #include "utils/assertion.hpp"
+#include "utils/networking.hpp"
 
 namespace precice {
 namespace com {
@@ -28,7 +29,7 @@ SocketCommunication::SocketCommunication(unsigned short     portNumber,
 }
 
 SocketCommunication::SocketCommunication(std::string const &addressDirectory)
-    : SocketCommunication(0, false, "lo", addressDirectory)
+    : SocketCommunication(0, false, utils::networking::loopbackInterfaceName(), addressDirectory)
 {
 }
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -7,6 +7,7 @@
 #include "com/Communication.hpp"
 #include "com/SocketSendQueue.hpp"
 #include "logging/Logger.hpp"
+#include "utils/networking.hpp"
 
 namespace precice {
 namespace com {
@@ -15,7 +16,7 @@ class SocketCommunication : public Communication {
 public:
   SocketCommunication(unsigned short     portNumber       = 0,
                       bool               reuseAddress     = false,
-                      std::string const &networkName      = "lo",
+                      std::string const &networkName      = utils::networking::loopbackInterfaceName(),
                       std::string const &addressDirectory = ".");
 
   explicit SocketCommunication(std::string const &addressDirectory);

--- a/src/com/SocketCommunicationFactory.cpp
+++ b/src/com/SocketCommunicationFactory.cpp
@@ -2,6 +2,7 @@
 
 #include "SocketCommunicationFactory.hpp"
 #include "com/SharedPointer.hpp"
+#include "utils/networking.hpp"
 
 namespace precice {
 namespace com {
@@ -22,7 +23,7 @@ SocketCommunicationFactory::SocketCommunicationFactory(
 
 SocketCommunicationFactory::SocketCommunicationFactory(
     std::string const &addressDirectory)
-    : SocketCommunicationFactory(0, false, "lo", addressDirectory)
+    : SocketCommunicationFactory(0, false, utils::networking::loopbackInterfaceName(), addressDirectory)
 {
 }
 

--- a/src/com/SocketCommunicationFactory.hpp
+++ b/src/com/SocketCommunicationFactory.hpp
@@ -2,6 +2,7 @@
 
 #include "CommunicationFactory.hpp"
 #include "com/SharedPointer.hpp"
+#include "utils/networking.hpp"
 
 #include <string>
 
@@ -11,7 +12,7 @@ class SocketCommunicationFactory : public CommunicationFactory {
 public:
   SocketCommunicationFactory(unsigned short     portNumber       = 0,
                              bool               reuseAddress     = false,
-                             std::string const &networkName      = "lo",
+                             std::string const &networkName      = utils::networking::loopbackInterfaceName(),
                              std::string const &addressDirectory = ".");
 
   explicit SocketCommunicationFactory(std::string const &addressDirectory);

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -8,6 +8,7 @@
 #include "m2n/M2N.hpp"
 #include "m2n/PointToPointComFactory.hpp"
 #include "utils/Helpers.hpp"
+#include "utils/networking.hpp"
 #include "xml/XMLAttribute.hpp"
 
 namespace precice {
@@ -31,13 +32,12 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
                             "bind it automatically.");
     tag.addAttribute(attrPort);
 
-    auto attrNetwork = makeXMLAttribute("network", "lo")
+    auto attrNetwork = makeXMLAttribute("network", utils::networking::loopbackInterfaceName())
                            .setDocumentation(
                                "Interface name to be used for socket communiation. "
-                               "Default is \"lo\", i.e., the local host loopback. "
+                               "Default is the cannonical name of the loopback interface of your platform. "
                                "Might be different on supercomputing systems, e.g. \"ib0\" "
-                               "for the InfiniBand on SuperMUC. "
-                               "For macOS use \"lo0\". ");
+                               "for the InfiniBand on SuperMUC. ");
     tag.addAttribute(attrNetwork);
 
     auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -156,10 +156,12 @@ ParticipantConfiguration::ParticipantConfiguration(
                             "bind it automatically.");
     tagMaster.addAttribute(attrPort);
 
-    auto attrNetwork = makeXMLAttribute(ATTR_NETWORK, "lo")
+    auto attrNetwork = makeXMLAttribute(ATTR_NETWORK, utils::networking::loopbackInterfaceName())
                            .setDocumentation(
-                               "Network name to be used for socket communiation. "
-                               "Default is \"lo\", i.e., the local host loopback.");
+                               "Interface name to be used for socket communiation. "
+                               "Default is the cannonical name of the loopback interface of your platform. "
+                               "Might be different on supercomputing systems, e.g. \"ib0\" "
+                               "for the InfiniBand on SuperMUC. ");
     tagMaster.addAttribute(attrNetwork);
 
     auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -7,6 +7,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "precice/impl/Participant.hpp"
 #include "xml/XMLTag.hpp"
+#include "utils/networking.hpp"
 
 namespace precice {
 namespace config {

--- a/src/precice/tests/master-sockets.xml
+++ b/src/precice/tests/master-sockets.xml
@@ -33,7 +33,7 @@
       <write-data  name="MyData2"      mesh="SerialMesh"/>
     </participant>
 
-    <m2n:sockets from="ParallelSolver" to="SerialSolver" network="lo" enforce-gather-scatter="true" />
+    <m2n:sockets from="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
 
     <coupling-scheme:parallel-explicit>
       <participants first="ParallelSolver" second="SerialSolver"/>

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -46,9 +46,9 @@ target_sources(precice
     src/action/ScaleByAreaAction.hpp
     src/action/ScaleByDtAction.cpp
     src/action/ScaleByDtAction.hpp
+    src/action/SharedPointer.hpp
     src/action/SummationAction.cpp
     src/action/SummationAction.hpp
-    src/action/SharedPointer.hpp
     src/action/config/ActionConfiguration.cpp
     src/action/config/ActionConfiguration.hpp
     src/com/CommunicateBoundingBox.cpp
@@ -270,6 +270,8 @@ target_sources(precice
     src/utils/TypeNames.hpp
     src/utils/algorithm.hpp
     src/utils/assertion.hpp
+    src/utils/networking.cpp
+    src/utils/networking.hpp
     src/utils/stacktrace.cpp
     src/utils/stacktrace.hpp
     src/utils/traits.hpp

--- a/src/utils/networking.cpp
+++ b/src/utils/networking.cpp
@@ -14,7 +14,7 @@ std::string loopbackInterfaceName()
   // Not required as we directly use the 127.0.0.1 under Windows
   return "";
 #else
-#warning "Your target architecture does not define a loopback interface. Please consider reporting this upstream."
+#warning "Your target architecture does not define a loopback interface. Please consider reporting this to the preCICE developers."
   return "";
 #endif
 }

--- a/src/utils/networking.cpp
+++ b/src/utils/networking.cpp
@@ -1,0 +1,24 @@
+#include "utils/networking.hpp"
+
+namespace precice {
+namespace utils {
+namespace networking {
+
+std::string loopbackInterfaceName()
+{
+#if defined(__linux__)
+  return "lo";
+#elif defined(__APPLE__)
+  return "lo0";
+#elif defined(__WIN32)
+  // Not required as we directly use the 127.0.0.1 under Windows
+  return "";
+#else
+#warning "Your target architecture does not define a loopback interface. Please consider reporting this upstream."
+  return "";
+#endif
+}
+
+} // namespace networking
+} // namespace utils
+} // namespace precice

--- a/src/utils/networking.hpp
+++ b/src/utils/networking.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace precice {
+namespace utils {
+namespace networking {
+
+/// Returns the name of the canonical loopback interface on this system
+std::string loopbackInterfaceName();
+
+} // namespace networking
+
+} // namespace utils
+} // namespace precice


### PR DESCRIPTION
This PR adds a platform-specific default name for the loopback interface.
Unsupported platforms will display a warning at compile-time and default to `""`.

Currently supported are:
* Windows (do nothing)
* Linux `lo`
* Apple `lo0`

Closes #198
