### PR TITLE
C bindings: Add missing getMeshIDs

### DIFF
--- a/docs/changelog/813.md
+++ b/docs/changelog/813.md
@@ -1,0 +1,1 @@
+* Port the API method `getMeshIDs` to the C bindings as `precicec_getMeshIDs`.

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -164,6 +164,13 @@ int precicec_hasMesh(const char *meshName);
 int precicec_getMeshID(const char *meshName);
 
 /**
+ * @brief Returns the ids of all used meshes by this participant.
+ *
+ * @param[out] ids the mesh ids
+ */
+void precicec_getMeshIDs(int *ids);
+
+/**
  * @brief Creates a mesh vertex
  *
  * @param[in] meshID the id of the mesh to add the vertex to.

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -166,6 +166,14 @@ int precicec_getMeshID(const char *meshName)
   return impl->getMeshID(stringMeshName);
 }
 
+void precicec_getMeshIDs(int *ids)
+{
+  size_t i = 0;
+  for (auto const &id : impl->getMeshIDs()) {
+    ids[i++] = id;
+  }
+}
+
 int precicec_hasData(const char *dataName, int meshID)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);


### PR DESCRIPTION
This ports the C++ API method `getMeshIDs` to the C bindings.

The original returns an `std::set`:
https://github.com/precice/precice/blob/493f85ab723fe35d1ad4a484f9cd6d7e08266fd0/src/precice/SolverInterface.hpp#L340-L345

The C bindings return an int pointer as an argument, similar to the style we are using e.g. for `getMeshVertices`. Some serialization is also needed:
```c++
void precicec_getMeshIDs(int *ids)
{
  size_t i = 0;
  for (auto const &id : impl->getMeshIDs()) {
    ids[i++] = id;
  }
}
```

You can check this e.g. by adding the following to the C solverdummy:
```c
int *   meshIDs  = malloc(3 * sizeof(double));

precicec_getMeshIDs(meshIDs);
for (int i = 0; i < 3; i++) {
  printf("### MESH ID: %d \n", meshIDs[i]);
}
```
I am still not really sure about a use case here, especially since in C we would need to somehow know the number of meshes beforehand.

@fsimonis please comment on these snippets and especially the conversion from `std::set` to `int*`.
@uekerman do we actually want to integrate this?

Related to #520.