### PR TITLE
Remove testMode

### DIFF
--- a/docs/changelog/742.md
+++ b/docs/changelog/742.md
@@ -1,0 +1,1 @@
+* Removes the summary of event timing when preCICE finalizes and writes it to the file `precice-PARTICIPANT-events-summary.log` instead.

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -26,7 +26,6 @@ struct SolutionCaching;
 } // namespace MappingTests
 
 namespace precice {
-extern bool testMode;
 extern bool syncMode;
 } // namespace precice
 
@@ -884,15 +883,13 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshSecondRound()
 template <typename RADIAL_BASIS_FUNCTION_T>
 void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::printMappingInfo(int inputDataID, int dim) const
 {
-  if (not precice::testMode) {
-    const std::string constraintName = getConstraint() == CONSERVATIVE ? "conservative" : "consistent";
-    const std::string polynomialName = _polynomial == Polynomial::ON ? "on" : _polynomial == Polynomial::OFF ? "off" : "separate";
+  const std::string constraintName = getConstraint() == CONSERVATIVE ? "conservative" : "consistent";
+  const std::string polynomialName = _polynomial == Polynomial::ON ? "on" : _polynomial == Polynomial::OFF ? "off" : "separate";
 
-    PRECICE_INFO("Mapping " << input()->data(inputDataID)->getName() << " " << constraintName
-                            << " from " << input()->getName() << " (ID " << input()->getID() << ")"
-                            << " to " << output()->getName() << " (ID " << output()->getID() << ") "
-                            << "for dimension " << dim << ") with polynomial set to " << polynomialName);
-  }
+  PRECICE_INFO("Mapping " << input()->data(inputDataID)->getName() << " " << constraintName
+      << " from " << input()->getName() << " (ID " << input()->getID() << ")"
+      << " to " << output()->getName() << " (ID " << output()->getID() << ") "
+      << "for dimension " << dim << ") with polynomial set to " << polynomialName);
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -25,7 +25,8 @@ struct MappingContext;
 // Forward declaration to friend the boost test struct
 namespace PreciceTests {
 namespace Serial {
-struct TestConfiguration;
+struct TestConfigurationPeano;
+struct TestConfigurationComsol;
 }
 } // namespace PreciceTests
 
@@ -189,7 +190,8 @@ private:
   void checkDuplicatedData(const mesh::PtrData &data);
 
   /// To allow white box tests.
-  friend struct PreciceTests::Serial::TestConfiguration;
+  friend struct PreciceTests::Serial::TestConfigurationPeano;
+  friend struct PreciceTests::Serial::TestConfigurationComsol;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -42,9 +42,6 @@ using precice::utils::EventRegistry;
 
 namespace precice {
 
-/// Set to true if unit/integration tests are executed
-bool testMode = false;
-
 /// Enabled further inter- and intra-solver synchronisation
 bool syncMode = false;
 
@@ -112,7 +109,7 @@ void SolverInterfaceImpl::configure(
     const std::string &configurationFileName)
 {
   config::Configuration config;
-  utils::Parallel::initializeMPI(nullptr, nullptr);
+  utils::Parallel::initializeManagedMPI(nullptr, nullptr);
   logging::setMPIRank(utils::Parallel::current()->rank());
   xml::ConfigurationContext context{
       _accessorName,
@@ -447,7 +444,7 @@ void SolverInterfaceImpl::finalize()
 
   // Stop and print Event logging
   e.stop();
-  if (not precice::testMode and not precice::utils::MasterSlave::isSlave()) {
+  if (not precice::utils::MasterSlave::isSlave()) {
     utils::EventRegistry::instance().printAll();
   }
 
@@ -455,9 +452,7 @@ void SolverInterfaceImpl::finalize()
   utils::Petsc::finalize();
   utils::EventRegistry::instance().clear();
   utils::EventRegistry::instance().finalize();
-  if (not precice::testMode) {
-    utils::Parallel::finalizeMPI();
-  }
+  utils::Parallel::finalizeManagedMPI();
 }
 
 int SolverInterfaceImpl::getDimensions() const

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -444,14 +444,18 @@ void SolverInterfaceImpl::finalize()
 
   // Stop and print Event logging
   e.stop();
+
+  // Finalize PETSc and Events first
+  utils::Petsc::finalize();
+  utils::EventRegistry::instance().finalize();
+
+  // Printing requires finalization
   if (not precice::utils::MasterSlave::isSlave()) {
     utils::EventRegistry::instance().printAll();
   }
 
-  // Tear down MPI and PETSc
-  utils::Petsc::finalize();
+  // Finally clear events and finalize MPI
   utils::EventRegistry::instance().clear();
-  utils::EventRegistry::instance().finalize();
   utils::Parallel::finalizeManagedMPI();
 }
 

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -24,7 +24,8 @@ class SolverInterfaceConfiguration;
 // Forward declaration to friend the boost test struct
 namespace PreciceTests {
 namespace Serial {
-struct TestConfiguration;
+struct TestConfigurationPeano;
+struct TestConfigurationComsol;
 }
 } // namespace PreciceTests
 
@@ -624,7 +625,8 @@ private:
   void syncTimestep(double computedTimestepLength);
 
   /// To allow white box tests.
-  friend struct PreciceTests::Serial::TestConfiguration;
+  friend struct PreciceTests::Serial::TestConfigurationPeano;
+  friend struct PreciceTests::Serial::TestConfigurationComsol;
 };
 
 } // namespace impl

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -34,10 +34,11 @@ BOOST_AUTO_TEST_SUITE(PreciceTests)
 BOOST_FIXTURE_TEST_SUITE(Serial, SerialTestFixture)
 
 /// Test reading of a full features coupling configuration file.
-BOOST_AUTO_TEST_CASE(TestConfiguration)
+BOOST_AUTO_TEST_CASE(TestConfigurationPeano)
 {
   PRECICE_TEST(1_rank);
-  std::string filename = _pathToTests + "/configuration.xml";
+  std::string filename = _pathToTests + "configuration.xml";
+
   // Test configuration for accessor "Peano"
   SolverInterface interfacePeano("Peano", filename, 0, 1);
 
@@ -55,6 +56,12 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
 
   BOOST_TEST(meshContexts[0]->mesh->getName() == std::string("PeanoNodes"));
   BOOST_TEST(meshContexts[1]->mesh->getName() == std::string("ComsolNodes"));
+}
+
+BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
+{
+  PRECICE_TEST(1_rank);
+  std::string filename = _pathToTests + "configuration.xml";
 
   // Test configuration for accessor "Comsol"
   SolverInterface interfaceComsol("Comsol", filename, 0, 1);
@@ -66,7 +73,7 @@ BOOST_AUTO_TEST_CASE(TestConfiguration)
   BOOST_TEST(comsol->getName() == "Comsol");
   BOOST_TEST(comsol->getID() == 1);
 
-  meshContexts = comsol->_meshContexts;
+  std::vector<impl::MeshContext *> meshContexts = comsol->_meshContexts;
   BOOST_TEST(meshContexts.size() == 2);
   BOOST_TEST(meshContexts[0] == static_cast<void *>(nullptr));
   BOOST_TEST(meshContexts[1]->mesh->getName() == std::string("ComsolNodes"));

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -41,6 +41,7 @@ TestContext::~TestContext() noexcept
 
   // Reset communicators
   Par::resetCommState();
+  Par::resetManagedMPI();
 }
 
 bool TestContext::hasSize(int size) const

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -11,7 +11,6 @@
 #include "utils/Petsc.hpp"
 
 namespace precice {
-extern bool testMode;
 extern bool syncMode;
 } // namespace precice
 
@@ -97,7 +96,6 @@ int main(int argc, char *argv[])
 {
   using namespace precice;
 
-  precice::testMode = true;
   precice::syncMode = false;
   logging::setupLogging(); // first logging initalization, as early as possible
   utils::Parallel::initializeMPI(&argc, &argv);

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -16,10 +16,6 @@
 #include "utils/assertion.hpp"
 
 namespace precice {
-extern bool testMode;
-}
-
-namespace precice {
 namespace utils {
 
 using sys_clk  = std::chrono::system_clock;
@@ -223,12 +219,10 @@ void EventRegistry::finalize()
   for (auto &e : storedEvents)
     e.second.stop();
 
-  // @todo remove testMode flag once we have properly refactored the tests, cf. issue #597
-  if (initialized && not precice::testMode) // this makes only sense when it was properly initialized
+  if (initialized) // this makes only sense when it was properly initialized
     normalize();
 
-  if (not precice::testMode)
-    collect();
+  collect();
 
   initialized = false;
   finalized   = true;

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -272,14 +272,19 @@ void EventRegistry::printAll() const
     return;
 
   std::string logFile;
-  if (applicationName.empty())
+  std::string summaryFile;
+  if (applicationName.empty()) {
     logFile = "Events.json";
-  else
+    summaryFile = "Events-summary.log";
+  } else {
     logFile = applicationName + "-events.json";
+    summaryFile = applicationName + "-events-summary.log";
+  }
 
-  writeSummary(std::cout);
-  std::ofstream ofs(logFile);
-  writeJSON(ofs);
+  std::ofstream summaryFS{summaryFile};
+  writeSummary(summaryFS);
+  std::ofstream logFS{logFile};
+  writeJSON(logFS);
 }
 
 void EventRegistry::writeSummary(std::ostream &out) const

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -47,9 +47,7 @@ int Parallel::CommState::rank() const
 {
   int processRank = 0;
 #ifndef PRECICE_NO_MPI
-  if (_isInitialized) {
-    MPI_Comm_rank(comm, &processRank);
-  }
+  MPI_Comm_rank(comm, &processRank);
 #endif // not PRECICE_NO_MPI
   return processRank;
 }
@@ -59,9 +57,7 @@ int Parallel::CommState::size() const
 
   int communicatorSize = 1;
 #ifndef PRECICE_NO_MPI
-  if (_isInitialized) {
-    MPI_Comm_size(comm, &communicatorSize);
-  }
+  MPI_Comm_size(comm, &communicatorSize);
 #endif // not PRECICE_NO_MPI
   return communicatorSize;
 }
@@ -70,7 +66,6 @@ void Parallel::CommState::synchronize() const
 {
 #ifndef PRECICE_NO_MPI
   PRECICE_TRACE();
-  PRECICE_ASSERT(_isInitialized);
   if (!isNull()) {
     MPI_Barrier(comm);
   }
@@ -158,6 +153,12 @@ void Parallel::resetCommState()
   _currentState = CommState::world();
 }
 
+void Parallel::resetManagedMPI()
+{
+  _mpiInitializedByPrecice = false;
+  _isInitialized = false;
+}
+
 void Parallel::pushState(CommStatePtr newState)
 {
   PRECICE_TRACE();
@@ -179,22 +180,74 @@ void Parallel::pushState(CommStatePtr newState)
 // #endif
 // }
 
-void Parallel::initializeMPI(
+void Parallel::initializeManagedMPI(
     int *   argc,
     char ***argv)
 {
 #ifndef PRECICE_NO_MPI
   PRECICE_TRACE();
-  int isMPIInitialized;
+  PRECICE_ASSERT(!_isInitialized, "A managed MPI session already exists.");
+  PRECICE_ASSERT(!_mpiInitializedByPrecice);
+  int isMPIInitialized{-1};
   MPI_Initialized(&isMPIInitialized);
-  if (not isMPIInitialized) {
-    PRECICE_DEBUG("Initialize MPI");
+  if (isMPIInitialized) {
+    PRECICE_DEBUG("Initializing unmanaged MPI.");
+    _mpiInitializedByPrecice = false;
+  } else {
+    PRECICE_DEBUG("Initializing managed MPI");
     _mpiInitializedByPrecice = true;
-    MPI_Init(argc, argv);
+    initializeMPI(argc, argv);
   }
-  _isInitialized = true;
+    _isInitialized = true;
 #endif // not PRECICE_NO_MPI
 }
+
+void Parallel::initializeMPI(
+    int *   argc,
+    char ***argv)
+{
+#ifndef PRECICE_NO_MPI
+  int isMPIInitialized{-1};
+  MPI_Initialized(&isMPIInitialized);
+  PRECICE_ASSERT(!isMPIInitialized, "MPI was already initalized.");
+  PRECICE_DEBUG("Initialize MPI");
+  MPI_Init(argc, argv);
+#endif // not PRECICE_NO_MPI
+}
+
+
+
+void Parallel::finalizeManagedMPI()
+{
+  PRECICE_TRACE();
+  // Make sure all com states were freed at this point in time
+  resetCommState();
+#ifndef PRECICE_NO_MPI
+  PRECICE_ASSERT(_isInitialized, "There is no managed MPI session.");
+  if (_mpiInitializedByPrecice) {
+    PRECICE_DEBUG("Finalizing managed MPI.");
+    finalizeMPI();
+  } else {
+    PRECICE_DEBUG("Finalizing unmanaged MPI");
+  }
+  _mpiInitializedByPrecice = false;
+  _isInitialized = false;
+#endif // not PRECICE_NO_MPI
+}
+
+
+void Parallel::finalizeMPI()
+{
+#ifndef PRECICE_NO_MPI
+  PRECICE_TRACE();
+  int isMPIInitialized;
+  MPI_Initialized(&isMPIInitialized);
+  PRECICE_ASSERT(isMPIInitialized, "MPI was not initalized.");
+  PRECICE_DEBUG("Finalize MPI");
+  MPI_Finalize();
+#endif // not PRECICE_NO_MPI
+}
+
 
 void Parallel::registerUserProvidedComm(Communicator comm)
 {
@@ -323,20 +376,6 @@ void Parallel::popState()
   }
 }
 
-void Parallel::finalizeMPI()
-{
-  PRECICE_TRACE();
-  // Make sure all com states were freed at this point in time
-  resetCommState();
-#ifndef PRECICE_NO_MPI
-  if (_mpiInitializedByPrecice) {
-    PRECICE_DEBUG("preCICE finalizes MPI");
-    MPI_Finalize();
-  }
-#endif // not PRECICE_NO_MPI
-  _isInitialized = false;
-}
-
 // void Parallel::clearGroups()
 // {
 //   _accessorGroups.clear();
@@ -439,7 +478,6 @@ void Parallel::restrictCommunicator(int newSize)
   PRECICE_ASSERT(newSize > 0, "Cannot restrict a communicator to nothing!");
 
 #ifndef PRECICE_NO_MPI
-  PRECICE_ASSERT(_isInitialized);
   auto       baseState = current();
   const auto size      = baseState->size();
   const auto rank      = baseState->rank();

--- a/src/utils/Parallel.hpp
+++ b/src/utils/Parallel.hpp
@@ -122,9 +122,24 @@ public:
 
   /// @name Initialization and Finalization
   /// @{
+  
+  /**
+   * @brief Initializes the MPI environment and manages it.
+   *
+   * This keeps track of the state when called by setting _isInitialized and _mpiInitializedByPrecice
+   * To finalize the managed MPI call @ref finalizeManagedMPI().
+   *
+   * @param[in] argc Parameter count
+   * @param[in] argv Parameter values, is passed to MPI_Init
+   *
+   * @see finalizeManagedMPI
+   */
+  static void initializeManagedMPI(
+      int *   argc,
+      char ***argv);
 
   /**
-   * @brief Initializes the MPI environment.
+   * @brief Unconditionally initializes the MPI environment.
    *
    * @param[in] argc Parameter count
    * @param[in] argv Parameter values, is passed to MPI_Init
@@ -133,7 +148,17 @@ public:
       int *   argc,
       char ***argv);
 
-  /// Finalizes MPI environment.
+  /**
+   * @brief Finalized a managed MPI environment.
+   *
+   * To initialize the managed MPI call @ref initializeManagedMPI().
+   * This finalizes MPI only if it was not initialized before the call to @ref initializeManagedMPI()
+   *
+   * @see InitializeManagedMPI
+   */
+  static void finalizeManagedMPI();
+
+  /// Unconditionally finalizes MPI environment.
   static void finalizeMPI();
 
   /// Registers a user-provided communicator
@@ -173,6 +198,12 @@ public:
    * 
    */
   static void resetCommState();
+
+  /** Resets managed MPI
+   *
+   * This resets _mpiInitializedByPrecice and _isInitialized to false
+   */
+  static void resetManagedMPI();
 
   /** Sets the current state to its parent
    *


### PR DESCRIPTION
This PR removes the `testMode` from preCICE.
After the refactoring done in #702, this was only truly required to steer the MPI initialization.
Tests initialize MPI the same way as the SolverInterface leading to ownership problems.
I solved this by splitting `initializeMPI` into two functions:
* `initializeMPI` asserts that MPI is inititlaized using `MPI_Inititalized()` and calls `MPI_Init()`.
* `initializeManagedMPI` asserts that `_isInitialized` and `_mpiInitializedByPrecice` are false, then calls `initializeMPI` if `MPI_Initalized` returns true.  
  This starts to "manage" an MPI environment. It creates it if necessary.

I used the same concept for finalize.
The TestContext now always resets the management flags on destruction.

Due to the additional assertions, I had to split up `PreciceTests/Serial/TestConfiguration` into 2 Tests.

 Related to #742