### PR TITLE
Set BUILD_SHARED_LIBS to True by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ option(PRECICE_PETScMapping "Enable use of the PETSc linear algebra library." ON
 option(PRECICE_PythonActions "Python support" ON)
 option(PRECICE_Packages "Configure package generation." ON)
 option(PRECICE_InstallTest "Add test binary and necessary files to install target." OFF)
-option(BUILD_SHARED_LIBS "Build shared libraries by default" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries by default" ON)
 option(PRECICE_ALWAYS_VALIDATE_LIBS "Validate libraries even after the validatation succeeded." OFF)
 option(PRECICE_ENABLE_C "Enable the native C bindings" ON)
 option(PRECICE_ENABLE_FORTRAN "Enable the native Fortran bindings" ON)

--- a/docs/changelog/796.md
+++ b/docs/changelog/796.md
@@ -1,0 +1,1 @@
+* Change CMake option `BUILD_SHARED_LIBS` to `ON` by default.


### PR DESCRIPTION
**List the core changes of this PR**

This PR changes the default value of the option for `BUILD_SHARED_LIBS` to `ON`.

**Motivation**

We constantly run into issues with users (and developers) running into issues with a statically build preCICE library.
Sometimes new users don't read the documentation and sometimes seasoned users simply don't remember it.

Setting the `option(` to `On` has the following effects:
* It does not override the setting if is present in the CMakeCache.
* It defaults to `ON` when the user did not set anything.

