### PR TITLE
Fix: preCICE erroneously expects cyclic communicator for IMVJ with restart

### DIFF
--- a/src/acceleration/impl/ParallelMatrixOperations.cpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.cpp
@@ -11,7 +11,7 @@ void ParallelMatrixOperations::initialize(bool needCyclicComm)
 {
   PRECICE_TRACE();
 
-  if (_needCyclicComm && (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave())) {
+  if (needCyclicComm && (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave())) {
     _needCyclicComm = needCyclicComm;
     establishCircularCommunication();
   } else {

--- a/src/acceleration/impl/ParallelMatrixOperations.cpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.cpp
@@ -11,7 +11,7 @@ void ParallelMatrixOperations::initialize(bool needCyclicComm)
 {
   PRECICE_TRACE();
 
-  if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
+  if (_needCyclicComm && (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave())) {
     _needCyclicComm = needCyclicComm;
     establishCircularCommunication();
   } else {

--- a/src/acceleration/impl/ParallelMatrixOperations.cpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.cpp
@@ -7,12 +7,12 @@ namespace precice {
 namespace acceleration {
 namespace impl {
 
-void ParallelMatrixOperations::initialize(bool needCyclicComm)
+void ParallelMatrixOperations::initialize(const bool needCyclicComm)
 {
   PRECICE_TRACE();
 
   if (needCyclicComm && (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave())) {
-    _needCyclicComm = needCyclicComm;
+    _needCyclicComm = true;
     establishCircularCommunication();
   } else {
     _needCyclicComm = false;

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -25,7 +25,7 @@ public:
   ~ParallelMatrixOperations();
 
   /// Initializes the acceleration.
-  void initialize(bool needcyclicComm);
+  void initialize(const bool needCyclicComm);
 
   template <typename Derived1, typename Derived2>
   void multiply(


### PR DESCRIPTION
Fixes #851 

I have tested in on my laptop (Ubuntu 18.04) and it worked fine there. I would test it on another machine tomorrow as well.
