### PR TITLE
Add docker release

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,20 +1,26 @@
 name: "Release Dockerfile"
 on:
   release:
-    types: [published, released]
+    types: released
 jobs:
   latest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        env:
-          version: ${{ github.events.release.tag_name }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASS }}
-          dockerfile: "./tools/releasing/packaging/docker/Dockerfile"
-          repository: precice/precice
-          tags: ${{ env.version }},latest
+          username: precice
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Dockerfile
+        uses: docker/build-push-action@v2
+        env:
+          version: ${{ github.event.release.tag_name }}
+        with:
+          push: true
+          file: "./tools/releasing/packaging/docker/Dockerfile"
+          tags: precice/precice:${{ env.version }},precice/precice:latest
           build-args: |
             version=${{ env.version }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,20 @@
+name: "Release Dockerfile"
+on:
+  release:
+    types: [published, released]
+jobs:
+  latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        env:
+          version: ${{ github.events.release.tag_name }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+          dockerfile: "./tools/releasing/packaging/docker/Dockerfile"
+          repository: precice/precice
+          tags: ${{ env.version }},latest
+          build-args: |
+            version=${{ env.version }}

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -1,0 +1,13 @@
+# Dockerfile to build a ubuntu image containing the installed Debian package of a release 
+
+FROM ubuntu:20.04
+# Fix the installation of tzdata for Ubuntu 20.04
+ARG TIMEZONE=Europe/Berlin
+RUN export TZ=$TIMEZONE && echo $TZ > /etc/timezone && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    apt-get -yy update && apt-get -yy install wget tzdata
+# The version to fetch the package for: vX.Y.Z
+ARG version
+RUN echo "$version" | grep "v[0-9]\+\.[0-9]\+\.[0-9]\+" > /dev/null # The version must follow the format vX.Y.Z
+RUN wget -q -O libprecice.deb https://github.com/precice/precice/releases/download/${version}/libprecice`echo ${version} | sed 's/v\([0-9]\+\)\.\([0-9]\+\.[0-9]\+\)/\1_\1.\2/'`_focal.deb && \
+    ( dpkg -i libprecice.deb || apt-get install -fyy ) && \
+    rm libprecice.deb

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -10,4 +10,5 @@ ARG version
 RUN echo "$version" | grep "v[0-9]\+\.[0-9]\+\.[0-9]\+" > /dev/null # The version must follow the format vX.Y.Z
 RUN wget -q -O libprecice.deb https://github.com/precice/precice/releases/download/${version}/libprecice`echo ${version} | sed 's/v\([0-9]\+\)\.\([0-9]\+\.[0-9]\+\)/\1_\1.\2/'`_focal.deb && \
     ( dpkg -i libprecice.deb || apt-get install -fyy ) && \
-    rm libprecice.deb
+    rm libprecice.deb && \
+    binprecice xml > /dev/null # Make sure the installation is functional

--- a/tools/releasing/packaging/docker/README.md
+++ b/tools/releasing/packaging/docker/README.md
@@ -1,0 +1,10 @@
+# preCICE Dockerfile
+
+The point of this dockerfile is to build a Ubuntu-based distribution of preCICE.
+It uses named releases of precice such as `v2.1.1` and installs the attached debian package in the container.
+
+Use the following to build the `v2.1.1` image locally:
+```
+cd tools/releasing/packaging/docker/
+docker build -t precice/precice --build-arg=version=v2.1.1 .
+```


### PR DESCRIPTION
This PR adds a docker release workflow.

Once a release is published, this action will run and build a dockerimage installing the uploaded debian package of the release.
It will then push the result to `precice/precice:vX.Y.Z` and `precice/precice:latest`.