### PR TITLE
Fix vector access patterns

### DIFF
--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -54,9 +54,9 @@ int main(int argc, char **argv)
 
   for (int i = 0; i < numberOfVertices; i++) {
     for (int j = 0; j < dimensions; j++) {
-      vertices[j + numberOfVertices * i]  = i;
-      readData[j + numberOfVertices * i]  = i;
-      writeData[j + numberOfVertices * i] = i;
+      vertices.at(j + numberOfVertices * i)  = i;
+      readData.at(j + numberOfVertices * i)  = i;
+      writeData.at(j + numberOfVertices * i) = i;
     }
   }
 
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
     }
 
     for (int i = 0; i < numberOfVertices * dimensions; i++) {
-      writeData[i] = readData[i] + 1;
+      writeData.at(i) = readData.at(i) + 1;
     }
 
     if (interface.isWriteDataRequired(dt)) {

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -97,13 +97,13 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations)
   }
 
   // ------ test Allreduce/ Reduce ---------------------------
-  std::vector<double> aa = {a, a};
+  std::vector<double> aa   = {a, a};
   std::vector<double> res2 = {0, 0};
   std::vector<double> res3 = {0, 0};
-  
-  double  res1 = 0;
-  int iaa   = (int) a;
-  int ires1 = 0, ires2 = 0;
+
+  double res1  = 0;
+  int    iaa   = (int) a;
+  int    ires1 = 0, ires2 = 0;
 
   utils::MasterSlave::allreduceSum(a, res1, 1);
   utils::MasterSlave::allreduceSum(iaa, ires2, 1);

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -97,47 +97,38 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations)
   }
 
   // ------ test Allreduce/ Reduce ---------------------------
+  std::vector<double> aa = {a, a};
+  std::vector<double> res2 = {0, 0};
+  std::vector<double> res3 = {0, 0};
+  
   double  res1 = 0;
-  double *aa   = new double[2];
-  aa[0]        = a;
-  aa[1]        = a;
-  double *res2 = new double[2];
-  res2[0]      = 0;
-  res2[1]      = 0;
-  double *res3 = new double[2];
-  res3[0]      = 0;
-  res3[1]      = 0;
-
   int iaa   = (int) a;
   int ires1 = 0, ires2 = 0;
 
   utils::MasterSlave::allreduceSum(a, res1, 1);
   utils::MasterSlave::allreduceSum(iaa, ires2, 1);
-  utils::MasterSlave::allreduceSum(aa, res2, 2);
+  utils::MasterSlave::allreduceSum(aa.data(), res2.data(), 2);
 
-  utils::MasterSlave::reduceSum(aa, res3, 2);
+  utils::MasterSlave::reduceSum(aa.data(), res3.data(), 2);
   utils::MasterSlave::reduceSum(iaa, ires1, 1);
 
   BOOST_TEST(testing::equals(res1, 10.));
   BOOST_TEST(testing::equals(ires2, 10));
-  BOOST_TEST(testing::equals(res2[0], 10.));
-  BOOST_TEST(testing::equals(res2[1], 10.));
+  BOOST_TEST(testing::equals(res2.at(0), 10.));
+  BOOST_TEST(testing::equals(res2.at(1), 10.));
 
   if (utils::MasterSlave::isMaster()) {
-    BOOST_TEST(testing::equals(res3[0], 10.));
-    BOOST_TEST(testing::equals(res3[1], 10.));
+    BOOST_TEST(testing::equals(res3.at(0), 10.));
+    BOOST_TEST(testing::equals(res3.at(1), 10.));
     BOOST_TEST(testing::equals(ires1, 10));
   }
-  delete[] aa;
-  delete[] res2;
-  delete[] res3;
   // ---------------------------------------------------------
 
   Eigen::VectorXd vec1_local(n_local);
   Eigen::VectorXd vec2_local(n_local);
 
   // partition and distribute
-  int off = vertexOffsets[context.rank];
+  int off = vertexOffsets.at(context.rank);
   for (int i = 0; i < n_local; i++) {
     vec1_local(i) = vec1(i + off);
     vec2_local(i) = vec2(i + off);
@@ -267,7 +258,7 @@ BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp)
 
   // partition and distribute matrices
 
-  int off = vertexOffsets[context.rank];
+  int off = vertexOffsets.at(context.rank);
   for (int i = 0; i < n_global; i++)
     for (int j = 0; j < n_local; j++) {
       J_local(i, j)  = J_global(i, j + off);
@@ -302,32 +293,32 @@ BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp)
   // 1.) multiply JW = J * W (n x m), parallel: (n_local x m)
   Eigen::MatrixXd resJW_local(n_local, m_global);
   parMatrixOps.multiply(J_local, W_local, resJW_local, vertexOffsets, n_global, n_global, m_global);
-  validate_result_equals_reference(resJW_local, JW_global, vertexOffsets[context.rank], true);
+  validate_result_equals_reference(resJW_local, JW_global, vertexOffsets.at(context.rank), true);
 
   BOOST_TEST_MESSAGE("Test 2");
   // 2.) multiply WZ = W * Z (n x n), parallel: (n_global x n_local)
   Eigen::MatrixXd resWZ_local(n_global, n_local);
   parMatrixOps.multiply(W_local, Z_local, resWZ_local, vertexOffsets, n_global, m_global, n_global);
-  validate_result_equals_reference(resWZ_local, WZ_global, vertexOffsets[context.rank], false);
+  validate_result_equals_reference(resWZ_local, WZ_global, vertexOffsets.at(context.rank), false);
 
   BOOST_TEST_MESSAGE("Test 3");
   // 3.) multiply Jres = J * res (n x 1), parallel: (n_local x 1)
   Eigen::MatrixXd resJres_local(n_local, 1);
   parMatrixOps.multiply(J_local, res_local, resJres_local, vertexOffsets, n_global, n_global, 1);
-  validate_result_equals_reference(resJres_local, Jres_global, vertexOffsets[context.rank], true);
+  validate_result_equals_reference(resJres_local, Jres_global, vertexOffsets.at(context.rank), true);
 
   BOOST_TEST_MESSAGE("Test 4");
   // 4.) multiply JW = J * W (n x m), parallel: (n_local x m) with block-wise multiplication
   Eigen::MatrixXd resJW_local2(n_local, m_global);
   parMatrixOps.multiply(J_local, W_local, resJW_local2, vertexOffsets, n_global, n_global, m_global, false);
-  validate_result_equals_reference(resJW_local2, JW_global, vertexOffsets[context.rank], true);
+  validate_result_equals_reference(resJW_local2, JW_global, vertexOffsets.at(context.rank), true);
 
   BOOST_TEST_MESSAGE("Test 5");
   // 5.) multiply Jres = J * res (n x 1), parallel: (n_local x 1) with block-wise multiplication
   Eigen::VectorXd resJres_local2(n_local); // use the function with parameter of type Eigen::VectorXd
   parMatrixOps.multiply(J_local, res_local_vec, resJres_local2, vertexOffsets, n_global, n_global, 1, false);
   Eigen::MatrixXd matrix_cast = resJres_local2;
-  validate_result_equals_reference(matrix_cast, Jres_global, vertexOffsets[context.rank], true);
+  validate_result_equals_reference(matrix_cast, Jres_global, vertexOffsets.at(context.rank), true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -46,9 +46,9 @@ BOOST_AUTO_TEST_CASE(DivideByArea)
   auto &values = data->values();
   values << 2.0, 3.0, 4.0;
 
-  BOOST_TEST(values[0] == 2.0);
-  BOOST_TEST(values[1] == 3.0);
-  BOOST_TEST(values[2] == 4.0);
+  BOOST_TEST(values(0) == 2.0);
+  BOOST_TEST(values(1) == 3.0);
+  BOOST_TEST(values(2) == 4.0);
 
   // Scale properties
   action::ScaleByAreaAction scale(
@@ -57,9 +57,9 @@ BOOST_AUTO_TEST_CASE(DivideByArea)
 
   scale.performAction(0.0, 0.0, 0.0, 0.0);
 
-  BOOST_TEST(values[0] == 4.0);
-  BOOST_TEST(values[1] == 3.0);
-  BOOST_TEST(values[2] == 8.0);
+  BOOST_TEST(values(0) == 4.0);
+  BOOST_TEST(values(1) == 3.0);
+  BOOST_TEST(values(2) == 8.0);
 }
 
 BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepLength)
@@ -86,36 +86,36 @@ BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepLength)
       action::ScaleByDtAction::SCALING_BY_COMPUTED_DT_RATIO);
 
   scale.performAction(0.0, 0.0, 0.0, 1.0);
-  BOOST_TEST(sourceValues[0] == 2.0);
-  BOOST_TEST(sourceValues[1] == 3.0);
-  BOOST_TEST(sourceValues[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 0.0);
-  BOOST_TEST(targetValues[1] == 0.0);
-  BOOST_TEST(targetValues[2] == 0.0);
+  BOOST_TEST(sourceValues(0) == 2.0);
+  BOOST_TEST(sourceValues(1) == 3.0);
+  BOOST_TEST(sourceValues(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 0.0);
+  BOOST_TEST(targetValues(1) == 0.0);
+  BOOST_TEST(targetValues(2) == 0.0);
 
   scale.performAction(0.0, 0.5, 0.5, 1.0);
-  BOOST_TEST(sourceValues[0] == 2.0);
-  BOOST_TEST(sourceValues[1] == 3.0);
-  BOOST_TEST(sourceValues[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 1.0);
-  BOOST_TEST(targetValues[1] == 1.5);
-  BOOST_TEST(targetValues[2] == 2.0);
+  BOOST_TEST(sourceValues(0) == 2.0);
+  BOOST_TEST(sourceValues(1) == 3.0);
+  BOOST_TEST(sourceValues(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 1.0);
+  BOOST_TEST(targetValues(1) == 1.5);
+  BOOST_TEST(targetValues(2) == 2.0);
 
   scale.performAction(0.0, 0.25, 0.75, 1.0);
-  BOOST_TEST(sourceValues[0] == 2.0);
-  BOOST_TEST(sourceValues[1] == 3.0);
-  BOOST_TEST(sourceValues[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 0.5);
-  BOOST_TEST(targetValues[1] == 0.75);
-  BOOST_TEST(targetValues[2] == 1.0);
+  BOOST_TEST(sourceValues(0) == 2.0);
+  BOOST_TEST(sourceValues(1) == 3.0);
+  BOOST_TEST(sourceValues(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 0.5);
+  BOOST_TEST(targetValues(1) == 0.75);
+  BOOST_TEST(targetValues(2) == 1.0);
 
   scale.performAction(0.0, 0.25, 1.0, 1.0);
-  BOOST_TEST(sourceValues[0] == 2.0);
-  BOOST_TEST(sourceValues[1] == 3.0);
-  BOOST_TEST(sourceValues[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 0.5);
-  BOOST_TEST(targetValues[1] == 0.75);
-  BOOST_TEST(targetValues[2] == 1.0);
+  BOOST_TEST(sourceValues(0) == 2.0);
+  BOOST_TEST(sourceValues(1) == 3.0);
+  BOOST_TEST(sourceValues(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 0.5);
+  BOOST_TEST(targetValues(1) == 0.75);
+  BOOST_TEST(targetValues(2) == 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepPartLength)
@@ -141,28 +141,28 @@ BOOST_AUTO_TEST_CASE(ScaleByComputedTimestepPartLength)
       action::ScaleByDtAction::SCALING_BY_COMPUTED_DT_PART_RATIO);
 
   scale.performAction(0.0, 0.0, 0.0, 1.0);
-  BOOST_TEST(sourceValues[0] == 2.0);
-  BOOST_TEST(sourceValues[1] == 3.0);
-  BOOST_TEST(sourceValues[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 0.0);
-  BOOST_TEST(targetValues[1] == 0.0);
-  BOOST_TEST(targetValues[2] == 0.0);
+  BOOST_TEST(sourceValues(0) == 2.0);
+  BOOST_TEST(sourceValues(1) == 3.0);
+  BOOST_TEST(sourceValues(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 0.0);
+  BOOST_TEST(targetValues(1) == 0.0);
+  BOOST_TEST(targetValues(2) == 0.0);
 
   scale.performAction(0.0, 0.5, 0.5, 1.0);
-  BOOST_TEST(sourceValues[0] == 2.0);
-  BOOST_TEST(sourceValues[1] == 3.0);
-  BOOST_TEST(sourceValues[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 1.0);
-  BOOST_TEST(targetValues[1] == 1.5);
-  BOOST_TEST(targetValues[2] == 2.0);
+  BOOST_TEST(sourceValues(0) == 2.0);
+  BOOST_TEST(sourceValues(1) == 3.0);
+  BOOST_TEST(sourceValues(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 1.0);
+  BOOST_TEST(targetValues(1) == 1.5);
+  BOOST_TEST(targetValues(2) == 2.0);
 
   scale.performAction(0.0, 0.5, 1.0, 1.0);
-  BOOST_TEST(sourceValues[0] == 2.0);
-  BOOST_TEST(sourceValues[1] == 3.0);
-  BOOST_TEST(sourceValues[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 2.0);
-  BOOST_TEST(targetValues[1] == 3.0);
-  BOOST_TEST(targetValues[2] == 4.0);
+  BOOST_TEST(sourceValues(0) == 2.0);
+  BOOST_TEST(sourceValues(1) == 3.0);
+  BOOST_TEST(sourceValues(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 2.0);
+  BOOST_TEST(targetValues(1) == 3.0);
+  BOOST_TEST(targetValues(2) == 4.0);
 }
 
 BOOST_AUTO_TEST_CASE(Configuration)

--- a/src/action/tests/SummationActionTest.cpp
+++ b/src/action/tests/SummationActionTest.cpp
@@ -53,32 +53,32 @@ BOOST_AUTO_TEST_CASE(SummationOneDimensional)
       action::SummationAction::WRITE_MAPPING_PRIOR, sourceDataIDs, targetDataID, mesh);
 
   sum.performAction(0.0, 0.25, 0.0, 0.25);
-  BOOST_TEST(sourceValues1[0] == 2.0);
-  BOOST_TEST(sourceValues1[1] == 3.0);
-  BOOST_TEST(sourceValues1[2] == 4.0);
-  BOOST_TEST(sourceValues2[0] == 1.0);
-  BOOST_TEST(sourceValues2[1] == 2.0);
-  BOOST_TEST(sourceValues2[2] == 3.0);
-  BOOST_TEST(sourceValues3[0] == 2.0);
-  BOOST_TEST(sourceValues3[1] == 3.0);
-  BOOST_TEST(sourceValues3[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 5.0);
-  BOOST_TEST(targetValues[1] == 8.0);
-  BOOST_TEST(targetValues[2] == 11.0);
+  BOOST_TEST(sourceValues1(0) == 2.0);
+  BOOST_TEST(sourceValues1(1) == 3.0);
+  BOOST_TEST(sourceValues1(2) == 4.0);
+  BOOST_TEST(sourceValues2(0) == 1.0);
+  BOOST_TEST(sourceValues2(1) == 2.0);
+  BOOST_TEST(sourceValues2(2) == 3.0);
+  BOOST_TEST(sourceValues3(0) == 2.0);
+  BOOST_TEST(sourceValues3(1) == 3.0);
+  BOOST_TEST(sourceValues3(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 5.0);
+  BOOST_TEST(targetValues(1) == 8.0);
+  BOOST_TEST(targetValues(2) == 11.0);
 
   sum.performAction(0.0, 0.25, 0.25, 0.25);
-  BOOST_TEST(sourceValues1[0] == 2.0);
-  BOOST_TEST(sourceValues1[1] == 3.0);
-  BOOST_TEST(sourceValues1[2] == 4.0);
-  BOOST_TEST(sourceValues2[0] == 1.0);
-  BOOST_TEST(sourceValues2[1] == 2.0);
-  BOOST_TEST(sourceValues2[2] == 3.0);
-  BOOST_TEST(sourceValues3[0] == 2.0);
-  BOOST_TEST(sourceValues3[1] == 3.0);
-  BOOST_TEST(sourceValues3[2] == 4.0);
-  BOOST_TEST(targetValues[0] == 5.0);
-  BOOST_TEST(targetValues[1] == 8.0);
-  BOOST_TEST(targetValues[2] == 11.0);
+  BOOST_TEST(sourceValues1(0) == 2.0);
+  BOOST_TEST(sourceValues1(1) == 3.0);
+  BOOST_TEST(sourceValues1(2) == 4.0);
+  BOOST_TEST(sourceValues2(0) == 1.0);
+  BOOST_TEST(sourceValues2(1) == 2.0);
+  BOOST_TEST(sourceValues2(2) == 3.0);
+  BOOST_TEST(sourceValues3(0) == 2.0);
+  BOOST_TEST(sourceValues3(1) == 3.0);
+  BOOST_TEST(sourceValues3(2) == 4.0);
+  BOOST_TEST(targetValues(0) == 5.0);
+  BOOST_TEST(targetValues(1) == 8.0);
+  BOOST_TEST(targetValues(2) == 11.0);
 }
 
 BOOST_AUTO_TEST_CASE(SummationThreeDimensional)
@@ -107,41 +107,41 @@ BOOST_AUTO_TEST_CASE(SummationThreeDimensional)
       action::SummationAction::WRITE_MAPPING_PRIOR, sourceDataIDs, targetDataID, mesh);
 
   sum.performAction(0.0, 0.25, 0.0, 0.25);
-  BOOST_TEST(sourceValues1[0] == 1.0);
-  BOOST_TEST(sourceValues2[0] == 2.0);
-  BOOST_TEST(targetValues[0] == 3.0);
+  BOOST_TEST(sourceValues1(0) == 1.0);
+  BOOST_TEST(sourceValues2(0) == 2.0);
+  BOOST_TEST(targetValues(0) == 3.0);
 
-  BOOST_TEST(sourceValues1[1] == 2.0);
-  BOOST_TEST(sourceValues2[1] == 3.0);
-  BOOST_TEST(targetValues[1] == 5.0);
+  BOOST_TEST(sourceValues1(1) == 2.0);
+  BOOST_TEST(sourceValues2(1) == 3.0);
+  BOOST_TEST(targetValues(1) == 5.0);
 
-  BOOST_TEST(sourceValues1[2] == 3.0);
-  BOOST_TEST(sourceValues2[2] == 4.0);
-  BOOST_TEST(targetValues[2] == 7.0);
+  BOOST_TEST(sourceValues1(2) == 3.0);
+  BOOST_TEST(sourceValues2(2) == 4.0);
+  BOOST_TEST(targetValues(2) == 7.0);
 
-  BOOST_TEST(sourceValues1[3] == 4.0);
-  BOOST_TEST(sourceValues2[3] == 5.0);
-  BOOST_TEST(targetValues[3] == 9.0);
+  BOOST_TEST(sourceValues1(3) == 4.0);
+  BOOST_TEST(sourceValues2(3) == 5.0);
+  BOOST_TEST(targetValues(3) == 9.0);
 
-  BOOST_TEST(sourceValues1[4] == 5.0);
-  BOOST_TEST(sourceValues2[4] == 6.0);
-  BOOST_TEST(targetValues[4] == 11.0);
+  BOOST_TEST(sourceValues1(4) == 5.0);
+  BOOST_TEST(sourceValues2(4) == 6.0);
+  BOOST_TEST(targetValues(4) == 11.0);
 
-  BOOST_TEST(sourceValues1[5] == 6.0);
-  BOOST_TEST(sourceValues2[5] == 7.0);
-  BOOST_TEST(targetValues[5] == 13.0);
+  BOOST_TEST(sourceValues1(5) == 6.0);
+  BOOST_TEST(sourceValues2(5) == 7.0);
+  BOOST_TEST(targetValues(5) == 13.0);
 
-  BOOST_TEST(sourceValues1[6] == 7.0);
-  BOOST_TEST(sourceValues2[6] == 8.0);
-  BOOST_TEST(targetValues[6] == 15.0);
+  BOOST_TEST(sourceValues1(6) == 7.0);
+  BOOST_TEST(sourceValues2(6) == 8.0);
+  BOOST_TEST(targetValues(6) == 15.0);
 
-  BOOST_TEST(sourceValues1[7] == 8.0);
-  BOOST_TEST(sourceValues2[7] == 9.0);
-  BOOST_TEST(targetValues[7] == 17.0);
+  BOOST_TEST(sourceValues1(7) == 8.0);
+  BOOST_TEST(sourceValues2(7) == 9.0);
+  BOOST_TEST(targetValues(7) == 17.0);
 
-  BOOST_TEST(sourceValues1[8] == 9.0);
-  BOOST_TEST(sourceValues2[8] == 10.0);
-  BOOST_TEST(targetValues[8] == 19.0);
+  BOOST_TEST(sourceValues1(8) == 9.0);
+  BOOST_TEST(sourceValues2(8) == 10.0);
+  BOOST_TEST(targetValues(8) == 19.0);
 }
 
 BOOST_AUTO_TEST_CASE(Configuration)

--- a/src/com/tests/CommunicateBoundingBoxTest.cpp
+++ b/src/com/tests/CommunicateBoundingBoxTest.cpp
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveConnectionMap)
 
     for (int rank = 0; rank < 3; rank++) {
 
-      BOOST_TEST(fbm[rank] == fbmCompare[rank]);
+      BOOST_TEST(fbm.at(rank) == fbmCompare.at(rank));
     }
   }
 }
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveConnectionMap)
 
     for (int rank = 0; rank < 3; rank++) {
 
-      BOOST_TEST(fbm[rank] == fbmCompare[rank]);
+      BOOST_TEST(fbm.at(rank) == fbmCompare.at(rank));
     }
   }
 }

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -50,13 +50,13 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh)
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       comMesh.receiveMesh(recvMesh, 0);
       BOOST_TEST(recvMesh.vertices().size() == 4);
-      BOOST_TEST(testing::equals(recvMesh.vertices()[0].getCoords(), Eigen::VectorXd::Constant(dim, 9)));
-      BOOST_TEST(recvMesh.vertices()[1] == v0);
-      BOOST_TEST(recvMesh.vertices()[2] == v1);
-      BOOST_TEST(recvMesh.vertices()[3] == v2);
-      BOOST_TEST(recvMesh.edges()[0] == e0);
-      BOOST_TEST(recvMesh.edges()[1] == e1);
-      BOOST_TEST(recvMesh.edges()[2] == e2);
+      BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+      BOOST_TEST(recvMesh.vertices().at(1) == v0);
+      BOOST_TEST(recvMesh.vertices().at(2) == v1);
+      BOOST_TEST(recvMesh.vertices().at(3) == v2);
+      BOOST_TEST(recvMesh.edges().at(0) == e0);
+      BOOST_TEST(recvMesh.edges().at(1) == e1);
+      BOOST_TEST(recvMesh.edges().at(2) == e2);
     }
   }
 }
