### PR TITLE
Configuration: Add warning, if data name is provided multiple times in acceleration

### DIFF
--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -141,11 +141,10 @@ void AccelerationConfiguration::xmlTagCallback(
   } else if (callingTag.getName() == TAG_DATA) {
     std::string dataName = callingTag.getStringAttributeValue(ATTR_NAME);
     auto success = _uniqueDataNames.insert(dataName);
-    if (!success.second) {
+    if (not success.second) {
       PRECICE_ERROR("You have provided a subtag "
-                    << "<data name=\"" << dataName << "\" ... /> more than once on your <acceleration:.../>. "
-                    << "This is probably unintended and might lead to unexpected behavior. "
-                    << "Note that this warning will throw an error in future preCICE versions.");
+                    << "<data name=\"" << dataName << "\" ... /> more than once in your <acceleration:.../>. "
+                    << "Please remove the duplicated entry.");
     }
     _meshName            = callingTag.getStringAttributeValue(ATTR_MESH);
     double scaling       = 1.0;

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -142,10 +142,10 @@ void AccelerationConfiguration::xmlTagCallback(
     std::string dataName = callingTag.getStringAttributeValue(ATTR_NAME);
     auto success = _uniqueDataNames.insert(dataName);
     if (!success.second) {
-      PRECICE_WARN("You have provided a subtag "
-                   << "<data name=\"" << dataName << "\" ... /> more than once on your <acceleration:.../>. "
-                   << "This is probably unintended and might lead to unexpected behavior. "
-                   << "Note that this warning will throw an error in future preCICE versions.");
+      PRECICE_ERROR("You have provided a subtag "
+                    << "<data name=\"" << dataName << "\" ... /> more than once on your <acceleration:.../>. "
+                    << "This is probably unintended and might lead to unexpected behavior. "
+                    << "Note that this warning will throw an error in future preCICE versions.");
     }
     _meshName            = callingTag.getStringAttributeValue(ATTR_MESH);
     double scaling       = 1.0;

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -140,6 +140,13 @@ void AccelerationConfiguration::xmlTagCallback(
     _config.relaxationFactor = callingTag.getDoubleAttributeValue(ATTR_VALUE);
   } else if (callingTag.getName() == TAG_DATA) {
     std::string dataName = callingTag.getStringAttributeValue(ATTR_NAME);
+    auto success = _uniqueDataNames.insert(dataName);
+    if (!success.second) {
+      PRECICE_WARN("You have provided a subtag "
+                   << "<data name=\"" << dataName << "\" ... /> more than once on your <acceleration:.../>. "
+                   << "This is probably unintended and might lead to unexpected behavior. "
+                   << "Note that this warning will throw an error in future preCICE versions.");
+    }
     _meshName            = callingTag.getStringAttributeValue(ATTR_MESH);
     double scaling       = 1.0;
     if (_config.type == VALUE_IQNILS || _config.type == VALUE_MVQN || _config.type == VALUE_BROYDEN) {

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -95,7 +95,7 @@ private:
   std::set<std::string> _uniqueDataNames;  // @todo remove this member and use an appropriate data structure for dataIDs. See https://github.com/precice/precice/issues/766
 
   struct ConfigurationData {
-    std::vector<int>      dataIDs;
+    std::vector<int>      dataIDs;  // @todo use a std::set. dataIDs should be unique. See https://github.com/precice/precice/issues/766
     std::map<int, double> scalings;
     std::string           type;
     double                relaxationFactor           = 0;

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -92,7 +92,7 @@ private:
 
   impl::PtrPreconditioner _preconditioner;
 
-  std::set<std::string> _uniqueDataNames;  // @todo remove this member and use an appropriate data structure for dataIDs. See https://github.com/precice/precice/issues/766
+  std::set<std::string> _uniqueDataNames;  
 
   struct ConfigurationData {
     std::vector<int>      dataIDs;  // @todo use a std::set. dataIDs should be unique. See https://github.com/precice/precice/issues/766

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -95,7 +95,7 @@ private:
   std::set<std::string> _uniqueDataNames;  
 
   struct ConfigurationData {
-    std::vector<int>      dataIDs;  // @todo use a std::set. dataIDs should be unique. See https://github.com/precice/precice/issues/766
+    std::vector<int>      dataIDs;
     std::map<int, double> scalings;
     std::string           type;
     double                relaxationFactor           = 0;

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -92,6 +92,8 @@ private:
 
   impl::PtrPreconditioner _preconditioner;
 
+  std::set<std::string> _uniqueDataNames;  // @todo remove this member and use an appropriate data structure for dataIDs. See https://github.com/precice/precice/issues/766
+
   struct ConfigurationData {
     std::vector<int>      dataIDs;
     std::map<int, double> scalings;


### PR DESCRIPTION
This PR adds a warning, if data name is provided multiple times. 

~~Resolves the first todo in #766. Refer to the issue for more information.~~

Closes #766 