### PR TITLE
Allow multiple mappings to and from the same mesh

### DIFF
--- a/docs/changelog/849.md
+++ b/docs/changelog/849.md
@@ -1,0 +1,1 @@
+- Extended configuration and repartitioning to allow the user to define multiple mappings from and/or to the same mesh.

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -393,9 +393,9 @@ void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
   for (const ConfiguredMapping &configuredMapping : _mappings) {
     bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
     bool sameToMesh   = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
-    PRECICE_CHECK(!sameFromMesh, "There cannot be two mappings from mesh \""
-                                     << mapping.fromMesh->getName() << "\". "
-                                     << "Please remove any duplicate mapping definitions with from=\"" << mapping.fromMesh->getName() << "\" or use a different mesh.");
+    // PRECICE_CHECK(!sameFromMesh, "There cannot be two mappings from mesh \""
+    //                                  << mapping.fromMesh->getName() << "\". "
+    //                                  << "Please remove any duplicate mapping definitions with from=\"" << mapping.fromMesh->getName() << "\" or use a different mesh.");
     PRECICE_CHECK(!sameToMesh, "There cannot be two mappings to mesh \""
                                    << mapping.toMesh->getName() << "\". "
                                    << "Please remove any duplicate mapping definitions with to=\"" << mapping.toMesh->getName() << "\" or use a different mesh.");

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -392,21 +392,13 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
 void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
 {
   for (const ConfiguredMapping &configuredMapping : _mappings) {
-    bool sameToMesh = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
-
-    if (sameToMesh) {
-      for (const mesh::PtrData data : mapping.fromMesh->data()) {
-        for (const mesh::PtrData configuredData : configuredMapping.fromMesh->data()) {
-          bool sameToData = data->getName() == configuredData->getName();
-          PRECICE_CHECK(!sameToData, "There cannot be two mappings to mesh \""
-                                         << mapping.toMesh->getName() << "\" "
-                                         << "if the meshes from which is mapped contain duplicated data fields. "
-                                         << "Here, both from meshes contain data \"" << data->getName() << "\". "
-                                         << "The mapping is not well defined. Which data \"" << data->getName() << "\" "
-                                         << "should be mapped to mesh \"" << mapping.toMesh->getName() << "\"?");
-        }
-      }
-    }
+    bool sameToMesh   = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
+    bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
+    bool sameMapping  = sameToMesh && sameFromMesh;
+    PRECICE_CHECK(!sameMapping, "There cannot be two mappings from mesh \""
+                                    << mapping.fromMesh->getName() << "\" to mesh \""
+                                    << mapping.toMesh->getName() << "\". "
+                                    << "Please remove one of the duplicated meshes. ");
   }
 }
 

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -14,6 +14,7 @@
 #include "mapping/RadialBasisFctMapping.hpp"
 #include "mapping/impl/BasisFunctions.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/Petsc.hpp"
@@ -391,14 +392,21 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
 void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
 {
   for (const ConfiguredMapping &configuredMapping : _mappings) {
-    bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
-    bool sameToMesh   = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
-    // PRECICE_CHECK(!sameFromMesh, "There cannot be two mappings from mesh \""
-    //                                  << mapping.fromMesh->getName() << "\". "
-    //                                  << "Please remove any duplicate mapping definitions with from=\"" << mapping.fromMesh->getName() << "\" or use a different mesh.");
-    // PRECICE_CHECK(!sameToMesh, "There cannot be two mappings to mesh \""
-    //                                << mapping.toMesh->getName() << "\". "
-    //                                << "Please remove any duplicate mapping definitions with to=\"" << mapping.toMesh->getName() << "\" or use a different mesh.");
+    bool sameToMesh = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
+
+    if (sameToMesh) {
+      for (const mesh::PtrData data : mapping.fromMesh->data()) {
+        for (const mesh::PtrData configuredData : configuredMapping.fromMesh->data()) {
+          bool sameToData = data->getName() == configuredData->getName();
+          PRECICE_CHECK(!sameToData, "There cannot be two mappings to mesh \""
+                                         << mapping.toMesh->getName() << "\" "
+                                         << "if the meshes from which is mapped contain duplicated data fields. "
+                                         << "Here, both from meshes contain data \"" << data->getName() << "\". "
+                                         << "The mapping is not well defined. Which data \"" << data->getName() << "\" "
+                                         << "should be mapped to mesh \"" << mapping.toMesh->getName() << "\"?");
+        }
+      }
+    }
   }
 }
 

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -396,9 +396,9 @@ void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
     // PRECICE_CHECK(!sameFromMesh, "There cannot be two mappings from mesh \""
     //                                  << mapping.fromMesh->getName() << "\". "
     //                                  << "Please remove any duplicate mapping definitions with from=\"" << mapping.fromMesh->getName() << "\" or use a different mesh.");
-    PRECICE_CHECK(!sameToMesh, "There cannot be two mappings to mesh \""
-                                   << mapping.toMesh->getName() << "\". "
-                                   << "Please remove any duplicate mapping definitions with to=\"" << mapping.toMesh->getName() << "\" or use a different mesh.");
+    // PRECICE_CHECK(!sameToMesh, "There cannot be two mappings to mesh \""
+    //                                << mapping.toMesh->getName() << "\". "
+    //                                << "Please remove any duplicate mapping definitions with to=\"" << mapping.toMesh->getName() << "\" or use a different mesh.");
   }
 }
 

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -157,7 +157,7 @@ private:
       Polynomial                       polynomial,
       Preallocation                    preallocation) const;
 
-  /// Check whether a mapping to the same mesh and with similar data fields already exists
+  /// Check whether a mapping to and from the same mesh already exists
   void checkDuplicates(const ConfiguredMapping &mapping);
 
   Timing getTiming(const std::string &timing) const;

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -157,6 +157,7 @@ private:
       Polynomial                       polynomial,
       Preallocation                    preallocation) const;
 
+  /// Check whether a mapping to the same mesh and with similar data fields already exists
   void checkDuplicates(const ConfiguredMapping &mapping);
 
   Timing getTiming(const std::string &timing) const;

--- a/src/partition/Partition.hpp
+++ b/src/partition/Partition.hpp
@@ -45,14 +45,14 @@ public:
   /// The partition is computed, i.e. the mesh re-partitioned if required and all data structures are set up.
   virtual void compute() = 0;
 
-  void setFromMapping(mapping::PtrMapping fromMapping)
+  void addFromMapping(mapping::PtrMapping fromMapping)
   {
-    _fromMapping = fromMapping;
+    _fromMappings.push_back(fromMapping);
   }
 
-  void setToMapping(mapping::PtrMapping toMapping)
+  void addToMapping(mapping::PtrMapping toMapping)
   {
-    _toMapping = toMapping;
+    _toMappings.push_back(toMapping);
   }
 
   void addM2N(m2n::PtrM2N m2n)
@@ -63,9 +63,9 @@ public:
 protected:
   mesh::PtrMesh _mesh;
 