@@ -87,15 +87,15 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh)
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     comMesh.receiveMesh(recvMesh, 0);
     BOOST_TEST(recvMesh.vertices().size() == 4);
-    BOOST_TEST(testing::equals(recvMesh.vertices()[0].getCoords(), Eigen::VectorXd::Constant(dim, 9)));
-    BOOST_TEST(recvMesh.vertices()[1] == v0);
-    BOOST_TEST(recvMesh.vertices()[2] == v1);
-    BOOST_TEST(recvMesh.vertices()[3] == v2);
-    BOOST_TEST(recvMesh.edges()[0] == e0);
-    BOOST_TEST(recvMesh.edges()[1] == e1);
-    BOOST_TEST(recvMesh.edges()[2] == e2);
+    BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+    BOOST_TEST(recvMesh.vertices().at(1) == v0);
+    BOOST_TEST(recvMesh.vertices().at(2) == v1);
+    BOOST_TEST(recvMesh.vertices().at(3) == v2);
+    BOOST_TEST(recvMesh.edges().at(0) == e0);
+    BOOST_TEST(recvMesh.edges().at(1) == e1);
+    BOOST_TEST(recvMesh.edges().at(2) == e2);
 
-    BOOST_TEST(recvMesh.triangles()[0] == t0);
+    BOOST_TEST(recvMesh.triangles().at(0) == t0);
   }
 }
 
@@ -124,14 +124,14 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh)
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     comMesh.broadcastReceiveMesh(recvMesh);
     BOOST_TEST(recvMesh.vertices().size() == 4);
-    BOOST_TEST(testing::equals(recvMesh.vertices()[0].getCoords(), Eigen::VectorXd::Constant(dim, 9)));
-    BOOST_TEST(recvMesh.vertices()[1] == v0);
-    BOOST_TEST(recvMesh.vertices()[2] == v1);
-    BOOST_TEST(recvMesh.vertices()[3] == v2);
-    BOOST_TEST(recvMesh.edges()[0] == e0);
-    BOOST_TEST(recvMesh.edges()[1] == e1);
-    BOOST_TEST(recvMesh.edges()[2] == e2);
-    BOOST_TEST(recvMesh.triangles()[0] == t0);
+    BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+    BOOST_TEST(recvMesh.vertices().at(1) == v0);
+    BOOST_TEST(recvMesh.vertices().at(2) == v1);
+    BOOST_TEST(recvMesh.vertices().at(3) == v2);
+    BOOST_TEST(recvMesh.edges().at(0) == e0);
+    BOOST_TEST(recvMesh.edges().at(1) == e1);
+    BOOST_TEST(recvMesh.edges().at(2) == e2);
+    BOOST_TEST(recvMesh.triangles().at(0) == t0);
   }
 }
 

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -57,10 +57,10 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
     xml::configure(root, ccontext, configFilename);
 
     // some dummy mesh
-    meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
-    meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
-    meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
-    meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
+    meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
+    meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
+    meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
+    meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
 
     m2n::PtrM2N m2n0 = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
     m2n::PtrM2N m2n1 = m2nConfig->getM2N(nameParticipant1, nameParticipant2);
@@ -84,7 +84,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       mesh::PtrMeshConfiguration meshConfig)
   {
     BOOST_TEST(meshConfig->meshes().size() == 1);
-    mesh::PtrMesh mesh = meshConfig->meshes()[0];
+    mesh::PtrMesh mesh = meshConfig->meshes().at(0);
     BOOST_TEST(mesh->data().size() == 3);
     BOOST_TEST(mesh->vertices().size() > 0);
 

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -37,12 +37,12 @@ void runSimpleExplicitCoupling(
     const mesh::MeshConfiguration &meshConfig)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
-  mesh::PtrMesh mesh = meshConfig.meshes()[0];
+  mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_TEST(mesh->data().size() == 2);
-  auto &dataValues0 = mesh->data()[0]->values();
-  auto &dataValues1 = mesh->data()[1]->values();
+  auto &dataValues0 = mesh->data().at(0)->values();
+  auto &dataValues1 = mesh->data().at(1)->values();
   BOOST_TEST(mesh->vertices().size() > 0);
-  mesh::Vertex &  vertex     = mesh->vertices()[0];
+  mesh::Vertex &  vertex     = mesh->vertices().at(0);
   double          valueData0 = 1.0;
   Eigen::VectorXd valueData1 = Eigen::VectorXd::Constant(3, 1.0);
 
@@ -114,7 +114,7 @@ void runSimpleExplicitCoupling(
         // The participant not starting the coupled simulation does neither
         // receive nor send data in the last call to advance
         BOOST_TEST(cplScheme.hasDataBeenReceived());
-        double value = dataValues0[vertex.getID()];
+        double value = dataValues0(vertex.getID());
         BOOST_TEST(testing::equals(value, valueData0));
       }
       valueData0 += 1.0;
@@ -138,14 +138,14 @@ void runExplicitCouplingWithSubcycling(
     const mesh::MeshConfiguration &meshConfig)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
-  mesh::PtrMesh mesh = meshConfig.meshes()[0];
+  mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_TEST(mesh->data().size() == 2);
   BOOST_TEST(mesh->vertices().size() > 0);
-  mesh::Vertex &  vertex      = mesh->vertices()[0];
+  mesh::Vertex &  vertex      = mesh->vertices().at(0);
   double          valueData0  = 1.0;
   Eigen::VectorXd valueData1  = Eigen::VectorXd::Constant(3, 1.0);
-  auto &          dataValues0 = mesh->data()[0]->values();
-  auto &          dataValues1 = mesh->data()[1]->values();
+  auto &          dataValues0 = mesh->data().at(0)->values();
+  auto &          dataValues1 = mesh->data().at(1)->values();
 
   double      computedTime      = 0.0;
   int         computedTimesteps = 0;
@@ -313,8 +313,8 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
       maxTime, maxTimesteps, timestepLength, 12, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Explicit);
-  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
+  cplScheme.addDataToSend(mesh->data().at(sendDataIndex), mesh, false);
+  cplScheme.addDataToReceive(mesh->data().at(receiveDataIndex), mesh, false);
   runSimpleExplicitCoupling(cplScheme, context.name, meshConfig);
 }
 
@@ -342,11 +342,11 @@ BOOST_AUTO_TEST_CASE(testConfiguredSimpleExplicitCoupling)
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
   // some dummy mesh
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->allocateDataValues();
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
+  meshConfig->meshes().at(0)->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, context.name, m2n);
   runSimpleExplicitCoupling(*cplSchemeConfig.getCouplingScheme(context.name),
@@ -376,11 +376,11 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
   // some dummy mesh
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->allocateDataValues();
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
+  meshConfig->meshes().at(0)->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, context.name, m2n);
   CouplingScheme &cplScheme = *cplSchemeConfig.getCouplingScheme(context.name);
@@ -458,21 +458,21 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
   // some dummy mesh
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(2.0, -1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(3.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(4.0, -1.0));
-  meshConfig->meshes()[0]->allocateDataValues();
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(2.0, -1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(3.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(4.0, -1.0));
+  meshConfig->meshes().at(0)->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, context.name, m2n);
   CouplingScheme &cplScheme = *cplSchemeConfig.getCouplingScheme(context.name);
 
   BOOST_TEST(meshConfig->meshes().size() == 1);
-  mesh::PtrMesh mesh = meshConfig->meshes()[0];
+  mesh::PtrMesh mesh = meshConfig->meshes().at(0);
   BOOST_TEST(mesh->data().size() == 3);
-  auto &dataValues0 = mesh->data()[0]->values();
-  auto &dataValues1 = mesh->data()[1]->values();
-  auto &dataValues2 = mesh->data()[2]->values();
+  auto &dataValues0 = mesh->data().at(0)->values();
+  auto &dataValues1 = mesh->data().at(1)->values();
+  auto &dataValues2 = mesh->data().at(2)->values();
 
   if (context.isNamed(nameParticipant0)) {
     cplScheme.initialize(0.0, 1);
@@ -526,21 +526,21 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
 
   // some dummy mesh
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(2.0, -1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(3.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector2d(4.0, -1.0));
-  meshConfig->meshes()[0]->allocateDataValues();
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(2.0, -1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(3.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector2d(4.0, -1.0));
+  meshConfig->meshes().at(0)->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, context.name, m2n);
   CouplingScheme &cplScheme = *cplSchemeConfig.getCouplingScheme(context.name);
 
   BOOST_TEST(meshConfig->meshes().size() == 1);
-  mesh::PtrMesh mesh = meshConfig->meshes()[0];
+  mesh::PtrMesh mesh = meshConfig->meshes().at(0);
   BOOST_TEST(mesh->data().size() == 3);
-  auto &dataValues0 = mesh->data()[0]->values();
-  auto &dataValues1 = mesh->data()[1]->values();
-  auto &dataValues2 = mesh->data()[2]->values();
+  auto &dataValues0 = mesh->data().at(0)->values();
+  auto &dataValues1 = mesh->data().at(1)->values();
+  auto &dataValues2 = mesh->data().at(2)->values();
 
   if (context.isNamed(nameParticipant0)) {
     cplScheme.initialize(0.0, 1);
@@ -616,8 +616,8 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
       maxTime, maxTimesteps, timestepLength, 12, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Explicit);
-  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
+  cplScheme.addDataToSend(mesh->data().at(sendDataIndex), mesh, false);
+  cplScheme.addDataToReceive(mesh->data().at(receiveDataIndex), mesh, false);
   runExplicitCouplingWithSubcycling(cplScheme, context.name, meshConfig);
 }
 
@@ -644,11 +644,11 @@ BOOST_AUTO_TEST_CASE(testConfiguredExplicitCouplingWithSubcycling)
   xml::configure(root, ccontext, configurationPath);
   m2n::PtrM2N m2n = m2nConfig->getM2N(nameParticipant0, nameParticipant1);
   // some dummy mesh
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, -1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, -1.0, 1.0));
-  meshConfig->meshes()[0]->allocateDataValues();
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(2.0, -1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(4.0, -1.0, 1.0));
+  meshConfig->meshes().at(0)->allocateDataValues();
 
   connect(nameParticipant0, nameParticipant1, context.name, m2n);
   runExplicitCouplingWithSubcycling(

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -316,8 +316,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   ParallelCouplingScheme cplScheme(
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE, BaseCouplingScheme::Implicit, 100);
-  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, dataRequiresInitialization);
-  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, dataRequiresInitialization);
+  cplScheme.addDataToSend(mesh->data().at(sendDataIndex), mesh, dataRequiresInitialization);
+  cplScheme.addDataToReceive(mesh->data().at(receiveDataIndex), mesh, dataRequiresInitialization);
 
   // Add convergence measures
   int                                    minIterations = 3;
@@ -325,8 +325,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure2(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1, true);
-  cplScheme.addConvergenceMeasure(mesh->data()[0], false, false, minIterationConvMeasure2, true);
+  cplScheme.addConvergenceMeasure(mesh->data().at(1), false, false, minIterationConvMeasure1, true);
+  cplScheme.addConvergenceMeasure(mesh->data().at(0), false, false, minIterationConvMeasure2, true);
 
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -47,13 +47,13 @@ void runCoupling(
     const std::vector<int> &       validIterations)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
-  mesh::PtrMesh mesh = meshConfig.meshes()[0];
+  mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_TEST(mesh->data().size() == 2);
   BOOST_TEST(mesh->vertices().size() > 0);
-  mesh::Vertex &  vertex               = mesh->vertices()[0];
+  mesh::Vertex &  vertex               = mesh->vertices().at(0);
   int             index                = vertex.getID();
