### PR TITLE
Make the system tests badge static

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,8 @@
 <a style="text-decoration: none" href="https://travis-ci.org/precice/precice" target="_blank">
     <img src="https://travis-ci.org/precice/precice.svg?branch=develop" alt="Build status">
 </a>
-<a style="text-decoration: none" href="https://travis-ci.org/precice/systemtests" target="_blank">
-    <img src="https://img.shields.io/travis/precice/systemtests.svg?label=system%20tests&style=flat" alt="Build status">
+<a style="text-decoration: none" href="https://travis-ci.org/github/precice/systemtests/builds" target="_blank">
+    <img src="https://img.shields.io/badge/system%20tests-check-blue" alt="Build status">
 </a>
 
 **Code Quality**  


### PR DESCRIPTION
With our current implementation of system tests, it is not easy to get the system tests status for each branch of preCICE. This makes it always blue and "system tests: check", pointing to the build history page: https://travis-ci.org/github/precice/systemtests/builds

Closes #664, offering an alternative solution to the same problem.