### PR TITLE
Use renamed functions in Fortran solverdummy

### DIFF
--- a/examples/solverdummies/fortran/solverdummy.f90
+++ b/examples/solverdummies/fortran/solverdummy.f90
@@ -34,25 +34,25 @@ PROGRAM main
         
   CALL precicef_initialize(dtlimit)            
 
-  CALL precicef_action_required(writeInitialData, bool)
+  CALL precicef_is_action_required(writeInitialData, bool)
   IF (bool.EQ.1) THEN
     WRITE (*,*) 'DUMMY: Writing initial data'
   ENDIF
   CALL precicef_initialize_data()
 
-  CALL precicef_ongoing(ongoing)
+  CALL precicef_is_coupling_ongoing(ongoing)
   DO WHILE (ongoing.NE.0)
   
-    CALL precicef_action_required(writeItCheckp, bool)
+    CALL precicef_is_action_required(writeItCheckp, bool)
     IF (bool.EQ.1) THEN
       WRITE (*,*) 'DUMMY: Writing iteration checkpoint'
       CALL precicef_mark_action_fulfilled(writeItCheckp)
     ENDIF
 
     CALL precicef_advance(dtlimit)
-    CALL precicef_ongoing(ongoing)
+    CALL precicef_is_coupling_ongoing(ongoing)
 
-    CALL precicef_action_required(readItCheckp, bool)
+    CALL precicef_is_action_required(readItCheckp, bool)
     IF (bool.EQ.1) THEN
       WRITE (*,*) 'DUMMY: Reading iteration checkpoint'
       CALL precicef_mark_action_fulfilled(readItCheckp)


### PR DESCRIPTION
#815 renamed a few functions in the Fortran bindings. This PR also uses the new names in the Fortran solverdummy (missing in the previous PR).