### PR TITLE
Fix Resource Finalization of SolverInterface

### DIFF
--- a/docs/changelog/772.md
+++ b/docs/changelog/772.md
@@ -1,3 +1,3 @@
-* Fix value sematics of `precice::SolverInterface`
+* Fix value semantics of `precice::SolverInterface`
 * Fix memory leaks and hanging communication when not calling `precice::SolverInterface::finalize()`
 * Fix occasional errors when using PETRBF with a preCICE-managed MPI Communicator.

--- a/docs/changelog/772.md
+++ b/docs/changelog/772.md
@@ -1,0 +1,3 @@
+* Fix value sematics of `precice::SolverInterface`
+* Fix memory leaks and hanging communication when not calling `precice::SolverInterface::finalize()`
+* Fix occasional errors when using PETRBF with a preCICE-managed MPI Communicator.

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -145,7 +145,7 @@ public:
   /**
    * @brief Finalizes preCICE.
    *
-   * @pre initialize() has been called successfully.
+   * @pre finalize() has not been called.
    *
    * @post Communication channels are closed.
    * @post Meshes and data are deallocated

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -414,7 +414,7 @@ void SolverInterfaceImpl::finalize()
 
   if (_state == State::Initialized) {
 
-    // PRECICE_CHECK(_couplingScheme->isInitialized(), "initialize() has to be called before finalize()");
+    PRECICE_ASSERT(_couplingScheme->isInitialized());
     PRECICE_DEBUG("Finalize coupling scheme");
     _couplingScheme->finalize();
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -108,6 +108,7 @@ SolverInterfaceImpl::SolverInterfaceImpl(
 SolverInterfaceImpl::~SolverInterfaceImpl()
 {
   if (_state != State::Finalized) {
+    PRECICE_INFO("Implicitly finalizing in destructor");
     finalize();
   }
 }

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -88,6 +88,12 @@ public:
       int                accessorCommunicatorSize,
       void *             communicator);
 
+  /** Ensures that finalize() has been called.
+   *
+   * @see finalize()
+   */
+  ~SolverInterfaceImpl();
+
   /**
    * @brief Initializes all coupling data and starts (coupled) simulation.
    *
@@ -127,8 +133,25 @@ public:
   /**
    * @brief Finalizes the coupled simulation.
    *
-   * - Tears down communication means used for coupling.
-   * - Finalizes MPI if initialized in initializeCoupling.
+   * If initialize() has been called:
+   *
+   * - Synchronizes with remote partiticipants
+   * - handles final exports
+   * - cleans up general state
+   *
+   * Always:
+   *
+   * - flushes and finalizes Events
+   * - finalizes managed PETSc
+   * - finalizes managed MPI
+   *
+   * @post Closes MasterSlave communication
+   * @post Finalized managed PETSc
+   * @post Finalized managed MPI
+   *
+   * @warning
+   * Finalize is not the inverse of initialize().
+   * It has to be called after constuction.
    */
   void finalize();
 
@@ -516,6 +539,16 @@ private:
   std::vector<impl::PtrParticipant> _participants;
 
   cplscheme::PtrCouplingScheme _couplingScheme;
+
+  /// Represents the various states a solverinterface can be in.
+  enum struct State {
+    Constructed,
+    Initialized,
+    Finalized
+  };
+
+  /// The current State of the solverinterface
+  State _state {State::Constructed};
 
   /// Counts calls to advance for plotting.
   long int _numberAdvanceCalls = 0;

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -151,7 +151,7 @@ public:
    *
    * @warning
    * Finalize is not the inverse of initialize().
-   * It has to be called after constuction.
+   * Finalize has to be called after construction.
    */
   void finalize();
 

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -75,6 +75,102 @@ BOOST_AUTO_TEST_CASE(TestFinalize)
   }
 }
 
