### PR TITLE
Deprecate API method getMeshIDs

### DIFF
--- a/docs/940.md
+++ b/docs/940.md
@@ -1,1 +1,1 @@
-- Deprecated API method `getMeshIDs`. Call `getMeshID` for each `meshName` instead. This method will be removed in a future release.
+- Deprecated API method `getMeshIDs`. Call `getMeshID` for specific mesh names instead. This method will be removed in a future release.

--- a/docs/940.md
+++ b/docs/940.md
@@ -1,0 +1,1 @@
+- Deprecated API method `getMeshIDs`. Call `getMeshID` for each `meshName` instead. This method will be removed in a future release.

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -89,7 +89,7 @@ void precicef_get_dims_(int *dimensions);
 /**
  * @brief See precice::SolverInterface::isOngoing().
  *
- * Deprecated - Forwards to precicef_is_coupling_ongoing_
+ * @deprecated Forwards to precicef_is_coupling_ongoing_
  *
  * Fortran syntax:
  * precicef_ongoing( INTEGER isOngoing )
@@ -97,7 +97,7 @@ void precicef_get_dims_(int *dimensions);
  * IN:  -
  * OUT: isOngoing(1:true, 0:false)
  */
-void precicef_ongoing_(int *isOngoing);
+[[deprecated("Use precicef_is_coupling_ongoing_() instead.")]] void precicef_ongoing_(int *isOngoing);
 
 /**
  * @brief See precice::SolverInterface::isCouplingOngoing().
@@ -113,7 +113,7 @@ void precicef_is_coupling_ongoing_(int *isOngoing);
 /**
  * @brief See precice::SolverInterface::isWriteDataRequired().
  *
- * Deprecated - Forwards to precicef_is_write_data_required_
+ * @deprecated Forwards to precicef_is_write_data_required_
  *
  * Fortran syntax:
  * precicef_write_data_required(
@@ -123,7 +123,7 @@ void precicef_is_coupling_ongoing_(int *isOngoing);
  * IN:  computedTimestepLength
  * OUT: isRequired(1:true, 0:false)
  */
