### PR TITLE
Rework MPI[Single]Ports and add Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,16 @@ precice_validate_prettyprint()
 
 # Option: PRECICE_MPICommunication
 if (PRECICE_MPICommunication)
+  set(MPI_DETERMINE_LIBRARY_VERSION ON) # Try to detect the library vendor
+
   find_package(MPI REQUIRED)
+  message(STATUS "MPI Version: ${MPI_CXX_LIBRARY_VERSION_STRING}")
+
+  # We need to disable the MPIPorts tests in case we detect Open MPI
+  if(MPI_CXX_LIBRARY_VERSION_STRING MATCHES "Open MPI")
+    set(PRECICE_MPI_OPENMPI TRUE CACHE BOOL "Is the MPI implementation OpenMPI?" FORCE)
+    mark_as_advanced(PRECICE_MPI_OPENMPI)
+  endif()
 endif()
 
 # Option: PETSC

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -26,7 +26,7 @@ mark_as_advanced(PRECICE_TEST_WRAPPER_SCRIPT)
 
 
 function(add_precice_test)
-  cmake_parse_arguments(PARSE_ARGV 0 PAT "PETSC;CANFAIL" "NAME;ARGUMENTS;TIMEOUT;LABELS" "")
+  cmake_parse_arguments(PARSE_ARGV 0 PAT "PETSC;CANFAIL;MPIPORTS" "NAME;ARGUMENTS;TIMEOUT;LABELS" "")
   # Check arguments
   if(NOT PAT_NAME)
     message(FATAL_ERROR "Argument NAME not passed")
@@ -38,6 +38,11 @@ function(add_precice_test)
   # Are direct dependencies fullfilled?
   if( (NOT PRECICE_MPICommunication) OR (PAT_PETSC AND NOT PRECICE_PETScMapping) )
     message(STATUS "Test ${PAT_FULL_NAME} - skipped")
+    return()
+  endif()
+
+  if(PAT_MPIPORTS AND PRECICE_MPI_OPENMPI)
+    message(STATUS "Test ${PAT_FULL_NAME} - skipped (OpenMPI)")
     return()
   endif()
 
@@ -218,6 +223,7 @@ add_precice_test(
   ARGUMENTS "--run_test=CommunicationTests/MPIPorts:CommunicationTests/MPISinglePorts"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   LABELS "mpiports;canfail"
+  MPIPORTS
   )
 add_precice_test(
   NAME cplscheme
@@ -239,6 +245,7 @@ add_precice_test(
   ARGUMENTS "--run_test=M2NTests/MPIPorts:M2NTests/MPISinglePorts"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   LABELS "mpiports;canfail"
+  MPIPORTS
   )
 add_precice_test(
   NAME mapping

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -210,12 +210,12 @@ add_precice_test(
   )
 add_precice_test(
   NAME com
-  ARGUMENTS "--run_test=CommunicationTests:\!CommunicationTests/MPIPorts"
+  ARGUMENTS "--run_test=CommunicationTests:\!CommunicationTests/MPIPorts:\!CommunicationTests/MPISinglePorts"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   )
 add_precice_test(
   NAME com.mpiports
-  ARGUMENTS "--run_test=CommunicationTests/MPIPorts"
+  ARGUMENTS "--run_test=CommunicationTests/MPIPorts:CommunicationTests/MPISinglePorts"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   LABELS "mpiports;canfail"
   )
@@ -231,12 +231,12 @@ add_precice_test(
   )
 add_precice_test(
   NAME m2n
-  ARGUMENTS "--run_test=M2NTests:\!M2NTests/MPIPorts"
+  ARGUMENTS "--run_test=M2NTests:\!M2NTests/MPIPorts:\!M2NTets/MPISinglePorts"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   )
 add_precice_test(
   NAME m2n.mpiports
-  ARGUMENTS "--run_test=M2NTests/MPIPorts"
+  ARGUMENTS "--run_test=M2NTests/MPIPorts:M2NTests/MPISinglePorts"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   LABELS "mpiports;canfail"
   )

--- a/docs/changelog/747.md
+++ b/docs/changelog/747.md
@@ -1,4 +1,4 @@
-* Add MPI version detection and prints it during the CMake configuration
+* Add MPI version detection and print it during the CMake configuration
 * Disable tests based on MPIPorts and MPISinglePorts when using Open MPI
 * Fix MPIPorts and MPISinglePorts not always closing ports
 * Fix SocketCommunication setting up a port and writing connection info even if there are no requesters

--- a/docs/changelog/747.md
+++ b/docs/changelog/747.md
@@ -1,0 +1,4 @@
+* Add MPI version detection and prints it during the CMake configuration
+* Disable tests based on MPIPorts and MPISinglePorts when using Open MPI
+* Fix MPIPorts and MPISinglePorts not always closing ports
+* Fix SocketCommunication setting up a port and writing connection info even if there are no requesters

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -1,3 +1,4 @@
+#include "utils/assertion.hpp"
 #ifndef PRECICE_NO_MPI
 
 #include <Eigen/Core>
@@ -10,7 +11,6 @@
 #include "acceleration/impl/QRFactorization.hpp"
 #include "com/Communication.hpp"
 #include "com/MPIPortsCommunication.hpp"
-#include "com/SocketCommunication.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
@@ -48,8 +48,6 @@ MVQNAcceleration::MVQNAcceleration(
       _matrixV_RSLS(),
       _matrixW_RSLS(),
       _matrixCols_RSLS(),
-      _cyclicCommLeft(nullptr),
-      _cyclicCommRight(nullptr),
       _parMatrixOps(nullptr),
       _svdJ(RSSVDtruncationEps, preconditioner),
       _alwaysBuildJacobian(alwaysBuildJacobian),
@@ -67,22 +65,6 @@ MVQNAcceleration::MVQNAcceleration(
 // ==================================================================================
 MVQNAcceleration::~MVQNAcceleration()
 {
-  //if(utils::MasterSlave::isMaster() ||utils::MasterSlave::isSlave()){ // not possible because of tests, MasterSlave is deactivated when PP is killed
-
-  // close and shut down cyclic communication connections
-  if (not _imvjRestart) {
-    if (_cyclicCommRight != nullptr || _cyclicCommLeft != nullptr) {
-      if ((utils::MasterSlave::getRank() % 2) == 0) {
-        _cyclicCommLeft->closeConnection();
-        _cyclicCommRight->closeConnection();
-      } else {
-        _cyclicCommRight->closeConnection();
-        _cyclicCommLeft->closeConnection();
-      }
-      _cyclicCommRight = nullptr;
-      _cyclicCommLeft  = nullptr;
-    }
-  }
 }
 
 // ==================================================================================
@@ -97,36 +79,9 @@ void MVQNAcceleration::initialize(
   if (_imvjRestartType > 0)
     _imvjRestart = true;
 
-  // only need cyclic communication if no MVJ restart mode is used
-  if (not _imvjRestart) {
-    if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
-      /*
-     * @todo: FIXME: This is a temporary and hacky realization of the cyclic commmunication between slaves
-     *        Therefore the requesterName and accessorName are not given (cf solverInterfaceImpl).
-     *        The master-slave communication should be modified such that direct communication between
-     *        slaves is possible (via MPIDirect)
-     */
-      _cyclicCommLeft  = com::PtrCommunication(new com::MPIPortsCommunication());
-      _cyclicCommRight = com::PtrCommunication(new com::MPIPortsCommunication());
-      //_cyclicCommLeft = com::Communication::SharedPointer(new com::SocketCommunication(0, false, "ib0", "."));
-      //_cyclicCommRight = com::Communication::SharedPointer(new com::SocketCommunication(0, false, "ib0", "."));
-
-      // initialize cyclic communication between successive slaves
-      int prevProc = (utils::MasterSlave::getRank() - 1 < 0) ? utils::MasterSlave::getSize() - 1 : utils::MasterSlave::getRank() - 1;
-      if ((utils::MasterSlave::getRank() % 2) == 0) {
-        _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "", utils::MasterSlave::getRank());
-        _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::MasterSlave::getRank()), "", "", 0, 1);
-      } else {
-        _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(utils::MasterSlave::getRank()), "", "", 0, 1);
-        _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "", utils::MasterSlave::getRank());
-      }
-      _cyclicCommLeft->cleanupEstablishment("cyclicComm-" + std::to_string(prevProc), "");
-    }
-  }
-
   // initialize parallel matrix-matrix operation module
   _parMatrixOps = impl::PtrParMatrixOps(new impl::ParallelMatrixOperations());
