### PR TITLE
Add CI Format Checker

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,0 +1,17 @@
+name: code-style
+on:
+  pull_request:
+    paths:
+      - '**.[ch]pp'
+      - '**.[ch]'
+      - '**.xml'
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    container: precice/ci-formatting:latest
+    steps:
+      - name: Checkout preCICE
+        uses: actions/checkout@v2
+      - name: Check formatting
+        run: tools/formatting/check-format


### PR DESCRIPTION
This PR adds a code format checker for pull requests. It runs only when C/C++ files were changed.
It currently checks all files, which takes about 1 minute in total.

Partially replaces #391 
Closes #171 