### PR TITLE
Use RTree intersects() with BoundingBoxes

### DIFF
--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -8,6 +8,7 @@
 #include "mesh/RTree.hpp"
 #include "utils/Event.hpp"
 #include "utils/MasterSlave.hpp"
+#include "mesh/impl/BBUtils.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/QR>
@@ -487,7 +488,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
     auto bb       = otherMesh->getBoundingBox();
     // Enlarge by support radius
     bb.expandBy(_basisFunction.getSupportRadius());
-    rtree->query(bgi::satisfies([&](size_t const i) { return bb.contains(filterMesh->vertices()[i]); }),
+    rtree->query(bgi::intersects(toRTreeBox(bb)),
                  boost::make_function_output_iterator([&filterMesh](size_t idx) {
                    filterMesh->vertices()[idx].tag();
                  }));
@@ -525,7 +526,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshSecondRound()
   bb.expandBy(_basisFunction.getSupportRadius());
   auto rtree = mesh::rtree::getVertexRTree(mesh);
 
-  rtree->query(bgi::satisfies([&](size_t const i) { return bb.contains(mesh->vertices()[i]); }),
+  rtree->query(bgi::intersects(toRTreeBox(bb)),
                boost::make_function_output_iterator([&mesh](size_t idx) {
                  mesh->vertices()[idx].tag();
                }));

--- a/src/mesh/BoundingBox.cpp
+++ b/src/mesh/BoundingBox.cpp
@@ -1,9 +1,9 @@
-#include "BoundingBox.hpp"
 #include <algorithm>
 #include <limits>
 #include <ostream>
 #include <string>
 #include <utility>
+#include "BoundingBox.hpp"
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
 #include "mesh/Vertex.hpp"
@@ -71,6 +71,24 @@ Eigen::VectorXd BoundingBox::center() const
     cog[d] = (_bounds[2 * d + 1] - _bounds[2 * d]) / 2.0 + _bounds[2 * d];
   }
   return cog;
+}
+
+Eigen::VectorXd BoundingBox::minCorner() const
+{
+  Eigen::VectorXd min(_dimensions);
+  for (int d = 0; d < _dimensions; d++) {
+    min[d] = _bounds[2 * d];
+  }
+  return min;
+}
+
+Eigen::VectorXd BoundingBox::maxCorner() const
+{
+  Eigen::VectorXd max(_dimensions);
+  for (int d = 0; d < _dimensions; d++) {
+    max[d] = _bounds[2 * d + 1];
+  }
+  return max;
 }
 
 double BoundingBox::getArea(std::vector<bool> deadAxis)

--- a/src/mesh/BoundingBox.hpp
+++ b/src/mesh/BoundingBox.hpp
@@ -73,6 +73,12 @@ public:
    */
   Eigen::VectorXd center() const;
 
+  /// the min corner of the bounding box
+  Eigen::VectorXd minCorner() const;
+
+  /// the max corner of the bounding box
+  Eigen::VectorXd maxCorner() const;
+
   /// Calculate the area of bounding box
   double getArea(std::vector<bool> deadAxis);
 

--- a/src/mesh/impl/BBUtils.hpp
+++ b/src/mesh/impl/BBUtils.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "mesh/BoundingBox.hpp"
+#include "mesh/RTree.hpp"
+
+namespace precice {
+namespace mesh {
+
+inline RTreeBox toRTreeBox(BoundingBox const &bb)
+{
+  return RTreeBox{bb.minCorner(), bb.maxCorner()};
+}
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/tests/BoundingBoxTest.cpp
+++ b/src/mesh/tests/BoundingBoxTest.cpp
@@ -136,6 +136,30 @@ BOOST_AUTO_TEST_CASE(CenterOfGravity)
   }
 } // CenterOfGravity
 
+BOOST_AUTO_TEST_CASE(MinMaxCorner)
+{
+  PRECICE_TEST(1_rank);
+  { // 3D
+    BoundingBox bb({0.0, 1.0,
+                    -1.0, 3.0,
+                    2.0, 4.0});
+
+    Eigen::Vector3d compareMin(0.0, -1.0, 2.0);
+    Eigen::Vector3d compareMax(1.0, 3.0, 4.0);
+    BOOST_TEST(compareMin == bb.minCorner());
+    BOOST_TEST(compareMax == bb.maxCorner());
+  }
+  { // 2D
+    BoundingBox bb({-1.0, 3.0,
+                    2.0, 4.0});
+
+    Eigen::Vector2d compareMin(-1.0, 2.0);
+    Eigen::Vector2d compareMax(3.0, 4.0);
+    BOOST_TEST(compareMin == bb.minCorner());
+    BOOST_TEST(compareMax == bb.maxCorner());
+  }
+} // CenterOfGravity
+
 BOOST_AUTO_TEST_CASE(Area)
 {
   PRECICE_TEST(1_rank);

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -16,6 +16,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
+#include "mesh/impl/BBUtils.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 
@@ -84,6 +85,7 @@ PtrMesh vertexMesh3D()
   mesh->createVertex(Eigen::Vector3d(1, 0, 1));
   mesh->createVertex(Eigen::Vector3d(1, 1, 0));
   mesh->createVertex(Eigen::Vector3d(1, 1, 1));
+  mesh->computeBoundingBox();
   return mesh;
 }
 } // namespace
@@ -189,7 +191,7 @@ BOOST_AUTO_TEST_CASE(QueryWithBoxEmpty)
       searchVector - Eigen::VectorXd::Constant(3, radius),
       searchVector + Eigen::VectorXd::Constant(3, radius));
 
-  tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
               std::back_inserter(results));
 
   BOOST_TEST(results.empty());
@@ -212,7 +214,7 @@ BOOST_AUTO_TEST_CASE(QueryWithBox2Matches)
       searchVector - Eigen::VectorXd::Constant(3, radius),
       searchVector + Eigen::VectorXd::Constant(3, radius));
 
-  tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
               std::back_inserter(results));
 
   BOOST_TEST(results.size() == 2);
@@ -237,10 +239,28 @@ BOOST_AUTO_TEST_CASE(QueryWithBoxEverything)
       searchVector - Eigen::VectorXd::Constant(3, radius),
       searchVector + Eigen::VectorXd::Constant(3, radius));
 
-  tree->query(bg::index::within(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
               std::back_inserter(results));
 
   BOOST_TEST(results.size() == 8);
+}
+
+BOOST_AUTO_TEST_CASE(QueryWithBoundingBox)
+{
+  PRECICE_TEST(1_rank);
+  auto mesh = vertexMesh3D();
+
+  auto tree = rtree::getVertexRTree(mesh);
+  BOOST_TEST(tree->size() == 8);
+
+  Eigen::VectorXd searchVector(Eigen::Vector3d(0.8, 1, 0));
+
+  std::vector<size_t> results;
+
+  auto search_box = toRTreeBox(mesh->getBoundingBox());
+  tree->query(bg::index::intersects(search_box), std::back_inserter(results));
+
+  BOOST_TEST(results.size() == tree->size());
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Vertex


### PR DESCRIPTION
This PR adds a transformation from `mesh::BoundingBox` to `mesh::RTreeBox` and uses it with `boost::geometry::index::intersects()` instead of using `mesh::BoundingBox::contains()` as a predicate.
This restores the lookup complexity of `O(log(n))` which was lost in #712.

The change from `within()` to `intersects()` allows for cleaner usage as the BoundingBox of a mesh now sellects all vertices. This was not the case using `within()`.

Closes #762 