### PR TITLE
Fix and Format XML

### DIFF
--- a/examples/solverdummies/precice-config.xml
+++ b/examples/solverdummies/precice-config.xml
@@ -1,52 +1,41 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
   <log>
-    <sink type="stream" output="stdout"  filter= "%Severity% > debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true" />
+    <sink type="stream" output="stdout" filter="%Severity% &gt; debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true"/>
   </log>
-
-  <solver-interface dimensions="3" >
-
-    <data:vector name="dataOne"  />
-    <data:vector name="dataTwo"  />
-
+  <solver-interface dimensions="3">
+    <data:vector name="dataOne"/>
+    <data:vector name="dataTwo"/>
     <mesh name="MeshOne">
-      <use-data name="dataOne" />
-      <use-data name="dataTwo" />
+      <use-data name="dataOne"/>
+      <use-data name="dataTwo"/>
     </mesh>
-
     <mesh name="MeshTwo">
-      <use-data name="dataOne" />
-      <use-data name="dataTwo" />
+      <use-data name="dataOne"/>
+      <use-data name="dataTwo"/>
     </mesh>
-
     <participant name="SolverOne">
       <use-mesh name="MeshOne" provide="yes"/>
-      <write-data name="dataOne" mesh="MeshOne" />
-      <read-data  name="dataTwo" mesh="MeshOne" />
+      <write-data name="dataOne" mesh="MeshOne"/>
+      <read-data name="dataTwo" mesh="MeshOne"/>
     </participant>
-
     <participant name="SolverTwo">
       <use-mesh name="MeshOne" from="SolverOne"/>
       <use-mesh name="MeshTwo" provide="yes"/>
       <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
-      <mapping:nearest-neighbor direction="read"  from="MeshOne" to="MeshTwo" constraint="consistent" />
-      <write-data name="dataTwo" mesh="MeshTwo" />
-      <read-data  name="dataOne" mesh="MeshTwo" />
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <write-data name="dataTwo" mesh="MeshTwo"/>
+      <read-data name="dataOne" mesh="MeshTwo"/>
     </participant>
-
     <m2n:sockets from="SolverOne" to="SolverTwo"/>
-
     <coupling-scheme:serial-implicit>
-      <participants first="SolverOne" second="SolverTwo" />
-      <max-time-windows value="2" />
-      <time-window-size value="1.0" />
-      <max-iterations value="2" />
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="2"/>
       <min-iteration-convergence-measure min-iterations="5" data="dataOne" mesh="MeshOne"/>
-      <exchange data="dataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="dataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
       <exchange data="dataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
     </coupling-scheme:serial-implicit>
   </solver-interface>
-
 </precice-configuration>

--- a/src/action/tests/ScaleActionTest-testConfiguration-1.xml
+++ b/src/action/tests/ScaleActionTest-testConfiguration-1.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <configuration>
-   <data:scalar name="Data"/>
-   <mesh name="Mesh">
-      <use-data name="Data"/>
-   </mesh>
-   <action:divide-by-area timing="regular-prior" mesh="Mesh">
-      <target-data name="Data" />
-   </action:divide-by-area>  
+  <data:scalar name="Data"/>
+  <mesh name="Mesh">
+    <use-data name="Data"/>
+  </mesh>
+  <action:divide-by-area timing="regular-prior" mesh="Mesh">
+    <target-data name="Data"/>
+  </action:divide-by-area>
 </configuration>
-

--- a/src/action/tests/ScaleActionTest-testConfiguration-2.xml
+++ b/src/action/tests/ScaleActionTest-testConfiguration-2.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <configuration>
-   <data:scalar name="Data"/>
-   <mesh name="Mesh">
-      <use-data name="Data"/>
-   </mesh>
-   <action:multiply-by-area timing="regular-prior" mesh="Mesh">
-      <target-data name="Data" />
-   </action:multiply-by-area>  
+  <data:scalar name="Data"/>
+  <mesh name="Mesh">
+    <use-data name="Data"/>
+  </mesh>
+  <action:multiply-by-area timing="regular-prior" mesh="Mesh">
+    <target-data name="Data"/>
+  </action:multiply-by-area>
 </configuration>
-

--- a/src/action/tests/ScaleActionTest-testConfiguration-3.xml
+++ b/src/action/tests/ScaleActionTest-testConfiguration-3.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <configuration>
-   <data:scalar name="SourceData"/>
-   <data:scalar name="TargetData"/>
-   <mesh name="Mesh">
-      <use-data name="SourceData"/>
-      <use-data name="TargetData"/>
-   </mesh>
-   <action:scale-by-computed-dt-ratio timing="regular-prior" mesh="Mesh">
-      <source-data name="SourceData" />
-      <target-data name="TargetData" />
-   </action:scale-by-computed-dt-ratio>  
+  <data:scalar name="SourceData"/>
+  <data:scalar name="TargetData"/>
+  <mesh name="Mesh">
+    <use-data name="SourceData"/>
+    <use-data name="TargetData"/>
+  </mesh>
+  <action:scale-by-computed-dt-ratio timing="regular-prior" mesh="Mesh">
+    <source-data name="SourceData"/>
+    <target-data name="TargetData"/>
+  </action:scale-by-computed-dt-ratio>
 </configuration>
-

--- a/src/action/tests/ScaleActionTest-testConfiguration-4.xml
+++ b/src/action/tests/ScaleActionTest-testConfiguration-4.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
 <configuration>
-   <data:scalar name="SourceData"/>
-   <data:scalar name="TargetData"/>
-   <mesh name="Mesh">
-      <use-data name="SourceData"/>
-      <use-data name="TargetData"/>
-   </mesh>
-   <action:scale-by-computed-dt-part-ratio timing="regular-prior" mesh="Mesh">
-      <source-data name="SourceData" />
-      <target-data name="TargetData" />
-   </action:scale-by-computed-dt-part-ratio>  
+  <data:scalar name="SourceData"/>
+  <data:scalar name="TargetData"/>
+  <mesh name="Mesh">
+    <use-data name="SourceData"/>
+    <use-data name="TargetData"/>
+  </mesh>
+  <action:scale-by-computed-dt-part-ratio timing="regular-prior" mesh="Mesh">
+    <source-data name="SourceData"/>
+    <target-data name="TargetData"/>
+  </action:scale-by-computed-dt-part-ratio>
 </configuration>
-

--- a/src/action/tests/SummationActionTest-testConfiguration-1.xml
+++ b/src/action/tests/SummationActionTest-testConfiguration-1.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0"?>
 <configuration>
-   <data:scalar name="SourceData1"/>
-   <data:scalar name="SourceData2"/>
-   <data:scalar name="SourceData3"/>
-   <data:scalar name="TargetData"/>
-   <mesh name="Mesh">
-      <use-data name="SourceData1"/>
-      <use-data name="SourceData2"/>
-      <use-data name="SourceData3"/>
-      <use-data name="TargetData"/>
-   </mesh>
-   <action:summation timing="regular-prior" mesh="Mesh">
-      <source-data name="SourceData1"/>
-      <source-data name="SourceData2"/>
-      <source-data name="SourceData3"/>
-      <target-data name="TargetData"/>
-   </action:summation>  
+  <data:scalar name="SourceData1"/>
+  <data:scalar name="SourceData2"/>
+  <data:scalar name="SourceData3"/>
+  <data:scalar name="TargetData"/>
+  <mesh name="Mesh">
+    <use-data name="SourceData1"/>
+    <use-data name="SourceData2"/>
+    <use-data name="SourceData3"/>
+    <use-data name="TargetData"/>
+  </mesh>
+  <action:summation timing="regular-prior" mesh="Mesh">
+    <source-data name="SourceData1"/>
+    <source-data name="SourceData2"/>
+    <source-data name="SourceData3"/>
+    <target-data name="TargetData"/>
+  </action:summation>
 </configuration>
-

--- a/src/cplscheme/tests/explicit-coupling-scheme-1.xml
+++ b/src/cplscheme/tests/explicit-coupling-scheme-1.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
-
 <!--
   Configuration for test with explicit coupling scheme and fixed timestepping.
   -->
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <coupling-scheme:serial-explicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-   </coupling-scheme:serial-explicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <coupling-scheme:serial-explicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+  </coupling-scheme:serial-explicit>
 </configuration>

--- a/src/cplscheme/tests/explicit-coupling-scheme-2.xml
+++ b/src/cplscheme/tests/explicit-coupling-scheme-2.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
-
 <!--
    Configuration for test with explicit coupling scheme and timestep length
    set by first participant.
   -->
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <coupling-scheme:serial-explicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size method="first-participant"/>
-      <max-time value="1.0"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-   </coupling-scheme:serial-explicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <coupling-scheme:serial-explicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size method="first-participant"/>
+    <max-time value="1.0"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+  </coupling-scheme:serial-explicit>
 </configuration>

--- a/src/cplscheme/tests/multi-solver-coupling-1.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-1.xml
@@ -1,34 +1,33 @@
 <?xml version="1.0"?>
-
 <!--
    Configuration for tests
    * CompositionalCouplingScheme::testExplicitSchemeComposition1()
   -->
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <data:vector name="Data2"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-      <use-data name="Data2"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <m2n:sockets from="Participant1" to="Participant2"/>
-   <coupling-scheme:serial-explicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-   </coupling-scheme:serial-explicit>
-   <coupling-scheme:serial-explicit>
-      <participants first="Participant1" second="Participant2"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
-      <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
-   </coupling-scheme:serial-explicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <data:vector name="Data2"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+    <use-data name="Data2"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <m2n:sockets from="Participant1" to="Participant2"/>
+  <coupling-scheme:serial-explicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+  </coupling-scheme:serial-explicit>
+  <coupling-scheme:serial-explicit>
+    <participants first="Participant1" second="Participant2"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
+    <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
+  </coupling-scheme:serial-explicit>
 </configuration>

--- a/src/cplscheme/tests/multi-solver-coupling-2.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-2.xml
@@ -1,38 +1,37 @@
 <?xml version="1.0"?>
-
 <!--
    Configuration for tests
    * CompositionalCouplingScheme::testImplicitSchemeComposition()
   -->
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <data:vector name="Data2"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-      <use-data name="Data2"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <m2n:sockets from="Participant1" to="Participant2"/>
-   <coupling-scheme:serial-implicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <max-iterations value="10"/>
-      <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="Mesh"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-   </coupling-scheme:serial-implicit>
-   <coupling-scheme:serial-implicit>
-      <participants first="Participant1" second="Participant2"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <max-iterations value="10"/>
-      <min-iteration-convergence-measure min-iterations="3" data="Data2" mesh="Mesh"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
-      <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
-   </coupling-scheme:serial-implicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <data:vector name="Data2"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+    <use-data name="Data2"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <m2n:sockets from="Participant1" to="Participant2"/>
+  <coupling-scheme:serial-implicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <max-iterations value="10"/>
+    <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="Mesh"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+  </coupling-scheme:serial-implicit>
+  <coupling-scheme:serial-implicit>
+    <participants first="Participant1" second="Participant2"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <max-iterations value="10"/>
+    <min-iteration-convergence-measure min-iterations="3" data="Data2" mesh="Mesh"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
+    <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
+  </coupling-scheme:serial-implicit>
 </configuration>

--- a/src/cplscheme/tests/multi-solver-coupling-3.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-3.xml
@@ -1,36 +1,35 @@
 <?xml version="1.0"?>
-
 <!--
    Configuration for tests
    * CompositionalCouplingScheme::testImplicitExplicitSchemeComposition()
   -->
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <data:vector name="Data2"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-      <use-data name="Data2"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <m2n:sockets from="Participant1" to="Participant2"/>
-   <coupling-scheme:serial-implicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <max-iterations value="10"/>
-      <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="Mesh"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-   </coupling-scheme:serial-implicit>
-   <coupling-scheme:serial-explicit>
-      <participants first="Participant1" second="Participant2"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
-      <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
-   </coupling-scheme:serial-explicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <data:vector name="Data2"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+    <use-data name="Data2"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <m2n:sockets from="Participant1" to="Participant2"/>
+  <coupling-scheme:serial-implicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <max-iterations value="10"/>
+    <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="Mesh"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+  </coupling-scheme:serial-implicit>
+  <coupling-scheme:serial-explicit>
+    <participants first="Participant1" second="Participant2"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
+    <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
+  </coupling-scheme:serial-explicit>
 </configuration>

--- a/src/cplscheme/tests/multi-solver-coupling-4.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-4.xml
@@ -1,36 +1,35 @@
 <?xml version="1.0"?>
-
 <!--
    Configuration for tests
    * CompositionalCouplingScheme::testExplicitImplicitSchemeComposition()
   -->
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <data:vector name="Data2"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-      <use-data name="Data2"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <m2n:sockets from="Participant1" to="Participant2"/>
-   <coupling-scheme:serial-explicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-   </coupling-scheme:serial-explicit>
-   <coupling-scheme:serial-implicit>
-      <participants first="Participant1" second="Participant2"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time value="1.0"/>
-      <max-time-windows value="10"/>
-      <max-iterations value="10"/>
-      <min-iteration-convergence-measure min-iterations="3" data="Data2" mesh="Mesh"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
-      <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
-   </coupling-scheme:serial-implicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <data:vector name="Data2"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+    <use-data name="Data2"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <m2n:sockets from="Participant1" to="Participant2"/>
+  <coupling-scheme:serial-explicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+  </coupling-scheme:serial-explicit>
+  <coupling-scheme:serial-implicit>
+    <participants first="Participant1" second="Participant2"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="10"/>
+    <max-iterations value="10"/>
+    <min-iteration-convergence-measure min-iterations="3" data="Data2" mesh="Mesh"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant2"/>
+    <exchange data="Data2" mesh="Mesh" from="Participant2" to="Participant1"/>
+  </coupling-scheme:serial-implicit>
 </configuration>

--- a/src/cplscheme/tests/parallel-explicit-coupling-datainit.xml
+++ b/src/cplscheme/tests/parallel-explicit-coupling-datainit.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0"?>
-
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <data:scalar name="Data2"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-      <use-data name="Data2"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <coupling-scheme:parallel-explicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time-windows value="1"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant1" to="Participant0"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0" initialize="on"/>
-      <exchange data="Data2" mesh="Mesh" from="Participant0" to="Participant1" initialize="on"/>
-   </coupling-scheme:parallel-explicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <data:scalar name="Data2"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+    <use-data name="Data2"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <coupling-scheme:parallel-explicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time-windows value="1"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant1" to="Participant0"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0" initialize="on"/>
+    <exchange data="Data2" mesh="Mesh" from="Participant0" to="Participant1" initialize="on"/>
+  </coupling-scheme:parallel-explicit>
 </configuration>

--- a/src/cplscheme/tests/parallel-implicit-cplscheme-relax-const-config.xml
+++ b/src/cplscheme/tests/parallel-implicit-cplscheme-relax-const-config.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
-
 <configuration>
-
-   <data:scalar name="Data0"  />
-   <data:vector name="Data1"  />
-
-   <mesh name="Mesh">
-      <use-data name="Data0" />
-      <use-data name="Data1" />
-   </mesh>
-
-   <m2n:sockets from="Participant0" to="Participant1" />
-
-   <!--
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <!--
    <participant name="Participant0">
       <use-mesh name="Mesh" />
       <write data="Data0" Mesh="Mesh" />
@@ -25,21 +20,17 @@
       <read  data="Data0" mesh="Mesh" />
    </participant>
    -->
-   <coupling-scheme:parallel-implicit>
-      <participants first="Participant0" second="Participant1" />
-      <time-window-size value="1e-1" />
-      <max-time value="1.0" />
-      <max-time-windows value="3" />
-      <max-iterations value="100"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-      <acceleration:constant>
-         <relaxation value="0.01" />
-      </acceleration:constant>
-      <absolute-convergence-measure
-         data="Data1"
-         mesh="Mesh"
-         limit="1.7320508075688772" />
-   </coupling-scheme:parallel-implicit>
-
+  <coupling-scheme:parallel-implicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="1e-1"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="3"/>
+    <max-iterations value="100"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+    <acceleration:constant>
+      <relaxation value="0.01"/>
+    </acceleration:constant>
+    <absolute-convergence-measure data="Data1" mesh="Mesh" limit="1.7320508075688772"/>
+  </coupling-scheme:parallel-implicit>
 </configuration>

--- a/src/cplscheme/tests/serial-explicit-coupling-datainit.xml
+++ b/src/cplscheme/tests/serial-explicit-coupling-datainit.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0"?>
-
 <configuration>
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-   <data:scalar name="Data2"/>
-   <mesh name="Mesh">
-      <use-data name="Data0"/>
-      <use-data name="Data1"/>
-      <use-data name="Data2"/>
-   </mesh>
-   <m2n:sockets from="Participant0" to="Participant1"/>
-   <coupling-scheme:serial-explicit>
-      <participants first="Participant0" second="Participant1"/>
-      <time-window-size value="0.1" method="fixed"/>
-      <max-time-windows value="1"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant1" to="Participant0"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0" initialize="on"/>
-      <exchange data="Data2" mesh="Mesh" from="Participant0" to="Participant1"/>
-   </coupling-scheme:serial-explicit>
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <data:scalar name="Data2"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+    <use-data name="Data2"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <coupling-scheme:serial-explicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="0.1" method="fixed"/>
+    <max-time-windows value="1"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant1" to="Participant0"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0" initialize="on"/>
+    <exchange data="Data2" mesh="Mesh" from="Participant0" to="Participant1"/>
+  </coupling-scheme:serial-explicit>
 </configuration>

--- a/src/cplscheme/tests/serial-implicit-cplscheme-absolute-config.xml
+++ b/src/cplscheme/tests/serial-implicit-cplscheme-absolute-config.xml
@@ -1,29 +1,20 @@
 <?xml version="1.0"?>
-
 <configuration>
-
-   <data:scalar name="Data0"/>
-   <data:vector name="Data1"/>
-
-   <mesh name="Mesh">
-      <use-data name="Data0" />
-      <use-data name="Data1" />
-   </mesh>
-
-   <m2n:sockets from="Participant0" to="Participant1" />
-
-   <coupling-scheme:serial-implicit>
-      <participants first="Participant0" second="Participant1" />
-      <time-window-size value="1e-1" />
-      <max-time value="1.0" />
-      <max-time-windows value="3" />
-      <max-iterations value="100" />
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-      <absolute-convergence-measure
-         data="Data1"
-         mesh="Mesh"
-         limit="1.7320508075688772" />
-   </coupling-scheme:serial-implicit>
-
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <coupling-scheme:serial-implicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="1e-1"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="3"/>
+    <max-iterations value="100"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+    <absolute-convergence-measure data="Data1" mesh="Mesh" limit="1.7320508075688772"/>
+  </coupling-scheme:serial-implicit>
 </configuration>

