### PR TITLE
Bump required PETSc version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ if (PRECICE_PETScMapping)
     unset(ENV{PETSC_DIR})
     unset(ENV{PETSC_ARCH})
   endif()
-  find_package(PETSc 3.6 REQUIRED)
+  find_package(PETSc 3.12 REQUIRED)
   # No validation required as PETSc does this internally
 
   set(PETSC_VERSIONS "")

--- a/docs/changelog/792.md
+++ b/docs/changelog/792.md
@@ -1,0 +1,1 @@
+* Changes the minimum required PETSc version to 3.12, which delivers consistent results across platforms.

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -818,15 +818,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
     return; // Ranks not at the interface should never hold interface vertices
 
   // Tags all vertices that are inside otherMesh's bounding box, enlarged by the support radius
-  if (
-#if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
-      _basisFunction.hasCompactSupport()
-#else
-      false
-#warning "Mesh filtering deactivated, due to PETSc version < 3.8. \
-      preCICE is fully functional, but performance for large cases is degraded."
-#endif
-  ) {
+  if (_basisFunction.hasCompactSupport()) {
     auto rtree    = mesh::rtree::getVertexRTree(filterMesh);
     namespace bgi = boost::geometry::index;
     auto bb       = otherMesh->getBoundingBox();

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -376,7 +376,6 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3Vector)
                   globalIndexOffsets[context.rank]);
 }
 
-#if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
 /// Some ranks are empty, does not converge
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
 {
@@ -431,9 +430,6 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
                    {2, {8}}},
                   globalIndexOffsets[context.rank]);
 }
-#else
-#warning "Test case MappingTests/PetRadialBasisFunctionMapping/Parallel/DistributedConsistent2DV4 deactivated, due to PETSc version < 3.8"
-#endif
 
 // same as 2DV4, but all ranks have vertices
 BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
@@ -814,7 +810,6 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV3)
                   globalIndexOffsets[context.rank]);
 }
 
-#if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
 /// Using meshes of different sizes, outMesh is smaller then inMesh
 BOOST_AUTO_TEST_CASE(DistributedConservative2DV4,
                      *boost::unit_test::tolerance(1e-6))
@@ -875,9 +870,6 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV4,
                    {3, {7.571428}}}, // Sum is ~36
                   globalIndexOffsets[context.rank]);
 }
-#else
-#warning "Test case MappingTests/PetRadialBasisFunctionMapping/Parallel/DistributedConservative2DV4 deactivated, due to PETSc version < 3.8."
-#endif
 
 /// Tests a non-contigous owner distributed at the outMesh
 BOOST_AUTO_TEST_CASE(testDistributedConservative2DV5)
@@ -1041,7 +1033,6 @@ void testTagging(const TestContext &context,
 
   // Expected set of tagged elements for first round
   std::set<Eigen::VectorXd, utils::ComponentWiseLess> expectedFirst;
-#if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
   for (const auto &vspec : shouldTagFirstRound) {
     expectedFirst.emplace(vspec.asEigen());
   }
@@ -1053,13 +1044,6 @@ void testTagging(const TestContext &context,
     BOOST_TEST((found || !v.isTagged()),
                "FirstRound: Vertex " << v << " is not tagged, but should be.");
   }
-#else
-  BOOST_TEST_MESSAGE("PETSc < 3.8: all vertices should be tagged in first round.");
-  for (const auto &v : taggedMesh->vertices()) {
-    expectedFirst.emplace(v.getCoords()); // everything should be tagged
-    BOOST_TEST(v.isTagged(), "FirstRound: Vertex " << v << " is not tagged, but should be.");
-  }
-#endif
 
   // Expected set of tagged elements for second round
   std::set<Eigen::VectorXd, utils::ComponentWiseLess> expectedSecond(

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -527,85 +527,36 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
     part.communicate();
     part.compute();
 
-    bool supportPETScFiltering = false;
-#if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
-    supportPETScFiltering = true;
-#endif
-
     BOOST_TEST_CONTEXT(*pSolidzMesh)
     {
-      if (supportPETScFiltering) {
-        BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 3);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 3);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 6);
-        BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 3);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 3);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 6);
+      BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
 
