### PR TITLE
Improve configuration checks for data access

### DIFF
--- a/docs/changelog/912.md
+++ b/docs/changelog/912.md
@@ -1,0 +1,1 @@
+- Improved checks of configuration related to data access

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -397,7 +397,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                   "Participant \"" << participant->getName() << "\" has mapping"
                                    << " to mesh \"" << confMapping.toMesh->getName() << "\", without using this mesh. "
                                    << "Please add a use-mesh tag with name=\"" << confMapping.toMesh->getName() << "\"");
-    PRECICE_CHECK((participant->isMeshProvided(toMeshID) || participant->isMeshProvided(toMeshID)),
+    PRECICE_CHECK((participant->isMeshProvided(fromMeshID) || participant->isMeshProvided(toMeshID)),
                   "Participant \"" << participant->getName() << "\" has mapping"
                                    << " from mesh \"" << confMapping.fromMesh->getName() << "\", "
                                    << " to mesh \"" << confMapping.toMesh->getName() << "\", but neither are provided. "

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -397,6 +397,12 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                   "Participant \"" << participant->getName() << "\" has mapping"
                                    << " to mesh \"" << confMapping.toMesh->getName() << "\", without using this mesh. "
                                    << "Please add a use-mesh tag with name=\"" << confMapping.toMesh->getName() << "\"");
+    PRECICE_CHECK((participant->isMeshProvided(toMeshID) || participant->isMeshProvided(toMeshID)),
+                  "Participant \"" << participant->getName() << "\" has mapping"
+                                   << " from mesh \"" << confMapping.fromMesh->getName() << "\", "
+                                   << " to mesh \"" << confMapping.toMesh->getName() << "\", but neither are provided. "
+                                   << "Please mark the mesh provided by this participant by configuring its use-mesh tag with provided=\"true\".");
+
     if (context.size > 1) {
       if ((confMapping.direction == mapping::MappingConfiguration::WRITE &&
            confMapping.mapping->getConstraint() == mapping::Mapping::CONSISTENT) ||

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -479,10 +479,10 @@ void ParticipantConfiguration::finishParticipantConfiguration(
   // Set participant data for data contexts
   for (impl::DataContext &dataContext : participant->writeDataContexts()) {
     int fromMeshID = dataContext.mesh->getID();
-    PRECICE_CHECK(participant->isMeshUsed(fromMeshID),
-                  "Participant \"" << participant->getName() << "\" has to use mesh \""
+    PRECICE_CHECK(participant->isMeshProvided(fromMeshID),
+                  "Participant \"" << participant->getName() << "\" has to use and provide mesh \""
                                    << dataContext.mesh->getName() << "\" to be able to write data to it. "
-                                   << "Please add a use-mesh node with name=\"" << dataContext.mesh->getName() << "\".");
+                                   << "Please add a use-mesh node with name=\"" << dataContext.mesh->getName() << "\" and provide=\"true\".");
 
     for (impl::MappingContext &mappingContext : participant->writeMappingContexts()) {
       if (mappingContext.fromMeshID == fromMeshID) {
@@ -503,10 +503,10 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
   for (impl::DataContext &dataContext : participant->readDataContexts()) {
     int toMeshID = dataContext.mesh->getID();
-    PRECICE_CHECK(participant->isMeshUsed(toMeshID),
-                  "Participant \"" << participant->getName() << "\" has to use mesh \""
+    PRECICE_CHECK(participant->isMeshProvided(toMeshID),
+                  "Participant \"" << participant->getName() << "\" has to use and provide mesh \""
                                    << dataContext.mesh->getName() << "\" in order to read data from it. "
-                                   << "Please add a use-mesh node with name=\"" << dataContext.mesh->getName() << "\".");
+                                   << "Please add a use-mesh node with name=\"" << dataContext.mesh->getName() << "\" and provide=\"true\".");
 
     for (impl::MappingContext &mappingContext : participant->readMappingContexts()) {
       if (mappingContext.toMeshID == toMeshID) {

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -197,6 +197,14 @@ bool Participant::isMeshUsed(
   return _meshContexts[meshID] != nullptr;
 }
 
+bool Participant::isMeshProvided(
+    int meshID) const
+{
+  PRECICE_ASSERT((meshID >= 0) && (meshID < (int) _meshContexts.size()));
+  auto context = _meshContexts[meshID];
+  return (context != nullptr) && context->provideMesh;
+}
+
 bool Participant::isDataUsed(
     int dataID) const
 {

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -87,6 +87,8 @@ public:
 
   bool isMeshUsed(int meshID) const;
 
+  bool isMeshProvided(int meshID) const;
+
   bool isDataUsed(int dataID) const;
 
   bool isDataRead(int dataID) const;

--- a/src/precice/tests/explicit-mpi.xml
+++ b/src/precice/tests/explicit-mpi.xml
@@ -28,8 +28,8 @@
         to="MeshOne"
         constraint="consistent"
         timing="onadvance" />
-      <write-data name="Forces" mesh="Test-Square" />
-      <read-data name="Velocities" mesh="Test-Square" />
+      <write-data name="Forces" mesh="MeshOne" />
+      <read-data name="Velocities" mesh="MeshOne" />
     </participant>
 
     <participant name="SolverTwo">

--- a/src/precice/tests/explicit-sockets.xml
+++ b/src/precice/tests/explicit-sockets.xml
@@ -28,8 +28,8 @@
         to="MeshOne"
         constraint="consistent"
         timing="onadvance" />
-      <write-data name="Forces" mesh="Test-Square" />
-      <read-data name="Velocities" mesh="Test-Square" />
+      <write-data name="Forces" mesh="MeshOne" />
+      <read-data name="Velocities" mesh="MeshOne" />
     </participant>
 
     <participant name="SolverTwo">

--- a/src/precice/tests/implicit.xml
+++ b/src/precice/tests/implicit.xml
@@ -30,8 +30,8 @@
         from="SquareTwo"
         to="Square"
         constraint="conservative" />
-      <write-data name="Velocities" mesh="Square" />
-      <read-data name="Forces" mesh="Square" />
+      <write-data name="Velocities" mesh="SquareTwo" />
+      <read-data name="Forces" mesh="SquareTwo" />
     </participant>
 
     <coupling-scheme:serial-implicit>


### PR DESCRIPTION

**List the core changes of this PR**

- Add `isMeshProvided` to Participant
- Add check for mapping between non-provided meshes
- Improve config checks for read and write data
- Fix test configurations

**Additional Information**

Closes #909
