### PR TITLE
Clang scan fixes

### DIFF
--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -91,7 +91,8 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations)
   } else if (context.isRank(2)) {
     n_local = 0;
     a       = 3;
-  } else if (context.isRank(3)) {
+  } else {
+    BOOST_REQUIRE(context.isRank(3));
     n_local = 3;
     a       = 4;
   }
@@ -243,7 +244,8 @@ BOOST_AUTO_TEST_CASE(ParallelMatrixMatrixOp)
     n_local = 4;
   } else if (context.isRank(2)) {
     n_local = 0;
-  } else if (context.isRank(3)) {
+  } else {
+    BOOST_REQUIRE(context.isRank(3));
     n_local = 3;
   }
 

--- a/src/mesh/impl/RTreeAdapter.hpp
+++ b/src/mesh/impl/RTreeAdapter.hpp
@@ -42,7 +42,7 @@ template <size_t Dimension>
 struct access<Eigen::VectorXd, Dimension> {
   static double get(Eigen::VectorXd const &p)
   {
-    if (Dimension > static_cast<size_t>(p.rows()) - 1)
+    if (Dimension >= static_cast<size_t>(p.rows()))
       return 0;
 
     return p[Dimension];
@@ -84,7 +84,7 @@ template <size_t Dimension>
 struct access<pm::Vertex, Dimension> {
   static double get(pm::Vertex const &p)
   {
-    if (Dimension > static_cast<size_t>(p.getDimensions()) - 1)
+    if (Dimension >= static_cast<size_t>(p.getDimensions()))
       return 0;
 
     return p.getCoords()[Dimension];

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
     /* int squareID = */ cplInterface.getMeshID("Test-Square");
     int forcesID     = cplInterface.getDataID("Forces", meshOneID);
     int velocitiesID = cplInterface.getDataID("Velocities", meshOneID);
-    int indices[8];
+    std::vector<int>indices(8);
     int i = 0;
 
     //need one vertex to start
@@ -309,11 +309,12 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
     const auto &vertices = impl(cplInterface).mesh("Test-Square").vertices();
     while (cplInterface.isCouplingOngoing()) {
       impl(cplInterface).resetMesh(meshOneID);
+
       i = 0;
       for (auto &vertex : vertices) {
         int index = cplInterface.setMeshVertex(meshOneID, vertex.getCoords().data());
         BOOST_TEST(index == vertex.getID());
-        indices[i] = index;
+        indices.at(i) = index;
         i++;
       }
       //for (VertexIterator it = vertices.begin(); it != vertices.end(); it++) {
@@ -326,7 +327,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
         i = 0;
         for (auto &vertex : vertices) {
           Vector3d vel   = Vector3d::Zero();
-          int      index = indices[i];
+          int      index = indices.at(i);
           i++;
           cplInterface.readVectorData(velocitiesID, index, vel.data());
           BOOST_TEST(vel == Vector3d::Constant(counter) + vertex.getCoords());

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -296,10 +296,10 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
   if (context.isNamed("SolverOne")) {
     int meshOneID = cplInterface.getMeshID("MeshOne");
     /* int squareID = */ cplInterface.getMeshID("Test-Square");
-    int forcesID     = cplInterface.getDataID("Forces", meshOneID);
-    int velocitiesID = cplInterface.getDataID("Velocities", meshOneID);
-    std::vector<int>indices(8);
-    int i = 0;
+    int              forcesID     = cplInterface.getDataID("Forces", meshOneID);
+    int              velocitiesID = cplInterface.getDataID("Velocities", meshOneID);
+    std::vector<int> indices(8);
+    int              i = 0;
 
     //need one vertex to start
     Vector3d vertex = Vector3d::Zero();

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -356,8 +356,6 @@ void Parallel::splitCommunicator(const std::string &groupName)
     // Assemble and set new state
     newState = CommState::fromComm(newComm);
   }
-  newState->groups = std::move(accessorGroups);
-  pushState(newState);
 
 #ifndef NDEBUG
   PRECICE_DEBUG("Detected " << accessorGroups.size() << " groups");
@@ -367,6 +365,10 @@ void Parallel::splitCommunicator(const std::string &groupName)
                            << ", size = " << group.size);
   }
 #endif // NDEBUG
+
+  newState->groups = std::move(accessorGroups);
+  pushState(newState);
+
 #endif // not PRECICE_NO_MPI
 }
 

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -150,7 +150,7 @@ struct Viewer {
   }
 
   int         popformats{0};
-  PetscViewer viewer;
+  PetscViewer viewer{nullptr};
 };
 
 template <class T>

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -330,6 +330,7 @@ void Vector::sort()
   ierr = VecGetArray(vector, &a);
   CHKERRV(ierr);
   ierr = VecGetSize(vector, &size);
+  CHKERRV(ierr);
   ierr = PetscSortReal(size, a);
   CHKERRV(ierr);
   ierr = VecRestoreArray(vector, &a);

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -111,19 +111,47 @@ namespace precice {
 namespace utils {
 namespace petsc {
 
-void openViewer(PetscViewer &viewer, std::string filename, VIEWERFORMAT format, MPI_Comm comm)
-{
-  PetscErrorCode ierr = 0;
-  if (format == ASCII) {
-    ierr = PetscViewerASCIIOpen(comm, filename.c_str(), &viewer);
+struct Viewer {
+  Viewer(const std::string &filename, VIEWERFORMAT format, MPI_Comm comm)
+  {
+    PetscErrorCode ierr = 0;
+    if (format == ASCII) {
+      ierr = PetscViewerASCIIOpen(comm, filename.c_str(), &viewer);
+      CHKERRV(ierr);
+    } else if (format == BINARY) {
+      ierr = PetscViewerBinaryOpen(comm, filename.c_str(), FILE_MODE_WRITE, &viewer);
+      CHKERRV(ierr);
+      pushFormat(PETSC_VIEWER_NATIVE);
+    }
+  }
+
+  Viewer(PetscViewerType type, MPI_Comm comm)
+  {
+    PetscErrorCode ierr = 0;
+    ierr                = PetscViewerCreate(comm, &viewer);
     CHKERRV(ierr);
-  } else if (format == BINARY) {
-    ierr = PetscViewerBinaryOpen(comm, filename.c_str(), FILE_MODE_WRITE, &viewer);
-    CHKERRV(ierr);
-    ierr = PetscViewerPushFormat(viewer, PETSC_VIEWER_NATIVE);
+    ierr = PetscViewerSetType(viewer, PETSCVIEWERASCII);
     CHKERRV(ierr);
   }
-}
+
+  ~Viewer()
+  {
+    while (popformats--) {
+      PetscViewerPopFormat(viewer);
+    }
+    PetscViewerDestroy(&viewer);
+  }
+
+  void pushFormat(PetscViewerFormat format)
+  {
+    auto ierr = PetscViewerPushFormat(viewer, format);
+    CHKERRV(ierr);
+    popformats++;
+  }
+
+  int         popformats{0};
+  PetscViewer viewer;
+};
 
 template <class T>
 MPI_Comm getCommunicator(T obj)
@@ -355,23 +383,14 @@ std::pair<PetscInt, PetscInt> Vector::ownerRange() const
 
 void Vector::write(std::string filename, VIEWERFORMAT format) const
 {
-  PetscErrorCode ierr = 0;
-  PetscViewer    viewer;
-  openViewer(viewer, filename, format, getCommunicator(vector));
-  VecView(vector, viewer);
-  CHKERRV(ierr);
-  PetscViewerDestroy(&viewer);
+  Viewer viewer{filename, format, getCommunicator(vector)};
+  VecView(vector, viewer.viewer);
 }
 
 void Vector::read(std::string filename, VIEWERFORMAT format)
 {
-  PetscErrorCode ierr = 0;
-  PetscViewer    viewer;
-  openViewer(viewer, filename, format, getCommunicator(vector));
-  VecLoad(vector, viewer);
-  CHKERRV(ierr);
-  CHKERRV(ierr);
-  PetscViewerDestroy(&viewer);
+  Viewer viewer{filename, format, getCommunicator(vector)};
+  VecLoad(vector, viewer.viewer);
 }
 
 void Vector::view() const
@@ -540,58 +559,41 @@ PetscInt Matrix::blockSize() const
 void Matrix::write(std::string filename, VIEWERFORMAT format) const
 {
   PetscErrorCode ierr = 0;
-  PetscViewer    viewer;
-  openViewer(viewer, filename, format, getCommunicator(matrix));
-  ierr = MatView(matrix, viewer);
+  Viewer         viewer{filename, format, getCommunicator(matrix)};
+  ierr = MatView(matrix, viewer.viewer);
   CHKERRV(ierr);
-  PetscViewerDestroy(&viewer);
 }
 
 void Matrix::read(std::string filename)
 {
   PetscErrorCode ierr = 0;
-  PetscViewer    viewer;
-  openViewer(viewer, filename, BINARY, getCommunicator(matrix));
-  ierr = MatLoad(matrix, viewer);
+  Viewer         viewer{filename, BINARY, getCommunicator(matrix)};
+  ierr = MatLoad(matrix, viewer.viewer);
   CHKERRV(ierr);
-  PetscViewerDestroy(&viewer);
 }
 
 void Matrix::view() const
 {
-  PetscErrorCode ierr = 0;
-  PetscViewer    viewer;
-  ierr = PetscViewerCreate(getCommunicator(matrix), &viewer);
-  CHKERRV(ierr);
-  ierr = PetscViewerSetType(viewer, PETSCVIEWERASCII);
-  CHKERRV(ierr);
-  ierr = PetscViewerPushFormat(viewer, PETSC_VIEWER_ASCII_DENSE);
-  CHKERRV(ierr);
-  ierr = MatView(matrix, viewer);
-  CHKERRV(ierr);
-  ierr = PetscViewerPopFormat(viewer);
-  CHKERRV(ierr);
-  ierr = PetscViewerDestroy(&viewer);
+  Viewer viewer{PETSCVIEWERASCII, getCommunicator(matrix)};
+  viewer.pushFormat(PETSC_VIEWER_ASCII_DENSE);
+  PetscErrorCode ierr = MatView(matrix, viewer.viewer);
   CHKERRV(ierr);
 }
 
 void Matrix::viewDraw() const
 {
-  PetscErrorCode ierr = 0;
-  PetscViewer    viewer;
-  PetscDraw      draw;
-  ierr = PetscViewerCreate(getCommunicator(matrix), &viewer);
+  Viewer viewer{PETSCVIEWERDRAW, getCommunicator(matrix)};
+  viewer.pushFormat(PETSC_VIEWER_ASCII_DENSE);
+  PetscErrorCode ierr = MatView(matrix, viewer.viewer);
   CHKERRV(ierr);
-  ierr = PetscViewerSetType(viewer, PETSCVIEWERDRAW);
+  ierr = MatView(matrix, viewer.viewer);
   CHKERRV(ierr);
-  ierr = MatView(matrix, viewer);
-  CHKERRV(ierr);
-  ierr = PetscViewerDrawGetDraw(viewer, 0, &draw);
+
+  PetscDraw draw;
+  ierr = PetscViewerDrawGetDraw(viewer.viewer, 0, &draw);
   CHKERRV(ierr);
   ierr = PetscDrawSetPause(draw, -1);
   CHKERRV(ierr); // Wait for user
-  ierr = PetscViewerDestroy(&viewer);
-  CHKERRV(ierr);
 }
 
 /////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**List the core changes of this PR**

These are some fixes based on running the llvm static analyzer on our codebase.

- Fix use after move in debug builds
- Add missing petsc checks
- Refactor PetscViewer
- Improve some serial tests
- Rewrite unsigned comparisons