--- a/src/cplscheme/tests/serial-implicit-cplscheme-relax-const-config.xml
+++ b/src/cplscheme/tests/serial-implicit-cplscheme-relax-const-config.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
-
 <configuration>
-
-   <data:scalar name="Data0"  />
-   <data:vector name="Data1"  />
-
-   <mesh name="Mesh">
-      <use-data name="Data0" />
-      <use-data name="Data1" />
-   </mesh>
-
-   <m2n:sockets from="Participant0" to="Participant1" />
-
-   <!--
+  <data:scalar name="Data0"/>
+  <data:vector name="Data1"/>
+  <mesh name="Mesh">
+    <use-data name="Data0"/>
+    <use-data name="Data1"/>
+  </mesh>
+  <m2n:sockets from="Participant0" to="Participant1"/>
+  <!--
    <participant name="Participant0">
       <use-mesh name="Mesh" />
       <write data="Data0" mesh="Mesh" />
@@ -25,21 +20,17 @@
       <read  data="Data0" mesh="Mesh" />
    </participant>
    -->
-   <coupling-scheme:serial-implicit>
-      <participants first="Participant0" second="Participant1" />
-      <time-window-size value="1e-1" />
-      <max-time value="1.0" />
-      <max-time-windows value="3" />
-      <max-iterations value="100"/>
-      <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1" />
-      <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
-      <acceleration:constant>
-         <relaxation value="0.01" />
-      </acceleration:constant>
-      <absolute-convergence-measure
-         data="Data1"
-         mesh="Mesh"
-         limit="1.7320508075688772" />
-   </coupling-scheme:serial-implicit>
-
+  <coupling-scheme:serial-implicit>
+    <participants first="Participant0" second="Participant1"/>
+    <time-window-size value="1e-1"/>
+    <max-time value="1.0"/>
+    <max-time-windows value="3"/>
+    <max-iterations value="100"/>
+    <exchange data="Data0" mesh="Mesh" from="Participant0" to="Participant1"/>
+    <exchange data="Data1" mesh="Mesh" from="Participant1" to="Participant0"/>
+    <acceleration:constant>
+      <relaxation value="0.01"/>
+    </acceleration:constant>
+    <absolute-convergence-measure data="Data1" mesh="Mesh" limit="1.7320508075688772"/>
+  </coupling-scheme:serial-implicit>
 </configuration>

--- a/src/io/tests/config1.xml
+++ b/src/io/tests/config1.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0"?>
-
 <configuration>
-   <export:vtk every-n-time-windows="10" trigger-solver="on"
-           normals="on" directory="./" />
+  <export:vtk every-n-time-windows="10" trigger-solver="on" normals="on" directory="./"/>
 </configuration>

--- a/src/io/tests/config2.xml
+++ b/src/io/tests/config2.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?> 
-
+<?xml version="1.0"?>
 <configuration>
   <export:vtk directory="somepath"/>
 </configuration>

--- a/src/mapping/tests/mapping-config.xml
+++ b/src/mapping/tests/mapping-config.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0"?>
-
 <configuration>
-   <mesh name="TestMesh"></mesh>
-   <mesh name="TestMeshTwo"></mesh>
-   <mesh name="TestMeshThree"></mesh>
-   <mapping:nearest-projection direction="write" from="TestMesh" to="TestMeshThree"
-   				 constraint="conservative" timing="ondemand"/>
-   <mapping:nearest-projection direction="read" from="TestMeshThree" to="TestMeshTwo"
-   				 constraint="consistent"/>
-   <mapping:nearest-projection direction="write" from="TestMeshTwo" to="TestMesh"
-   				 constraint="conservative" timing="onadvance"/>
+  <mesh name="TestMesh"/>
+  <mesh name="TestMeshTwo"/>
+  <mesh name="TestMeshThree"/>
+  <mapping:nearest-projection direction="write" from="TestMesh" to="TestMeshThree" constraint="conservative" timing="ondemand"/>
+  <mapping:nearest-projection direction="read" from="TestMeshThree" to="TestMeshTwo" constraint="consistent"/>
+  <mapping:nearest-projection direction="write" from="TestMeshTwo" to="TestMesh" constraint="conservative" timing="onadvance"/>
 </configuration>

--- a/src/mesh/tests/data-config.xml
+++ b/src/mesh/tests/data-config.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
-
 <configuration>
-  <data:vector name="vector-data"  />
-  <data:scalar name="floating-data"  />
-  <data:vector name="second-vector-data"  />
+  <data:vector name="vector-data"/>
+  <data:scalar name="floating-data"/>
+  <data:vector name="second-vector-data"/>
 </configuration>