-  mapping::PtrMapping _fromMapping;
+  std::vector<mapping::PtrMapping> _fromMappings;
 
-  mapping::PtrMapping _toMapping;
+  std::vector<mapping::PtrMapping> _toMappings;
 
   /// m2n connection to each connected participant
   std::vector<m2n::PtrM2N> _m2ns;

--- a/src/partition/Partition.hpp
+++ b/src/partition/Partition.hpp
@@ -47,7 +47,7 @@ public:
 
   void addFromMapping(mapping::PtrMapping fromMapping)
   {
-    _fromMappings.push_back(fromMapping);
+    _fromMappings.push_back(std::move(fromMapping));
   }
 
   void addToMapping(mapping::PtrMapping toMapping)

--- a/src/partition/Partition.hpp
+++ b/src/partition/Partition.hpp
@@ -52,7 +52,7 @@ public:
 
   void addToMapping(mapping::PtrMapping toMapping)
   {
-    _toMappings.push_back(toMapping);
+    _toMappings.push_back(std::move(toMapping));
   }
 
   void addM2N(m2n::PtrM2N m2n)

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -104,7 +104,7 @@ void ReceivedPartition::compute()
 
   // check to prevent false configuration
   if (not utils::MasterSlave::isSlave()) {
-    PRECICE_CHECK(_fromMapping || _toMapping,
+    PRECICE_CHECK(not(_fromMappings.empty() && _toMappings.empty()),
                   "The received mesh " << _mesh->getName()
                                        << " needs a mapping, either from it, to it, or both. Maybe you don't want to receive this mesh at all?")
   }
@@ -119,10 +119,12 @@ void ReceivedPartition::compute()
   PRECICE_DEBUG("Tag vertices for filtering: 1st round.");
   _mesh->computeState(); // normals need to be ready for NP mapping
   // go to both meshes, vertex is tagged if already one mesh tags him
-  if (_fromMapping)
-    _fromMapping->tagMeshFirstRound();
-  if (_toMapping)
-    _toMapping->tagMeshFirstRound();
+  for (mapping::PtrMapping fromMapping : _fromMappings) {
+    fromMapping->tagMeshFirstRound();
+  }
+  for (mapping::PtrMapping toMapping : _toMappings) {
+    toMapping->tagMeshFirstRound();
+  }
 
   // (3) Define which vertices are owned by this rank
   PRECICE_DEBUG("Create owner information.");
@@ -130,10 +132,12 @@ void ReceivedPartition::compute()
 
   // (4) Tag vertices 2nd round (what should be filtered out)
   PRECICE_DEBUG("Tag vertices for filtering: 2nd round.");
-  if (_fromMapping)
-    _fromMapping->tagMeshSecondRound();
-  if (_toMapping)
-    _toMapping->tagMeshSecondRound();
+  for (mapping::PtrMapping fromMapping : _fromMappings) {
+    fromMapping->tagMeshSecondRound();
+  }
+  for (mapping::PtrMapping toMapping : _toMappings) {
+    toMapping->tagMeshSecondRound();
+  }
 
   // (5) Filter mesh according to tag
   PRECICE_INFO("Filter mesh " << _mesh->getName() << " by mappings");
@@ -281,7 +285,7 @@ void ReceivedPartition::filterByBoundingBox()
       PRECICE_DEBUG("Receive filtered mesh");
       com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(*_mesh, 0);
 
-      if (areProvidedMeshesEmpty()) {
+      if (isAnyProvidedMeshNonEmpty()) {
         PRECICE_CHECK(not _mesh->vertices().empty(), errorMeshFilteredOut(_mesh->getName()));
       }
 
@@ -310,7 +314,7 @@ void ReceivedPartition::filterByBoundingBox()
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
 
-      if (areProvidedMeshesEmpty()) {
+      if (isAnyProvidedMeshNonEmpty()) {
         PRECICE_CHECK(not _mesh->vertices().empty(), errorMeshFilteredOut(_mesh->getName()));
       }
     }
@@ -334,7 +338,7 @@ void ReceivedPartition::filterByBoundingBox()
       mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
       mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return _bb.contains(v); });
 
