### PR TITLE
Errors 1.9 - Technical Config

### DIFF
--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -63,7 +63,7 @@ void DataConfiguration::xmlTagCallback(
     int         dataDimensions = getDataDimensions(typeName);
     addData(name, dataDimensions);
   } else {
-    PRECICE_ERROR("Received callback from tag " << tag.getName());
+    PRECICE_ASSERT(false, "Received callback from unknown tag " << tag.getName());
   }
 }
 

--- a/src/precice/config/SolverInterfaceConfiguration.cpp
+++ b/src/precice/config/SolverInterfaceConfiguration.cpp
@@ -57,7 +57,7 @@ void SolverInterfaceConfiguration::xmlTagCallback(
     _meshConfiguration->setDimensions(_dimensions);
     _participantConfiguration->setDimensions(_dimensions);
   } else {
-    PRECICE_ERROR("Received callback from tag " << tag.getName());
+    PRECICE_ASSERT(false, "Received callback from unknown tag " << tag.getName());
   }
 }
 

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -1,5 +1,6 @@
 #include "ConfigParser.hpp"
 #include <algorithm>
+#include <exception>
 #include <fstream>
 #include <iterator>
 #include <libxml/SAX.h>
@@ -91,8 +92,8 @@ ConfigParser::ConfigParser(const std::string &filePath, const ConfigurationConte
 
   try {
     connectTags(context, DefTags, SubTags);
-  } catch (const std::string &error) {
-    PRECICE_ERROR(error);
+  } catch (const std::exception &e) {
+    PRECICE_ERROR("And unexpected exception occurred during configuration: " << e.what() << '.');
   }
 }
 
@@ -157,7 +158,7 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
         });
 
     if (tagPosition == DefTags.end()) {
-      PRECICE_ERROR("Tag <" + expectedName + "> is unknown");
+      PRECICE_ERROR("The configuration contains an unknown tag <" + expectedName + ">.");
     }
 
     auto pDefSubTag = *tagPosition;
@@ -165,7 +166,7 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 
     if ((pDefSubTag->_occurrence == XMLTag::OCCUR_ONCE) || (pDefSubTag->_occurrence == XMLTag::OCCUR_NOT_OR_ONCE)) {
       if (usedTags.count(pDefSubTag->_fullName)) {
-        PRECICE_ERROR("Tag <" + pDefSubTag->_fullName + "> is already used");
+        PRECICE_ERROR("Tag <" + pDefSubTag->_fullName + "> is not allowed to occur multiple times.");
       }
       usedTags.emplace(pDefSubTag->_fullName);
     }

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -93,7 +93,7 @@ ConfigParser::ConfigParser(const std::string &filePath, const ConfigurationConte
   try {
     connectTags(context, DefTags, SubTags);
   } catch (const std::exception &e) {
-    PRECICE_ERROR("And unexpected exception occurred during configuration: " << e.what() << '.');
+    PRECICE_ERROR("An unexpected exception occurred during configuration: " << e.what() << '.');
   }
 }
 

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -8,8 +8,8 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
 #include "logging/Logger.hpp"
