### PR TITLE
Update removes build/last and adds mpirun -np 4

### DIFF
--- a/docs/documents/050_tests.dox
+++ b/docs/documents/050_tests.dox
@@ -6,11 +6,10 @@ Running and writing tests
 
 Running
 ------
-The ```tools/compileAndTest.py``` script simplifies running all tsts.
+Use ```ctest``` or ```make test``` within the build folder to run all tests.
 
-- ```./tools/compileAndTest.py -t``` runs all tests on 4 MPI ranks.
-- ```./build/last/testprecice -x``` runs boost test with colored output.
-- ```./build/last/testprecice -x -r detailed -t "+/+PetRadial+"``` (replace all + by *, due to Doxygen) runs all ```PetRadial*``` tests from all test suites using colored output and detailed reporting.
+- ```mpirun -np 4 ./build/testprecice -x``` runs boost test with colored output.
+- ```mpirun -np 4 ./build/testprecice -x -r detailed -t "+/+PetRadial+"``` (replace all + by *, due to Doxygen) runs all ```PetRadial*``` tests from all test suites using colored output and detailed reporting.
 
 Writing
 -------


### PR DESCRIPTION
Documentation update

* `tools/compileAndTest.py` was removed. We now use `ctest`
* `build/last` was removed, when migrating to cmake. `testprecice` is now directly in `build`
* `mpirun -np 4` is required. If running `testprecice` without `mpirun -np 4` I get the error:

```
~/precice$ ./build/testprecice 
ERROR: The tests require at least 4 MPI processes.
```