### PR TITLE
Fix BoundingBox failure of systemtests on Ubuntu16.04

### DIFF
--- a/src/com/tests/CommunicateBoundingBoxTest.cpp
+++ b/src/com/tests/CommunicateBoundingBoxTest.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveBoundingBoxMap)
         bounds.push_back(rank*i);
         bounds.push_back(i + 1);
       }
-      bbm.emplace(rank, bounds);
+      bbm.emplace(rank, mesh::BoundingBox(bounds));
     }
 
     CommunicateBoundingBox comBB(m2n->getMasterCommunication());
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveBoundingBoxMap)
       bounds.push_back(rank*i);
       bounds.push_back(i + 1);
     }
-    bbm.emplace(rank, bounds);
+    bbm.emplace(rank, mesh::BoundingBox(bounds));
   }
 
   CommunicateBoundingBox comBB(utils::MasterSlave::_communication);

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -363,9 +363,9 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
     mesh::BoundingBox    localBB{dimensions};
 
     mesh::Mesh::BoundingBoxMap compareBB;
-    compareBB.emplace(0, (std::vector<double>) {-1, 5, 0, 3});
-    compareBB.emplace(1, (std::vector<double>) {0, 1, 3.5, 4.5});
-    compareBB.emplace(2, (std::vector<double>) {2.5, 4.5, 5.5, 7.0});
+    compareBB.emplace(0, mesh::BoundingBox({-1, 5, 0, 3}));
+    compareBB.emplace(1, mesh::BoundingBox({0, 1, 3.5, 4.5}));
+    compareBB.emplace(2, mesh::BoundingBox({2.5, 4.5, 5.5, 7.0}));
 
     // we receive other participants communicator size
     int receivedFeedbackSize = 3;
@@ -459,9 +459,9 @@ BOOST_AUTO_TEST_CASE(TestSendBoundingBoxes3D)
     mesh::BoundingBox    localBB{dimensions};
 
     mesh::Mesh::BoundingBoxMap compareBB;
-    compareBB.emplace(0, (std::vector<double>) {-1, 5, 0, 3, -1, 5});
-    compareBB.emplace(1, (std::vector<double>) {0, 1, 3.5, 4.5, 0, 1});
-    compareBB.emplace(2, (std::vector<double>) {2.5, 4.5, 5.5, 7.0, 2.5, 4.5});
+    compareBB.emplace(0, mesh::BoundingBox({-1, 5, 0, 3, -1, 5}));
+    compareBB.emplace(1, mesh::BoundingBox({0, 1, 3.5, 4.5, 0, 1}));
+    compareBB.emplace(2, mesh::BoundingBox({2.5, 4.5, 5.5, 7.0, 2.5, 4.5}));
 
     // we receive other participants communicator size
     int remoteParComSize = 3;

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -1057,7 +1057,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
       bounds.push_back(3 - remoteRank - 1);
       bounds.push_back(3 - remoteRank);
     }
-    sendGlobalBB.emplace(remoteRank, bounds);
+    sendGlobalBB.emplace(remoteRank, mesh::BoundingBox(bounds));
   }
 
   if (context.isNamed("SOLIDZ")) {
@@ -1128,7 +1128,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
       bounds.push_back(3 - remoteRank - 1);
       bounds.push_back(3 - remoteRank);
     }
-    sendGlobalBB.emplace(remoteRank, bounds);
+    sendGlobalBB.emplace(remoteRank, mesh::BoundingBox(bounds));
   }
 
   if (context.isNamed("SOLIDZ")) {


### PR DESCRIPTION
Apparently, while using `emplace()` on `std::map` compilers on Ubuntu18.04 and Ubuntu20.04 can directly take the parameter given in the `emplace()` to create an object and Ubuntu16.04 cannot which results in failure in the `systemtests` 

More robust (and probably more true) usage is changing `emplace(std::vector)` to `emplace(BoundingBox(std::vector)` and it solves the issue.