### PR TITLE
Simplify and Refactor Basis Functions

### DIFF
--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -148,15 +148,16 @@ public:
     PRECICE_CHECK(math::greater(_supportRadius, 0.0),
                   "Support radius for radial-basis-function gaussian has to be larger than zero!");
 
-    _deltaY          = hasCompactSupport() ? evaluate(supportRadius) : 0;
+    if (supportRadius < std::numeric_limits<double>::infinity()) {
+      _deltaY = evaluate(supportRadius);
+    }
     double threshold = std::sqrt(-std::log(cutoffThreshold)) / shape;
     _supportRadius   = std::min(supportRadius, threshold);
   }
 
-  /// Compact support if supportRadius is not infinity
   bool hasCompactSupport() const
   {
-    return not(_supportRadius == std::numeric_limits<double>::infinity());
+    return true;
   }
 
   double getSupportRadius() const

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -6,6 +6,27 @@
 namespace precice {
 namespace mapping {
 
+/// Base class for RBF with compact support
+struct CompactSupportBase {
+  static constexpr bool hasCompactSupport()
+  {
+    return true;
+  }
+};
+
+/// Base class for RBF without compact support
+struct NoCompactSupportBase {
+  static constexpr bool hasCompactSupport()
+  {
+    return false;
+  }
+
+  static constexpr double getSupportRadius()
+  {
+    return std::numeric_limits<double>::max();
+  }
+};
+
 /**
  * @brief Radial basis function with global support.
  *
@@ -13,18 +34,8 @@ namespace mapping {
  *
  * Evaluates to: radius^2 * log(radius).
  */
-class ThinPlateSplines {
+class ThinPlateSplines : public NoCompactSupportBase {
 public:
-  bool hasCompactSupport() const
-  {
-    return false;
-  }
-
-  double getSupportRadius() const
-  {
-    return std::numeric_limits<double>::max();
-  }
-
   double evaluate(double radius) const
   {
     double result = 0.0;
@@ -42,20 +53,10 @@ public:
  *
  * Evaluates to: sqrt(shape^2 + radius^2).
  */
-class Multiquadrics {
+class Multiquadrics : public NoCompactSupportBase {
 public:
   explicit Multiquadrics(double c)
       : _cPow2(std::pow(c, 2)) {}
-
-  bool hasCompactSupport() const
-  {
-    return false;
-  }
-
-  double getSupportRadius() const
-  {
-    return std::numeric_limits<double>::max();
-  }
 
   double evaluate(double radius) const
   {
@@ -74,23 +75,13 @@ private:
  *
  * Evaluates to: 1 / (shape^2 + radius^2).
  */
-class InverseMultiquadrics {
+class InverseMultiquadrics : public NoCompactSupportBase {
 public:
   explicit InverseMultiquadrics(double c)
       : _cPow2(std::pow(c, 2))
   {
     PRECICE_CHECK(math::greater(c, 0.0),
                   "Shape parameter for radial-basis-function inverse multiquadric has to be larger than zero!");
-  }
-
-  bool hasCompactSupport() const
-  {
-    return false;
-  }
-
-  double getSupportRadius() const
-  {
-    return std::numeric_limits<double>::max();
   }
 
   double evaluate(double radius) const
@@ -111,18 +102,8 @@ private:
  *
  * Evaluates to: radius.
  */
-class VolumeSplines {
+class VolumeSplines : public NoCompactSupportBase {
 public:
-  bool hasCompactSupport() const
-  {
-    return false;
-  }
-
-  double getSupportRadius() const
-  {
-    return std::numeric_limits<double>::max();
-  }
-
   double evaluate(double radius) const
   {
     return std::abs(radius);
@@ -137,7 +118,7 @@ public:
  *
  * Evaluates to: exp(-1 * (shape * radius)^2).
  */
-class Gaussian {
+class Gaussian : public CompactSupportBase {
 public:
   Gaussian(const double shape, const double supportRadius = std::numeric_limits<double>::infinity())
       : _shape(shape),
@@ -153,11 +134,6 @@ public:
     }
     double threshold = std::sqrt(-std::log(cutoffThreshold)) / shape;
     _supportRadius   = std::min(supportRadius, threshold);
-  }
-
-  bool hasCompactSupport() const
-  {
-    return true;
   }
 
   double getSupportRadius() const
@@ -198,18 +174,13 @@ private:
  * where rn is the radius r normalized over the support radius sr: rn = r/sr.
  * To work around the issue of log(0), the equation is formulated differently in the last term.
  */
-class CompactThinPlateSplinesC2 {
+class CompactThinPlateSplinesC2 : public CompactSupportBase {
 public:
   explicit CompactThinPlateSplinesC2(double supportRadius)
       : _r(supportRadius)
   {
     PRECICE_CHECK(math::greater(_r, 0.0),
                   "Support radius for radial-basis-function compact thin-plate-splines c2 has to be larger than zero!");
-  }
-
-  bool hasCompactSupport() const
-  {
-    return true;
   }
 
   double getSupportRadius() const
@@ -243,18 +214,13 @@ private:
  * Evaluates to: (1 - rn)^2,
  * where rn is the radius r normalized over the support radius sr: rn = r/sr.
  */
-class CompactPolynomialC0 {
+class CompactPolynomialC0 : public CompactSupportBase {
 public:
   explicit CompactPolynomialC0(double supportRadius)
       : _r(supportRadius)
   {
     PRECICE_CHECK(math::greater(_r, 0.0),
                   "Support radius for radial-basis-function compact polynomial c0 has to be larger than zero!");
-  }
-
-  bool hasCompactSupport() const
-  {
-    return true;
   }
 
   double getSupportRadius() const
@@ -285,18 +251,13 @@ private:
  * Evaluates to: (1 - rn)^8 * (32*rn^3 + 25*rn^2 + 8*rn + 1),
  * where rn is the radius r normalized over the support radius sr: rn = r/sr.
  */
-class CompactPolynomialC6 {
+class CompactPolynomialC6 : public CompactSupportBase {
 public:
   explicit CompactPolynomialC6(double supportRadius)
       : _r(supportRadius)
   {
     PRECICE_CHECK(math::greater(_r, 0.0),
                   "Support radius for radial-basis-function compact polynomial c6 has to be larger than zero!");
-  }
-
-  bool hasCompactSupport() const
-  {
-    return true;
   }
 
   double getSupportRadius() const


### PR DESCRIPTION
This PR:
* simplified the Gaussian similar to #769, but without altering the interface of the ctor.
  As we always use a cut-off threshold for the Gaussian, it always has compact support.
* refactors the compact-supportness of basis functions into 2 classes. This simplifies the implementation and allows for easier lifting of this information to compile time.

Closes #769 