+
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+
+// Test representing the full explicit lifecycle of a SolverInterface
+BOOST_AUTO_TEST_CASE(Full)
+{
+  PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+
+  constexpr double y{0};
+  constexpr double z{0};
+  constexpr double x1{1};
+  constexpr double dx{1};
+
+  if(context.isNamed("SolverOne")) {
+    auto meshid = interface.getMeshID("MeshOne");
+    double coords[] = {x1 + dx*context.rank, y, z};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataOne", meshid);
+    double data[] = {3.4, 4.5, 5.6};
+    interface.writeVectorData(dataid, vertexid, data);
+  } else {
+    auto meshid = interface.getMeshID("MeshTwo");
+    double coords[] = {x1 + dx*context.rank, y, z};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataTwo", meshid);
+    interface.writeScalarData(dataid, vertexid, 7.8);
+  }
+  interface.initialize();
+  BOOST_TEST(interface.isCouplingOngoing());
+  interface.finalize();
+}
+
+// Test representing the full lifecycle of a SolverInterface
+// Finalize is not called explicitly here.
+// The destructor has to cleanup.
+BOOST_AUTO_TEST_CASE(ImplicitFinalize)
+{
+  PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+
+  constexpr double y{0};
+  constexpr double z{0};
+  constexpr double x1{1};
+  constexpr double dx{1};
+
+  if(context.isNamed("SolverOne")) {
+    auto meshid = interface.getMeshID("MeshOne");
+    double coords[] = {x1 + dx*context.rank, y, z};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataOne", meshid);
+    double data[] = {3.4, 4.5, 5.6};
+    interface.writeVectorData(dataid, vertexid, data);
+  } else {
+    auto meshid = interface.getMeshID("MeshTwo");
+    double coords[] = {x1 + dx*context.rank, y, z};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataTwo", meshid);
+    interface.writeScalarData(dataid, vertexid, 7.8);
+  }
+  interface.initialize();
+  BOOST_TEST(interface.isCouplingOngoing());
+}
+
+// Test representing the minimal lifecylce, which consists out of construction only.
+// The destructor has to cleanup correctly.
+BOOST_AUTO_TEST_CASE(ConstructOnly)
+{
+  PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+}
+
+// Test representing the minimal lifecylce with explicit finalization.
+// This shows how to manually finalize MPI etc without using the SolverInterface.
+BOOST_AUTO_TEST_CASE(ConstructAndExplicitFinalize)
+{
+  PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+
+  interface.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 #ifndef PRECICE_NO_PETSC
 
 BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning)

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -45,9 +45,6 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup)
   BOOST_TEST(utils::MasterSlave::getSize() == context.size);
   BOOST_TEST(utils::MasterSlave::_communication.use_count() > 0);
   BOOST_TEST(utils::MasterSlave::_communication->isConnected());