-  _parMatrixOps->initialize(_cyclicCommLeft, _cyclicCommRight, not _imvjRestart);
+  _parMatrixOps->initialize(not _imvjRestart);
   _svdJ.initialize(_parMatrixOps, getLSSystemRows());
 
   int entries  = _residuals.size();
@@ -863,6 +818,7 @@ void MVQNAcceleration::removeMatrixColumnRSLS(
     iter++;
   }
 }
+
 } // namespace acceleration
 } // namespace precice
 

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -1,4 +1,3 @@
-#include "utils/assertion.hpp"
 #ifndef PRECICE_NO_MPI
 
 #include <Eigen/Core>

--- a/src/acceleration/MVQNAcceleration.hpp
+++ b/src/acceleration/MVQNAcceleration.hpp
@@ -96,12 +96,6 @@ private:
   /// @brief number of cols per time step
   std::deque<int> _matrixCols_RSLS;
 
-  /// @brief Communication between neighboring slaves, backwards
-  com::PtrCommunication _cyclicCommLeft;
-
-  /// @brief Communication between neighboring slaves, forward
-  com::PtrCommunication _cyclicCommRight;
-
   /// @brief encapsulates matrix-matrix and matrix-vector multiplications for serial and parallel execution
   impl::PtrParMatrixOps _parMatrixOps;
 
@@ -199,6 +193,7 @@ private:
 
   /// @brief: Removes one column form the V_RSLS and W_RSLS matrices and adapts _matrixCols_RSLS
   void removeMatrixColumnRSLS(int columnINdex);
+
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/impl/ParallelMatrixOperations.cpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.cpp
@@ -8,27 +8,81 @@ namespace precice {
 namespace acceleration {
 namespace impl {
 
-void ParallelMatrixOperations::initialize(
-    com::PtrCommunication leftComm,
-    com::PtrCommunication rightComm,
-    bool                  needCyclicComm)
+void ParallelMatrixOperations::initialize(bool needCyclicComm)
 {
   PRECICE_TRACE();
 
-  _needCycliclComm = needCyclicComm;
   if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
-
-    _cyclicCommLeft  = leftComm;
-    _cyclicCommRight = rightComm;
-
-    if (_needCycliclComm) {
-      PRECICE_ASSERT(_cyclicCommLeft.get() != NULL);
-      PRECICE_ASSERT(_cyclicCommLeft->isConnected());
-      PRECICE_ASSERT(_cyclicCommRight.get() != NULL);
-      PRECICE_ASSERT(_cyclicCommRight->isConnected());
-    }
+    _needCyclicComm = needCyclicComm;
+    establishCircularCommunication();
+  } else {
+    _needCyclicComm = false;
   }
 }
+
+ParallelMatrixOperations::~ParallelMatrixOperations()
+{
+  PRECICE_TRACE();
+
+  if(_needCyclicComm) {
+    closeCircularCommunication();
+  }
+}
+
+void ParallelMatrixOperations::establishCircularCommunication()
+{
+  PRECICE_ASSERT(_needCyclicComm);
+  PRECICE_ASSERT(_cyclicCommRight == nullptr);
+  PRECICE_ASSERT(_cyclicCommLeft == nullptr);
+
+  com::PtrCommunication cyclicCommLeft  = com::PtrCommunication(new com::MPIPortsCommunication("."));
+  com::PtrCommunication cyclicCommRight = com::PtrCommunication(new com::MPIPortsCommunication("."));
+
+  const auto size = utils::MasterSlave::getSize();
+  const auto rank = utils::MasterSlave::getRank();
+  const int prevProc = (rank - 1 + size) % size;
+  const int nextProc = (rank + 1) % size;
+
+  std::string prefix = "MVQNCyclicComm";
+  std::string prevName = prefix + std::to_string(prevProc);
+  std::string thisName = prefix + std::to_string(rank);
+  std::string nextName = prefix + std::to_string(nextProc);
+  if ((rank % 2) == 0) {
+    cyclicCommLeft->prepareEstablishment(prevName, thisName);
+    cyclicCommLeft->acceptConnection(prevName, thisName, "", 0);
+    cyclicCommLeft->cleanupEstablishment(prevName, thisName);
+
+    cyclicCommRight->requestConnection(thisName, nextName, "", 0, 1);
+  } else {
+    cyclicCommRight->requestConnection(thisName, nextName, "", 0, 1);
+
+    cyclicCommLeft->prepareEstablishment(prevName, thisName);
+    cyclicCommLeft->acceptConnection(prevName, thisName, "", 0);
+    cyclicCommLeft->cleanupEstablishment(prevName, thisName);
+  }
+
+  _cyclicCommLeft = std::move(cyclicCommLeft);
+  _cyclicCommRight = std::move(cyclicCommRight);
+}
+
+void ParallelMatrixOperations::closeCircularCommunication()
+{
+  // Enforce consistency
+  PRECICE_ASSERT(static_cast<bool>(_cyclicCommLeft) == static_cast<bool>(_cyclicCommRight));
+  PRECICE_ASSERT(_needCyclicComm);
+
+  if ((utils::MasterSlave::getRank() % 2) == 0) {
+    _cyclicCommLeft->closeConnection();
+    _cyclicCommRight->closeConnection();
+  } else {
+    _cyclicCommRight->closeConnection();
+    _cyclicCommLeft->closeConnection();
+  }
+
+  _cyclicCommRight = nullptr;
+  _cyclicCommLeft  = nullptr;
+}
+
 
 } // namespace impl
 } // namespace acceleration

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -16,13 +16,10 @@ namespace impl {
 
 class ParallelMatrixOperations {
 public:
-  /// Destructor, empty.
-  virtual ~ParallelMatrixOperations(){};
+  ~ParallelMatrixOperations();
 
   /// Initializes the acceleration.
-  void initialize(com::PtrCommunication leftComm,
-                  com::PtrCommunication rightComm,
-                  bool                  needcyclicComm);
+  void initialize(bool                  needcyclicComm);
 
   template <typename Derived1, typename Derived2>
   void multiply(
@@ -50,7 +47,7 @@ public:
       // if p equals r (and p = global_n), we have to perform the
       // cyclic communication with block-wise matrix-matrix multiplication
       if (p == r) {
-        PRECICE_ASSERT(_needCycliclComm);
+        PRECICE_ASSERT(_needCyclicComm);
         PRECICE_ASSERT(_cyclicCommLeft.get() != NULL);
         PRECICE_ASSERT(_cyclicCommLeft->isConnected());
         PRECICE_ASSERT(_cyclicCommRight.get() != NULL);
@@ -129,7 +126,7 @@ private:
      * -----------------------------------------------------------------------
      */
 
-    PRECICE_ASSERT(_needCycliclComm);
+    PRECICE_ASSERT(_needCyclicComm);
     PRECICE_ASSERT(leftMatrix.cols() == q, leftMatrix.cols(), q);
     PRECICE_ASSERT(leftMatrix.rows() == rightMatrix.cols(), leftMatrix.rows(), rightMatrix.cols());
     PRECICE_ASSERT(result.rows() == p, result.rows(), p);
@@ -308,7 +305,24 @@ private:
   /// Communication between neighboring slaves, forward
   com::PtrCommunication _cyclicCommRight = nullptr;
 
-  bool _needCycliclComm = true;
+  bool _needCyclicComm = true;
+
+  /** Establishes the circular connection between slaves
+   *
+   * This creates and connects the slaves.
+   *
+   * @precondition _cyclicCommLeft and _cyclicCommRight must be nullptr
+   * @postcondition _cyclicCommLeft, _cyclicCommRight are connected
+   */
+  void establishCircularCommunication();
+
+  /** Closes the circular connection between slaves
+   *
+   * @precondition establishCircularCommunication() was called
+   * @postcondition _cyclicCommLeft, _cyclicCommRight are disconnected and set to nullptr
+   */
+  void closeCircularCommunication();
+
 };
 
 } // namespace impl

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -1,3 +1,4 @@
+#include <boost/test/unit_test_log.hpp>
 #ifndef PRECICE_NO_MPI
 
 #include <Eigen/Core>
@@ -22,18 +23,17 @@ BOOST_AUTO_TEST_SUITE(ParallelMatrixOperationsTests)
 void validate_result_equals_reference(
     Eigen::MatrixXd & result_local,
     Eigen::MatrixXd & reference_global,
-    std::vector<int> &offsets,
+    int               offset,
     bool              partitionedRowWise)
 {
-  int off = offsets[utils::MasterSlave::getRank()];
   for (int i = 0; i < result_local.rows(); i++) {
     for (int j = 0; j < result_local.cols(); j++) {
       if (partitionedRowWise) {
-        BOOST_TEST(testing::equals(result_local(i, j), reference_global(i + off, j)),
-                   "Failed: (" << i + off << ", " << j << ") result, reference:" << result_local(i, j) << ", " << reference_global(i + off, j));
+        BOOST_TEST(testing::equals(result_local(i, j), reference_global(i + offset, j)),
+                   "Failed: (" << i + offset << ", " << j << ") result, reference:" << result_local(i, j) << ", " << reference_global(i + offset, j));
       } else {
-        BOOST_TEST(testing::equals(result_local(i, j), reference_global(i, j + off)),
-                   "Failed: (" << i << ", " << j + off << ") result, reference:" << result_local(i, j) << ", " << reference_global(i, j + off));
+        BOOST_TEST(testing::equals(result_local(i, j), reference_global(i, j + offset)),
+                   "Failed: (" << i << ", " << j + offset << ") result, reference:" << result_local(i, j) << ", " << reference_global(i, j + offset));
       }
     }
   }
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations)
   Eigen::VectorXd vec2_local(n_local);
 
   // partition and distribute
-  int off = vertexOffsets[utils::MasterSlave::getRank()];
+  int off = vertexOffsets[context.rank];
   for (int i = 0; i < n_local; i++) {
     vec1_local(i) = vec1(i + off);
     vec2_local(i) = vec2(i + off);
@@ -155,19 +155,6 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations)
 BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp)
 {
   PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
-  com::PtrCommunication _cyclicCommLeft  = com::PtrCommunication(new com::MPIPortsCommunication("."));
-  com::PtrCommunication _cyclicCommRight = com::PtrCommunication(new com::MPIPortsCommunication("."));
-
-  // initialize cyclic communication between successive slaves
-  int prevProc = (context.rank - 1 < 0) ? context.size - 1 : context.rank - 1;
-  if ((context.rank % 2) == 0) {
-    _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "Test", context.rank);
-    _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(context.rank), "", "Test", 0, 1);
-  } else {
-    _cyclicCommRight->requestConnection("cyclicComm-" + std::to_string(context.rank), "", "Test", 0, 1);
-    _cyclicCommLeft->acceptConnection("cyclicComm-" + std::to_string(prevProc), "", "Test", context.rank);
-  }
-  _cyclicCommLeft->cleanupEstablishment("cyclicComm-" + std::to_string(prevProc), "");
 
   int              n_global = 10, m_global = 5;
   int              n_local;