-  auto &          dataValues0          = mesh->data()[0]->values();
-  auto &          dataValues1          = mesh->data()[1]->values();
+  auto &          dataValues0          = mesh->data().at(0)->values();
+  auto &          dataValues1          = mesh->data().at(1)->values();
   double          initialStepsizeData0 = 5.0;
   double          stepsizeData0        = 5.0;
   Eigen::VectorXd initialStepsizeData1 = Eigen::VectorXd::Constant(3, 5.0);
@@ -79,7 +79,7 @@ void runCoupling(
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
 
     while (cplScheme.isCouplingOngoing()) {
-      dataValues0[index] += stepsizeData0;
+      dataValues0(index) += stepsizeData0;
       // The max timestep length is required to be obeyed.
       double maxLengthTimestep = cplScheme.getNextTimestepMaxLength();
       cplScheme.addComputedTime(maxLengthTimestep);
@@ -210,7 +210,7 @@ void runCouplingWithSubcycling(
     const std::vector<int> &       validIterations)
 {
   BOOST_TEST(meshConfig.meshes().size() == 1);
-  mesh::PtrMesh mesh = meshConfig.meshes()[0];
+  mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_TEST(mesh->data().size() == 2);
   BOOST_TEST(mesh->vertices().size() > 0);
   double          initialStepsizeData0 = 5.0;
@@ -456,23 +456,23 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(cplData->values().size() == 1);
   BOOST_TEST(cplData->oldValues.cols() == 2);
   BOOST_TEST(cplData->oldValues.rows() == 1);
-  BOOST_TEST(testing::equals(cplData->values()[0], 0.0));
+  BOOST_TEST(testing::equals(cplData->values()(0), 0.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 0.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 0.0));
 
-  cplData->values()[0] = 1.0;
+  cplData->values()(0) = 1.0;
   scheme.setTimeWindows(scheme.getTimeWindows() + 1);
   scheme.storeData();
   scheme.extrapolateData(scheme.getSendData());
-  BOOST_TEST(testing::equals(cplData->values()[0], 2.0));
+  BOOST_TEST(testing::equals(cplData->values()(0), 2.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 2.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 1.0));
 
-  cplData->values()[0] = 4.0;
+  cplData->values()(0) = 4.0;
   scheme.setTimeWindows(scheme.getTimeWindows() + 1);
   scheme.storeData();
   scheme.extrapolateData(scheme.getSendData());
-  BOOST_TEST(testing::equals(cplData->values()[0], 7.0));
+  BOOST_TEST(testing::equals(cplData->values()(0), 7.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 7.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 4.0));
 
@@ -491,25 +491,25 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(cplData->values().size() == 1);
   BOOST_TEST(cplData->oldValues.cols() == 3);
   BOOST_TEST(cplData->oldValues.rows() == 1);
-  BOOST_TEST(testing::equals(cplData->values()[0], 0.0));
+  BOOST_TEST(testing::equals(cplData->values()(0), 0.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 0.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 0.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 0.0));
 
-  cplData->values()[0] = 1.0;
+  cplData->values()(0) = 1.0;
   scheme2.setTimeWindows(scheme2.getTimeWindows() + 1);
   scheme2.storeData();
   scheme2.extrapolateData(scheme2.getSendData());
-  BOOST_TEST(testing::equals(cplData->values()[0], 2.0));
+  BOOST_TEST(testing::equals(cplData->values()(0), 2.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 2.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 1.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 0.0));
 
-  cplData->values()[0] = 4.0;
+  cplData->values()(0) = 4.0;
   scheme2.setTimeWindows(scheme2.getTimeWindows() + 1);
   scheme2.storeData();
   scheme2.extrapolateData(scheme2.getSendData());
-  BOOST_TEST(testing::equals(cplData->values()[0], 8.0));
+  BOOST_TEST(testing::equals(cplData->values()(0), 8.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 0), 8.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 1), 4.0));
   BOOST_TEST(testing::equals(cplData->oldValues(0, 2), 1.0));
@@ -562,13 +562,13 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100);
-  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
+  cplScheme.addDataToSend(mesh->data().at(sendDataIndex), mesh, false);
+  cplScheme.addDataToReceive(mesh->data().at(receiveDataIndex), mesh, false);
 
   double                                 convergenceLimit1 = sqrt(3.0); // when diff_vector = (1.0, 1.0, 1.0)
   cplscheme::impl::PtrConvergenceMeasure absoluteConvMeasure1(
       new cplscheme::impl::AbsoluteConvergenceMeasure(convergenceLimit1));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, absoluteConvMeasure1, true);
+  cplScheme.addConvergenceMeasure(mesh->data().at(1), false, false, absoluteConvMeasure1, true);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {5, 5, 5};
@@ -597,11 +597,11 @@ BOOST_AUTO_TEST_CASE(testConfiguredAbsConvergenceMeasureSynchronized)
   useOnlyMasterCom(m2n) = true;
 
   // some dummy mesh
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
-  meshConfig->meshes()[0]->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
-  meshConfig->meshes()[0]->allocateDataValues();
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(2.0, 1.0, -1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(3.0, 1.0, 1.0));
+  meshConfig->meshes().at(0)->createVertex(Eigen::Vector3d(4.0, 1.0, -1.0));
+  meshConfig->meshes().at(0)->allocateDataValues();
 
   std::vector<int> validIterations = {5, 5, 5};
 
@@ -659,14 +659,14 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100);
-  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
+  cplScheme.addDataToSend(mesh->data().at(sendDataIndex), mesh, false);
+  cplScheme.addDataToReceive(mesh->data().at(receiveDataIndex), mesh, false);
 
   // Add convergence measures
   int                                    minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1, true);
+  cplScheme.addConvergenceMeasure(mesh->data().at(1), false, false, minIterationConvMeasure1, true);
 
   // Expected iterations per implicit timesptep
   std::vector<int> validIterations = {3, 3, 3};
@@ -720,14 +720,14 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100);
-  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, false);
-  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, false);
+  cplScheme.addDataToSend(mesh->data().at(sendDataIndex), mesh, false);
+  cplScheme.addDataToReceive(mesh->data().at(receiveDataIndex), mesh, false);
 
   // Add convergence measures
   int                                    minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1, true);
+  cplScheme.addConvergenceMeasure(mesh->data().at(1), false, false, minIterationConvMeasure1, true);
   runCouplingWithSubcycling(
       cplScheme, context.name, meshConfig, validIterations);
 }
@@ -780,14 +780,14 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100);
-  cplScheme.addDataToSend(mesh->data()[sendDataIndex], mesh, dataRequiresInitialization);
-  cplScheme.addDataToReceive(mesh->data()[receiveDataIndex], mesh, not dataRequiresInitialization);
+  cplScheme.addDataToSend(mesh->data().at(sendDataIndex), mesh, dataRequiresInitialization);
+  cplScheme.addDataToReceive(mesh->data().at(receiveDataIndex), mesh, not dataRequiresInitialization);
 
   // Add convergence measures
   int                                    minIterations = 3;
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
-  cplScheme.addConvergenceMeasure(mesh->data()[1], false, false, minIterationConvMeasure1, true);
+  cplScheme.addConvergenceMeasure(mesh->data().at(1), false, false, minIterationConvMeasure1, true);
 
   std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Constant(dim, 0.0);
-  coords3[0]              = 1.0;
+  coords3(0)              = 1.0;
   mesh::Vertex &v3        = mesh.createVertex(coords3);
 
   mesh.createEdge(v1, v2);
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
-  coords3[0]              = 1.0;
+  coords3(0)              = 1.0;
   mesh::Vertex &v3        = mesh.createVertex(coords3);
 
   mesh::Edge &e1 = mesh.createEdge(v1, v2);

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));
     mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
-    coords3[0]              = 1.0;
+    coords3(0)              = 1.0;
     mesh::Vertex &v3        = mesh.createVertex(coords3);
 
     mesh.createEdge(v1, v2);
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
     Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
-    coords3[1]              = 1.0;
+    coords3(1)              = 1.0;
     mesh::Vertex &v3        = mesh.createVertex(coords3);
 
     mesh.createEdge(v1, v2);
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));
     mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
-    coords3[0]              = 1.0;
+    coords3(0)              = 1.0;
     mesh::Vertex &v3        = mesh.createVertex(coords3);
 
     mesh::Edge &e1 = mesh.createEdge(v1, v2);
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
     Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
-    coords3[1]              = 1.0;
+    coords3(1)              = 1.0;
     mesh::Vertex &v3        = mesh.createVertex(coords3);
 
     mesh::Edge &e1 = mesh.createEdge(v1, v2);

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -45,12 +45,12 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
     m2n->send(values.data(), numberOfVertices, pMesh->getID(), valueDimension);
     m2n->receive(values.data(), numberOfVertices, pMesh->getID(),
                  valueDimension);
-    BOOST_TEST(values[0] == 2.0);
-    BOOST_TEST(values[1] == 4.0);
-    BOOST_TEST(values[2] == 6.0);
-    BOOST_TEST(values[3] == 16.0);
-    BOOST_TEST(values[4] == 10.0);
-    BOOST_TEST(values[5] == 12.0);
+    BOOST_TEST(values(0) == 2.0);
+    BOOST_TEST(values(1) == 4.0);
+    BOOST_TEST(values(2) == 6.0);
+    BOOST_TEST(values(3) == 16.0);
+    BOOST_TEST(values(4) == 10.0);
+    BOOST_TEST(values(5) == 12.0);
 
   } else {
     BOOST_TEST(context.isNamed("Part2"));
@@ -70,9 +70,9 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
 
       Eigen::Vector3d values(0.0, 0.0, 0.0);
       m2n->receive(values.data(), 3, pMesh->getID(), valueDimension);
-      BOOST_TEST(values[0] == 1.0);
-      BOOST_TEST(values[1] == 2.0);
-      BOOST_TEST(values[2] == 4.0);
+      BOOST_TEST(values(0) == 1.0);
+      BOOST_TEST(values(1) == 2.0);
+      BOOST_TEST(values(2) == 4.0);
       values = values * 2;
       m2n->send(values.data(), 3, pMesh->getID(), valueDimension);
     } else if (context.isRank(1)) { // Slave1
@@ -83,10 +83,10 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
       BOOST_TEST(context.isRank(2));
       Eigen::Vector4d values(0.0, 0.0, 0.0, 0.0);
       m2n->receive(values.data(), 4, pMesh->getID(), valueDimension);
-      BOOST_TEST(values[0] == 3.0);
-      BOOST_TEST(values[1] == 4.0);
-      BOOST_TEST(values[2] == 5.0);
-      BOOST_TEST(values[3] == 6.0);
+      BOOST_TEST(values(0) == 3.0);
+      BOOST_TEST(values(1) == 4.0);
+      BOOST_TEST(values(2) == 5.0);
+      BOOST_TEST(values(3) == 6.0);
       values = values * 2;
       m2n->send(values.data(), 4, pMesh->getID(), valueDimension);
     }

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -244,9 +244,9 @@ void runSameConnectionTest(const TestContext &context, com::PtrCommunicationFact
     c.broadcastReceiveAll(receiveData);
 
     if (context.isMaster()) {
-      BOOST_TEST(receiveData[0] == 5);
+      BOOST_TEST(receiveData.at(0) == 5);
     } else {
-      BOOST_TEST(receiveData[0] == 10);
+      BOOST_TEST(receiveData.at(0) == 10);
     }
   }
 }
@@ -301,9 +301,9 @@ void runCrossConnectionTest(const TestContext &context, com::PtrCommunicationFac
     c.broadcastReceiveAll(receiveData);
 
     if (context.isMaster()) {
-      BOOST_TEST(receiveData[0] == 10);
+      BOOST_TEST(receiveData.at(0) == 10);
     } else {
-      BOOST_TEST(receiveData[0] == 5);
+      BOOST_TEST(receiveData.at(0) == 5);
     }
   }
 }
@@ -345,7 +345,7 @@ void runEmptyConnectionTest(const TestContext &context, com::PtrCommunicationFac
     c.broadcastReceiveAll(receiveData);
 
     if (context.isMaster()) {
-      BOOST_TEST(receiveData[0] == 5);
+      BOOST_TEST(receiveData.at(0) == 5);
 
     } else {
       BOOST_TEST(receiveData.size() == 0);
@@ -406,17 +406,17 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
     if (context.isMaster()) {
       // This rank should receive the mesh from rank 0 (fluid master)
       BOOST_TEST(mesh->vertices().size() == 2);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 5.50);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 1.0);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 2.0);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 5.50);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.0);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 2.0);
     } else {
       // This rank should receive the mesh from rank 1 (fluid slave)
       BOOST_TEST(mesh->vertices().size() == 2);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 1.50);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 1.50);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 2.0);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 1.50);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.50);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 2.0);
     }
   }
 }
@@ -487,19 +487,19 @@ void runP2PComLocalCommunicationMapTest(const TestContext &context, com::PtrComm
       // The numbers are chosen in this way to make it easy to test weather
       // correct values are communicated or not!
       BOOST_TEST(localCommunicationMap.size() == 1);
-      BOOST_TEST(localCommunicationMap[0].size() == 3);
-      BOOST_TEST(localCommunicationMap[0][0] == 102);
-      BOOST_TEST(localCommunicationMap[0][1] == 1022);
-      BOOST_TEST(localCommunicationMap[0][2] == 10222);
+      BOOST_TEST(localCommunicationMap.at(0).size() == 3);
+      BOOST_TEST(localCommunicationMap.at(0).at(0) == 102);
+      BOOST_TEST(localCommunicationMap.at(0).at(1) == 1022);
+      BOOST_TEST(localCommunicationMap.at(0).at(2) == 10222);
 
     } else {
       // The numbers are chosen in this way to make it easy to test weather
       // correct values are communicated or not!
       BOOST_TEST(localCommunicationMap.size() == 1);
-      BOOST_TEST(localCommunicationMap[1].size() == 3);
-      BOOST_TEST(localCommunicationMap[1][0] == 113);
-      BOOST_TEST(localCommunicationMap[1][1] == 1133);
-      BOOST_TEST(localCommunicationMap[1][2] == 11333);
+      BOOST_TEST(localCommunicationMap.at(1).size() == 3);
+      BOOST_TEST(localCommunicationMap.at(1).at(0) == 113);
+      BOOST_TEST(localCommunicationMap.at(1).at(1) == 1133);
+      BOOST_TEST(localCommunicationMap.at(1).at(2) == 11333);
     }
   }
 }

--- a/src/mapping/tests/MappingConfigurationTest.cpp
+++ b/src/mapping/tests/MappingConfigurationTest.cpp
@@ -34,20 +34,20 @@ BOOST_AUTO_TEST_CASE(Configuration)
 
   BOOST_TEST(meshConfig->meshes().size() == 3);
   BOOST_TEST(mappingConfig.mappings().size() == 3);
-  BOOST_TEST(mappingConfig.mappings()[0].timing == MappingConfiguration::ON_DEMAND);
-  BOOST_TEST(mappingConfig.mappings()[0].fromMesh == meshConfig->meshes()[0]);
-  BOOST_TEST(mappingConfig.mappings()[0].toMesh == meshConfig->meshes()[2]);
-  BOOST_TEST(mappingConfig.mappings()[0].direction == MappingConfiguration::WRITE);
+  BOOST_TEST(mappingConfig.mappings().at(0).timing == MappingConfiguration::ON_DEMAND);
+  BOOST_TEST(mappingConfig.mappings().at(0).fromMesh == meshConfig->meshes().at(0));
+  BOOST_TEST(mappingConfig.mappings().at(0).toMesh == meshConfig->meshes().at(2));
+  BOOST_TEST(mappingConfig.mappings().at(0).direction == MappingConfiguration::WRITE);
 
-  BOOST_TEST(mappingConfig.mappings()[1].timing == MappingConfiguration::INITIAL);
-  BOOST_TEST(mappingConfig.mappings()[1].fromMesh == meshConfig->meshes()[2]);
-  BOOST_TEST(mappingConfig.mappings()[1].toMesh == meshConfig->meshes()[1]);
-  BOOST_TEST(mappingConfig.mappings()[1].direction == MappingConfiguration::READ);
+  BOOST_TEST(mappingConfig.mappings().at(1).timing == MappingConfiguration::INITIAL);
+  BOOST_TEST(mappingConfig.mappings().at(1).fromMesh == meshConfig->meshes().at(2));
+  BOOST_TEST(mappingConfig.mappings().at(1).toMesh == meshConfig->meshes().at(1));
+  BOOST_TEST(mappingConfig.mappings().at(1).direction == MappingConfiguration::READ);
 
-  BOOST_TEST(mappingConfig.mappings()[2].timing == MappingConfiguration::ON_ADVANCE);
-  BOOST_TEST(mappingConfig.mappings()[2].fromMesh == meshConfig->meshes()[1]);
-  BOOST_TEST(mappingConfig.mappings()[2].toMesh == meshConfig->meshes()[0]);
-  BOOST_TEST(mappingConfig.mappings()[2].direction == MappingConfiguration::WRITE);
+  BOOST_TEST(mappingConfig.mappings().at(2).timing == MappingConfiguration::ON_ADVANCE);
+  BOOST_TEST(mappingConfig.mappings().at(2).fromMesh == meshConfig->meshes().at(1));
+  BOOST_TEST(mappingConfig.mappings().at(2).toMesh == meshConfig->meshes().at(0));
+  BOOST_TEST(mappingConfig.mappings().at(2).direction == MappingConfiguration::WRITE);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -163,18 +163,18 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
     // Validate results
     BOOST_TEST(mapping.hasComputedMapping() == true);
