### PR TITLE
Fix and simplify PETRBF Tagging Tests

### DIFF
--- a/src/mesh/tests/BoundingBoxTest.cpp
+++ b/src/mesh/tests/BoundingBoxTest.cpp
@@ -262,6 +262,22 @@ BOOST_AUTO_TEST_CASE(Contains)
     BOOST_TEST(bb.contains(v1));
     BOOST_TEST(!bb.contains(v2));
   }
+  { // 3D Point
+    BoundingBox bb({0.0, 0.0, 0.0, 0.0, 0.0, 0.0});
+    Vertex      v1(Eigen::Vector3d(0.0, 0.0, 0.0), 0);
+    Vertex      v2(Eigen::Vector3d(1.2, -2.0, 1.0), 0);
+
+    BOOST_TEST(bb.contains(v1));
+    BOOST_TEST(!bb.contains(v2));
+  }
+  { // 2D Point
+    BoundingBox bb({0.0, 0.0, 0.0, 0.0});
+    Vertex      v1(Eigen::Vector2d(0.0, 0.0), 0);
+    Vertex      v2(Eigen::Vector2d(1.2, -2.0), 0);
+
+    BOOST_TEST(bb.contains(v1));
+    BOOST_TEST(!bb.contains(v2));
+  }
 } // Contains
 
 BOOST_AUTO_TEST_CASE(EmptyCase)

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -70,20 +70,14 @@ const RangePreview<Iter> previewRange(Size n, const Eigen::PlainObjectBase<Deriv
 template <typename DerivedLHS, typename DerivedRHS>
 bool componentWiseLess(const Eigen::PlainObjectBase<DerivedLHS> &lhs, const Eigen::PlainObjectBase<DerivedRHS> &rhs)
 {
-  const auto lhs_begin = lhs.data();
-  const auto lhs_end   = lhs.data() + lhs.size();
-  const auto rhs_begin = rhs.data();
-  const auto rhs_end   = rhs.data() + rhs.size();
+  if (lhs.size() != rhs.size()) return false;
 
-  auto mismatch = utils::mismatch(lhs_begin, lhs_end, rhs_begin, rhs_end);
-
-  if (mismatch.first == lhs_end) {
-    return true;
+  for(int i = 0; i < rhs.size(); ++i) {
+    if (lhs[i] != rhs[i]) {
+      return lhs[i] < rhs[i];
+    }
   }
-  if (mismatch.second == rhs_end) {
-    return false;
-  }
-  return *mismatch.first < *mismatch.second;
+  return false;
 }
 
 struct ComponentWiseLess {

--- a/src/utils/tests/EigenHelperFunctionsTest.cpp
+++ b/src/utils/tests/EigenHelperFunctionsTest.cpp
@@ -50,10 +50,10 @@ BOOST_AUTO_TEST_CASE(ComponentWiseLess)
 
   Eigen::VectorXd c = b;
 
-  BOOST_TEST(componentWiseLess(c, b));
-  BOOST_TEST(componentWiseLess(b, c));
-  BOOST_TEST(cwl(c, b));
-  BOOST_TEST(cwl(b, c));
+  BOOST_TEST(!componentWiseLess(c, b));
+  BOOST_TEST(!componentWiseLess(b, c));
+  BOOST_TEST(!cwl(c, b));
+  BOOST_TEST(!cwl(b, c));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR:
* simplifies and fixes the petsc tagging test for PETSc < 3.8
* splits the tagging test into a conservative and a consistent tagging test
* fixes the component-wise less for eigen VectorXd (required for using `std::set`)