-
-  //necessary as this test does not call finalize
-  utils::MasterSlave::_communication = nullptr;
 }
 
 BOOST_AUTO_TEST_CASE(TestFinalize)

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -77,6 +77,91 @@ BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
   BOOST_TEST(comsol->_usedMeshContexts.size() == 1);
 }
 
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+
+// Test representing the full explicit lifecycle of a SolverInterface
+BOOST_AUTO_TEST_CASE(Full)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+
+  if(context.isNamed("SolverOne")) {
+    auto meshid = interface.getMeshID("MeshOne");
+    double coords[] = {0.1, 1.2, 2.3};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataOne", meshid);
+    double data[] = {3.4, 4.5, 5.6};
+    interface.writeVectorData(dataid, vertexid, data);
+  } else {
+    auto meshid = interface.getMeshID("MeshTwo");
+    double coords[] = {0.12, 1.21, 2.2};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataTwo", meshid);
+    interface.writeScalarData(dataid, vertexid, 7.8);
+  }
+  interface.initialize();
+  BOOST_TEST(interface.isCouplingOngoing());
+  interface.finalize();
+}
+
+// Test representing the full lifecycle of a SolverInterface
+// Finalize is not called explicitly here.
+// The destructor has to cleanup.
+BOOST_AUTO_TEST_CASE(ImplicitFinalize)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+
+  if(context.isNamed("SolverOne")) {
+    auto meshid = interface.getMeshID("MeshOne");
+    double coords[] = {0.1, 1.2, 2.3};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataOne", meshid);
+    double data[] = {3.4, 4.5, 5.6};
+    interface.writeVectorData(dataid, vertexid, data);
+  } else {
+    auto meshid = interface.getMeshID("MeshTwo");
+    double coords[] = {0.12, 1.21, 2.2};
+    auto vertexid = interface.setMeshVertex(meshid, coords);
+
+    auto dataid = interface.getDataID("DataTwo", meshid);
+    interface.writeScalarData(dataid, vertexid, 7.8);
+  }
+  interface.initialize();
+  BOOST_TEST(interface.isCouplingOngoing());
+}
+
+// Test representing the minimal lifecylce, which consists out of construction only.
+// The destructor has to cleanup correctly.
+BOOST_AUTO_TEST_CASE(ConstructOnly)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+}
+
+// Test representing the minimal lifecylce with explicit finalization.
+// This shows how to manually finalize MPI etc without using the SolverInterface.
+BOOST_AUTO_TEST_CASE(ConstructAndExplicitFinalize)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  std::string config = _pathToTests + "lifecycle.xml";
+
+  SolverInterface interface(context.name, config, context.rank, context.size);
+
+  interface.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 /// Test to run simple "do nothing" coupling between two solvers.
 void runTestExplicit(std::string const &configurationFileName, TestContext const &context)
 {

--- a/src/precice/tests/lifecycle.xml
+++ b/src/precice/tests/lifecycle.xml
@@ -29,7 +29,7 @@
          <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo"
                   constraint="consistent" timing="initial"/>
          <write-data name="DataTwo" mesh="MeshTwo"/>
-         <read-data  name="DataOne"     mesh="MeshTwo"/>
+         <read-data  name="DataOne" mesh="MeshTwo"/>
       </participant>
 
       <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/src/precice/tests/lifecycle.xml
+++ b/src/precice/tests/lifecycle.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+   <solver-interface dimensions="3" >
+      <data:vector name="DataOne"/>
+      <data:scalar name="DataTwo"/>
+
+      <mesh name="MeshOne">
+         <use-data name="DataOne"/>
+         <use-data name="DataTwo"/>
+      </mesh>
+
+      <mesh name="MeshTwo">
+         <use-data name="DataOne"/>
+         <use-data name="DataTwo"/>
+      </mesh>
+
+      <participant name="SolverOne">
+         <use-mesh name="MeshOne" provide="on"/>
+         <write-data name="DataOne" mesh="MeshOne"/>
+         <read-data  name="DataTwo" mesh="MeshOne"/>
+      </participant>
+
+      <participant name="SolverTwo">
+         <use-mesh name="MeshOne" from="SolverOne"/>
+         <use-mesh name="MeshTwo" provide="on"/>
+         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne"
+          	      constraint="conservative" timing="initial"/>
+         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo"
+                  constraint="consistent" timing="initial"/>
+         <write-data name="DataTwo" mesh="MeshTwo"/>
+         <read-data  name="DataOne"     mesh="MeshTwo"/>
+      </participant>
+
+      <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+      <coupling-scheme:parallel-explicit>
+         <participants first="SolverOne" second="SolverTwo"/>
+         <max-time-windows value="5"/>
+         <time-window-size value="1.0"/>
+         <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+         <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      </coupling-scheme:parallel-explicit>
+
+   </solver-interface>
+
+</precice-configuration>


### PR DESCRIPTION
This PR refactors and fixes the resource cleanup of the SolverInterface(Impl).

It:
* adds state tracking to the SolverInterfaceImpl
* adds a destructor to SolverInterfaceImpl which calls finalize if it was not called explicitly prior to the destructor
* changes `finalize()` to only finalize the SolverInterface state (accessor, m2ns, cplscheme) if `initialize` has been called
* changes `finalize()` to release ownership of Participants and M2Ns

**The Problem**

The SolverInterface exists in various states:
```cpp
{
  auto interface =  precice::SolverInterface(...);
  // State : constructed
  interface.initialize();
  // State : initialized
  interface.finalize();
  // State : finalized
}  /* end of sope: interface.~SolverInterface() */
// State : gone / deconstructed and deleted
```

The current implementation **exclusively** supports the above lifecycle.

The following results in leaks:
```cpp
{ 
  auto leaky_interface =  precice::SolverInterface(...);
} // At least MPI / PETSc / Events are not finalized here
```

As does this:
```cpp
{ 
  auto leaky_interface =  precice::SolverInterface(...);
  interface.initialize();
} // MPI / PETSc / Events are not finalized
```

Even the correct example can hang and crash as the lifetime of the PETRBF mapping end with the destruction of the SolverInterface. PETSc will be finalized in `finalize`, which can result in errors if MPI is managed by preCICE.

![lifecycle](https://user-images.githubusercontent.com/13552216/84758754-29545700-afc6-11ea-9b21-5ce5b59db3a5.png)




**Additional Context**

Related to #768 

Special thanks to @ajaust for pointing out the lifetime issues!
