### PR TITLE
Add warings when configuring OpenMPI with MPI m2n

### DIFF
--- a/docs/changelog/797.md
+++ b/docs/changelog/797.md
@@ -1,0 +1,1 @@
+* Add warning when configuring m2n as mpi when preCICE is compiled with OpenMPI. This is known to cause connection issues.

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -18,6 +18,10 @@
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLAttribute.hpp"
 
+#ifndef PRECICE_NO_MPI
+#include <mpi.h>
+#endif
+
 namespace precice {
 namespace m2n {
 M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
@@ -152,6 +156,9 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
 #ifdef PRECICE_NO_MPI
       throw std::runtime_error{"Communication type \"mpi\" can only be used when preCICE is compiled with argument \"mpi=on\""};
 #else
+#ifdef OMPI_MAJOR_VERSION
+      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:mpi />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.");
+#endif
       comFactory = std::make_shared<com::MPIPortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
 #endif
@@ -160,6 +167,9 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
 #ifdef PRECICE_NO_MPI
       throw std::runtime_error{"Communication type \"mpi-singleports\" can only be used when preCICE is compiled with argument \"mpi=on\""};
 #else
+#ifdef OMPI_MAJOR_VERSION
+      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:mpi-singleports />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.");
+#endif
       comFactory = std::make_shared<com::MPISinglePortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
 #endif


### PR DESCRIPTION
**List the core changes of this PR**

Add a warning when configuring `<m2n:mpi[-singleports] />` when preCICE is compiled with OpenMPI.
It suggests to switch to sockets in case of problems.

**Motivation**

This gives the user a direct hint on what to do when running into issues.

Follow-up of #747 