### PR TITLE
Clarify error message for checkIfDataIsExchanged

### DIFF
--- a/docs/941.md
+++ b/docs/941.md
@@ -1,0 +1,1 @@
+- Improved the error message for not exchanging data over the same mesh used for convergence measures.

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -757,13 +757,13 @@ mesh::PtrData CouplingSchemeConfiguration::getData(
                           << meshName << "\" is not configured.");
 }
 
-mesh::PtrData CouplingSchemeConfiguration::findDataByID(
+std::pair<mesh::PtrData, mesh::PtrMesh> CouplingSchemeConfiguration::findDataByID(
     int ID) const
 {
   for (mesh::PtrMesh mesh : _meshConfig->meshes()) {
     for (mesh::PtrData data : mesh->data()) {
       if (data->getID() == ID) {
-        return data;
+        return {data, mesh};
       }
     }
   }
@@ -1113,7 +1113,7 @@ void CouplingSchemeConfiguration::checkIfDataIsExchanged(
 
   PRECICE_ERROR("You need to exchange every data that you use for convergence measures "
                 << "and/or the iteration acceleration. Data \"" << dataName << "\" is "
-                << "currently not exchanged, but used for convergence measures and/or iteration "
+                << "currently not exchanged over the respective mesh on which it is used for convergence measures and/or iteration "
                 << "acceleration. Please check the <exchange ... /> and "
                 << "<...-convergence-measure ... /> tags in the "
                 << "<coupling-scheme:... /> of your precice-config.xml.");

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -757,13 +757,13 @@ mesh::PtrData CouplingSchemeConfiguration::getData(
                           << meshName << "\" is not configured.");
 }
 
-std::pair<mesh::PtrData, mesh::PtrMesh> CouplingSchemeConfiguration::findDataByID(
+mesh::PtrData CouplingSchemeConfiguration::findDataByID(
     int ID) const
 {
   for (mesh::PtrMesh mesh : _meshConfig->meshes()) {
     for (mesh::PtrData data : mesh->data()) {
       if (data->getID() == ID) {
-        return {data, mesh};
+        return data;
       }
     }
   }


### PR DESCRIPTION
Closes #842.

The error message is now much more helpful, as the user gets the hint to check which mesh the data is being exchanged through. I tried also exporting the exact names, but this information was not easy to extract (see issue) and decided to go with the simplest solution, which is already good enough.

Reviewers:
- [x] @uekerman Check if the meaning of the error message is clear and agrees with what the method is actually checking.
- [x] @uekerman Check if my (upcoming) changelog entry is fine.
- [ ] @MakisH squash before merging.