### PR TITLE
Fix out-of-range bug in local RBF ReceivedPartitionTest

### DIFF
--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -631,8 +631,8 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
         BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
         BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
         BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 1);
         BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 2);
         BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 3);


### PR DESCRIPTION
A stupid bug in a `ReceivedPartitionTest`. Not defined behavior probably causes part of the problem of #879, could also be the problem of #847.

@oguzziya Please check #879 
@MakisH Please check #847 