### PR TITLE
Re-enable reset of written data at the end of advance

### DIFF
--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -1,5 +1,6 @@
 #include "Data.hpp"
 #include "Mesh.hpp"
+#include <algorithm>
 
 namespace precice {
 namespace mesh {
@@ -50,6 +51,13 @@ const std::string &Data::getName() const
 int Data::getID() const
 {
   return _id;
+}
+
+void Data::toZero()
+{
+  auto begin = _values.data();
+  auto end   = begin + _values.size();
+  std::fill(begin, end, 0.0);
 }
 
 int Data::getDimensions() const

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -80,6 +80,9 @@ public:
    * @brief Returns the type constant of the data set.
    */
   //  DataType getType () const;
+  
+  /// Sets all values to zero
+  void toZero();
 
   /// Returns the dimension (i.e., number of components) of one data value.
   int getDimensions() const;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -381,6 +381,8 @@ double SolverInterfaceImpl::advance(
   PRECICE_DEBUG("Handle exports");
   handleExports();
 
+  resetWrittenData();
+
   _meshLock.lockAll();
   solverEvent.start(precice::syncMode);
   return _couplingScheme->getNextTimestepMaxLength();

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1390,9 +1390,9 @@ void SolverInterfaceImpl::resetWrittenData()
 {
   PRECICE_TRACE();
   for (DataContext &context : _accessor->writeDataContexts()) {
-    context.fromData->values() = Eigen::VectorXd::Zero(context.fromData->values().size());
+    context.fromData->toZero();
     if (context.toData != context.fromData) {
-      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
+      context.toData->toZero();
     }
   }
 }

--- a/src/precice/tests/BB-sockets-explicit-twoway.xml
+++ b/src/precice/tests/BB-sockets-explicit-twoway.xml
@@ -43,7 +43,7 @@
 
       <coupling-scheme:serial-explicit>
          <participants first="Fluid" second="Structure" />
-         <max-time-windows value="2" />
+         <max-time-windows value="1" />
          <time-window-size value="1.0" />
          <exchange data="Forces"     mesh="StructureMesh" from="Fluid" to="Structure" />
          <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -598,8 +598,6 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationTwoWay)
     }
   }
 
-  precice.advance(1.0);
-
   if (context.isNamed("Structure")) {
     for (size_t i = 0; i < vertexIDs.size(); i++) {
       precice.readVectorData(forcesID, vertexIDs[i], data[i + i1].data());


### PR DESCRIPTION
For the manifold mapping, some years ago, we had to disable the reset of written data at the end of `advance()`. Since we recently removed manifold mapping this PR re-enables this safeguard.

**Example:**

Before this PR ...

```c++
writeBlockVectorData(forces);
advance();
advance();
```

uses `forces` twice. Now, the preCICE data structures are reset to zero at the end of the first `advance()`. Thus, the second `advance()` uses zero and not `forces`.

**Argument in favor of this safeguard:** it has already revealed a bug in an integration test, which I fixed on-the-fly.
