### PR TITLE
Cleanup Interface Data Access

### DIFF
--- a/docs/changelog/932.md
+++ b/docs/changelog/932.md
@@ -1,0 +1,2 @@
+- Fixed input checks for data access functions.
+- Clarified the wording of errors messages in data access functions. They now refer to vertex IDs instead of indices.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1047,30 +1047,31 @@ void SolverInterfaceImpl::mapReadDataTo(
 }
 
 void SolverInterfaceImpl::writeBlockVectorData(
-    int           fromDataID,
+    int           dataID,
     int           size,
     const int *   valueIndices,
     const double *values)
 {
-  PRECICE_TRACE(fromDataID, size);
+  PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "writeBlockVectorData(...) cannot be called after finalize().");
-  PRECICE_VALIDATE_DATA_ID(fromDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
   if (size == 0)
     return;
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-  DataContext &context = _accessor->dataContext(fromDataID);
-  PRECICE_CHECK(context.fromData->getDimensions() == _dimensions,
-                "You cannot call writeBlockVectorData on the scalar data type \"" << context.fromData->getName()
+  PRECICE_REQUIRE_DATA_WRITE(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.fromData != nullptr);
+  mesh::Data &data = *context.fromData;
+  PRECICE_CHECK(data.getDimensions() == _dimensions,
+                "You cannot call writeBlockVectorData on the scalar data type \"" << data.getName()
                                                                                   << "\". Use writeBlockScalarData or change the data type for \""
-                                                                                  << context.fromData->getName() << "\" to vector.");
-  PRECICE_ASSERT(context.toData.get() != nullptr);
-  auto &valuesInternal = context.fromData->values();
+                                                                                  << data.getName() << "\" to vector.");
+  auto &valuesInternal = data.values();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / context.fromData->getDimensions(), "Value index out of range. Please check that the size of "
-                                                                                                                 << context.fromData->getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / data.getDimensions(), "Value index out of range. Please check that the size of "
+                                                                                                    << data.getName() << " is correct.");
     int offsetInternal = valueIndex * _dimensions;
     int offset         = i * _dimensions;
     for (int dim = 0; dim < _dimensions; dim++) {
@@ -1082,24 +1083,25 @@ void SolverInterfaceImpl::writeBlockVectorData(
 }
 
 void SolverInterfaceImpl::writeVectorData(
-    int           fromDataID,
+    int           dataID,
     int           valueIndex,
     const double *value)
 {
-  PRECICE_TRACE(fromDataID, valueIndex);
+  PRECICE_TRACE(dataID, valueIndex);
   PRECICE_CHECK(_state != State::Finalized, "writeVectorData(...) cannot be called before finalize().");
-  PRECICE_VALIDATE_DATA_ID(fromDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
   PRECICE_DEBUG("value = " << Eigen::Map<const Eigen::VectorXd>(value, _dimensions));
-  PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-  DataContext &context = _accessor->dataContext(fromDataID);
-  PRECICE_CHECK(context.fromData->getDimensions() == _dimensions,
-                "You cannot call writeVectorData on the scalar data type \"" << context.fromData->getName()
+  PRECICE_REQUIRE_DATA_WRITE(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.fromData != nullptr);
+  mesh::Data &data = *context.fromData;
+  PRECICE_CHECK(data.getDimensions() == _dimensions,
+                "You cannot call writeVectorData on the scalar data type \"" << data.getName()
                                                                              << "\". Use writeScalarData or change the data type for \""
-                                                                             << context.fromData->getName() << "\" to vector.");
-  PRECICE_ASSERT(context.toData.get() != nullptr);
-  auto &values = context.fromData->values();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / context.fromData->getDimensions(), "Value index out of range. Please check that the valueIndex for "
-                                                                                                       << context.fromData->getName() << " is in the correct range.");
+                                                                             << data.getName() << "\" to vector.");
+  auto &values = data.values();
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / data.getDimensions(), "Value index out of range. Please check that the valueIndex for "
+                                                                                          << data.getName() << " is in the correct range.");
   int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     values[offset + dim] = value[dim];
@@ -1107,84 +1109,87 @@ void SolverInterfaceImpl::writeVectorData(
 }
 
 void SolverInterfaceImpl::writeBlockScalarData(
-    int           fromDataID,
+    int           dataID,
     int           size,
     const int *   valueIndices,
     const double *values)
 {
-  PRECICE_TRACE(fromDataID, size);
+  PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "writeBlockScalarData(...) cannot be called after finalize().");
-  PRECICE_VALIDATE_DATA_ID(fromDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
   if (size == 0)
     return;
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-  DataContext &context = _accessor->dataContext(fromDataID);
-  PRECICE_CHECK(context.fromData->getDimensions() == 1,
-                "You cannot call writeBlockScalarData on the vector data type \"" << context.fromData->getName()
+  PRECICE_REQUIRE_DATA_WRITE(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.fromData != nullptr);
+  mesh::Data &data = *context.fromData;
+  PRECICE_CHECK(data.getDimensions() == 1,
+                "You cannot call writeBlockScalarData on the vector data type \"" << data.getName()
                                                                                   << "\". Use writeBlockVectorData or change the data type for \""
-                                                                                  << context.fromData->getName() << "\" to scalar.");
-  PRECICE_ASSERT(context.toData.get() != nullptr);
-  auto &valuesInternal = context.fromData->values();
+                                                                                  << data.getName() << "\" to scalar.");
+  auto &valuesInternal = data.values();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / context.fromData->getDimensions(), "Value index out of range. Please check that the size of "
-                                                                                                                 << context.fromData->getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / data.getDimensions(), "Value index out of range. Please check that the size of "
+                                                                                                    << data.getName() << " is correct.");
     PRECICE_ASSERT(i < valuesInternal.size(), i, valuesInternal.size());
     valuesInternal[valueIndex] = values[i];
   }
 }
 
 void SolverInterfaceImpl::writeScalarData(
-    int    fromDataID,
+    int    dataID,
     int    valueIndex,
     double value)
 {
-  PRECICE_TRACE(fromDataID, valueIndex, value);
+  PRECICE_TRACE(dataID, valueIndex, value);
   PRECICE_CHECK(_state != State::Finalized, "writeScalarData(...) cannot be called after finalize().");
-  PRECICE_VALIDATE_DATA_ID(fromDataID);
-  PRECICE_REQUIRE_DATA_WRITE(fromDataID);
-  DataContext &context = _accessor->dataContext(fromDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
+  PRECICE_REQUIRE_DATA_WRITE(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.fromData != nullptr);
+  mesh::Data &data = *context.fromData;
   PRECICE_CHECK(valueIndex >= -1, "Invalid value index (" << valueIndex << ") when writing scalar data. Value index must be >= 0. "
                                                                            "Please check the value index for "
-                                                          << context.fromData->getName());
-  PRECICE_CHECK(context.fromData->getDimensions() == 1,
-                "You cannot call writeScalarData on the vector data type \"" << context.fromData->getName()
+                                                          << data.getName());
+  PRECICE_CHECK(data.getDimensions() == 1,
+                "You cannot call writeScalarData on the vector data type \"" << data.getName()
                                                                              << "\". Use writeVectorData or change the data type for \""
-                                                                             << context.fromData->getName() << "\" to scalar.");
-  PRECICE_ASSERT(context.toData);
-  auto &values = context.fromData->values();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / context.fromData->getDimensions(), "Value index out of range. Please check that the valueIndex for "
-                                                                                                       << context.fromData->getName() << " is in the correct range.");
+                                                                             << data.getName() << "\" to scalar.");
+  auto &values = data.values();
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / data.getDimensions(), "Value index out of range. Please check that the valueIndex for "
+                                                                                          << data.getName() << " is in the correct range.")
   values[valueIndex] = value;
 }
 
 void SolverInterfaceImpl::readBlockVectorData(
-    int        toDataID,
+    int        dataID,
     int        size,
     const int *valueIndices,
     double *   values) const
 {
-  PRECICE_TRACE(toDataID, size);
+  PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockVectorData(...) cannot be called after finalize().");
-  PRECICE_VALIDATE_DATA_ID(toDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
   if (size == 0)
     return;
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  PRECICE_REQUIRE_DATA_READ(toDataID);
-  DataContext &context = _accessor->dataContext(toDataID);
-  PRECICE_CHECK(context.toData->getDimensions() == _dimensions,
-                "You cannot call readBlockVectorData on the scalar data type \"" << context.toData->getName()
+  PRECICE_REQUIRE_DATA_READ(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.toData != nullptr);
+  mesh::Data &data = *context.toData;
+  PRECICE_CHECK(data.getDimensions() == _dimensions,
+                "You cannot call readBlockVectorData on the scalar data type \"" << data.getName()
                                                                                  << "\". Use readBlockScalarData or change the data type for \""
-                                                                                 << context.fromData->getName() << "\" to vector.");
-  PRECICE_ASSERT(context.fromData.get() != nullptr);
-  auto &valuesInternal = context.toData->values();
+                                                                                 << data.getName() << "\" to vector.");
+  auto &valuesInternal = data.values();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / context.fromData->getDimensions(), "Value index out of range. Please check that the size of "
-                                                                                                                 << context.fromData->getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / data.getDimensions(), "Value index out of range. Please check that the size of "
+                                                                                                    << data.getName() << " is correct.");
     int offsetInternal = valueIndex * _dimensions;
     int offset         = i * _dimensions;
     for (int dim = 0; dim < _dimensions; dim++) {
@@ -1196,26 +1201,27 @@ void SolverInterfaceImpl::readBlockVectorData(
 }
 
 void SolverInterfaceImpl::readVectorData(
-    int     toDataID,
+    int     dataID,
     int     valueIndex,
     double *value) const
 {
-  PRECICE_TRACE(toDataID, valueIndex);
+  PRECICE_TRACE(dataID, valueIndex);
   PRECICE_CHECK(_state != State::Finalized, "readVectorData(...) cannot be called after finalize().");
-  PRECICE_VALIDATE_DATA_ID(toDataID);
-  PRECICE_REQUIRE_DATA_READ(toDataID);
-  DataContext &context = _accessor->dataContext(toDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
+  PRECICE_REQUIRE_DATA_READ(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.toData != nullptr);
+  mesh::Data &data = *context.toData;
   PRECICE_CHECK(valueIndex >= -1, "Invalid value index ( " << valueIndex << " ) when reading vector data. Value index must be >= 0. "
                                                                             "Please check the value index for "
-                                                           << context.fromData->getName());
-  PRECICE_CHECK(context.toData->getDimensions() == _dimensions,
-                "You cannot call readVectorData on the scalar data type \"" << context.toData->getName()
+                                                           << data.getName());
+  PRECICE_CHECK(data.getDimensions() == _dimensions,
+                "You cannot call readVectorData on the scalar data type \"" << data.getName()
                                                                             << "\". Use readScalarData or change the data type for \""
-                                                                            << context.fromData->getName() << "\" to vector.");
-  PRECICE_ASSERT(context.fromData);
-  auto &values = context.toData->values();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / context.fromData->getDimensions(), "Value index out of range. Please check that the valueIndex for "
-                                                                                                       << context.fromData->getName() << " is in the correct range.");
+                                                                            << data.getName() << "\" to vector.");
+  auto &values = data.values();
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / data.getDimensions(), "Value index out of range. Please check that the valueIndex for "
+                                                                                          << data.getName() << " is in the correct range.");
   int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     value[dim] = values[offset + dim];
@@ -1224,55 +1230,57 @@ void SolverInterfaceImpl::readVectorData(
 }
 
 void SolverInterfaceImpl::readBlockScalarData(
-    int        toDataID,
+    int        dataID,
     int        size,
     const int *valueIndices,
     double *   values) const
 {
-  PRECICE_TRACE(toDataID, size);
+  PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockScalarData(...) cannot be called after finalize().");
-  PRECICE_VALIDATE_DATA_ID(toDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
   if (size == 0)
     return;
   PRECICE_DEBUG("size = " << size);
   PRECICE_ASSERT(valueIndices != nullptr);
   PRECICE_ASSERT(values != nullptr);
-  PRECICE_REQUIRE_DATA_READ(toDataID);
-  DataContext &context = _accessor->dataContext(toDataID);
-  PRECICE_CHECK(context.toData->getDimensions() == 1,
-                "You cannot call readBlockScalarData on the vector data type \"" << context.toData->getName()
-                                                                                 << "\". Use readBlockVectorData or change the data type for \"" << context.fromData->getName() << "\" to scalar.");
-  PRECICE_ASSERT(context.fromData.get() != nullptr);
-  auto &valuesInternal = context.toData->values();
+  PRECICE_REQUIRE_DATA_READ(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.toData != nullptr);
+  mesh::Data &data = *context.toData;
+  PRECICE_CHECK(data.getDimensions() == 1,
+                "You cannot call readBlockScalarData on the vector data type \"" << data.getName()
+                                                                                 << "\". Use readBlockVectorData or change the data type for \"" << data.getName() << "\" to scalar.");
+  auto &valuesInternal = data.values();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
     PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size(), "Value index out of range. Please check that the size of "
-                                                                             << context.fromData->getName() << " is correct.");
+                                                                             << data.getName() << " is correct.");
     values[i] = valuesInternal[valueIndex];
   }
 }
 
 void SolverInterfaceImpl::readScalarData(
-    int     toDataID,
+    int     dataID,
     int     valueIndex,
     double &value) const
 {
-  PRECICE_TRACE(toDataID, valueIndex, value);
+  PRECICE_TRACE(dataID, valueIndex, value);
   PRECICE_CHECK(_state != State::Finalized, "readScalarData(...) cannot be called after finalize().");
-  PRECICE_VALIDATE_DATA_ID(toDataID);
-  PRECICE_REQUIRE_DATA_READ(toDataID);
-  DataContext &context = _accessor->dataContext(toDataID);
+  PRECICE_VALIDATE_DATA_ID(dataID);
+  PRECICE_REQUIRE_DATA_READ(dataID);
+  DataContext &context = _accessor->dataContext(dataID);
+  PRECICE_ASSERT(context.toData != nullptr);
+  mesh::Data &data = *context.toData;
   PRECICE_CHECK(valueIndex >= -1, "Invalid value index ( " << valueIndex << " ) when reading scalar data. Value index must be >= 0. "
                                                                             "Please check the value index for "
-                                                           << context.fromData->getName());
-  PRECICE_CHECK(context.toData->getDimensions() == 1,
-                "You cannot call readScalarData on the vector data type \"" << context.toData->getName()
+                                                           << data.getName());
+  PRECICE_CHECK(data.getDimensions() == 1,
+                "You cannot call readScalarData on the vector data type \"" << data.getName()
                                                                             << "\". Use readVectorData or change the data type for \""
-                                                                            << context.fromData->getName() << "\" to scalar.");
-  PRECICE_ASSERT(context.fromData);
-  auto &values = context.toData->values();
+                                                                            << data.getName() << "\" to scalar.");
+  auto &values = data.values();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size(), "Value index out of range. Please check that the valueIndex for "
-                                                                   << context.fromData->getName() << " is in the correct range.");
+                                                                   << data.getName() << " is in the correct range.");
   value = values[valueIndex];
   PRECICE_DEBUG("Read value = " << value);
 }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1071,8 +1071,7 @@ void SolverInterfaceImpl::writeBlockVectorData(
   const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
-                                                                   << data.getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot write data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
     int offsetInternal = valueIndex * _dimensions;
     int offset         = i * _dimensions;
     for (int dim = 0; dim < _dimensions; dim++) {
@@ -1102,8 +1101,7 @@ void SolverInterfaceImpl::writeVectorData(
                                                                              << data.getName() << "\" to vector.");
   auto &     values      = data.values();
   const auto vertexCount = values.size() / data.getDimensions();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the valueIndex for "
-                                                                 << data.getName() << " is in the correct range.");
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot write data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
   int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     values[offset + dim] = value[dim];
@@ -1135,8 +1133,7 @@ void SolverInterfaceImpl::writeBlockScalarData(
   const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
-                                                                   << data.getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot write data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
     valuesInternal[valueIndex] = values[i];
   }
 }