--- a/src/precice/tests/BB-sockets-explicit-oneway.xml
+++ b/src/precice/tests/BB-sockets-explicit-oneway.xml
@@ -1,42 +1,30 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-   <solver-interface dimensions="3" >
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="FluidMesh">
-         <use-data name="Forces" />
-      </mesh>
-
-      <mesh name="StructureMesh">
-         <use-data name="Forces" />
-      </mesh>
-
-      <participant name="Fluid">
-         <use-mesh name="FluidMesh" provide="yes" />
-         <write-data name="Forces" mesh="FluidMesh" />
-      </participant>
-
-      <participant name="Structure">
-         <use-mesh name="StructureMesh" provide="yes"/>
-         <use-mesh name="FluidMesh" provide="no"  from="Fluid"/>
-         <read-data name="Forces"  mesh="StructureMesh" />
-         <mapping:nearest-neighbor direction="read" from="FluidMesh" to="StructureMesh"  constraint="consistent"  />
-
-      </participant>
-
-      <m2n:sockets from="Fluid" to="Structure" use-two-level-initialization="true"/>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="Fluid" second="Structure" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces" mesh="FluidMesh" from="Fluid" to="Structure" />
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="FluidMesh">
+      <use-data name="Forces"/>
+    </mesh>
+    <mesh name="StructureMesh">
+      <use-data name="Forces"/>
+    </mesh>
+    <participant name="Fluid">
+      <use-mesh name="FluidMesh" provide="yes"/>
+      <write-data name="Forces" mesh="FluidMesh"/>
+    </participant>
+    <participant name="Structure">
+      <use-mesh name="StructureMesh" provide="yes"/>
+      <use-mesh name="FluidMesh" provide="no" from="Fluid"/>
+      <read-data name="Forces" mesh="StructureMesh"/>
+      <mapping:nearest-neighbor direction="read" from="FluidMesh" to="StructureMesh" constraint="consistent"/>
+    </participant>
+    <m2n:sockets from="Fluid" to="Structure" use-two-level-initialization="true"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="Fluid" second="Structure"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="FluidMesh" from="Fluid" to="Structure"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/BB-sockets-explicit-twoway.xml
+++ b/src/precice/tests/BB-sockets-explicit-twoway.xml
@@ -1,54 +1,36 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-
-
-  <solver-interface dimensions="3" >
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="FluidMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="StructureMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-
-      <participant name="Fluid">
-         <use-mesh name="FluidMesh" provide="yes" />
-         <use-mesh name="StructureMesh" from="Structure" />
-         <write-data name="Forces"     mesh="FluidMesh" />
-         <read-data  name="Velocities" mesh="FluidMesh" />
-         <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh"
-                  constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh"
-                  constraint="consistent" timing="initial" />
-
-      </participant>
-
-      <participant name="Structure">
-         <use-mesh name="StructureMesh" provide="yes"/>
-         <write-data name="Velocities" mesh="StructureMesh" />
-         <read-data name="Forces"      mesh="StructureMesh" />
-
-      </participant>
-
-      <m2n:sockets from="Fluid" to="Structure" use-two-level-initialization="true" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="Fluid" second="Structure" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="StructureMesh" from="Fluid" to="Structure" />
-         <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="FluidMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="StructureMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="Fluid">
+      <use-mesh name="FluidMesh" provide="yes"/>
+      <use-mesh name="StructureMesh" from="Structure"/>
+      <write-data name="Forces" mesh="FluidMesh"/>
+      <read-data name="Velocities" mesh="FluidMesh"/>
+      <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh" constraint="consistent" timing="initial"/>
+    </participant>
+    <participant name="Structure">
+      <use-mesh name="StructureMesh" provide="yes"/>
+      <write-data name="Velocities" mesh="StructureMesh"/>
+      <read-data name="Forces" mesh="StructureMesh"/>
+    </participant>
+    <m2n:sockets from="Fluid" to="Structure" use-two-level-initialization="true"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="Fluid" second="Structure"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure"/>
+      <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/QN1.xml
+++ b/src/precice/tests/QN1.xml
@@ -1,56 +1,46 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="yes" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data  name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <master:mpi-single/>
-         <use-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" />
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" />
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-         <max-iterations value="100"/>
-         <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne"/>
-         <acceleration:IQN-ILS>
-            <data name="Data2" mesh="MeshOne"/>
-            <filter type="QR2" limit="1e-1"/>
-            <initial-relaxation value="1.0"/>
-            <max-used-iterations value="10"/>
-            <time-windows-reused value="0"/>
-        </acceleration:IQN-ILS>
-      </coupling-scheme:serial-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <master:mpi-single/>
+      <use-mesh name="MeshOne" from="SolverOne" safety-factor="0.1"/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      <max-iterations value="100"/>
+      <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne"/>
+      <acceleration:IQN-ILS>
+        <data name="Data2" mesh="MeshOne"/>
+        <filter type="QR2" limit="1e-1"/>
+        <initial-relaxation value="1.0"/>
+        <max-used-iterations value="10"/>
+        <time-windows-reused value="0"/>
+      </acceleration:IQN-ILS>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/QN2.xml
+++ b/src/precice/tests/QN2.xml
@@ -1,58 +1,48 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="yes" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data  name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <master:mpi-single/>
-         <use-mesh name="MeshOne" from="SolverOne" safety-factor="0.1"/>
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" />
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" />
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:parallel-implicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-         <max-iterations value="100"/>
-         <relative-convergence-measure limit="1e-7" data="Data1" mesh="MeshOne"/>
-         <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne"/>
-         <acceleration:IQN-ILS>
-            <data name="Data1" mesh="MeshOne"/>
-            <data name="Data2" mesh="MeshOne"/>
-            <filter type="QR2" limit="1e-1"/>
-            <initial-relaxation value="1.0"/>
-            <max-used-iterations value="10"/>
-            <time-windows-reused value="0"/>
-     </acceleration:IQN-ILS>
-      </coupling-scheme:parallel-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <master:mpi-single/>
+      <use-mesh name="MeshOne" from="SolverOne" safety-factor="0.1"/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:parallel-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      <max-iterations value="100"/>
+      <relative-convergence-measure limit="1e-7" data="Data1" mesh="MeshOne"/>
+      <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne"/>
+      <acceleration:IQN-ILS>
+        <data name="Data1" mesh="MeshOne"/>
+        <data name="Data2" mesh="MeshOne"/>
+        <filter type="QR2" limit="1e-1"/>
+        <initial-relaxation value="1.0"/>
+        <max-used-iterations value="10"/>
+        <time-windows-reused value="0"/>
+      </acceleration:IQN-ILS>
+    </coupling-scheme:parallel-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/QN3.xml
+++ b/src/precice/tests/QN3.xml
@@ -1,56 +1,46 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="yes" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data  name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <master:mpi-single/>
-         <use-mesh name="MeshOne" from="SolverOne" safety-factor="0.1"/>
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" />
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" />
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-         <max-iterations value="100"/>
-         <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne"/>
-         <acceleration:IQN-IMVJ>
-            <data name="Data2" mesh="MeshOne"/>
-            <filter type="QR2" limit="1e-3"/>
-            <initial-relaxation value="1.0"/>
-            <max-used-iterations value="10"/>
-            <time-windows-reused value="0"/>
-        </acceleration:IQN-IMVJ>
-      </coupling-scheme:serial-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <master:mpi-single/>
+      <use-mesh name="MeshOne" from="SolverOne" safety-factor="0.1"/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      <max-iterations value="100"/>
+      <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne"/>
+      <acceleration:IQN-IMVJ>
+        <data name="Data2" mesh="MeshOne"/>
+        <filter type="QR2" limit="1e-3"/>
+        <initial-relaxation value="1.0"/>
+        <max-used-iterations value="10"/>
+        <time-windows-reused value="0"/>
+      </acceleration:IQN-IMVJ>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/bug.xml
+++ b/src/precice/tests/bug.xml
@@ -1,56 +1,42 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-   <solver-interface dimensions="3">
-      <data:vector name="Forces"           />
-      <data:vector name="Displacements"    />
-      <data:vector name="OldDisplacements" />
-
-      <mesh name="FliteNodes">
-         <use-data name="Forces"/>
-         <use-data name="Displacements"/>
-         <use-data name="OldDisplacements"/>
-      </mesh>
-
-      <mesh name="CalculixNodes">
-         <use-data name="Forces"/>
-         <use-data name="Displacements"/>
-         <use-data name="OldDisplacements"/>
-      </mesh>
-
-      <participant name="Flite">
-         <use-mesh name="FliteNodes" provide="yes"/>
-         <use-mesh name="CalculixNodes"	from="Calculix"/>
-         <mapping:rbf-thin-plate-splines direction="write"
-                  constraint="conservative" from="FliteNodes"
-                  to="CalculixNodes" timing="initial"
-                  use-qr-decomposition="yes"/>
-         <mapping:rbf-thin-plate-splines direction="read"
-                  constraint="consistent" from="CalculixNodes"
-                  to="FliteNodes" timing="initial"
-                  use-qr-decomposition="yes"/>
-         <write-data name="Forces"           mesh="FliteNodes"/>
-         <read-data  name="Displacements"    mesh="FliteNodes"/>
-         <read-data  name="OldDisplacements" mesh="FliteNodes"/>
-         <export:vtk every-n-time-windows="1" normals="on"/>
-      </participant>
-
-      <participant name="Calculix">
-         <use-mesh name="CalculixNodes" provide="yes"/>
-         <write-data name="Displacements" mesh="CalculixNodes"/>
-         <read-data  name="Forces"        mesh="CalculixNodes"/>
-	      <export:vtk every-n-time-windows="1" normals="on"/>
-      </participant>
-
-      <m2n:mpi enforce-gather-scatter="true" from="Flite" to="Calculix"/>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="Flite" second="Calculix"/>
-         <max-time value="2.0e-5" />
-         <time-window-size value="1e-5" method="fixed"/>
-         <exchange data="Forces"        mesh="CalculixNodes" from="Flite" to="Calculix" />
-         <exchange data="Displacements" mesh="CalculixNodes" from="Calculix" to="Flite"/>
-      </coupling-scheme:serial-explicit>
-   </solver-interface>
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Displacements"/>
+    <data:vector name="OldDisplacements"/>
+    <mesh name="FliteNodes">
+      <use-data name="Forces"/>
+      <use-data name="Displacements"/>
+      <use-data name="OldDisplacements"/>
+    </mesh>
+    <mesh name="CalculixNodes">
+      <use-data name="Forces"/>
+      <use-data name="Displacements"/>
+      <use-data name="OldDisplacements"/>
+    </mesh>
+    <participant name="Flite">
+      <use-mesh name="FliteNodes" provide="yes"/>
+      <use-mesh name="CalculixNodes" from="Calculix"/>
+      <mapping:rbf-thin-plate-splines direction="write" constraint="conservative" from="FliteNodes" to="CalculixNodes" timing="initial" use-qr-decomposition="yes"/>
+      <mapping:rbf-thin-plate-splines direction="read" constraint="consistent" from="CalculixNodes" to="FliteNodes" timing="initial" use-qr-decomposition="yes"/>
+      <write-data name="Forces" mesh="FliteNodes"/>
+      <read-data name="Displacements" mesh="FliteNodes"/>
+      <read-data name="OldDisplacements" mesh="FliteNodes"/>
+      <export:vtk every-n-time-windows="1" normals="on"/>
+    </participant>
+    <participant name="Calculix">
+      <use-mesh name="CalculixNodes" provide="yes"/>
+      <write-data name="Displacements" mesh="CalculixNodes"/>
+      <read-data name="Forces" mesh="CalculixNodes"/>
+      <export:vtk every-n-time-windows="1" normals="on"/>
+    </participant>
+    <m2n:mpi enforce-gather-scatter="true" from="Flite" to="Calculix"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="Flite" second="Calculix"/>
+      <max-time value="2.0e-5"/>
+      <time-window-size value="1e-5" method="fixed"/>
+      <exchange data="Forces" mesh="CalculixNodes" from="Flite" to="Calculix"/>
+      <exchange data="Displacements" mesh="CalculixNodes" from="Calculix" to="Flite"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/config1.xml
+++ b/src/precice/tests/config1.xml
@@ -1,48 +1,38 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-
-      <data:vector name="Data1"  />
-      <data:vector name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <master:mpi-single/>
-         <use-mesh name="MeshTwo" from="SolverTwo" />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative" />
-         <mapping:nearest-neighbor direction="read" from="MeshTwo" to="MeshOne" constraint="consistent" />
-         <write-data name="Data1"     mesh="MeshOne" />
-         <read-data  name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <master:mpi-single/>
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <write-data name="Data1" mesh="MeshTwo" />
-         <read-data name="Data2" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Data1"/>
+    <data:vector name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <master:mpi-single/>
+      <use-mesh name="MeshTwo" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative"/>
+      <mapping:nearest-neighbor direction="read" from="MeshTwo" to="MeshOne" constraint="consistent"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <master:mpi-single/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <write-data name="Data1" mesh="MeshTwo"/>
+      <read-data name="Data2" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/configuration.xml
+++ b/src/precice/tests/configuration.xml
@@ -1,66 +1,54 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Forces"          />
-      <data:vector name="Velocities"      />
-      <data:vector name="Displacements"   />
-      <data:vector name="VelocityDeltas"  />
-
-      <mesh name="PeanoNodes" flip-normals="no">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-         <use-data name="Displacements" />
-         <use-data name="VelocityDeltas" />
-      </mesh>
-
-      <mesh name="ComsolNodes" flip-normals="no">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-         <use-data name="Displacements" />
-         <use-data name="VelocityDeltas" />
-      </mesh>
-
-      <m2n:sockets from="Comsol" to="Peano" />
-
-      <participant name="Peano">
-         <use-mesh name="PeanoNodes" provide="yes" />
-         <use-mesh name="ComsolNodes" from="Comsol"/>
-         <mapping:nearest-projection direction="write" from="PeanoNodes"
-                  to="ComsolNodes"
-                  constraint="conservative" timing="onadvance" />
-         <mapping:nearest-projection direction="read" from="ComsolNodes"
-                  to="PeanoNodes"
-                  constraint="consistent" timing="onadvance" />
-         <write-data name="Forces"         mesh="PeanoNodes" />
-         <read-data  name="Displacements"  mesh="PeanoNodes" />
-         <read-data  name="Velocities"     mesh="PeanoNodes" />
-         <read-data  name="VelocityDeltas" mesh="PeanoNodes" />
-         <export:vtk every-n-time-windows="100" directory="output/"/>
-         <export:vtk every-n-time-windows="100" directory=""/>
-         <watch-point name="pointa" mesh="PeanoNodes" coordinate="1.0; 1.0" />
-      </participant>
-
-      <participant name="Comsol">
-         <use-mesh name="ComsolNodes" provide="yes" />
-         <write-data name="Displacements"  mesh="ComsolNodes" />
-         <write-data name="Velocities"     mesh="ComsolNodes" />
-         <write-data name="VelocityDeltas" mesh="ComsolNodes" />
-         <read-data  name="Forces"         mesh="ComsolNodes" />
-         <action:divide-by-area mesh="ComsolNodes" timing="on-exchange-post">
-            <target-data name="Forces"/>
-         </action:divide-by-area>
-      </participant>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="Peano" second="Comsol" />
-         <max-time value="1.0" />
-         <time-window-size value="0.1" />
-         <exchange data="Forces"         mesh="ComsolNodes" from="Peano" to="Comsol"/>
-         <exchange data="Velocities"     mesh="ComsolNodes" from="Comsol" to="Peano"/>
-         <exchange data="Displacements"  mesh="ComsolNodes" from="Comsol" to="Peano"/>
-         <exchange data="VelocityDeltas" mesh="ComsolNodes" from="Comsol" to="Peano"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <data:vector name="Displacements"/>
+    <data:vector name="VelocityDeltas"/>
+    <mesh name="PeanoNodes" flip-normals="no">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+      <use-data name="Displacements"/>
+      <use-data name="VelocityDeltas"/>
+    </mesh>
+    <mesh name="ComsolNodes" flip-normals="no">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+      <use-data name="Displacements"/>
+      <use-data name="VelocityDeltas"/>
+    </mesh>
+    <m2n:sockets from="Comsol" to="Peano"/>
+    <participant name="Peano">
+      <use-mesh name="PeanoNodes" provide="yes"/>
+      <use-mesh name="ComsolNodes" from="Comsol"/>
+      <mapping:nearest-projection direction="write" from="PeanoNodes" to="ComsolNodes" constraint="conservative" timing="onadvance"/>
+      <mapping:nearest-projection direction="read" from="ComsolNodes" to="PeanoNodes" constraint="consistent" timing="onadvance"/>
+      <write-data name="Forces" mesh="PeanoNodes"/>
+      <read-data name="Displacements" mesh="PeanoNodes"/>
+      <read-data name="Velocities" mesh="PeanoNodes"/>
+      <read-data name="VelocityDeltas" mesh="PeanoNodes"/>
+      <export:vtk every-n-time-windows="100" directory="output/"/>
+      <export:vtk every-n-time-windows="100" directory=""/>
+      <watch-point name="pointa" mesh="PeanoNodes" coordinate="1.0; 1.0"/>
+    </participant>
+    <participant name="Comsol">
+      <use-mesh name="ComsolNodes" provide="yes"/>
+      <write-data name="Displacements" mesh="ComsolNodes"/>
+      <write-data name="Velocities" mesh="ComsolNodes"/>
+      <write-data name="VelocityDeltas" mesh="ComsolNodes"/>
+      <read-data name="Forces" mesh="ComsolNodes"/>
+      <action:divide-by-area mesh="ComsolNodes" timing="on-exchange-post">
+        <target-data name="Forces"/>
+      </action:divide-by-area>
+    </participant>
+    <coupling-scheme:serial-explicit>
+      <participants first="Peano" second="Comsol"/>
+      <max-time value="1.0"/>
+      <time-window-size value="0.1"/>
+      <exchange data="Forces" mesh="ComsolNodes" from="Peano" to="Comsol"/>
+      <exchange data="Velocities" mesh="ComsolNodes" from="Comsol" to="Peano"/>
+      <exchange data="Displacements" mesh="ComsolNodes" from="Comsol" to="Peano"/>
+      <exchange data="VelocityDeltas" mesh="ComsolNodes" from="Comsol" to="Peano"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/convergence-measures1.xml
+++ b/src/precice/tests/convergence-measures1.xml
@@ -1,49 +1,39 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="yes" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data  name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshOne" from="SolverOne" />
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" />
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" />
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="2" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-         <max-iterations value="100"/>
-         <absolute-convergence-measure limit="1e-1" data="Data2" mesh="MeshOne" suffices="true"/>
-         <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshOne"/>
-      </coupling-scheme:serial-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      <max-iterations value="100"/>
+      <absolute-convergence-measure limit="1e-1" data="Data2" mesh="MeshOne" suffices="true"/>
+      <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshOne"/>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/convergence-measures2.xml
+++ b/src/precice/tests/convergence-measures2.xml
@@ -1,49 +1,39 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="yes" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data  name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshOne" from="SolverOne" />
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" />
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" />
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="2" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-         <max-iterations value="100"/>
-         <absolute-convergence-measure limit="1e-1" data="Data2" mesh="MeshOne" />
-         <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshOne" suffices="true"/>
-      </coupling-scheme:serial-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      <max-iterations value="100"/>
+      <absolute-convergence-measure limit="1e-1" data="Data2" mesh="MeshOne"/>
+      <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshOne" suffices="true"/>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/convergence-measures3.xml
+++ b/src/precice/tests/convergence-measures3.xml
@@ -1,49 +1,39 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="yes" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data  name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshOne" from="SolverOne" />
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" />
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" />
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="2" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-         <max-iterations value="100"/>
-         <absolute-convergence-measure limit="1e-1" data="Data2" mesh="MeshOne" strict="true"/>
-         <min-iteration-convergence-measure min-iterations="2" data="Data1" mesh="MeshOne" suffices="true"/>
-      </coupling-scheme:serial-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      <max-iterations value="100"/>
+      <absolute-convergence-measure limit="1e-1" data="Data2" mesh="MeshOne" strict="true"/>
+      <min-iteration-convergence-measure min-iterations="2" data="Data1" mesh="MeshOne" suffices="true"/>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/cplmode-1.xml
+++ b/src/precice/tests/cplmode-1.xml
@@ -1,38 +1,32 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:scalar name="ScalarData" />
-      <data:vector name="VectorData" />
-      
-      <mesh name="Mesh">
-         <use-data name="ScalarData"/>
-         <use-data name="VectorData"/>
-      </mesh>
-      
-      <participant name="ParticipantA">
-         <use-mesh name="Mesh" provide="true"/>
-         <write-data name="ScalarData" mesh="Mesh"/>
-         <read-data  name="VectorData" mesh="Mesh"/>
-         <export:vtk/>
-      </participant>
-      
-      <participant name="ParticipantB">
-         <server:mpi-single/>
-         <use-mesh name="Mesh" from="ParticipantA" />
-         <write-data name="VectorData" mesh="Mesh"/>
-         <read-data  name="ScalarData" mesh="Mesh"/>
-         <export:vtk/>
-      </participant>
-      
-      <m2n:sockets from="ParticipantA" to="ParticipantB"/>
-      
-      <coupling-scheme:serial-explicit>
-         <participants first="ParticipantA" second="ParticipantB"/>
-         <max-timesteps value="5"/>
-         <timestep-length value="1.0"/>
-         <exchange data="ScalarData" mesh="Mesh" from="ParticipantA" to="ParticipantB"/>
-         <exchange data="VectorData"  mesh="Mesh" from="ParticipantB" to="ParticipantA"/>
-      </coupling-scheme:serial-explicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:scalar name="ScalarData"/>
+    <data:vector name="VectorData"/>
+    <mesh name="Mesh">
+      <use-data name="ScalarData"/>
+      <use-data name="VectorData"/>
+    </mesh>
+    <participant name="ParticipantA">
+      <use-mesh name="Mesh" provide="true"/>
+      <write-data name="ScalarData" mesh="Mesh"/>
+      <read-data name="VectorData" mesh="Mesh"/>
+      <export:vtk/>
+    </participant>
+    <participant name="ParticipantB">
+      <server:mpi-single/>
+      <use-mesh name="Mesh" from="ParticipantA"/>
+      <write-data name="VectorData" mesh="Mesh"/>
+      <read-data name="ScalarData" mesh="Mesh"/>
+      <export:vtk/>
+    </participant>
+    <m2n:sockets from="ParticipantA" to="ParticipantB"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="ParticipantA" second="ParticipantB"/>
+      <max-timesteps value="5"/>
+      <timestep-length value="1.0"/>
+      <exchange data="ScalarData" mesh="Mesh" from="ParticipantA" to="ParticipantB"/>
+      <exchange data="VectorData" mesh="Mesh" from="ParticipantB" to="ParticipantA"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/explicit-data-init.xml
+++ b/src/precice/tests/explicit-data-init.xml
@@ -1,47 +1,36 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-      <data:vector name="DataOne"/>
-      <data:scalar name="DataTwo"/>
-
-      <mesh name="MeshOne">
-         <use-data name="DataOne"/>
-         <use-data name="DataTwo"/>
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="DataOne"/>
-         <use-data name="DataTwo"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="on"/>
-         <write-data name="DataOne" mesh="MeshOne"/>
-         <read-data  name="DataTwo" mesh="MeshOne"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshOne" from="SolverOne"/>
-         <use-mesh name="MeshTwo" provide="on"/>
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne"
-          	      constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo"
-                  constraint="consistent" timing="initial"/>
-         <write-data name="DataTwo" mesh="MeshTwo"/>
-         <read-data  name="DataOne"     mesh="MeshTwo"/>
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="5"/>
-         <time-window-size value="1.0"/>
-         <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
-         <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="DataOne"/>
+    <data:scalar name="DataTwo"/>
+    <mesh name="MeshOne">
+      <use-data name="DataOne"/>
+      <use-data name="DataTwo"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="DataOne"/>
+      <use-data name="DataTwo"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on"/>
+      <write-data name="DataOne" mesh="MeshOne"/>
+      <read-data name="DataTwo" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="on"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" timing="initial"/>
+      <write-data name="DataTwo" mesh="MeshTwo"/>
+      <read-data name="DataOne" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="5"/>
+      <time-window-size value="1.0"/>
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/explicit-datascaling.xml
+++ b/src/precice/tests/explicit-datascaling.xml
@@ -1,54 +1,45 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Forces"     />
-      <data:vector name="Velocities" />
-
-      <mesh name="Test-Square-One">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="Test-Square-Two">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-
-      <participant name="SolverOne">
-         <use-mesh name="Test-Square-One" provide="yes"/>
-         <write-data name="Velocities" mesh="Test-Square-One" />
-         <read-data  name="Forces"     mesh="Test-Square-One" />
-         <action:divide-by-area timing="on-exchange-post" mesh="Test-Square-One">
-            <target-data name="Forces"/>
-         </action:divide-by-area>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="Test-Square-Two" provide="yes"/>
-         <use-mesh name="Test-Square-One" from="SolverOne"/>
-         <write-data name="Forces"    mesh="Test-Square-Two" />
-         <read-data name="Velocities" mesh="Test-Square-Two" />
-         <mapping:nearest-neighbor direction="read" from="Test-Square-One" to="Test-Square-Two" constraint="consistent" />
-         <mapping:nearest-neighbor direction="write" from="Test-Square-Two" to="Test-Square-One" constraint="conservative" />
-         <action:divide-by-area timing="on-exchange-post" mesh="Test-Square-Two">
-            <target-data name="Velocities"/>
-         </action:divide-by-area>
-         <action:divide-by-area timing="on-exchange-post" mesh="Test-Square-One">
-            <target-data name="Velocities"/>
-         </action:divide-by-area>
-      </participant>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="0.01" />
-         <exchange data="Forces"     mesh="Test-Square-One" from="SolverTwo" to="SolverOne"/>
-         <exchange data="Velocities" mesh="Test-Square-One" from="SolverOne" to="SolverTwo"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="Test-Square-One">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="Test-Square-Two">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <participant name="SolverOne">
+      <use-mesh name="Test-Square-One" provide="yes"/>
+      <write-data name="Velocities" mesh="Test-Square-One"/>
+      <read-data name="Forces" mesh="Test-Square-One"/>
+      <action:divide-by-area timing="on-exchange-post" mesh="Test-Square-One">
+        <target-data name="Forces"/>
+      </action:divide-by-area>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="Test-Square-Two" provide="yes"/>
+      <use-mesh name="Test-Square-One" from="SolverOne"/>
+      <write-data name="Forces" mesh="Test-Square-Two"/>
+      <read-data name="Velocities" mesh="Test-Square-Two"/>
+      <mapping:nearest-neighbor direction="read" from="Test-Square-One" to="Test-Square-Two" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="write" from="Test-Square-Two" to="Test-Square-One" constraint="conservative"/>
+      <action:divide-by-area timing="on-exchange-post" mesh="Test-Square-Two">
+        <target-data name="Velocities"/>
+      </action:divide-by-area>
+      <action:divide-by-area timing="on-exchange-post" mesh="Test-Square-One">
+        <target-data name="Velocities"/>
+      </action:divide-by-area>
+    </participant>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="0.01"/>
+      <exchange data="Forces" mesh="Test-Square-One" from="SolverTwo" to="SolverOne"/>
+      <exchange data="Velocities" mesh="Test-Square-One" from="SolverOne" to="SolverTwo"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/explicit-mpi-single-non-inc.xml
+++ b/src/precice/tests/explicit-mpi-single-non-inc.xml
@@ -1,63 +1,48 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-
-
-   <solver-interface dimensions="3">
-
-      <data:vector name="Forces"/>
-      <data:vector name="Velocities"/>
-      <data:scalar name="Pressures"/>
-      <data:scalar name="Temperatures"/>
-
-      <mesh name="Test-Square">
-         <use-data name="Forces"/>
-         <use-data name="Velocities"/>
-         <use-data name="Pressures"/>
-         <use-data name="Temperatures"/>
-      </mesh>
-
-      <mesh name="MeshOne">
-         <use-data name="Forces"/>
-         <use-data name="Velocities"/>
-         <use-data name="Pressures"/>
-         <use-data name="Temperatures"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="Test-Square" from="SolverTwo"/>
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
-                  constraint="conservative" timing="onadvance"/>
-         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
-                  constraint="consistent" timing="ondemand"/>
-         <write-data name="Forces"       mesh="MeshOne"/>
-         <write-data name="Pressures"    mesh="MeshOne"/>
-         <read-data  name="Velocities"   mesh="MeshOne"/>
-         <read-data  name="Temperatures" mesh="MeshOne"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="Test-Square" provide="yes"/>
-         <write-data name="Velocities"   mesh="Test-Square"/>
-         <write-data name="Temperatures" mesh="Test-Square"/>
-         <read-data name="Forces"        mesh="Test-Square"/>
-         <read-data name="Pressures"     mesh="Test-Square"/>
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="Test-Square" from="SolverOne" to="SolverTwo"/>
-         <exchange data="Pressures"  mesh="Test-Square" from="SolverOne" to="SolverTwo"/>
-         <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
-         <exchange data="Temperatures" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <data:scalar name="Pressures"/>
+    <data:scalar name="Temperatures"/>
+    <mesh name="Test-Square">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+      <use-data name="Pressures"/>
+      <use-data name="Temperatures"/>
+    </mesh>
+    <mesh name="MeshOne">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+      <use-data name="Pressures"/>
+      <use-data name="Temperatures"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="Test-Square" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square" constraint="conservative" timing="onadvance"/>
+      <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne" constraint="consistent" timing="ondemand"/>
+      <write-data name="Forces" mesh="MeshOne"/>
+      <write-data name="Pressures" mesh="MeshOne"/>
+      <read-data name="Velocities" mesh="MeshOne"/>
+      <read-data name="Temperatures" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="Test-Square" provide="yes"/>
+      <write-data name="Velocities" mesh="Test-Square"/>
+      <write-data name="Temperatures" mesh="Test-Square"/>
+      <read-data name="Forces" mesh="Test-Square"/>
+      <read-data name="Pressures" mesh="Test-Square"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Pressures" mesh="Test-Square" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
+      <exchange data="Temperatures" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/explicit-mpi-single.xml
+++ b/src/precice/tests/explicit-mpi-single.xml
@@ -1,48 +1,36 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="Test-Square">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="MeshOne">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="Test-Square" from="SolverTwo" />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
-                  constraint="conservative" timing="onadvance"/>
-         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
-                  constraint="consistent" timing="onadvance" />
-         <write-data name="Forces"     mesh="MeshOne" />
-         <read-data  name="Velocities" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="Test-Square" provide="yes"/>
-         <write-data name="Velocities" mesh="Test-Square" />
-         <read-data name="Forces"      mesh="Test-Square" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="Test-Square" from="SolverOne" to="SolverTwo" />
-         <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="Test-Square">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="MeshOne">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="Test-Square" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square" constraint="conservative" timing="onadvance"/>
+      <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne" constraint="consistent" timing="onadvance"/>
+      <write-data name="Forces" mesh="MeshOne"/>
+      <read-data name="Velocities" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="Test-Square" provide="yes"/>
+      <write-data name="Velocities" mesh="Test-Square"/>
+      <read-data name="Forces" mesh="Test-Square"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/explicit-mpi.xml
+++ b/src/precice/tests/explicit-mpi.xml
@@ -1,48 +1,36 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="Test-Square">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="MeshOne">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="Test-Square" from="SolverTwo"  />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
-                  constraint="conservative"/>
-         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
-                  constraint="consistent" timing="onadvance" />
-         <write-data name="Forces"     mesh="Test-Square" />
-         <read-data  name="Velocities" mesh="Test-Square" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="Test-Square" provide="yes"/>
-         <write-data name="Velocities" mesh="Test-Square" />
-         <read-data name="Forces"      mesh="Test-Square" />
-      </participant>
-
-      <m2n:mpi from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="Test-Square" from="SolverOne" to="SolverTwo" />
-         <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="Test-Square">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="MeshOne">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="Test-Square" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square" constraint="conservative"/>
+      <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne" constraint="consistent" timing="onadvance"/>
+      <write-data name="Forces" mesh="Test-Square"/>
+      <read-data name="Velocities" mesh="Test-Square"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="Test-Square" provide="yes"/>
+      <write-data name="Velocities" mesh="Test-Square"/>
+      <read-data name="Forces" mesh="Test-Square"/>
+    </participant>
+    <m2n:mpi from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/explicit-sockets.xml
+++ b/src/precice/tests/explicit-sockets.xml
@@ -1,49 +1,36 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-   <solver-interface dimensions="3" >
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="Test-Square">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="MeshOne">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="Test-Square" from="SolverTwo" />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square"
-                  constraint="conservative"/>
-         <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne"
-                  constraint="consistent" timing="onadvance" />
-         <write-data name="Forces"     mesh="Test-Square" />
-         <read-data  name="Velocities" mesh="Test-Square" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="Test-Square" provide="yes"/>
-         <write-data name="Velocities" mesh="Test-Square" />
-         <read-data name="Forces"      mesh="Test-Square" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="Test-Square" from="SolverOne" to="SolverTwo" />
-         <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="Test-Square">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="MeshOne">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="Test-Square" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="Test-Square" constraint="conservative"/>
+      <mapping:nearest-neighbor direction="read" from="Test-Square" to="MeshOne" constraint="consistent" timing="onadvance"/>
+      <write-data name="Forces" mesh="Test-Square"/>
+      <read-data name="Velocities" mesh="Test-Square"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="Test-Square" provide="yes"/>
+      <write-data name="Velocities" mesh="Test-Square"/>
+      <read-data name="Forces" mesh="Test-Square"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/explicit-solvergeometry.xml
+++ b/src/precice/tests/explicit-solvergeometry.xml
@@ -1,54 +1,42 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
   <solver-interface dimensions="3">
