### PR TITLE
Convergence measure logging overhaul

### DIFF
--- a/docs/changelog/799.md
+++ b/docs/changelog/799.md
@@ -1,0 +1,7 @@
+* Sorted out and improved convergence measure logging:
+  * Increased readability of relative convergence measure INFO logs.
+  * Extended title headers of convergence and iteration files by measure abbreviation.
+  * Allowed multiple convergence measures of same coupling data.
+  * Suppressd convergence file logging for min-iterations convergence measure.
+  * Removed logging of average convergence rates.
+  * Extended iteration logging by total and dropped quasi-Newton columns. 

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -47,6 +47,16 @@ public:
   {
     return 0;
   }
+
+  virtual int getDroppedColumns()
+  {
+    return 0;
+  }
+
+  virtual int getLSSystemCols()
+  {
+    return 0;
+  }
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -43,17 +43,20 @@ public:
 
   virtual void importState(io::TXTReader &reader) {}
 
-  virtual int getDeletedColumns()
+  /// Gives the number of QN columns that where filtered out (i.e. deleted) in this time window
+  virtual int getDeletedColumns() const
   {
     return 0;
   }
 
-  virtual int getDroppedColumns()
+  /// Gives the number of QN columns that went out of scope in this time window
+  virtual int getDroppedColumns() const
   {
     return 0;
   }
 
