### PR TITLE
Add support for escaped XML characters

### DIFF
--- a/docs/changelog/862.md
+++ b/docs/changelog/862.md
@@ -1,0 +1,1 @@
+- Add support for escaped characters in XML

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -1,4 +1,4 @@
-#include "ConfigParser.hpp"
+#include "xml/ConfigParser.hpp"
 #include <algorithm>
 #include <exception>
 #include <fstream>
@@ -14,6 +14,25 @@
 
 namespace precice {
 namespace xml {
+
+std::string decodeXML(std::string xml)
+{
+  static const std::map<std::string, char> escapes{{"&lt;", '<'}, {"&gt;", '>'}, {"&amp;", '&'}, {"&quot;", '"'}, {"&apos;", '\''}};
+  while (true) {
+    bool changes{false};
+    for (const auto &kv : escapes) {
+      auto position = xml.find(kv.first);
+      if (position != std::string::npos) {
+        xml.replace(position, kv.first.length(), 1, kv.second);
+        changes = true;
+      }
+    }
+    if (!changes) {
+      break;
+    }
+  };
+  return xml;
+}
 
 // ------------------------- Callback functions for libxml2  -------------------------
 
@@ -37,7 +56,7 @@ void OnStartElementNs(
     auto        valueEnd   = reinterpret_cast<const char *>(attributes[index + 4]);
     std::string value(valueBegin, valueEnd);
 
-    attributesMap[attributeName] = value;
+    attributesMap[attributeName] = decodeXML(value);
   }
 
   auto pParser = static_cast<ConfigParser *>(ctx);

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -16,6 +16,9 @@ namespace xml {
 class XMLTag; // forward declaration to resolve circular import
 struct ConfigurationContext;
 
+/// Decodes escape sequences of a given xml
+std::string decodeXML(std::string xml);
+
 class ConfigParser {
 public:
   /// Struct holding the read tag from xml file

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -4,6 +4,7 @@
 #include "math/constants.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
+#include "xml/ConfigParser.hpp"
 #include "xml/ValueParser.hpp"
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
@@ -179,6 +180,19 @@ BOOST_AUTO_TEST_CASE(Context)
   BOOST_TEST(cl.endContext.name == "test");
   BOOST_TEST(cl.endContext.rank == 12);
   BOOST_TEST(cl.endContext.size == 32);
+}
+
+BOOST_AUTO_TEST_CASE(Decode)
+{
+  PRECICE_TEST(1_rank);
+
+  BOOST_TEST(decodeXML("Less than &lt; test") == "Less than < test");
+  BOOST_TEST(decodeXML("Greater than &gt; test") == "Greater than > test");
+  BOOST_TEST(decodeXML("Ampersand &amp; test") == "Ampersand & test");
+  BOOST_TEST(decodeXML("Quotation &quot; test") == "Quotation \" test");
+  BOOST_TEST(decodeXML("Apostrophe &apos; test") == "Apostrophe ' test");
+
+  BOOST_TEST(decodeXML("&quot; &lt; &gt; &gt; &lt; &amp; &quot; &amp; &apos;") == "\" < > > < & \" & '");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**List the core changes of this PR**

* Adds support for escaped XML characters e.g. `&lt;`
* Adds tests

**Motivation**

Signs `<>&'"` have to be escaped in XML.
In practise, this really only affects the `filer` attribute of a log sink `<sink filter="%Severity% > debug" />`.

This makes #862 obsolete