-
-      <data:vector name="Forces"         />
-      <data:vector name="Velocities"      />
-      <data:vector name="Displacements"  />
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <mesh name="MeshOne">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-         <use-data name="Displacements" />
-      </mesh>
-
-      <mesh name="SolverGeometry" flip-normals="inside">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-         <use-data name="Displacements" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="yes"/>
-         <use-mesh name="SolverGeometry" from="SolverTwo" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="SolverGeometry"
-                  constraint="conservative" timing="initial" />
-         <mapping:nearest-neighbor direction="read" from="SolverGeometry" to="MeshOne"
-                  constraint="consistent" timing="initial" />
-         <write-data name="Forces"        mesh="MeshOne" />
-         <read-data  name="Velocities"    mesh="MeshOne" />
-         <read-data  name="Displacements" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="SolverGeometry" provide="yes" />
-         <write-data name="Displacements" mesh="SolverGeometry" />
-         <write-data name="Velocities"    mesh="SolverGeometry" />
-         <read-data name="Forces"         mesh="SolverGeometry" />
-      </participant>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="5" />
-         <time-window-size value="0.01" />
-         <exchange data="Forces"        mesh="SolverGeometry" from="SolverOne" to="SolverTwo"/>
-         <exchange data="Velocities"    mesh="SolverGeometry" from="SolverTwo" to="SolverOne"/>
-         <exchange data="Displacements" mesh="SolverGeometry" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <data:vector name="Displacements"/>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <mesh name="MeshOne">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+      <use-data name="Displacements"/>
+    </mesh>
+    <mesh name="SolverGeometry" flip-normals="inside">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+      <use-data name="Displacements"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <use-mesh name="SolverGeometry" from="SolverTwo"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="SolverGeometry" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="SolverGeometry" to="MeshOne" constraint="consistent" timing="initial"/>
+      <write-data name="Forces" mesh="MeshOne"/>
+      <read-data name="Velocities" mesh="MeshOne"/>
+      <read-data name="Displacements" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="SolverGeometry" provide="yes"/>
+      <write-data name="Displacements" mesh="SolverGeometry"/>
+      <write-data name="Velocities" mesh="SolverGeometry"/>
+      <read-data name="Forces" mesh="SolverGeometry"/>
+    </participant>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="5"/>
+      <time-window-size value="0.01"/>
+      <exchange data="Forces" mesh="SolverGeometry" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Velocities" mesh="SolverGeometry" from="SolverTwo" to="SolverOne"/>
+      <exchange data="Displacements" mesh="SolverGeometry" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/gather-scatter-mpi.xml
+++ b/src/precice/tests/gather-scatter-mpi.xml
@@ -1,54 +1,38 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-
-
-   <solver-interface dimensions="3">
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="FluidMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="StructureMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-
-      <participant name="Fluid">
-         <master:mpi-single/>
-         <use-mesh name="FluidMesh" provide="yes" />
-         <use-mesh name="StructureMesh" from="Structure" />
-         <write-data name="Forces"     mesh="FluidMesh" />
-         <read-data  name="Velocities" mesh="FluidMesh" />
-         <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh"
-                  constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh"
-                  constraint="consistent" timing="initial" />
-      </participant>
-
-      <participant name="Structure">
-         <master:mpi-single/>
-         <use-mesh name="StructureMesh" provide="yes"/>
-         <write-data name="Velocities" mesh="StructureMesh" />
-         <read-data name="Forces"      mesh="StructureMesh" />
-      </participant>
-
-      <m2n:mpi enforce-gather-scatter="true" from="Fluid" to="Structure" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="Fluid" second="Structure" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="StructureMesh" from="Fluid" to="Structure" />
-         <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="FluidMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="StructureMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="Fluid">
+      <master:mpi-single/>
+      <use-mesh name="FluidMesh" provide="yes"/>
+      <use-mesh name="StructureMesh" from="Structure"/>
+      <write-data name="Forces" mesh="FluidMesh"/>
+      <read-data name="Velocities" mesh="FluidMesh"/>
+      <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh" constraint="consistent" timing="initial"/>
+    </participant>
+    <participant name="Structure">
+      <master:mpi-single/>
+      <use-mesh name="StructureMesh" provide="yes"/>
+      <write-data name="Velocities" mesh="StructureMesh"/>
+      <read-data name="Forces" mesh="StructureMesh"/>
+    </participant>
+    <m2n:mpi enforce-gather-scatter="true" from="Fluid" to="Structure"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="Fluid" second="Structure"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure"/>
+      <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/globalRBFPartitioning.xml
+++ b/src/precice/tests/globalRBFPartitioning.xml
@@ -1,47 +1,37 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <master:mpi-single/>
-         <use-mesh name="MeshTwo" from="SolverTwo" />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative" />
-         <mapping:rbf-thin-plate-splines direction="read" from="MeshTwo" to="MeshOne" constraint="consistent" y-dead="true"/>
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <master:mpi-single/>
+      <use-mesh name="MeshTwo" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative"/>
+      <mapping:rbf-thin-plate-splines direction="read" from="MeshTwo" to="MeshOne" constraint="consistent" y-dead="true"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/implicit-data-init.xml
+++ b/src/precice/tests/implicit-data-init.xml
@@ -1,48 +1,38 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-  <solver-interface dimensions="2" >
-
-    <data:vector name="Forces"  />
-    <data:vector name="Velocities"  />
-
+  <solver-interface dimensions="2">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
     <mesh name="MeshOne">
-      <use-data name="Forces" />
-      <use-data name="Velocities" />
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
     </mesh>
-
     <mesh name="MeshTwo">
-      <use-data name="Forces" />
-      <use-data name="Velocities" />
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
     </mesh>
-
     <participant name="SolverOne">
       <use-mesh name="MeshOne" provide="yes"/>
-      <write-data name="Forces"     mesh="MeshOne" />
-      <read-data  name="Velocities" mesh="MeshOne" />
+      <write-data name="Forces" mesh="MeshOne"/>
+      <read-data name="Velocities" mesh="MeshOne"/>
     </participant>
-
     <participant name="SolverTwo">
       <use-mesh name="MeshOne" from="SolverOne"/>
       <use-mesh name="MeshTwo" provide="yes"/>
       <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
-      <mapping:nearest-neighbor direction="read"  from="MeshOne" to="MeshTwo" constraint="consistent" />
-      <write-data name="Velocities" mesh="MeshTwo" />
-      <read-data  name="Forces"     mesh="MeshTwo" />
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <write-data name="Velocities" mesh="MeshTwo"/>
+      <read-data name="Forces" mesh="MeshTwo"/>
     </participant>
-
     <m2n:sockets from="SolverOne" to="SolverTwo"/>
-
     <coupling-scheme:serial-implicit>
-      <participants first="SolverOne" second="SolverTwo" />
-      <max-time-windows value="10" />
-      <time-window-size value="1.0" />
-      <max-iterations value="3" />
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="3"/>
       <min-iteration-convergence-measure min-iterations="5" data="Forces" mesh="MeshOne"/>
-      <exchange data="Forces"     mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="Forces" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
       <exchange data="Velocities" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="true"/>
     </coupling-scheme:serial-implicit>
-
   </solver-interface>
-
 </precice-configuration>

--- a/src/precice/tests/implicit.xml
+++ b/src/precice/tests/implicit.xml
@@ -1,50 +1,37 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-   <solver-interface dimensions="3">
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <mesh name="Square" flip-normals="inside">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="SquareTwo" flip-normals="inside">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="Square" provide="yes"/>
-         <write-data name="Forces"    mesh="Square" />
-         <read-data name="Velocities" mesh="Square" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="Square" from="SolverOne"/>
-         <use-mesh name="SquareTwo" provide="yes"/>
-         <mapping:nearest-neighbor direction="write" from="SquareTwo" to="Square" constraint="conservative" />
-         <write-data name="Velocities" mesh="Square" />
-         <read-data name="Forces"      mesh="Square" />
-      </participant>
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="4" />
-         <time-window-size value="0.01" />
-         <max-iterations value="100" />
-         <absolute-convergence-measure
-            data="Velocities"
-            mesh="Square"
-            limit="1.73205080756887729" />
-         <exchange data="Forces"     mesh="Square" from="SolverOne" to="SolverTwo"/>
-         <exchange data="Velocities" mesh="Square" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <mesh name="Square" flip-normals="inside">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="SquareTwo" flip-normals="inside">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="Square" provide="yes"/>
+      <write-data name="Forces" mesh="Square"/>
+      <read-data name="Velocities" mesh="Square"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="Square" from="SolverOne"/>
+      <use-mesh name="SquareTwo" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="SquareTwo" to="Square" constraint="conservative"/>
+      <write-data name="Velocities" mesh="Square"/>
+      <read-data name="Forces" mesh="Square"/>
+    </participant>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="4"/>
+      <time-window-size value="0.01"/>
+      <max-iterations value="100"/>
+      <absolute-convergence-measure data="Velocities" mesh="Square" limit="1.73205080756887729"/>
+      <exchange data="Forces" mesh="Square" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Velocities" mesh="Square" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/lifecycle.xml
+++ b/src/precice/tests/lifecycle.xml
@@ -1,47 +1,36 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-      <data:vector name="DataOne"/>
-      <data:scalar name="DataTwo"/>
-
-      <mesh name="MeshOne">
-         <use-data name="DataOne"/>
-         <use-data name="DataTwo"/>
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="DataOne"/>
-         <use-data name="DataTwo"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="on"/>
-         <write-data name="DataOne" mesh="MeshOne"/>
-         <read-data  name="DataTwo" mesh="MeshOne"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshOne" from="SolverOne"/>
-         <use-mesh name="MeshTwo" provide="on"/>
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne"
-          	      constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo"
-                  constraint="consistent" timing="initial"/>
-         <write-data name="DataTwo" mesh="MeshTwo"/>
-         <read-data  name="DataOne" mesh="MeshTwo"/>
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="5"/>
-         <time-window-size value="1.0"/>
-         <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
-         <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="DataOne"/>
+    <data:scalar name="DataTwo"/>
+    <mesh name="MeshOne">
+      <use-data name="DataOne"/>
+      <use-data name="DataTwo"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="DataOne"/>
+      <use-data name="DataTwo"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on"/>
+      <write-data name="DataOne" mesh="MeshOne"/>
+      <read-data name="DataTwo" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="on"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" timing="initial"/>
+      <write-data name="DataTwo" mesh="MeshTwo"/>
+      <read-data name="DataOne" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="5"/>
+      <time-window-size value="1.0"/>
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/line-coupling.xml
+++ b/src/precice/tests/line-coupling.xml
@@ -1,39 +1,29 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-
-      <data:scalar name="Pressure"  />
-
-      <mesh name="FASTEST_Mesh">
-         <use-data name="Pressure" />
-      </mesh>
-
-      <mesh name="Ateles_Mesh">
-         <use-data name="Pressure" />
-      </mesh>
-
-      <participant name="Ateles">
-         <use-mesh name="FASTEST_Mesh" from="FASTEST" />
-         <use-mesh name="Ateles_Mesh" provide="yes" />
-         <mapping:nearest-neighbor direction="read" from="FASTEST_Mesh" to="Ateles_Mesh" constraint="consistent" />
-         <read-data name="Pressure" mesh="Ateles_Mesh" />
-      </participant>
-
-      <participant name="FASTEST">
-         <use-mesh name="FASTEST_Mesh" provide="yes"/>
-         <write-data name="Pressure" mesh="FASTEST_Mesh" />
-      </participant>
-
-      <m2n:sockets from="FASTEST" to="Ateles" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="FASTEST" second="Ateles" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Pressure" mesh="FASTEST_Mesh" from="FASTEST" to="Ateles" />
-      </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:scalar name="Pressure"/>
+    <mesh name="FASTEST_Mesh">
+      <use-data name="Pressure"/>
+    </mesh>
+    <mesh name="Ateles_Mesh">
+      <use-data name="Pressure"/>
+    </mesh>
+    <participant name="Ateles">
+      <use-mesh name="FASTEST_Mesh" from="FASTEST"/>
+      <use-mesh name="Ateles_Mesh" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="FASTEST_Mesh" to="Ateles_Mesh" constraint="consistent"/>
+      <read-data name="Pressure" mesh="Ateles_Mesh"/>
+    </participant>
+    <participant name="FASTEST">
+      <use-mesh name="FASTEST_Mesh" provide="yes"/>
+      <write-data name="Pressure" mesh="FASTEST_Mesh"/>
+    </participant>
+    <m2n:sockets from="FASTEST" to="Ateles"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="FASTEST" second="Ateles"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Pressure" mesh="FASTEST_Mesh" from="FASTEST" to="Ateles"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/localRBFPartitioning.xml
+++ b/src/precice/tests/localRBFPartitioning.xml
@@ -1,47 +1,37 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <master:mpi-single/>
-         <use-mesh name="MeshTwo" from="SolverTwo" />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative" />
-         <mapping:rbf-compact-tps-c2 direction="read" from="MeshTwo" to="MeshOne" constraint="consistent" support-radius="0.3" y-dead="true"/>
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <master:mpi-single/>
+      <use-mesh name="MeshTwo" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative"/>
+      <mapping:rbf-compact-tps-c2 direction="read" from="MeshTwo" to="MeshOne" constraint="consistent" support-radius="0.3" y-dead="true"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/mapping-nearest-projection.xml
+++ b/src/precice/tests/mapping-nearest-projection.xml
@@ -1,39 +1,29 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-      <data:scalar name="DataOne"/>
-
-      <mesh name="MeshOne">
-         <use-data name="DataOne"/>
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="DataOne"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="on"/>
-         <write-data name="DataOne" mesh="MeshOne"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshOne" from="SolverOne"/>
-         <use-mesh name="MeshTwo" provide="on"/>
-         <mapping:nearest-projection direction="read" from="MeshOne" to="MeshTwo"
-                  constraint="consistent" timing="initial"/>
-         <read-data  name="DataOne" mesh="MeshTwo"/>
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="1"/>
-         <time-window-size value="1.0"/>
-         <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:scalar name="DataOne"/>
+    <mesh name="MeshOne">
+      <use-data name="DataOne"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="DataOne"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on"/>
+      <write-data name="DataOne" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="on"/>
+      <mapping:nearest-projection direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" timing="initial"/>
+      <read-data name="DataOne" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/mapping-without-geo-2D.xml
+++ b/src/precice/tests/mapping-without-geo-2D.xml
@@ -1,54 +1,43 @@
+<?xml version="1.0"?>
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Forces"        />
-      <data:vector name="Displacements" />
-
-      <mesh name="MeshForcesA">
-         <use-data name="Forces"/>
-      </mesh>
-      <mesh name="MeshDisplacementsA">
-         <use-data name="Displacements"/>
-      </mesh>
-
-      <mesh name="MeshForcesB">
-         <use-data name="Forces"/>
-      </mesh>
-      <mesh name="MeshDisplacementsB">
-         <use-data name="Displacements"/>
-      </mesh>
-
-      <m2n:sockets from="SolverA" to="SolverB"/>
-
-      <participant name="SolverA">
-         <use-mesh name="MeshDisplacementsA" provide="yes"/>
-         <use-mesh name="MeshForcesA"        provide="yes"/>
-         <use-mesh name="MeshForcesB"        from="SolverB"/>
-         <use-mesh name="MeshDisplacementsB" from="SolverB"/>
-         <mapping:rbf-thin-plate-splines direction="write"
-                  constraint="conservative" from="MeshForcesA"
-                  to="MeshForcesB" timing="ondemand"
-                  use-qr-decomposition="yes"/>
-         <mapping:rbf-thin-plate-splines direction="read"
-                  constraint="consistent" from="MeshDisplacementsB"
-                  to="MeshDisplacementsA" timing="ondemand"
-                  use-qr-decomposition="yes"/>
-         <write-data name="Forces"        mesh="MeshForcesA"/>
-         <read-data  name="Displacements" mesh="MeshDisplacementsA"/>
-      </participant>
-
-      <participant name="SolverB">
-         <use-mesh name="MeshDisplacementsB" provide="yes"/>
-         <use-mesh name="MeshForcesB"        provide="yes"/>
-         <write-data name="Displacements" mesh="MeshDisplacementsB"/>
-         <read-data  name="Forces"        mesh="MeshForcesB"/>
-      </participant>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverA" second="SolverB"/>
-         <max-time-windows value="2"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Forces"        mesh="MeshForcesB"        from="SolverA" to="SolverB"/>
-         <exchange data="Displacements" mesh="MeshDisplacementsB" from="SolverB" to="SolverA"/>
-      </coupling-scheme:serial-explicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Forces"/>
+    <data:vector name="Displacements"/>
+    <mesh name="MeshForcesA">
+      <use-data name="Forces"/>
+    </mesh>
+    <mesh name="MeshDisplacementsA">
+      <use-data name="Displacements"/>
+    </mesh>
+    <mesh name="MeshForcesB">
+      <use-data name="Forces"/>
+    </mesh>
+    <mesh name="MeshDisplacementsB">
+      <use-data name="Displacements"/>
+    </mesh>
+    <m2n:sockets from="SolverA" to="SolverB"/>
+    <participant name="SolverA">
+      <use-mesh name="MeshDisplacementsA" provide="yes"/>
+      <use-mesh name="MeshForcesA" provide="yes"/>
+      <use-mesh name="MeshForcesB" from="SolverB"/>
+      <use-mesh name="MeshDisplacementsB" from="SolverB"/>
+      <mapping:rbf-thin-plate-splines direction="write" constraint="conservative" from="MeshForcesA" to="MeshForcesB" timing="ondemand" use-qr-decomposition="yes"/>
+      <mapping:rbf-thin-plate-splines direction="read" constraint="consistent" from="MeshDisplacementsB" to="MeshDisplacementsA" timing="ondemand" use-qr-decomposition="yes"/>
+      <write-data name="Forces" mesh="MeshForcesA"/>
+      <read-data name="Displacements" mesh="MeshDisplacementsA"/>
+    </participant>
+    <participant name="SolverB">
+      <use-mesh name="MeshDisplacementsB" provide="yes"/>
+      <use-mesh name="MeshForcesB" provide="yes"/>
+      <write-data name="Displacements" mesh="MeshDisplacementsB"/>
+      <read-data name="Forces" mesh="MeshForcesB"/>
+    </participant>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverA" second="SolverB"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="MeshForcesB" from="SolverA" to="SolverB"/>
+      <exchange data="Displacements" mesh="MeshDisplacementsB" from="SolverB" to="SolverA"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/mapping-without-geo-3D.xml
+++ b/src/precice/tests/mapping-without-geo-3D.xml
@@ -1,54 +1,43 @@
+<?xml version="1.0"?>
 <precice-configuration>
