### PR TITLE
Make locale selection optional

### DIFF
--- a/docs/changelog/868.md
+++ b/docs/changelog/868.md
@@ -1,0 +1,1 @@
+- Fix parsing error on systems without locales installed. This fixes issues when running preCICE in minimal docker containers.

--- a/src/xml/ValueParser.cpp
+++ b/src/xml/ValueParser.cpp
@@ -15,7 +15,10 @@ constexpr static const char *PARSING_LOCALE = "en_US.UTF-8";
 double parseDouble(const std::string &rawValue)
 {
   std::istringstream iss{rawValue};
-  iss.imbue(std::locale(PARSING_LOCALE));
+  try {
+    iss.imbue(std::locale(PARSING_LOCALE));
+  } catch (...) {
+  }
   double value;
   iss >> value;
   if (!iss.eof()) {
@@ -40,7 +43,10 @@ void readValueSpecific(const std::string &rawValue, double &value)
 void readValueSpecific(const std::string &rawValue, int &value)
 {
   std::istringstream iss{rawValue};
-  iss.imbue(std::locale(PARSING_LOCALE));
+  try {
+    iss.imbue(std::locale(PARSING_LOCALE));
+  } catch (...) {
+  }
   iss >> value;
   if (!iss.eof()) {
     throw std::runtime_error{"Could not fully parse value \"" + rawValue + "\" as an int."};


### PR DESCRIPTION
**List the core changes of this PR**

The locale selection is now _optional_.
Meaning that it won't fail on system that do not have a `en_us.uf8` locale installed.

Examples for such stripped down systems are docker containers.