-    BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
-    BOOST_TEST(outData->values()[1] == valueVertex1);
-    BOOST_TEST(outData->values()[2] == valueVertex2);
+    BOOST_TEST(outData->values()(0) == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()(1) == valueVertex1);
+    BOOST_TEST(outData->values()(2) == valueVertex2);
 
     // Redo mapping, results should be
     //assign(outData->values()) = 0.0;
     outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
     mapping.map(inDataID, outDataID);
-    BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
-    BOOST_TEST(outData->values()[1] == valueVertex1);
-    BOOST_TEST(outData->values()[2] == valueVertex2);
+    BOOST_TEST(outData->values()(0) == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()(1) == valueVertex1);
+    BOOST_TEST(outData->values()(2) == valueVertex2);
   }
 
   {
@@ -198,18 +198,18 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
     mapping.computeMapping();
     mapping.map(inDataID, outDataID);
-    BOOST_TEST(outData->values()[0] == valueVertex1);
-    BOOST_TEST(outData->values()[1] == valueVertex2);
-    BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()(0) == valueVertex1);
+    BOOST_TEST(outData->values()(1) == valueVertex2);
+    BOOST_TEST(outData->values()(2) == (valueVertex1 + valueVertex2) * 0.5);
 
     // Reset output data to zero and redo the mapping
     //assign(outData->values()) = 0.0;
     outData->values() = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
 
     mapping.map(inDataID, outDataID);
-    BOOST_TEST(outData->values()[0] == valueVertex1);
-    BOOST_TEST(outData->values()[1] == valueVertex2);
-    BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()(0) == valueVertex1);
+    BOOST_TEST(outData->values()(1) == valueVertex2);
+    BOOST_TEST(outData->values()(2) == (valueVertex1 + valueVertex2) * 0.5);
   }
 }
 
@@ -265,9 +265,9 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
     BOOST_TEST(mapping.hasComputedMapping() == true);
     BOOST_TEST_CONTEXT(*inMesh)
     {
-      BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
-      BOOST_TEST(outData->values()[1] == valueVertex1);
-      BOOST_TEST(outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5);
+      BOOST_TEST(outData->values()(0) == (valueVertex1 + valueVertex2) * 0.5);
+      BOOST_TEST(outData->values()(1) == valueVertex1);
+      BOOST_TEST(outData->values()(2) == (valueVertex2 + valueVertex3) * 0.5);
     }
 
     // Redo mapping, results should be
@@ -277,9 +277,9 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
     mapping.map(inDataID, outDataID);
     BOOST_TEST_CONTEXT(*inMesh)
     {
-      BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
-      BOOST_TEST(outData->values()[1] == valueVertex1);
-      BOOST_TEST(outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5);
+      BOOST_TEST(outData->values()(0) == (valueVertex1 + valueVertex2) * 0.5);
+      BOOST_TEST(outData->values()(1) == valueVertex1);
+      BOOST_TEST(outData->values()(2) == (valueVertex2 + valueVertex3) * 0.5);
     }
   }
   {
@@ -306,9 +306,9 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
     mapping.map(inDataID, outDataID);
     BOOST_TEST_CONTEXT(*inMesh)
     {
-      BOOST_TEST(outData->values()[0] == valueVertex1);
-      BOOST_TEST(outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5);
-      BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
+      BOOST_TEST(outData->values()(0) == valueVertex1);
+      BOOST_TEST(outData->values()(1) == (valueVertex2 + valueVertex3) * 0.5);
+      BOOST_TEST(outData->values()(2) == (valueVertex1 + valueVertex2) * 0.5);
     }
 
     // Reset output data to zero and redo the mapping
@@ -318,9 +318,9 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
     mapping.map(inDataID, outDataID);
     BOOST_TEST_CONTEXT(*inMesh)
     {
-      BOOST_TEST(outData->values()[0] == valueVertex1);
-      BOOST_TEST(outData->values()[1] == (valueVertex2 + valueVertex3) * 0.5);
-      BOOST_TEST(outData->values()[2] == (valueVertex1 + valueVertex2) * 0.5);
+      BOOST_TEST(outData->values()(0) == valueVertex1);
+      BOOST_TEST(outData->values()(1) == (valueVertex2 + valueVertex3) * 0.5);
+      BOOST_TEST(outData->values()(2) == (valueVertex1 + valueVertex2) * 0.5);
     }
   }
 }
@@ -375,9 +375,9 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST_CONTEXT(*inMesh)
   {
-    BOOST_TEST(outData->values()[0] == (valueVertex1 + valueVertex2) * 0.5);
-    BOOST_TEST(outData->values()[1] == (valueVertex1 + valueVertex3) * 0.5);
-    BOOST_TEST(outData->values()[2] == (valueVertex2 + valueVertex3) * 0.5);
+    BOOST_TEST(outData->values()(0) == (valueVertex1 + valueVertex2) * 0.5);
+    BOOST_TEST(outData->values()(1) == (valueVertex1 + valueVertex3) * 0.5);
+    BOOST_TEST(outData->values()(2) == (valueVertex2 + valueVertex3) * 0.5);
   }
 }
 
@@ -428,9 +428,9 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST_CONTEXT(*inMesh)
   {
-    BOOST_TEST(outData->values()[0] == valueVertex1);
-    BOOST_TEST(outData->values()[1] == valueVertex2);
-    BOOST_TEST(outData->values()[2] == valueVertex3);
+    BOOST_TEST(outData->values()(0) == valueVertex1);
+    BOOST_TEST(outData->values()(1) == valueVertex2);
+    BOOST_TEST(outData->values()(2) == valueVertex3);
   }
 }
 
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   BOOST_TEST_INFO("Out Data before Mapping:" << outData->values());
   mapping.map(inData->getID(), outData->getID());
   BOOST_TEST_INFO("Out Data after Mapping:" << outData->values());
-  BOOST_TEST(outData->values()[0] == 1.0);
+  BOOST_TEST(outData->values()(0) == 1.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -101,7 +101,7 @@ void getDistributedMesh(const TestContext &      context,
       d.conservativeResize(i * valueDimension + valueDimension);
       // Get data in every dimension
       for (int dim = 0; dim < valueDimension; ++dim) {
-        d[i * valueDimension + dim] = vertex.value[dim];
+        d(i * valueDimension + dim) = vertex.value.at(dim);
       }
       i++;
     }
@@ -118,8 +118,8 @@ void testDistributed(const TestContext &    context,
                      ReferenceSpecification referenceSpec,
                      int                    inGlobalIndexOffset = 0)
 {
-  int meshDimension  = inMeshSpec[0].position.size();
-  int valueDimension = inMeshSpec[0].value.size();
+  int meshDimension  = inMeshSpec.at(0).position.size();
+  int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", valueDimension);
@@ -145,7 +145,7 @@ void testDistributed(const TestContext &    context,
     if (referenceVertex.first == context.rank or referenceVertex.first == -1) {
       for (int dim = 0; dim < valueDimension; ++dim) {
         BOOST_TEST_INFO("Index of vertex: " << index << " - Dimension: " << dim);
-        BOOST_TEST(outData->values()[index * valueDimension + dim] == referenceVertex.second[dim]);
+        BOOST_TEST(outData->values()(index * valueDimension + dim) == referenceVertex.second.at(dim));
       }
       ++index;
     }
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3)
                    {2, {6}},
                    {3, {7}},
                    {3, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Test with a very heterogenous distributed and non-continues ownership
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3Vector)
                    {2, {6, 9}},
                    {3, {7, 10}},
                    {3, {8, 11}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Some ranks are empty, does not converge
@@ -428,7 +428,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
                    {2, {6}},
                    {2, {7}},
                    {2, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 // same as 2DV4, but all ranks have vertices
@@ -496,7 +496,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
                    {2, {6}},
                    {2, {7}},
                    {2, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// same as 2DV4, but strictly linear input values, converges and gives correct results
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV6,
                    {2, {6}},
                    {2, {7}},
                    {2, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Test with a homogenous distribution of mesh amoung ranks
@@ -743,7 +743,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV2)
                    {3, {0}},
                    {3, {7}},
                    {3, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Using meshes of different sizes, inMesh is smaller then outMesh
@@ -807,7 +807,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV3)
                    {3, {0}},
                    {3, {7}},
                    {3, {8}}}, // Sum of reference is also 34
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Using meshes of different sizes, outMesh is smaller then inMesh
@@ -868,7 +868,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV4,
                    {3, {0}},
                    {3, {7.047619}},
                    {3, {7.571428}}}, // Sum is ~36
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Tests a non-contigous owner distributed at the outMesh
@@ -1004,8 +1004,8 @@ void testTagging(const TestContext &context,
                  MeshSpecification  shouldTagSecondRound,
                  bool               consistent)
 {
-  int meshDimension  = inMeshSpec[0].position.size();
-  int valueDimension = inMeshSpec[0].value.size();
+  int meshDimension  = inMeshSpec.at(0).position.size();
+  int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
@@ -1158,63 +1158,63 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value = outData->values()[0];
+  double value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Vector2d(0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Vector2d(0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Vector2d(1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Vector2d(1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Vector2d(1.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Vector2d(0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Vector2d(0.5, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Vector2d(0.5, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 }
@@ -1253,8 +1253,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value1 = outData->values()[0];
-  double value2 = outData->values()[1];
+  double value1 = outData->values()(0);
+  double value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.0);
   BOOST_TEST(value2 == 4.0);
@@ -1262,8 +1262,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.0);
   BOOST_TEST(value2 == 4.0);
@@ -1271,8 +1271,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.0);
   BOOST_TEST(value2 == 4.0);
@@ -1280,8 +1280,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 2.0);
   BOOST_TEST(value2 == 5.0);
@@ -1289,8 +1289,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 2.0);
   BOOST_TEST(value2 == 5.0);
@@ -1298,8 +1298,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(1.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 2.0);
   BOOST_TEST(value2 == 5.0);
@@ -1307,8 +1307,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.5);
   BOOST_TEST(value2 == 4.5);
@@ -1316,8 +1316,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.5, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.5);
   BOOST_TEST(value2 == 4.5);
@@ -1325,8 +1325,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.5, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.5);
   BOOST_TEST(value2 == 4.5);
@@ -1369,98 +1369,98 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value = outData->values()[0];
+  double value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value, 1.5);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 }
@@ -1839,7 +1839,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
   vertex.setCoords(Vector2d(0.0, 3.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value = outData->values()[0];
+  double value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 }
@@ -1891,10 +1891,10 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   mapping.map(inDataID, outDataID);
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  BOOST_TEST(outData->values()[0] == 1.0);
-  BOOST_TEST(outData->values()[1] == 2.0);
-  BOOST_TEST(outData->values()[2] == 2.9);
-  BOOST_TEST(outData->values()[3] == 4.3);
+  BOOST_TEST(outData->values()(0) == 1.0);
+  BOOST_TEST(outData->values()(1) == 2.0);
+  BOOST_TEST(outData->values()(2) == 2.9);
+  BOOST_TEST(outData->values()(3) == 4.3);
 }
 
 BOOST_AUTO_TEST_CASE(SolutionCaching)
@@ -1938,7 +1938,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
   BOOST_TEST(mapping.previousSolution.empty());
   mapping.map(inDataID, outDataID);
   BOOST_TEST(mapping.hasComputedMapping() == true);
-  BOOST_TEST(outData->values()[0] == 1.0);
+  BOOST_TEST(outData->values()(0) == 1.0);
 
   PetscInt its;
   KSPGetIterationNumber(mapping._solver, &its);
@@ -1989,7 +1989,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   mappingOff.computeMapping();
   mappingOff.map(inDataID, outDataID);
 
-  BOOST_TEST(outData->values()[0] <= 0.01); // Mapping to almost 0 since almost no basis function at (3,3) and no polynomial
+  BOOST_TEST(outData->values()(0) <= 0.01); // Mapping to almost 0 since almost no basis function at (3,3) and no polynomial
 
   // Test integrated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingOn(Mapping::CONSISTENT, dimensions, fct,
@@ -2000,7 +2000,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   mappingOn.computeMapping();
   mappingOn.map(inDataID, outDataID);
 
-  BOOST_TEST(outData->values()[0] == 1.0); // Mapping to 1 since there is the polynomial
+  BOOST_TEST(outData->values()(0) == 1.0); // Mapping to 1 since there is the polynomial
 
   // Test separated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingSep(Mapping::CONSISTENT, dimensions, fct,
@@ -2011,7 +2011,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   mappingSep.computeMapping();
   mappingSep.map(inDataID, outDataID);
 
-  BOOST_TEST(outData->values()[0] == 1.0); // Mapping to 1 since there is the polynomial
+  BOOST_TEST(outData->values()(0) == 1.0); // Mapping to 1 since there is the polynomial
 }
 
 BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
@@ -2056,9 +2056,9 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   mappingOff.computeMapping();
   mappingOff.map(inDataID, outDataID);
 
-  BOOST_TEST(outData->values()[0] == 2.119967); // Conservativness is not retained, because no polynomial
-  BOOST_TEST(outData->values()[1] == 0.0);      // Mapping to 0 since no basis function at (5,5) and no polynomial
-  BOOST_TEST(outData->values()[2] == 0.0);      // Mapping to 0 since no basis function at (5,5) and no polynomial
+  BOOST_TEST(outData->values()(0) == 2.119967); // Conservativness is not retained, because no polynomial
+  BOOST_TEST(outData->values()(1) == 0.0);      // Mapping to 0 since no basis function at (5,5) and no polynomial
+  BOOST_TEST(outData->values()(2) == 0.0);      // Mapping to 0 since no basis function at (5,5) and no polynomial
 
   // Test integrated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingOn(Mapping::CONSERVATIVE, dimensions, fct,
@@ -2069,9 +2069,9 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   mappingOn.computeMapping();
   mappingOn.map(inDataID, outDataID);
 
-  BOOST_TEST(outData->values()[0] == 0);
-  BOOST_TEST(outData->values()[1] == 26.0);
-  BOOST_TEST(outData->values()[2] == -22.0);
+  BOOST_TEST(outData->values()(0) == 0);
+  BOOST_TEST(outData->values()(1) == 26.0);
+  BOOST_TEST(outData->values()(2) == -22.0);
 
   // Test separated polynomial
   PetRadialBasisFctMapping<Gaussian> mappingSep(Mapping::CONSERVATIVE, dimensions, fct,
@@ -2082,9 +2082,9 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   mappingSep.computeMapping();
   mappingSep.map(inDataID, outDataID);
 
-  BOOST_TEST(outData->values()[0] == 0);
-  BOOST_TEST(outData->values()[1] == 26.0);
-  BOOST_TEST(outData->values()[2] == -22.0);
+  BOOST_TEST(outData->values()(0) == 0);
+  BOOST_TEST(outData->values()(1) == 26.0);
+  BOOST_TEST(outData->values()(2) == -22.0);
 }
 
 BOOST_AUTO_TEST_CASE(NoMapping)
@@ -2163,7 +2163,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   mapping1.computeMapping();
   mapping1.map(inDataID, outDataID);
 
-  BOOST_TEST(outData->values()[0] == 1);
+  BOOST_TEST(outData->values()(0) == 1);
 
   PetRadialBasisFctMapping<Gaussian> mapping2(Mapping::CONSERVATIVE, dimensions, fct,
                                               xDead, yDead, zDead);
@@ -2173,10 +2173,10 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   mapping2.computeMapping();
   mapping2.map(outDataID, inDataID);
 
