### PR TITLE
Forbid Watchpoint on Receiving Meshes

### DIFF
--- a/docs/changelog/763.md
+++ b/docs/changelog/763.md
@@ -1,0 +1,1 @@
+* Restrict the configuration of WatchPoints to provided meshes.

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -499,19 +499,26 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
   // Create watch points
   for (const WatchPointConfig &config : _watchPointConfigs) {
-    mesh::PtrMesh mesh;
+    const impl::MeshContext *meshContext = nullptr;
     for (const impl::MeshContext *context : participant->usedMeshContexts()) {
       if (context->mesh->getName() == config.nameMesh) {
-        mesh = context->mesh;
+        meshContext = context;
       }
     }
-    PRECICE_CHECK(mesh,
+    PRECICE_CHECK(meshContext && meshContext->mesh,
                   "Participant \"" << participant->getName()
                                    << "\" defines watchpoint \"" << config.name
                                    << "\" for mesh \"" << config.nameMesh
-                                   << "\" which is not used by him!");
+                                   << "\" which is not used by the participant. "
+                                   << "Please add a use-mesh node with name=\"" << config.nameMesh << "\".");
+    PRECICE_CHECK(meshContext->provideMesh,
+                  "Participant \"" << participant->getName()
+                                   << "\" defines watchpoint \"" << config.name
+                                   << "\" for the received mesh \"" << config.nameMesh << ", which is not allowed. "
+                                   << "Please move the watchpoint definition to the participant providing mesh \"" << config.nameMesh << "\".");
+
     std::string         filename = "precice-" + participant->getName() + "-watchpoint-" + config.name + ".log";
-    impl::PtrWatchPoint watchPoint(new impl::WatchPoint(config.coordinates, mesh, filename));
+    impl::PtrWatchPoint watchPoint(new impl::WatchPoint(config.coordinates, meshContext->mesh, filename));
     participant->addWatchPoint(watchPoint);
   }
   _watchPointConfigs.clear();


### PR DESCRIPTION
This PR forbids to create watchpoints for non-provided meshes.

Defining a mesh for a receiving mesh only works in some conditions and can lead to highly confusing error messages as [reported in discourse](https://precice.discourse.group/t/error-in-writing-watch-point-for-received-mesh/242).

This PR could conflict with #733 