-   <solver-interface dimensions="3">
-      <data:vector name="Forces"        />
-      <data:vector name="Displacements" />
-
-      <mesh name="MeshForcesA">
-         <use-data name="Forces"/>
-      </mesh>
-      <mesh name="MeshDisplacementsA">
-         <use-data name="Displacements"/>
-      </mesh>
-
-      <mesh name="MeshForcesB">
-         <use-data name="Forces"/>
-      </mesh>
-      <mesh name="MeshDisplacementsB">
-         <use-data name="Displacements"/>
-      </mesh>
-
-      <m2n:sockets from="SolverA" to="SolverB"/>
-
-      <participant name="SolverA">
-         <use-mesh name="MeshDisplacementsA" provide="yes"/>
-         <use-mesh name="MeshForcesA"        provide="yes"/>
-         <use-mesh name="MeshForcesB"        from="SolverB"/>
-         <use-mesh name="MeshDisplacementsB" from="SolverB"/>
-         <mapping:rbf-thin-plate-splines direction="write"
-                  constraint="conservative" from="MeshForcesA"
-                  to="MeshForcesB" timing="ondemand"
-                  use-qr-decomposition="yes"/>
-         <mapping:rbf-thin-plate-splines direction="read"
-                  constraint="consistent" from="MeshDisplacementsB"
-                  to="MeshDisplacementsA" timing="ondemand"
-                  use-qr-decomposition="yes"/>
-         <write-data name="Forces"        mesh="MeshForcesA"/>
-         <read-data  name="Displacements" mesh="MeshDisplacementsA"/>
-      </participant>
-
-      <participant name="SolverB">
-         <use-mesh name="MeshDisplacementsB" provide="yes"/>
-         <use-mesh name="MeshForcesB"        provide="yes"/>
-         <write-data name="Displacements" mesh="MeshDisplacementsB"/>
-         <read-data  name="Forces"        mesh="MeshForcesB"/>
-      </participant>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverA" second="SolverB"/>
-         <max-time-windows value="2"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Forces"        mesh="MeshForcesB"        from="SolverA" to="SolverB"/>
-         <exchange data="Displacements" mesh="MeshDisplacementsB" from="SolverB" to="SolverA"/>
-      </coupling-scheme:serial-explicit>
-   </solver-interface>
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Displacements"/>
+    <mesh name="MeshForcesA">
+      <use-data name="Forces"/>
+    </mesh>
+    <mesh name="MeshDisplacementsA">
+      <use-data name="Displacements"/>
+    </mesh>
+    <mesh name="MeshForcesB">
+      <use-data name="Forces"/>
+    </mesh>
+    <mesh name="MeshDisplacementsB">
+      <use-data name="Displacements"/>
+    </mesh>
+    <m2n:sockets from="SolverA" to="SolverB"/>
+    <participant name="SolverA">
+      <use-mesh name="MeshDisplacementsA" provide="yes"/>
+      <use-mesh name="MeshForcesA" provide="yes"/>
+      <use-mesh name="MeshForcesB" from="SolverB"/>
+      <use-mesh name="MeshDisplacementsB" from="SolverB"/>
+      <mapping:rbf-thin-plate-splines direction="write" constraint="conservative" from="MeshForcesA" to="MeshForcesB" timing="ondemand" use-qr-decomposition="yes"/>
+      <mapping:rbf-thin-plate-splines direction="read" constraint="consistent" from="MeshDisplacementsB" to="MeshDisplacementsA" timing="ondemand" use-qr-decomposition="yes"/>
+      <write-data name="Forces" mesh="MeshForcesA"/>
+      <read-data name="Displacements" mesh="MeshDisplacementsA"/>
+    </participant>
+    <participant name="SolverB">
+      <use-mesh name="MeshDisplacementsB" provide="yes"/>
+      <use-mesh name="MeshForcesB" provide="yes"/>
+      <write-data name="Displacements" mesh="MeshDisplacementsB"/>
+      <read-data name="Forces" mesh="MeshForcesB"/>
+    </participant>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverA" second="SolverB"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="MeshForcesB" from="SolverA" to="SolverB"/>
+      <exchange data="Displacements" mesh="MeshDisplacementsB" from="SolverB" to="SolverA"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/master-sockets.xml
+++ b/src/precice/tests/master-sockets.xml
@@ -1,47 +1,37 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
   <solver-interface dimensions="2">
-
     <data:scalar name="MyData1"/>
     <data:scalar name="MyData2"/>
-
     <mesh name="ParallelMesh">
       <use-data name="MyData1"/>
       <use-data name="MyData2"/>
     </mesh>
-
     <mesh name="SerialMesh">
       <use-data name="MyData1"/>
       <use-data name="MyData2"/>
     </mesh>
-
     <participant name="ParallelSolver">
-      <master:sockets />
+      <master:sockets/>
       <use-mesh name="ParallelMesh" provide="yes"/>
       <use-mesh name="SerialMesh" from="SerialSolver"/>
       <write-data name="MyData1" mesh="ParallelMesh"/>
       <read-data name="MyData2" mesh="ParallelMesh"/>
-      <mapping:nearest-neighbor direction="write" from="ParallelMesh" to="SerialMesh"    constraint="conservative" timing="initial"/>
-      <mapping:nearest-neighbor direction="read"  from="SerialMesh"   to="ParallelMesh"  constraint="consistent" timing="initial"/>
+      <mapping:nearest-neighbor direction="write" from="ParallelMesh" to="SerialMesh" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="SerialMesh" to="ParallelMesh" constraint="consistent" timing="initial"/>
     </participant>
-
     <participant name="SerialSolver">
-      <use-mesh name="SerialMesh"         provide="yes"/>
-      <read-data  name="MyData1"      mesh="SerialMesh"/>
-      <write-data  name="MyData2"      mesh="SerialMesh"/>
+      <use-mesh name="SerialMesh" provide="yes"/>
+      <read-data name="MyData1" mesh="SerialMesh"/>
+      <write-data name="MyData2" mesh="SerialMesh"/>
     </participant>
-
-    <m2n:sockets from="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
-
+    <m2n:sockets from="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true"/>
     <coupling-scheme:parallel-explicit>
       <participants first="ParallelSolver" second="SerialSolver"/>
       <max-time value="1.0"/>
       <time-window-size value="1.0" valid-digits="8"/>
-      <exchange data="MyData1"      mesh="SerialMesh"   from="ParallelSolver" to="SerialSolver" />
-      <exchange data="MyData2"      mesh="SerialMesh"   from="SerialSolver"   to="ParallelSolver" />
+      <exchange data="MyData1" mesh="SerialMesh" from="ParallelSolver" to="SerialSolver"/>
+      <exchange data="MyData2" mesh="SerialMesh" from="SerialSolver" to="ParallelSolver"/>
     </coupling-scheme:parallel-explicit>
-
   </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/multi.xml
