### PR TITLE
Fix error message for unique acceleration subtags

### DIFF
--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -149,10 +149,11 @@ void AccelerationConfiguration::xmlTagCallback(
     _config.relaxationFactor = callingTag.getDoubleAttributeValue(ATTR_VALUE);
   } else if (callingTag.getName() == TAG_DATA) {
     std::string dataName = callingTag.getStringAttributeValue(ATTR_NAME);
-    auto        success  = _uniqueDataNames.insert(dataName);
+    std::string meshName = callingTag.getStringAttributeValue(ATTR_MESH);
+    auto        success  = _uniqueDataAndMeshNames.insert(std::pair<std::string, std::string>(dataName, meshName));
     if (not success.second) {
       PRECICE_ERROR("You have provided a subtag "
-                    << "<data name=\"" << dataName << "\" ... /> more than once in your <acceleration:.../>. "
+                    << "<data name=\"" << dataName << "\" mesh=\"" << meshName << "\"/> more than once in your <acceleration:.../>. "
                     << "Please remove the duplicated entry.");
     }
     _meshName      = callingTag.getStringAttributeValue(ATTR_MESH);

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -150,7 +150,7 @@ void AccelerationConfiguration::xmlTagCallback(
   } else if (callingTag.getName() == TAG_DATA) {
     std::string dataName = callingTag.getStringAttributeValue(ATTR_NAME);
     std::string meshName = callingTag.getStringAttributeValue(ATTR_MESH);
-    auto        success  = _uniqueDataAndMeshNames.insert(std::pair<std::string, std::string>(dataName, meshName));
+    auto        success = _uniqueDataAndMeshNames.emplace(dataName, meshName);
     if (not success.second) {
       PRECICE_ERROR("You have provided a subtag "
                     << "<data name=\"" << dataName << "\" mesh=\"" << meshName << "\"/> more than once in your <acceleration:.../>. "

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -95,7 +95,7 @@ private:
 
   impl::PtrPreconditioner _preconditioner;
 
-  std::set<std::string> _uniqueDataNames;
+  std::set<std::pair<std::string, std::string>> _uniqueDataAndMeshNames;
 
   struct ConfigurationData {
     std::vector<int>      dataIDs;


### PR DESCRIPTION
Check for unique combinations of mesh AND data name. Not only data name.

Closes https://github.com/precice/precice/issues/850.

I verified the correct behaviour with the two attached configuration files and the cpp solverdummy:

* [precice-config-error.xml](https://github.com/precice/precice/files/5255221/precice-config-error.txt)
* [precice-config-ok.xml](https://github.com/precice/precice/files/5255222/precice-config-ok.txt)

