### PR TITLE
Add a log file to tests

### DIFF
--- a/docs/changelog/945.md
+++ b/docs/changelog/945.md
@@ -1,0 +1,1 @@
+- Added a verbose log file `test.all.log` to tests. Submitting this file alongside bug reports will significantly simplify debugging the tests.

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -79,9 +79,9 @@ bool init_unit_test()
     config.output = "test.log";
     logConfigs.push_back(config);
 
-    // The full log
-    config.output = "test.full.log";
-    config.filter = "";
+    // The full debug log
+    config.output = "test.debug.log";
+    config.filter = "%Severity% >= debug";
     logConfigs.push_back(config);
   }
 

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -65,14 +65,23 @@ bool init_unit_test()
 
     const std::string prefix{"%TimeStamp(format=\"%H:%M:%S.%f\")%|%Participant%|%Rank%|%Module%|l%Line%|%Function%|"};
 
+    // Console output
     config.format = prefix + "%ColorizedSeverity%%Message%";
     config.type   = "stream";
     config.output = "stdout";
     logConfigs.push_back(config);
 
+    // File Outputs
     config.format = prefix + "%Severity%%Message%";
     config.type   = "file";
+
+    // Same as console output
     config.output = "test.log";
+    logConfigs.push_back(config);
+
+    // The full log
+    config.output = "test.full.log";
+    config.filter = "";
     logConfigs.push_back(config);
   }
 


### PR DESCRIPTION
**List the core changes of this PR**

Add a verbose log-sink to the testrunner, which writes all log statements to the file`tests.all.log`.

**Motivation**

This file will contain the full story of the tests and can be submitted along a bug report.

**Additional Information**

Closes #848