-  BOOST_TEST(inData->values()[0] == 1.0);
-  BOOST_TEST(inData->values()[1] == 1.0);
-  BOOST_TEST(inData->values()[2] == 1.0);
-  BOOST_TEST(inData->values()[3] == 1.0);
+  BOOST_TEST(inData->values()(0) == 1.0);
+  BOOST_TEST(inData->values()(1) == 1.0);
+  BOOST_TEST(inData->values()(2) == 1.0);
+  BOOST_TEST(inData->values()(3) == 1.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Serial

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -88,7 +88,7 @@ void getDistributedMesh(const TestContext &      context,
       d.conservativeResize(i * valueDimension + valueDimension);
       // Get data in every dimension
       for (int dim = 0; dim < valueDimension; ++dim) {
-        d[i * valueDimension + dim] = vertex.value[dim];
+        d(i * valueDimension + dim) = vertex.value.at(dim);
       }
       i++;
     }
@@ -105,8 +105,8 @@ void testDistributed(const TestContext &    context,
                      ReferenceSpecification referenceSpec,
                      int                    inGlobalIndexOffset = 0)
 {
-  int meshDimension  = inMeshSpec[0].position.size();
-  int valueDimension = inMeshSpec[0].value.size();
+  int meshDimension  = inMeshSpec.at(0).position.size();
+  int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", valueDimension);
@@ -132,7 +132,7 @@ void testDistributed(const TestContext &    context,
     if (referenceVertex.first == context.rank or referenceVertex.first == -1) {
       for (int dim = 0; dim < valueDimension; ++dim) {
         BOOST_TEST_INFO("Index of vertex: " << index << " - Dimension: " << dim);
-        BOOST_TEST(outData->values()[index * valueDimension + dim] == referenceVertex.second[dim]);
+        BOOST_TEST(outData->values()(index * valueDimension + dim) == referenceVertex.second.at(dim));
       }
       ++index;
     }
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3)
                    {2, {6}},
                    {3, {7}},
                    {3, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Test with a very heterogenous distributed and non-continues ownership
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3Vector)
                    {2, {6, 9}},
                    {3, {7, 10}},
                    {3, {8, 11}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Some ranks are empty, does not converge
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
                    {2, {6}},
                    {2, {7}},
                    {2, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 // same as 2DV4, but all ranks have vertices
@@ -483,7 +483,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
                    {2, {6}},
                    {2, {7}},
                    {2, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// same as 2DV4, but strictly linear input values, converges and gives correct results
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV6,
                    {2, {6}},
                    {2, {7}},
                    {2, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Test with a homogenous distribution of mesh amoung ranks
@@ -730,7 +730,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV2)
                    {3, {0}},
                    {3, {7}},
                    {3, {8}}},
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Using meshes of different sizes, inMesh is smaller then outMesh
@@ -794,7 +794,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV3)
                    {3, {0}},
                    {3, {7}},
                    {3, {8}}}, // Sum of reference is also 34
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Using meshes of different sizes, outMesh is smaller then inMesh
@@ -855,7 +855,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV4,
                    {3, {0}},
                    {3, {7.047619}},
                    {3, {7.571428}}}, // Sum is ~36
-                  globalIndexOffsets[context.rank]);
+                  globalIndexOffsets.at(context.rank));
 }
 
 /// Tests a non-contigous owner distributed at the outMesh
@@ -991,8 +991,8 @@ void testTagging(const TestContext &context,
                  MeshSpecification  shouldTagSecondRound,
                  bool               consistent)
 {
-  int meshDimension  = inMeshSpec[0].position.size();
-  int valueDimension = inMeshSpec[0].value.size();
+  int meshDimension  = inMeshSpec.at(0).position.size();
+  int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
@@ -1115,63 +1115,63 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value = outData->values()[0];
+  double value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Vector2d(0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Vector2d(0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Vector2d(1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Vector2d(1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Vector2d(1.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Vector2d(0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Vector2d(0.5, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Vector2d(0.5, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 }
@@ -1210,8 +1210,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value1 = outData->values()[0];
-  double value2 = outData->values()[1];
+  double value1 = outData->values()(0);
+  double value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.0);
   BOOST_TEST(value2 == 4.0);
@@ -1219,8 +1219,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.0);
   BOOST_TEST(value2 == 4.0);
@@ -1228,8 +1228,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.0);
   BOOST_TEST(value2 == 4.0);
@@ -1237,8 +1237,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 2.0);
   BOOST_TEST(value2 == 5.0);
@@ -1246,8 +1246,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 2.0);
   BOOST_TEST(value2 == 5.0);
@@ -1255,8 +1255,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(1.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 2.0);
   BOOST_TEST(value2 == 5.0);
@@ -1264,8 +1264,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.5);
   BOOST_TEST(value2 == 4.5);
@@ -1273,8 +1273,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.5, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.5);
   BOOST_TEST(value2 == 4.5);
@@ -1282,8 +1282,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   vertex.setCoords(Vector2d(0.5, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value1 = outData->values()[0];
-  value2 = outData->values()[1];
+  value1 = outData->values()(0);
+  value2 = outData->values()(1);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value1 == 1.5);
   BOOST_TEST(value2 == 4.5);
@@ -1326,98 +1326,98 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value = outData->values()[0];
+  double value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 0.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 1.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 2.0);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value, 1.5);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 0.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(0.0, 1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(1.0, 1.0, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 
   vertex.setCoords(Eigen::Vector3d(0.5, 0.5, 0.5));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  value = outData->values()[0];
+  value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.5);
 }
@@ -1796,7 +1796,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
   vertex.setCoords(Vector2d(0.0, 3.0));
   mapping.computeMapping();
   mapping.map(inDataID, outDataID);
-  double value = outData->values()[0];
+  double value = outData->values()(0);
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(value == 1.0);
 }
@@ -1848,10 +1848,10 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   mapping.map(inDataID, outDataID);
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  BOOST_TEST(outData->values()[0] == 1.0);
-  BOOST_TEST(outData->values()[1] == 2.0);
-  BOOST_TEST(outData->values()[2] == 2.9);
-  BOOST_TEST(outData->values()[3] == 4.3);
+  BOOST_TEST(outData->values()(0) == 1.0);
+  BOOST_TEST(outData->values()(1) == 2.0);
+  BOOST_TEST(outData->values()(2) == 2.9);
+  BOOST_TEST(outData->values()(3) == 4.3);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Serial

--- a/src/math/tests/GeometryTest.cpp
+++ b/src/math/tests/GeometryTest.cpp
@@ -722,10 +722,10 @@ BOOST_AUTO_TEST_CASE(ComputeUnitQuadConvexity)
   BOOST_TEST(result.convex);
   BOOST_TEST(utils::unique_elements(result.vertexOrder));
   BOOST_TEST_MESSAGE("Vertex Order" << result.vertexOrder);
-  BOOST_TEST(result.vertexOrder[0] == 0);
-  BOOST_TEST(result.vertexOrder[1] == 3);
-  BOOST_TEST(result.vertexOrder[2] == 2);
-  BOOST_TEST(result.vertexOrder[3] == 1);
+  BOOST_TEST(result.vertexOrder.at(0) == 0);
+  BOOST_TEST(result.vertexOrder.at(1) == 3);
+  BOOST_TEST(result.vertexOrder.at(2) == 2);
+  BOOST_TEST(result.vertexOrder.at(3) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(ComputeReversedUnitQuadConvexity)
@@ -747,10 +747,10 @@ BOOST_AUTO_TEST_CASE(ComputeReversedUnitQuadConvexity)
   BOOST_TEST(result.convex);
   BOOST_TEST(utils::unique_elements(result.vertexOrder));
   BOOST_TEST_MESSAGE("Vertex Order" << result.vertexOrder);
-  BOOST_TEST(result.vertexOrder[0] == 0);
-  BOOST_TEST(result.vertexOrder[1] == 3);
-  BOOST_TEST(result.vertexOrder[2] == 2);
-  BOOST_TEST(result.vertexOrder[3] == 1);
+  BOOST_TEST(result.vertexOrder.at(0) == 0);
+  BOOST_TEST(result.vertexOrder.at(1) == 3);
+  BOOST_TEST(result.vertexOrder.at(2) == 2);
+  BOOST_TEST(result.vertexOrder.at(3) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(ComputeValidQuadConvexity)
@@ -772,10 +772,10 @@ BOOST_AUTO_TEST_CASE(ComputeValidQuadConvexity)
   BOOST_TEST(result.convex);
   BOOST_TEST(utils::unique_elements(result.vertexOrder));
   BOOST_TEST_MESSAGE("Vertex Order" << result.vertexOrder);
-  BOOST_TEST(result.vertexOrder[0] == 3);
-  BOOST_TEST(result.vertexOrder[1] == 2);
-  BOOST_TEST(result.vertexOrder[2] == 1);
-  BOOST_TEST(result.vertexOrder[3] == 0);
+  BOOST_TEST(result.vertexOrder.at(0) == 3);
+  BOOST_TEST(result.vertexOrder.at(1) == 2);
+  BOOST_TEST(result.vertexOrder.at(2) == 1);
+  BOOST_TEST(result.vertexOrder.at(3) == 0);
 }
 
 BOOST_AUTO_TEST_CASE(ComputeValidQuadConvexityWithOffPlane)
@@ -798,10 +798,10 @@ BOOST_AUTO_TEST_CASE(ComputeValidQuadConvexityWithOffPlane)
   // BOOST_TEST(result.convex);
   // BOOST_TEST(utils::unique_elements(result.vertexOrder));
   // BOOST_TEST_MESSAGE("Vertex Order" << result.vertexOrder);
-  // BOOST_TEST(result.vertexOrder[0] == 3);
-  // BOOST_TEST(result.vertexOrder[1] == 2);
-  // BOOST_TEST(result.vertexOrder[2] == 1);
-  // BOOST_TEST(result.vertexOrder[3] == 0);
+  // BOOST_TEST(result.vertexOrder.at(0) == 3);
+  // BOOST_TEST(result.vertexOrder.at(1) == 2);
+  // BOOST_TEST(result.vertexOrder.at(2) == 1);
+  // BOOST_TEST(result.vertexOrder.at(3) == 0);
 }
 
 BOOST_AUTO_TEST_CASE(ComputeInvalidUnitQuadConvexity)

--- a/src/mesh/tests/DataConfigurationTest.cpp
+++ b/src/mesh/tests/DataConfigurationTest.cpp
@@ -22,12 +22,12 @@ BOOST_AUTO_TEST_CASE(DataConfig)
   dataConfig.setDimensions(dim);
   xml::configure(tag, xml::ConfigurationContext{}, filename);
   BOOST_TEST(dataConfig.data().size() == 3);
-  BOOST_TEST(dataConfig.data()[0].name == "vector-data");
-  BOOST_TEST(dataConfig.data()[0].dimensions == 3);
-  BOOST_TEST(dataConfig.data()[1].name == "floating-data");
-  BOOST_TEST(dataConfig.data()[1].dimensions == 1);
-  BOOST_TEST(dataConfig.data()[2].name == "second-vector-data");
-  BOOST_TEST(dataConfig.data()[2].dimensions == 3);
+  BOOST_TEST(dataConfig.data().at(0).name == "vector-data");
+  BOOST_TEST(dataConfig.data().at(0).dimensions == 3);
+  BOOST_TEST(dataConfig.data().at(1).name == "floating-data");
+  BOOST_TEST(dataConfig.data().at(1).dimensions == 1);
+  BOOST_TEST(dataConfig.data().at(2).name == "second-vector-data");
+  BOOST_TEST(dataConfig.data().at(2).dimensions == 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
   BOOST_TEST(referenceBox == bBox);
 
   for (decltype(cog.size()) d = 0; d < cog.size(); d++) {
-    BOOST_TEST(referenceCOG[d] == cog[d]);
+    BOOST_TEST(referenceCOG.at(d) == cog(d));
   }
 }
 
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
   BOOST_TEST(referenceBox == bBox);
 
   for (decltype(cog.size()) d = 0; d < cog.size(); d++) {
-    BOOST_TEST(referenceCOG[d] == cog[d]);
+    BOOST_TEST(referenceCOG.at(d) == cog(d));
   }
 }
 
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(Demonstration)
 
     // Validate state of mesh with data
     BOOST_TEST(mesh.data().size() == 1);
-    BOOST_TEST(mesh.data()[0]->getName() == dataName);
+    BOOST_TEST(mesh.data().at(0)->getName() == dataName);
 
     // Compute the state of the mesh elements (vertices, edges, triangles)
     mesh.computeState();
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
   Mesh  mesh1("Mesh1", dim, false, testing::nextMeshID());
   Mesh  mesh1flipped("Mesh1flipped", dim, true, testing::nextMeshID());
   Mesh  mesh2("Mesh2", dim, false, testing::nextMeshID());
-  Mesh *meshes[3] = {&mesh1, &mesh1flipped, &mesh2};
+  std::array<Mesh*, 3> meshes = {&mesh1, &mesh1flipped, &mesh2};
   for (auto ptr : meshes) {
     auto &          mesh = *ptr;
     Eigen::VectorXd coords0(dim);
@@ -514,15 +514,15 @@ BOOST_AUTO_TEST_CASE(AsChain)
 
   BOOST_REQUIRE(chain.connected);
 
-  BOOST_TEST(chain.edges[0] == &e0);
-  BOOST_TEST(chain.edges[1] == &e2);
-  BOOST_TEST(chain.edges[2] == &e1);
-  BOOST_TEST(chain.edges[3] == &e3);
+  BOOST_TEST(chain.edges.at(0) == &e0);
+  BOOST_TEST(chain.edges.at(1) == &e2);
+  BOOST_TEST(chain.edges.at(2) == &e1);
+  BOOST_TEST(chain.edges.at(3) == &e3);
 
-  BOOST_TEST(chain.vertices[0] == &v1);
-  BOOST_TEST(chain.vertices[1] == &v3);
-  BOOST_TEST(chain.vertices[2] == &v2);
-  BOOST_TEST(chain.vertices[3] == &v0);
+  BOOST_TEST(chain.vertices.at(0) == &v1);
+  BOOST_TEST(chain.vertices.at(1) == &v3);
+  BOOST_TEST(chain.vertices.at(2) == &v2);
+  BOOST_TEST(chain.vertices.at(3) == &v0);
 }
 
 BOOST_AUTO_TEST_CASE(ShareVertex)

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -297,11 +297,11 @@ BOOST_AUTO_TEST_CASE(Demonstration)
 BOOST_AUTO_TEST_CASE(MeshEquality)
 {
   PRECICE_TEST(1_rank);
-  int   dim = 3;
-  Mesh  mesh1("Mesh1", dim, false, testing::nextMeshID());
-  Mesh  mesh1flipped("Mesh1flipped", dim, true, testing::nextMeshID());
-  Mesh  mesh2("Mesh2", dim, false, testing::nextMeshID());
-  std::array<Mesh*, 3> meshes = {&mesh1, &mesh1flipped, &mesh2};
+  int                   dim = 3;
+  Mesh                  mesh1("Mesh1", dim, false, testing::nextMeshID());
+  Mesh                  mesh1flipped("Mesh1flipped", dim, true, testing::nextMeshID());
+  Mesh                  mesh2("Mesh2", dim, false, testing::nextMeshID());
+  std::array<Mesh *, 3> meshes = {&mesh1, &mesh1flipped, &mesh2};
   for (auto ptr : meshes) {
     auto &          mesh = *ptr;
     Eigen::VectorXd coords0(dim);

--- a/src/mesh/tests/RTreeTests.cpp
+++ b/src/mesh/tests/RTreeTests.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(Query2DVertex)
   tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
 
   BOOST_TEST(results.size() == 1);
-  BOOST_TEST(mesh->vertices().at(results[0]).getCoords() == Eigen::Vector2d(0, 1));
+  BOOST_TEST(mesh->vertices().at(results.at(0)).getCoords() == Eigen::Vector2d(0, 1));
 }
 
 BOOST_AUTO_TEST_CASE(Query3DVertex)
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(Query3DVertex)
     tree->query(bgi::nearest(searchVector, 1), std::back_inserter(results));
 
     BOOST_TEST(results.size() == 1);
-    BOOST_TEST(mesh->vertices()[results[0]].getCoords() == Eigen::Vector3d(1, 0, 1));
+    BOOST_TEST(mesh->vertices().at(results.at(0)).getCoords() == Eigen::Vector3d(1, 0, 1));
   }
 }
 
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(QueryWithBoxEmpty)
       searchVector - Eigen::VectorXd::Constant(3, radius),
       searchVector + Eigen::VectorXd::Constant(3, radius));
 
-  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices().at(i)) <= radius; }),
               std::back_inserter(results));
 
   BOOST_TEST(results.empty());
@@ -214,12 +214,12 @@ BOOST_AUTO_TEST_CASE(QueryWithBox2Matches)
       searchVector - Eigen::VectorXd::Constant(3, radius),
       searchVector + Eigen::VectorXd::Constant(3, radius));
 
-  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices().at(i)) <= radius; }),
               std::back_inserter(results));
 
   BOOST_TEST(results.size() == 2);
-  BOOST_TEST(mesh->vertices()[results[0]].getCoords() == Eigen::Vector3d(0, 1, 0));
-  BOOST_TEST(mesh->vertices()[results[1]].getCoords() == Eigen::Vector3d(1, 1, 0));
+  BOOST_TEST(mesh->vertices().at(results.at(0)).getCoords() == Eigen::Vector3d(0, 1, 0));
+  BOOST_TEST(mesh->vertices().at(results.at(1)).getCoords() == Eigen::Vector3d(1, 1, 0));
 }
 
 /// Resembles how boost geometry is used inside the PetRBF
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(QueryWithBoxEverything)
       searchVector - Eigen::VectorXd::Constant(3, radius),
       searchVector + Eigen::VectorXd::Constant(3, radius));
 
-  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices()[i]) <= radius; }),
+  tree->query(bg::index::intersects(search_box) and bg::index::satisfies([&](size_t const i) { return bg::distance(searchVector, mesh->vertices().at(i)) <= radius; }),
               std::back_inserter(results));
 
   BOOST_TEST(results.size() == 8);
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(Query3DEdge)
   auto match = results.front();
 
   BOOST_TEST(match < mesh->edges().size());
-  auto &          edge = mesh->edges()[match];
+  auto &          edge = mesh->edges().at(match);
   Eigen::Vector3d p1(1, 1, 0);
   Eigen::Vector3d p2(1, 1, 1);
   BOOST_TEST((edge.vertex(0).getCoords() == p1 || edge.vertex(0).getCoords() == p2));
