### PR TITLE
Fix type of exported VTK to double and precision to maximum needed

### DIFF
--- a/docs/942.md
+++ b/docs/942.md
@@ -1,0 +1,1 @@
+- Fixed the data type and precision in exported VTK files.

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -55,7 +55,7 @@ void ExportVTK::exportMesh(std::ofstream &outFile, mesh::Mesh const &mesh)
   PRECICE_TRACE(mesh.getName());
 
   // Plot vertices
-  outFile << "POINTS " << mesh.vertices().size() << " float \n\n";
+  outFile << "POINTS " << mesh.vertices().size() << " double \n\n";
   for (const mesh::Vertex &vertex : mesh.vertices()) {
     writeVertex(vertex.getCoords(), outFile);
   }
@@ -102,7 +102,7 @@ void ExportVTK::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
 
   if (_writeNormals) { // Plot vertex normals
-    outFile << "VECTORS VertexNormals float\n\n";
+    outFile << "VECTORS VertexNormals double\n\n";
     for (auto const &vertex : mesh.vertices()) {
       int i = 0;
       for (; i < mesh.getDimensions(); i++) {
@@ -136,7 +136,7 @@ void ExportVTK::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
     Eigen::VectorXd &values = data->values();
     if (data->getDimensions() > 1) {
       Eigen::VectorXd viewTemp(data->getDimensions());
-      outFile << "VECTORS " << data->getName() << " float\n";
+      outFile << "VECTORS " << data->getName() << " double\n";
       for (const mesh::Vertex &vertex : mesh.vertices()) {
         int offset = vertex.getID() * data->getDimensions();
         for (int i = 0; i < data->getDimensions(); i++) {
@@ -153,7 +153,7 @@ void ExportVTK::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
       }
       outFile << '\n';
     } else if (data->getDimensions() == 1) {
-      outFile << "SCALARS " << data->getName() << " float\n";
+      outFile << "SCALARS " << data->getName() << " double\n";
       outFile << "LOOKUP_TABLE default\n";
       for (const mesh::Vertex &vertex : mesh.vertices()) {
         outFile << values(vertex.getID()) << '\n';
@@ -172,7 +172,7 @@ void ExportVTK::initializeWriting(
   //}
   filestream.setf(std::ios::showpoint);
   filestream.setf(std::ios::scientific);
-  filestream << std::setprecision(16);
+  filestream << std::setprecision(std::numeric_limits<double>::max_digits10);
 }
 
 void ExportVTK::writeHeader(

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -90,7 +90,7 @@ void ExportVTKXML::writeMasterFile(
   outMasterFile << "   <PUnstructuredGrid GhostLevel=\"0\">\n";
 
   outMasterFile << "      <PPoints>\n";
-  outMasterFile << "         <PDataArray type=\"Float32\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>\n";
+  outMasterFile << "         <PDataArray type=\"Float64\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>\n";
   outMasterFile << "      </PPoints>\n";
 
   outMasterFile << "      <PCells>\n";
@@ -112,11 +112,11 @@ void ExportVTKXML::writeMasterFile(
   outMasterFile << "\">\n";
 
   for (size_t i = 0; i < _scalarDataNames.size(); ++i) {
-    outMasterFile << "         <PDataArray type=\"Float32\" Name=\"" << _scalarDataNames[i] << "\" NumberOfComponents=\"" << 1 << "\"/>\n";
+    outMasterFile << "         <PDataArray type=\"Float64\" Name=\"" << _scalarDataNames[i] << "\" NumberOfComponents=\"" << 1 << "\"/>\n";
   }
 
   for (size_t i = 0; i < _vectorDataNames.size(); ++i) {
-    outMasterFile << "         <PDataArray type=\"Float32\" Name=\"" << _vectorDataNames[i] << "\" NumberOfComponents=\"" << 3 << "\"/>\n";
+    outMasterFile << "         <PDataArray type=\"Float64\" Name=\"" << _vectorDataNames[i] << "\" NumberOfComponents=\"" << 3 << "\"/>\n";
   }
   outMasterFile << "      </PPointData>\n";
 
@@ -159,7 +159,7 @@ void ExportVTKXML::writeSubFile(
   outSubFile << "   <UnstructuredGrid>\n";
   outSubFile << "      <Piece NumberOfPoints=\"" << numPoints << "\" NumberOfCells=\"" << numCells << "\"> \n";
   outSubFile << "         <Points> \n";
-  outSubFile << "            <DataArray type=\"Float32\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\" format=\"ascii\"> \n";
+  outSubFile << "            <DataArray type=\"Float64\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\" format=\"ascii\"> \n";
   for (const mesh::Vertex &vertex : mesh.vertices()) {
     writeVertex(vertex.getCoords(), outSubFile);
   }
@@ -252,7 +252,7 @@ void ExportVTKXML::exportData(
   // Print VertexNormals
   if (_writeNormals) {
     const auto dimensions = mesh.getDimensions();
-    outFile << "            <DataArray type=\"Float32\" Name=\"VertexNormals\" NumberOfComponents=\"";
+    outFile << "            <DataArray type=\"Float64\" Name=\"VertexNormals\" NumberOfComponents=\"";
     outFile << std::max(3, dimensions) << "\" format=\"ascii\">\n";
     outFile << "               ";
     for (const auto &vertex : mesh.vertices()) {
@@ -274,7 +274,7 @@ void ExportVTKXML::exportData(
     int              dataDimensions = data->getDimensions();
     std::string      dataName(data->getName());
     int              numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
-    outFile << "            <DataArray type=\"Float32\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
+    outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
     outFile << "\" format=\"ascii\">\n";
     outFile << "               ";
     if (dataDimensions > 1) {


### PR DESCRIPTION
Closes #779.

Three main types of changes:
- Change type of data in legacy VTK from `float` to `double`:
   ```diff
   - outFile << "POINTS " << mesh.vertices().size() << " float \n\n";
   + outFile << "POINTS " << mesh.vertices().size() << " double \n\n";
   ```
- Change type of data in XML VTK from `Float32` to `Float64`:
   ```diff
   - outMasterFile << "         <PDataArray type=\"Float32\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>\n";
   + outMasterFile << "         <PDataArray type=\"Float64\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>\n";
   ```
- Change the precision of ASCII representation from 16 digits to the maximum needed for doubles:
   ```diff
   - filestream << std::setprecision(16);
   + filestream << std::setprecision(std::numeric_limits<double>::max_digits10);
   ```
   @fsimonis in #779 you mentioned 
   > the precision when writing is currently set fixed at 9 digits.
   
   I am not sure where you saw the 9 or if the code was different when you wrote the comment.
   
I changed the types based on a quick reading of [ lorensen/VTKExamples](https://lorensen.github.io/VTKExamples/site/VTKFileFormats/).

Here are two example legacy VTK files (I am not sure how to write XML):
- [before.vtk.txt](https://github.com/precice/precice/files/5827070/before.vtk.txt)
- [after.vtk.txt](https://github.com/precice/precice/files/5827071/after.vtk.txt)
ParaView 5.7.0 did not complain about neither of these files.

Reviewers:
- [x] @fsimonis does the produced file fulfill your wishes?
- [x] @fsimonis check my (upcoming) changelog entry.
- [ ] @MakisH squash before merging.