@@ -1161,10 +1158,9 @@ void SolverInterfaceImpl::writeScalarData(
                                                                              << "\". Use writeVectorData or change the data type for \""
                                                                              << data.getName() << "\" to scalar.");
   auto &     values      = data.values();
-  const auto vertexCount = values.size() / data.getDimensions()
-                                               PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the valueIndex for "
-                                                                                                              << data.getName() << " is in the correct range.")
-                                                   values[valueIndex] = value;
+  const auto vertexCount = values.size() / data.getDimensions();
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot write data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
+  values[valueIndex] = value;
 }
 
 void SolverInterfaceImpl::readBlockVectorData(
@@ -1192,8 +1188,7 @@ void SolverInterfaceImpl::readBlockVectorData(
   const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
-                                                                   << data.getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot read data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
     int offsetInternal = valueIndex * _dimensions;
     int offset         = i * _dimensions;
     for (int dim = 0; dim < _dimensions; dim++) {
@@ -1223,8 +1218,7 @@ void SolverInterfaceImpl::readVectorData(
                                                                             << data.getName() << "\" to vector.");
   auto &     values      = data.values();
   const auto vertexCount = values.size() / data.getDimensions();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the valueIndex for "
-                                                                 << data.getName() << " is in the correct range.");
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot read data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
   int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     value[dim] = values[offset + dim];
@@ -1257,8 +1251,7 @@ void SolverInterfaceImpl::readBlockScalarData(
   const auto vertexCount    = valuesInternal.size();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
-                                                                   << data.getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot read data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
     values[i] = valuesInternal[valueIndex];
   }
 }
@@ -1282,9 +1275,9 @@ void SolverInterfaceImpl::readScalarData(
                 "You cannot call readScalarData on the vector data type \"" << data.getName()
                                                                             << "\". Use readVectorData or change the data type for \""
                                                                             << data.getName() << "\" to scalar.");
-  auto &values = data.values();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size(), "Value index out of range. Please check that the valueIndex for "
-                                                                   << data.getName() << " is in the correct range.");
+  auto &     values      = data.values();
+  const auto vertexCount = values.size();
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Cannot read data \"" << data.getName() << "\" to invalid Vertex ID (" << valueIndex << "). Please make sure you only use the results from calls to setMeshVertex/Vertices().");
   value = values[valueIndex];
   PRECICE_DEBUG("Read value = " << value);
 }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1067,11 +1067,12 @@ void SolverInterfaceImpl::writeBlockVectorData(
                 "You cannot call writeBlockVectorData on the scalar data type \"" << data.getName()
                                                                                   << "\". Use writeBlockScalarData or change the data type for \""
                                                                                   << data.getName() << "\" to vector.");
