### PR TITLE
Add nightly coverity-scan workflow

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,0 +1,50 @@
+name: coverity-scan
+on:
+  schedule:
+    - cron: '0 3 * * *' # Daily at 03:00 UTC
+
+jobs:
+  latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install libraries
+        run: |
+          set -x
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake git libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy 
+
+      - name: Download Coverity Build Tool
+        run: |
+          wget -q https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=precice%2Fprecice" -O coverity_tool.tgz
+          mkdir coverity
+          tar xzf coverity_tool.tgz --strip 1 -C coverity
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+      - name: Checkout preCICE
+        uses: actions/checkout@v2
+        with:
+          path: 'precice'
+
+      - name: Configure
+        run:  |
+          mkdir build && cd build
+          cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug ../precice
+
+      - name: Build with cov-build
+        run: |
+          ../coverity/bin/cov-build --dir cov-int make
+
+      - name: Submit the result to Coverity Scan
+        run: |
+          tar czvf precice.tgz cov-int
+          curl \
+            --form token=$TOKEN \
+            --form email=$EMAIL \
+            --form file=@precice.tgz \
+            --form version="develop" \
+            --form description="Nightly Coverity Scan of preCICE" \
+            https://scan.coverity.com/builds?project=precice%2Fprecice
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          EMAIL: ${{ secrets.COVERITY_SUBMITTER_EMAIL }}


### PR DESCRIPTION
This PR adds a nightly coverity-scan build which is executed via GitHub actions.
It runs every day at `02:00` and thus should not impact our normal development.

The workflow checks our default branch including python, petsc and mpi.
The results are then displayed on our [dashboard](https://scan.coverity.com/projects/precice-precice).
You need to login and "Add yourself to project" to gain detailed insights.