@@ -400,17 +400,17 @@ BOOST_AUTO_TEST_CASE(Query3DFullTriangle)
                 results.push_back(std::make_pair(
                     boost::geometry::distance(
                         searchVector,
-                        mesh->triangles()[val.second]),
+                        mesh->triangles().at(val.second)),
                     val.second));
               }));
 
   std::sort(results.begin(), results.end());
   BOOST_TEST_INFO(results);
   BOOST_TEST(results.size() == 3);
-  BOOST_TEST(results[0].second == tlb.getID());
-  BOOST_TEST(results[1].second == tlt.getID());
-  BOOST_TEST(results[2].second == trt.getID());
-  BOOST_TEST(results[2].second != trb.getID());
+  BOOST_TEST(results.at(0).second == tlb.getID());
+  BOOST_TEST(results.at(1).second == tlt.getID());
+  BOOST_TEST(results.at(2).second == trt.getID());
+  BOOST_TEST(results.at(2).second != trb.getID());
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Triangle

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
     BOOST_TEST(pSolidzMesh->edges().size() == 4);
 
     for (int i = 0; i < 6; i++) {
-      BOOST_TEST(pSolidzMesh->vertices()[i].getGlobalIndex() == i);
+      BOOST_TEST(pSolidzMesh->vertices().at(i).getGlobalIndex() == i);
     }
   } else { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
@@ -102,17 +102,17 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
 
     BOOST_REQUIRE(pSolidzMesh->getVertexOffsets().size() == 3);
     if (context.isMaster()) { //master
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 2);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 2);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 2);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(1) == 2);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 6);
     } else if (context.isRank(1)) { //Slave1
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 2);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 2);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 2);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(1) == 2);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 6);
     } else {
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 2);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 2);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 2);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(1) == 2);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 6);
     }
   }
 
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
     BOOST_TEST(pSolidzMesh->triangles().size() == 2);
 
     for (int i = 0; i < 6; i++) {
-      BOOST_TEST(pSolidzMesh->vertices()[i].getGlobalIndex() == i);
+      BOOST_TEST(pSolidzMesh->vertices().at(i).getGlobalIndex() == i);
     }
   } else { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
@@ -188,46 +188,46 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
 
     if (context.isMaster()) { //master
       BOOST_REQUIRE(vertexOffsets.size() == 3);
-      BOOST_TEST(vertexOffsets[0] == 2);
-      BOOST_TEST(vertexOffsets[1] == 2);
-      BOOST_TEST(vertexOffsets[2] == 6);
+      BOOST_TEST(vertexOffsets.at(0) == 2);
+      BOOST_TEST(vertexOffsets.at(1) == 2);
+      BOOST_TEST(vertexOffsets.at(2) == 6);
 
       BOOST_REQUIRE(vertices.size() == 2);
-      BOOST_TEST(vertices[0].getGlobalIndex() == 0);
-      BOOST_TEST(vertices[1].getGlobalIndex() == 1);
-      BOOST_TEST(vertices[0].isOwner() == true);
-      BOOST_TEST(vertices[1].isOwner() == true);
+      BOOST_TEST(vertices.at(0).getGlobalIndex() == 0);
+      BOOST_TEST(vertices.at(1).getGlobalIndex() == 1);
+      BOOST_TEST(vertices.at(0).isOwner() == true);
+      BOOST_TEST(vertices.at(1).isOwner() == true);
 
       BOOST_REQUIRE((vertexDistribution.size()) == 3);
       BOOST_TEST(vertexDistribution.at(0).size() == 2);
       BOOST_TEST(vertexDistribution.at(1).size() == 0);
       BOOST_TEST(vertexDistribution.at(2).size() == 4);
-      BOOST_TEST(vertexDistribution.at(0)[0] == 0);
-      BOOST_TEST(vertexDistribution.at(0)[1] == 1);
-      BOOST_TEST(vertexDistribution.at(2)[0] == 2);
-      BOOST_TEST(vertexDistribution.at(2)[1] == 3);
-      BOOST_TEST(vertexDistribution.at(2)[2] == 4);
-      BOOST_TEST(vertexDistribution.at(2)[3] == 5);
+      BOOST_TEST(vertexDistribution.at(0).at(0) == 0);
+      BOOST_TEST(vertexDistribution.at(0).at(1) == 1);
+      BOOST_TEST(vertexDistribution.at(2).at(0) == 2);
+      BOOST_TEST(vertexDistribution.at(2).at(1) == 3);
+      BOOST_TEST(vertexDistribution.at(2).at(2) == 4);
+      BOOST_TEST(vertexDistribution.at(2).at(3) == 5);
     } else if (context.isRank(1)) { //Slave1
       BOOST_REQUIRE(vertexOffsets.size() == 3);
-      BOOST_TEST(vertexOffsets[0] == 2);
-      BOOST_TEST(vertexOffsets[1] == 2);
-      BOOST_TEST(vertexOffsets[2] == 6);
+      BOOST_TEST(vertexOffsets.at(0) == 2);
+      BOOST_TEST(vertexOffsets.at(1) == 2);
+      BOOST_TEST(vertexOffsets.at(2) == 6);
     } else if (context.isRank(2)) { //Slave2
       BOOST_REQUIRE(vertexOffsets.size() == 3);
-      BOOST_TEST(vertexOffsets[0] == 2);
-      BOOST_TEST(vertexOffsets[1] == 2);
-      BOOST_TEST(vertexOffsets[2] == 6);
+      BOOST_TEST(vertexOffsets.at(0) == 2);
+      BOOST_TEST(vertexOffsets.at(1) == 2);
+      BOOST_TEST(vertexOffsets.at(2) == 6);
 
       BOOST_REQUIRE(vertices.size() == 4);
-      BOOST_TEST(vertices[0].getGlobalIndex() == 2);
-      BOOST_TEST(vertices[1].getGlobalIndex() == 3);
-      BOOST_TEST(vertices[2].getGlobalIndex() == 4);
-      BOOST_TEST(vertices[3].getGlobalIndex() == 5);
-      BOOST_TEST(vertices[0].isOwner() == true);
-      BOOST_TEST(vertices[1].isOwner() == true);
-      BOOST_TEST(vertices[2].isOwner() == true);
-      BOOST_TEST(vertices[3].isOwner() == true);
+      BOOST_TEST(vertices.at(0).getGlobalIndex() == 2);
+      BOOST_TEST(vertices.at(1).getGlobalIndex() == 3);
+      BOOST_TEST(vertices.at(2).getGlobalIndex() == 4);
+      BOOST_TEST(vertices.at(3).getGlobalIndex() == 5);
+      BOOST_TEST(vertices.at(0).isOwner() == true);
+      BOOST_TEST(vertices.at(1).isOwner() == true);
+      BOOST_TEST(vertices.at(2).isOwner() == true);
+      BOOST_TEST(vertices.at(3).isOwner() == true);
     }
   }
 
@@ -273,41 +273,41 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
     if (context.isMaster()) { //Master
       BOOST_TEST(pMesh->getGlobalNumberOfVertices() == 5);
       BOOST_TEST_REQUIRE(pMesh->getVertexOffsets().size() == 4);
-      BOOST_TEST(pMesh->getVertexOffsets()[0] == 2);
-      BOOST_TEST(pMesh->getVertexOffsets()[1] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[2] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[3] == 5);
-      BOOST_TEST(pMesh->vertices()[0].getGlobalIndex() == 0);
-      BOOST_TEST(pMesh->vertices()[1].getGlobalIndex() == 1);
-      BOOST_TEST(pMesh->vertices()[0].isOwner() == true);
-      BOOST_TEST(pMesh->vertices()[1].isOwner() == true);
+      BOOST_TEST(pMesh->getVertexOffsets().at(0) == 2);
+      BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(3) == 5);
+      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 0);
+      BOOST_TEST(pMesh->vertices().at(1).getGlobalIndex() == 1);
+      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertices().at(1).isOwner() == true);
     } else if (context.isRank(1)) { //Slave1
       BOOST_TEST(pMesh->getGlobalNumberOfVertices() == 5);
       BOOST_TEST_REQUIRE(pMesh->getVertexOffsets().size() == 4);
-      BOOST_TEST(pMesh->getVertexOffsets()[0] == 2);
-      BOOST_TEST(pMesh->getVertexOffsets()[1] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[2] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[3] == 5);
-      BOOST_TEST(pMesh->vertices()[0].getGlobalIndex() == 2);
-      BOOST_TEST(pMesh->vertices()[0].isOwner() == true);
+      BOOST_TEST(pMesh->getVertexOffsets().at(0) == 2);
+      BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(3) == 5);
+      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 2);
+      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
     } else if (context.isRank(2)) { //Slave2
       BOOST_TEST(pMesh->getGlobalNumberOfVertices() == 5);
       BOOST_TEST_REQUIRE(pMesh->getVertexOffsets().size() == 4);
-      BOOST_TEST(pMesh->getVertexOffsets()[0] == 2);
-      BOOST_TEST(pMesh->getVertexOffsets()[1] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[2] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[3] == 5);
+      BOOST_TEST(pMesh->getVertexOffsets().at(0) == 2);
+      BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(3) == 5);
     } else if (context.isRank(3)) { //Slave3
       BOOST_TEST(pMesh->getGlobalNumberOfVertices() == 5);
       BOOST_TEST_REQUIRE(pMesh->getVertexOffsets().size() == 4);
-      BOOST_TEST(pMesh->getVertexOffsets()[0] == 2);
-      BOOST_TEST(pMesh->getVertexOffsets()[1] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[2] == 3);
-      BOOST_TEST(pMesh->getVertexOffsets()[3] == 5);
-      BOOST_TEST(pMesh->vertices()[0].getGlobalIndex() == 3);
-      BOOST_TEST(pMesh->vertices()[1].getGlobalIndex() == 4);
-      BOOST_TEST(pMesh->vertices()[0].isOwner() == true);
-      BOOST_TEST(pMesh->vertices()[1].isOwner() == true);
+      BOOST_TEST(pMesh->getVertexOffsets().at(0) == 2);
+      BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
+      BOOST_TEST(pMesh->getVertexOffsets().at(3) == 5);
+      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 3);
+      BOOST_TEST(pMesh->vertices().at(1).getGlobalIndex() == 4);
+      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertices().at(1).isOwner() == true);
     }
   }
 }
@@ -363,16 +363,16 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
 
     if (context.isMaster()) { //Master
       BOOST_TEST(pSolidzMesh->getConnectedRanks().size() == 2);
-      BOOST_TEST(pSolidzMesh->getConnectedRanks()[0] == 1);
-      BOOST_TEST(pSolidzMesh->getConnectedRanks()[1] == 2);
+      BOOST_TEST(pSolidzMesh->getConnectedRanks().at(0) == 1);
+      BOOST_TEST(pSolidzMesh->getConnectedRanks().at(1) == 2);
     } else if (context.isRank(1)) { //Slave1
       BOOST_TEST(pSolidzMesh->getConnectedRanks().size() == 2);
-      BOOST_TEST(pSolidzMesh->getConnectedRanks()[0] == 0);
-      BOOST_TEST(pSolidzMesh->getConnectedRanks()[1] == 2);
+      BOOST_TEST(pSolidzMesh->getConnectedRanks().at(0) == 0);
+      BOOST_TEST(pSolidzMesh->getConnectedRanks().at(1) == 2);
     } else if (context.isRank(2)) { //Slave2
       BOOST_TEST(pSolidzMesh->getConnectedRanks().size() == 2);
-      BOOST_TEST(pSolidzMesh->getConnectedRanks()[0] == 0);
-      BOOST_TEST(pSolidzMesh->getConnectedRanks()[1] == 1);
+      BOOST_TEST(pSolidzMesh->getConnectedRanks().at(0) == 0);
+      BOOST_TEST(pSolidzMesh->getConnectedRanks().at(1) == 1);
     }
 
   } else { //NASTIN
@@ -587,23 +587,23 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
     BOOST_TEST(mesh->vertices().size() == 4);
 
     if (context.isMaster()) {
-      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 0.5);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 1.5);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 0.0);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[0] == 2.0);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[1] == 1.0);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[0] == 0.5);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[1] == 1.0);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 0.5);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.5);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(2).getCoords()(0) == 2.0);
+      BOOST_TEST(mesh->vertices().at(2).getCoords()(1) == 1.0);
+      BOOST_TEST(mesh->vertices().at(3).getCoords()(0) == 0.5);
+      BOOST_TEST(mesh->vertices().at(3).getCoords()(1) == 1.0);
     } else {
-      BOOST_TEST(mesh->vertices()[0].getCoords()[0] == 2.5);
-      BOOST_TEST(mesh->vertices()[0].getCoords()[1] == 0.0);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[0] == 3.5);
-      BOOST_TEST(mesh->vertices()[1].getCoords()[1] == 0.0);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[0] == 3.5);
-      BOOST_TEST(mesh->vertices()[2].getCoords()[1] == 1.0);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[0] == 2.0);
-      BOOST_TEST(mesh->vertices()[3].getCoords()[1] == 1.0);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 2.5);
+      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 3.5);
+      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(2).getCoords()(0) == 3.5);
+      BOOST_TEST(mesh->vertices().at(2).getCoords()(1) == 1.0);
+      BOOST_TEST(mesh->vertices().at(3).getCoords()(0) == 2.0);
+      BOOST_TEST(mesh->vertices().at(3).getCoords()(1) == 1.0);
     }
   }
 
@@ -706,12 +706,12 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning2D)
 
     if (context.isMaster()) {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
-      BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
-      BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
+      BOOST_TEST(mesh->getConnectedRanks().at(0) == 0);
+      BOOST_TEST(mesh->getConnectedRanks().at(1) == 1);
     } else {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
-      BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
-      BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
+      BOOST_TEST(mesh->getConnectedRanks().at(0) == 0);
+      BOOST_TEST(mesh->getConnectedRanks().at(1) == 1);
     }
 
     m2n->acceptSlavesPreConnection("FluidSlaves", "SolidSlaves");
@@ -720,12 +720,12 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning2D)
     part.compute();
 
     if (context.isMaster()) {
-      BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
-      BOOST_TEST(mesh->getCommunicationMap()[0][1] == 1);
+      BOOST_TEST(mesh->getCommunicationMap().at(0).at(0) == 0);
+      BOOST_TEST(mesh->getCommunicationMap().at(0).at(1) == 1);
     } else {
-      BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
-      BOOST_TEST(mesh->getCommunicationMap()[1][0] == 1);
-      BOOST_TEST(mesh->getCommunicationMap()[1][1] == 2);
+      BOOST_TEST(mesh->getCommunicationMap().at(0).at(0) == 0);
+      BOOST_TEST(mesh->getCommunicationMap().at(1).at(0) == 1);
+      BOOST_TEST(mesh->getCommunicationMap().at(1).at(1) == 2);
     }
   } else {
     m2n->createDistributedCommunication(receivedMesh);
@@ -838,12 +838,12 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning3D)
 
     if (context.isMaster()) {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
-      BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
-      BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
+      BOOST_TEST(mesh->getConnectedRanks().at(0) == 0);
+      BOOST_TEST(mesh->getConnectedRanks().at(1) == 1);
     } else {
       BOOST_TEST(mesh->getConnectedRanks().size() == 2);
-      BOOST_TEST(mesh->getConnectedRanks()[0] == 0);
-      BOOST_TEST(mesh->getConnectedRanks()[1] == 1);
+      BOOST_TEST(mesh->getConnectedRanks().at(0) == 0);
+      BOOST_TEST(mesh->getConnectedRanks().at(1) == 1);
     }
 
     m2n->acceptSlavesPreConnection("FluidSlaves", "SolidSlaves");
@@ -852,12 +852,12 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning3D)
     part.compute();
 
     if (context.isMaster()) {
-      BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
-      BOOST_TEST(mesh->getCommunicationMap()[0][1] == 1);
+      BOOST_TEST(mesh->getCommunicationMap().at(0).at(0) == 0);
+      BOOST_TEST(mesh->getCommunicationMap().at(0).at(1) == 1);
     } else {
-      BOOST_TEST(mesh->getCommunicationMap()[0][0] == 0);
-      BOOST_TEST(mesh->getCommunicationMap()[1][0] == 1);
-      BOOST_TEST(mesh->getCommunicationMap()[1][1] == 2);
+      BOOST_TEST(mesh->getCommunicationMap().at(0).at(0) == 0);
+      BOOST_TEST(mesh->getCommunicationMap().at(1).at(0) == 1);
+      BOOST_TEST(mesh->getCommunicationMap().at(1).at(1) == 2);
     }
   } else {
     m2n->createDistributedCommunication(receivedMesh);

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -443,45 +443,45 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
     BOOST_TEST_CONTEXT(*pSolidzMesh)
     {
       BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 6);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 6);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 12);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(1) == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 12);
       BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
 
       // check if the sending and filtering worked right
       if (context.isMaster()) { //Master
         BOOST_TEST(pSolidzMesh->vertices().size() == 6);
         BOOST_TEST(pSolidzMesh->edges().size() == 5);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
       } else if (context.isRank(1)) { //Slave2
         BOOST_TEST(pSolidzMesh->vertices().size() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Slave3
         BOOST_TEST(pSolidzMesh->vertices().size() == 6);
         BOOST_TEST(pSolidzMesh->edges().size() == 5);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
       }
     }
   }
