### PR TITLE
Add check for advance timestep size

### DIFF
--- a/docs/changelog/916.md
+++ b/docs/changelog/916.md
@@ -1,0 +1,1 @@
+- Added check to ensure `advance()` isn't called with invalid timestep size.

--- a/src/math/differences.hpp
+++ b/src/math/differences.hpp
@@ -17,12 +17,6 @@ constexpr bool equals(const Eigen::MatrixBase<DerivedA> &A,
   return A.isApprox(B, tolerance);
 }
 
-/// Compares two doubles for equality up to tolerance
-constexpr inline bool equals(double a, double b, double tolerance = NUMERICAL_ZERO_DIFFERENCE)
-{
-  return std::abs(a - b) < tolerance;
-}
-
 /// Compares two scalar (arithmetic) types
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type equals(const Scalar a, const Scalar b, const Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)

--- a/src/math/differences.hpp
+++ b/src/math/differences.hpp
@@ -17,6 +17,12 @@ constexpr bool equals(const Eigen::MatrixBase<DerivedA> &A,
   return A.isApprox(B, tolerance);
 }
 
+/// Compares two doubles for equality up to tolerance
+constexpr inline bool equals(double a, double b, double tolerance = NUMERICAL_ZERO_DIFFERENCE)
+{
+  return std::abs(a - b) < tolerance;
+}
+
 /// Compares two scalar (arithmetic) types
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type equals(const Scalar a, const Scalar b, const Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -388,6 +388,8 @@ double SolverInterfaceImpl::advance(
   PRECICE_CHECK(isCouplingOngoing(), "advance() cannot be called when isCouplingOngoing() returns false.");
   PRECICE_CHECK((not _couplingScheme->receivesInitializedData() && not _couplingScheme->sendsInitializedData()) || (_hasInitializedData),
                 "initializeData() needs to be called before advance if data has to be initialized.");
+  PRECICE_CHECK(!math::equals(computedTimestepLength, 0.0), "advance() cannot be called with a timestep size of 0.");
+  PRECICE_CHECK(computedTimestepLength > 0.0, "advance() cannot be called with a negative timestep size " << computedTimestepLength << '.');
   _numberAdvanceCalls++;
 
 #ifndef NDEBUG


### PR DESCRIPTION
**List the core changes of this PR**

This PR adds checks for the timestep size to enforce the following:
* It cannot be approximately zero.
* It cannot be negative.


**Additional Information**

Closes #915
