### PR TITLE
Add CII Best practices badge

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,9 +21,6 @@
 <a style="text-decoration: none" href="https://github.com/precice/precice/releases/latest" target="_blank">
     <img src="https://img.shields.io/github/release/precice/precice.svg" alt="Release">
 </a>
-<a style="text-decoration: none" href="https://bestpractices.coreinfrastructure.org/projects/3895" target="_blank">
-    <img src="https://bestpractices.coreinfrastructure.org/projects/3895/badge" alt="CII Best Practices">
-</a>
 <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">
     <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
 </a>
@@ -31,7 +28,8 @@
     <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
 </a>
 
-**Code Quality**  
+**Project Quality**  
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3895/badge)](https://bestpractices.coreinfrastructure.org/projects/3895)
 [![CodeFactor](https://www.codefactor.io/repository/github/precice/precice/badge)](https://www.codefactor.io/repository/github/precice/precice)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/498adf8b3dcb4543b828e443396eb66c)](https://www.codacy.com/app/fsimonis/precice?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=precice/precice&amp;utm_campaign=Badge_Grade)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/precice/precice.svg?logo=lgtm&logoWidth=18&label=lgtm%3AC%2B%2B)](https://lgtm.com/projects/g/precice/precice/context:cpp)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,9 @@
 <a style="text-decoration: none" href="https://github.com/precice/precice/releases/latest" target="_blank">
     <img src="https://img.shields.io/github/release/precice/precice.svg" alt="Release">
 </a>
+<a style="text-decoration: none" href="https://bestpractices.coreinfrastructure.org/projects/3895" target="_blank">
+    <img src="https://bestpractices.coreinfrastructure.org/projects/3895/badge" alt="CII Best Practices">
+</a>
 <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">
     <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
 </a>


### PR DESCRIPTION
Pointing to https://bestpractices.coreinfrastructure.org/en/projects/3895

This is based on recent input from @fsimonis (mainly) and me (a bit) on the respective "passing" level of the badge. We plan to extend the data to give a clear image on how we also conform to the silver/gold levels.

@uekerman check the location:

![Screenshot from 2020-07-09 10-29-09](https://user-images.githubusercontent.com/4943683/87016481-0be26980-c1cf-11ea-8991-a2df3b9f7bbf.png)