@@ -530,33 +530,33 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
     BOOST_TEST_CONTEXT(*pSolidzMesh)
     {
       BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 3);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 3);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 6);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 3);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(1) == 3);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 6);
       BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
 
       // check if the sending and filtering worked right
       if (context.isMaster()) { //Master
         BOOST_TEST(pSolidzMesh->vertices().size() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
       } else if (context.isRank(1)) { //Slave2
         BOOST_TEST(pSolidzMesh->vertices().size() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Slave3
         BOOST_TEST(pSolidzMesh->vertices().size() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 5);
       }
     }
   }
@@ -605,39 +605,39 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
     BOOST_TEST_CONTEXT(*pSolidzMesh)
     {
       BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 4);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 4);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 9);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 4);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(1) == 4);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 9);
       BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
 
       // check if the sending and filtering worked right
       if (context.isMaster()) { //Master
         BOOST_TEST(pSolidzMesh->vertices().size() == 4);
         BOOST_TEST(pSolidzMesh->edges().size() == 3);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
       } else if (context.isRank(1)) { //Slave2
         BOOST_TEST(pSolidzMesh->vertices().size() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Slave3
         BOOST_TEST(pSolidzMesh->vertices().size() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 4);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 5);
       }
     }
   }
@@ -688,9 +688,9 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
     BOOST_TEST_CONTEXT(*pSolidzMesh)
     {
       BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 3);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 5);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[1] == 5);
-      BOOST_TEST(pSolidzMesh->getVertexOffsets()[2] == 10);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 5);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(1) == 5);
+      BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 10);
       BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 5);
 
       // check if the sending and filtering worked right
@@ -698,16 +698,16 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
         BOOST_TEST(pSolidzMesh->vertices().size() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 6);
         BOOST_TEST(pSolidzMesh->triangles().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
       } else if (context.isRank(1)) { //Slave2
         BOOST_TEST(pSolidzMesh->vertices().size() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
@@ -716,16 +716,16 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
         BOOST_TEST(pSolidzMesh->vertices().size() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 6);
         BOOST_TEST(pSolidzMesh->triangles().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
       }
     }
   }
@@ -850,26 +850,26 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
     part.compute();
 
     BOOST_TEST(pMesh->getVertexOffsets().size() == 3);
-    BOOST_TEST(pMesh->getVertexOffsets()[0] == 2);
-    BOOST_TEST(pMesh->getVertexOffsets()[1] == 3);
-    BOOST_TEST(pMesh->getVertexOffsets()[2] == 3);
+    BOOST_TEST(pMesh->getVertexOffsets().at(0) == 2);
+    BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
+    BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
 
     if (context.isMaster()) { //Master
-      BOOST_TEST(pMesh->getVertexDistribution()[0].size() == 2);
-      BOOST_TEST(pMesh->getVertexDistribution()[1].size() == 1);
-      BOOST_TEST(pMesh->getVertexDistribution()[2].size() == 0);
-      BOOST_TEST(pMesh->getVertexDistribution()[0][0] == 0);
-      BOOST_TEST(pMesh->getVertexDistribution()[0][1] == 1);
-      BOOST_TEST(pMesh->getVertexDistribution()[1][0] == 1);
+      BOOST_TEST(pMesh->getVertexDistribution().at(0).size() == 2);
+      BOOST_TEST(pMesh->getVertexDistribution().at(1).size() == 1);
+      BOOST_TEST(pMesh->getVertexDistribution().at(2).size() == 0);
+      BOOST_TEST(pMesh->getVertexDistribution().at(0).at(0) == 0);
+      BOOST_TEST(pMesh->getVertexDistribution().at(0).at(1) == 1);
+      BOOST_TEST(pMesh->getVertexDistribution().at(1).at(0) == 1);
       BOOST_TEST(pMesh->vertices().size() == 2);
-      BOOST_TEST(pMesh->vertices()[0].getGlobalIndex() == 0);
-      BOOST_TEST(pMesh->vertices()[1].getGlobalIndex() == 1);
-      BOOST_TEST(pMesh->vertices()[0].isOwner() == true);
-      BOOST_TEST(pMesh->vertices()[1].isOwner() == false);
+      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 0);
+      BOOST_TEST(pMesh->vertices().at(1).getGlobalIndex() == 1);
+      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertices().at(1).isOwner() == false);
     } else if (context.isRank(1)) { //Slave2
       BOOST_TEST(pMesh->vertices().size() == 1);
-      BOOST_TEST(pMesh->vertices()[0].getGlobalIndex() == 1);
-      BOOST_TEST(pMesh->vertices()[0].isOwner() == true);
+      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 1);
+      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
     } else if (context.isRank(2)) { //Slave3
       BOOST_TEST(pMesh->vertices().size() == 0);
     }
@@ -896,19 +896,19 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
     BOOST_TEST(pSolidzMesh->vertices().size() == 6);
     BOOST_TEST(pSolidzMesh->edges().size() == 5);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 1);
-    BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 6);
-    BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-    BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-    BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-    BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-    BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-    BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
-    BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
+    BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 6);
+    BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+    BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+    BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+    BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
+    BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
+    BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
+    BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == true);
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
@@ -929,19 +929,19 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
     BOOST_TEST(pSolidzMesh->vertices().size() == 6);
     BOOST_TEST(pSolidzMesh->edges().size() == 5);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 1);
-    BOOST_TEST(pSolidzMesh->getVertexOffsets()[0] == 6);
-    BOOST_TEST(pSolidzMesh->vertices()[0].getGlobalIndex() == 0);
-    BOOST_TEST(pSolidzMesh->vertices()[1].getGlobalIndex() == 1);
-    BOOST_TEST(pSolidzMesh->vertices()[2].getGlobalIndex() == 2);
-    BOOST_TEST(pSolidzMesh->vertices()[3].getGlobalIndex() == 3);
-    BOOST_TEST(pSolidzMesh->vertices()[4].getGlobalIndex() == 4);
-    BOOST_TEST(pSolidzMesh->vertices()[5].getGlobalIndex() == 5);
-    BOOST_TEST(pSolidzMesh->vertices()[0].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[1].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[2].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[3].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[4].isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices()[5].isOwner() == true);
+    BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 6);
+    BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
+    BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
+    BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+    BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
+    BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
+    BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
+    BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == true);
   }
 }
 
@@ -1059,8 +1059,8 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).receiveConnectionMap(receivedConnectionMap, 0);
 
     // test whether we receive correct connection map
-    BOOST_TEST(receivedConnectionMap[0][0] == 2);
-    BOOST_TEST(receivedConnectionMap[2][0] == 0);
+    BOOST_TEST(receivedConnectionMap.at(0).at(0) == 2);
+    BOOST_TEST(receivedConnectionMap.at(2).at(0) == 0);
 
   } else {
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(TestConfigurationPeano)
   BOOST_TEST(impl(interfacePeano)._participants.size() == 2);
   BOOST_TEST(interfacePeano.getDimensions() == 2);
 
-  impl::PtrParticipant peano = impl(interfacePeano)._participants[0];
+  impl::PtrParticipant peano = impl(interfacePeano)._participants.at(0);
   BOOST_TEST(peano);
   BOOST_TEST(peano->getName() == "Peano");
 
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE(TestConfigurationPeano)
   BOOST_TEST(meshContexts.size() == 2);
   BOOST_TEST(peano->_usedMeshContexts.size() == 2);
 
-  BOOST_TEST(meshContexts[0]->mesh->getName() == std::string("PeanoNodes"));
-  BOOST_TEST(meshContexts[1]->mesh->getName() == std::string("ComsolNodes"));
+  BOOST_TEST(meshContexts.at(0)->mesh->getName() == std::string("PeanoNodes"));
+  BOOST_TEST(meshContexts.at(1)->mesh->getName() == std::string("ComsolNodes"));
 }
 
 BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
@@ -78,14 +78,14 @@ BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
   BOOST_TEST(impl(interfaceComsol)._participants.size() == 2);
   BOOST_TEST(interfaceComsol.getDimensions() == 2);
 
-  impl::PtrParticipant comsol = impl(interfaceComsol)._participants[1];
+  impl::PtrParticipant comsol = impl(interfaceComsol)._participants.at(1);
   BOOST_TEST(comsol);
   BOOST_TEST(comsol->getName() == "Comsol");
 
   std::vector<impl::MeshContext *> meshContexts = comsol->_meshContexts;
   BOOST_TEST(meshContexts.size() == 2);
-  BOOST_TEST(meshContexts[0] == static_cast<void *>(nullptr));
-  BOOST_TEST(meshContexts[1]->mesh->getName() == std::string("ComsolNodes"));
+  BOOST_TEST(meshContexts.at(0) == static_cast<void *>(nullptr));
+  BOOST_TEST(meshContexts.at(1)->mesh->getName() == std::string("ComsolNodes"));
   BOOST_TEST(comsol->_usedMeshContexts.size() == 1);
 }
 
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange)
       impl(cplInterface).resetMesh(meshOneID);
       for (auto &vertex : vertices) {
         for (int dim = 0; dim < 3; dim++) {
-          writePositions[vertex.getID() * 3 + dim] = vertex.getCoords()[dim];
+          writePositions(vertex.getID() * 3 + dim) = vertex.getCoords()(dim);
         }
       }
       cplInterface.setMeshVertices(meshOneID, size, writePositions.data(),
@@ -460,8 +460,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange)
         // Vector3d force ( Vector3D(counter) + wrap<3,double>(vertex.getCoords()) );
         Vector3d force(Vector3d::Constant(counter) + vertex.getCoords());
         for (int dim = 0; dim < 3; dim++)
-          forces[vertex.getID() * 3 + dim] = force[dim];
-        pressures[vertex.getID()] = counter + vertex.getCoords()[0];
+          forces(vertex.getID() * 3 + dim) = force(dim);
+        pressures(vertex.getID()) = counter + vertex.getCoords()(0);
       }
       cplInterface.writeBlockVectorData(forcesID, size, writeIDs.data(), forces.data());
       cplInterface.writeBlockScalarData(pressuresID, size, writeIDs.data(), pressures.data());
@@ -479,10 +479,10 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange)
         for (auto &vertex : vertices) {
           for (int dim = 0; dim < 3; dim++) {
             int index                 = vertex.getID() * 3 + dim;
-            readPositions[index]      = vertex.getCoords()[dim];
-            expectedVelocities[index] = counter + vertex.getCoords()[dim];
+            readPositions(index)      = vertex.getCoords()(dim);
+            expectedVelocities(index) = counter + vertex.getCoords()(dim);
           }
-          expectedTemperatures[vertex.getID()] = counter + vertex.getCoords()[0];
+          expectedTemperatures(vertex.getID()) = counter + vertex.getCoords()(0);
         }
         impl(cplInterface).resetMesh(meshOneID);
         cplInterface.setMeshVertices(meshOneID, size, readPositions.data(), readIDs.data());
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange)
       cplInterface.readVectorData(forcesID, vertex.getID(), force.data());
       cplInterface.readScalarData(pressuresID, vertex.getID(), pressure);
       BOOST_TEST(force == Vector3d::Constant(counter) + vertex.getCoords());
-      BOOST_TEST(pressure == counter + vertex.getCoords()[0]);
+      BOOST_TEST(pressure == counter + vertex.getCoords()(0));
     }
     counter += 1.0;
 
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange)
       for (auto &vertex : vertices) {
         Vector3d vel(Vector3d::Constant(counter - 1.0) + vertex.getCoords());
         cplInterface.writeVectorData(velocitiesID, vertex.getID(), vel.data());
-        double temperature = counter - 1.0 + vertex.getCoords()[0];
+        double temperature = counter - 1.0 + vertex.getCoords()(0);
         cplInterface.writeScalarData(temperaturesID, vertex.getID(), temperature);
       }
       maxDt = cplInterface.advance(maxDt);
@@ -540,7 +540,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange)
           cplInterface.readVectorData(forcesID, vertex.getID(), force.data());
           cplInterface.readScalarData(pressuresID, vertex.getID(), pressure);
           BOOST_TEST(force == Vector3d::Constant(counter) + vertex.getCoords());
-          BOOST_TEST(pressure == counter + vertex.getCoords()[0]);
+          BOOST_TEST(pressure == counter + vertex.getCoords()(0));
         }
         counter += 1.0;
       }
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling)
     int meshID = cplInterface.getMeshID("Test-Square-One");
     cplInterface.setMeshVertices(meshID, 4, positions.data(), ids.data());
     for (int i = 0; i < 4; i++)
-      cplInterface.setMeshEdge(meshID, ids[i], ids[(i + 1) % 4]);
+      cplInterface.setMeshEdge(meshID, ids.at(i), ids.at((i + 1) % 4));
 
     double dt = cplInterface.initialize();
 
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling)
     int meshID = cplInterface.getMeshID("Test-Square-Two");
     cplInterface.setMeshVertices(meshID, 4, positions.data(), ids.data());
     for (int i = 0; i < 4; i++)
-      cplInterface.setMeshEdge(meshID, ids[i], ids[(i + 1) % 4]);
+      cplInterface.setMeshEdge(meshID, ids.at(i), ids.at((i + 1) % 4));
 
     double dt = cplInterface.initialize();
 
@@ -654,8 +654,8 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling)
         Eigen::Vector2d readData;
         cplInterface.readVectorData(velocitiesID, i, readData.data());
         Eigen::Vector2d expectedData = Eigen::Vector2d::Constant(i * 10.0);
-        BOOST_TEST(readData[0] == expectedData[0]);
-        BOOST_TEST(readData[1] == expectedData[1]);
+        BOOST_TEST(readData(0) == expectedData(0));
+        BOOST_TEST(readData(1) == expectedData(1));
       }
       dt = cplInterface.advance(dt);
     }
@@ -800,8 +800,8 @@ BOOST_AUTO_TEST_CASE(testImplicitWithDataInitialization)
       couplingInterface.markActionFulfilled(actionWriteIterationCheckpoint());
     }
     couplingInterface.readVectorData(readDataID, vertexID, readData.data());
-    BOOST_TEST(expectedReadValue == readData[0]);
-    BOOST_TEST(expectedReadValue == readData[1]);
+    BOOST_TEST(expectedReadValue == readData.at(0));
+    BOOST_TEST(expectedReadValue == readData.at(1));
     couplingInterface.writeVectorData(writeDataID, vertexID, writeData.data());
     dt = couplingInterface.advance(dt);
     if (couplingInterface.isActionRequired(actionReadIterationCheckpoint())) {
@@ -858,9 +858,9 @@ void runTestStationaryMappingWithSolverMesh(std::string const &config, int dim, 
 
     // Set solver mesh positions for reading and writing data with mappings
     for (size_t i = 0; i < size; i++) {
-      position = positions[i].array() + 0.1;
+      position = positions.at(i).array() + 0.1;
       interface.setMeshVertex(meshForcesID, position.data());
-      position = positions[i].array() + 0.6;
+      position = positions.at(i).array() + 0.6;
       interface.setMeshVertex(meshDisplID, position.data());
     }
     double maxDt = interface.initialize();
@@ -881,7 +881,7 @@ void runTestStationaryMappingWithSolverMesh(std::string const &config, int dim, 
     force.array() += 1.0;
     for (size_t i = 0; i < size; i++) {
       interface.readVectorData(dataDisplID, i, displ.data());
-      BOOST_TEST(displ[0] == positions[i][0] + 0.1);
+      BOOST_TEST(displ(0) == positions.at(i)(0) + 0.1);
       interface.writeVectorData(dataForcesID, i, force.data());
     }
     interface.mapWriteDataFrom(meshForcesID);
@@ -892,7 +892,7 @@ void runTestStationaryMappingWithSolverMesh(std::string const &config, int dim, 
     BOOST_TEST(interface.isReadDataAvailable());
     for (size_t i = 0; i < size; i++) {
       interface.readVectorData(dataDisplID, i, displ.data());
-      BOOST_TEST(displ[0] == 2.0 * (positions[i][0] + 0.1));
+      BOOST_TEST(displ(0) == 2.0 * (positions.at(i)(0) + 0.1));
     }
     interface.finalize();
   } else {
@@ -904,8 +904,8 @@ void runTestStationaryMappingWithSolverMesh(std::string const &config, int dim, 
 
     // Set solver mesh positions provided to SolverA for data mapping
     for (size_t i = 0; i < size; i++) {
-      interface.setMeshVertex(meshForcesID, positions[i].data());
-      position = positions[i].array() + 0.5;
+      interface.setMeshVertex(meshForcesID, positions.at(i).data());
+      position = positions.at(i).array() + 0.5;
       interface.setMeshVertex(meshDisplID, position.data());
     }
     double maxDt = interface.initialize();
@@ -918,7 +918,7 @@ void runTestStationaryMappingWithSolverMesh(std::string const &config, int dim, 
     for (size_t i = 0; i < size; i++) {
       interface.readVectorData(dataForcesID, i, force.data());
       totalForce += force;
-      displ.setConstant(positions[i][0]);
+      displ.setConstant(positions.at(i)(0));
       interface.writeVectorData(dataDisplID, i, displ.data());
     }
     Eigen::VectorXd expected = Eigen::VectorXd::Constant(dim, size);
@@ -931,7 +931,7 @@ void runTestStationaryMappingWithSolverMesh(std::string const &config, int dim, 
     for (size_t i = 0; i < positions.size(); i++) {
       interface.readVectorData(dataForcesID, i, force.data());
       totalForce += force;
-      displ.setConstant(2.0 * positions[i][0]);
+      displ.setConstant(2.0 * positions.at(i)(0));
       interface.writeVectorData(dataDisplID, i, displ.data());
     }
     expected.setConstant(2.0 * (double) size);
@@ -1085,7 +1085,7 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
       callsOfAdvance++;
     }
     precice.finalize();
-    BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[0]);
+    BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance.at(0));
   } else if (context.isNamed("SolverTwo")) {
     SolverInterface precice(context.name, config, 0, 1);
 
@@ -1109,7 +1109,7 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
       callsOfAdvance++;
     }
     precice.finalize();
-    BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[1]);
+    BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance.at(1));
   } else {
     BOOST_TEST(context.isNamed("SolverThree"));
     SolverInterface precice(context.name, config, 0, 1);
@@ -1134,7 +1134,7 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
       callsOfAdvance++;
     }
     precice.finalize();
