### PR TITLE
Remove obsolete trigger solver plot option

### DIFF
--- a/docs/changelog/939.md
+++ b/docs/changelog/939.md
@@ -1,0 +1,1 @@
+- Removed obsolete `trigger-solver-plot` config option.

--- a/src/io/ExportContext.hpp
+++ b/src/io/ExportContext.hpp
@@ -17,9 +17,6 @@ struct ExportContext {
   // @brief Exporting every N time windows (equals -1 when not set).
   int everyNTimeWindows;
 
-  // @brief Flag for synchronuous triggering of solver plots.
-  bool triggerSolverPlot;
-
   // @brief If true, export is done in every iteration (also implicit).
   bool everyIteration;
 
@@ -36,7 +33,6 @@ struct ExportContext {
       : exporter(),
         location(),
         everyNTimeWindows(-1),
-        triggerSolverPlot(false),
         everyIteration(false),
         type(),
         plotNormals(false) {}

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -24,11 +24,6 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
   auto attrEveryNTimeWindows = makeXMLAttribute(ATTR_EVERY_N_TIME_WINDOWS, 1)
                                    .setDocumentation("preCICE does an export every X time windows. Choose -1 for no exports.");
 
-  auto attrTriggerSolver = makeXMLAttribute(ATTR_TRIGGER_SOLVER, false)
-                               .setDocumentation(
-                                   std::string("If set to on/yes, an action requirement is set for the participant ") +
-                                   "with frequency defined by attribute " + ATTR_EVERY_N_TIME_WINDOWS + ".");
-
   auto attrNormals = makeXMLAttribute(ATTR_NORMALS, true)
                          .setDocumentation("If set to on/yes, mesh normals (if available) are added to the export.");
 
@@ -38,7 +33,6 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
   for (XMLTag &tag : tags) {
     tag.addAttribute(attrLocation);
     tag.addAttribute(attrEveryNTimeWindows);
-    tag.addAttribute(attrTriggerSolver);
     tag.addAttribute(attrNormals);
     tag.addAttribute(attrEveryIteration);
     parent.addSubtag(tag);
@@ -52,7 +46,6 @@ void ExportConfiguration::xmlTagCallback(
   if (tag.getNamespace() == TAG) {
     ExportContext econtext;
     econtext.location          = tag.getStringAttributeValue(ATTR_LOCATION);
-    econtext.triggerSolverPlot = tag.getBooleanAttributeValue(ATTR_TRIGGER_SOLVER);
     econtext.everyNTimeWindows = tag.getIntAttributeValue(ATTR_EVERY_N_TIME_WINDOWS);
     econtext.plotNormals       = tag.getBooleanAttributeValue(ATTR_NORMALS);
     econtext.everyIteration    = tag.getBooleanAttributeValue(ATTR_EVERY_ITERATION);

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -46,7 +46,6 @@ private:
 
   const std::string ATTR_EVERY_N_TIME_WINDOWS = "every-n-time-windows";
   const std::string ATTR_NEIGHBORS            = "neighbors";
-  const std::string ATTR_TRIGGER_SOLVER       = "trigger-solver";
   const std::string ATTR_NORMALS              = "normals";
   const std::string ATTR_EVERY_ITERATION      = "every-iteration";
 

--- a/src/io/tests/ExportConfigurationTest.cpp
+++ b/src/io/tests/ExportConfigurationTest.cpp
@@ -23,7 +23,6 @@ BOOST_AUTO_TEST_CASE(Configuration)
     const io::ExportContext &context = config.exportContexts().front();
     BOOST_TEST(context.type == "vtk");
     BOOST_TEST(context.everyNTimeWindows == 10);
-    BOOST_TEST(context.triggerSolverPlot);
   }
   {
     tag.clear();
@@ -34,7 +33,6 @@ BOOST_AUTO_TEST_CASE(Configuration)
     BOOST_TEST(context.type == "vtk");
     BOOST_TEST(context.everyNTimeWindows == 1);
     BOOST_TEST(context.location == "somepath");
-    BOOST_TEST(not context.triggerSolverPlot);
   }
 }
 

--- a/src/io/tests/config1.xml
+++ b/src/io/tests/config1.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
-  <export:vtk every-n-time-windows="10" trigger-solver="on" normals="on" directory="./" />
+  <export:vtk every-n-time-windows="10" normals="on" directory="./" />
 </configuration>

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -358,9 +358,6 @@ void SolverInterfaceImpl::initializeData()
       std::ostringstream suffix;
       suffix << _accessorName << ".init";
       exportMesh(suffix.str());
-      if (context.triggerSolverPlot) {
-        _couplingScheme->requireAction(std::string("plot-output"));
-      }
     }
   }
   solverInitEvent.start(precice::syncMode);
@@ -470,9 +467,6 @@ void SolverInterfaceImpl::finalize()
         std::ostringstream suffix;
         suffix << _accessorName << ".final";
         exportMesh(suffix.str());
-        if (context.triggerSolverPlot) {
-          _couplingScheme->requireAction(std::string("plot-output"));
-        }
       }
     }
     // Apply some final ping-pong to synch solver that run e.g. with a uni-directional coupling only
@@ -1586,9 +1580,6 @@ void SolverInterfaceImpl::handleExports()
           std::ostringstream suffix;
           suffix << _accessorName << ".dt" << _couplingScheme->getTimeWindows() - 1;
           exportMesh(suffix.str());
-          if (context.triggerSolverPlot) {
-            _couplingScheme->requireAction(std::string("plot-output"));
-          }
         }
       }
     }


### PR DESCRIPTION
* closes #407 
* was a left-over TODO from #395, was still configurable, but not reachable through the `isActionRequired` interface (if you didn't guess the correct name by accident)