+++ b/src/precice/tests/multi.xml
@@ -1,144 +1,120 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Forces1"/>
-      <data:vector name="Forces2"/>
-      <data:vector name="Forces3"/>
-      <data:vector name="Displacements1"/>
-      <data:vector name="Displacements2"/>
-      <data:vector name="Displacements3"/>
-      <data:vector name="DisplacementDeltas1"/>
-      <data:vector name="DisplacementDeltas2"/>
-      <data:vector name="DisplacementDeltas3"/>
-
-      <mesh name="NASTIN_Mesh1">
-         <use-data name="DisplacementDeltas1"/>
-         <use-data name="Forces1"/>
-      </mesh>
-
-      <mesh name="SOLIDZ_Mesh1">
-         <use-data name="Displacements1"/>
-         <use-data name="DisplacementDeltas1"/>
-         <use-data name="Forces1"/>
-      </mesh>
-
-      <mesh name="NASTIN_Mesh2">
-         <use-data name="DisplacementDeltas2"/>
-         <use-data name="Forces2"/>
-      </mesh>
-
-      <mesh name="SOLIDZ_Mesh2">
-         <use-data name="Displacements2"/>
-         <use-data name="DisplacementDeltas2"/>
-         <use-data name="Forces2"/>
-      </mesh>
-
-      <mesh name="NASTIN_Mesh3">
-         <use-data name="DisplacementDeltas3"/>
-         <use-data name="Forces3"/>
-      </mesh>
-
-      <mesh name="SOLIDZ_Mesh3">
-         <use-data name="Displacements3"/>
-         <use-data name="DisplacementDeltas3"/>
-         <use-data name="Forces3"/>
-      </mesh>
-
-      <participant name="NASTIN">
-         <use-mesh name="NASTIN_Mesh1" provide="yes"/>
-         <use-mesh name="NASTIN_Mesh2" provide="yes"/>
-         <use-mesh name="NASTIN_Mesh3" provide="yes"/>
-         <use-mesh name="SOLIDZ_Mesh1" from="SOLIDZ1"/>
-         <use-mesh name="SOLIDZ_Mesh2" from="SOLIDZ2"/>
-         <use-mesh name="SOLIDZ_Mesh3" from="SOLIDZ3"/>
-         <write-data name="Forces1" mesh="NASTIN_Mesh1"/>
-         <write-data name="Forces2" mesh="NASTIN_Mesh2"/>
-         <write-data name="Forces3" mesh="NASTIN_Mesh3"/>
-         <read-data  name="DisplacementDeltas1" mesh="NASTIN_Mesh1"/>
-         <read-data  name="DisplacementDeltas2" mesh="NASTIN_Mesh2"/>
-         <read-data  name="DisplacementDeltas3" mesh="NASTIN_Mesh3"/>
-         <mapping:nearest-neighbor
-            direction="write" from="NASTIN_Mesh1" to="SOLIDZ_Mesh1"
-            constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor
-            direction="write" from="NASTIN_Mesh2" to="SOLIDZ_Mesh2"
-            constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor
-            direction="write" from="NASTIN_Mesh3" to="SOLIDZ_Mesh3"
-            constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor
-            direction="read" from="SOLIDZ_Mesh1" to="NASTIN_Mesh1"
-            constraint="consistent" timing="initial"/>
-         <mapping:nearest-neighbor
-            direction="read" from="SOLIDZ_Mesh2" to="NASTIN_Mesh2"
-            constraint="consistent" timing="initial"/>
-         <mapping:nearest-neighbor
-            direction="read" from="SOLIDZ_Mesh3" to="NASTIN_Mesh3"
-            constraint="consistent" timing="initial"/>
-      </participant>
-
-      <participant name="SOLIDZ1">
-         <use-mesh name="SOLIDZ_Mesh1" provide="yes"/>
-         <write-data name="Displacements1" mesh="SOLIDZ_Mesh1"/>
-         <write-data name="DisplacementDeltas1" mesh="SOLIDZ_Mesh1"/>
-         <read-data  name="Forces1"      mesh="SOLIDZ_Mesh1"/>
-      </participant>
-      <participant name="SOLIDZ2">
-         <use-mesh name="SOLIDZ_Mesh2" provide="yes"/>
-         <write-data name="Displacements2" mesh="SOLIDZ_Mesh2"/>
-         <write-data name="DisplacementDeltas2" mesh="SOLIDZ_Mesh2"/>
-         <read-data  name="Forces2"      mesh="SOLIDZ_Mesh2"/>
-      </participant>
-      <participant name="SOLIDZ3">
-         <use-mesh name="SOLIDZ_Mesh3" provide="yes"/>
-         <write-data name="Displacements3" mesh="SOLIDZ_Mesh3"/>
-         <write-data name="DisplacementDeltas3" mesh="SOLIDZ_Mesh3"/>
-         <read-data  name="Forces3"      mesh="SOLIDZ_Mesh3"/>
-      </participant>
-
-      <m2n:sockets from="NASTIN" to="SOLIDZ1" />
-      <m2n:sockets from="NASTIN" to="SOLIDZ2" />
-      <m2n:sockets from="NASTIN" to="SOLIDZ3" />
-
-      <coupling-scheme:multi>
-         <participant name="SOLIDZ1" />
-         <participant name="SOLIDZ2" />
-         <participant name="NASTIN" control="yes"/>
-         <participant name="SOLIDZ3" />
-         <max-time value="40.0"/>
-         <time-window-size value="1e-4" valid-digits="8"/>
-         <exchange data="Forces1"        mesh="SOLIDZ_Mesh1" from="NASTIN" to="SOLIDZ1" />
-         <exchange data="Forces2"        mesh="SOLIDZ_Mesh2" from="NASTIN" to="SOLIDZ2"/>
-         <exchange data="Forces3"        mesh="SOLIDZ_Mesh3" from="NASTIN" to="SOLIDZ3"/>
-         <exchange data="Displacements1" mesh="SOLIDZ_Mesh1" from="SOLIDZ1" to="NASTIN"/>
-         <exchange data="Displacements2" mesh="SOLIDZ_Mesh2" from="SOLIDZ2" to="NASTIN"/>
-         <exchange data="Displacements3" mesh="SOLIDZ_Mesh3" from="SOLIDZ3" to="NASTIN"/>
-         <exchange data="DisplacementDeltas1" mesh="SOLIDZ_Mesh1" from="SOLIDZ1" to="NASTIN"/>
-         <exchange data="DisplacementDeltas2" mesh="SOLIDZ_Mesh2" from="SOLIDZ2" to="NASTIN"/>
-         <exchange data="DisplacementDeltas3" mesh="SOLIDZ_Mesh3" from="SOLIDZ3" to="NASTIN"/>
-         <max-iterations value="50"/>
-         <relative-convergence-measure data="Displacements1" mesh="SOLIDZ_Mesh1" limit="1e-4"/>
-         <relative-convergence-measure data="Displacements2" mesh="SOLIDZ_Mesh2" limit="1e-4"/>
-         <relative-convergence-measure data="Displacements3" mesh="SOLIDZ_Mesh3" limit="1e-4"/>
-         <relative-convergence-measure data="Forces1" mesh="SOLIDZ_Mesh1" limit="1e-4"/>
-         <relative-convergence-measure data="Forces2" mesh="SOLIDZ_Mesh2" limit="1e-4"/>
-         <relative-convergence-measure data="Forces3" mesh="SOLIDZ_Mesh3" limit="1e-4"/>
-         <extrapolation-order value="2"/>
-         <acceleration:IQN-ILS>
-            <data name="DisplacementDeltas1" mesh="SOLIDZ_Mesh1"/>
-            <data name="DisplacementDeltas2" mesh="SOLIDZ_Mesh2"/>
-            <data name="DisplacementDeltas3" mesh="SOLIDZ_Mesh3"/>
-            <data name="Forces1" mesh="SOLIDZ_Mesh1" scaling="1e6"/>
-            <data name="Forces2" mesh="SOLIDZ_Mesh2" scaling="1e6"/>
-            <data name="Forces3" mesh="SOLIDZ_Mesh3" scaling="1e6"/>
-            <preconditioner type="constant"/>
-            <filter type="QR1-absolute" limit="1e-12"/>
-            <initial-relaxation value="0.001"/>
-            <max-used-iterations value="100"/>
-            <time-windows-reused value="8"/>
-         </acceleration:IQN-ILS>
-      </coupling-scheme:multi>
-
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Forces1"/>
+    <data:vector name="Forces2"/>
+    <data:vector name="Forces3"/>
+    <data:vector name="Displacements1"/>
+    <data:vector name="Displacements2"/>
+    <data:vector name="Displacements3"/>
+    <data:vector name="DisplacementDeltas1"/>
+    <data:vector name="DisplacementDeltas2"/>
+    <data:vector name="DisplacementDeltas3"/>
+    <mesh name="NASTIN_Mesh1">
+      <use-data name="DisplacementDeltas1"/>
+      <use-data name="Forces1"/>
+    </mesh>
+    <mesh name="SOLIDZ_Mesh1">
+      <use-data name="Displacements1"/>
+      <use-data name="DisplacementDeltas1"/>
+      <use-data name="Forces1"/>
+    </mesh>
+    <mesh name="NASTIN_Mesh2">
+      <use-data name="DisplacementDeltas2"/>
+      <use-data name="Forces2"/>
+    </mesh>
+    <mesh name="SOLIDZ_Mesh2">
+      <use-data name="Displacements2"/>
+      <use-data name="DisplacementDeltas2"/>
+      <use-data name="Forces2"/>
+    </mesh>
+    <mesh name="NASTIN_Mesh3">
+      <use-data name="DisplacementDeltas3"/>
+      <use-data name="Forces3"/>
+    </mesh>
+    <mesh name="SOLIDZ_Mesh3">
+      <use-data name="Displacements3"/>
+      <use-data name="DisplacementDeltas3"/>
+      <use-data name="Forces3"/>
+    </mesh>
+    <participant name="NASTIN">
+      <use-mesh name="NASTIN_Mesh1" provide="yes"/>
+      <use-mesh name="NASTIN_Mesh2" provide="yes"/>
+      <use-mesh name="NASTIN_Mesh3" provide="yes"/>
+      <use-mesh name="SOLIDZ_Mesh1" from="SOLIDZ1"/>
+      <use-mesh name="SOLIDZ_Mesh2" from="SOLIDZ2"/>
+      <use-mesh name="SOLIDZ_Mesh3" from="SOLIDZ3"/>
+      <write-data name="Forces1" mesh="NASTIN_Mesh1"/>
+      <write-data name="Forces2" mesh="NASTIN_Mesh2"/>
+      <write-data name="Forces3" mesh="NASTIN_Mesh3"/>
+      <read-data name="DisplacementDeltas1" mesh="NASTIN_Mesh1"/>
+      <read-data name="DisplacementDeltas2" mesh="NASTIN_Mesh2"/>
+      <read-data name="DisplacementDeltas3" mesh="NASTIN_Mesh3"/>
+      <mapping:nearest-neighbor direction="write" from="NASTIN_Mesh1" to="SOLIDZ_Mesh1" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="write" from="NASTIN_Mesh2" to="SOLIDZ_Mesh2" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="write" from="NASTIN_Mesh3" to="SOLIDZ_Mesh3" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="SOLIDZ_Mesh1" to="NASTIN_Mesh1" constraint="consistent" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="SOLIDZ_Mesh2" to="NASTIN_Mesh2" constraint="consistent" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="SOLIDZ_Mesh3" to="NASTIN_Mesh3" constraint="consistent" timing="initial"/>
+    </participant>
+    <participant name="SOLIDZ1">
+      <use-mesh name="SOLIDZ_Mesh1" provide="yes"/>
+      <write-data name="Displacements1" mesh="SOLIDZ_Mesh1"/>
+      <write-data name="DisplacementDeltas1" mesh="SOLIDZ_Mesh1"/>
+      <read-data name="Forces1" mesh="SOLIDZ_Mesh1"/>
+    </participant>
+    <participant name="SOLIDZ2">
+      <use-mesh name="SOLIDZ_Mesh2" provide="yes"/>
+      <write-data name="Displacements2" mesh="SOLIDZ_Mesh2"/>
+      <write-data name="DisplacementDeltas2" mesh="SOLIDZ_Mesh2"/>
+      <read-data name="Forces2" mesh="SOLIDZ_Mesh2"/>
+    </participant>
+    <participant name="SOLIDZ3">
+      <use-mesh name="SOLIDZ_Mesh3" provide="yes"/>
+      <write-data name="Displacements3" mesh="SOLIDZ_Mesh3"/>
+      <write-data name="DisplacementDeltas3" mesh="SOLIDZ_Mesh3"/>
+      <read-data name="Forces3" mesh="SOLIDZ_Mesh3"/>
+    </participant>
+    <m2n:sockets from="NASTIN" to="SOLIDZ1"/>
+    <m2n:sockets from="NASTIN" to="SOLIDZ2"/>
+    <m2n:sockets from="NASTIN" to="SOLIDZ3"/>
+    <coupling-scheme:multi>
+      <participant name="SOLIDZ1"/>
+      <participant name="SOLIDZ2"/>
+      <participant name="NASTIN" control="yes"/>
+      <participant name="SOLIDZ3"/>
+      <max-time value="40.0"/>
+      <time-window-size value="1e-4" valid-digits="8"/>
+      <exchange data="Forces1" mesh="SOLIDZ_Mesh1" from="NASTIN" to="SOLIDZ1"/>
+      <exchange data="Forces2" mesh="SOLIDZ_Mesh2" from="NASTIN" to="SOLIDZ2"/>
+      <exchange data="Forces3" mesh="SOLIDZ_Mesh3" from="NASTIN" to="SOLIDZ3"/>
+      <exchange data="Displacements1" mesh="SOLIDZ_Mesh1" from="SOLIDZ1" to="NASTIN"/>
+      <exchange data="Displacements2" mesh="SOLIDZ_Mesh2" from="SOLIDZ2" to="NASTIN"/>
+      <exchange data="Displacements3" mesh="SOLIDZ_Mesh3" from="SOLIDZ3" to="NASTIN"/>
+      <exchange data="DisplacementDeltas1" mesh="SOLIDZ_Mesh1" from="SOLIDZ1" to="NASTIN"/>
+      <exchange data="DisplacementDeltas2" mesh="SOLIDZ_Mesh2" from="SOLIDZ2" to="NASTIN"/>
+      <exchange data="DisplacementDeltas3" mesh="SOLIDZ_Mesh3" from="SOLIDZ3" to="NASTIN"/>
+      <max-iterations value="50"/>
+      <relative-convergence-measure data="Displacements1" mesh="SOLIDZ_Mesh1" limit="1e-4"/>
+      <relative-convergence-measure data="Displacements2" mesh="SOLIDZ_Mesh2" limit="1e-4"/>
+      <relative-convergence-measure data="Displacements3" mesh="SOLIDZ_Mesh3" limit="1e-4"/>
+      <relative-convergence-measure data="Forces1" mesh="SOLIDZ_Mesh1" limit="1e-4"/>
+      <relative-convergence-measure data="Forces2" mesh="SOLIDZ_Mesh2" limit="1e-4"/>
+      <relative-convergence-measure data="Forces3" mesh="SOLIDZ_Mesh3" limit="1e-4"/>
+      <extrapolation-order value="2"/>
+      <acceleration:IQN-ILS>
+        <data name="DisplacementDeltas1" mesh="SOLIDZ_Mesh1"/>
+        <data name="DisplacementDeltas2" mesh="SOLIDZ_Mesh2"/>
+        <data name="DisplacementDeltas3" mesh="SOLIDZ_Mesh3"/>
+        <data name="Forces1" mesh="SOLIDZ_Mesh1" scaling="1e6"/>
+        <data name="Forces2" mesh="SOLIDZ_Mesh2" scaling="1e6"/>
+        <data name="Forces3" mesh="SOLIDZ_Mesh3" scaling="1e6"/>
+        <preconditioner type="constant"/>
+        <filter type="QR1-absolute" limit="1e-12"/>
+        <initial-relaxation value="0.001"/>
+        <max-used-iterations value="100"/>
+        <time-windows-reused value="8"/>
+      </acceleration:IQN-ILS>
+    </coupling-scheme:multi>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/np-repartitioning.xml
+++ b/src/precice/tests/np-repartitioning.xml
@@ -1,42 +1,32 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-
-      <data:scalar name="Data1"  />
-
-      <mesh name="CellCenters">
-         <use-data name="Data1" />
-      </mesh>
-
-      <mesh name="Nodes">
-         <use-data name="Data1" />
-      </mesh>
-
-      <participant name="FluidSolver">
-         <master:mpi-single/>
-         <use-mesh name="CellCenters" provide="yes" />
-         <use-mesh name="Nodes" from="SolidSolver" safety-factor="0.5"/>
-         <mapping:nearest-projection direction="read" from="Nodes" to="CellCenters" constraint="consistent" />
-         <read-data name="Data1" mesh="CellCenters" />
-         <export:vtk/>
-      </participant>
-
-      <participant name="SolidSolver">
-         <use-mesh name="Nodes" provide="yes"/>
-         <write-data name="Data1" mesh="Nodes" />
-         <export:vtk/>
-      </participant>
-
-      <m2n:sockets from="FluidSolver" to="SolidSolver" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="FluidSolver" second="SolidSolver" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="Nodes" from="SolidSolver" to="FluidSolver" />
-   </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:scalar name="Data1"/>
+    <mesh name="CellCenters">
+      <use-data name="Data1"/>
+    </mesh>
+    <mesh name="Nodes">
+      <use-data name="Data1"/>
+    </mesh>
+    <participant name="FluidSolver">
+      <master:mpi-single/>
+      <use-mesh name="CellCenters" provide="yes"/>
+      <use-mesh name="Nodes" from="SolidSolver" safety-factor="0.5"/>
+      <mapping:nearest-projection direction="read" from="Nodes" to="CellCenters" constraint="consistent"/>
+      <read-data name="Data1" mesh="CellCenters"/>
+      <export:vtk/>
+    </participant>
+    <participant name="SolidSolver">
+      <use-mesh name="Nodes" provide="yes"/>
+      <write-data name="Data1" mesh="Nodes"/>
+      <export:vtk/>
+    </participant>
+    <m2n:sockets from="FluidSolver" to="SolidSolver"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="FluidSolver" second="SolidSolver"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="Nodes" from="SolidSolver" to="FluidSolver"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/point-to-point-mpi.xml
+++ b/src/precice/tests/point-to-point-mpi.xml
@@ -1,54 +1,38 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-
-
-   <solver-interface dimensions="3">
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="FluidMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="StructureMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-
-      <participant name="Fluid">
-         <master:mpi-single/>
-         <use-mesh name="FluidMesh" provide="yes" />
-         <use-mesh name="StructureMesh" from="Structure" />
-         <write-data name="Forces"     mesh="FluidMesh" />
-         <read-data  name="Velocities" mesh="FluidMesh" />
-         <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh"
-                  constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh"
-                  constraint="consistent" timing="initial" />
-      </participant>
-
-      <participant name="Structure">
-         <master:mpi-single/>
-         <use-mesh name="StructureMesh" provide="yes"/>
-         <write-data name="Velocities" mesh="StructureMesh" />
-         <read-data name="Forces"      mesh="StructureMesh" />
-      </participant>
-
-      <m2n:mpi from="Fluid" to="Structure" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="Fluid" second="Structure" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="StructureMesh" from="Fluid" to="Structure" />
-         <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="FluidMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="StructureMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="Fluid">
+      <master:mpi-single/>
+      <use-mesh name="FluidMesh" provide="yes"/>
+      <use-mesh name="StructureMesh" from="Structure"/>
+      <write-data name="Forces" mesh="FluidMesh"/>
+      <read-data name="Velocities" mesh="FluidMesh"/>
+      <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh" constraint="consistent" timing="initial"/>
+    </participant>
+    <participant name="Structure">
+      <master:mpi-single/>
+      <use-mesh name="StructureMesh" provide="yes"/>
+      <write-data name="Velocities" mesh="StructureMesh"/>
+      <read-data name="Forces" mesh="StructureMesh"/>
+    </participant>
+    <m2n:mpi from="Fluid" to="Structure"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="Fluid" second="Structure"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure"/>
+      <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/point-to-point-sockets.xml
+++ b/src/precice/tests/point-to-point-sockets.xml
@@ -1,56 +1,38 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
-
-
-   <solver-interface dimensions="3" >
-
-      <data:vector name="Forces"  />
-      <data:vector name="Velocities"  />
-
-      <mesh name="FluidMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-      <mesh name="StructureMesh">
-         <use-data name="Forces" />
-         <use-data name="Velocities" />
-      </mesh>
-
-
-      <participant name="Fluid">
-         <master:mpi-single/>
-         <use-mesh name="FluidMesh" provide="yes" />
-         <use-mesh name="StructureMesh" from="Structure" />
-         <write-data name="Forces"     mesh="FluidMesh" />
-         <read-data  name="Velocities" mesh="FluidMesh" />
-         <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh"
-                  constraint="conservative" timing="initial"/>
-         <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh"
-                  constraint="consistent" timing="initial" />
-
-      </participant>
-
-      <participant name="Structure">
-         <master:mpi-single/>
-         <use-mesh name="StructureMesh" provide="yes"/>
-         <write-data name="Velocities" mesh="StructureMesh" />
-         <read-data name="Forces"      mesh="StructureMesh" />
-
-      </participant>
-
-      <m2n:sockets from="Fluid" to="Structure" />
-
-      <coupling-scheme:serial-explicit>
-         <participants first="Fluid" second="Structure" />
-         <max-time-windows value="1" />
-         <time-window-size value="1.0" />
-         <exchange data="Forces"     mesh="StructureMesh" from="Fluid" to="Structure" />
-         <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
+    <mesh name="FluidMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <mesh name="StructureMesh">
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
+    </mesh>
+    <participant name="Fluid">
+      <master:mpi-single/>
+      <use-mesh name="FluidMesh" provide="yes"/>
+      <use-mesh name="StructureMesh" from="Structure"/>
+      <write-data name="Forces" mesh="FluidMesh"/>
+      <read-data name="Velocities" mesh="FluidMesh"/>
+      <mapping:nearest-neighbor direction="write" from="FluidMesh" to="StructureMesh" constraint="conservative" timing="initial"/>
+      <mapping:nearest-neighbor direction="read" from="StructureMesh" to="FluidMesh" constraint="consistent" timing="initial"/>
+    </participant>
+    <participant name="Structure">
+      <master:mpi-single/>
+      <use-mesh name="StructureMesh" provide="yes"/>
+      <write-data name="Velocities" mesh="StructureMesh"/>
+      <read-data name="Forces" mesh="StructureMesh"/>
+    </participant>
+    <m2n:sockets from="Fluid" to="Structure"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="Fluid" second="Structure"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure"/>
+      <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/preconditioner-bug.xml
+++ b/src/precice/tests/preconditioner-bug.xml
@@ -1,52 +1,42 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2" >
-      <data:vector name="DataOne"/>
-      <data:vector name="DataTwo"/>
-
-      <mesh name="MeshOne">
-         <use-data name="DataOne"/>
-         <use-data name="DataTwo"/>
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="DataOne"/>
-         <use-data name="DataTwo"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshOne" provide="on"/>
-         <read-data name="DataOne" mesh="MeshOne"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshOne" from="SolverOne"/>
-         <use-mesh name="MeshTwo" provide="on"/>
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne"
-                  constraint="consistent" timing="initial"/>
-         <write-data  name="DataOne" mesh="MeshTwo"/>
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="2"/>
-         <time-window-size value="1.0"/>
-         <exchange data="DataOne" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-         <exchange data="DataTwo" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
-         <absolute-convergence-measure limit="1e-5" data="DataOne" mesh="MeshOne"/>
-         <max-iterations value="2" />
-         <acceleration:IQN-ILS>
-            <data name="DataOne" mesh="MeshOne"/>
-            <initial-relaxation value="1.0"/>
-            <max-used-iterations value="50"/>
-            <time-windows-reused value="0"/>
-            <filter type="QR2" limit="1e-3"/>
-         </acceleration:IQN-ILS>
-      </coupling-scheme:serial-implicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:vector name="DataOne"/>
+    <data:vector name="DataTwo"/>
+    <mesh name="MeshOne">
+      <use-data name="DataOne"/>
+      <use-data name="DataTwo"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="DataOne"/>
+      <use-data name="DataTwo"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on"/>
+      <read-data name="DataOne" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="on"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="consistent" timing="initial"/>
+      <write-data name="DataOne" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="DataOne" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
+      <absolute-convergence-measure limit="1e-5" data="DataOne" mesh="MeshOne"/>
+      <max-iterations value="2"/>
+      <acceleration:IQN-ILS>
+        <data name="DataOne" mesh="MeshOne"/>
+        <initial-relaxation value="1.0"/>
+        <max-used-iterations value="50"/>
+        <time-windows-reused value="0"/>
+        <filter type="QR2" limit="1e-3"/>
+      </acceleration:IQN-ILS>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/recorder-action-explicit.xml
+++ b/src/precice/tests/recorder-action-explicit.xml
@@ -1,60 +1,49 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
   <log>
-    <sink type="stream" output="stdout"  filter= "%Severity% > debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true" />	
+    <sink type="stream" output="stdout" filter="%Severity% &gt; debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true"/>
   </log>
-
-  <solver-interface dimensions="2" >
-
-    <data:vector name="Forces"  />
-    <data:vector name="Velocities"  />
-
+  <solver-interface dimensions="2">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
     <mesh name="MeshOne">
-      <use-data name="Forces" />
-      <use-data name="Velocities" />
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
     </mesh>
-
     <mesh name="MeshTwo">
-      <use-data name="Forces" />
-      <use-data name="Velocities" />
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
     </mesh>
-
     <participant name="SolverOne">
       <use-mesh name="MeshOne" provide="yes"/>
-      <write-data name="Forces"     mesh="MeshOne" />
-      <read-data  name="Velocities" mesh="MeshOne" />
-      <action:recorder timing="on-time-window-complete-post" mesh="MeshOne" />
-      <action:recorder timing="write-mapping-prior" mesh="MeshOne" />
-      <action:recorder timing="write-mapping-post" mesh="MeshOne" />
-      <action:recorder timing="read-mapping-prior" mesh="MeshOne" />
-      <action:recorder timing="read-mapping-post" mesh="MeshOne" />
+      <write-data name="Forces" mesh="MeshOne"/>
+      <read-data name="Velocities" mesh="MeshOne"/>
+      <action:recorder timing="on-time-window-complete-post" mesh="MeshOne"/>
+      <action:recorder timing="write-mapping-prior" mesh="MeshOne"/>
+      <action:recorder timing="write-mapping-post" mesh="MeshOne"/>
+      <action:recorder timing="read-mapping-prior" mesh="MeshOne"/>
+      <action:recorder timing="read-mapping-post" mesh="MeshOne"/>
     </participant>
-
     <participant name="SolverTwo">
       <use-mesh name="MeshOne" from="SolverOne"/>
       <use-mesh name="MeshTwo" provide="yes"/>
-      <mapping:nearest-neighbor   direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
-      <mapping:nearest-projection direction="read"  from="MeshOne" to="MeshTwo" constraint="consistent" />
-      <write-data name="Velocities" mesh="MeshTwo" />
-      <read-data  name="Forces"     mesh="MeshTwo" />
-      <action:recorder timing="on-time-window-complete-post" mesh="MeshTwo" />
-      <action:recorder timing="write-mapping-prior" mesh="MeshTwo" />
-      <action:recorder timing="write-mapping-post" mesh="MeshTwo" />
-      <action:recorder timing="read-mapping-prior" mesh="MeshTwo" />
-      <action:recorder timing="read-mapping-post" mesh="MeshTwo" />
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <mapping:nearest-projection direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <write-data name="Velocities" mesh="MeshTwo"/>
+      <read-data name="Forces" mesh="MeshTwo"/>
+      <action:recorder timing="on-time-window-complete-post" mesh="MeshTwo"/>
+      <action:recorder timing="write-mapping-prior" mesh="MeshTwo"/>
+      <action:recorder timing="write-mapping-post" mesh="MeshTwo"/>
+      <action:recorder timing="read-mapping-prior" mesh="MeshTwo"/>
+      <action:recorder timing="read-mapping-post" mesh="MeshTwo"/>
     </participant>
-
     <m2n:sockets from="SolverOne" to="SolverTwo"/>
-
-    <coupling-scheme:serial-explicit> 
-      <participants first="SolverOne" second="SolverTwo" /> 
-      <max-time-windows value="10" />
-      <time-window-size value="1.0" />
-      <exchange data="Forces"     mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Forces" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
       <exchange data="Velocities" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
     </coupling-scheme:serial-explicit>
   </solver-interface>
-
 </precice-configuration>

--- a/src/precice/tests/recorder-action-implicit.xml
+++ b/src/precice/tests/recorder-action-implicit.xml
@@ -1,62 +1,51 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-
   <log>