-  auto &valuesInternal = data.values();
+  auto &     valuesInternal = data.values();
+  const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / data.getDimensions(), "Value index out of range. Please check that the size of "
-                                                                                                    << data.getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
+                                                                   << data.getName() << " is correct.");
     int offsetInternal = valueIndex * _dimensions;
     int offset         = i * _dimensions;
     for (int dim = 0; dim < _dimensions; dim++) {
@@ -1099,9 +1100,10 @@ void SolverInterfaceImpl::writeVectorData(
                 "You cannot call writeVectorData on the scalar data type \"" << data.getName()
                                                                              << "\". Use writeScalarData or change the data type for \""
                                                                              << data.getName() << "\" to vector.");
-  auto &values = data.values();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / data.getDimensions(), "Value index out of range. Please check that the valueIndex for "
-                                                                                          << data.getName() << " is in the correct range.");
+  auto &     values      = data.values();
+  const auto vertexCount = values.size() / data.getDimensions();
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the valueIndex for "
+                                                                 << data.getName() << " is in the correct range.");
   int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     values[offset + dim] = value[dim];
@@ -1129,12 +1131,12 @@ void SolverInterfaceImpl::writeBlockScalarData(
                 "You cannot call writeBlockScalarData on the vector data type \"" << data.getName()
                                                                                   << "\". Use writeBlockVectorData or change the data type for \""
                                                                                   << data.getName() << "\" to scalar.");
