### PR TITLE
Improve assertion

### DIFF
--- a/docs/930.md
+++ b/docs/930.md
@@ -1,0 +1,2 @@
+- Fixed interleaved assertion output.
+- Improved compiler compatibility of assertion.

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -12,10 +12,10 @@
 #include <iostream>
 
 #include <boost/current_function.hpp>
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
-#include <boost/preprocessor/seq/seq.hpp> // SEQ_TAIL
 #include <boost/preprocessor/stringize.hpp>
-#include <boost/preprocessor/variadic/elem.hpp>
 #include <boost/preprocessor/variadic/to_seq.hpp>
 
 #include "Parallel.hpp"
@@ -23,22 +23,23 @@
 
 /// Helper macro, used by assertion.
 #define PRECICE_PRINT_ARGUMENT(r, data, i, elem) \
-  std::cerr << "  Argument " << i << ": " << elem << '\n';
+  BOOST_PP_IF(BOOST_PP_IS_EMPTY(elem), ,         \
+              std::cerr << "  Argument " << i << ": " << elem << '\n';)
 
 /// Asserts that expr evaluates to true, prints all other arguments and calls assert(false).
-#define PRECICE_ASSERT(...)                                                                                      \
-  if (not(BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__))) {                                                             \
-    std::cerr << "ASSERTION FAILED\n"                                                                            \
-              << "  Location:          " << BOOST_CURRENT_FUNCTION << '\n'                                       \
-              << "  File:              " << __FILE__ << ":" << __LINE__ << '\n'                                  \
-              << "  Rank:              " << precice::utils::Parallel::getProcessRank() << '\n'                   \
-              << "  Failed expression: " << BOOST_PP_STRINGIZE(BOOST_PP_VARIADIC_ELEM(0, __VA_ARGS__))           \
-              << '\n';                                                                                           \
-    BOOST_PP_SEQ_FOR_EACH_I(PRECICE_PRINT_ARGUMENT, , BOOST_PP_SEQ_TAIL(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))); \
-    std::cerr << getStacktrace() << '\n';                                                                        \
-    std::cerr.flush();                                                                                           \
-    std::cout.flush();                                                                                           \
-    assert(false);                                                                                               \
+#define PRECICE_ASSERT(check, ...)                                                             \
+  if (!(check)) {                                                                              \
+    std::cerr << "ASSERTION FAILED\n"                                                          \
+              << "  Location:          " << BOOST_CURRENT_FUNCTION << '\n'                     \
+              << "  File:              " << __FILE__ << ":" << __LINE__ << '\n'                \
+              << "  Rank:              " << precice::utils::Parallel::getProcessRank() << '\n' \
+              << "  Failed expression: " << BOOST_PP_STRINGIZE(check)                          \
+              << '\n';                                                                         \
+    BOOST_PP_SEQ_FOR_EACH_I(PRECICE_PRINT_ARGUMENT, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))   \
+    std::cerr << getStacktrace() << '\n';                                                      \
+    std::cerr.flush();                                                                         \
+    std::cout.flush();                                                                         \
+    assert(false);                                                                             \
   }
 
 #endif

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -10,6 +10,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <sstream>
 
 #include <boost/current_function.hpp>
 #include <boost/preprocessor/control/if.hpp>
@@ -22,24 +23,25 @@
 #include "stacktrace.hpp"
 
 /// Helper macro, used by assertion.
-#define PRECICE_PRINT_ARGUMENT(r, data, i, elem) \
-  BOOST_PP_IF(BOOST_PP_IS_EMPTY(elem), ,         \
-              std::cerr << "  Argument " << i << ": " << elem << '\n';)
+#define PRECICE_PRINT_ARGUMENT(r, out, i, elem) \
+  BOOST_PP_IF(BOOST_PP_IS_EMPTY(elem), ,        \
+              out << "  Argument " << i << ": " << elem << '\n';)
 
 /// Asserts that expr evaluates to true, prints all other arguments and calls assert(false).
-#define PRECICE_ASSERT(check, ...)                                                             \
-  if (!(check)) {                                                                              \
-    std::cerr << "ASSERTION FAILED\n"                                                          \
-              << "  Location:          " << BOOST_CURRENT_FUNCTION << '\n'                     \
-              << "  File:              " << __FILE__ << ":" << __LINE__ << '\n'                \
-              << "  Rank:              " << precice::utils::Parallel::getProcessRank() << '\n' \
-              << "  Failed expression: " << BOOST_PP_STRINGIZE(check)                          \
-              << '\n';                                                                         \
-    BOOST_PP_SEQ_FOR_EACH_I(PRECICE_PRINT_ARGUMENT, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))   \
-    std::cerr << getStacktrace() << '\n';                                                      \
-    std::cerr.flush();                                                                         \
-    std::cout.flush();                                                                         \
-    assert(false);                                                                             \
+#define PRECICE_ASSERT(check, ...)                                                              \
+  if (!(check)) {                                                                               \
+    std::ostringstream oss;                                                                     \
+    oss << "ASSERTION FAILED\n"                                                                 \
+        << "  Location:          " << BOOST_CURRENT_FUNCTION << '\n'                            \
+        << "  File:              " << __FILE__ << ":" << __LINE__ << '\n'                       \
+        << "  Rank:              " << precice::utils::Parallel::getProcessRank() << '\n'        \
+        << "  Failed expression: " << BOOST_PP_STRINGIZE(check)                                 \
+        << '\n';                                                                                \
+    BOOST_PP_SEQ_FOR_EACH_I(PRECICE_PRINT_ARGUMENT, oss, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
+    oss << getStacktrace() << '\n';                                                             \
+    std::cerr << oss.str() << std::flush;                                                       \
+    std::cout.flush();                                                                          \
+    assert(false);                                                                              \
   }
 
 #endif


### PR DESCRIPTION

**List the core changes of this PR**

- Improve compiler compatibility of PRECICE_ASSERT (authored by @Eder-K)
- Fix interleaved assertion output

**Motivation**

https://github.com/precice/precice/issues/200#issuecomment-748105047

Also, the assertions are interleaved. Multiple MPI programms produced interleaved and thus useless output.

**Additional Information**

Closes #662
