### PR TITLE
Move reduceVector to Eigen helper functions

### DIFF
--- a/src/utils/EigenHelperFunctions.cpp
+++ b/src/utils/EigenHelperFunctions.cpp
@@ -55,5 +55,28 @@ void append(
   v(n) = value;
 }
 
+Eigen::VectorXd reduceVector(
+    const Eigen::VectorXd &fullVector,
+    const std::vector<bool>& deadAxis)
+{
+  int deadDimensions = 0;
+  int dimensions = deadAxis.size();
+  for (int d = 0; d < dimensions; d++) {
+    if (deadAxis[d])
+      deadDimensions += 1;
+  }
+  PRECICE_ASSERT(dimensions > deadDimensions, dimensions, deadDimensions);
+  Eigen::VectorXd reducedVector(dimensions - deadDimensions);
+  int             k = 0;
+  for (int d = 0; d < dimensions; d++) {
+    if (not deadAxis[d]) {
+      reducedVector[k] = fullVector[d];
+      k++;
+    }
+  }
+  return reducedVector;
+}
+
+
 } // namespace utils
 } // namespace precice

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 #include <iterator>
+#include <vector>
 #include "utils/algorithm.hpp"
 #include "utils/assertion.hpp"
 

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -14,6 +14,9 @@ void appendFront(Eigen::MatrixXd &A, Eigen::VectorXd &v);
 
 void removeColumnFromMatrix(Eigen::MatrixXd &A, int col);
 
+/// Deletes all dead directions from fullVector and returns a vector of reduced dimensionality.
+Eigen::VectorXd reduceVector(const Eigen::VectorXd &fullVector, const std::vector<bool> &deadAxis);
+
 void append(Eigen::VectorXd &v, double value);
 
 template <typename Derived1>


### PR DESCRIPTION
The `reduceVector()` member function in Eigen RBF mapping was made a non-member function in #739. However, it results in a multiple definition problem in linking phase as @MakisH reported. 

``` bash
[100%] Linking CXX executable testprecice
libprecice.a(MappingConfiguration.cpp.o): In function `boost::container::vector<boost::container::dtl::pair<int, precice::mesh::Edge*>, boost::container::new_allocator<boost::container::dtl::pair<int, precice::mesh::Edge*> >, void>::priv_reserve_no_capacity(unsigned long, boost::move_detail::integral_constant<unsigned int, 1u>)':
/home/makish/github/precice_develop/src/mapping/RadialBasisFctMapping.hpp:537: multiple definition of `precice::mapping::reduceVector(Eigen::Matrix<double, -1, 1, 0, -1, 1> const&, std::vector<bool, std::allocator<bool> >)'
CMakeFiles/testprecice.dir/src/mapping/tests/RadialBasisFctMappingTest.cpp.o:/home/makish/github/precice_develop/src/mapping/RadialBasisFctMapping.hpp:537: first defined here
collect2: error: ld returned 1 exit status
CMakeFiles/testprecice.dir/build.make:1150: recipe for target 'testprecice' failed
```

As a solution, `reduceVector()` function is moved to `precice::utils::EigenHelperFunctions`