@@ -275,7 +262,7 @@ BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp)
 
   // partition and distribute matrices
 
-  int off = vertexOffsets[utils::MasterSlave::getRank()];
+  int off = vertexOffsets[context.rank];
   for (int i = 0; i < n_global; i++)
     for (int j = 0; j < n_local; j++) {
       J_local(i, j)  = J_global(i, j + off);
@@ -301,49 +288,41 @@ BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp)
 
   // initialize ParallelMatrixOperations object
   ParallelMatrixOperations parMatrixOps{};
-  parMatrixOps.initialize(_cyclicCommLeft, _cyclicCommRight, true);
+  parMatrixOps.initialize(true);
 
   /*
    * test parallel multiplications
    */
+  BOOST_TEST_MESSAGE("Test 1");
   // 1.) multiply JW = J * W (n x m), parallel: (n_local x m)
   Eigen::MatrixXd resJW_local(n_local, m_global);
   parMatrixOps.multiply(J_local, W_local, resJW_local, vertexOffsets, n_global, n_global, m_global);
-  validate_result_equals_reference(resJW_local, JW_global, vertexOffsets, true);
+  validate_result_equals_reference(resJW_local, JW_global, vertexOffsets[context.rank], true);
 
+  BOOST_TEST_MESSAGE("Test 2");
   // 2.) multiply WZ = W * Z (n x n), parallel: (n_global x n_local)
   Eigen::MatrixXd resWZ_local(n_global, n_local);
   parMatrixOps.multiply(W_local, Z_local, resWZ_local, vertexOffsets, n_global, m_global, n_global);
-  validate_result_equals_reference(resWZ_local, WZ_global, vertexOffsets, false);
+  validate_result_equals_reference(resWZ_local, WZ_global, vertexOffsets[context.rank], false);
 
+  BOOST_TEST_MESSAGE("Test 3");
   // 3.) multiply Jres = J * res (n x 1), parallel: (n_local x 1)
   Eigen::MatrixXd resJres_local(n_local, 1);
   parMatrixOps.multiply(J_local, res_local, resJres_local, vertexOffsets, n_global, n_global, 1);
-  validate_result_equals_reference(resJres_local, Jres_global, vertexOffsets, true);
+  validate_result_equals_reference(resJres_local, Jres_global, vertexOffsets[context.rank], true);
 
+  BOOST_TEST_MESSAGE("Test 4");
   // 4.) multiply JW = J * W (n x m), parallel: (n_local x m) with block-wise multiplication
   Eigen::MatrixXd resJW_local2(n_local, m_global);
   parMatrixOps.multiply(J_local, W_local, resJW_local2, vertexOffsets, n_global, n_global, m_global, false);
-  validate_result_equals_reference(resJW_local2, JW_global, vertexOffsets, true);
+  validate_result_equals_reference(resJW_local2, JW_global, vertexOffsets[context.rank], true);
 
+  BOOST_TEST_MESSAGE("Test 5");
   // 5.) multiply Jres = J * res (n x 1), parallel: (n_local x 1) with block-wise multiplication
   Eigen::VectorXd resJres_local2(n_local); // use the function with parameter of type Eigen::VectorXd
   parMatrixOps.multiply(J_local, res_local_vec, resJres_local2, vertexOffsets, n_global, n_global, 1, false);
   Eigen::MatrixXd matrix_cast = resJres_local2;
-  validate_result_equals_reference(matrix_cast, Jres_global, vertexOffsets, true);
-
-  // close and shut down cyclic communication connections
-  if (_cyclicCommRight != nullptr || _cyclicCommLeft != nullptr) {
-    if ((context.rank % 2) == 0) {
-      _cyclicCommLeft->closeConnection();
-      _cyclicCommRight->closeConnection();
-    } else {
-      _cyclicCommRight->closeConnection();
-      _cyclicCommLeft->closeConnection();
-    }
-    _cyclicCommRight = nullptr;
-    _cyclicCommLeft  = nullptr;
-  }
+  validate_result_equals_reference(matrix_cast, Jres_global, vertexOffsets[context.rank], true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -94,7 +94,7 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
                                                      int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
-  PRECICE_ASSERT(requesterCommunicatorSize >= 0, "Requester communicator size has to be positive!");
+  PRECICE_ASSERT(requesterCommunicatorSize >= 0, "Requester communicator size has to be positive.");
   PRECICE_ASSERT(not isConnected());
 
   _isAcceptor = true;

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -59,7 +59,7 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
     int requesterRank = -1;
     MPI_Recv(&requesterRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
     // Who big is the communicator of the requester
-    int requesterCommunicatorSize = -1; 
+    int requesterCommunicatorSize = -1;
     MPI_Recv(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
     // Send the rank of the acceptor (this rank).
     MPI_Send(&acceptorRank, 1, MPI_INT, 0, 42, communicator);
@@ -152,7 +152,7 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
   // intra Communication.
   //
   // PRECICE_ASSERT(acceptorRank == 0, "The acceptor always has to be 0.");
-  
+
   _communicators.emplace(acceptorRank, communicator);
 }
 

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -90,7 +90,7 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
                                                      int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
-  PRECICE_ASSERT(requesterCommunicatorSize > 0, "Requester communicator size has to be > 0!");
+  PRECICE_ASSERT(requesterCommunicatorSize >= 0, "Requester communicator size has to be positive!");
   PRECICE_ASSERT(not isConnected());
 
   _isAcceptor = true;

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -196,6 +196,7 @@ void MPIPortsCommunication::closeConnection()
   for (auto &communicator : _communicators) {
     MPI_Comm_disconnect(&communicator.second);
   }
+  _communicators.clear();
 
   PRECICE_DEBUG("Disconnected");
 

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -80,6 +80,10 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
   } while (++peerCurrent < peerCount);
 
+  MPI_Close_port(const_cast<char *>(_portName.c_str()));
+  _portName.clear();
+  PRECICE_DEBUG("Closed Port");
+
   _isConnected = true;
 }
 
