### PR TITLE
Migrate Fortran bindings to use unique_ptr

### DIFF
--- a/docs/changelog/776.md
+++ b/docs/changelog/776.md
@@ -1,0 +1,1 @@
+* Fix memory leaks in Fortran bindings in case of missing call to`X_finalize()`

--- a/extras/bindings/fortran/src/SolverInterfaceFASTEST.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFASTEST.cpp
@@ -4,11 +4,12 @@
 #include "logging/Logger.hpp"
 #include "precice/SolverInterface.hpp"
 #include "precice/SolverInterfaceFortran.hpp"
+#include <memory>
 
 using namespace std;
 
-static precice::SolverInterface *implAcoustic = nullptr;
-static precice::SolverInterface *implFluid    = nullptr;
+static std::unique_ptr<precice::SolverInterface> implAcoustic = nullptr;
+static std::unique_ptr<precice::SolverInterface> implFluid   = nullptr;
 
 static precice::logging::Logger _log("SolverInterfaceFASTEST");
 
@@ -43,14 +44,14 @@ void precice_fastest_create_(
   //cout << "Accessor: " << stringAccessorName << "!" << '\n';
   //cout << "Config  : " << stringConfigFileName << "!" << '\n';
   if (isAcousticUsed) {
-    implAcoustic = new precice::SolverInterface(stringAccessorNameAcoustic,
+    implAcoustic.reset(new precice::SolverInterface(stringAccessorNameAcoustic,
                                                 stringConfigFileName,
-                                                *solverProcessIndex, *solverProcessSize);
+                                                *solverProcessIndex, *solverProcessSize));
   }
   if (isFluidUsed) {
-    implFluid = new precice::SolverInterface(stringAccessorNameFluid,
+    implFluid.reset(new precice::SolverInterface(stringAccessorNameFluid,
                                              stringConfigFileName,
-                                             *solverProcessIndex, *solverProcessSize);
+                                             *solverProcessIndex, *solverProcessSize));
   }
   PRECICE_CHECK(implAcoustic != nullptr || implFluid != nullptr, "Either the Fluid interface or the Acoustic"
                                                                  " interface or both need to be used");
@@ -101,10 +102,10 @@ void precice_fastest_finalize_(
 
   if (*useFluid == 0) {
     implAcoustic->finalize();
-    delete implAcoustic;
+    implAcoustic.reset();
   } else {
     implFluid->finalize();
-    delete implFluid;
+    implFluid.reset();
   }
 }
 

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -5,10 +5,11 @@
 #include "precice/SolverInterface.hpp"
 #include "precice/impl/versions.hpp"
 #include "utils/assertion.hpp"
+#include <memory>
 
 using namespace std;
 
-static precice::SolverInterface *impl = nullptr;
+static std::unique_ptr<precice::SolverInterface> impl = nullptr;
 
 static precice::logging::Logger _log("SolverInterfaceFortran");
 
@@ -41,9 +42,9 @@ void precicef_create_(
   string stringConfigFileName(configFileName, strippedLength);
   //cout << "Accessor: " << stringAccessorName << "!" << '\n';
   //cout << "Config  : " << stringConfigFileName << "!" << '\n';
-  impl = new precice::SolverInterface(stringAccessorName,
+  impl.reset(new precice::SolverInterface(stringAccessorName,
                                       stringConfigFileName,
-                                      *solverProcessIndex, *solverProcessSize);
+                                      *solverProcessIndex, *solverProcessSize));
 }
 
 void precicef_initialize_(
@@ -70,7 +71,7 @@ void precicef_finalize_()
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->finalize();
-  delete impl;
+  impl.reset();
 }
 
 void precicef_get_dims_(


### PR DESCRIPTION
This PR:
* Migrates Fortran bindings to use unique_ptr
* Fixes memory leaks in case of missing finalize

Related to #768 

Reviewers: Please test the bindings with your Fortran codes.