-    <sink type="stream" output="stdout"  filter= "%Severity% > debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true" />	
+    <sink type="stream" output="stdout" filter="%Severity% &gt; debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true"/>
   </log>
-
-  <solver-interface dimensions="2" >
-
-    <data:vector name="Forces"  />
-    <data:vector name="Velocities"  />
-
+  <solver-interface dimensions="2">
+    <data:vector name="Forces"/>
+    <data:vector name="Velocities"/>
     <mesh name="MeshOne">
-      <use-data name="Forces" />
-      <use-data name="Velocities" />
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
     </mesh>
-
     <mesh name="MeshTwo">
-      <use-data name="Forces" />
-      <use-data name="Velocities" />
+      <use-data name="Forces"/>
+      <use-data name="Velocities"/>
     </mesh>
-
     <participant name="SolverOne">
       <use-mesh name="MeshOne" provide="yes"/>
-      <write-data name="Forces"     mesh="MeshOne" />
-      <read-data  name="Velocities" mesh="MeshOne" />
-      <action:recorder timing="on-time-window-complete-post" mesh="MeshOne" />
-      <action:recorder timing="write-mapping-prior" mesh="MeshOne" />
-      <action:recorder timing="write-mapping-post" mesh="MeshOne" />
-      <action:recorder timing="read-mapping-prior" mesh="MeshOne" />
-      <action:recorder timing="read-mapping-post" mesh="MeshOne" />
+      <write-data name="Forces" mesh="MeshOne"/>
+      <read-data name="Velocities" mesh="MeshOne"/>
+      <action:recorder timing="on-time-window-complete-post" mesh="MeshOne"/>
+      <action:recorder timing="write-mapping-prior" mesh="MeshOne"/>
+      <action:recorder timing="write-mapping-post" mesh="MeshOne"/>
+      <action:recorder timing="read-mapping-prior" mesh="MeshOne"/>
+      <action:recorder timing="read-mapping-post" mesh="MeshOne"/>
     </participant>
-
     <participant name="SolverTwo">
       <use-mesh name="MeshOne" from="SolverOne"/>
       <use-mesh name="MeshTwo" provide="yes"/>
-      <mapping:nearest-neighbor   direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
-      <mapping:nearest-projection direction="read"  from="MeshOne" to="MeshTwo" constraint="consistent" />
-      <write-data name="Velocities" mesh="MeshTwo" />
-      <read-data  name="Forces"     mesh="MeshTwo" />
-      <action:recorder timing="on-time-window-complete-post" mesh="MeshTwo" />
-      <action:recorder timing="write-mapping-prior" mesh="MeshTwo" />
-      <action:recorder timing="write-mapping-post" mesh="MeshTwo" />
-      <action:recorder timing="read-mapping-prior" mesh="MeshTwo" />
-      <action:recorder timing="read-mapping-post" mesh="MeshTwo" />
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <mapping:nearest-projection direction="read" from="MeshOne" to="MeshTwo" constraint="consistent"/>
+      <write-data name="Velocities" mesh="MeshTwo"/>
+      <read-data name="Forces" mesh="MeshTwo"/>
+      <action:recorder timing="on-time-window-complete-post" mesh="MeshTwo"/>
+      <action:recorder timing="write-mapping-prior" mesh="MeshTwo"/>
+      <action:recorder timing="write-mapping-post" mesh="MeshTwo"/>
+      <action:recorder timing="read-mapping-prior" mesh="MeshTwo"/>
+      <action:recorder timing="read-mapping-post" mesh="MeshTwo"/>
     </participant>
-
     <m2n:sockets from="SolverOne" to="SolverTwo"/>
-
-    <coupling-scheme:serial-implicit> 
-      <participants first="SolverOne" second="SolverTwo" /> 
-      <max-time-windows value="10" />
-      <time-window-size value="1.0" />
-      <max-iterations value="3" />
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="3"/>
       <min-iteration-convergence-measure min-iterations="5" data="Forces" mesh="MeshOne"/>
-      <exchange data="Forces"     mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="Forces" mesh="MeshOne" from="SolverOne" to="SolverTwo"/>
       <exchange data="Velocities" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
     </coupling-scheme:serial-implicit>
   </solver-interface>
-
 </precice-configuration>

--- a/src/precice/tests/send-mesh-to-multiple-participants.xml
+++ b/src/precice/tests/send-mesh-to-multiple-participants.xml
@@ -1,55 +1,45 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:scalar name="Data"/>
-
-      <mesh name="MeshA">
-         <use-data name="Data"/>
-      </mesh>
-
-      <mesh name="MeshB">
-         <use-data name="Data"/>
-      </mesh>
-
-      <mesh name="MeshC">
-         <use-data name="Data"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshA" provide="yes"/>
-         <write-data name="Data" mesh="MeshA" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshA" from="SolverOne"/>
-         <use-mesh name="MeshB" provide="yes"/>
-         <read-data name="Data" mesh="MeshB" />
-         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB" constraint="conservative" />
-      </participant>
-
-      <participant name="SolverThree">
-         <use-mesh name="MeshA" from="SolverOne"/>
-         <use-mesh name="MeshC" provide="yes"/>
-         <read-data name="Data" mesh="MeshC" />
-         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-      <m2n:sockets from="SolverOne" to="SolverThree"/>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="1"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Data" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
-      </coupling-scheme:serial-explicit>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverThree"/>
-         <max-time-windows value="1"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Data" mesh="MeshA" from="SolverOne" to="SolverThree"/>
-      </coupling-scheme:serial-explicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:scalar name="Data"/>
+    <mesh name="MeshA">
+      <use-data name="Data"/>
+    </mesh>
+    <mesh name="MeshB">
+      <use-data name="Data"/>
+    </mesh>
+    <mesh name="MeshC">
+      <use-data name="Data"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshA" provide="yes"/>
+      <write-data name="Data" mesh="MeshA"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshA" from="SolverOne"/>
+      <use-mesh name="MeshB" provide="yes"/>
+      <read-data name="Data" mesh="MeshB"/>
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB" constraint="conservative"/>
+    </participant>
+    <participant name="SolverThree">
+      <use-mesh name="MeshA" from="SolverOne"/>
+      <use-mesh name="MeshC" provide="yes"/>
+      <read-data name="Data" mesh="MeshC"/>
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <m2n:sockets from="SolverOne" to="SolverThree"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
+    </coupling-scheme:serial-explicit>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverThree"/>
+      <max-time-windows value="1"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data" mesh="MeshA" from="SolverOne" to="SolverThree"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/summation-action.xml
+++ b/src/precice/tests/summation-action.xml
@@ -1,66 +1,54 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="3" >
-      <data:scalar name="SourceOne"/>
-      <data:scalar name="SourceTwo"/>
-      <data:scalar name="Target"/>
-
-      <mesh name="MeshOne">
-         <use-data name="SourceOne"/>
-      </mesh>
-      
-      <mesh name="MeshTwo">
-         <use-data name="SourceTwo"/>
-      </mesh>
-      
-      <mesh name="MeshTarget">
-         <use-data name="SourceOne"/>
-         <use-data name="SourceTwo"/>
-         <use-data name="Target"/>
-      </mesh>
-
-      <participant name="SolverTarget">
-         <use-mesh name="MeshTarget" provide="yes"/>
-         <read-data name="Target" mesh="MeshTarget"/> 
-         <action:summation timing="regular-post" mesh="MeshTarget">
-            <source-data name="SourceOne"/>
-            <source-data name="SourceTwo"/>
-            <target-data name="Target"/>
-         </action:summation> 
-      </participant>
-
-      <participant name="SolverSourceOne">
-         <use-mesh name="MeshOne" provide="yes"/>
-         <use-mesh name="MeshTarget" from="SolverTarget"/>
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTarget" constraint="consistent"/>
-         <write-data name="SourceOne" mesh="MeshOne"/>
-      </participant>
-
-      <participant name="SolverSourceTwo">
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <use-mesh name="MeshTarget" from="SolverTarget"/>
-         <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshTarget" constraint="consistent"/>
-         <write-data name="SourceTwo" mesh="MeshTwo"/>
-      </participant>
-
-      <m2n:sockets from="SolverSourceOne" to="SolverTarget"/>
-      <m2n:sockets from="SolverSourceTwo" to="SolverTarget"/>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverSourceOne" second="SolverTarget"/>
-         <max-time-windows value="2"/>
-         <time-window-size value="1.0"/>
-         <exchange data="SourceOne" mesh="MeshTarget" from="SolverSourceOne" to="SolverTarget"/>
-      </coupling-scheme:serial-explicit>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverSourceTwo" second="SolverTarget"/>
-         <max-time-windows value="2"/>
-         <time-window-size value="1.0"/>
-         <exchange data="SourceTwo" mesh="MeshTarget" from="SolverSourceTwo" to="SolverTarget"/>
-      </coupling-scheme:serial-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="3">
+    <data:scalar name="SourceOne"/>
+    <data:scalar name="SourceTwo"/>
+    <data:scalar name="Target"/>
+    <mesh name="MeshOne">
+      <use-data name="SourceOne"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="SourceTwo"/>
+    </mesh>
+    <mesh name="MeshTarget">
+      <use-data name="SourceOne"/>
+      <use-data name="SourceTwo"/>
+      <use-data name="Target"/>
+    </mesh>
+    <participant name="SolverTarget">
+      <use-mesh name="MeshTarget" provide="yes"/>
+      <read-data name="Target" mesh="MeshTarget"/>
+      <action:summation timing="regular-post" mesh="MeshTarget">
+        <source-data name="SourceOne"/>
+        <source-data name="SourceTwo"/>
+        <target-data name="Target"/>
+      </action:summation>
+    </participant>
+    <participant name="SolverSourceOne">
+      <use-mesh name="MeshOne" provide="yes"/>
+      <use-mesh name="MeshTarget" from="SolverTarget"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTarget" constraint="consistent"/>
+      <write-data name="SourceOne" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverSourceTwo">
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <use-mesh name="MeshTarget" from="SolverTarget"/>
+      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshTarget" constraint="consistent"/>
+      <write-data name="SourceTwo" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverSourceOne" to="SolverTarget"/>
+    <m2n:sockets from="SolverSourceTwo" to="SolverTarget"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverSourceOne" second="SolverTarget"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="SourceOne" mesh="MeshTarget" from="SolverSourceOne" to="SolverTarget"/>
+    </coupling-scheme:serial-explicit>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverSourceTwo" second="SolverTarget"/>
+      <max-time-windows value="2"/>
+      <time-window-size value="1.0"/>
+      <exchange data="SourceTwo" mesh="MeshTarget" from="SolverSourceTwo" to="SolverTarget"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/three-solver-explicit-explicit.xml
+++ b/src/precice/tests/three-solver-explicit-explicit.xml
@@ -1,60 +1,49 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Data"/>
-
-      <mesh name="MeshA">
-         <use-data name="Data"/>
-      </mesh>
-
-      <mesh name="MeshB">
-         <use-data name="Data"/>
-      </mesh>
-
-      <mesh name="MeshC">
-         <use-data name="Data"/>
-      </mesh>
-
-      <mesh name="MeshD">
-         <use-data name="Data"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshA" provide="yes"/>
-         <use-mesh name="MeshB" provide="yes"/>
-         <write-data name="Data" mesh="MeshA" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshA" from="SolverOne"/>
-         <use-mesh name="MeshC" provide="yes"/>
-         <read-data name="Data" mesh="MeshC" />
-         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
-      </participant>
-
-      <participant name="SolverThree">
-         <use-mesh name="MeshB" from="SolverOne"/>
-         <use-mesh name="MeshD" provide="yes"/>
-         <read-data name="Data" mesh="MeshD" />
-         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-      <m2n:sockets from="SolverOne" to="SolverThree"/>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Data" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
-      </coupling-scheme:serial-explicit>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverThree"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Data" mesh="MeshB" from="SolverOne" to="SolverThree"/>
-      </coupling-scheme:serial-explicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Data"/>
+    <mesh name="MeshA">
+      <use-data name="Data"/>
+    </mesh>
+    <mesh name="MeshB">
+      <use-data name="Data"/>
+    </mesh>
+    <mesh name="MeshC">
+      <use-data name="Data"/>
+    </mesh>
+    <mesh name="MeshD">
+      <use-data name="Data"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshA" provide="yes"/>
+      <use-mesh name="MeshB" provide="yes"/>
+      <write-data name="Data" mesh="MeshA"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshA" from="SolverOne"/>
+      <use-mesh name="MeshC" provide="yes"/>
+      <read-data name="Data" mesh="MeshC"/>
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative"/>
+    </participant>
+    <participant name="SolverThree">
+      <use-mesh name="MeshB" from="SolverOne"/>
+      <use-mesh name="MeshD" provide="yes"/>
+      <read-data name="Data" mesh="MeshD"/>
+      <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <m2n:sockets from="SolverOne" to="SolverThree"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
+    </coupling-scheme:serial-explicit>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverThree"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data" mesh="MeshB" from="SolverOne" to="SolverThree"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/three-solver-explicit-implicit.xml
+++ b/src/precice/tests/three-solver-explicit-implicit.xml
@@ -1,78 +1,67 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Data0"/>
-      <data:scalar name="Data1"/>
-      <data:vector name="Data2"/>
-
-      <mesh name="MeshA">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshB">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshC">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshD">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshA" provide="yes"/>
-         <use-mesh name="MeshB" provide="yes"/>
-         <write-data name="Data0" mesh="MeshA"/>
-         <read-data  name="Data1" mesh="MeshA"/>
-         <read-data  name="Data2" mesh="MeshB"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshA" from="SolverOne"/>
-         <write-data name="Data1" mesh="MeshC"/>
-         <read-data  name="Data0" mesh="MeshC"/>
-         <use-mesh name="MeshC" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
-      </participant>
-
-      <participant name="SolverThree">
-         <use-mesh name="MeshB" from="SolverOne"/>
-         <write-data name="Data2" mesh="MeshD"/>
-         <read-data  name="Data0" mesh="MeshD"/>
-         <use-mesh name="MeshD" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-      <m2n:sockets from="SolverOne" to="SolverThree"/>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
-         <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-explicit>
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverThree"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <max-iterations value="10"/>
-         <min-iteration-convergence-measure min-iterations="3" data="Data2" mesh="MeshB"/>
-         <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree"/>
-         <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne"/>
-      </coupling-scheme:serial-implicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Data0"/>
+    <data:scalar name="Data1"/>
+    <data:vector name="Data2"/>
+    <mesh name="MeshA">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshB">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshC">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshD">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshA" provide="yes"/>
+      <use-mesh name="MeshB" provide="yes"/>
+      <write-data name="Data0" mesh="MeshA"/>
+      <read-data name="Data1" mesh="MeshA"/>
+      <read-data name="Data2" mesh="MeshB"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshA" from="SolverOne"/>
+      <write-data name="Data1" mesh="MeshC"/>
+      <read-data name="Data0" mesh="MeshC"/>
+      <use-mesh name="MeshC" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative"/>
+    </participant>
+    <participant name="SolverThree">
+      <use-mesh name="MeshB" from="SolverOne"/>
+      <write-data name="Data2" mesh="MeshD"/>
+      <read-data name="Data0" mesh="MeshD"/>
+      <use-mesh name="MeshD" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <m2n:sockets from="SolverOne" to="SolverThree"/>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-explicit>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverThree"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="10"/>
+      <min-iteration-convergence-measure min-iterations="3" data="Data2" mesh="MeshB"/>
+      <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree"/>
+      <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne"/>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/three-solver-implicit-explicit.xml
+++ b/src/precice/tests/three-solver-implicit-explicit.xml
@@ -1,78 +1,67 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Data0"/>
-      <data:scalar name="Data1"/>
-      <data:vector name="Data2"/>
-
-      <mesh name="MeshA">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshB">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshC">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshD">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshA" provide="yes"/>
-         <use-mesh name="MeshB" provide="yes"/>
-         <write-data name="Data0" mesh="MeshA"/>
-         <read-data  name="Data1" mesh="MeshA"/>
-         <read-data  name="Data2" mesh="MeshB"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshA" from="SolverOne"/>
-         <write-data name="Data1" mesh="MeshC"/>
-         <read-data  name="Data0" mesh="MeshC"/>
-         <use-mesh name="MeshC" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
-      </participant>
-
-      <participant name="SolverThree">
-         <use-mesh name="MeshB" from="SolverOne"/>
-         <write-data name="Data2" mesh="MeshD"/>
-         <read-data  name="Data0" mesh="MeshD"/>
-         <use-mesh name="MeshD" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-      <m2n:sockets from="SolverOne" to="SolverThree"/>
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <max-iterations value="10"/>
-         <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA"/>
-         <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
-         <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-implicit>
-
-      <coupling-scheme:serial-explicit>
-         <participants first="SolverOne" second="SolverThree"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree"/>
-         <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne"/>
-      </coupling-scheme:serial-explicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Data0"/>
+    <data:scalar name="Data1"/>
+    <data:vector name="Data2"/>
+    <mesh name="MeshA">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshB">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshC">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshD">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshA" provide="yes"/>
+      <use-mesh name="MeshB" provide="yes"/>
+      <write-data name="Data0" mesh="MeshA"/>
+      <read-data name="Data1" mesh="MeshA"/>
+      <read-data name="Data2" mesh="MeshB"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshA" from="SolverOne"/>
+      <write-data name="Data1" mesh="MeshC"/>
+      <read-data name="Data0" mesh="MeshC"/>
+      <use-mesh name="MeshC" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative"/>
+    </participant>
+    <participant name="SolverThree">
+      <use-mesh name="MeshB" from="SolverOne"/>
+      <write-data name="Data2" mesh="MeshD"/>
+      <read-data name="Data0" mesh="MeshD"/>
+      <use-mesh name="MeshD" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <m2n:sockets from="SolverOne" to="SolverThree"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="10"/>
+      <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA"/>
+      <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-implicit>
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverThree"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree"/>
+      <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne"/>
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/three-solver-implicit-implicit.xml
+++ b/src/precice/tests/three-solver-implicit-implicit.xml
@@ -1,80 +1,69 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Data0"/>
-      <data:scalar name="Data1"/>
-      <data:vector name="Data2"/>
-
-      <mesh name="MeshA">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshB">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshC">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshD">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshA" provide="yes"/>
-         <use-mesh name="MeshB" provide="yes"/>
-         <write-data name="Data0" mesh="MeshA"/>
-         <read-data  name="Data1" mesh="MeshA"/>
-         <read-data  name="Data2" mesh="MeshB"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshA" from="SolverOne"/>
-         <write-data name="Data1" mesh="MeshC"/>
-         <read-data  name="Data0" mesh="MeshC"/>
-         <use-mesh name="MeshC" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
-      </participant>
-
-      <participant name="SolverThree">
-         <use-mesh name="MeshB" from="SolverOne"/>
-         <write-data name="Data2" mesh="MeshD"/>
-         <read-data  name="Data0" mesh="MeshD"/>
-         <use-mesh name="MeshD" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-      <m2n:sockets from="SolverOne" to="SolverThree"/>
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <max-iterations value="10"/>
-         <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA"/>
-         <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:serial-implicit>
-
-      <coupling-scheme:serial-implicit>
-         <participants first="SolverOne" second="SolverThree"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <max-iterations value="10"/>
-         <min-iteration-convergence-measure min-iterations="2" data="Data2" mesh="MeshB"/>
-         <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree"/>
-         <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne"/>
-      </coupling-scheme:serial-implicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Data0"/>
+    <data:scalar name="Data1"/>
+    <data:vector name="Data2"/>
+    <mesh name="MeshA">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshB">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshC">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshD">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshA" provide="yes"/>
+      <use-mesh name="MeshB" provide="yes"/>
+      <write-data name="Data0" mesh="MeshA"/>
+      <read-data name="Data1" mesh="MeshA"/>
+      <read-data name="Data2" mesh="MeshB"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshA" from="SolverOne"/>
+      <write-data name="Data1" mesh="MeshC"/>
+      <read-data name="Data0" mesh="MeshC"/>
+      <use-mesh name="MeshC" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative"/>
+    </participant>
+    <participant name="SolverThree">
+      <use-mesh name="MeshB" from="SolverOne"/>
+      <write-data name="Data2" mesh="MeshD"/>
+      <read-data name="Data0" mesh="MeshD"/>
+      <use-mesh name="MeshD" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <m2n:sockets from="SolverOne" to="SolverThree"/>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="10"/>
+      <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA"/>
+      <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-implicit>
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverThree"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="10"/>
+      <min-iteration-convergence-measure min-iterations="2" data="Data2" mesh="MeshB"/>
+      <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree"/>
+      <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne"/>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/three-solver-parallel.xml
+++ b/src/precice/tests/three-solver-parallel.xml
@@ -1,78 +1,67 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-      <data:vector name="Data0"/>
-      <data:scalar name="Data1"/>
-      <data:vector name="Data2"/>
-
-      <mesh name="MeshA">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshB">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshC">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <mesh name="MeshD">
-         <use-data name="Data0"/>
-         <use-data name="Data1"/>
-         <use-data name="Data2"/>
-      </mesh>
-
-      <participant name="SolverOne">
-         <use-mesh name="MeshA" provide="yes"/>
-         <use-mesh name="MeshB" provide="yes"/>
-         <write-data name="Data0" mesh="MeshA"/>
-         <read-data  name="Data1" mesh="MeshA"/>
-         <read-data  name="Data2" mesh="MeshB"/>
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshA" from="SolverOne"/>
-         <write-data name="Data1" mesh="MeshC"/>
-         <read-data  name="Data0" mesh="MeshC"/>
-         <use-mesh name="MeshC" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
-      </participant>
-
-      <participant name="SolverThree">
-         <use-mesh name="MeshB" from="SolverOne"/>
-         <write-data name="Data2" mesh="MeshD"/>
-         <read-data  name="Data0" mesh="MeshD"/>
-         <use-mesh name="MeshD" provide="yes"/>
-         <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo"/>
-      <m2n:sockets from="SolverOne" to="SolverThree"/>
-
-      <coupling-scheme:parallel-implicit>
-         <participants first="SolverOne" second="SolverTwo"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <max-iterations value="10"/>
-         <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA"/>
-         <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
-         <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:parallel-implicit>
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="SolverOne" second="SolverThree"/>
-         <max-time-windows value="10"/>
-         <time-window-size value="1.0"/>
-         <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree" initialize="1"/>
-         <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne" initialize="1"/>
-      </coupling-scheme:parallel-explicit>
-   </solver-interface>
+  <solver-interface dimensions="2">
+    <data:vector name="Data0"/>
+    <data:scalar name="Data1"/>
+    <data:vector name="Data2"/>
+    <mesh name="MeshA">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshB">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshC">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshD">
+      <use-data name="Data0"/>
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <use-mesh name="MeshA" provide="yes"/>
+      <use-mesh name="MeshB" provide="yes"/>
+      <write-data name="Data0" mesh="MeshA"/>
+      <read-data name="Data1" mesh="MeshA"/>
+      <read-data name="Data2" mesh="MeshB"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshA" from="SolverOne"/>
+      <write-data name="Data1" mesh="MeshC"/>
+      <read-data name="Data0" mesh="MeshC"/>
+      <use-mesh name="MeshC" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative"/>
+    </participant>
+    <participant name="SolverThree">
+      <use-mesh name="MeshB" from="SolverOne"/>
+      <write-data name="Data2" mesh="MeshD"/>
+      <read-data name="Data0" mesh="MeshD"/>
+      <use-mesh name="MeshD" provide="yes"/>
+      <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshD" constraint="conservative"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <m2n:sockets from="SolverOne" to="SolverThree"/>
+    <coupling-scheme:parallel-implicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <max-iterations value="10"/>
+      <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA"/>
+      <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:parallel-implicit>
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverThree"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree" initialize="1"/>
+      <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne" initialize="1"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/userDefinedMPICommunicator.xml
+++ b/src/precice/tests/userDefinedMPICommunicator.xml
@@ -1,47 +1,37 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <master:mpi-single/>
-         <use-mesh name="MeshTwo" from="SolverTwo" />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative" />
-         <mapping:nearest-neighbor direction="read" from="MeshTwo" to="MeshOne" constraint="consistent" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <master:mpi-single/>
+      <use-mesh name="MeshTwo" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:nearest-neighbor direction="write" from="MeshOne" to="MeshTwo" constraint="conservative"/>
+      <mapping:nearest-neighbor direction="read" from="MeshTwo" to="MeshOne" constraint="consistent"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/precice/tests/userDefinedMPICommunicatorPetRBF.xml
+++ b/src/precice/tests/userDefinedMPICommunicatorPetRBF.xml
@@ -1,47 +1,37 @@
 <?xml version="1.0"?>