-      if (areProvidedMeshesEmpty()) {
+      if (isAnyProvidedMeshNonEmpty()) {
         PRECICE_CHECK(not _mesh->vertices().empty(), errorMeshFilteredOut(_mesh->getName()));
       }
 
@@ -450,15 +454,15 @@ void ReceivedPartition::prepareBoundingBox()
 
   PRECICE_DEBUG("Merge bounding boxes and increase by safety factor");
 
-  // Create BB around both "other" meshes
-  if (_fromMapping) {
-    auto other_bb = _fromMapping->getOutputMesh()->getBoundingBox();
+  // Create BB around all "other" meshes
+  for (mapping::PtrMapping fromMapping : _fromMappings) {
+    auto other_bb = fromMapping->getOutputMesh()->getBoundingBox();
     _bb.expandBy(other_bb);
     _bb.scaleBy(_safetyFactor);
     _boundingBoxPrepared = true;
   }
-  if (_toMapping) {
-    auto other_bb = _toMapping->getInputMesh()->getBoundingBox();
+  for (mapping::PtrMapping toMapping : _toMappings) {
+    auto other_bb = toMapping->getInputMesh()->getBoundingBox();
     _bb.expandBy(other_bb);
     _bb.scaleBy(_safetyFactor);
     _boundingBoxPrepared = true;
@@ -610,10 +614,19 @@ void ReceivedPartition::createOwnerInformation()
   }
 }
 
-bool ReceivedPartition::areProvidedMeshesEmpty() const
+bool ReceivedPartition::isAnyProvidedMeshNonEmpty() const
 {
-  return (_fromMapping && not _fromMapping->getOutputMesh()->vertices().empty()) ||
-         (_toMapping && not _toMapping->getInputMesh()->vertices().empty());
+  for (mapping::PtrMapping fromMapping : _fromMappings) {
+    if (not fromMapping->getOutputMesh()->vertices().empty()) {
+      return true;
+    }
+  }
+  for (mapping::PtrMapping toMapping : _toMappings) {
+    if (not toMapping->getInputMesh()->vertices().empty()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void ReceivedPartition::setOwnerInformation(const std::vector<int> &ownerVec)

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -461,7 +461,7 @@ void ReceivedPartition::prepareBoundingBox()
     _bb.scaleBy(_safetyFactor);
     _boundingBoxPrepared = true;
   }
-  for (mapping::PtrMapping toMapping : _toMappings) {
+  for (mapping::PtrMapping& toMapping : _toMappings) {
     auto other_bb = toMapping->getInputMesh()->getBoundingBox();
     _bb.expandBy(other_bb);
     _bb.scaleBy(_safetyFactor);

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -616,7 +616,7 @@ void ReceivedPartition::createOwnerInformation()
 
 bool ReceivedPartition::isAnyProvidedMeshNonEmpty() const
 {
-  for (mapping::PtrMapping fromMapping : _fromMappings) {
+  for (const auto& fromMapping : _fromMappings) {
     if (not fromMapping->getOutputMesh()->vertices().empty()) {
       return true;
     }

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -621,7 +621,7 @@ bool ReceivedPartition::isAnyProvidedMeshNonEmpty() const
       return true;
     }
   }
-  for (mapping::PtrMapping toMapping : _toMappings) {
+  for (const auto& toMapping : _toMappings) {
     if (not toMapping->getInputMesh()->vertices().empty()) {
       return true;
     }

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -455,7 +455,7 @@ void ReceivedPartition::prepareBoundingBox()
   PRECICE_DEBUG("Merge bounding boxes and increase by safety factor");
 
   // Create BB around all "other" meshes
-  for (mapping::PtrMapping fromMapping : _fromMappings) {
+  for (mapping::PtrMapping& fromMapping : _fromMappings) {
     auto other_bb = fromMapping->getOutputMesh()->getBoundingBox();
     _bb.expandBy(other_bb);
     _bb.scaleBy(_safetyFactor);

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -61,7 +61,7 @@ private:
    * Empty provided meshes mean that the re-partitioning completely filtered
    * out the mesh received on this rank at the coupling interface.
    */
-  bool areProvidedMeshesEmpty() const;
+  bool isAnyProvidedMeshNonEmpty() const;
 
   void createOwnerInformation();
 

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -63,6 +63,15 @@ private:
    */
   bool isAnyProvidedMeshNonEmpty() const;
 
+  /// Returns whether any mapping is defined
+  bool hasAnyMapping() const;
+
+  /// Tag mesh in first round accoring to all mappings
+  void tagMeshFirstRound();
+
+  /// Tag mesh in second round accoring to all mappings
+  void tagMeshSecondRound();
+
   void createOwnerInformation();
 
   /// Helper function for 'createOwnerFunction' to set local owner information

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -738,8 +738,8 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning2D)
 
     part.addM2N(m2n);
 
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
 
     part.compareBoundingBoxes();
 
@@ -869,8 +869,8 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning3D)
     ReceivedPartition part(receivedMesh, ReceivedPartition::ON_SLAVES, safetyFactor);
     part.addM2N(m2n);
 
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
 
     part.compareBoundingBoxes();
 

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -271,8 +271,8 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D)
 
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::ON_MASTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -328,8 +328,8 @@ BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D)
 
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::ON_SLAVES, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -379,8 +379,8 @@ BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D)
     double            safetyFactor = 0.1;
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::ON_MASTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -435,8 +435,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
     double            safetyFactor = 20.0;
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::NO_FILTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -522,8 +522,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
     double            safetyFactor = 20.0;
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::NO_FILTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -597,8 +597,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
     double            safetyFactor = 20.0;
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::NO_FILTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -680,8 +680,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
     double            safetyFactor = 20.0;
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::NO_FILTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -765,8 +765,8 @@ BOOST_AUTO_TEST_CASE(RePartitionNPBroadcastFilter3D)
     double            safetyFactor = 20.0;
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::ON_MASTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.communicate();
     part.compute();
 
@@ -845,7 +845,7 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
     double            safetyFactor = 20.0;
     ReceivedPartition part(pMesh, ReceivedPartition::ON_MASTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
+    part.addFromMapping(boundingFromMapping);
     part.communicate();
     part.compute();
 
@@ -920,7 +920,7 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
 
     double            safetyFactor = 0.1;
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::ON_MASTER, safetyFactor);
-    part.setFromMapping(boundingFromMapping);
+    part.addFromMapping(boundingFromMapping);
     part.addM2N(m2n);
     part.communicate();
     part.compute();
@@ -1009,8 +1009,8 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
 
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::NO_FILTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.compareBoundingBoxes();
   }
   tearDownParallelEnvironment();
@@ -1080,8 +1080,8 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
 
     ReceivedPartition part(pSolidzMesh, ReceivedPartition::NO_FILTER, safetyFactor);
     part.addM2N(m2n);
-    part.setFromMapping(boundingFromMapping);
-    part.setToMapping(boundingToMapping);
+    part.addFromMapping(boundingFromMapping);
+    part.addToMapping(boundingToMapping);
     part.compareBoundingBoxes();
   }
   tearDownParallelEnvironment();

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -438,8 +438,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     toMeshContext.meshRequirement = std::max(
         toMeshContext.meshRequirement, map->getOutputRequirement());
 
-    fromMeshContext.fromMappingContext = *mappingContext;
-    toMeshContext.toMappingContext     = *mappingContext;
+    fromMeshContext.fromMappingContexts.push_back(*mappingContext);
+    toMeshContext.toMappingContexts.push_back(*mappingContext);
   }
   _mappingConfig->resetMappings();
 

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -578,7 +578,7 @@ void ParticipantConfiguration::checkIllDefinedMappings(
 
     if (sameToMesh) {
       for (const mesh::PtrData& data : mapping.fromMesh->data()) {
-        for (const mesh::PtrData configuredData : configuredMapping.fromMesh->data()) {
+        for (const mesh::PtrData& configuredData : configuredMapping.fromMesh->data()) {
           bool sameFromData = data->getName() == configuredData->getName();
 
           if (sameFromData) {

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -577,7 +577,7 @@ void ParticipantConfiguration::checkIllDefinedMappings(
     }
 
     if (sameToMesh) {
-      for (const mesh::PtrData data : mapping.fromMesh->data()) {
+      for (const mesh::PtrData& data : mapping.fromMesh->data()) {
         for (const mesh::PtrData configuredData : configuredMapping.fromMesh->data()) {
           bool sameFromData = data->getName() == configuredData->getName();
 

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -590,7 +590,7 @@ void ParticipantConfiguration::checkIllDefinedMappings(
               }
             }
             if (mapping.direction == mapping::MappingConfiguration::READ) {
-              for (impl::DataContext &dataContext : participant->readDataContexts()) {
+              for (const impl::DataContext &dataContext : participant->readDataContexts()) {
                 sameDirection |= data->getName() == dataContext.getName();
               }
             }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -572,13 +572,13 @@ void ParticipantConfiguration::checkIllDefinedMappings(
     bool sameToMesh   = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
     bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
     if (sameToMesh && sameFromMesh) {
-      // It's really the same mapping, duplicated mappings are already checked for in MappingConfiguration
+      // It's really the same mapping, not a duplicated one. Those are already checked for in MappingConfiguration.
       return;
     }
 
     if (sameToMesh) {
-      for (const mesh::PtrData& data : mapping.fromMesh->data()) {
-        for (const mesh::PtrData& configuredData : configuredMapping.fromMesh->data()) {
+      for (const mesh::PtrData &data : mapping.fromMesh->data()) {
+        for (const mesh::PtrData &configuredData : configuredMapping.fromMesh->data()) {
           bool sameFromData = data->getName() == configuredData->getName();
 
           if (sameFromData) {

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -581,27 +581,29 @@ void ParticipantConfiguration::checkIllDefinedMappings(
         for (const mesh::PtrData &configuredData : configuredMapping.fromMesh->data()) {
           bool sameFromData = data->getName() == configuredData->getName();
 
-          if (sameFromData) {
-            bool sameDirection = false;
-
-            if (mapping.direction == mapping::MappingConfiguration::WRITE) {
-              for (const impl::DataContext &dataContext : participant->writeDataContexts()) {
-                sameDirection |= data->getName() == dataContext.getName();
-              }
-            }
-            if (mapping.direction == mapping::MappingConfiguration::READ) {
-              for (const impl::DataContext &dataContext : participant->readDataContexts()) {
-                sameDirection |= data->getName() == dataContext.getName();
-              }
-            }
-            PRECICE_CHECK(!sameDirection, "There cannot be two mappings to mesh \""
-                                              << mapping.toMesh->getName() << "\" "
-                                              << "if the meshes from which is mapped contain duplicated data fields "
-                                              << "that are also actually mapped on this participant. "
-                                              << "Here, both from meshes contain data \"" << data->getName() << "\". "
-                                              << "The mapping is not well defined. Which data \"" << data->getName() << "\" "
-                                              << "should be mapped to mesh \"" << mapping.toMesh->getName() << "\"?");
+          if (not sameFromData) {
+            continue;
           }
+
+          bool sameDirection = false;
+
+          if (mapping.direction == mapping::MappingConfiguration::WRITE) {
+            for (const impl::DataContext &dataContext : participant->writeDataContexts()) {
+              sameDirection |= data->getName() == dataContext.getName();
+            }
+          }
+          if (mapping.direction == mapping::MappingConfiguration::READ) {
+            for (const impl::DataContext &dataContext : participant->readDataContexts()) {
+              sameDirection |= data->getName() == dataContext.getName();
+            }
+          }
+          PRECICE_CHECK(!sameDirection, "There cannot be two mappings to mesh \""
+                                            << mapping.toMesh->getName() << "\" "
+                                            << "if the meshes from which is mapped contain duplicated data fields "
+                                            << "that are also actually mapped on this participant. "
+                                            << "Here, both from meshes contain data \"" << data->getName() << "\". "
+                                            << "The mapping is not well defined. Which data \"" << data->getName() << "\" "
+                                            << "should be mapped to mesh \"" << mapping.toMesh->getName() << "\"?");
         }
       }
     }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -15,7 +15,6 @@
 #include "io/config/ExportConfiguration.hpp"
 #include "logging/LogMacros.hpp"
 #include "mapping/Mapping.hpp"
-#include "mapping/config/MappingConfiguration.hpp"
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
@@ -359,6 +358,9 @@ void ParticipantConfiguration::finishParticipantConfiguration(
   // Set input/output meshes for data mappings and mesh requirements
   using ConfMapping = mapping::MappingConfiguration::ConfiguredMapping;
   for (const ConfMapping &confMapping : _mappingConfig->mappings()) {
+
+    checkIllDefinedMappings(confMapping, participant);
+
     int fromMeshID = confMapping.fromMesh->getID();
     int toMeshID   = confMapping.toMesh->getID();
 
@@ -557,6 +559,53 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 #endif
   }
   _isMasterDefined = false; // to not mess up with previous participant
+}
+
+void ParticipantConfiguration::checkIllDefinedMappings(
+    const mapping::MappingConfiguration::ConfiguredMapping &mapping,
+    const impl::PtrParticipant &                            participant)
+{
+  PRECICE_TRACE();
+  using ConfMapping = mapping::MappingConfiguration::ConfiguredMapping;
+
+  for (const ConfMapping &configuredMapping : _mappingConfig->mappings()) {
+    bool sameToMesh   = mapping.toMesh->getName() == configuredMapping.toMesh->getName();
+    bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
+    if (sameToMesh && sameFromMesh) {
+      // It's really the same mapping, duplicated mappings are already checked for in MappingConfiguration
+      return;
+    }
+
+    if (sameToMesh) {
+      for (const mesh::PtrData data : mapping.fromMesh->data()) {
+        for (const mesh::PtrData configuredData : configuredMapping.fromMesh->data()) {
+          bool sameFromData = data->getName() == configuredData->getName();
+
+          if (sameFromData) {
+            bool sameDirection = false;
+
+            if (mapping.direction == mapping::MappingConfiguration::WRITE) {
+              for (impl::DataContext &dataContext : participant->writeDataContexts()) {
+                sameDirection |= data->getName() == dataContext.getName();
+              }
+            }
+            if (mapping.direction == mapping::MappingConfiguration::READ) {
+              for (impl::DataContext &dataContext : participant->readDataContexts()) {
+                sameDirection |= data->getName() == dataContext.getName();
+              }
+            }
+            PRECICE_CHECK(!sameDirection, "There cannot be two mappings to mesh \""
+                                              << mapping.toMesh->getName() << "\" "
+                                              << "if the meshes from which is mapped contain duplicated data fields "
+                                              << "that are also actually mapped on this participant. "
+                                              << "Here, both from meshes contain data \"" << data->getName() << "\". "
+                                              << "The mapping is not well defined. Which data \"" << data->getName() << "\" "
+                                              << "should be mapped to mesh \"" << mapping.toMesh->getName() << "\"?");
+          }
+        }
+      }
+    }
+  }
 }
 
 } // namespace config

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -585,7 +585,7 @@ void ParticipantConfiguration::checkIllDefinedMappings(
             bool sameDirection = false;
 
             if (mapping.direction == mapping::MappingConfiguration::WRITE) {
-              for (impl::DataContext &dataContext : participant->writeDataContexts()) {
+              for (const impl::DataContext &dataContext : participant->writeDataContexts()) {
                 sameDirection |= data->getName() == dataContext.getName();
               }
             }

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -7,6 +7,7 @@
 #include "io/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "mapping/SharedPointer.hpp"
+#include "mapping/config/MappingConfiguration.hpp"
 #include "mesh/SharedPointer.hpp"
 #include "partition/ReceivedPartition.hpp"
 #include "precice/impl/Participant.hpp"
@@ -121,6 +122,11 @@ private:
   void finishParticipantConfiguration(
       const xml::ConfigurationContext &context,
       const impl::PtrParticipant &     participant);
+
+  /// Check whether a mapping to the same mesh and with similar data fields already exists
+  void checkIllDefinedMappings(
+      const mapping::MappingConfiguration::ConfiguredMapping &mapping,
+      const impl::PtrParticipant &                            participant);
 };
 
 } // namespace config

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -51,11 +51,11 @@ struct MeshContext {
   /// Partition creating the parallel decomposition of the mesh
   partition::PtrPartition partition;
 
-  /// Mapping used when mapping data from the mesh. Can be empty.
-  MappingContext fromMappingContext;
+  /// Mappings used when mapping data from the mesh. Can be empty.
+  std::vector<MappingContext> fromMappingContexts;
 
-  /// Mapping used when mapping data to the mesh. Can be empty.
-  MappingContext toMappingContext;
+  /// Mappings used when mapping data to the mesh. Can be empty.
+  std::vector<MappingContext> toMappingContexts;
 };
 
 inline void MeshContext::require(mapping::Mapping::MeshRequirement requirement)

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -998,13 +998,11 @@ void SolverInterfaceImpl::mapWriteDataFrom(
         continue;
       }
 
-      int inDataID             = context.fromData->getID();
-      int outDataID            = context.toData->getID();
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
                                   << "\" from mesh \"" << context.mesh->getName() << "\"");
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
-      mappingContext.mapping->map(inDataID, outDataID);
+      mappingContext.mapping->map(context.fromData->getID(), context.toData->getID());
     }
     mappingContext.hasMappedData = true;
   }
@@ -1036,13 +1034,11 @@ void SolverInterfaceImpl::mapReadDataTo(
       if (context.mesh->getID() != toMeshID) {
         continue;
       }
-      int inDataID             = context.fromData->getID();
-      int outDataID            = context.toData->getID();
       context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
                                   << "\" to mesh \"" << context.mesh->getName() << "\"");
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
-      mappingContext.mapping->map(inDataID, outDataID);
+      mappingContext.mapping->map(context.fromData->getID(), context.toData->getID());
       PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
     }
     mappingContext.hasMappedData = true;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1380,10 +1380,10 @@ void SolverInterfaceImpl::configurePartitions(
       m2n::PtrM2N m2n = m2nConfig->getM2N(receiver, provider);
       m2n->createDistributedCommunication(context->mesh);
       context->partition->addM2N(m2n);
-      for (MappingContext &mappingContext : context->fromMappingContexts) {
+      for (const MappingContext &mappingContext : context->fromMappingContexts) {
         context->partition->addFromMapping(mappingContext.mapping);
       }
-      for (MappingContext &mappingContext : context->toMappingContexts) {
+      for (const MappingContext &mappingContext : context->toMappingContexts) {
         context->partition->addToMapping(mappingContext.mapping);
       }
     }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -978,13 +978,11 @@ void SolverInterfaceImpl::mapWriteDataFrom(
   PRECICE_VALIDATE_MESH_ID(fromMeshID);
   impl::MeshContext &context = _accessor->meshContext(fromMeshID);
 
-  if (context.fromMappingContexts.empty()) {
-    PRECICE_ERROR("You attempt to \"mapWriteDataFrom\" mesh "
-                  << context.mesh->getName()
-                  << ", but there is no mapping from this mesh configured."
-                     "Maybe you don't want to call this function at all or you forgot to configure the mapping.");
-    return;
-  }
+  PRECICE_CHECK(not context.fromMappingContexts.empty(),
+                "You attempt to \"mapWriteDataFrom\" mesh "
+                    << context.mesh->getName()
+                    << ", but there is no mapping from this mesh configured."
+                       "Maybe you don't want to call this function at all or you forgot to configure the mapping.");
 
   double time = _couplingScheme->getTime();
   performDataActions({action::Action::WRITE_MAPPING_PRIOR}, time, 0, 0, 0);
@@ -1020,13 +1018,11 @@ void SolverInterfaceImpl::mapReadDataTo(
   PRECICE_VALIDATE_MESH_ID(toMeshID);
   impl::MeshContext &context = _accessor->meshContext(toMeshID);
 
-  if (context.toMappingContexts.empty()) {
-    PRECICE_ERROR("You attempt to \"mapReadDataTo\" mesh "
-                  << context.mesh->getName()
-                  << ", but there is no mapping to this mesh configured."
-                     "Maybe you don't want to call this function at all or you forgot to configure the mapping.");
-    return;
-  }
+  PRECICE_CHECK(not context.toMappingContexts.empty(),
+                "You attempt to \"mapReadDataTo\" mesh "
+                    << context.mesh->getName()
+                    << ", but there is no mapping to this mesh configured."
+                       "Maybe you don't want to call this function at all or you forgot to configure the mapping.");
 
   double time = _couplingScheme->getTime();
   performDataActions({action::Action::READ_MAPPING_PRIOR}, time, 0, 0, 0);

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -995,15 +995,18 @@ void SolverInterfaceImpl::mapWriteDataFrom(
       mappingContext.mapping->computeMapping();
     }
     for (impl::DataContext &context : _accessor->writeDataContexts()) {
-      if (context.mesh->getID() == fromMeshID) {
-        int inDataID             = context.fromData->getID();
-        int outDataID            = context.toData->getID();
-        context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-        PRECICE_DEBUG("Map data \"" << context.fromData->getName()
-                                    << "\" from mesh \"" << context.mesh->getName() << "\"");
-        PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
-        mappingContext.mapping->map(inDataID, outDataID);
+
+      if (context.mesh->getID() != fromMeshID) {
+        continue;
       }
+
+      int inDataID             = context.fromData->getID();
+      int outDataID            = context.toData->getID();
+      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
+      PRECICE_DEBUG("Map data \"" << context.fromData->getName()
+                                  << "\" from mesh \"" << context.mesh->getName() << "\"");
+      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
+      mappingContext.mapping->map(inDataID, outDataID);
     }
     mappingContext.hasMappedData = true;
   }
@@ -1034,16 +1037,17 @@ void SolverInterfaceImpl::mapReadDataTo(
       mappingContext.mapping->computeMapping();
     }
     for (impl::DataContext &context : _accessor->readDataContexts()) {
-      if (context.mesh->getID() == toMeshID) {
-        int inDataID             = context.fromData->getID();
-        int outDataID            = context.toData->getID();
-        context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
-        PRECICE_DEBUG("Map data \"" << context.fromData->getName()
-                                    << "\" to mesh \"" << context.mesh->getName() << "\"");
-        PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
-        mappingContext.mapping->map(inDataID, outDataID);
-        PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
+      if (context.mesh->getID() != toMeshID) {
+        continue;
       }
+      int inDataID             = context.fromData->getID();
+      int outDataID            = context.toData->getID();
+      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
+      PRECICE_DEBUG("Map data \"" << context.fromData->getName()
+                                  << "\" to mesh \"" << context.mesh->getName() << "\"");
+      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
+      mappingContext.mapping->map(inDataID, outDataID);
+      PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
     }
     mappingContext.hasMappedData = true;
   }

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -2273,51 +2273,51 @@ BOOST_AUTO_TEST_CASE(MultipleFromMappings)
     interface.finalize();
   }
 }
-
-BOOST_AUTO_TEST_CASE(MultipleToMappings)
-{
-  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
-
-  using Eigen::Vector2d;
-  using namespace precice::constants;
-
-  const std::string configFile = _pathToTests + "multiple-to-mappings.xml";
-
-  SolverInterface interface(context.name, configFile, 0, 1);
-  Vector2d        vertex{0.0, 0.0};
-
-  if (context.isNamed("A")) {
-    const int meshIDTop      = interface.getMeshID("MeshATop");
-    const int meshIDBottom   = interface.getMeshID("MeshABottom");
-    int       vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
-    int       vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
-    int       dataIDTop      = interface.getDataID("DisplacementTop", meshIDTop);
-    int       dataIDBottom   = interface.getDataID("DisplacementBottom", meshIDBottom);
-
-    double dt              = interface.initialize();
-    double displacementTop = 1.0;
-    interface.writeScalarData(dataIDTop, vertexIDTop, displacementTop);
-    double displacementBottom = 2.0;
-    interface.writeScalarData(dataIDTop, vertexIDTop, displacementBottom);
-    interface.advance(dt);
-    BOOST_TEST(not interface.isCouplingOngoing());
-    interface.finalize();
-
-  } else {
-    BOOST_TEST(context.isNamed("B"));
-    const int meshID   = interface.getMeshID("MeshB");
-    int       vertexID = interface.setMeshVertex(meshID, vertex.data());
-    int       dataID   = interface.getDataID("DisplacementSum", meshID);
-
-    double dt = interface.initialize();
-    interface.advance(dt);
-    double displacement = -1.0;
-    interface.readScalarData(dataID, vertexID, displacement);
-    BOOST_TEST(displacement == 3.0);
-    BOOST_TEST(not interface.isCouplingOngoing());
-    interface.finalize();
-  }
-}
+//
+// BOOST_AUTO_TEST_CASE(MultipleToMappings)
+// {
+//   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+//
+//   using Eigen::Vector2d;
+//   using namespace precice::constants;
+//
+//   const std::string configFile = _pathToTests + "multiple-to-mappings.xml";
+//
+//   SolverInterface interface(context.name, configFile, 0, 1);
+//   Vector2d        vertex{0.0, 0.0};
+//
+//   if (context.isNamed("A")) {
+//     const int meshIDTop      = interface.getMeshID("MeshATop");
+//     const int meshIDBottom   = interface.getMeshID("MeshABottom");
+//     int       vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
+//     int       vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
+//     int       dataIDTop      = interface.getDataID("DisplacementTop", meshIDTop);
+//     int       dataIDBottom   = interface.getDataID("DisplacementBottom", meshIDBottom);
+//
+//     double dt              = interface.initialize();
+//     double displacementTop = 1.0;
+//     interface.writeScalarData(dataIDTop, vertexIDTop, displacementTop);
+//     double displacementBottom = 2.0;
+//     interface.writeScalarData(dataIDTop, vertexIDTop, displacementBottom);
+//     interface.advance(dt);
+//     BOOST_TEST(not interface.isCouplingOngoing());
+//     interface.finalize();
+//
+//   } else {
+//     BOOST_TEST(context.isNamed("B"));
+//     const int meshID   = interface.getMeshID("MeshB");
+//     int       vertexID = interface.setMeshVertex(meshID, vertex.data());
+//     int       dataID   = interface.getDataID("DisplacementSum", meshID);
+//
+//     double dt = interface.initialize();
+//     interface.advance(dt);
+//     double displacement = -1.0;
+//     interface.readScalarData(dataID, vertexID, displacement);
+//     BOOST_TEST(displacement == 3.0);
+//     BOOST_TEST(not interface.isCouplingOngoing());
+//     interface.finalize();
+//   }
+// }
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -2273,51 +2273,51 @@ BOOST_AUTO_TEST_CASE(MultipleFromMappings)
     interface.finalize();
   }
 }
-//
-// BOOST_AUTO_TEST_CASE(MultipleToMappings)
-// {
-//   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
-//
-//   using Eigen::Vector2d;
-//   using namespace precice::constants;
-//
-//   const std::string configFile = _pathToTests + "multiple-to-mappings.xml";
-//
-//   SolverInterface interface(context.name, configFile, 0, 1);
-//   Vector2d        vertex{0.0, 0.0};
-//
-//   if (context.isNamed("A")) {
-//     const int meshIDTop      = interface.getMeshID("MeshATop");
-//     const int meshIDBottom   = interface.getMeshID("MeshABottom");
-//     int       vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
-//     int       vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
-//     int       dataIDTop      = interface.getDataID("DisplacementTop", meshIDTop);
-//     int       dataIDBottom   = interface.getDataID("DisplacementBottom", meshIDBottom);
-//
-//     double dt              = interface.initialize();
-//     double displacementTop = 1.0;
-//     interface.writeScalarData(dataIDTop, vertexIDTop, displacementTop);
-//     double displacementBottom = 2.0;
-//     interface.writeScalarData(dataIDTop, vertexIDTop, displacementBottom);
-//     interface.advance(dt);
-//     BOOST_TEST(not interface.isCouplingOngoing());
-//     interface.finalize();
-//
-//   } else {
-//     BOOST_TEST(context.isNamed("B"));
-//     const int meshID   = interface.getMeshID("MeshB");
-//     int       vertexID = interface.setMeshVertex(meshID, vertex.data());
-//     int       dataID   = interface.getDataID("DisplacementSum", meshID);
-//
-//     double dt = interface.initialize();
-//     interface.advance(dt);
-//     double displacement = -1.0;
-//     interface.readScalarData(dataID, vertexID, displacement);
-//     BOOST_TEST(displacement == 3.0);
-//     BOOST_TEST(not interface.isCouplingOngoing());
-//     interface.finalize();
-//   }
-// }
+
+BOOST_AUTO_TEST_CASE(MultipleToMappings)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+
+  using Eigen::Vector2d;
+  using namespace precice::constants;
+
+  const std::string configFile = _pathToTests + "multiple-to-mappings.xml";
+
+  SolverInterface interface(context.name, configFile, 0, 1);
+  Vector2d        vertex{0.0, 0.0};
+
+  if (context.isNamed("A")) {
+    const int meshIDTop      = interface.getMeshID("MeshATop");
+    const int meshIDBottom   = interface.getMeshID("MeshABottom");
+    int       vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
+    int       vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
+    int       dataIDTop      = interface.getDataID("DisplacementTop", meshIDTop);
+    int       dataIDBottom   = interface.getDataID("DisplacementBottom", meshIDBottom);
+
+    double dt              = interface.initialize();
+    double displacementTop = 1.0;
+    interface.writeScalarData(dataIDTop, vertexIDTop, displacementTop);
+    double displacementBottom = 2.0;
+    interface.writeScalarData(dataIDBottom, vertexIDBottom, displacementBottom);
+    interface.advance(dt);
+    BOOST_TEST(not interface.isCouplingOngoing());
+    interface.finalize();
+
+  } else {
+    BOOST_TEST(context.isNamed("B"));
+    const int meshID   = interface.getMeshID("MeshB");
+    int       vertexID = interface.setMeshVertex(meshID, vertex.data());
+    int       dataID   = interface.getDataID("DisplacementSum", meshID);
+
+    double dt = interface.initialize();
+    interface.advance(dt);
+    double displacement = -1.0;
+    interface.readScalarData(dataID, vertexID, displacement);
+    BOOST_TEST(displacement == 3.0);
+    BOOST_TEST(not interface.isCouplingOngoing());
+    interface.finalize();
+  }
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/multiple-from-mappings.xml
+++ b/src/precice/tests/multiple-from-mappings.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+
+<solver-interface dimensions="2">
+
+  <data:scalar name="Pressure"/>
+
+  <mesh name="MeshB">
+    <use-data name="Pressure" />
+  </mesh>
+
+  <mesh name="MeshATop">
+    <use-data name="Pressure" />
+  </mesh>
+
+  <mesh name="MeshABottom">
+    <use-data name="Pressure" />
+  </mesh>
+
+  <participant name="A">
+    <use-mesh name="MeshATop" provide="yes"/>
+    <use-mesh name="MeshABottom" provide="yes"/>
+    <use-mesh name="MeshB" from="B"/>
+
+    <read-data name="Pressure" mesh="MeshATop"/>
+    <read-data name="Pressure" mesh="MeshABottom"/>
+
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshATop" constraint="consistent"/>
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshABottom" constraint="consistent"/>
+  </participant>
+
+  <participant name="B">
+    <use-mesh name="BMesh" provide="yes"/>
+    <write-data name="Pressure" mesh="BMesh"/>
+  </participant>
+
+  <m2n:sockets from="B" to="A"/>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="B"/>
+    <max-time value="1.0"/>
+    <time-window-size value="1.0" />
+    <exchange data="Pressure" mesh="BMesh" from="B" to="A" />
+  </coupling-scheme:parallel-explicit>
+
+</solver-interface>
+
+</precice-configuration>

--- a/src/precice/tests/multiple-from-mappings.xml
+++ b/src/precice/tests/multiple-from-mappings.xml
@@ -31,8 +31,8 @@
   </participant>
 
   <participant name="B">
-    <use-mesh name="BMesh" provide="yes"/>
-    <write-data name="Pressure" mesh="BMesh"/>
+    <use-mesh name="MeshB" provide="yes"/>
+    <write-data name="Pressure" mesh="MeshB"/>
   </participant>
 
   <m2n:sockets from="B" to="A"/>
@@ -41,7 +41,7 @@
     <participants first="A" second="B"/>
     <max-time value="1.0"/>
     <time-window-size value="1.0" />
-    <exchange data="Pressure" mesh="BMesh" from="B" to="A" />
+    <exchange data="Pressure" mesh="MeshB" from="B" to="A" />
   </coupling-scheme:parallel-explicit>
 
 </solver-interface>

--- a/src/precice/tests/multiple-from-mappings.xml
+++ b/src/precice/tests/multiple-from-mappings.xml
@@ -1,49 +1,50 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
+  <solver-interface dimensions="2">
+    <data:scalar name="Pressure" />
 
-<solver-interface dimensions="2">
+    <mesh name="MeshB">
+      <use-data name="Pressure" />
+    </mesh>
 
-  <data:scalar name="Pressure"/>
+    <mesh name="MeshATop">
+      <use-data name="Pressure" />
+    </mesh>
 
-  <mesh name="MeshB">
-    <use-data name="Pressure" />
-  </mesh>
+    <mesh name="MeshABottom">
+      <use-data name="Pressure" />
+    </mesh>
 
-  <mesh name="MeshATop">
-    <use-data name="Pressure" />
-  </mesh>
+    <participant name="A">
+      <use-mesh name="MeshATop" provide="yes" />
+      <use-mesh name="MeshABottom" provide="yes" />
+      <use-mesh name="MeshB" from="B" />
+      <read-data name="Pressure" mesh="MeshATop" />
+      <read-data name="Pressure" mesh="MeshABottom" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshB"
+        to="MeshATop"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshB"
+        to="MeshABottom"
+        constraint="consistent" />
+    </participant>
 
-  <mesh name="MeshABottom">
-    <use-data name="Pressure" />
-  </mesh>
+    <participant name="B">
+      <use-mesh name="MeshB" provide="yes" />
+      <write-data name="Pressure" mesh="MeshB" />
+    </participant>
 
-  <participant name="A">
-    <use-mesh name="MeshATop" provide="yes"/>
-    <use-mesh name="MeshABottom" provide="yes"/>
-    <use-mesh name="MeshB" from="B"/>
+    <m2n:sockets from="B" to="A" />
 
-    <read-data name="Pressure" mesh="MeshATop"/>
-    <read-data name="Pressure" mesh="MeshABottom"/>
-
-    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshATop" constraint="consistent"/>
-    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshABottom" constraint="consistent"/>
-  </participant>
-
-  <participant name="B">
-    <use-mesh name="MeshB" provide="yes"/>
-    <write-data name="Pressure" mesh="MeshB"/>
-  </participant>
-
-  <m2n:sockets from="B" to="A"/>
-
-  <coupling-scheme:parallel-explicit>
-    <participants first="A" second="B"/>
-    <max-time value="1.0"/>
-    <time-window-size value="1.0" />
-    <exchange data="Pressure" mesh="MeshB" from="B" to="A" />
-  </coupling-scheme:parallel-explicit>
-
-</solver-interface>
-
+    <coupling-scheme:parallel-explicit>
+      <participants first="A" second="B" />
+      <max-time value="1.0" />
+      <time-window-size value="1.0" />
+      <exchange data="Pressure" mesh="MeshB" from="B" to="A" />
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/multiple-to-mappings.xml
+++ b/src/precice/tests/multiple-to-mappings.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+
+<solver-interface dimensions="2">
+
+  <data:scalar name="DisplacementSum"/>
+  <data:scalar name="DisplacementTop"/>
+  <data:scalar name="DisplacementBottom"/>
+
+  <mesh name="MeshB">
+    <use-data name="DisplacementTop" />
+    <use-data name="DisplacementBottom" />
+    <use-data name="DisplacementSum" />
+  </mesh>
+
+  <mesh name="MeshATop">
+    <use-data name="DisplacementTop" />
+  </mesh>
+
+  <mesh name="MeshABottom">
+    <use-data name="DisplacementBottom" />
+  </mesh>
+
+  <participant name="A">
+    <use-mesh name="MeshATop" provide="yes"/>
+    <use-mesh name="MeshABottom" provide="yes"/>
+    <use-mesh name="MeshB" from="B"/>
+
+    <action:summation timing="write-mapping-post" mesh="MeshB">
+      <source-data name="DisplacementTop"/>
+      <source-data name="DisplacementBottom"/>
+      <target-data name="DisplacementSum"/>
+    </action:summation>
+
+    <write-data name="DisplacementTop" mesh="MeshATop"/>
+    <write-data name="DisplacementBottom" mesh="MeshABottom"/>
+
+    <mapping:nearest-neighbor direction="write" from="MeshATop" to="MeshB" constraint="consistent"/>
+    <mapping:nearest-neighbor direction="write" from="MeshABottom" to="MeshB" constraint="consistent"/>
+  </participant>
+
+  <participant name="B">
+    <use-mesh name="BMesh" provide="yes"/>
+    <read-data name="DisplacementSum" mesh="BMesh"/>
+  </participant>
+
+  <m2n:sockets from="B" to="A"/>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="B"/>
+    <max-time value="1.0"/>
+    <time-window-size value="1.0" />
+    <exchange data="DisplacementSum" mesh="BMesh" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+
+</solver-interface>
+
+</precice-configuration>

--- a/src/precice/tests/multiple-to-mappings.xml
+++ b/src/precice/tests/multiple-to-mappings.xml
@@ -4,19 +4,23 @@
     <data:scalar name="DisplacementSum" />
     <data:scalar name="DisplacementTop" />
     <data:scalar name="DisplacementBottom" />
+    <data:scalar name="Pressure" />
 
     <mesh name="MeshB">
       <use-data name="DisplacementTop" />
       <use-data name="DisplacementBottom" />
       <use-data name="DisplacementSum" />
+      <use-data name="Pressure" />
     </mesh>
 
     <mesh name="MeshATop">
       <use-data name="DisplacementTop" />
+      <use-data name="Pressure" />
     </mesh>
 
     <mesh name="MeshABottom">
       <use-data name="DisplacementBottom" />
+      <use-data name="Pressure" />
     </mesh>
 
     <participant name="A">

--- a/src/precice/tests/multiple-to-mappings.xml
+++ b/src/precice/tests/multiple-to-mappings.xml
@@ -41,8 +41,8 @@
   </participant>
 
   <participant name="B">
-    <use-mesh name="BMesh" provide="yes"/>
-    <read-data name="DisplacementSum" mesh="BMesh"/>
+    <use-mesh name="MeshB" provide="yes"/>
+    <read-data name="DisplacementSum" mesh="MeshB"/>
   </participant>
 
   <m2n:sockets from="B" to="A"/>
@@ -51,7 +51,7 @@
     <participants first="A" second="B"/>
     <max-time value="1.0"/>
     <time-window-size value="1.0" />
-    <exchange data="DisplacementSum" mesh="BMesh" from="A" to="B" />
+    <exchange data="DisplacementSum" mesh="MeshB" from="A" to="B" />
   </coupling-scheme:parallel-explicit>
 
 </solver-interface>

--- a/src/precice/tests/multiple-to-mappings.xml
+++ b/src/precice/tests/multiple-to-mappings.xml
@@ -1,59 +1,59 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
+  <solver-interface dimensions="2">
+    <data:scalar name="DisplacementSum" />
+    <data:scalar name="DisplacementTop" />
+    <data:scalar name="DisplacementBottom" />
 
-<solver-interface dimensions="2">
+    <mesh name="MeshB">
+      <use-data name="DisplacementTop" />
+      <use-data name="DisplacementBottom" />
+      <use-data name="DisplacementSum" />
+    </mesh>
 
-  <data:scalar name="DisplacementSum"/>
-  <data:scalar name="DisplacementTop"/>
-  <data:scalar name="DisplacementBottom"/>
+    <mesh name="MeshATop">
+      <use-data name="DisplacementTop" />
+    </mesh>
 
-  <mesh name="MeshB">
-    <use-data name="DisplacementTop" />
-    <use-data name="DisplacementBottom" />
-    <use-data name="DisplacementSum" />
-  </mesh>
+    <mesh name="MeshABottom">
+      <use-data name="DisplacementBottom" />
+    </mesh>
 
-  <mesh name="MeshATop">
-    <use-data name="DisplacementTop" />
-  </mesh>
+    <participant name="A">
+      <use-mesh name="MeshATop" provide="yes" />
+      <use-mesh name="MeshABottom" provide="yes" />
+      <use-mesh name="MeshB" from="B" />
+      <action:summation timing="write-mapping-post" mesh="MeshB">
+        <source-data name="DisplacementTop" />
+        <source-data name="DisplacementBottom" />
+        <target-data name="DisplacementSum" />
+      </action:summation>
+      <write-data name="DisplacementTop" mesh="MeshATop" />
+      <write-data name="DisplacementBottom" mesh="MeshABottom" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshATop"
+        to="MeshB"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshABottom"
+        to="MeshB"
+        constraint="consistent" />
+    </participant>
 
-  <mesh name="MeshABottom">
-    <use-data name="DisplacementBottom" />
-  </mesh>
+    <participant name="B">
+      <use-mesh name="MeshB" provide="yes" />
+      <read-data name="DisplacementSum" mesh="MeshB" />
+    </participant>
 
-  <participant name="A">
-    <use-mesh name="MeshATop" provide="yes"/>
-    <use-mesh name="MeshABottom" provide="yes"/>
-    <use-mesh name="MeshB" from="B"/>
+    <m2n:sockets from="B" to="A" />
 
-    <action:summation timing="write-mapping-post" mesh="MeshB">
-      <source-data name="DisplacementTop"/>
-      <source-data name="DisplacementBottom"/>
-      <target-data name="DisplacementSum"/>
-    </action:summation>
-
-    <write-data name="DisplacementTop" mesh="MeshATop"/>
-    <write-data name="DisplacementBottom" mesh="MeshABottom"/>
-
-    <mapping:nearest-neighbor direction="write" from="MeshATop" to="MeshB" constraint="consistent"/>
-    <mapping:nearest-neighbor direction="write" from="MeshABottom" to="MeshB" constraint="consistent"/>
-  </participant>
-
-  <participant name="B">
-    <use-mesh name="MeshB" provide="yes"/>
-    <read-data name="DisplacementSum" mesh="MeshB"/>
-  </participant>
-
-  <m2n:sockets from="B" to="A"/>
-
-  <coupling-scheme:parallel-explicit>
-    <participants first="A" second="B"/>
-    <max-time value="1.0"/>
-    <time-window-size value="1.0" />
-    <exchange data="DisplacementSum" mesh="MeshB" from="A" to="B" />
-  </coupling-scheme:parallel-explicit>
-
-</solver-interface>
-
+    <coupling-scheme:parallel-explicit>
+      <participants first="A" second="B" />
+      <max-time value="1.0" />
+      <time-window-size value="1.0" />
+      <exchange data="DisplacementSum" mesh="MeshB" from="A" to="B" />
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>


### PR DESCRIPTION
Closes #840 
Ready for review.

* [x] Add integration tests that separately use multiple mappings from and to the same mesh, respectively
* [x] Allow multiple mappings from same mesh
* [x] Allow multiple mappings to same mesh if there are no overlaps
* [x] Extend unit tests of `ReceivedPartition`
