### PR TITLE
Disable KSP_DIVERGED_DTOL for very small RHS in PETSc KSPLSQR

### DIFF
--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -561,10 +561,11 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   // considered as diverged and the computation is aborted. The PETSC_DEFAULT value is 1e9. However, the
   // divergence residual is scaled using the RHS b of the system. In case the RHS is (still nonzero) very small
   // and we have a (bad) nonzero initial guess x as defined below, the divergence tolerance might be exceeded
-  // in the first iteration, although the system could be solved in the usual way. Therefore, we select a very
-  // high value (1e30) in order to disable the divergence check. In practice, the check is very rarely needed
-  // with Krylov methods. According to the PETSc people, even the rare use cases aim for a bad preconditioner,
-  // which is not used in our configuration. Hence, we can disable the divergence check without concerns.
+  // in the first iteration, although the system could be solved in the usual way. This behavior is essentially
+  // a glitch in the divergence check. Therefore, we select a very high value (1e30) in order to disable the
+  // divergence check. In practice, the check is very rarely needed with Krylov methods. According to the PETSc
+  // people, the rare use cases aim for a bad preconditioner, which is not even used in our configuration.
+  // Hence, we can disable the divergence check without concerns.
   KSPSetTolerances(_solver, _solverRtol, PETSC_DEFAULT, 1e30, PETSC_DEFAULT);
   KSPSetInitialGuessNonzero(_solver, PETSC_TRUE);
   CHKERRV(ierr);                            // Reuse the results from the last iteration, held in the out vector.

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -557,7 +557,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   // -- CONFIGURE SOLVER FOR SYSTEM MATRIX --
   KSPSetOperators(_solver, _matrixC, _matrixC);
   CHKERRV(ierr);
-  KSPSetTolerances(_solver, _solverRtol, PETSC_DEFAULT, PETSC_DEFAULT, PETSC_DEFAULT);
+  KSPSetTolerances(_solver, _solverRtol, PETSC_DEFAULT, 1e30, PETSC_DEFAULT);
   KSPSetInitialGuessNonzero(_solver, PETSC_TRUE);
   CHKERRV(ierr);                            // Reuse the results from the last iteration, held in the out vector.
   KSPSetOptionsPrefix(_solver, "solverC_"); // s.t. options for only this solver can be set on the command line

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -557,6 +557,14 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   // -- CONFIGURE SOLVER FOR SYSTEM MATRIX --
   KSPSetOperators(_solver, _matrixC, _matrixC);
   CHKERRV(ierr);
+  // The fourth argument defines the divergence tolerance, i.e. the tolerance, for which the linear system is
+  // considered as diverged and the computation is aborted. The PETSC_DEFAULT value is 1e9. However, the
+  // divergence residual is scaled using the RHS b of the system. In case the RHS is (still nonzero) very small
+  // and we have a (bad) nonzero initial guess x as defined below, the divergence tolerance might be exceeded
+  // in the first iteration, although the system could be solved in the usual way. Therefore, we select a very
+  // high value (1e30) in order to disable the divergence check. In practice, the check is very rarely needed
+  // with Krylov methods. According to the PETSc people, even the rare use cases aim for a bad preconditioner,
+  // which is not used in our configuration. Hence, we can disable the divergence check without concerns.
   KSPSetTolerances(_solver, _solverRtol, PETSC_DEFAULT, 1e30, PETSC_DEFAULT);
   KSPSetInitialGuessNonzero(_solver, PETSC_TRUE);
   CHKERRV(ierr);                            // Reuse the results from the last iteration, held in the out vector.


### PR DESCRIPTION
Resolves #904.

The problem and a workaround are described [on the PETSc mailing list](https://lists.mcs.anl.gov/pipermail/petsc-users/2017-March/032000.html). Using this workaround resolves the (original) problem and all tests pass. Since the maximum iteration option is still active, we cannot really do anything wrong when we change this option. However, I would like to have a look at the divergence residual for our original problem case before merging this. 

A general remark: applying the clang-format to the modified file changes some lines in my case and removes some whitespace errors.