### PR TITLE
Add check for serial implicit acceleration data

### DIFF
--- a/docs/changelog/913.md
+++ b/docs/changelog/913.md
@@ -1,0 +1,1 @@
+- Added error message for incorrectly configured acceleration data in a serial implicit coupling scheme.

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -807,7 +807,7 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
 {
   PRECICE_TRACE(accessor);
 
-  const auto first = _config.participants[0];
+  const auto first  = _config.participants[0];
   const auto second = _config.participants[1];
 
   m2n::PtrM2N m2n = _m2nConfig->getM2N(

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -279,8 +279,7 @@ void CouplingSchemeConfiguration::xmlTagCallback(
                                                 << "/> tag in the <coupling-scheme:... /> of your precice-config.xml.");
     _meshConfig->addNeededMesh(nameParticipantFrom, nameMesh);
     _meshConfig->addNeededMesh(nameParticipantTo, nameMesh);
-    _config.exchanges.push_back(std::make_tuple(exchangeData, exchangeMesh,
-                                                nameParticipantFrom, nameParticipantTo, initialize));
+    _config.exchanges.emplace_back(Config::Exchange{exchangeData, exchangeMesh, nameParticipantFrom, nameParticipantTo, initialize});
   } else if (tag.getName() == TAG_MAX_ITERATIONS) {
     PRECICE_ASSERT(_config.type == VALUE_SERIAL_IMPLICIT || _config.type == VALUE_PARALLEL_IMPLICIT || _config.type == VALUE_MULTI);
     _config.maxIterations = tag.getIntAttributeValue(ATTR_VALUE);
@@ -837,6 +836,7 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
       _meshConfig->addNeededMesh(_config.participants[1], neededMesh);
     }
     for (const int dataID : _accelerationConfig->getAcceleration()->getDataIDs()) {
+      //checkIfDataIsExchangedBetween(dataID, _config.participants[1], _config.participants[0]);
       checkIfDataIsExchanged(dataID);
     }
     scheme->setAcceleration(_accelerationConfig->getAcceleration());
@@ -983,17 +983,16 @@ void CouplingSchemeConfiguration::addDataToBeExchanged(
     const std::string &accessor) const
 {
   PRECICE_TRACE();
-  using std::get;
-  for (const Config::Exchange &tuple : _config.exchanges) {
-    mesh::PtrData      data = get<0>(tuple);
-    mesh::PtrMesh      mesh = get<1>(tuple);
-    const std::string &from = get<2>(tuple);
-    const std::string &to   = get<3>(tuple);
+  for (const Config::Exchange &exchange : _config.exchanges) {
+    const std::string &from     = exchange.from;
+    const std::string &to       = exchange.to;
+    const std::string &dataName = exchange.data->getName();
+    const std::string &meshName = exchange.mesh->getName();
 
     PRECICE_CHECK(to != from, "You cannot define an exchange from and to the same participant. "
                                   << "Please check the <exchange "
-                                  << "data=\"" << data->getName() << "\" "
-                                  << "mesh=\"" << mesh->getName() << "\" "
+                                  << "data=\"" << dataName << "\" "
+                                  << "mesh=\"" << meshName << "\" "
                                   << "from=\"" << from << "\" "
                                   << "to=\"" << to << "\" "
                                   << "/> tag in the <coupling-scheme:... /> of your precice-config.xml.");
@@ -1001,8 +1000,8 @@ void CouplingSchemeConfiguration::addDataToBeExchanged(
     if (not(utils::contained(from, _config.participants) || from == _config.controller)) {
       PRECICE_CHECK(false, "Participant \"" + from + "\" is not configured for coupling scheme. "
                                                      "Please check the <exchange "
-                               << "data=\"" << data->getName() << "\" "
-                               << "mesh=\"" << mesh->getName() << "\" "
+                               << "data=\"" << dataName << "\" "
+                               << "mesh=\"" << meshName << "\" "
                                << "from=\"" << from << "\" "
                                << "to=\"" << to << "\" "
                                << "/> tag in the <coupling-scheme:... /> of your precice-config.xml.");
@@ -1011,33 +1010,33 @@ void CouplingSchemeConfiguration::addDataToBeExchanged(
     if (not(utils::contained(to, _config.participants) || to == _config.controller)) {
       PRECICE_CHECK(false, "Participant \"" + to + "\" is not configured for coupling scheme. "
                                << "Please check the <exchange "
-                               << "data=\"" << data->getName() << "\" "
-                               << "mesh=\"" << mesh->getName() << "\" "
+                               << "data=\"" << dataName << "\" "
+                               << "mesh=\"" << meshName << "\" "
                                << "from=\"" << from << "\" "
                                << "to=\"" << to << "\" "
                                << "/> tag in the <coupling-scheme:... /> of your precice-config.xml.");
     }
 
-    bool requiresInitialization = get<4>(tuple);
+    const bool requiresInitialization = exchange.requiresInitialization;
     if (from == accessor) {
-      scheme.addDataToSend(data, mesh, requiresInitialization);
+      scheme.addDataToSend(exchange.data, exchange.mesh, requiresInitialization);
       if (requiresInitialization && (_config.type == VALUE_SERIAL_EXPLICIT || _config.type == VALUE_SERIAL_IMPLICIT)) {
         PRECICE_CHECK(not scheme.doesFirstStep(), "In serial coupling only second participant can initialize data and send it. "
                                                       << "Please check the <exchange "
-                                                      << "data=\"" << data->getName() << "\" "
-                                                      << "mesh=\"" << mesh->getName() << "\" "
+                                                      << "data=\"" << dataName << "\" "
+                                                      << "mesh=\"" << meshName << "\" "
                                                       << "from=\"" << from << "\" "
                                                       << "to=\"" << to << "\" "
                                                       << "initialize=\"" << requiresInitialization << "\" "
                                                       << "/> tag in the <coupling-scheme:... /> of your precice-config.xml.");
       }
     } else if (to == accessor) {
-      scheme.addDataToReceive(data, mesh, requiresInitialization);
+      scheme.addDataToReceive(exchange.data, exchange.mesh, requiresInitialization);
       if (requiresInitialization && (_config.type == VALUE_SERIAL_EXPLICIT || _config.type == VALUE_SERIAL_IMPLICIT)) {
         PRECICE_CHECK(scheme.doesFirstStep(), "In serial coupling only first participant can receive initial data. "
                                                   << "Please check the <exchange "
-                                                  << "data=\"" << data->getName() << "\" "
-                                                  << "mesh=\"" << mesh->getName() << "\" "
+                                                  << "data=\"" << dataName << "\" "
+                                                  << "mesh=\"" << meshName << "\" "
                                                   << "from=\"" << from << "\" "
                                                   << "to=\"" << to << "\" "
                                                   << "initialize=\"" << requiresInitialization << "\" "
@@ -1054,12 +1053,9 @@ void CouplingSchemeConfiguration::addMultiDataToBeExchanged(
     const std::string &  accessor) const
 {
   PRECICE_TRACE();
-  using std::get;
-  for (const Config::Exchange &tuple : _config.exchanges) {
-    mesh::PtrData      data = get<0>(tuple);
-    mesh::PtrMesh      mesh = get<1>(tuple);
-    const std::string &from = get<2>(tuple);
-    const std::string &to   = get<3>(tuple);
+  for (const Config::Exchange &exchange : _config.exchanges) {
+    const std::string &from = exchange.from;
+    const std::string &to   = exchange.to;
 
     if (not(utils::contained(from, _config.participants) || from == _config.controller)) {
       throw std::runtime_error{"Participant \"" + from + "\" is not configured for coupling scheme"};
@@ -1069,7 +1065,7 @@ void CouplingSchemeConfiguration::addMultiDataToBeExchanged(
       throw std::runtime_error{"Participant \"" + to + "\" is not configured for coupling scheme"};
     }
 
-    bool initialize = get<4>(tuple);
+    const bool initialize = exchange.requiresInitialization;
     if (from == accessor) {
       size_t index = 0;
       for (const std::string &participant : _config.participants) {
@@ -1080,7 +1076,7 @@ void CouplingSchemeConfiguration::addMultiDataToBeExchanged(
         index++;
       }
       PRECICE_ASSERT(index < _config.participants.size(), index, _config.participants.size());
-      scheme.addDataToSend(data, mesh, initialize, index);
+      scheme.addDataToSend(exchange.data, exchange.mesh, initialize, index);
     } else {
       size_t index = 0;
       for (const std::string &participant : _config.participants) {
@@ -1091,7 +1087,7 @@ void CouplingSchemeConfiguration::addMultiDataToBeExchanged(
         index++;
       }
       PRECICE_ASSERT(index < _config.participants.size(), index, _config.participants.size());
-      scheme.addDataToReceive(data, mesh, initialize, index);
+      scheme.addDataToReceive(exchange.data, exchange.mesh, initialize, index);
     }
   }
 }
@@ -1099,26 +1095,26 @@ void CouplingSchemeConfiguration::addMultiDataToBeExchanged(
 void CouplingSchemeConfiguration::checkIfDataIsExchanged(
     int dataID) const
 {
-  bool hasFound = false;
-  for (const Config::Exchange &tuple : _config.exchanges) {
-    mesh::PtrData data = std::get<0>(tuple);
-    if (data->getID() == dataID) {
-      hasFound = true;
-    }
+  const auto match = std::find_if(_config.exchanges.begin(),
+                                  _config.exchanges.end(),
+                                  [dataID](const Config::Exchange &exchange) { return exchange.data->getID() == dataID; });
+  if (match != _config.exchanges.end()) {
+    return;
   }
 
+  // Data is not being exchanged
   std::string dataName = "";
   auto        dataptr  = findDataByID(dataID);
   if (dataptr) {
     dataName = dataptr->getName();
   }
 
-  PRECICE_CHECK(hasFound, "You need to exchange every data that you use for convergence measures "
-                              << "and/or the iteration acceleration. Data \"" << dataName << "\" is "
-                              << "currently not exchanged, but used for convergence measures and/or iteration "
-                              << "acceleration. Please check the <exchange ... /> and "
-                              << "<...-convergence-measure ... /> tags in the "
-                              << "<coupling-scheme:... /> of your precice-config.xml.");
+  PRECICE_ERROR("You need to exchange every data that you use for convergence measures "
+                << "and/or the iteration acceleration. Data \"" << dataName << "\" is "
+                << "currently not exchanged, but used for convergence measures and/or iteration "
+                << "acceleration. Please check the <exchange ... /> and "
+                << "<...-convergence-measure ... /> tags in the "
+                << "<coupling-scheme:... /> of your precice-config.xml.");
 }
 
 } // namespace cplscheme

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -1147,7 +1147,6 @@ void CouplingSchemeConfiguration::checkSerialImplicitAccelerationData(
       "You configured acceleration data \"" << dataName << "\" in the serial implicit coupling scheme between participants \"" << first << "\" and \"" << second << "\". "
       "For serial implicit coupling schemes, only data exchanged from the second to the first participant can be used for acceleration. Here, from \"" << second << "\" to \"" << first "\". "
       "However, you also configured data \"" << dataName << "\" to be exchanged from \"" << first << "\" to \"" << second << "\". "
-      "This combination is illegal. "
       "Please select an acceleration data which is exchanged from \"" << second << "\" to \"" << first << "\" using the <exchange> tag in your precice configuration.");
   // clang-format on
 }

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -1145,7 +1145,7 @@ void CouplingSchemeConfiguration::checkSerialImplicitAccelerationData(
   // clang-format off
   PRECICE_ERROR(
       "You configured acceleration data \"" << dataName << "\" in the serial implicit coupling scheme between participants \"" << first << "\" and \"" << second << "\". "
-      "In this case, only the data from the second participant \"" << second << "\" is accelerated. "
+      "For serial implicit coupling schemes, only data exchanged from the second to the first participant can be used for acceleration. Here, from \"" << second << "\" to \"" << first "\". "
       "However, you also configured data \"" << dataName << "\" to be exchanged from \"" << first << "\" to \"" << second << "\". "
       "This combination is illegal. "
       "Please select an acceleration data which is exchanged from \"" << second << "\" to \"" << first << "\" using the <exchange> tag in your precice configuration.");

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -1146,7 +1146,7 @@ void CouplingSchemeConfiguration::checkSerialImplicitAccelerationData(
   PRECICE_ERROR(
       "You configured acceleration data \"" << dataName << "\" in the serial implicit coupling scheme between participants \"" << first << "\" and \"" << second << "\". "
       "For serial implicit coupling schemes, only data exchanged from the second to the first participant can be used for acceleration. Here, from \"" << second << "\" to \"" << first "\". "
-      "However, you also configured data \"" << dataName << "\" to be exchanged from \"" << first << "\" to \"" << second << "\". "
+      "However, you configured data \"" << dataName << "\" for acceleration, which is exchanged from \"" << first << "\" to \"" << second << "\". "
       "Please select an acceleration data which is exchanged from \"" << second << "\" to \"" << first << "\" using the <exchange> tag in your precice configuration.");
   // clang-format on
 }

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -1145,7 +1145,7 @@ void CouplingSchemeConfiguration::checkSerialImplicitAccelerationData(
   // clang-format off
   PRECICE_ERROR(
       "You configured acceleration data \"" << dataName << "\" in the serial implicit coupling scheme between participants \"" << first << "\" and \"" << second << "\". "
-      "For serial implicit coupling schemes, only data exchanged from the second to the first participant can be used for acceleration. Here, from \"" << second << "\" to \"" << first "\". "
+      "For serial implicit coupling schemes, only data exchanged from the second to the first participant can be used for acceleration. Here, from \"" << second << "\" to \"" << first << "\". "
       "However, you configured data \"" << dataName << "\" for acceleration, which is exchanged from \"" << first << "\" to \"" << second << "\". "
       "Please remove this acceleration data tag or switch to a parallel implicit coupling scheme.");
   // clang-format on

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -807,11 +807,14 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
 {
   PRECICE_TRACE(accessor);
 
+  const auto first = _config.participants[0];
+  const auto second = _config.participants[1];
+
   m2n::PtrM2N m2n = _m2nConfig->getM2N(
-      _config.participants[0], _config.participants[1]);
+      first, second);
   SerialCouplingScheme *scheme = new SerialCouplingScheme(
       _config.maxTime, _config.maxTimeWindows, _config.timeWindowSize,
-      _config.validDigits, _config.participants[0], _config.participants[1],
+      _config.validDigits, first, second,
       accessor, m2n, _config.dtMethod, BaseCouplingScheme::Implicit, _config.maxIterations);
   scheme->setExtrapolationOrder(_config.extrapolationOrder);
 
@@ -825,7 +828,7 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
                 "At least one convergence measure has to be defined for an implicit coupling scheme. "
                 "Please check your <coupling-scheme ... /> and make sure that you provide at least one <...-convergence-measure/> subtag in the precice-config.xml.");
   for (auto &elem : _config.convergenceMeasureDefinitions) {
-    _meshConfig->addNeededMesh(_config.participants[1], elem.meshName);
+    _meshConfig->addNeededMesh(second, elem.meshName);
     checkIfDataIsExchanged(elem.data->getID());
     scheme->addConvergenceMeasure(elem.data, elem.suffices, elem.strict, elem.measure, elem.doesLogging);
   }
@@ -833,10 +836,10 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
   // Set relaxation parameters
   if (_accelerationConfig->getAcceleration().get() != nullptr) {
     for (std::string &neededMesh : _accelerationConfig->getNeededMeshes()) {
-      _meshConfig->addNeededMesh(_config.participants[1], neededMesh);
+      _meshConfig->addNeededMesh(second, neededMesh);
     }
     for (const int dataID : _accelerationConfig->getAcceleration()->getDataIDs()) {
-      checkSerialImplicitAccelerationData(dataID, _config.participants[0], _config.participants[1]);
+      checkSerialImplicitAccelerationData(dataID, first, second);
     }
     scheme->setAcceleration(_accelerationConfig->getAcceleration());
   }

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -1147,7 +1147,7 @@ void CouplingSchemeConfiguration::checkSerialImplicitAccelerationData(
       "You configured acceleration data \"" << dataName << "\" in the serial implicit coupling scheme between participants \"" << first << "\" and \"" << second << "\". "
       "For serial implicit coupling schemes, only data exchanged from the second to the first participant can be used for acceleration. Here, from \"" << second << "\" to \"" << first "\". "
       "However, you configured data \"" << dataName << "\" for acceleration, which is exchanged from \"" << first << "\" to \"" << second << "\". "
-      "Please select an acceleration data which is exchanged from \"" << second << "\" to \"" << first << "\" using the <exchange> tag in your precice configuration.");
+      "Please remove this acceleration data tag or switch to a parallel implicit coupling scheme.");
   // clang-format on
 }
 

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -260,6 +260,9 @@ private:
   void checkIfDataIsExchanged(
       int dataID) const;
 
+  void checkSerialImplicitAccelerationData(
+      int dataID, const std::string &first, const std::string &second) const;
+
   friend struct CplSchemeTests::ParallelImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation; // For whitebox tests
   friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation;   // For whitebox tests
 };

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -139,12 +139,18 @@ private:
     double                        timeWindowSize = CouplingScheme::UNDEFINED_TIME_WINDOW_SIZE;
     int                           validDigits    = 16;
     constants::TimesteppingMethod dtMethod       = constants::FIXED_TIME_WINDOW_SIZE;
-    /// Tuples of exchange data, mesh, and participant name.
-    typedef std::tuple<mesh::PtrData, mesh::PtrMesh, std::string, std::string, bool> Exchange;
-    std::vector<Exchange>                                                            exchanges;
-    std::vector<ConvergenceMeasureDefintion>                                         convergenceMeasureDefinitions;
-    int                                                                              maxIterations      = -1;
-    int                                                                              extrapolationOrder = 0;
+
+    struct Exchange {
+      mesh::PtrData data;
+      mesh::PtrMesh mesh;
+      std::string   from;
+      std::string   to;
+      bool          requiresInitialization;
+    };
+    std::vector<Exchange>                    exchanges;
+    std::vector<ConvergenceMeasureDefintion> convergenceMeasureDefinitions;
+    int                                      maxIterations      = -1;
+    int                                      extrapolationOrder = 0;
   } _config;
 
   mesh::PtrMeshConfiguration _meshConfig;


### PR DESCRIPTION
**List the core changes of this PR**

This PR adds a check for serial implicit acceleration data.
This following error should triggered in the case descibled in #907 (wording will be different).

```
ERROR: You configured acceleration data "Data1" in the serial implicit coupling scheme between participants "SolverOne" and "SolverTwo". In this case, only the data from the second participant "SolverTwo" is accelerated. However, you also configured data "Data1" to be exchanged from "SolverOne" to "SolverTwo". This combination is illegal. Please select an acceleration data which is exchanged from "SolverTwo" to "SolverOne" using the <exchange> tag in your precice configuration.
```

Formatted 
```
ERROR:
You configured acceleration data "Data1" in the serial implicit coupling scheme between participants "SolverOne" and "SolverTwo".
In this case, only the data from the second participant "SolverTwo" is accelerated.
However, you also configured data "Data1" to be exchanged from "SolverOne" to "SolverTwo".
This combination is illegal.

Please select an acceleration data which is exchanged from "SolverTwo" to "SolverOne" using the <exchange> tag in your precice configuration.
```


**Additional Information**

Closes #907 

**Review Information**

@uekermann Can you please check the wording of the message?
