### PR TITLE
Fix MacOS Compilation and Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,7 +295,7 @@ target_link_libraries(precice PRIVATE
   Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
-  target_compile_definitions(precice PRIVATE _GNU_SOURCE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
+  target_compile_definitions(precice PRIVATE _GNU_SOURCE)
   target_link_libraries(precice PRIVATE ${CMAKE_DL_LIBS})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ target_link_libraries(precice PRIVATE
   Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
+  target_compile_definitions(precice PRIVATE _GNU_SOURCE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
   target_link_libraries(precice PRIVATE ${CMAKE_DL_LIBS})
 endif()
 

--- a/docs/changelog/877.md
+++ b/docs/changelog/877.md
@@ -1,0 +1,1 @@
+- Fix MacOS compilation and test errors

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -326,7 +326,13 @@ void SocketCommunication::closeConnection()
 
   for (auto &socket : _sockets) {
     PRECICE_ASSERT(socket.second->is_open());
-    socket.second->shutdown(Socket::shutdown_both);
+    
+    try{
+      socket.second->shutdown(Socket::shutdown_send);
+    }
+    catch(std::exception &e){
+      PRECICE_WARN("Socket shutdown failed with system error: " << e.what());
+    }
     socket.second->close();
   }
 

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -46,8 +46,8 @@ bool init_unit_test()
   auto logConfigs = logging::readLogConfFile("log.conf");
 
   if (logConfigs.empty()) { // nothing has been read from log.conf
-#if BOOST_VERSION == 106900
-    std::cerr << "Boost 1.69 get log_level is broken, preCICE log level set to debug.\n";
+#if BOOST_VERSION == 106900 || BOOST_VERSION == 107300
+    std::cerr << "Boost 1.69 and 1.73 get log_level is broken, preCICE log level set to debug.\n";
     auto logLevel = log_successful_tests;
 #else
     auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);


### PR DESCRIPTION
This PR applies following changes to be able to compile and run on MacOS

- Conditional compile definition `_GNU_SOURCE` is added. (Refer to https://github.com/boostorg/stacktrace/issues/94 and https://github.com/boostorg/stacktrace/issues/88) 

- With Boost 1.73.0, a new `log_level` is introduced, which breaks the preCICE logging and causing all tests to fail on MacOS. (Refer to https://github.com/precice/precice/issues/870 and https://precice.discourse.group/t/testing-precice-installation-on-macos/296). This is solved by setting `log_level` to debug manually.

- During the socket shutdown, there was an uncaught exception which causes most of the tests to fail. The main reason behind this is that the socket is tried to be shut down while it is already shut down. It is solved by catching the exception.