-  auto &valuesInternal = data.values();
+  auto &     valuesInternal = data.values();
+  const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / data.getDimensions(), "Value index out of range. Please check that the size of "
-                                                                                                    << data.getName() << " is correct.");
-    PRECICE_ASSERT(i < valuesInternal.size(), i, valuesInternal.size());
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
+                                                                   << data.getName() << " is correct.");
     valuesInternal[valueIndex] = values[i];
   }
 }
@@ -1158,10 +1160,11 @@ void SolverInterfaceImpl::writeScalarData(
                 "You cannot call writeScalarData on the vector data type \"" << data.getName()
                                                                              << "\". Use writeVectorData or change the data type for \""
                                                                              << data.getName() << "\" to scalar.");
-  auto &values = data.values();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / data.getDimensions(), "Value index out of range. Please check that the valueIndex for "
-                                                                                          << data.getName() << " is in the correct range.")
-  values[valueIndex] = value;
+  auto &     values      = data.values();
+  const auto vertexCount = values.size() / data.getDimensions()
+                                               PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the valueIndex for "
+                                                                                                              << data.getName() << " is in the correct range.")
+                                                   values[valueIndex] = value;
 }
 
 void SolverInterfaceImpl::readBlockVectorData(
@@ -1185,16 +1188,15 @@ void SolverInterfaceImpl::readBlockVectorData(
                 "You cannot call readBlockVectorData on the scalar data type \"" << data.getName()
                                                                                  << "\". Use readBlockScalarData or change the data type for \""
                                                                                  << data.getName() << "\" to vector.");
-  auto &valuesInternal = data.values();
+  auto &     valuesInternal = data.values();
+  const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size() / data.getDimensions(), "Value index out of range. Please check that the size of "
-                                                                                                    << data.getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
+                                                                   << data.getName() << " is correct.");
     int offsetInternal = valueIndex * _dimensions;
     int offset         = i * _dimensions;
     for (int dim = 0; dim < _dimensions; dim++) {
-      PRECICE_ASSERT(offsetInternal + dim < valuesInternal.size(),
-                     offsetInternal + dim, valuesInternal.size());
       values[offset + dim] = valuesInternal[offsetInternal + dim];
     }
   }
