### PR TITLE
Use correct function interface in header

### DIFF
--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -351,7 +351,7 @@ void precicef_set_vertex_(
  */
 void precicef_get_mesh_vertex_size_(
     const int *meshID,
-    int *meshSize);
+    int *      meshSize);
 
 /**
  * @brief See precice::SolverInterface::setMeshVertices().

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -350,7 +350,7 @@ void precicef_set_vertex_(
  * OUT: meshSize
  */
 void precicef_get_mesh_vertex_size_(
-    int *meshID,
+    const int *meshID,
     int *meshSize);
 
 /**


### PR DESCRIPTION
Otherwise the function does not get de-mangled in the `extern "C" {..}` block and is not available to Fortran calls.