-
 <precice-configuration>
-   <solver-interface dimensions="2">
-
-      <data:scalar name="Data1"  />
-      <data:scalar name="Data2"  />
-
-      <mesh name="MeshOne">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <mesh name="MeshTwo">
-         <use-data name="Data1" />
-         <use-data name="Data2" />
-      </mesh>
-
-      <participant name="SolverOne">
-         <master:mpi-single/>
-         <use-mesh name="MeshTwo" from="SolverTwo" />
-         <use-mesh name="MeshOne" provide="yes" />
-         <mapping:rbf-thin-plate-splines direction="write" from="MeshOne" to="MeshTwo" constraint="conservative" />
-         <mapping:rbf-thin-plate-splines direction="read" from="MeshTwo" to="MeshOne" constraint="consistent" />
-         <write-data name="Data1" mesh="MeshOne" />
-         <read-data name="Data2" mesh="MeshOne" />
-      </participant>
-
-      <participant name="SolverTwo">
-         <use-mesh name="MeshTwo" provide="yes"/>
-         <write-data name="Data2" mesh="MeshTwo" />
-         <read-data name="Data1" mesh="MeshTwo" />
-      </participant>
-
-      <m2n:sockets from="SolverOne" to="SolverTwo" />
-
-      <coupling-scheme:parallel-explicit>
-         <participants first="SolverOne" second="SolverTwo" />
-         <max-time-windows value="10" />
-         <time-window-size value="1.0" />
-         <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
-         <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
-      </coupling-scheme:parallel-explicit>
-
-   </solver-interface>
-
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1"/>
+    <data:scalar name="Data2"/>
+    <mesh name="MeshOne">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <mesh name="MeshTwo">
+      <use-data name="Data1"/>
+      <use-data name="Data2"/>
+    </mesh>
+    <participant name="SolverOne">
+      <master:mpi-single/>
+      <use-mesh name="MeshTwo" from="SolverTwo"/>
+      <use-mesh name="MeshOne" provide="yes"/>
+      <mapping:rbf-thin-plate-splines direction="write" from="MeshOne" to="MeshTwo" constraint="conservative"/>
+      <mapping:rbf-thin-plate-splines direction="read" from="MeshTwo" to="MeshOne" constraint="consistent"/>
+      <write-data name="Data1" mesh="MeshOne"/>
+      <read-data name="Data2" mesh="MeshOne"/>
+    </participant>
+    <participant name="SolverTwo">
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <write-data name="Data2" mesh="MeshTwo"/>
+      <read-data name="Data1" mesh="MeshTwo"/>
+    </participant>
+    <m2n:sockets from="SolverOne" to="SolverTwo"/>
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverTwo"/>
+      <max-time-windows value="10"/>
+      <time-window-size value="1.0"/>
+      <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo"/>
+      <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
 </precice-configuration>

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -1,4 +1,4 @@
-#include "ConfigParser.hpp"
+#include "xml/ConfigParser.hpp"
 #include <algorithm>
 #include <exception>
 #include <fstream>
@@ -14,6 +14,25 @@
 
 namespace precice {
 namespace xml {
+
+std::string decodeXML(std::string xml)
+{
+  static const std::map<std::string, char> escapes{{"&lt;", '<'}, {"&gt;", '>'}, {"&amp;", '&'}, {"&quot;", '"'}, {"&apos;", '\''}};
+  while (true) {
+    bool changes{false};
+    for (const auto &kv : escapes) {
+      auto position = xml.find(kv.first);
+      if (position != std::string::npos) {
+        xml.replace(position, kv.first.length(), 1, kv.second);
+        changes = true;
+      }
+    }
+    if (!changes) {
+      break;
+    }
+  };
+  return xml;
+}
 
 // ------------------------- Callback functions for libxml2  -------------------------
 
@@ -37,7 +56,7 @@ void OnStartElementNs(
     auto        valueEnd   = reinterpret_cast<const char *>(attributes[index + 4]);
     std::string value(valueBegin, valueEnd);
 
-    attributesMap[attributeName] = value;
+    attributesMap[attributeName] = decodeXML(value);
   }
 
   auto pParser = static_cast<ConfigParser *>(ctx);

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -16,6 +16,9 @@ namespace xml {
 class XMLTag; // forward declaration to resolve circular import
 struct ConfigurationContext;
 
+/// Decodes escape sequences of a given xml
+std::string decodeXML(std::string xml);
+
 class ConfigParser {
 public:
   /// Struct holding the read tag from xml file

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -4,6 +4,7 @@
 #include "math/constants.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
+#include "xml/ConfigParser.hpp"
 #include "xml/ValueParser.hpp"
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
@@ -179,6 +180,19 @@ BOOST_AUTO_TEST_CASE(Context)
   BOOST_TEST(cl.endContext.name == "test");
   BOOST_TEST(cl.endContext.rank == 12);
   BOOST_TEST(cl.endContext.size == 32);
+}
+
+BOOST_AUTO_TEST_CASE(Decode)
+{
+  PRECICE_TEST(1_rank);
+
+  BOOST_TEST(decodeXML("Less than &lt; test") == "Less than < test");
+  BOOST_TEST(decodeXML("Greater than &gt; test") == "Greater than > test");
+  BOOST_TEST(decodeXML("Ampersand &amp; test") == "Ampersand & test");
+  BOOST_TEST(decodeXML("Quotation &quot; test") == "Quotation \" test");
+  BOOST_TEST(decodeXML("Apostrophe &apos; test") == "Apostrophe ' test");
+
+  BOOST_TEST(decodeXML("&quot; &lt; &gt; &gt; &lt; &amp; &quot; &amp; &apos;") == "\" < > > < & \" & '");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/xml/tests/config_xmltest_concatenation.xml
+++ b/src/xml/tests/config_xmltest_concatenation.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0"?>
-
 <configuration>
-    <test-attribute-concatenation>
-        <test attribute="value-one" />
-        <test attribute="value-two" />
-        <test attribute="value-three" />
-    </test-attribute-concatenation>
+  <test-attribute-concatenation>
+    <test attribute="value-one"/>
+    <test attribute="value-two"/>
+    <test attribute="value-three"/>
+  </test-attribute-concatenation>
 </configuration>

--- a/src/xml/tests/config_xmltest_context.xml
+++ b/src/xml/tests/config_xmltest_context.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0"?>
-
 <configuration>
 </configuration>

--- a/src/xml/tests/config_xmltest_vectorattributes.xml
+++ b/src/xml/tests/config_xmltest_vectorattributes.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-
 <configuration>
-  <test-eigen-vectorxd-attributes value="3.0; 2.0; 1.0" />
+  <test-eigen-vectorxd-attributes value="3.0; 2.0; 1.0"/>
 </configuration>

--- a/src/xml/tests/xmlparser_nstest.xml
+++ b/src/xml/tests/xmlparser_nstest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
-
 <configuration>
-    <test-config>
-	<test-no_ns/>
-	<ns:test-ns/>
-    </test-config>
+  <test-config>
+    <test-no_ns/>
+    <ns:test-ns/>
+  </test-config>
 </configuration>

--- a/src/xml/tests/xmlparser_occtest.xml
+++ b/src/xml/tests/xmlparser_occtest.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0"?>
-
 <configuration>
-    <test-config>
-	<test-occ_once_or_more-once/>
-  	<test-occ_arbitrary/>
-	<test-occ_arbitrary/>
-  	<test-occ_not_or_once/>
-  
-  	<test-occ_once_or_more-more/>
-	<test-occ_once_or_more-more/>
-    </test-config>
+  <test-config>
+    <test-occ_once_or_more-once/>
+    <test-occ_arbitrary/>
+    <test-occ_arbitrary/>
+    <test-occ_not_or_once/>
+    <test-occ_once_or_more-more/>
+    <test-occ_once_or_more-more/>
+  </test-config>
 </configuration>

--- a/src/xml/tests/xmlparser_test.xml
+++ b/src/xml/tests/xmlparser_test.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
-
 <configuration>
-    <test-config>
-	<test-double attribute="1/3"/>
-        <test-double attribute="3.1"/>
-
-	<test-int attribute="4"/>
-
-	<test-string text="Hello World"/>
-
-	<test-bool attribute="No"/>
-	<test-bool attribute="Yes"/>
-	<test-bool attribute="1"/>
-
-	<test-eigen attribute="3.0; 2.0; 1.0"/>
-    </test-config>
+  <test-config>
+    <test-double attribute="1/3"/>
+    <test-double attribute="3.1"/>
+    <test-int attribute="4"/>
+    <test-string text="Hello World"/>
+    <test-bool attribute="No"/>
+    <test-bool attribute="Yes"/>
+    <test-bool attribute="1"/>
+    <test-eigen attribute="3.0; 2.0; 1.0"/>
+  </test-config>
 </configuration>

--- a/src/xml/tests/xmltest-nesting-config.xml
+++ b/src/xml/tests/xmltest-nesting-config.xml
@@ -1,12 +1,13 @@
+<?xml version="1.0"?>
 <nested-tag>
-   <subtag attribute="1"/>
-   <nested-tag>
-      <subtag attribute="11"/>
-   </nested-tag>
-   <nested-tag>
-      <subtag attribute="12"/>
-      <nested-tag>
-         <subtag attribute="121"/>
-      </nested-tag>
-   </nested-tag>
+  <subtag attribute="1"/>
+  <nested-tag>
+    <subtag attribute="11"/>
+  </nested-tag>
+  <nested-tag>
+    <subtag attribute="12"/>
+    <nested-tag>
+      <subtag attribute="121"/>
+    </nested-tag>
+  </nested-tag>
 </nested-tag>

--- a/src/xml/tests/xmltest-unique-attribute-config.xml
+++ b/src/xml/tests/xmltest-unique-attribute-config.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-
 <configuration>
-    <test-tag value="a" />
-    <test-tag value="a" />
+  <test-tag value="a"/>
+  <test-tag value="a"/>
 </configuration>

--- a/tools/formatting/format-all
+++ b/tools/formatting/format-all
@@ -6,7 +6,7 @@
 # 0 on success
 # 2 is clang-format 8 could not be found 
 
-# Detect version
+# Detect clang-format version
 if command -v clang-format-8 > /dev/null; then
     BINARY="clang-format-8"
 elif command -v clang-format > /dev/null; then
@@ -24,18 +24,44 @@ else
 fi
 echo "Using binary: $BINARY"
 
-FILES=$(find . -type f -name \*.hpp -or -name \*.h -or -name \*.cpp -or -name \*.c)
-echo "Formatting $(echo "$FILES" | wc -l) files"
+# Detect GNU parallel
 if command -v parallel > /dev/null ; then
-    echo "Using GNU parallel"
-    echo "$FILES" | parallel --bar "${BINARY} -style=file -i {}"
+    echo "GNU parallel detected."
+    HAS_PARALLEL=true
 else
     echo "Install GNU parallel to format in parallel."
-    for cfile in $FILES
-    do
+    HAS_PARALLEL=false
+fi
+
+# Format C/C++
+CFILES=$(find . -type f -name \*.hpp -or -name \*.h -or -name \*.cpp -or -name \*.c)
+echo "Formatting $(echo "$CFILES" | wc -l) C/C++ files"
+if  $HAS_PARALLEL; then
+    echo "$CFILES" | parallel --bar "${BINARY} -style=file -i {}"
+else
+    for cfile in $CFILES; do
         ${BINARY} -style=file -i $cfile
         echo -n "."
     done
+    echo
+fi
+
+# Format XML
+if ! command -v xmllint > /dev/null; then
+    echo "xmllint not found!"
+    echo "Please install xmllint to format xml files."
+else
+    XMLFILES=$(find . -type f -name \*.xml)
+    echo "Formatting $(echo "$XMLFILES" | wc -l) XML files"
+    if $HAS_PARALLEL; then
+        echo "$XMLFILES" | parallel --bar "xmllint --nonet --format --output {} {} 2> /dev/null"
+    else
+      for xmlfile in $XMLFILES; do
+        xmllint --nonet --format --output $xmlfile $xmlfile 2> /dev/null
+        echo -n "."
+      done
+    echo
+    fi
 fi
 
 echo -e "\nDone"


### PR DESCRIPTION
The aim of this PR is to consistently format our XML files, which revealed some small issues.

This PR:
* adds formatting support based on xmllint (Debian package name: `libxml-utils`).
* formats our xml files using the aforementioned tool. This fixed the incorrectly escaped sign '<' in our log filter.
* adds decoding support for escaped characters (e.g `&lt;`)

These changes are backwards compatible, so incorrectly escaped xml files will still work.