### PR TITLE
Replace word 'freezed' by more common past-tense version 'frozen'

### DIFF
--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -448,7 +448,7 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     auto nonconstTSteps = makeXMLAttribute(ATTR_PRECOND_NONCONST_TIME_WINDOWS, -1)
                               .setDocumentation(
                                   "After the given number of time steps, the preconditioner weights "
-                                  "are freezed and the preconditioner acts like a constant preconditioner.");
+                                  "are frozen and the preconditioner acts like a constant preconditioner.");
     tagPreconditioner.addAttribute(nonconstTSteps);
     tag.addSubtag(tagPreconditioner);
 
@@ -518,7 +518,7 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                       .setDocumentation("Type of the preconditioner.");
     tagPreconditioner.addAttribute(attrPreconditionerType);
     auto nonconstTSteps = makeXMLAttribute(ATTR_PRECOND_NONCONST_TIME_WINDOWS, -1)
-                              .setDocumentation("After the given number of time steps, the preconditioner weights are freezed and the preconditioner acts like a constant preconditioner.");
+                              .setDocumentation("After the given number of time steps, the preconditioner weights are frozen and the preconditioner acts like a constant preconditioner.");
     tagPreconditioner.addAttribute(nonconstTSteps);
     tag.addSubtag(tagPreconditioner);
 

--- a/src/acceleration/impl/ConstantPreconditioner.cpp
+++ b/src/acceleration/impl/ConstantPreconditioner.cpp
@@ -19,7 +19,7 @@ void ConstantPreconditioner::initialize(std::vector<size_t> &svs)
   Preconditioner::initialize(svs);
 
   // is always constant by definition
-  _freezed = true;
+  _frozen = true;
   PRECICE_ASSERT(_maxNonConstTimesteps == -1, _maxNonConstTimesteps);
 
   PRECICE_ASSERT(_factors.size() == _subVectorSizes.size());

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -162,17 +162,17 @@ public:
    */
   void update(bool timestepComplete, const Eigen::VectorXd &oldValues, const Eigen::VectorXd &res)
   {
-    PRECICE_TRACE(_nbNonConstTimesteps, _freezed);
+    PRECICE_TRACE(_nbNonConstTimesteps, _frozen);
 
     // if number of allowed non-const time steps is exceeded, do not update weights
-    if (_freezed)
+    if (_frozen)
       return;
 
     // increment number of time steps that has been scaled with changing preconditioning weights
     if (timestepComplete) {
       _nbNonConstTimesteps++;
       if (_nbNonConstTimesteps >= _maxNonConstTimesteps && _maxNonConstTimesteps > 0)
-        _freezed = true;
+        _frozen = true;
     }
 
     // type specific update functionality
@@ -199,7 +199,7 @@ public:
 
   bool isConst()
   {
-    return _freezed;
+    return _frozen;
   }
 
 protected:
@@ -213,7 +213,7 @@ protected:
   std::vector<size_t> _subVectorSizes;
 
   /** @brief maximum number of non-const time steps, i.e., after this number of time steps,
-   *  the preconditioner is freezed with the current weights and becomes a constant preconditioner
+   *  the preconditioner is frozen with the current weights and becomes a constant preconditioner
    */
   int _maxNonConstTimesteps;
 
@@ -224,7 +224,7 @@ protected:
   bool _requireNewQR = false;
 
   /// True if _nbNonConstTimesteps >= _maxNonConstTimesteps, i.e., preconditioner is not updated any more.
-  bool _freezed = false;
+  bool _frozen = false;
 
   /**
    * @brief Update the scaling after every FSI iteration and require a new QR decomposition (if necessary)


### PR DESCRIPTION
The word `freezed` was used in the documentation (XML reference) and some parts of the code. This PR changes the work `freezed` to the more common past tense form `frozen`. This affects some variables and some parts of the documentation.