### PR TITLE
Remove a user-side reference to PRECICE_ROOT

### DIFF
--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -1,6 +1,3 @@
-// To compile use:
-// mpic++ -I$PRECICE_ROOT/src main.cpp -lprecice -o solverdummy
-
 #include <iostream>
 #include <sstream>
 #include "precice/SolverInterface.hpp"


### PR DESCRIPTION
In our `solverdummy.cpp`, there is currently a comment leading the user to use `PRECICE_ROOT` to build the code. This is contradictory to the instructions we give at the `README.md` of the solver dummy and has already confused one user that looked at the `.cpp` first.

I checked the rest of the repostiory and I could not find any user-side references to `PRECICE_ROOT`.