### PR TITLE
Fix boost test log_level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ target_link_libraries(precice PRIVATE
   )
 if(UNIX OR APPLE OR MINGW)
   target_compile_definitions(precice PRIVATE _GNU_SOURCE)
+  target_compile_definitions(precice PRIVATE MACOS)
   target_link_libraries(precice PRIVATE ${CMAKE_DL_LIBS})
 endif()
 

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -46,8 +46,8 @@ bool init_unit_test()
   auto logConfigs = logging::readLogConfFile("log.conf");
 
   if (logConfigs.empty()) { // nothing has been read from log.conf
-#if BOOST_VERSION == 106900 || BOOST_VERSION == 107300
-    std::cerr << "Boost 1.69 and 1.73 get log_level is broken, preCICE log level set to debug.\n";
+#if BOOST_VERSION == 106900 || defined(MACOS)
+    std::cerr << "Boost 1.69 and on macOS get log_level is broken, preCICE log level set to debug.\n";
     auto logLevel = log_successful_tests;
 #else
     auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);


### PR DESCRIPTION
Previous macOS boost `log_level` [fix](https://github.com/precice/precice/pull/877) was only specific for Boost 1.73.0. However, brew updated boost to 1.74.0, and the error still persists. Therefore, the fix is extended to cover directly macOS independent of Boost version.