### PR TITLE
Write events summary to file

### DIFF
--- a/docs/changelog/742.md
+++ b/docs/changelog/742.md
@@ -1,1 +1,1 @@
-* Removes the summary of event timing when preCICE finalizes and writes it to the file `PARTICIPANT-events-summary.log` instead.
+* Removes the summary of event timing when preCICE finalizes and writes it to the file `precice-PARTICIPANT-events-summary.log` instead.

--- a/docs/changelog/742.md
+++ b/docs/changelog/742.md
@@ -1,0 +1,1 @@
+* Removes the summary of event timing when preCICE finalizes and writes it to the file `PARTICIPANT-events-summary.log` instead.

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -278,14 +278,19 @@ void EventRegistry::printAll() const
     return;
 
   std::string logFile;
-  if (applicationName.empty())
+  std::string summaryFile;
+  if (applicationName.empty()) {
     logFile = "Events.json";
-  else
+    summaryFile = "Events-summary.log";
+  } else {
     logFile = applicationName + "-events.json";
+    summaryFile = applicationName + "-events-summary.log";
+  }
 
-  writeSummary(std::cout);
-  std::ofstream ofs(logFile);
-  writeJSON(ofs);
+  std::ofstream summaryFS{summaryFile};
+  writeSummary(summaryFS);
+  std::ofstream logFS{logFile};
+  writeJSON(logFS);
 }
 
 void EventRegistry::writeSummary(std::ostream &out) const


### PR DESCRIPTION
This PR changes eventutils to write the final events summary to a file instead of printing it to the console output.
The generated filename is `PARTICIPANT-events-summary.log`.

Closes #696