-        // check if the sending and filtering worked right
-        if (context.isMaster()) { //Master
-          BOOST_TEST(pSolidzMesh->vertices().size() == 3);
-          BOOST_TEST(pSolidzMesh->edges().size() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-        } else if (context.isRank(1)) { //Slave2
-          BOOST_TEST(pSolidzMesh->vertices().size() == 0);
-          BOOST_TEST(pSolidzMesh->edges().size() == 0);
-        } else if (context.isRank(2)) { //Slave3
-          BOOST_TEST(pSolidzMesh->vertices().size() == 3);
-          BOOST_TEST(pSolidzMesh->edges().size() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 3);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 4);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 5);
-        }
-      } else {
-        BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 6);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 6);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 12);
-        BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
-
-        // check if the sending and filtering worked right
-        if (context.isMaster()) { //Master
-          BOOST_TEST(pSolidzMesh->vertices().size() == 6);
-          BOOST_TEST(pSolidzMesh->edges().size() == 5);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-          BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-          BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
-        } else if (context.isRank(1)) { //Slave2
-          BOOST_TEST(pSolidzMesh->vertices().size() == 0);
-          BOOST_TEST(pSolidzMesh->edges().size() == 0);
-        } else if (context.isRank(2)) { //Slave3
-          BOOST_TEST(pSolidzMesh->vertices().size() == 6);
-          BOOST_TEST(pSolidzMesh->edges().size() == 5);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-          BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-          BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
-        }
+      // check if the sending and filtering worked right
+      if (context.isMaster()) { //Master
+        BOOST_TEST(pSolidzMesh->vertices().size() == 3);
+        BOOST_TEST(pSolidzMesh->edges().size() == 2);
+        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
+      } else if (context.isRank(1)) { //Slave2
+        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->edges().size() == 0);
+      } else if (context.isRank(2)) { //Slave3
+        BOOST_TEST(pSolidzMesh->vertices().size() == 3);
+        BOOST_TEST(pSolidzMesh->edges().size() == 2);
+        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 5);
       }
     }
   }
@@ -651,91 +602,42 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
     part.communicate();
     part.compute();
 
-    bool supportPETScFiltering = false;
-#if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
-    supportPETScFiltering = true;
-#endif
-
     BOOST_TEST_CONTEXT(*pSolidzMesh)
     {
-      if (supportPETScFiltering) {
-        BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 4);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 4);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 9);
-        BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 4);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 4);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 9);
+      BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
 
-        // check if the sending and filtering worked right
-        if (context.isMaster()) { //Master
-          BOOST_TEST(pSolidzMesh->vertices().size() == 4);
-          BOOST_TEST(pSolidzMesh->edges().size() == 3);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-        } else if (context.isRank(1)) { //Slave2
-          BOOST_TEST(pSolidzMesh->vertices().size() == 0);
-          BOOST_TEST(pSolidzMesh->edges().size() == 0);
-        } else if (context.isRank(2)) { //Slave3
-          BOOST_TEST(pSolidzMesh->vertices().size() == 5);
-          BOOST_TEST(pSolidzMesh->edges().size() == 4);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 1);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 3);
-          BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 4);
-          BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 5);
-        }
-      } else {
-        BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 6);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 6);
-        BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 12);
-        BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
-
-        // check if the sending and filtering worked right
-        if (context.isMaster()) { //Master
-          BOOST_TEST(pSolidzMesh->vertices().size() == 6);
-          BOOST_TEST(pSolidzMesh->edges().size() == 5);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-          BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-          BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
-        } else if (context.isRank(1)) { //Slave2
-          BOOST_TEST(pSolidzMesh->vertices().size() == 0);
-          BOOST_TEST(pSolidzMesh->edges().size() == 0);
-        } else if (context.isRank(2)) { //Slave3
-          BOOST_TEST(pSolidzMesh->vertices().size() == 6);
-          BOOST_TEST(pSolidzMesh->edges().size() == 5);
-          BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == false);
-          BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
-          BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-          BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-          BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-          BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-          BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-          BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
-        }
+      // check if the sending and filtering worked right
+      if (context.isMaster()) { //Master
+        BOOST_TEST(pSolidzMesh->vertices().size() == 4);
+        BOOST_TEST(pSolidzMesh->edges().size() == 3);
+        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
+      } else if (context.isRank(1)) { //Slave2
+        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->edges().size() == 0);
+      } else if (context.isRank(2)) { //Slave3
+        BOOST_TEST(pSolidzMesh->vertices().size() == 5);
+        BOOST_TEST(pSolidzMesh->edges().size() == 4);
+        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 5);
       }
     }
   }
@@ -783,11 +685,6 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
     part.communicate();
     part.compute();
 
-    bool supportPETScFiltering = false;
-#if PETSC_MAJOR >= 3 and PETSC_MINOR >= 8
-    supportPETScFiltering = true;
-#endif
-
     BOOST_TEST_CONTEXT(*pSolidzMesh)
     {
       BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
@@ -805,11 +702,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
         BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == false);
         BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
-        if (supportPETScFiltering) {
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == false);
-        } else {
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-        }
+        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == false);
         BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
         BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
         BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
@@ -827,11 +720,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
         BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
         BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-        if (supportPETScFiltering) {
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-        } else {
-          BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == false);
-        }
+        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
         BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
         BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);


### PR DESCRIPTION
This PR enforces the new PETSc baseline and removes code for PETSc version < 3.8.