### PR TITLE
Fix parsing locale

### DIFF
--- a/docs/changelog/805.md
+++ b/docs/changelog/805.md
@@ -1,0 +1,1 @@
+* Fix silent truncation of numeric values in the config with C locales using decimal comma. The parser now always uses the locale `en_US.UTF-8`.

--- a/src/xml/ValueParser.cpp
+++ b/src/xml/ValueParser.cpp
@@ -1,11 +1,51 @@
-#include "xml/ValueParser.hpp"
 #include <boost/algorithm/string/constants.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <ostream>
+#include <sstream>
+#include <stdexcept>
 #include <vector>
+#include "xml/ValueParser.hpp"
 
 namespace precice {
 namespace xml {
+
+namespace {
+constexpr static const char *PARSING_LOCALE = "en_US.UTF-8";
+
+double parseDouble(const std::string &rawValue)
+{
+  std::istringstream iss{rawValue};
+  iss.imbue(std::locale(PARSING_LOCALE));
+  double value;
+  iss >> value;
+  if (!iss.eof()) {
+    throw std::runtime_error{"Could not fully parse value \"" + rawValue + "\" as a double."};
+  }
+  return value;
+}
+} // namespace
+
+void readValueSpecific(const std::string &rawValue, double &value)
+{
+  if (rawValue.find('/') != std::string::npos) {
+    std::string left  = rawValue.substr(0, rawValue.find('/'));
+    std::string right = rawValue.substr(rawValue.find('/') + 1, rawValue.size() - rawValue.find('/') - 1);
+
+    value = parseDouble(left) / parseDouble(right);
+  } else {
+    value = parseDouble(rawValue);
+  }
+}
+
+void readValueSpecific(const std::string &rawValue, int &value)
+{
+  std::istringstream iss{rawValue};
+  iss.imbue(std::locale(PARSING_LOCALE));
+  iss >> value;
+  if (!iss.eof()) {
+    throw std::runtime_error{"Could not fully parse value \"" + rawValue + "\" as an int."};
+  }
+}
 
 void readValueSpecific(const std::string &rawValue, Eigen::VectorXd &value)
 {
@@ -13,13 +53,13 @@ void readValueSpecific(const std::string &rawValue, Eigen::VectorXd &value)
   boost::split(
       components, rawValue, [](char c) { return c == ';'; }, boost::algorithm::token_compress_on);
   const int size = components.size();
-  PRECICE_CHECK(size == 2 || size == 3, "The value \"" << rawValue << "\" is not a 2D or 3D vector.");
+  if (size < 2 || size > 3) {
+    throw std::runtime_error{"The value \"" + rawValue + "\" is not a 2D or 3D vector."};
+  }
 
   Eigen::VectorXd vec(size);
   for (int i = 0; i != size; ++i) {
-    double component{0};
-    readValueSpecific(components[i], component);
-    vec(i) = component;
+    vec(i) = parseDouble(components[i]);
   }
   value = vec;
 }

--- a/src/xml/ValueParser.hpp
+++ b/src/xml/ValueParser.hpp
@@ -2,39 +2,14 @@
 
 #include <Eigen/Core>
 #include <string>
-#include "logging/LogMacros.hpp"
-#include "logging/Logger.hpp"
 #include "utils/String.hpp"
 
 namespace precice {
 namespace xml {
 
-static logging::Logger _log{"xml::ValueParser"};
+void readValueSpecific(const std::string &rawValue, double &value);
 
-inline void readValueSpecific(const std::string &rawValue, double &value)
-{
-  try {
-    if (rawValue.find('/') != std::string::npos) {
-      std::string left  = rawValue.substr(0, rawValue.find('/'));
-      std::string right = rawValue.substr(rawValue.find('/') + 1, rawValue.size() - rawValue.find('/') - 1);
-
-      value = std::stod(left) / std::stod(right);
-    } else {
-      value = std::stod(rawValue);
-    }
-  } catch (...) {
-    PRECICE_ERROR("String to Double error");
-  }
-}
-
-inline void readValueSpecific(const std::string &rawValue, int &value)
-{
-  try {
-    value = std::stoi(rawValue);
-  } catch (...) {
-    PRECICE_ERROR("String to Int error");
-  }
-}
+void readValueSpecific(const std::string &rawValue, int &value);
 
 inline void readValueSpecific(const std::string &rawValue, std::string &value)
 {

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <exception>
 #include <initializer_list>
 #include <map>
 #include <sstream>
@@ -165,7 +166,12 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(const std::map<std::string, std::strin
     }
     set(_value, _defaultValue);
   } else {
-    readValueSpecific(position->second, _value);
+    try {
+      readValueSpecific(position->second, _value);
+    }
+    catch(const std::exception& e) {
+      PRECICE_ERROR(e.what());
+    }
     if (_hasValidation) {
       if (std::find(_options.begin(), _options.end(), _value) == _options.end()) {
         std::ostringstream stream;


### PR DESCRIPTION
**List the core changes of this PR**

This PR fixes the locale for parsing `int` and `double` in the configuration to `en_US.UTF-8`.
The new parsing methods also check that parsing step fully consumes the value, which prevents silent truncation.

**Motivation**

On some systems, the default locale can result in a different decimal separator.
This quietly truncates decimal values in the configuration.

**Additional Information**

Closes #676
