### PR TITLE
Errors - section 5, pt2: Origin or reason unknown

### DIFF
--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -59,7 +59,7 @@ void BiCouplingScheme::addDataToSend(
     DataMap::value_type pair = std::make_pair(id, ptrCplData);
     _sendData.insert(pair);
   } else {
-    PRECICE_ERROR("Data \"" << data->getName() << "\" cannot be added twice for sending.");
+    PRECICE_ERROR("Data \"" << data->getName() << "\" cannot be added twice for sending. Please remove any duplicate <exchange data=\"" << data->getName() << "\" .../> tags");
   }
 }
 
@@ -75,7 +75,7 @@ void BiCouplingScheme::addDataToReceive(
     DataMap::value_type pair = std::make_pair(id, ptrCplData);
     _receiveData.insert(pair);
   } else {
-    PRECICE_ERROR("Data \"" << data->getName() << "\" cannot be added twice for receiving.");
+    PRECICE_ERROR("Data \"" << data->getName() << "\" cannot be added twice for receiving. Please remove any duplicate <exchange data=\"" << data->getName() << "\" ... /> tags");
   }
 }
 

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -715,7 +715,7 @@ mesh::PtrData CouplingSchemeConfiguration::getData(
     }
   }
   PRECICE_ERROR("Data \"" << dataName << "\" used by mesh \""
-                          << meshName << "\" is not configured!");
+                          << meshName << "\" is not configured.");
 }
 
 PtrCouplingScheme CouplingSchemeConfiguration::createSerialExplicitCouplingScheme(


### PR DESCRIPTION
This touches the last errors of section 5 that were not covered by #727:

* [x]  Name of local participant "MyParticipant" does not match any participant specified for the coupling scheme! --> Nothing to do (already ends with `.` instead of `!`).
* [x]  Data "MyData" used by mesh "MyMesh" is not configured! --> Replace `!` with `.`
* [x]  Data "MyData" of mesh "MyMesh" cannot be added twice for sending! --> Add suggestion.
* [x]  Data "MyData" of mesh "MyMesh" cannot be added twice for receiving! --> Add suggestion

Related to #698.