-    BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance[2]);
+    BOOST_TEST(callsOfAdvance == expectedCallsOfAdvance.at(2));
   }
 }
 
@@ -1234,14 +1234,14 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
     std::vector<int> vertexIDs;
     int              vertexID = -1;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshID, positions[i].data());
+      vertexID = precice.setMeshVertex(meshID, positions.at(i).data());
       vertexIDs.push_back(vertexID);
     }
 
     precice.initialize();
 
     for (size_t i = 0; i < 4; i++) {
-      precice.writeVectorData(dataWriteID, vertexIDs[i], datas[i].data());
+      precice.writeVectorData(dataWriteID, vertexIDs.at(i), datas.at(i).data());
     }
 
     if (precice.isActionRequired(writeIterCheckpoint)) {
@@ -1253,17 +1253,17 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
     }
 
     for (size_t i = 0; i < 4; i++) {
-      precice.readVectorData(dataReadID, vertexIDs[i], datas[i].data());
+      precice.readVectorData(dataReadID, vertexIDs.at(i), datas.at(i).data());
     }
 
-    BOOST_TEST(datas[0][0] == 1.00000000000000002082e-03);
-    BOOST_TEST(datas[0][1] == 1.00000000000000002082e-03);
-    BOOST_TEST(datas[1][0] == 0.00000000000000000000e+00);
-    BOOST_TEST(datas[1][1] == 1.00000000000000002082e-03);
-    BOOST_TEST(datas[2][0] == 3.00000000000000006245e-03);
-    BOOST_TEST(datas[2][1] == 3.00000000000000006245e-03);
-    BOOST_TEST(datas[3][0] == 4.00000000000000008327e-03);
-    BOOST_TEST(datas[3][1] == 5.00000000000000010408e-03);
+    BOOST_TEST(datas.at(0)(0) == 1.00000000000000002082e-03);
+    BOOST_TEST(datas.at(0)(1) == 1.00000000000000002082e-03);
+    BOOST_TEST(datas.at(1)(0) == 0.00000000000000000000e+00);
+    BOOST_TEST(datas.at(1)(1) == 1.00000000000000002082e-03);
+    BOOST_TEST(datas.at(2)(0) == 3.00000000000000006245e-03);
+    BOOST_TEST(datas.at(2)(1) == 3.00000000000000006245e-03);
+    BOOST_TEST(datas.at(3)(0) == 4.00000000000000008327e-03);
+    BOOST_TEST(datas.at(3)(1) == 5.00000000000000010408e-03);
 
     precice.finalize();
 
@@ -1281,26 +1281,26 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
     std::vector<int> vertexIDs1;
     int              vertexID = -1;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshID1, positions[i].data());
+      vertexID = precice.setMeshVertex(meshID1, positions.at(i).data());
       vertexIDs1.push_back(vertexID);
     }
     std::vector<int> vertexIDs2;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshID2, positions[i].data());
+      vertexID = precice.setMeshVertex(meshID2, positions.at(i).data());
       vertexIDs2.push_back(vertexID);
     }
     std::vector<int> vertexIDs3;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshID3, positions[i].data());
+      vertexID = precice.setMeshVertex(meshID3, positions.at(i).data());
       vertexIDs3.push_back(vertexID);
     }
 
     precice.initialize();
 
     for (size_t i = 0; i < 4; i++) {
-      precice.writeVectorData(dataWriteID1, vertexIDs1[i], datas[i].data());
-      precice.writeVectorData(dataWriteID2, vertexIDs2[i], datas[i].data());
-      precice.writeVectorData(dataWriteID3, vertexIDs3[i], datas[i].data());
+      precice.writeVectorData(dataWriteID1, vertexIDs1.at(i), datas.at(i).data());
+      precice.writeVectorData(dataWriteID2, vertexIDs2.at(i), datas.at(i).data());
+      precice.writeVectorData(dataWriteID3, vertexIDs3.at(i), datas.at(i).data());
     }
 
     if (precice.isActionRequired(writeIterCheckpoint)) {
@@ -1970,7 +1970,7 @@ void testConvergenceMeasures(const std::string configFile, TestContext const &co
 
     if (context.isNamed("SolverTwo")) {
       int dataID = cplInterface.getDataID("Data2", meshID);
-      cplInterface.writeScalarData(dataID, vertexID, writeValues[numberOfAdvanceCalls]);
+      cplInterface.writeScalarData(dataID, vertexID, writeValues.at(numberOfAdvanceCalls));
     }
 
     cplInterface.advance(1.0);

--- a/src/query/tests/FindClosestTest.cpp
+++ b/src/query/tests/FindClosestTest.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToVertices)
     mesh::Mesh mesh("RootMesh", dim, false, testing::nextMeshID());
     mesh.createVertex(Eigen::VectorXd::Zero(dim));
     Eigen::VectorXd queryCoords0 = Eigen::VectorXd::Zero(dim);
-    queryCoords0[0]              = 1.0;
+    queryCoords0(0)              = 1.0;
     FindClosest find(queryCoords0);
     find(mesh);
     query::ClosestElement closest  = find.getClosest();
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(SignOfShortestDistance)
     mesh::Mesh      mesh("Mesh", dim, false, testing::nextMeshID());
     mesh::Vertex &  vertex = mesh.createVertex(Eigen::VectorXd::Zero(dim));
     Eigen::VectorXd normal = Eigen::VectorXd::Zero(dim);
-    normal[0]              = 1.0;
+    normal(0)              = 1.0;
     vertex.setNormal(normal);
 
     // Check point that lies outside of mesh
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(SignOfShortestDistance)
     BOOST_TEST(distance == 1.0);
 
     // Check point that lies inside of mesh
-    normal[0] = -1.0;
+    normal(0) = -1.0;
     vertex.setNormal(normal);
     find.reset();
     find(mesh);
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(IndependenceOfSignOfShortestDistance)
 
     // Invert normal of futher away vertex, should have no influence
     Eigen::VectorXd normal = Eigen::VectorXd::Zero(dim);
-    normal[1]              = -1.0;
+    normal(1)              = -1.0;
     vertex2.setNormal(normal);
     find.reset();
     find(mesh);
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges)
     mesh::Vertex &  v2     = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Edge &    edge   = mesh.createEdge(v1, v2);
     Eigen::VectorXd normal = Eigen::VectorXd::Constant(dim, -1);
-    normal[1]              = 1.0;
+    normal(1)              = 1.0;
     v1.setNormal(normal);
     v2.setNormal(normal);
     edge.setNormal(normal);
@@ -128,10 +128,10 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges)
     // Create query points
     // Query point 0 lies outside of the mesh
     Eigen::VectorXd queryCoords0 = Eigen::VectorXd::Constant(dim, -1);
-    queryCoords0[1]              = 1.0;
+    queryCoords0(1)              = 1.0;
     // Query point 1 lies inside of the mesh
     Eigen::VectorXd queryCoords1 = Eigen::VectorXd::Constant(dim, 1);
-    queryCoords1[1]              = -1.0;
+    queryCoords1(1)              = -1.0;
     // Query point 2 lies on the query edge
     Eigen::VectorXd queryCoords2 = Eigen::VectorXd::Constant(dim, 0);
     // Query point 3 lies on the same line as the edge, but above
@@ -199,15 +199,15 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToEdges3D)
 
   // Perform queries
   for (size_t i = 0; i < finds.size(); i++) {
-    BOOST_TEST((*finds[i])(mesh));
+    BOOST_TEST((*finds.at(i))(mesh));
   }
 
   // Evaluate query results
-  BOOST_TEST(finds[0]->getClosest().distance == std::sqrt(1.0 / 8.0));
-  BOOST_TEST(finds[1]->getClosest().distance == std::sqrt(1.0 / 8.0));
-  BOOST_TEST(finds[2]->getClosest().distance == Eigen::Vector3d(0.5, -0.5, 0.0).norm());
-  BOOST_TEST(finds[3]->getClosest().distance == Eigen::Vector3d(0.5, -0.5, 0.5).norm());
-  BOOST_TEST(finds[4]->getClosest().distance == Eigen::Vector3d(0.5, -0.5, -0.5).norm());
+  BOOST_TEST(finds.at(0)->getClosest().distance == std::sqrt(1.0 / 8.0));
+  BOOST_TEST(finds.at(1)->getClosest().distance == std::sqrt(1.0 / 8.0));
+  BOOST_TEST(finds.at(2)->getClosest().distance == Eigen::Vector3d(0.5, -0.5, 0.0).norm());
+  BOOST_TEST(finds.at(3)->getClosest().distance == Eigen::Vector3d(0.5, -0.5, 0.5).norm());
+  BOOST_TEST(finds.at(4)->getClosest().distance == Eigen::Vector3d(0.5, -0.5, -0.5).norm());
 
   // Clean up
   for (auto &find : finds) {
@@ -245,30 +245,30 @@ BOOST_AUTO_TEST_CASE(FindClosestDistanceToTriangles)
   queries.push_back(Eigen::Vector3d(1.5, 1.5, 1.5));    // 11: outside vertex2
   std::vector<std::shared_ptr<FindClosest>> findVisitors;
   for (size_t i = 0; i < queries.size(); i++) {
-    std::shared_ptr<FindClosest> find(new FindClosest(queries[i]));
+    std::shared_ptr<FindClosest> find(new FindClosest(queries.at(i)));
     findVisitors.push_back(find);
-    (*findVisitors[i])(mesh);
+    (*findVisitors.at(i))(mesh);
   }
 
   // Validate results
   for (size_t i = 0; i < 7; i++) {
-    BOOST_TEST(findVisitors[i]->getClosest().distance == 0.0);
+    BOOST_TEST(findVisitors.at(i)->getClosest().distance == 0.0);
   }
   Eigen::Vector3d expect(0.5, -0.5, 0.0);
-  BOOST_TEST(testing::equals(findVisitors[7]->getClosest().vectorToElement, expect));
-  BOOST_TEST(findVisitors[7]->getClosest().distance == expect.norm());
+  BOOST_TEST(testing::equals(findVisitors.at(7)->getClosest().vectorToElement, expect));
+  BOOST_TEST(findVisitors.at(7)->getClosest().distance == expect.norm());
   expect << -0.5, 0.5, 0.0;
-  BOOST_TEST(testing::equals(findVisitors[8]->getClosest().vectorToElement, expect));
-  BOOST_TEST(findVisitors[8]->getClosest().distance == -1.0 * expect.norm());
+  BOOST_TEST(testing::equals(findVisitors.at(8)->getClosest().vectorToElement, expect));
+  BOOST_TEST(findVisitors.at(8)->getClosest().distance == -1.0 * expect.norm());
   expect << 0.5, 0.5, 0.5;
-  BOOST_TEST(testing::equals(findVisitors[9]->getClosest().vectorToElement, expect));
-  BOOST_TEST(std::abs(findVisitors[9]->getClosest().distance) == expect.norm());
+  BOOST_TEST(testing::equals(findVisitors.at(9)->getClosest().vectorToElement, expect));
+  BOOST_TEST(std::abs(findVisitors.at(9)->getClosest().distance) == expect.norm());
   expect << -0.5, -0.5, 0.5;
-  BOOST_TEST(testing::equals(findVisitors[10]->getClosest().vectorToElement, expect));
-  BOOST_TEST(std::abs(findVisitors[10]->getClosest().distance) == expect.norm());
+  BOOST_TEST(testing::equals(findVisitors.at(10)->getClosest().vectorToElement, expect));
+  BOOST_TEST(std::abs(findVisitors.at(10)->getClosest().distance) == expect.norm());
   expect << -0.5, -0.5, -0.5;
-  BOOST_TEST(testing::equals(findVisitors[11]->getClosest().vectorToElement, expect));
-  BOOST_TEST(std::abs(findVisitors[11]->getClosest().distance) == expect.norm());
+  BOOST_TEST(testing::equals(findVisitors.at(11)->getClosest().vectorToElement, expect));
+  BOOST_TEST(std::abs(findVisitors.at(11)->getClosest().distance) == expect.norm());
 }
 
 BOOST_AUTO_TEST_CASE(FindClosestDistanceToTrianglesAndVertices)
@@ -330,12 +330,12 @@ BOOST_AUTO_TEST_CASE(WeigthsOfVertices)
 
   // Validate results
   BOOST_TEST(closest.interpolationElements.size() == 2);
-  auto pointerVertex1 = closest.interpolationElements[0].element;
-  auto pointerVertex2 = closest.interpolationElements[1].element;
+  auto pointerVertex1 = closest.interpolationElements.at(0).element;
+  auto pointerVertex2 = closest.interpolationElements.at(1).element;
   BOOST_TEST(testing::equals(pointerVertex1->getCoords(), Eigen::Vector2d(0.0, 0.0)));
   BOOST_TEST(testing::equals(pointerVertex2->getCoords(), Eigen::Vector2d(1.0, 0.0)));
-  BOOST_TEST(closest.interpolationElements[0].weight == 0.7);
-  BOOST_TEST(closest.interpolationElements[1].weight == 0.3);
+  BOOST_TEST(closest.interpolationElements.at(0).weight == 0.7);
+  BOOST_TEST(closest.interpolationElements.at(1).weight == 0.3);
 }
 
 struct MeshFixture {

--- a/src/utils/tests/AlgorithmTest.cpp
+++ b/src/utils/tests/AlgorithmTest.cpp
@@ -23,9 +23,9 @@ BOOST_AUTO_TEST_CASE(MakeArray)
   PRECICE_TEST(1_rank);
   auto a = pu::make_array(1, 2, 3);
   BOOST_TEST(a.size() == 3);
-  BOOST_TEST(a[0] == 1);
-  BOOST_TEST(a[1] == 2);
-  BOOST_TEST(a[2] == 3);
+  BOOST_TEST(a.at(0) == 1);
+  BOOST_TEST(a.at(1) == 2);
+  BOOST_TEST(a.at(2) == 3);
 }
 
 BOOST_AUTO_TEST_CASE(UniqueElements)

--- a/src/utils/tests/ParallelTest.cpp
+++ b/src/utils/tests/ParallelTest.cpp
@@ -52,14 +52,14 @@ BOOST_AUTO_TEST_CASE(SplitCommTest)
 
   const auto &groups = splitComm->groups;
   BOOST_TEST(groups.size() == 2);
-  BOOST_TEST(groups[0].id == 0);
-  BOOST_TEST(groups[1].id == 1);
-  BOOST_TEST(groups[0].name == std::string("GroupOne"));
-  BOOST_TEST(groups[1].name == std::string("GroupTwo"));
-  BOOST_TEST(groups[0].leaderRank == 0);
-  BOOST_TEST(groups[1].leaderRank == 2);
-  BOOST_TEST(groups[0].size == 2);
-  BOOST_TEST(groups[1].size == 1);
+  BOOST_TEST(groups.at(0).id == 0);
+  BOOST_TEST(groups.at(1).id == 1);
+  BOOST_TEST(groups.at(0).name == std::string("GroupOne"));
+  BOOST_TEST(groups.at(1).name == std::string("GroupTwo"));
+  BOOST_TEST(groups.at(0).leaderRank == 0);
+  BOOST_TEST(groups.at(1).leaderRank == 2);
+  BOOST_TEST(groups.at(0).size == 2);
+  BOOST_TEST(groups.at(1).size == 1);
 }
 
 BOOST_AUTO_TEST_CASE(Master1SlaveTest)


### PR DESCRIPTION
This PR changes vector (or array) access patterns in tests to have more robust testing. Changes include
- All the standard library accesses are changed from `[ ]` to `.at()`. Only exception is `std::map` only while constructing the map
- There were some C-style heap-allocated arrays, these are transformed into `std::vector`
- Access for `Eigen`  containers are changed from `[ ]` to `( )` because of two reasons: First, It makes it easier to detect problematic `[ ]` usages; Second, only `Eigen::Vector` supports `[ ]` and in the case of `Eigen::Array` usage becomes consistent. This part is open to discussion actually.