@@ -116,6 +120,11 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
 
     _communicators.emplace(requesterRank, communicator);
   }
+
+  MPI_Close_port(const_cast<char *>(_portName.c_str()));
+  _portName.clear();
+  PRECICE_DEBUG("Closed Port");
+
   _isConnected = true;
 }
 
@@ -199,11 +208,6 @@ void MPIPortsCommunication::closeConnection()
   _communicators.clear();
 
   PRECICE_DEBUG("Disconnected");
-
-  if (_isAcceptor) {
-    MPI_Close_port(const_cast<char *>(_portName.c_str()));
-    PRECICE_DEBUG("Port closed");
-  }
 
   _isConnected = false;
 }

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -58,7 +58,7 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
     // Which rank is requesting a connection?
     int requesterRank = -1;
     MPI_Recv(&requesterRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
-    // Who big is the communicator of the requester
+    // How big is the communicator of the requester
     int requesterCommunicatorSize = -1;
     MPI_Recv(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
     // Send the rank of the acceptor (this rank).

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -41,7 +41,7 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
   _isAcceptor = true;
   _portName.reserve(MPI_MAX_PORT_NAME);
-  MPI_Open_port(MPI_INFO_NULL, &_portName[0]);
+  MPI_Open_port(MPI_INFO_NULL, &_portName.at(0));
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
   conInfo.write(_portName);
@@ -75,7 +75,7 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
     PRECICE_CHECK(_communicators.count(requesterRank) == 0,
                   "Duplicate request to connect by same rank (" << requesterRank << ")!");
 
-    _communicators[requesterRank] = communicator;
+    _communicators.at(requesterRank) = communicator;
 
   } while (++peerCurrent < requesterCommunicatorSize);
 
@@ -95,7 +95,7 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
   _isAcceptor = true;
 
   _portName.reserve(MPI_MAX_PORT_NAME);
-  MPI_Open_port(MPI_INFO_NULL, &_portName[0]);
+  MPI_Open_port(MPI_INFO_NULL, &_portName.at(0));
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
   conInfo.write(_portName);
@@ -110,7 +110,7 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
     // Receive the real rank of requester
     MPI_Recv(&requesterRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
     PRECICE_ASSERT(requesterRank >= 0, "Invalid requester rank!");
-    _communicators[requesterRank] = communicator;
+    _communicators.at(requesterRank) = communicator;
   }
   _isConnected = true;
 }
@@ -145,7 +145,7 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
   // intra Communication.
   //
   // PRECICE_ASSERT(acceptorRank == 0, "The acceptor always has to be 0.");
