### PR TITLE
Add oversubscribe flag to test environment

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -54,7 +54,7 @@ function(add_precice_test)
     PROPERTIES
     RUN_SERIAL TRUE # Do not run this test in parallel with others
     WORKING_DIRECTORY "${PAT_WDIR}"
-    ENVIRONMENT PRECICE_ROOT=${preCICE_SOURCE_DIR}
+    ENVIRONMENT "PRECICE_ROOT=${preCICE_SOURCE_DIR};OMPI_MCA_rmaps_base_oversubscribe=1"
     )
   if(PAT_TIMEOUT)
     set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PAT_TIMEOUT} )

--- a/docs/changelog/780.md
+++ b/docs/changelog/780.md
@@ -1,0 +1,1 @@
+* Fix over-subscription error when executing the tests with recent versions of Open MPI on less than 4 physical cores.


### PR DESCRIPTION
This PR sets the environment variable `OMPI_MCA_rmaps_base_oversubscribe=1` when executing the tests.
This allows over-subscription for Open MPI, which is relevant when running the tests on hardware with less than four physical cores.