### PR TITLE
Ability for Mesh Data to shrink

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -198,10 +198,18 @@ bool Mesh::isValidEdgeID(int edgeID) const
 void Mesh::allocateDataValues()
 {
   PRECICE_TRACE(_vertices.size());
+  const auto expectedCount = _vertices.size();
+  using SizeType = decltype(expectedCount);
   for (PtrData data : _data) {
-    int total          = _vertices.size() * data->getDimensions();
-    int leftToAllocate = total - data->values().size();
-    if (leftToAllocate > 0) {
+    const SizeType expectedSize = expectedCount * data->getDimensions();
+    const auto actualSize = static_cast<SizeType>(data->values().size());
+    // Shrink Buffer
+    if (expectedSize < actualSize) {
+        data->values().resize(expectedSize);
+    }
+    // Enlarge Buffer
+    if (expectedSize > actualSize) {
+      const auto leftToAllocate = expectedSize - actualSize;
       utils::append(data->values(), (Eigen::VectorXd) Eigen::VectorXd::Zero(leftToAllocate));
     }
     PRECICE_DEBUG("Data " << data->getName() << " now has " << data->values().size() << " values");

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -494,5 +494,28 @@ BOOST_AUTO_TEST_CASE(ComputeStateOfNotFullyConnectedMesh)
   }
 }
 
+BOOST_AUTO_TEST_CASE(ResizeDataGrow)
+{
+  PRECICE_TEST(1_rank);
+  precice::mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());
+  const auto& values = mesh.createData("Data", 1)->values();
+
+  // Create mesh
+  mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
+  mesh.createVertex(Vector3d(1.0, 0.0, 1.0));
+
+  BOOST_TEST(mesh.vertices().size() == 2);
+  mesh.allocateDataValues();
+  BOOST_TEST(values.size() == 2);
+
+  mesh.createVertex(Vector3d(1.0, 1.0, 1.0));
+  mesh.createVertex(Vector3d(2.0, 0.0, 2.0));
+  mesh.createVertex(Vector3d(2.0, 0.0, 2.1));
+
+  BOOST_TEST(mesh.vertices().size() == 5);
+  mesh.allocateDataValues();
+  BOOST_TEST(values.size() == 5);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Mesh
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -517,5 +517,30 @@ BOOST_AUTO_TEST_CASE(ResizeDataGrow)
   BOOST_TEST(values.size() == 5);
 }
 
+BOOST_AUTO_TEST_CASE(ResizeDataShrink)
+{
+  PRECICE_TEST(1_rank);
+  precice::mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());
+  const auto& values = mesh.createData("Data", 1)->values();
+
+  // Create mesh
+  mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
+  mesh.createVertex(Vector3d(1.0, 0.0, 1.0));
+  mesh.createVertex(Vector3d(1.0, 1.0, 1.0));
+  mesh.createVertex(Vector3d(2.0, 2.0, 2.0));
+
+  BOOST_TEST(mesh.vertices().size() == 4);
+  mesh.allocateDataValues();
+  BOOST_TEST(values.size() == 4);
+
+  mesh.clear();
+  mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
+  mesh.createVertex(Vector3d(1.0, 0.0, 1.0));
+
+  BOOST_TEST(mesh.vertices().size() == 2);
+  mesh.allocateDataValues();
+  BOOST_TEST(values.size() == 2);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Mesh
 BOOST_AUTO_TEST_SUITE_END() // Mesh


### PR DESCRIPTION
This PR adds the ability (and tests) for Mesh Data to shrink, which is relevant for adaptive meshes.

Prior to these changes, the following failed:
```cpp
precice::mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());

mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
mesh.createVertex(Vector3d(1.0, 0.0, 1.0));
mesh.allocateDataValues();

mesh.reset();
mesh.createVertex(Vector3d(1.0, 1.0, 1.0));
mesh.allocateDataValues(); // <--- Hit Assertion
```