-  _communicators[0] = communicator; // should be acceptorRank
+  _communicators.at(0) = communicator; // should be acceptorRank
 }
 
 void MPIPortsCommunication::requestConnectionAsClient(std::string const &  acceptorName,
@@ -168,7 +168,7 @@ void MPIPortsCommunication::requestConnectionAsClient(std::string const &  accep
     MPI_Comm communicator;
     MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
     PRECICE_DEBUG("Requested connection to " << _portName);
-    _communicators[acceptorRank] = communicator;
+    _communicators.at(acceptorRank) = communicator;
 
     // Rank 0 is always the peer, because we connected on COMM_SELF
     MPI_Send(&requesterRank, 1, MPI_INT, 0, 42, communicator);

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -41,26 +41,27 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
   _isAcceptor = true;
   _portName.reserve(MPI_MAX_PORT_NAME);
-  MPI_Open_port(MPI_INFO_NULL, &_portName.at(0));
+  MPI_Open_port(MPI_INFO_NULL, &_portName[0]);
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
   conInfo.write(_portName);
   PRECICE_DEBUG("Accept connection at " << _portName);
 
-  size_t peerCurrent               = 0; // Current peer to connect to
-  size_t peerCount                 = 0; // The total count of peers (initialized in the first iteration)
-  size_t requesterCommunicatorSize = 0;
-
+  int peerCount   = -1; // The total count of peers (initialized in the first iteration)
+  int peerCurrent = 0;  // Current peer to connect to
   do {
     // Connection
     MPI_Comm communicator;
     MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
     PRECICE_DEBUG("Accepted connection at " << _portName << " for peer " << peerCurrent);
 
+    // Which rank is requesting a connection?
     int requesterRank = -1;
-    // Exchange information to which rank I am connected and which communicator size on the other side
     MPI_Recv(&requesterRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
+    // Who big is the communicator of the requester
+    int requesterCommunicatorSize = -1; 
     MPI_Recv(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
+    // Send the rank of the acceptor (this rank).
     MPI_Send(&acceptorRank, 1, MPI_INT, 0, 42, communicator);
 
     // Initialize the count of peers to connect to
@@ -75,9 +76,9 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
     PRECICE_CHECK(_communicators.count(requesterRank) == 0,
                   "Duplicate request to connect by same rank (" << requesterRank << ")!");
 
-    _communicators.at(requesterRank) = communicator;
+    _communicators.emplace(requesterRank, communicator);
 
-  } while (++peerCurrent < requesterCommunicatorSize);
+  } while (++peerCurrent < peerCount);
 
   _isConnected = true;
 }
@@ -89,13 +90,13 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
                                                      int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
-  PRECICE_CHECK(requesterCommunicatorSize > 0, "Requester communicator size has to be > 0!");
+  PRECICE_ASSERT(requesterCommunicatorSize > 0, "Requester communicator size has to be > 0!");
   PRECICE_ASSERT(not isConnected());
 
   _isAcceptor = true;
 
   _portName.reserve(MPI_MAX_PORT_NAME);
-  MPI_Open_port(MPI_INFO_NULL, &_portName.at(0));
+  MPI_Open_port(MPI_INFO_NULL, &_portName[0]);
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
   conInfo.write(_portName);
@@ -106,11 +107,14 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
     MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
     PRECICE_DEBUG("Accepted connection at " << _portName);
 
+    // Receive the rank of requester
     int requesterRank = -1;
-    // Receive the real rank of requester
     MPI_Recv(&requesterRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
     PRECICE_ASSERT(requesterRank >= 0, "Invalid requester rank!");
-    _communicators.at(requesterRank) = communicator;
+
+    PRECICE_ASSERT(_communicators.count(requesterRank) == 0, "This connection has already been established.");
+
+    _communicators.emplace(requesterRank, communicator);
   }
   _isConnected = true;
 }
@@ -136,16 +140,20 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
 
   _isConnected = true;
 
-  int acceptorRank = -1;
+  // Send the rank of the requester (this rank)
   MPI_Send(&requesterRank, 1, MPI_INT, 0, 42, communicator);
+  // Send the size of the requester communicator size
   MPI_Send(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator);
+  // Receive the rank of the acceptor that we connected to.
+  int acceptorRank = -1;
   MPI_Recv(&acceptorRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
   // @todo The following assertion should always be the case, however the
   // acceleration package currently violates this in order to create a circular
   // intra Communication.
   //
   // PRECICE_ASSERT(acceptorRank == 0, "The acceptor always has to be 0.");
-  _communicators.at(0) = communicator; // should be acceptorRank
+  
+  _communicators.emplace(acceptorRank, communicator);
 }
 
 void MPIPortsCommunication::requestConnectionAsClient(std::string const &  acceptorName,
@@ -160,7 +168,7 @@ void MPIPortsCommunication::requestConnectionAsClient(std::string const &  accep
 
   _isAcceptor = false;
 
-  for (auto const &acceptorRank : acceptorRanks) {
+  for (int acceptorRank : acceptorRanks) {
     ConnectionInfoReader conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     _portName = conInfo.read();
     PRECICE_DEBUG("Request connection to " << _portName);
@@ -168,10 +176,12 @@ void MPIPortsCommunication::requestConnectionAsClient(std::string const &  accep
     MPI_Comm communicator;
     MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
     PRECICE_DEBUG("Requested connection to " << _portName);
-    _communicators.at(acceptorRank) = communicator;
 
     // Rank 0 is always the peer, because we connected on COMM_SELF
     MPI_Send(&requesterRank, 1, MPI_INT, 0, 42, communicator);
+
+    PRECICE_ASSERT(_communicators.count(acceptorRank) == 0, "This connection has already been established.");
+    _communicators.emplace(acceptorRank, communicator);
   }
   _isConnected = true;
 }

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -1,6 +1,6 @@
-#include <mpi.h>
 #ifndef PRECICE_NO_MPI
 
+#include <mpi.h>
 #include "MPISinglePortsCommunication.hpp"
 #include <boost/filesystem.hpp>
 #include "ConnectionInfoPublisher.hpp"

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -105,8 +105,6 @@ void MPISinglePortsCommunication::acceptConnectionAsServer(std::string const &ac
 
   const int rank = utils::Parallel::current()->rank();
 
-  ///@todo verify that getRank() makes sense in this case
-  //if (utils::MasterSlave::getRank() == 0) { // only master opens a port
   if (rank == 0) { // only master opens a port
     ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
 

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -28,7 +28,7 @@ size_t MPISinglePortsCommunication::getRemoteCommunicatorSize()
   PRECICE_TRACE();
   PRECICE_ASSERT(isConnected());
   int size = -1;
-  MPI_Comm_remote_size(_communicators[0], &size);
+  MPI_Comm_remote_size(_communicators.at(0), &size);
   return size;
 }
 
@@ -78,7 +78,7 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
     PRECICE_CHECK(_communicators.count(requesterRank) == 0,
                   "Duplicate request to connect by same rank (" << requesterRank << ")!");
 
-    _communicators[requesterRank] = communicator;
+    _communicators.at(requesterRank) = communicator;
 
   } while (++peerCurrent < requesterCommunicatorSize);
 
@@ -109,7 +109,7 @@ void MPISinglePortsCommunication::acceptConnectionAsServer(std::string const &ac
   MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0,
                   utils::Parallel::current()->comm, &communicator);
   PRECICE_DEBUG("Accepted connection at " << _portName);
-  _communicators[0] = communicator; // all comms are the same
+  _communicators.at(0) = communicator; // all comms are the same
 
   _isConnected = true;
 }
@@ -138,7 +138,7 @@ void MPISinglePortsCommunication::requestConnection(std::string const &acceptorN
   MPI_Send(&requesterRank, 1, MPI_INT, 0, 42, communicator);
   MPI_Send(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator);
   MPI_Recv(&acceptorRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
-  _communicators[0] = communicator; // should be acceptorRank
+  _communicators.at(0) = communicator; // should be acceptorRank
 }
 
 void MPISinglePortsCommunication::requestConnectionAsClient(std::string const &  acceptorName,
@@ -160,7 +160,7 @@ void MPISinglePortsCommunication::requestConnectionAsClient(std::string const & 
   MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0,
                    utils::Parallel::current()->comm, &communicator);
   PRECICE_DEBUG("Requested connection to " << _portName);
-  _communicators[0] = communicator; // all comms are the same
+  _communicators.at(0) = communicator; // all comms are the same
   _isConnected      = true;
 }
 
@@ -187,7 +187,7 @@ void MPISinglePortsCommunication::closeConnection()
 
 MPI_Comm &MPISinglePortsCommunication::communicator(int rank)
 {
-  return _communicators[0];
+  return _communicators.at(0);
 }
 
 int MPISinglePortsCommunication::rank(int rank)

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <mpi.h>
 #ifndef PRECICE_NO_MPI
 
+#include <mpi.h>
 #include <map>
 #include "MPICommunication.hpp"
 #include "logging/Logger.hpp"

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -77,10 +77,25 @@ private:
 
   std::string _addressDirectory;
 
-  /// A map of direct communication channels based on MPI_COMM_SELF on both sides
+  /** @brief A map of direct communication channels based on MPI_COMM_SELF on both sides
+   *
+   * These 1-1 connections are used until the has been a @ref _global communicator established.
+   *
+   * These direct connections connect MPI_COMM_SELF on both sides.
+   * The call to establish such a connection is thus not collective.
+   *
+   * These connections are required for the Master-Master and Master-Slaves connections.
+   */
   std::map<int, MPI_Comm> _direct;
 
-  /// The global intercommunicator that connects all ranks
+  /** @brief The global inter-communicator that connects all ranks
+   *
+   * Once established, this is the default communicator for all communication.
+   *
+   * The call to establish this communicator is collective over both communicators.
+   * Thus the call to @ref requestConnectionAsClient() and @ref acceptConnectionAsServer() is the
+   * only time window where this global communicator can be established.
+   */
   MPI_Comm _global = MPI_COMM_NULL;
 
   /// The communicator size known from acceptConnection and requestConnection

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <mpi.h>
 #ifndef PRECICE_NO_MPI
 
 #include <map>
@@ -76,8 +77,14 @@ private:
 
   std::string _addressDirectory;
 
-  /// Remote rank -> communicator map
-  std::map<int, MPI_Comm> _communicators;
+  /// A map of direct communication channels based on MPI_COMM_SELF on both sides
+  std::map<int, MPI_Comm> _direct;
+
+  /// The global intercommunicator that connects all ranks
+  MPI_Comm _global = MPI_COMM_NULL;
+
+  /// The communicator size known from acceptConnection and requestConnection
+  int _initialCommSize = -1;
 
   /// Name of the port used for connection.
   std::string _portName = std::string(MPI_MAX_PORT_NAME, '\0');

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -134,7 +134,7 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
                                                    int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
-  PRECICE_CHECK(requesterCommunicatorSize >= 0, "Requester communicator size has to be positve!");
+  PRECICE_ASSERT(requesterCommunicatorSize >= 0, "Requester communicator size has to be positve.");
   PRECICE_ASSERT(not isConnected());
 
   if (requesterCommunicatorSize == 0) {

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -137,6 +137,12 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
   PRECICE_CHECK(requesterCommunicatorSize >= 0, "Requester communicator size has to be positve!");
   PRECICE_ASSERT(not isConnected());
 
+  if (requesterCommunicatorSize == 0) {
+    PRECICE_DEBUG("Accepting no connections.");
+    _isConnected = true;
+    return;
+  }
+
   std::string address;
 
   try {

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -134,7 +134,7 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
                                                    int                requesterCommunicatorSize)
 {
   PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
-  PRECICE_CHECK(requesterCommunicatorSize > 0, "Requester communicator size has to be > 0!");
+  PRECICE_CHECK(requesterCommunicatorSize >= 0, "Requester communicator size has to be positve!");
   PRECICE_ASSERT(not isConnected());
 
   std::string address;

--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -9,8 +9,8 @@
 
 using namespace precice;
 
-/// Generic test function that is called from the tests for MPIPortsCommunication,
-/// MPIDirectCommunication and SocketCommunication
+/// Generic test function that is called from the tests for
+/// MPIPortsCommunication, MPIDirectCommunication and SocketCommunication
 
 namespace precice {
 namespace testing {
@@ -24,12 +24,12 @@ namespace mastermaster {
 ///
 
 template <typename T>
-void TestSendAndReceivePrimitiveTypes(int rank)
+void TestSendAndReceivePrimitiveTypes(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("process0", "process1", "", rank);
+  if (context.isNamed("A")) {
+    com.acceptConnection("process0", "process1", "", 0);
     {
       std::string msg("testOne");
       com.send(msg, 0);
@@ -55,7 +55,7 @@ void TestSendAndReceivePrimitiveTypes(int rank)
       BOOST_TEST(msg == false);
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       std::string msg;
@@ -90,12 +90,12 @@ void TestSendAndReceivePrimitiveTypes(int rank)
 }
 
 template <typename T>
-void TestSendAndReceiveVectors(int rank)
+void TestSendAndReceiveVectors(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("process0", "process1", "", rank);
+  if (context.isNamed("A")) {
+    com.acceptConnection("process0", "process1", "", 0);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
       com.receive(msg.data(), msg.size(), 0);
@@ -124,7 +124,7 @@ void TestSendAndReceiveVectors(int rank)
       com.send(msg, 0);
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(1);
@@ -155,62 +155,55 @@ void TestSendAndReceiveVectors(int rank)
 }
 
 template <typename T>
-void TestSendReceiveFourProcesses(int rank)
+void TestSendReceiveFourProcesses(TestContext const &context)
 {
   T   communication;
   int message = -1;
 
-  switch (rank) {
-  case 0: {
-    communication.acceptConnection("A", "B", "", rank);
+  if (context.isNamed("A")) {
+    if (context.isMaster()) {
+      communication.acceptConnection("A", "B", "", 0);
 
-    communication.send(10, 2);
-    communication.receive(message, 2);
-    BOOST_TEST(message == 20);
+      communication.send(10, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 20);
 
-    communication.send(20, 3);
-    communication.receive(message, 3);
-    BOOST_TEST(message == 40);
+      communication.send(20, 1);
+      communication.receive(message, 1);
+      BOOST_TEST(message == 40);
 
-    communication.closeConnection();
-    break;
-  }
-  case 1: {
-    // does not participate
-    break;
-  }
-  case 2: {
-    communication.requestConnection("A", "B", "", rank, 2);
+      communication.closeConnection();
+    }
+  } else {
+    if (context.isMaster()) {
+      communication.requestConnection("A", "B", "", 0, 2);
 
-    communication.receive(message, 0);
-    BOOST_TEST(message == 10);
-    message *= 2;
-    communication.send(message, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 10);
+      message *= 2;
+      communication.send(message, 0);
 
-    communication.closeConnection();
-    break;
-  }
-  case 3: {
-    communication.requestConnection("A", "B", "", rank, 2);
+      communication.closeConnection();
+    } else {
+      communication.requestConnection("A", "B", "", 1, 2);
 
-    communication.receive(message, 0);
-    BOOST_TEST(message == 20);
-    message *= 2;
-    communication.send(message, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 20);
+      message *= 2;
+      communication.send(message, 0);
 
-    communication.closeConnection();
-    break;
-  }
+      communication.closeConnection();
+    }
   }
 }
 
 template <typename T>
-void TestBroadcastPrimitiveTypes(int rank)
+void TestBroadcastPrimitiveTypes(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("process0", "process1", "", rank);
+  if (context.isNamed("A")) {
+    com.acceptConnection("process0", "process1", "", 0);
     {
       double msg = 0.0;
       com.broadcast(msg);
@@ -224,7 +217,7 @@ void TestBroadcastPrimitiveTypes(int rank)
       com.broadcast(msg);
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       double msg = 1.0;
@@ -246,12 +239,12 @@ void TestBroadcastPrimitiveTypes(int rank)
 }
 
 template <typename T>
-void TestBroadcastVectors(int rank)
+void TestBroadcastVectors(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("process0", "process1", "", rank);
+  if (context.isNamed("A")) {
+    com.acceptConnection("process0", "process1", "", 0);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(3.1415);
       com.broadcast(msg.data(), msg.size());
@@ -269,7 +262,7 @@ void TestBroadcastVectors(int rank)
       com.broadcast(msg.data(), msg.size());
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
@@ -296,11 +289,11 @@ void TestBroadcastVectors(int rank)
 }
 
 template <typename T>
-void TestReducePrimitiveTypes(int rank)
+void TestReducePrimitiveTypes(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
+  if (context.isNamed("A")) {
     com.acceptConnection("process0", "process1", "", 0);
     {
       int msg = 1;
@@ -325,7 +318,7 @@ void TestReducePrimitiveTypes(int rank)
     }
 
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       int msg = 3;
@@ -353,64 +346,72 @@ void TestReducePrimitiveTypes(int rank)
 }
 
 template <typename T>
-void TestReduceVectors(int rank)
+void TestReduceVectors(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("process0", "process1", "", rank);
+  if (context.isNamed("A")) {
+    com.acceptConnection("process0", "process1", "", 0);
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
       com.reduceSum(msg.data(), rcv.data(), msg.size());
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{1.1, 2.2, 3.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
       com.allreduceSum(msg.data(), rcv.data(), msg.size());
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{1.1, 2.2, 3.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
       com.reduceSum(msg.data(), rcv.data(), msg.size(), 0);
       std::vector<double> msg_expected{1, 2, 3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{0, 0, 0};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
       com.allreduceSum(msg.data(), rcv.data(), msg.size(), 0);
       std::vector<double> msg_expected{1, 2, 3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{1.1, 2.2, 3.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     com.closeConnection();
   }
 }
 
 template <typename T>
-void TestSendAndReceive(int rank)
+void TestSendAndReceive(TestContext const &context)
 {
-  TestSendAndReceivePrimitiveTypes<T>(rank);
-  TestSendAndReceiveVectors<T>(rank);
-  TestBroadcastPrimitiveTypes<T>(rank);
-  TestBroadcastVectors<T>(rank);
-  TestReducePrimitiveTypes<T>(rank);
-  TestReduceVectors<T>(rank);
+  TestSendAndReceivePrimitiveTypes<T>(context);
+  TestSendAndReceiveVectors<T>(context);
+  TestBroadcastPrimitiveTypes<T>(context);
+  TestBroadcastVectors<T>(context);
+  TestReducePrimitiveTypes<T>(context);
+  TestReduceVectors<T>(context);
 }
 
 } // namespace mastermaster
@@ -423,11 +424,11 @@ namespace masterslave {
 ///
 
 template <typename T>
-void TestSendAndReceivePrimitiveTypes(int rank)
+void TestSendAndReceivePrimitiveTypes(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
+  if (context.isMaster()) {
     com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       std::string msg("testOne");
@@ -454,7 +455,7 @@ void TestSendAndReceivePrimitiveTypes(int rank)
       BOOST_TEST(msg == false);
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       std::string msg;
@@ -489,11 +490,11 @@ void TestSendAndReceivePrimitiveTypes(int rank)
 }
 
 template <typename T>
-void TestSendAndReceiveVectors(int rank)
+void TestSendAndReceiveVectors(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
+  if (context.isMaster()) {
     com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
@@ -523,7 +524,7 @@ void TestSendAndReceiveVectors(int rank)
       com.send(msg, 1);
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(1);
@@ -554,12 +555,12 @@ void TestSendAndReceiveVectors(int rank)
 }
 
 template <typename T>
-void TestBroadcastPrimitiveTypes(int rank)
+void TestBroadcastPrimitiveTypes(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("Master", "Slave", "", rank, 1);
+  if (context.isMaster()) {
+    com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       double msg = 0.0;
       com.broadcast(msg);
@@ -573,7 +574,7 @@ void TestBroadcastPrimitiveTypes(int rank)
       com.broadcast(msg);
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       double msg = 1.0;
@@ -595,12 +596,12 @@ void TestBroadcastPrimitiveTypes(int rank)
 }
 
 template <typename T>
-void TestBroadcastVectors(int rank)
+void TestBroadcastVectors(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("Master", "Slave", "", rank, 1);
+  if (context.isMaster()) {
+    com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(3.1415);
       com.broadcast(msg.data(), msg.size());
@@ -618,7 +619,7 @@ void TestBroadcastVectors(int rank)
       com.broadcast(msg.data(), msg.size());
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
@@ -645,11 +646,11 @@ void TestBroadcastVectors(int rank)
 }
 
 template <typename T>
-void TestReducePrimitiveTypes(int rank)
+void TestReducePrimitiveTypes(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
+  if (context.isMaster()) {
     com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       int msg = 1;
@@ -674,7 +675,7 @@ void TestReducePrimitiveTypes(int rank)
     }
 
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       int msg = 3;
@@ -702,64 +703,72 @@ void TestReducePrimitiveTypes(int rank)
 }
 
 template <typename T>
-void TestReduceVectors(int rank)
+void TestReduceVectors(TestContext const &context)
 {
   T com;
 
-  if (rank == 0) {
-    com.acceptConnection("Master", "Slave", "", rank, 1);
+  if (context.isMaster()) {
+    com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
       com.reduceSum(msg.data(), rcv.data(), msg.size());
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{1.1, 2.2, 3.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
       com.allreduceSum(msg.data(), rcv.data(), msg.size());
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{1.1, 2.2, 3.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     com.closeConnection();
-  } else if (rank == 1) {
+  } else {
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
       com.reduceSum(msg.data(), rcv.data(), msg.size(), 0);
       std::vector<double> msg_expected{1, 2, 3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{0, 0, 0};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
       com.allreduceSum(msg.data(), rcv.data(), msg.size(), 0);
       std::vector<double> msg_expected{1, 2, 3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(), msg_expected.begin(), msg_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
+                                    msg_expected.begin(), msg_expected.end());
       std::vector<double> rcv_expected{1.1, 2.2, 3.3};
-      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(), rcv_expected.begin(), rcv_expected.end());
+      BOOST_CHECK_EQUAL_COLLECTIONS(rcv.begin(), rcv.end(),
+                                    rcv_expected.begin(), rcv_expected.end());
     }
     com.closeConnection();
   }
 }
 
 template <typename T>
-void TestSendAndReceive(int rank)
+void TestSendAndReceive(TestContext const &context)
 {
-  TestSendAndReceivePrimitiveTypes<T>(rank);
-  TestSendAndReceiveVectors<T>(rank);
-  TestBroadcastPrimitiveTypes<T>(rank);
-  TestBroadcastVectors<T>(rank);
-  TestReducePrimitiveTypes<T>(rank);
-  TestReduceVectors<T>(rank);
+  TestSendAndReceivePrimitiveTypes<T>(context);
+  TestSendAndReceiveVectors<T>(context);
+  TestBroadcastPrimitiveTypes<T>(context);
+  TestBroadcastVectors<T>(context);
+  TestReducePrimitiveTypes<T>(context);
+  TestReduceVectors<T>(context);
 }
 
 } // namespace masterslave
@@ -772,147 +781,144 @@ namespace serverclient {
 /// n Clients connect to the server
 /// The Server and the set of Clients are on different participants
 
-/// Tests connecting two processes using acceptConnectionAsServer and requestConnectionAsClient
+/// Tests connecting two processes using acceptConnectionAsServer and
+/// requestConnectionAsClient
 template <typename T>
-void TestSendReceiveTwoProcessesServerClient(int rank)
+void TestSendReceiveTwoProcessesServerClient(TestContext const &context)
 {
   T   communication;
   int message = 1;
+  BOOST_REQUIRE(context.hasSize(1));
 
-  switch (rank) {
-  case 0: {
-    communication.acceptConnectionAsServer("A", "B", "", rank, 1);
-    communication.send(message, 1);
-    communication.receive(message, 1);
+  if (context.isNamed("A")) {
+    communication.acceptConnectionAsServer("A", "B", "", 0, 1);
+    communication.send(message, 0);
+    communication.receive(message, 0);
     BOOST_TEST(message == 2);
     communication.closeConnection();
-    break;
-  }
-  case 1: {
-    communication.requestConnectionAsClient("A", "B", "", {0}, rank);
+  } else {
+    BOOST_REQUIRE(context.isNamed("B"));
+    communication.requestConnectionAsClient("A", "B", "", {0}, 0);
     communication.receive(message, 0);
     BOOST_TEST(message == 1);
     message = 2;
     communication.send(message, 0);
     communication.closeConnection();
-    break;
-  }
   }
 }
 
 template <typename T>
-void TestSendReceiveFourProcessesServerClient(int rank)
+void TestSendReceiveFourProcessesServerClient(TestContext const &context)
 {
   T   communication;
   int message = -1;
+  BOOST_REQUIRE(context.hasSize(2));
 
-  switch (rank) {
-  case 0: {
-    communication.acceptConnectionAsServer("A", "B", "", rank, 2);
+  if (context.isNamed("A")) {
+    if (context.isMaster()) {
+      communication.acceptConnectionAsServer("A", "B", "", context.rank, 2);
 
-    communication.send(10, 2);
-    communication.receive(message, 2);
-    BOOST_TEST(message == 20);
+      communication.send(10, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 20);
 
-    communication.send(20, 3);
-    communication.receive(message, 3);
-    BOOST_TEST(message == 40);
+      communication.send(20, 1);
+      communication.receive(message, 1);
+      BOOST_TEST(message == 40);
 
-    communication.closeConnection();
-    break;
-  }
-  case 1: {
-    // does not accept a connection
-    break;
-  }
-  case 2: {
-    communication.requestConnectionAsClient("A", "B", "", {0}, rank);
+      communication.closeConnection();
+    } else {
+      communication.acceptConnectionAsServer("A", "B", "", context.rank, 0);
+      communication.closeConnection();
+    }
+  } else {
+    BOOST_REQUIRE(context.isNamed("B"));
+    if (context.isMaster()) {
+      communication.requestConnectionAsClient("A", "B", "", {0}, context.rank);
 
-    communication.receive(message, 0);
-    BOOST_TEST(message == 10);
-    message *= 2;
-    communication.send(message, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 10);
+      message *= 2;
+      communication.send(message, 0);
 
-    communication.closeConnection();
-    break;
-  }
-  case 3: {
-    communication.requestConnectionAsClient("A", "B", "", {0}, rank);
+      communication.closeConnection();
+    } else {
+      communication.requestConnectionAsClient("A", "B", "", {0}, context.rank);
 
-    communication.receive(message, 0);
-    BOOST_TEST(message == 20);
-    message *= 2;
-    communication.send(message, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 20);
+      message *= 2;
+      communication.send(message, 0);
 
-    communication.closeConnection();
-    break;
-  }
+      communication.closeConnection();
+    }
   }
 }
 
 template <typename T>
-void TestSendReceiveFourProcessesServerClientV2(int rank)
+void TestSendReceiveFourProcessesServerClientV2(TestContext const &context)
 {
   T   communication;
   int message = -1;
 
-  switch (rank) {
-  case 0: {
-    communication.acceptConnectionAsServer("A", "B", "", rank, 2);
+  BOOST_REQUIRE(context.hasSize(2));
 
-    communication.send(10, 2);
-    communication.receive(message, 2);
-    BOOST_TEST(message == 20);
+  if (context.isNamed("A")) {
+    if (context.isMaster()) {
 
-    communication.send(100, 3);
-    communication.receive(message, 3);
-    BOOST_TEST(message == 200);
+      communication.acceptConnectionAsServer("A", "B", "", 0, 2);
 
-    communication.closeConnection();
-    break;
-  }
-  case 1: {
-    communication.acceptConnectionAsServer("A", "B", "", rank, 2);
+      communication.send(10, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 20);
 
-    communication.send(20, 2);
-    communication.receive(message, 2);
-    BOOST_TEST(message == 40);
+      communication.send(100, 1);
+      communication.receive(message, 1);
+      BOOST_TEST(message == 200);
 
-    communication.send(200, 3);
-    communication.receive(message, 3);
-    BOOST_TEST(message == 400);
+      communication.closeConnection();
+    } else {
+      communication.acceptConnectionAsServer("A", "B", "", 1, 2);
 
-    communication.closeConnection();
-    break;
-  }
-  case 2: {
-    communication.requestConnectionAsClient("A", "B", "", {0, 1}, rank);
+      communication.send(20, 0);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 40);
 
-    communication.receive(message, 0);
-    BOOST_TEST(message == 10);
-    communication.send(20, 0);
+      communication.send(200, 1);
+      communication.receive(message, 1);
+      BOOST_TEST(message == 400);
 
-    communication.receive(message, 1);
-    BOOST_TEST(message == 20);
-    communication.send(40, 1);
+      communication.closeConnection();
+    }
 
-    communication.closeConnection();
-    break;
-  }
-  case 3: {
-    communication.requestConnectionAsClient("A", "B", "", {0, 1}, rank);
+  } else {
+    BOOST_REQUIRE(context.isNamed("B"));
 
-    communication.receive(message, 0);
-    BOOST_TEST(message == 100);
-    communication.send(200, 0);
+    if (context.isMaster()) {
+      communication.requestConnectionAsClient("A", "B", "", {0, 1}, 0);
 
-    communication.receive(message, 1);
-    BOOST_TEST(message == 200);
-    communication.send(400, 1);
+      communication.receive(message, 0);
+      BOOST_TEST(message == 10);
+      communication.send(20, 0);
 
-    communication.closeConnection();
-    break;
-  }
+      communication.receive(message, 1);
+      BOOST_TEST(message == 20);
+      communication.send(40, 1);
+
+      communication.closeConnection();
+    } else {
+      communication.requestConnectionAsClient("A", "B", "", {0, 1}, 1);
+
+      communication.receive(message, 0);
+      BOOST_TEST(message == 100);
+      communication.send(200, 0);
+
+      communication.receive(message, 1);
+      BOOST_TEST(message == 200);
+      communication.send(400, 1);
+
+      communication.closeConnection();
+    }
   }
 }
 

--- a/src/com/tests/MPIDirectCommunicationTest.cpp
+++ b/src/com/tests/MPIDirectCommunicationTest.cpp
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_SUITE(MPIDirect)
 BOOST_AUTO_TEST_CASE(SendAndReceive)
 {
   PRECICE_TEST(2_ranks, Require::Events);
-  testing::com::masterslave::TestSendAndReceive<MPIDirectCommunication>(context.rank);
+  testing::com::masterslave::TestSendAndReceive<MPIDirectCommunication>(context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // MPIDirectCommunication

--- a/src/com/tests/MPIPortsCommunicationTest.cpp
+++ b/src/com/tests/MPIPortsCommunicationTest.cpp
@@ -15,46 +15,44 @@ BOOST_AUTO_TEST_SUITE(MPIPorts,
 
 BOOST_AUTO_TEST_CASE(SendAndReceiveMM)
 {
-  PRECICE_TEST(2_ranks, Require::Events);
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::mastermaster;
-  TestSendAndReceive<MPIPortsCommunication>(context.rank);
+  TestSendAndReceive<MPIPortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
 {
   PRECICE_TEST(2_ranks, Require::Events);
   using namespace precice::testing::com::masterslave;
-  TestSendAndReceive<MPIPortsCommunication>(context.rank);
+  TestSendAndReceive<MPIPortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesMM)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::mastermaster;
-  TestSendReceiveFourProcesses<MPIPortsCommunication>(context.rank);
+  TestSendReceiveFourProcesses<MPIPortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
-
 {
-  PRECICE_TEST(2_ranks, Require::Events);
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveTwoProcessesServerClient<MPIPortsCommunication>(context.rank);
+  TestSendReceiveTwoProcessesServerClient<MPIPortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient)
-
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveFourProcessesServerClient<MPIPortsCommunication>(context.rank);
+  TestSendReceiveFourProcessesServerClient<MPIPortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveFourProcessesServerClientV2<MPIPortsCommunication>(context.rank);
+  TestSendReceiveFourProcessesServerClientV2<MPIPortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // MPIPortsCommunication

--- a/src/com/tests/MPISinglePortsCommunicationTest.cpp
+++ b/src/com/tests/MPISinglePortsCommunicationTest.cpp
@@ -27,14 +27,12 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
   TestSendAndReceive<MPISinglePortsCommunication>(context);
 }
 
-#if 0
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesMM)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::mastermaster;
   TestSendReceiveFourProcesses<MPISinglePortsCommunication>(context);
 }
-#endif
 
 BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
 {

--- a/src/com/tests/MPISinglePortsCommunicationTest.cpp
+++ b/src/com/tests/MPISinglePortsCommunicationTest.cpp
@@ -15,44 +15,46 @@ BOOST_AUTO_TEST_SUITE(MPISinglePorts,
 
 BOOST_AUTO_TEST_CASE(SendAndReceiveMM)
 {
-  PRECICE_TEST(2_ranks, Require::Events);
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::mastermaster;
-  TestSendAndReceive<MPISinglePortsCommunication>(context.rank);
+  TestSendAndReceive<MPISinglePortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
 {
   PRECICE_TEST(2_ranks, Require::Events);
   using namespace precice::testing::com::masterslave;
-  TestSendAndReceive<MPISinglePortsCommunication>(context.rank);
+  TestSendAndReceive<MPISinglePortsCommunication>(context);
 }
 
+#if 0
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesMM)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::mastermaster;
-  TestSendReceiveFourProcesses<MPISinglePortsCommunication>(context.rank);
+  TestSendReceiveFourProcesses<MPISinglePortsCommunication>(context);
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
 {
-  PRECICE_TEST(2_ranks, Require::Events);
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveTwoProcessesServerClient<MPISinglePortsCommunication>(context.rank);
+  TestSendReceiveTwoProcessesServerClient<MPISinglePortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveFourProcessesServerClient<MPISinglePortsCommunication>(context.rank);
+  TestSendReceiveFourProcessesServerClient<MPISinglePortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveFourProcessesServerClientV2<MPISinglePortsCommunication>(context.rank);
+  TestSendReceiveFourProcessesServerClientV2<MPISinglePortsCommunication>(context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // MPISinglePortsCommunication

--- a/src/com/tests/MPISinglePortsCommunicationTest.cpp
+++ b/src/com/tests/MPISinglePortsCommunicationTest.cpp
@@ -1,0 +1,62 @@
+#ifndef PRECICE_NO_MPI
+
+#include "GenericTestFunctions.hpp"
+#include "com/MPISinglePortsCommunication.hpp"
+#include "testing/Testing.hpp"
+#include "utils/Parallel.hpp"
+
+using namespace precice;
+using namespace precice::com;
+
+BOOST_AUTO_TEST_SUITE(CommunicationTests)
+
+BOOST_AUTO_TEST_SUITE(MPISinglePorts,
+                      *boost::unit_test::label("MPI_Ports"))
+
+BOOST_AUTO_TEST_CASE(SendAndReceiveMM)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::mastermaster;
+  TestSendAndReceive<MPISinglePortsCommunication>(context.rank);
+}
+
+BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::masterslave;
+  TestSendAndReceive<MPISinglePortsCommunication>(context.rank);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesMM)
+{
+  PRECICE_TEST(4_ranks, Require::Events);
+  using namespace precice::testing::com::mastermaster;
+  TestSendReceiveFourProcesses<MPISinglePortsCommunication>(context.rank);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::serverclient;
+  TestSendReceiveTwoProcessesServerClient<MPISinglePortsCommunication>(context.rank);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient)
+{
+  PRECICE_TEST(4_ranks, Require::Events);
+  using namespace precice::testing::com::serverclient;
+  TestSendReceiveFourProcessesServerClient<MPISinglePortsCommunication>(context.rank);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2)
+{
+  PRECICE_TEST(4_ranks, Require::Events);
+  using namespace precice::testing::com::serverclient;
+  TestSendReceiveFourProcessesServerClientV2<MPISinglePortsCommunication>(context.rank);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MPISinglePortsCommunication
+
+BOOST_AUTO_TEST_SUITE_END() // Communication
+
+#endif // not PRECICE_NO_MPI

--- a/src/com/tests/SocketCommunicationTest.cpp
+++ b/src/com/tests/SocketCommunicationTest.cpp
@@ -13,44 +13,44 @@ BOOST_AUTO_TEST_SUITE(Socket)
 
 BOOST_AUTO_TEST_CASE(SendAndReceiveMM)
 {
-  PRECICE_TEST(2_ranks, Require::Events);
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::mastermaster;
-  TestSendAndReceive<SocketCommunication>(context.rank);
+  TestSendAndReceive<SocketCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
 {
   PRECICE_TEST(2_ranks, Require::Events);
   using namespace precice::testing::com::masterslave;
-  TestSendAndReceive<SocketCommunication>(context.rank);
+  TestSendAndReceive<SocketCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcesses)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::mastermaster;
-  TestSendReceiveFourProcesses<SocketCommunication>(context.rank);
+  TestSendReceiveFourProcesses<SocketCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
 {
-  PRECICE_TEST(2_ranks, Require::Events);
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveTwoProcessesServerClient<SocketCommunication>(context.rank);
+  TestSendReceiveTwoProcessesServerClient<SocketCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveFourProcessesServerClient<SocketCommunication>(context.rank);
+  TestSendReceiveFourProcessesServerClient<SocketCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2)
 {
-  PRECICE_TEST(4_ranks, Require::Events);
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
-  TestSendReceiveFourProcessesServerClientV2<SocketCommunication>(context.rank);
+  TestSendReceiveFourProcessesServerClientV2<SocketCommunication>(context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Socket

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -15,6 +15,7 @@ target_sources(testprecice
     src/com/tests/GenericTestFunctions.hpp
     src/com/tests/MPIDirectCommunicationTest.cpp
     src/com/tests/MPIPortsCommunicationTest.cpp
+    src/com/tests/MPISinglePortsCommunicationTest.cpp
     src/com/tests/SocketCommunicationTest.cpp
     src/cplscheme/tests/AbsoluteConvergenceMeasureTest.cpp
     src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp


### PR DESCRIPTION
Adding the MPISinglePorts tests revealed some problems, which required to finally migrate the tests, which revealed some issues in the acceleration and com packages.

This PR will:
* Add tests for MPISinglePorts similar to #624 
* Refactor MPISinglePorts to distinguish between direct and global communicators.
* Fix not properly closed ports in MPIPorts and MPISinglePorts
* Migrate the tests to the context-bases system #702 
* Add a bypass to SocketCommunication to prevent work
* Detect the MPI implementation in CMake
* Disable mpiports tests when OpenMPI was detected #746 
* Refactors the ownership of cyclic comms from MVQN into ParallelMatrixOperations