### PR TITLE
Check python action module path

### DIFF
--- a/docs/changelog/911.md
+++ b/docs/changelog/911.md
@@ -1,0 +1,1 @@
+- Added check for user-defined python actions.

--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -1,5 +1,5 @@
+#include <boost/filesystem/operations.hpp>
 #ifndef PRECICE_NO_PYTHON
-#include "PythonAction.hpp"
 #include <Eigen/Core>
 #include <Python.h>
 #include <cstdlib>
@@ -8,6 +8,7 @@
 #include <ostream>
 #include <pthread.h>
 #include <string>
+#include "PythonAction.hpp"
 #include "logging/LogMacros.hpp"
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
@@ -58,6 +59,8 @@ PythonAction::PythonAction(
       _modulePath(modulePath),
       _moduleName(moduleName)
 {
+  PRECICE_CHECK(boost::filesystem::is_directory(_modulePath),
+                "The module path of the python action \"" << _moduleName << "\" does not exist. The configured path is \"" << _modulePath << "\".");
   if (targetDataID != -1) {
     _targetData = getMesh()->data(targetDataID);
     _numberArguments++;


### PR DESCRIPTION
**List the core changes of this PR**

Add check to ensure the module path of a configured PythonAction actually exists.

Example error message
```
ERROR: The module path of the python action "TestAllAction" does not exist. The configured path is "/home/simonis/dev/precice/second/src/action/tests2/".
```

**Additional Information**

Closes #908
