### PR TITLE
Remove Participant ID

### DIFF
--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -12,23 +12,13 @@
 namespace precice {
 namespace impl {
 
-int Participant::_participantsSize = 0;
-
-void Participant::resetParticipantCount()
-{
-  _participantsSize = 0;
-}
-
 Participant::Participant(
     std::string                 name,
     mesh::PtrMeshConfiguration &meshConfig)
     : _name(std::move(name)),
-      _id(_participantsSize),
       _meshContexts(meshConfig->meshes().size(), nullptr),
       _dataContexts(meshConfig->getDataConfiguration()->data().size() * meshConfig->meshes().size(), nullptr)
-{
-  _participantsSize++;
-}
+{}
 
 Participant::~Participant()
 {
@@ -40,17 +30,11 @@ Participant::~Participant()
   _writeDataContexts.deleteElements();
   _readMappingContexts.deleteElements();
   _writeMappingContexts.deleteElements();
-  _participantsSize--;
 }
 
 const std::string &Participant::getName() const
 {
   return _name;
-}
-
-int Participant::getID() const
-{
-  return _id;
 }
 
 void Participant::addWatchPoint(

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -42,8 +42,6 @@ public:
     MAPPING_DIRECT
   };
 
-  static void resetParticipantCount();
-
   /**
    * @brief Constructor.
    *
@@ -57,8 +55,6 @@ public:
 
   /// Returns the name of the participant.
   const std::string &getName() const;
-
-  int getID() const;
 
   void addWriteData(
       const mesh::PtrData &data,
@@ -143,11 +139,7 @@ public:
 private:
   logging::Logger _log{"impl::Participant"};
 
-  static int _participantsSize;
-
   std::string _name;
-
-  int _id;
 
   std::vector<PtrWatchPoint> _watchPoints;
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -134,7 +134,6 @@ void SolverInterfaceImpl::configure(
   utils::ScopedEventPrefix sep("configure/");
 
   mesh::Data::resetDataCount();
-  Participant::resetParticipantCount();
   _meshLock.clear();
 
   _dimensions = config.getDimensions();

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -20,7 +20,6 @@ struct SerialTestFixture : testing::WhiteboxAccessor {
   void reset()
   {
     mesh::Data::resetDataCount();
-    impl::Participant::resetParticipantCount();
   }
 
   SerialTestFixture()
@@ -48,7 +47,6 @@ BOOST_AUTO_TEST_CASE(TestConfigurationPeano)
   impl::PtrParticipant peano = impl(interfacePeano)._participants[0];
   BOOST_TEST(peano);
   BOOST_TEST(peano->getName() == "Peano");
-  BOOST_TEST(peano->getID() == 0);
 
   std::vector<impl::MeshContext *> meshContexts = peano->_meshContexts;
   BOOST_TEST(meshContexts.size() == 2);
@@ -71,7 +69,6 @@ BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
   impl::PtrParticipant comsol = impl(interfaceComsol)._participants[1];
   BOOST_TEST(comsol);
   BOOST_TEST(comsol->getName() == "Comsol");
-  BOOST_TEST(comsol->getID() == 1);
 
   std::vector<impl::MeshContext *> meshContexts = comsol->_meshContexts;
   BOOST_TEST(meshContexts.size() == 2);

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -37,7 +37,6 @@ TestContext::~TestContext() noexcept
 
   // Reset static ids and counters
   mesh::Data::resetDataCount();
-  impl::Participant::resetParticipantCount();
 
   // Reset communicators
   Par::resetCommState();


### PR DESCRIPTION
This PR removes the participant ID which in turn removes the static participant counter.

Related to #385