-void precicef_write_data_required_(
+[[deprecated("Use precicef_is_write_data_required_(...) with the same arguments instead.")]] void precicef_write_data_required_(
     const double *computedTimestepLength,
     int *         isRequired);
 
@@ -145,7 +145,7 @@ void precicef_is_write_data_required_(
 /**
  * @brief See precice::SolverInterface::isReadDataAvailable().
  *
- * Deprecated - Forwards to precicef_is_read_data_available_
+ * @deprecated Forwards to precicef_is_read_data_available_
  *
  * Fortran syntax:
  * precicef_read_data_available( INTEGER isAvailable );
@@ -153,7 +153,7 @@ void precicef_is_write_data_required_(
  * IN:  -
  * OUT: isAvailable(1:true, 0:false)
  */
-void precicef_read_data_available_(int *isAvailable);
+[[deprecated("Use precicef_is_read_data_available_() instead.")]] void precicef_read_data_available_(int *isAvailable);
 
 /**
  * @brief See precice::SolverInterface::isReadDataAvailable().
@@ -202,7 +202,7 @@ void precicef_has_to_evaluate_fine_model_(int *hasToEvaluate);
 /**
  * @brief See precice::SolverInterface::isActionRequired().
  *
- * Deprecated - Forwards to precicef_is_action_required_
+ * @deprecated Forwards to precicef_is_action_required_
  *
  * Fortran syntax:
  * precicef_action_required(
@@ -212,7 +212,7 @@ void precicef_has_to_evaluate_fine_model_(int *hasToEvaluate);
  * IN:  action
  * OUT: isRequired(1:true, 0:false)
  */
-void precicef_action_required_(
+[[deprecated("Use precicef_is_action_required_(...) with the same arguments instead.")]] void precicef_action_required_(
     const char *action,
     int *       isRequired,
     int         lengthAction);

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -347,8 +347,7 @@ public:
    * 
    * @returns the set of ids.
    */
-  [[deprecated("Use getMeshID() for each meshName instead.")]]
-  std::set<int> getMeshIDs() const;
+  [[deprecated("Use getMeshID() for each meshName instead.")]] std::set<int> getMeshIDs() const;
 
   /**
    * @brief Creates a mesh vertex

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -342,8 +342,12 @@ public:
   /**
    * @brief Returns a id-set of all used meshes by this participant.
    *
+   * @deprecated Unclear use case and difficult to port to other languages.
+   *             Prefer calling getMeshID for each meshName.
+   * 
    * @returns the set of ids.
    */
+  [[deprecated("Use getMeshID() for each meshName instead.")]]
   std::set<int> getMeshIDs() const;
 
   /**

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -343,11 +343,11 @@ public:
    * @brief Returns a id-set of all used meshes by this participant.
    *
    * @deprecated Unclear use case and difficult to port to other languages.
-   *             Prefer calling getMeshID for each meshName.
+   *             Prefer calling getMeshID for specific mesh names.
    * 
    * @returns the set of ids.
    */
-  [[deprecated("Use getMeshID() for each meshName instead.")]] std::set<int> getMeshIDs() const;
+  [[deprecated("Use getMeshID() for specific mesh names instead.")]] std::set<int> getMeshIDs() const;
 
   /**
    * @brief Creates a mesh vertex

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -257,7 +257,7 @@ public:
    *
    * @see hasToEvaluateFineModel()
    */
-  [[deprecated("The manifold mapping feature is currently not maintained.")]] bool hasToEvaluateSurrogateModel() const;
+  [[deprecated("The manifold mapping feature is no longer supported.")]] bool hasToEvaluateSurrogateModel() const;
 
   /**
    * @brief Checks if the solver has to evaluate the fine model representation.

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -272,7 +272,7 @@ public:
    *
    * @see hasToEvaluateSurrogateModel()
    */
-  [[deprecated("The manifold mapping feature is currently not maintained.")]] bool hasToEvaluateFineModel() const;
+  [[deprecated("The manifold mapping feature is no longer supported.")]] bool hasToEvaluateFineModel() const;
 
   ///@}
 

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -257,7 +257,7 @@ public:
    *
    * @see hasToEvaluateFineModel()
    */
-  bool hasToEvaluateSurrogateModel() const;
+  [[deprecated("The manifold mapping feature is currently not maintained.")]] bool hasToEvaluateSurrogateModel() const;
 
   /**
    * @brief Checks if the solver has to evaluate the fine model representation.
@@ -272,7 +272,7 @@ public:
    *
    * @see hasToEvaluateSurrogateModel()
    */
-  bool hasToEvaluateFineModel() const;
+  [[deprecated("The manifold mapping feature is currently not maintained.")]] bool hasToEvaluateFineModel() const;
 
   ///@}
 


### PR DESCRIPTION
This closes #821 by:
- Adding the C++14 `[[deprecated]]` attribute in the declaration of `getMeshIDs()`
- Marking the method deprecated for Doxygen

```c++
  /**
   * @brief Returns a id-set of all used meshes by this participant.
   *
   * @deprecated Unclear use case and difficult to port to other languages.
   *             Prefer calling getMeshID for each meshName.
   * 
   * @returns the set of ids.
   */
  [[deprecated("Use getMeshID() for each meshName instead.")]]
  std::set<int> getMeshIDs() const;
```

If used at a solver, compilation will stop with the following error (g++ 10.2, assuming `-Wdeprecated-declarations`):
```
solverdummy.cpp:30:59: warning: ‘std::set<int> precice::SolverInterface::getMeshIDs() const’ is deprecated: Use getMeshID() for each meshName instead. [-Wdeprecated-declarations]
   30 |   std::set<int>         meshID     = interface.getMeshIDs();
      |                                                           ^
```

~~I am not sure if we should mark this as a breaking change: if a user enables `-Wdeprecated-declarations` or all warnings, it will complain. But the feature is still there, it just needs a "yes, I want to use deprecated things" action.~~ This should only be a warning, so everything is fine.

To reviewers:
- [x] @fsimonis looking at the code, do we need to update anything else?
- [x] @fsimonis check the (coming in a minute) changelog entry.
- [ ] @MakisH squash before merging.