+#include "utils/assertion.hpp"
 #include "xml/ValueParser.hpp"
 
 namespace precice {
@@ -154,9 +154,7 @@ template <typename ATTRIBUTE_T>
 void XMLAttribute<ATTRIBUTE_T>::readValue(const std::map<std::string, std::string> &aAttributes)
 {
   PRECICE_TRACE(_name);
-  if (_read) {
-    PRECICE_ERROR("Attribute \"" + _name + "\" has already been defined. Duplications are not permitted.");
-  }
+  PRECICE_ASSERT(!_read, "Attribute \"" + _name + "\" has already been read.");
 
   const auto position = aAttributes.find(getName());
   if (position == aAttributes.end()) {

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -155,13 +155,13 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(const std::map<std::string, std::strin
 {
   PRECICE_TRACE(_name);
   if (_read) {
-    PRECICE_ERROR("Attribute \"" + _name + "\" is defined multiple times");
+    PRECICE_ERROR("Attribute \"" + _name + "\" has already been defined. Duplications are not permitted.");
   }
 
   const auto position = aAttributes.find(getName());
   if (position == aAttributes.end()) {
     if (not _hasDefaultValue) {
-      PRECICE_ERROR("Attribute \"" + _name + "\" missing");
+      PRECICE_ERROR("Attribute \"" + _name + "\" is required, but was not defined.");
     }
     set(_value, _defaultValue);
   } else {

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -155,7 +155,6 @@ Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name, 
   return result;
 }
 
-// new readattributes fx
 void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttributes)
 {
   PRECICE_TRACE();
@@ -164,7 +163,7 @@ void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttribute
     auto name = element.first;
 
     if (not utils::contained(name, _attributes)) {
-      PRECICE_ERROR("Wrong attribute \"" << name << '\"');
+      PRECICE_ERROR("Tag <" << _name << "> contains an unknown attribute named \"" << name << "\".");
     }
   }
 
@@ -284,9 +283,9 @@ void XMLTag::areAllSubtagsConfigured() const
     if ((not configured) && (occurOnce || occurOnceOrMore)) {
 
       if (tag->getNamespace().empty()) {
-        PRECICE_ERROR("Tag <" << tag->getName() << "> is missing");
+        PRECICE_ERROR("Tag <" << tag->getName() << "> was not found but is required to occur at least once.");
       } else {
-        PRECICE_ERROR("Tag <" << tag->getNamespace() << ":...> is missing");
+        PRECICE_ERROR("Tag <" << tag->getNamespace() << ":... > was not found but is required to occur at least once.");
       }
     }
   }

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -143,7 +143,7 @@ Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name, 
   const auto size = iter->second.getValue().size();
   PRECICE_CHECK(size == dimensions,
                 "Vector attribute \"" << name << "\" of tag <" << getFullName() << "> is "
-                                      << size << "D, which does not match the dimension of the " << dimensions << "D SolverInterface.");
+                                      << size << "D, which does not match the dimension of the " << dimensions << "D solver-interface.");
 
   // Read only first "dimensions" components of the parsed vector values
   Eigen::VectorXd        result(dimensions);

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -1,4 +1,3 @@
-#include "xml/XMLTag.hpp"
 #include <Eigen/Core>
 #include <ostream>
 #include <utility>
@@ -6,6 +5,7 @@
 #include "utils/Helpers.hpp"
 #include "utils/assertion.hpp"
 #include "xml/ConfigParser.hpp"
+#include "xml/XMLTag.hpp"
 
 namespace precice {
 namespace xml {
@@ -140,10 +140,10 @@ Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name, 
   // std::map<std::string, XMLAttribute<utils::DynVector> >::const_iterator iter;
   auto iter = _eigenVectorXdAttributes.find(name);
   PRECICE_ASSERT(iter != _eigenVectorXdAttributes.end());
-  PRECICE_CHECK(iter->second.getValue().size() >= dimensions,
-                "Vector attribute \"" << name << "\" of tag <" << getFullName()
-                                      << "> has less dimensions than required (" << iter->second.getValue().size()
-                                      << " instead of " << dimensions << ")!");
+  const auto size = iter->second.getValue().size();
+  PRECICE_CHECK(size == dimensions,
+                "Vector attribute \"" << name << "\" of tag <" << getFullName() << "> is "
+                                      << size << "D, which does not match the dimension of the " << dimensions << "D SolverInterface.");
 
   // Read only first "dimensions" components of the parsed vector values
   Eigen::VectorXd        result(dimensions);


### PR DESCRIPTION
**List the core changes of this PR**

* Rewords the error messages related to XML parser, tags and attributes.
* Coordinates in attributes are now required to match the dimensions of the SolverInterface. Previous behaviour was to truncate the last component if the coordinate had more dimensions than required.

**Additional Information**

Related to #698
