### PR TITLE
Delete apt/lists/* after apt-get update

### DIFF
--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04
 # Fix the installation of tzdata for Ubuntu 20.04
 ARG TIMEZONE=Europe/Berlin
 RUN export TZ=$TIMEZONE && echo $TZ > /etc/timezone && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    apt-get -yy update && apt-get -yy install wget tzdata
+    apt-get -yy update && apt-get -yy install wget tzdata && rm -rf /var/lib/apt/lists/*
 # The version to fetch the package for: vX.Y.Z
 ARG version
 RUN echo "$version" | grep "v[0-9]\+\.[0-9]\+\.[0-9]\+" > /dev/null # The version must follow the format vX.Y.Z


### PR DESCRIPTION
Following recommended best practices. See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run

I stumbled across this issue here: https://github.com/precice/python-bindings/pull/67/files/1dc2a389e036d5c50b1f0671819406686c8b25dc#r553293590

This makes `precice/precice` consistent with our other Dockerfiles. E.g. https://github.com/precice/systemtests and https://github.com/precice/ci-images.

Please note that this is a breaking change for users that currently use `precice/precice` and do not call `apt-get update` in their respective workflows!