-  virtual int getLSSystemCols()
+  /// Gives the number of current QN columns (LS = least squares)
+  virtual int getLSSystemCols() const
   {
     return 0;
   }

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -630,17 +630,17 @@ void BaseQNAcceleration::importState(
 {
 }
 
-int BaseQNAcceleration::getDeletedColumns()
+int BaseQNAcceleration::getDeletedColumns() const
 {
   return _nbDelCols;
 }
 
-int BaseQNAcceleration::getDroppedColumns()
+int BaseQNAcceleration::getDroppedColumns() const
 {
   return _nbDropCols;
 }
 
-int BaseQNAcceleration::getLSSystemCols()
+int BaseQNAcceleration::getLSSystemCols() const
 {
   int cols = 0;
   for (int col : _matrixCols) {

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -126,10 +126,10 @@ public:
   virtual void importState(io::TXTReader &reader);
 
   /// how many QN columns were deleted in this timestep
-  virtual int getDeletedColumns();
+  virtual int getDeletedColumns() const;
 
   /// how many QN columns were dropped (went out of scope) in this timestep
-  virtual int getDroppedColumns();
+  virtual int getDroppedColumns() const;
 
   /** @brief: computes number of cols in least squares system, i.e, number of cols in
     *  _matrixV, _matrixW, _qrV, etc..
@@ -138,7 +138,7 @@ public:
     *  constructed and we have no information about the number of cols. This info
     *  is needed for master-slave communication. Number of its =! _cols in general.
     */
-  virtual int getLSSystemCols();
+  virtual int getLSSystemCols() const;
 
 protected:
   logging::Logger _log{"acceleration::BaseQNAcceleration"};

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -125,8 +125,20 @@ public:
     */
   virtual void importState(io::TXTReader &reader);
 
-  // delete this:
+  /// how many QN columns were deleted in this timestep
   virtual int getDeletedColumns();
+
+  /// how many QN columns were dropped (went out of scope) in this timestep
+  virtual int getDroppedColumns();
+
+  /** @brief: computes number of cols in least squares system, i.e, number of cols in
+    *  _matrixV, _matrixW, _qrV, etc..
+    *	 This is necessary only for master-slave mode, when some procs do not have
+    *	 any nodes on the coupling interface. In this case, the matrices are not
+    *  constructed and we have no information about the number of cols. This info
+    *  is needed for master-slave communication. Number of its =! _cols in general.
+    */
+  virtual int getLSSystemCols();
 
 protected:
   logging::Logger _log{"acceleration::BaseQNAcceleration"};
@@ -222,14 +234,6 @@ protected:
   std::ostringstream _infostringstream;
   std::fstream       _infostream;
 
-  /** @brief: computes number of cols in least squares system, i.e, number of cols in
-    *  _matrixV, _matrixW, _qrV, etc..
-    *	 This is necessary only for master-slave mode, when some procs do not have
-    *	 any nodes on the coupling interface. In this case, the matrices are not
-    *  constructed and we have no information about the number of cols. This info
-    *  is needed for master-slave communication. Number of its =! _cols in general.
-    */
-  int getLSSystemCols();
   int getLSSystemRows();
 
   /**
@@ -284,8 +288,11 @@ private:
   Eigen::MatrixXd _matrixWBackup;
   std::deque<int> _matrixColsBackup;
 
-  /// Additional debugging info, is not important for computation:
+  /// Number of filtered out columns in this time window
   int _nbDelCols = 0;
+
+  /// Number of dropped columns in this time window (old time window out of scope)
+  int _nbDropCols = 0;
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -157,7 +157,7 @@ void QRFactorization::applyFilter(double singularityLimit, std::vector<int> &del
 }
 
 /**
- * updates the factorization A=Q[1:n,1:m]R[1:m,1:n] when the kth column of A is deleted. 
+ * updates the factorization A=Q[1:n,1:m]R[1:m,1:n] when the kth column of A is deleted.
  * Returns the deleted column v(1:n)
  */
 void QRFactorization::deleteColumn(int k)
@@ -638,8 +638,8 @@ void QRFactorization::computeReflector(
 }
 
 /**
- *  @short this procedure replaces the two column matrix [p(k:l-1), q(k:l-1)] by [p(k:l), q(k:l)]*G, 
- *  where G is the Givens matrix grot, determined by sigma and gamma. 
+ *  @short this procedure replaces the two column matrix [p(k:l-1), q(k:l-1)] by [p(k:l), q(k:l)]*G,
+ *  where G is the Givens matrix grot, determined by sigma and gamma.
  */
 void QRFactorization::applyReflector(
     const QRFactorization::givensRot &grot,
@@ -673,12 +673,12 @@ Eigen::MatrixXd &QRFactorization::matrixR()
   return _R;
 }
 
-int QRFactorization::cols()
+int QRFactorization::cols() const
 {
   return _cols;
 }
 
-int QRFactorization::rows()
+int QRFactorization::rows() const
 {
   return _rows;
 }

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -13,12 +13,12 @@ namespace acceleration {
 namespace impl {
 
 /**
- * @brief Class that provides functionality for a dynamic QR-decomposition, that can be updated 
- * in O(mn) flops if a column is inserted or deleted. 
+ * @brief Class that provides functionality for a dynamic QR-decomposition, that can be updated
+ * in O(mn) flops if a column is inserted or deleted.
  * The new colmn is orthogonalized to the existing columns in Q using a modified GramSchmidt algorithm.
  * The zero-elements are generated using suitable givens-roatations.
- * The Interface provides fnctions such as insertColumn, deleteColumn at arbitrary position an push or pull 
- * column at front or back, resp. 
+ * The Interface provides fnctions such as insertColumn, deleteColumn at arbitrary position an push or pull
+ * column at front or back, resp.
  */
 class QRFactorization {
 public:
@@ -96,7 +96,7 @@ public:
   bool insertColumn(int k, const Eigen::VectorXd &v, double singularityLimit = 0);
 
   /**
-   * @brief updates the factorization A=Q[1:n,1:m]R[1:m,1:n] when the kth column of A is deleted. 
+   * @brief updates the factorization A=Q[1:n,1:m]R[1:m,1:n] when the kth column of A is deleted.
    * Returns the deleted column v(1:n)
    */
   void deleteColumn(int k);
@@ -145,9 +145,9 @@ public:
   Eigen::MatrixXd &matrixR();
 
   // @brief returns the number of columns in the QR-decomposition
-  int cols();
+  int cols() const;
   // @brief returns the number of rows in the QR-decomposition
-  int rows();
+  int rows() const;
 
   // @brief optional file-stream for logging output
   void setfstream(std::fstream *stream);
@@ -197,8 +197,8 @@ private:
   void computeReflector(givensRot &grot, double &x, double &y);
 
   /**
-  *  @short this procedure replaces the two column matrix [p(k:l-1), q(k:l-1)] by [p(k:l), q(k:l)]*G, 
-  *  where G is the Givens matrix grot, determined by sigma and gamma. 
+  *  @short this procedure replaces the two column matrix [p(k:l-1), q(k:l-1)] by [p(k:l), q(k:l)]*G,
+  *  where G is the Givens matrix grot, determined by sigma and gamma.
   */
   void applyReflector(const givensRot &grot, int k, int l, Eigen::VectorXd &p, Eigen::VectorXd &q);
 

--- a/src/acceleration/test/AccelerationMasterSlaveTest.cpp
+++ b/src/acceleration/test/AccelerationMasterSlaveTest.cpp
@@ -961,6 +961,128 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp)
   }
 }
 
+/// Test that runs on 4 processors.
+BOOST_AUTO_TEST_CASE(testColumnsLogging)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  double           initialRelaxation        = 0.1;
+  int              maxIterationsUsed        = 3;
+  int              timestepsReused          = 1;
+  int              filter                   = BaseQNAcceleration::QR1FILTER;
+  double           singularityLimit         = 0.1;
+  bool             enforceInitialRelaxation = false;
+  std::vector<int> dataIDs;
+  dataIDs.push_back(0);
+  std::vector<double> factors;
+  factors.resize(1.0, 1.0);
+  PtrPreconditioner prec(new ConstantPreconditioner(factors));
+  std::vector<int>  vertexOffsets{2, 3, 3, 4};
+
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
+  dummyMesh->setVertexOffsets(vertexOffsets);
+
+  IQNILSAcceleration acc(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
+                         timestepsReused, filter, singularityLimit, dataIDs, prec);
+
+  Eigen::VectorXd dvalues;
+  Eigen::VectorXd dcol1;
+
+  DataMap data;
+
+  if (context.isMaster()) { // 2 vertices
+    //init displacements
+    Eigen::VectorXd insert(2);
+    insert << 1.0, 1.0;
+    utils::append(dvalues, insert);
+    insert << 0.5, 0.5;
+    utils::append(dcol1, insert);
+  } else if (context.isRank(1)) { //1 vertex
+    Eigen::VectorXd insert(1);
+    insert << 1.0;
+    utils::append(dvalues, insert);
+    insert << 0.5;
+    utils::append(dcol1, insert);
+  } else if (context.isRank(2)) { //no vertices
+  } else {                        //1 vertex
+    Eigen::VectorXd insert(1);
+    insert << 1.0;
+    utils::append(dvalues, insert);
+    insert << 0.5;
+    utils::append(dcol1, insert);
+  }
+
+  PtrCouplingData dpcd(new CouplingData(&dvalues, dummyMesh, false, 1));
+  data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+  acc.initialize(data);
+  dpcd->oldValues.col(0) = dcol1;
+
+  acc.performAcceleration(data);
+
+  Eigen::VectorXd newdvalues1;
+  if (context.isMaster()) {
+    utils::append(newdvalues1, 1.1);
+    utils::append(newdvalues1, 1.0);
+  } else if (context.isRank(1)) {
+    utils::append(newdvalues1, 1.0);
+  } else if (context.isRank(2)) {
+  } else if (context.isRank(3)) {
+    utils::append(newdvalues1, 1.0);
+  }
+  data.begin()->second->values = &newdvalues1;
+
+  acc.performAcceleration(data);
+
+  Eigen::VectorXd newdvalues2;
+  if (context.isMaster()) {
+    utils::append(newdvalues2, 1.0);
+    utils::append(newdvalues2, 2.0);
+  } else if (context.isRank(1)) {
+    utils::append(newdvalues2, 1.0);
+  } else if (context.isRank(2)) {
+  } else if (context.isRank(3)) {
+    utils::append(newdvalues2, 1.0);
+  }
+  data.begin()->second->values = &newdvalues2;
+
+  acc.iterationsConverged(data);
+
+  BOOST_TEST(acc.getLSSystemCols() == 2);
+  BOOST_TEST(acc.getDeletedColumns() == 0);
+  BOOST_TEST(acc.getDroppedColumns() == 0);
+
+  Eigen::VectorXd newdvalues3;
+  if (context.isMaster()) {
+    utils::append(newdvalues3, 1.1);
+    utils::append(newdvalues3, 2.0);
+  } else if (context.isRank(1)) {
+    utils::append(newdvalues3, 1.0);
+  } else if (context.isRank(2)) {
+  } else if (context.isRank(3)) {
+    utils::append(newdvalues3, 1.0);
+  }
+  data.begin()->second->values = &newdvalues3;
+
+  acc.performAcceleration(data);
+
+  Eigen::VectorXd newdvalues4;
+  if (context.isMaster()) {
+    utils::append(newdvalues4, 1.0);
+    utils::append(newdvalues4, 1.0);
+  } else if (context.isRank(1)) {
+    utils::append(newdvalues4, 1.0);
+  } else if (context.isRank(2)) {
+  } else if (context.isRank(3)) {
+    utils::append(newdvalues4, 5.0);
+  }
+  data.begin()->second->values = &newdvalues4;
+
+  acc.iterationsConverged(data);
+
+  BOOST_TEST(acc.getLSSystemCols() == 1);
+  BOOST_TEST(acc.getDeletedColumns() == 1);
+  BOOST_TEST(acc.getDroppedColumns() == 1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -547,7 +547,7 @@ bool BaseCouplingScheme::measureConvergence()
 
     if (not utils::MasterSlave::isSlave()) {
       std::stringstream sstm;
-      sstm << "ResNorm(" << convMeasure.data->getName() << ")";
+      sstm << "Res" << convMeasure.measure->getAbbreviation() << "(" << convMeasure.data->getName() << ")";
       _convergenceWriter->writeData(sstm.str(), convMeasure.measure->getNormResidual());
     }
 
@@ -593,8 +593,8 @@ void BaseCouplingScheme::initializeTXTWriters()
     if (not doesFirstStep()) {
       for (ConvergenceMeasure &convMeasure : _convergenceMeasures) {
         std::stringstream sstm, sstm2;
-        sstm << "AvgConvRate(" << convMeasure.data->getName() << ")";
-        sstm2 << "ResNorm(" << convMeasure.data->getName() << ")";
+        sstm << "AvgConvRate" << convMeasure.measure->getAbbreviation() << "(" << convMeasure.data->getName() << ")";
+        sstm2 << "Res" << convMeasure.measure->getAbbreviation() << "(" << convMeasure.data->getName() << ")";
         _iterationsWriter->addData(sstm.str(), io::TXTTableWriter::DOUBLE);
         _convergenceWriter->addData(sstm2.str(), io::TXTTableWriter::DOUBLE);
       }
@@ -619,7 +619,7 @@ void BaseCouplingScheme::advanceTXTWriters()
         i++;
 
         std::stringstream sstm;
-        sstm << "AvgConvRate(" << convMeasure.data->getName() << ")";
+        sstm << "AvgConvRate" << convMeasure.measure->getAbbreviation() << "(" << convMeasure.data->getName() << ")";
         if (math::equals(_firstResiduumNorm[i], 0.)) {
           _iterationsWriter->writeData(sstm.str(), std::numeric_limits<double>::infinity());
         } else {

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -215,7 +215,8 @@ public:
   void addConvergenceMeasure(
       mesh::PtrData               data,
       bool                        suffices,
-      impl::PtrConvergenceMeasure measure);
+      impl::PtrConvergenceMeasure measure,
+      bool                        doesLogging);
 
   /// Set an acceleration technique.
   void setAcceleration(acceleration::PtrAcceleration acceleration);
@@ -332,12 +333,14 @@ protected:
    * @param couplingData Coupling data history
    * @param suffices Whether this measure already suffices for convergence
    * @param measure Link to the actual convergence measure
+   * @param doesLogging Whether this measure is logged in the convergence file
    */
   struct ConvergenceMeasure {
     mesh::PtrData               data;
     CouplingData *              couplingData;
     bool                        suffices;
     impl::PtrConvergenceMeasure measure;
+    bool                        doesLogging;
   };
 
   /**

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -458,10 +458,8 @@ private:
   /// Number of total iterations performed.
   int _totalIterations = -1;
 
-  /// TODO
+  /// Number of deleted columns in quasi-Newton matrix V in current timestep
   int _deletedColumnsPPFiltering = 0;
-
-  std::vector<double> _firstResiduumNorm = {0};
 
   /// Extrapolation order of coupling data for first iteration of every dt.
   int _extrapolationOrder = 0;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -12,6 +12,7 @@
 #include "CouplingScheme.hpp"
 #include "SharedPointer.hpp"
 #include "acceleration/SharedPointer.hpp"
+#include "impl/ConvergenceMeasure.hpp"
 #include "impl/SharedPointer.hpp"
 #include "io/TXTTableWriter.hpp"
 #include "logging/Logger.hpp"
@@ -335,12 +336,17 @@ protected:
    * @param measure Link to the actual convergence measure
    * @param doesLogging Whether this measure is logged in the convergence file
    */
-  struct ConvergenceMeasure {
+  struct ConvergenceMeasureContext {
     mesh::PtrData               data;
     CouplingData *              couplingData;
     bool                        suffices;
     impl::PtrConvergenceMeasure measure;
     bool                        doesLogging;
+
+    std::string logHeader() const
+    {
+      return "Res" + measure->getAbbreviation() + "(" + data->getName() + ")";
+    }
   };
 
   /**
@@ -508,7 +514,7 @@ private:
    * Before initialization, only dataID and measure variables are filled. Then,
    * the data is fetched from send and receive data assigned to the cpl scheme.
    */
-  std::vector<ConvergenceMeasure> _convergenceMeasures;
+  std::vector<ConvergenceMeasureContext> _convergenceMeasures;
 
   /// Functions needed for initialize()
 
@@ -586,8 +592,8 @@ private:
    * @param dataID Data field to be assigned
    */
   virtual void assignDataToConvergenceMeasure(
-      ConvergenceMeasure *convMeasure,
-      int                 dataID) = 0;
+      ConvergenceMeasureContext *convMeasure,
+      int                      dataID) = 0;
 
   /**
    * @brief used for storing send/receive data at end of acceleration, if not converged.

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -458,9 +458,6 @@ private:
   /// Number of total iterations performed.
   int _totalIterations = -1;
 
-  /// Number of deleted columns in quasi-Newton matrix V in current timestep
-  int _deletedColumnsPPFiltering = 0;
-
   /// Extrapolation order of coupling data for first iteration of every dt.
   int _extrapolationOrder = 0;
 

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -100,7 +100,7 @@ private:
   std::string _secondParticipant = "unknown";
 
   /// Implements functionality for setupConvergenceMeasures
-  void assignDataToConvergenceMeasure(ConvergenceMeasure *convMeasure, int dataID) override
+  void assignDataToConvergenceMeasure(ConvergenceMeasureContext *convMeasure, int dataID) override
   {
     if ((getSendData(dataID) != nullptr)) {
       convMeasure->couplingData = getSendData(dataID);

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -185,7 +185,7 @@ CouplingData *MultiCouplingScheme::getData(
   return nullptr;
 }
 
-void MultiCouplingScheme::assignDataToConvergenceMeasure(ConvergenceMeasure *convergenceMeasure, int dataID)
+void MultiCouplingScheme::assignDataToConvergenceMeasure(ConvergenceMeasureContext *convergenceMeasure, int dataID)
 {
   convergenceMeasure->couplingData = getData(dataID);
   PRECICE_ASSERT(convergenceMeasure->couplingData != nullptr);

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -127,9 +127,11 @@ private:
   void exchangeInitialData() override;
 
   /**
-   * @brief TODO
+   * @brief Needed for setting up convergence measures
+   * @param convMeasure Convergence measure to which the data field is assigned to
+   * @param dataID Data field to be assigned
    */
-  void assignDataToConvergenceMeasure(ConvergenceMeasure *convergenceMeasure, int dataID) override;
+  void assignDataToConvergenceMeasure(ConvergenceMeasureContext *convergenceMeasure, int dataID) override;
 
   /**
    * @brief MultiCouplingScheme has to call store for all receive and send data in the vectors

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -567,7 +567,8 @@ void CouplingSchemeConfiguration::addAbsoluteConvergenceMeasure(
 {
   PRECICE_TRACE();
   impl::PtrConvergenceMeasure measure(new impl::AbsoluteConvergenceMeasure(limit));
-  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure));
+  bool                        doesLogging = true;
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure, doesLogging));
 }
 
 void CouplingSchemeConfiguration::addRelativeConvergenceMeasure(
@@ -577,9 +578,9 @@ void CouplingSchemeConfiguration::addRelativeConvergenceMeasure(
     bool               suffices)
 {
   PRECICE_TRACE();
-  impl::PtrConvergenceMeasure measure(
-      new impl::RelativeConvergenceMeasure(limit));
-  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure));
+  impl::PtrConvergenceMeasure measure(new impl::RelativeConvergenceMeasure(limit));
+  bool                        doesLogging = true;
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure, doesLogging));
 }
 
 void CouplingSchemeConfiguration::addResidualRelativeConvergenceMeasure(
@@ -589,9 +590,9 @@ void CouplingSchemeConfiguration::addResidualRelativeConvergenceMeasure(
     bool               suffices)
 {
   PRECICE_TRACE();
-  impl::PtrConvergenceMeasure measure(
-      new impl::ResidualRelativeConvergenceMeasure(limit));
-  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure));
+  impl::PtrConvergenceMeasure measure(new impl::ResidualRelativeConvergenceMeasure(limit));
+  bool                        doesLogging = true;
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure, doesLogging));
 }
 
 void CouplingSchemeConfiguration::addMinIterationConvergenceMeasure(
@@ -601,9 +602,9 @@ void CouplingSchemeConfiguration::addMinIterationConvergenceMeasure(
     bool               suffices)
 {
   PRECICE_TRACE();
-  impl::PtrConvergenceMeasure measure(
-      new impl::MinIterationConvergenceMeasure(minIterations));
-  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure));
+  impl::PtrConvergenceMeasure measure(new impl::MinIterationConvergenceMeasure(minIterations));
+  bool                        doesLogging = false;
+  _config.convMeasures.push_back(std::make_tuple(getData(dataName, meshName), suffices, meshName, measure, doesLogging));
 }
 
 mesh::PtrData CouplingSchemeConfiguration::getData(
@@ -677,13 +678,14 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
   // Add convergence measures
   using std::get;
   for (auto &elem : _config.convMeasures) {
-    mesh::PtrData               data       = get<0>(elem);
-    bool                        suffices   = get<1>(elem);
-    std::string                 neededMesh = get<2>(elem);
-    impl::PtrConvergenceMeasure measure    = get<3>(elem);
+    mesh::PtrData               data        = get<0>(elem);
+    bool                        suffices    = get<1>(elem);
+    std::string                 neededMesh  = get<2>(elem);
+    impl::PtrConvergenceMeasure measure     = get<3>(elem);
+    bool                        doesLogging = get<4>(elem);
     _meshConfig->addNeededMesh(_config.participants[1], neededMesh);
     checkIfDataIsExchanged(data->getID());
-    scheme->addConvergenceMeasure(data, suffices, measure);
+    scheme->addConvergenceMeasure(data, suffices, measure, doesLogging);
   }
 
   // Set relaxation parameters
@@ -719,13 +721,14 @@ PtrCouplingScheme CouplingSchemeConfiguration::createParallelImplicitCouplingSch
   // Add convergence measures
   using std::get;
   for (auto &elem : _config.convMeasures) {
-    mesh::PtrData               data       = get<0>(elem);
-    bool                        suffices   = get<1>(elem);
-    std::string                 neededMesh = get<2>(elem);
-    impl::PtrConvergenceMeasure measure    = get<3>(elem);
+    mesh::PtrData               data        = get<0>(elem);
+    bool                        suffices    = get<1>(elem);
+    std::string                 neededMesh  = get<2>(elem);
+    impl::PtrConvergenceMeasure measure     = get<3>(elem);
+    bool                        doesLogging = get<4>(elem);
     _meshConfig->addNeededMesh(_config.participants[1], neededMesh);
     checkIfDataIsExchanged(data->getID());
-    scheme->addConvergenceMeasure(data, suffices, measure);
+    scheme->addConvergenceMeasure(data, suffices, measure, doesLogging);
   }
 
   // Set relaxation parameters
@@ -784,13 +787,14 @@ PtrCouplingScheme CouplingSchemeConfiguration::createMultiCouplingScheme(
   // Add convergence measures
   using std::get;
   for (auto &elem : _config.convMeasures) {
-    mesh::PtrData               data       = get<0>(elem);
-    bool                        suffices   = get<1>(elem);
-    std::string                 neededMesh = get<2>(elem);
-    impl::PtrConvergenceMeasure measure    = get<3>(elem);
+    mesh::PtrData               data        = get<0>(elem);
+    bool                        suffices    = get<1>(elem);
+    std::string                 neededMesh  = get<2>(elem);
+    impl::PtrConvergenceMeasure measure     = get<3>(elem);
+    bool                        doesLogging = get<4>(elem);
     _meshConfig->addNeededMesh(_config.controller, neededMesh);
     checkIfDataIsExchanged(data->getID());
-    scheme->addConvergenceMeasure(data, suffices, measure);
+    scheme->addConvergenceMeasure(data, suffices, measure, doesLogging);
   }
 
   // Set relaxation parameters

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -769,7 +769,7 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
                                               << "from=\"" << accessor << "\".");
 
   // Add convergence measures
-  PRECICE_CHECK(not _config.convMeasures.empty(),
+  PRECICE_CHECK(not _config.convergenceMeasureDefinitions.empty(),
                 "At least one convergence measure has to be defined for an implicit coupling scheme. "
                 "Please check your <coupling-scheme ... /> and make sure that you provide at least one <...-convergence-measure/> subtag in the precice-config.xml.");
   for (auto &elem : _config.convergenceMeasureDefinitions) {
@@ -816,7 +816,7 @@ PtrCouplingScheme CouplingSchemeConfiguration::createParallelImplicitCouplingSch
                                               << "from=\"" << accessor << "\".");
 
   // Add convergence measures
-  PRECICE_CHECK(not _config.convMeasures.empty(),
+  PRECICE_CHECK(not _config.convergenceMeasureDefinitions.empty(),
                 "At least one convergence measure has to be defined for an implicit coupling scheme. "
                 "Please check your <coupling-scheme ... /> and make sure that you provide at least one <...-convergence-measure/> subtag in the precice-config.xml.");
   for (auto &elem : _config.convergenceMeasureDefinitions) {
@@ -879,7 +879,7 @@ PtrCouplingScheme CouplingSchemeConfiguration::createMultiCouplingScheme(
                                               << "from=\"" << accessor << "\".");
 
   // Add convergence measures
-  PRECICE_CHECK(not _config.convMeasures.empty(),
+  PRECICE_CHECK(not _config.convergenceMeasureDefinitions.empty(),
                 "At least one convergence measure has to be defined for an implicit coupling scheme. "
                 "Please check your <coupling-scheme ... /> and make sure that you provide at least one <...-convergence-measure/> subtag in the precice-config.xml.");
   for (auto &elem : _config.convergenceMeasureDefinitions) {

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -132,10 +132,10 @@ private:
     /// Tuples of exchange data, mesh, and participant name.
     typedef std::tuple<mesh::PtrData, mesh::PtrMesh, std::string, std::string, bool> Exchange;
     std::vector<Exchange>                                                            exchanges;
-    /// Tuples of data ID, mesh ID, and convergence measure.
-    std::vector<std::tuple<mesh::PtrData, bool, std::string, impl::PtrConvergenceMeasure>> convMeasures;
-    int                                                                                    maxIterations      = -1;
-    int                                                                                    extrapolationOrder = 0;
+    /// Tuples of data, suffices, mesh name, convergence measure, and doesLogging.
+    std::vector<std::tuple<mesh::PtrData, bool, std::string, impl::PtrConvergenceMeasure, bool>> convMeasures;
+    int                                                                                          maxIterations      = -1;
+    int                                                                                          extrapolationOrder = 0;
 
   } _config;
 

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -118,6 +118,14 @@ private:
   const std::string VALUE_FIXED;
   const std::string VALUE_FIRST_PARTICIPANT;
 
+  struct ConvergenceMeasureDefintion {
+    mesh::PtrData               data;
+    bool                        suffices;
+    std::string                 meshName;
+    impl::PtrConvergenceMeasure measure;
+    bool                        doesLogging;
+  };
+
   struct Config {
     std::string                   type;
     std::string                   name;
@@ -132,11 +140,9 @@ private:
     /// Tuples of exchange data, mesh, and participant name.
     typedef std::tuple<mesh::PtrData, mesh::PtrMesh, std::string, std::string, bool> Exchange;
     std::vector<Exchange>                                                            exchanges;
-    /// Tuples of data, suffices, mesh name, convergence measure, and doesLogging.
-    std::vector<std::tuple<mesh::PtrData, bool, std::string, impl::PtrConvergenceMeasure, bool>> convMeasures;
-    int                                                                                          maxIterations      = -1;
-    int                                                                                          extrapolationOrder = 0;
-
+    std::vector<ConvergenceMeasureDefintion>                                         convergenceMeasureDefinitions;
+    int                                                                              maxIterations      = -1;
+    int                                                                              extrapolationOrder = 0;
   } _config;
 
   mesh::PtrMeshConfiguration _meshConfig;

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
@@ -46,10 +46,6 @@ public:
   {
     _normDiff      = utils::MasterSlave::l2norm(newValues - oldValues);
     _isConvergence = _normDiff <= _convergenceLimit;
-    //      PRECICE_INFO("Absolute convergence measure: "
-    //                     << "two-norm differences = " << normDiff
-    //                     << ", convergence limit = " << _convergenceLimit
-    //                     << ", convergence = " << _isConvergence );
   }
 
   virtual bool isConvergence() const

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
@@ -73,6 +73,11 @@ public:
     return _normDiff;
   }
 
+  virtual std::string getAbbreviation() const
+  {
+    return "Abs";
+  }
+
 private:
   logging::Logger _log{"cplscheme::AbsoluteConvergenceMeasure"};
 

--- a/src/cplscheme/impl/ConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ConvergenceMeasure.hpp
@@ -48,6 +48,12 @@ public:
   {
     return 0;
   }
+
+  /// Returns an abreviation of the name of the measure for the log file headers
+  virtual std::string getAbbreviation() const
+  {
+    return "";
+  }
 };
 } // namespace impl
 } // namespace cplscheme

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -69,11 +69,6 @@ public:
     _normDiff      = utils::MasterSlave::l2norm(newValues - oldValues);
     _norm          = utils::MasterSlave::l2norm(newValues);
     _isConvergence = _normDiff <= _norm * _convergenceLimitPercent;
-    //      PRECICE_INFO("Relative convergence measure: "
-    //                    << "two-norm differences = " << normDiff
-    //                    << ", convergence limit = "
-    //                    << normNew * _convergenceLimitPercent
-    //                    << ", convergence = " << _isConvergence );
   }
 
   virtual bool isConvergence() const
@@ -88,8 +83,9 @@ public:
   {
     std::ostringstream os;
     os << "relative convergence measure: ";
-    os << "two-norm diff = " << _normDiff;
-    os << ", relative limit = " << _norm * _convergenceLimitPercent;
+    os << "relative two-norm diff = " << getNormResidual();
+    os << ", limit = " << _convergenceLimitPercent;
+    os << ", normalization = " << _norm;
     os << ", conv = ";
     if (_isConvergence)
       os << "true";

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -102,6 +102,11 @@ public:
       return _normDiff / _norm;
   }
 
+  virtual std::string getAbbreviation() const
+  {
+    return "Rel";
+  }
+
 private:
   logging::Logger _log{"cplscheme::RelativeConvergenceMeasure"};
 

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
@@ -7,6 +7,7 @@
 #include "../CouplingData.hpp"
 #include "ConvergenceMeasure.hpp"
 #include "logging/Logger.hpp"
+#include "math/differences.hpp"
 #include "utils/MasterSlave.hpp"
 
 namespace precice {
@@ -54,11 +55,6 @@ public:
       _isFirstIteration  = false;
     }
     _isConvergence = _normDiff < _normFirstResidual * _convergenceLimitPercent;
-    //      PRECICE_INFO("Residual Relative convergence measure: "
-    //                    << "two-norm differences = " << normDiff
-    //                    << ", convergence limit = "
-    //                    << _normFirstResidual * _convergenceLimitPercent
-    //                    << ", convergence = " << _isConvergence );
   }
 
   virtual bool isConvergence() const
@@ -71,14 +67,23 @@ public:
   {
     std::ostringstream os;
     os << "residual relative convergence measure: ";
-    os << "two-norm diff = " << _normDiff;
-    os << ", relative limit = " << _normFirstResidual * _convergenceLimitPercent;
+    os << "relative two-norm diff = " << getNormResidual();
+    os << ", limit = " << _convergenceLimitPercent;
+    os << ", normalization = " << _normFirstResidual;
     os << ", conv = ";
     if (_isConvergence)
       os << "true";
     else
       os << "false";
     return os.str();
+  }
+
+  virtual double getNormResidual()
+  {
+    if (math::equals(_normFirstResidual, 0.))
+      return std::numeric_limits<double>::infinity();
+    else
+      return _normDiff / _normFirstResidual;
   }
 
 private:

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
@@ -86,6 +86,11 @@ public:
       return _normDiff / _normFirstResidual;
   }
 
+  virtual std::string getAbbreviation() const
+  {
+    return "Drop";
+  }
+
 private:
   logging::Logger _log{"cplscheme::ResidualRelativeConvergenceMeasure"};
 

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -323,8 +323,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure2(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1);
-  cplScheme.addConvergenceMeasure(mesh->data()[0], false, minIterationConvMeasure2);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1, true);
+  cplScheme.addConvergenceMeasure(mesh->data()[0], false, minIterationConvMeasure2, true);
 
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());

--- a/src/cplscheme/tests/ResidualRelativeConvergenceMeasureTest.cpp
+++ b/src/cplscheme/tests/ResidualRelativeConvergenceMeasureTest.cpp
@@ -1,0 +1,32 @@
+#include <Eigen/Core>
+#include "../impl/ResidualRelativeConvergenceMeasure.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(CplSchemeTests)
+
+BOOST_AUTO_TEST_CASE(ResidualRelativeConvergenceMeasureTest)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector3d;
+  double                                                       convergenceLimit = 0.1; // 10%
+  precice::cplscheme::impl::ResidualRelativeConvergenceMeasure measure(convergenceLimit);
+
+  // Create data sets for old state of data and new state of data
+  Vector3d oldValues0(2.9, 2.9, 2.9);
+  Vector3d oldValues1(2.95, 2.95, 2.95);
+  Vector3d oldValues2(2.991, 2.991, 2.991);
+  Vector3d newValues(3, 3, 3);
+
+  // define initial residual, which we want to decrease in the following
+  measure.measure(oldValues0, newValues);
+  BOOST_TEST(not measure.isConvergence());
+
+  measure.measure(oldValues1, newValues);
+  BOOST_TEST(not measure.isConvergence());
+
+  measure.measure(oldValues2, newValues);
+  BOOST_TEST(measure.isConvergence());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -564,7 +564,7 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
   double                                 convergenceLimit1 = sqrt(3.0); // when diff_vector = (1.0, 1.0, 1.0)
   cplscheme::impl::PtrConvergenceMeasure absoluteConvMeasure1(
       new cplscheme::impl::AbsoluteConvergenceMeasure(convergenceLimit1));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, absoluteConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, absoluteConvMeasure1, true);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {5, 5, 5};
@@ -662,7 +662,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
   int                                    minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1, true);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {3, 3, 3};
@@ -723,7 +723,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
   int                                    minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1, true);
   runCouplingWithSubcycling(
       cplScheme, context.name, meshConfig, validIterations);
 }
@@ -783,7 +783,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   int                                    minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1);
+  cplScheme.addConvergenceMeasure(mesh->data()[1], false, minIterationConvMeasure1, true);
 
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -32,7 +32,6 @@ void TXTTableWriter::addData(
   Data data;
   data.name = name;
   data.type = type;
-  PRECICE_ASSERT(not utils::contained(data, _data), data.name, data.type);
   _data.push_back(data);
   if ((type == INT) || (type == DOUBLE)) {
     _outputStream << name << "  ";

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -25,6 +25,7 @@ target_sources(testprecice
     src/cplscheme/tests/MinIterationConvergenceMeasureTest.cpp
     src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
     src/cplscheme/tests/RelativeConvergenceMeasureTest.cpp
+    src/cplscheme/tests/ResidualRelativeConvergenceMeasureTest.cpp
     src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
     src/io/tests/ExportConfigurationTest.cpp
     src/io/tests/ExportVTKTest.cpp


### PR DESCRIPTION
In was about time to clean up our convergence measure logging as more and more unsatisfactory compromises piled up. 

This PR ...

1. increases readability of relative convergence measure INFO logs

before:
```
relative convergence measure: two-norm diff = 2.6036e-08, relative limit = 1.0005e-08, conv = true
```
Problems: the relative limit changes in every iteration and the (absolute) two-norm diff does not match the entry in the convergence file. Pointed out by @ajaust.   

after:
```
relative convergence measure: relative two-norm diff = 2.6023e-05, limit = 1e-05, normalization = 0.00100051, conv = false
```

2. adds a unit test for `ResidualRelativeConvergenceMeasure`
3. remove the unnecessary assertion in TXTTableWriter (closes #786)
4. instead, extends the title headers of the convergence file by convergence measure abbreviations

Now, we have for example ...
```
TimeWindow  Iteration  ResRel(Pressure)  ResAbs(CrossSectionLength)  ResDrop(CrossSectionLength)  
1  1  1.0000000000000000  0.0000015151688798  1.0000000000000000  
1  2  0.0092426077637776  0.0000014861770983  0.9808656435350955  
1  3  0.8894974714023499  0.0000000036011503  0.0023767319918400  
1  4  0.0013652823318746  0.0000000000147103  0.0000097086996980  
1  5  0.0000009272349971  0.0000000000000499  0.0000000329390337
```

... for ... 
```xml
      <relative-convergence-measure data="Pressure" mesh="Fluid_Nodes" limit="1e-5"/>
      <absolute-convergence-measure data="CrossSectionLength" mesh="Structure_Nodes" limit="1e-5"/>
      <residual-relative-convergence-measure data="CrossSectionLength" mesh="Structure_Nodes" limit="1e-3"/>  
```

 <min-iteration-convergence-measure data="CrossSectionLength" mesh="Structure_Nodes" min-iterations="2"/>

5. suppresses convergence file logging for min-iterations convergence measures as it really makes no sense here

6. removes logging of average convergence rates in the iterations file. In my opinion, they had no practical use case at all. I don't think that any user ever looked at them and we, ourselves, did never use them in any publication.  

7. instead, extends the iterations file logging by the total and the dropped number of QN columns. In my opinion, this is very helpful information to better understand how well the QN coupling works. 

```
TimeWindow  TotalIterations  Iterations  Convergence  QNColumns  DeletedQNColumns  DroppedQNColumns  
1  5  5  1  4  0  0  
2  9  4  1  6  1  0  
3  12  3  1  7  1  0  
4  15  3  1  9  0  0  
5  18  3  1  10  1  0  
6  21  3  1  11  1  0  
7  24  3  1  12  1  0  
8  27  3  1  13  1  0  
9  30  3  1  13  2  0  
10  33  3  1  14  1  0  
11  36  3  1  15  1  0  
12  39  3  1  15  1  1  
13  42  3  1  15  1  1  
```

Deleted columns are columns that are filtered out. Dropped columns are columns that went out of scope (due to `max-used-iterations value` or `time-windows-reused value`. 5 iterations means 4 new columns (columns are diffs between iterations).


# Reviewers:

* @fsimonis Please check code quality
* @MakisH Please check usability with any tutorial