@@ -1219,9 +1221,10 @@ void SolverInterfaceImpl::readVectorData(
                 "You cannot call readVectorData on the scalar data type \"" << data.getName()
                                                                             << "\". Use readScalarData or change the data type for \""
                                                                             << data.getName() << "\" to vector.");
-  auto &values = data.values();
-  PRECICE_CHECK(0 <= valueIndex && valueIndex < values.size() / data.getDimensions(), "Value index out of range. Please check that the valueIndex for "
-                                                                                          << data.getName() << " is in the correct range.");
+  auto &     values      = data.values();
+  const auto vertexCount = values.size() / data.getDimensions();
+  PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the valueIndex for "
+                                                                 << data.getName() << " is in the correct range.");
   int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     value[dim] = values[offset + dim];
@@ -1250,11 +1253,12 @@ void SolverInterfaceImpl::readBlockScalarData(
   PRECICE_CHECK(data.getDimensions() == 1,
                 "You cannot call readBlockScalarData on the vector data type \"" << data.getName()
                                                                                  << "\". Use readBlockVectorData or change the data type for \"" << data.getName() << "\" to scalar.");
-  auto &valuesInternal = data.values();
+  auto &     valuesInternal = data.values();
+  const auto vertexCount    = valuesInternal.size();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
-    PRECICE_CHECK(0 <= valueIndex && valueIndex < valuesInternal.size(), "Value index out of range. Please check that the size of "
-                                                                             << data.getName() << " is correct.");
+    PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount, "Value index out of range. Please check that the size of "
+                                                                   << data.getName() << " is correct.");
     values[i] = valuesInternal[valueIndex];
   }
 }


### PR DESCRIPTION

**List the core changes of this PR**

- Unify and correct the data context access
  Accessor functions now extract and check the DataContext as well as its to/fromData and finally provide a `mesh::Data& data`.
  This allows to keep the remaining code short, clean and consistent.
- Refactor checks conditions to create a uniform look. This should simplify the refactoring of the solverinterface in the future.
- Reword index-related checks in the solverinterface from  
  `Error: Value index out of range. Please check that the size of dataOne is correct.` to  
  `Error: Cannot read data "dataOne" from invalid Vertex ID (42). Please make sure you only use the results from calls to setMeshVertex/Vertices().`

**Motivation**

The implementations now have a uniform look and there is no confusion of which data to use.

**Additional Information**

Related to #929
