### PR TITLE
Update wiki/documentation references to precice.org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/hotfix_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix_pull_request_template.md
@@ -27,7 +27,10 @@ Only the release manager should update this post (even tickboxes, due to race co
 * [ ] Fix potential problems in the hotfix branch (all)
 * [ ] Draft message to mailing list
 * [ ] Update documentation (all)
-  * [ ] Update markdown configuration reference in wiki
+   * [ ] Update [XML configuration reference](https://github.com/precice/precice.github.io/blob/master/_includes/xmlreference.md)
+   * [ ] Update version in [precice/precice.github.io](https://github.com/precice/precice.github.io):
+      * `_config.yml`
+      * `_data/sidebars/docs_sidebar.yml`
 * [ ] Approve the PR with at least two reviews (all)
 * [ ] Merge PR to master ( use `git merge --no-ff hotfix-N` )
 * [ ] Tag hotfix on master `vN` and verify by running `git describe --tags`

--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -81,6 +81,9 @@ Run all these tests manually on your system. If you succeed, please write a comm
 
 ## Post-release
 
+* [ ] Update version in the website:
+   * `_config.yml`
+   * `_data/sidebars/docs_sidebar.yml`
 * [ ] Update Arch Linux AUR Package
 * [ ] Update Spack recipe
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -12,7 +12,7 @@ Only the release manager should update this post (even tickboxes, due to race co
    * Extract summary
    * Fix wording and tense
    * Sort the entries lexicographically
-* [ ] Look over the [Roadmap](https://github.com/precice/precice/wiki/Roadmap) and update entries.
+* [ ] Look over the [Roadmap](https://www.precice.org/fundamentals-roadmap.html) and update entries.
 * [ ] Merge master to develop (No commits after the release on master)
 * [ ] Check code base w.r.t code formatting (run [`precice/tools/formatting/check-format`](https://github.com/precice/precice/blob/develop/tools/formatting/check-format)) and reformat if required (run [`precice/tools/formatting/format-all`](https://github.com/precice/precice/blob/develop/tools/formatting/format-all))
 * [ ] Create branch `release-N` from develop. If needed, `git rebase develop`.
@@ -30,7 +30,10 @@ Only the release manager should update this post (even tickboxes, due to race co
 * [ ] Draft message to mailing list
 * [ ] Write a draft "blog post" on [Discourse](https://precice.discourse.group/)
 * [ ] Update documentation (all)
-  * [ ] Update markdown configuration reference in wiki
+   * [ ] Update [XML configuration reference](https://github.com/precice/precice.github.io/blob/master/_includes/xmlreference.md)
+   * [ ] Update version in [precice/precice.github.io](https://github.com/precice/precice.github.io):
+      * `_config.yml`
+      * `_data/sidebars/docs_sidebar.yml`
 * [ ] Approve the PR with at least two reviews (all)
 * [ ] Merge PR to master ( use `git merge --no-ff release-N` )
 * [ ] Tag release on master `vN` and verify by running `git describe --tags`
@@ -81,9 +84,6 @@ Run all these tests manually on your system. If you succeed, please write a comm
 
 ## Post-release
 
-* [ ] Update version in the website:
-   * `_config.yml`
-   * `_data/sidebars/docs_sidebar.yml`
 * [ ] Update Arch Linux AUR Package
 * [ ] Update Spack recipe
 
@@ -125,7 +125,7 @@ Run all these tests manually on your system. If you succeed, please write a comm
 * [ ] Post on [Twitter](https://twitter.com/preCICE_org) (additionally to the automatic)
 * [ ] Post on [ResearchGate](https://www.researchgate.net/project/preCICE)
 * [ ] Post on LinkedIn (individuals)
-* [ ] Submit a short article to the [Quartl](https://www5.in.tum.de/wiki/index.php/Quartl)
+* [ ] Submit a short article to the [Quartl](https://www.in.tum.de/en/i05/further-activities/quartl/)
 
 
 ### Misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # preCICE Change Log
 
-All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://github.com/precice/precice/wiki/Roadmap).
+All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://www.precice.org/fundamentals-roadmap.html).
 
 ## 2.1.1
 

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
      In order for us to be able to help you more effectively, please also try to include (wherever appropriate):
      * The complete log files or as much as you have available.
        For more informative errors, you may use the logging functionality of preCICE:
-       https://github.com/precice/precice/wiki/Logging
+       https://www.precice.org/configuration-logging.html
      * Any relevant solver configuration
      * Your preCICE version or commit number
      * Information about your platform/OS and dependecies (e.g. MPI implementation and version, PETSc, Boost etc)

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@
 
 preCICE stands for Precise Code Interaction Coupling Environment. Its main component is a library that can be used by simulation programs to be coupled together in a partitioned way, enabling multi-physics simulations, such as fluid-structure interaction.
 
-If you are new to preCICE, please have a look at our [wiki (documentation)](https://github.com/precice/precice/wiki) and at [precice.org](https://www.precice.org). You may also prefer to [get and install a binary package for the latest release](https://github.com/precice/precice/releases/latest) ([master branch](https://github.com/precice/precice/tree/master)).
+If you are new to preCICE, please have a look at our [documentation](https://www.precice.org/docs.html) and at [precice.org](https://www.precice.org). You may also prefer to [get and install a binary package for the latest release](https://github.com/precice/precice/releases/latest) ([master branch](https://github.com/precice/precice/tree/master)).
 
 <div align="center" style="margin-bottom:30px">
 <img src="https://www.precice.org/assets/precice_overview.png" alt="preCICE overview" style="max-height: 100%; max-width: 100%">

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ preCICE stands for Precise Code Interaction Coupling Environment. Its main compo
 If you are new to preCICE, please have a look at our [documentation](https://www.precice.org/docs.html) and at [precice.org](https://www.precice.org). You may also prefer to [get and install a binary package for the latest release](https://github.com/precice/precice/releases/latest) ([master branch](https://github.com/precice/precice/tree/master)).
 
 <div align="center" style="margin-bottom:30px">
-<img src="https://www.precice.org/assets/precice_overview.png" alt="preCICE overview" style="max-height: 100%; max-width: 100%">
+<img src="https://www.precice.org/material/overview/preCICE_overview.png" alt="preCICE overview" style="max-height: 100%; max-width: 100%">
 </div>
 
 preCICE is an academic project, developed at the [Technical University of Munich](https://www5.in.tum.de/) and at the [University of Stuttgart](https://www.ipvs.uni-stuttgart.de/). If you use preCICE, please [cite us](https://www.precice.org/publications/):

--- a/docs/documents/000_main.dox
+++ b/docs/documents/000_main.dox
@@ -4,7 +4,7 @@
 
 # For Adapter Developers
 
-Please refer to the github wiki and the documentation of the \ref precice::SolverInterface SolverInterface.
+Please refer to the documentation on precice.org and to the documentation of the \ref precice::SolverInterface SolverInterface.
 
 # For Library Developers
 

--- a/docs/documents/050_tests.dox
+++ b/docs/documents/050_tests.dox
@@ -50,6 +50,6 @@ BOOST_AUTO_TEST_SUITE_END()
 FAQ
 ---
 - **How can I setup/tearDown a test case?** Use [fixtures](http://www.boost.org/doc/libs/1_65_1/libs/test/doc/html/boost_test/tests_organization/fixtures.html) and attach them to a test suite or case
-- **How to configure logging for the tests?** Use a file ```log.conf``` as described in [Logging](https://github.com/precice/precice/wiki/Logging).
+- **How to configure logging for the tests?** Use a file ```log.conf``` as described in [Logging](https://www.precice.org/configuration-logging.html).
 
 */

--- a/docs/documents/README.md
+++ b/docs/documents/README.md
@@ -1,2 +1,2 @@
 This folder contains documentation for developers only.
-For user documentation, consider our [wiki](https://github.com/precice/precice/wiki).
+For user documentation, refer to our [website](https://www.precice.org/docs.html).

--- a/examples/solverdummies/c/README.md
+++ b/examples/solverdummies/c/README.md
@@ -2,7 +2,7 @@
 
 ## With CMake
 
-**preCICE has to be installed using the provided binaries or built using CMake! Otherwise this approach does not work. For more information refer to [our wiki](https://github.com/precice/precice/wiki/Get-preCICE)**
+**preCICE has to be installed using the provided binaries or built using CMake! Otherwise this approach does not work. For more information refer to [our documentation](https://www.precice.org/docs.html)**
 
 You can use the provided `CMakeLists.txt` to build with CMake.
 
@@ -18,4 +18,4 @@ You can test the dummy solver by coupling two instances with each other. Open tw
 
 # Next Steps
 
-If you want to couple any other solver against the dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://github.com/precice/precice/wiki/Adapter-Example).
+If you want to couple any other solver against the dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://www.precice.org/couple-your-code-overview.html).

--- a/examples/solverdummies/cpp/README.md
+++ b/examples/solverdummies/cpp/README.md
@@ -2,7 +2,7 @@
 
 ## With CMake
 
-**preCICE has to be installed using the provided binaries or built using CMake! Otherwise this approach does not work. For more information refer to [our wiki](https://github.com/precice/precice/wiki/Get-preCICE)**
+**preCICE has to be installed using the provided binaries or built using CMake! Otherwise this approach does not work. For more information refer to [our documentation](https://www.precice.org/docs.html)**
 
 You can use the provided `CMakeLists.txt` to build with CMake.
 
@@ -20,4 +20,4 @@ You can test the dummy solver by coupling two instances with each other. Open tw
 
 # Next Steps
 
-If you want to couple any other solver against the dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://github.com/precice/precice/wiki/Adapter-Example).
+If you want to couple any other solver against the dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://www.precice.org/couple-your-code-overview.html).

--- a/examples/solverdummies/fortran/README.md
+++ b/examples/solverdummies/fortran/README.md
@@ -1,6 +1,6 @@
 # Compilation
 
-**preCICE has to be installed using the provided binaries or built using CMake! Otherwise this approach does not work. For more information refer to [our wiki](https://github.com/precice/precice/wiki/Get-preCICE)**
+**preCICE has to be installed using the provided binaries or built using CMake! Otherwise this approach does not work. For more information refer to [our documentation](https://www.precice.org/docs.html)**
 
 You can use the provided `CMakeLists.txt` to build with CMake.
 
@@ -15,4 +15,4 @@ You can test the dummy solver by coupling two instances with each other. Open tw
 
 # Next Steps
 
-If you want to couple any other solver against the dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://github.com/precice/precice/wiki/Adapter-Example).
+If you want to couple any other solver against the dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://www.precice.org/couple-your-code-overview.html).

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -31,7 +31,7 @@ public:
  * @param[in] validDigits valid digits for computation of the remainder of a time window
  * @param[in] localParticipant Name of participant using this coupling scheme.
  * @param[in] m2ns M2N communications to all other participants of coupling scheme.
- * @param[in] dtMethod Method used for determining the time window size, see https://github.com/precice/precice/wiki/Adapter's-Time-Step-Sizes
+ * @param[in] dtMethod Method used for determining the time window size, see https://www.precice.org/couple-your-code-timestep-sizes.html
  * @param[in] maxIterations maximum number of coupling sub-iterations allowed.
  */
   MultiCouplingScheme(

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -30,7 +30,7 @@ public:
    * @param[in] secondParticipant Name of second participant in coupling.
    * @param[in] localParticipant Name of participant using this coupling scheme.
    * @param[in] m2n Communication object for com. between participants.
-   * @param[in] dtMethod Method used for determining the time window size, see https://github.com/precice/precice/wiki/Adapter's-Time-Step-Sizes
+   * @param[in] dtMethod Method used for determining the time window size, see https://www.precice.org/couple-your-code-timestep-sizes.html
    * @param[in] cplMode Set implicit or explicit coupling
    * @param[in] maxIterations maximum number of coupling iterations allowed for implicit coupling per time window
    */

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -29,7 +29,7 @@ public:
  * @param[in] secondParticipant Name of second participant in coupling.
  * @param[in] localParticipant Name of participant using this coupling scheme.
  * @param[in] m2n Communication object for com. between participants.
- * @param[in] dtMethod Method used for determining the time window size, see https://github.com/precice/precice/wiki/Adapter's-Time-Step-Sizes
+ * @param[in] dtMethod Method used for determining the time window size, see https://www.precice.org/couple-your-code-timestep-sizes.html
  * @param[in] cplMode Set implicit or explicit coupling
  * @param[in] maxIterations maximum number of coupling iterations allowed for implicit coupling per time window
  */

--- a/tools/releasing/packaging/README.txt
+++ b/tools/releasing/packaging/README.txt
@@ -2,9 +2,9 @@ preCICE stands for Precise Code Interaction Coupling Environment.
 
 Its main component is a library that can be used by simulation programs to be coupled together in a partitioned way, enabling multi-physics simulations, such as fluid-structure interaction.
 
-If you are new to preCICE, please have a look at our wiki https://github.com/precice/precice/wiki and at precice.org https://www.precice.org.
+If you are new to preCICE, please have a look at our documentation https://www.precice.org/docs.html.
 
-preCICE is an academic project, developed at the Technical University of Munich https://www5.in.tum.de/, the University of Stuttgart https://www.ipvs.uni-stuttgart.de/, and the EIndhoven University of Technology https://www.tue.nl/en/research/research-groups/energy-technology/.
+preCICE is an academic project, developed at the Technical University of Munich https://www.in.tum.de/en/i05/home/, the University of Stuttgart https://www.ipvs.uni-stuttgart.de/, and the Eindhoven University of Technology https://www.tue.nl/en/research/research-groups/energy-technology/.
 
 If you use preCICE, please cite us!
 For a selection of publications please visit https://www.precice.org/publications/.

--- a/tools/releasing/packaging/README.txt
+++ b/tools/releasing/packaging/README.txt
@@ -4,7 +4,7 @@ Its main component is a library that can be used by simulation programs to be co
 
 If you are new to preCICE, please have a look at our documentation https://www.precice.org/docs.html.
 
-preCICE is an academic project, developed at the Technical University of Munich https://www.in.tum.de/en/i05/home/, the University of Stuttgart https://www.ipvs.uni-stuttgart.de/, and the Eindhoven University of Technology https://www.tue.nl/en/research/research-groups/energy-technology/.
+preCICE is an academic project, developed at the Technical University of Munich https://www.in.tum.de/en/i05/home/ and the University of Stuttgart https://www.ipvs.uni-stuttgart.de/.
 
 If you use preCICE, please cite us!
 For a selection of publications please visit https://www.precice.org/publications/.


### PR DESCRIPTION
We moved our documentation from GitHub wikis to our redesigned website on https://www.precice.org/docs.html.

This updates references to "wiki" to pages in the new documentation, as well as the PR templates to update the version on the website (two places at the moment).

@uekerman Have I forgotten anything / should I search for anything else than "wiki"? Also, in `tools/releasing/packaging/README.txt` you may at the same time want to update the Eindhoven reference to the new Stuttgart group.