### PR TITLE
Improve error message and improve default setting for zero subvector

### DIFF
--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -46,21 +46,19 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
     }
     sum = std::sqrt(sum);
     if (math::equals(sum, 0.0)) {
-      PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum << 
-                    "). This indicates that the data values exchanged between two succesive iterations did not change."
-                    " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged"
-                    " between the solvers is not identical between iterations. The preconditioner scaling factors were"
-                    " not updated in this iteration and the scaling factors determined in the previous iteration were used.");
+      PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum << "). This indicates that the data values exchanged between two succesive iterations did not change."
+                                                                                                                         " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged"
+                                                                                                                         " between the solvers is not identical between iterations. The preconditioner scaling factors were"
+                                                                                                                         " not updated in this iteration and the scaling factors determined in the previous iteration were used.");
     }
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       _residualSum[k] += norms[k] / sum;
       if (math::equals(_residualSum[k], 0.0)) {
-        PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = " << _residualSum[k] << 
-                    "). If this occured in the second iteration and the initial-relaxation factor is equal to 1.0,"
-                    " check if the coupling data values of one solver is zero in the first iteration."
-                    " The preconditioner scaling factors were not updated for this iteration and the scaling factors"
-                    " determined in the previous iteration were used.");
+        PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = " << _residualSum[k] << "). If this occured in the second iteration and the initial-relaxation factor is equal to 1.0,"
+                                                                                                                                     " check if the coupling data values of one solver is zero in the first iteration."
+                                                                                                                                     " The preconditioner scaling factors were not updated for this iteration and the scaling factors"
+                                                                                                                                     " determined in the previous iteration were used.");
       }
     }
 

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -45,20 +45,41 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
       norms[k] = std::sqrt(norms[k]);
     }
     sum = std::sqrt(sum);
-    PRECICE_CHECK(not math::equals(sum, 0.0), "All residual sub-vectors in the residual-sum preconditioner are numerically zero. "
-                                              "Your simulation probably got unstable, e.g. produces NAN values.");
+    //PRECICE_CHECK(not math::equals(sum, 0.0), "All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum <<
+    //                                          "). This indicates that the data values exchanged between two succesive iterations did not change."
+    //                                          " Your simulation probably got unstable, e.g. produces NAN values. Please check the data values exchanged" 
+    //                                          " between the solvers.");
+    if (math::equals(sum, 0.0)) {
+      PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum <<
+                                              "). This indicates that the data values exchanged between two succesive iterations did not change."
+                                              " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged" 
+                                              " between the solvers is not identical between iterations.");
+    }
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       _residualSum[k] += norms[k] / sum;
-      PRECICE_CHECK(not math::equals(_residualSum[k], 0.0), "A sub-vector in the residual-sum preconditioner became numerically zero. "
-                                                            "Thus, the preconditioner is no longer stable. Please try the value preconditioner instead.");
+      //PRECICE_CHECK(not math::equals(_residualSum[k], 0.0), "A sub-vector in the residual-sum preconditioner became numerically zero ( residualSum = " << _residualSum[k] <<
+      //                                                      ") . If this occured during the first iteration, check that the initial-relaxation factor is not equal to 1.0"
+      //                                                      " if the coupling values of one solver is zero in the first iterations. "
+      //                                                      " . Please try freezing the preconditioner weights or the value preconditioner instead.");
+      if (math::equals(_residualSum[k], 0.0)) {
+        PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( residualSum = " << _residualSum[k] <<
+                                                            ") . If this occured directly after the second iteration, check that the initial-relaxation"
+                                                            " factor is not equal to 1.0 if the coupling values of one solver"
+                                                            " is zero in the first iteration."
+                                                            " Please try freezing the preconditioner weights when using residual-sum"
+                                                            " or use the value preconditioner instead.");
+      }
     }
 
     offset = 0;
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+      if (!math::equals(_residualSum[k], 0.0)){
       for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-        _weights[i + offset]    = 1 / _residualSum[k];
-        _invWeights[i + offset] = _residualSum[k];
+          _weights[i + offset]    = 1 / _residualSum[k];
+          _invWeights[i + offset] = _residualSum[k];
+        }
+        PRECICE_DEBUG("preconditioner weight[" << k << "] = " << 1 / _residualSum[k]);
       }
       offset += _subVectorSizes[k];
     }

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -46,30 +46,32 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
     }
     sum = std::sqrt(sum);
     if (math::equals(sum, 0.0)) {
-      PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum << "). This indicates that the data values exchanged between two succesive iterations did not change."
-                                                                                                                         " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged"
-                                                                                                                         " between the solvers is not identical between iterations.");
+      PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum << 
+                    "). This indicates that the data values exchanged between two succesive iterations did not change."
+                    " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged"
+                    " between the solvers is not identical between iterations. The preconditioner scaling factors were"
+                    " not updated in this iteration and the scaling factors determined in the previous iteration were used.");
     }
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       _residualSum[k] += norms[k] / sum;
       if (math::equals(_residualSum[k], 0.0)) {
-        PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( residualSum = " << _residualSum[k] << ") . If this occured directly after the second iteration, check that the initial-relaxation"
-                                                                                                                                      " factor is not equal to 1.0 if the coupling values of one solver"
-                                                                                                                                      " is zero in the first iteration."
-                                                                                                                                      " Please try freezing the preconditioner weights when using residual-sum"
-                                                                                                                                      " or use the value preconditioner instead.");
+        PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = " << _residualSum[k] << 
+                    "). If this occured in the second iteration and the initial-relaxation factor is equal to 1.0,"
+                    " check if the coupling data values of one solver is zero in the first iteration."
+                    " The preconditioner scaling factors were not updated for this iteration and the scaling factors"
+                    " determined in the previous iteration were used.");
       }
     }
 
     offset = 0;
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      if (!math::equals(_residualSum[k], 0.0)) {
+      if (not math::equals(_residualSum[k], 0.0)) {
         for (size_t i = 0; i < _subVectorSizes[k]; i++) {
           _weights[i + offset]    = 1 / _residualSum[k];
           _invWeights[i + offset] = _residualSum[k];
         }
-        PRECICE_DEBUG("preconditioner weight[" << k << "] = " << 1 / _residualSum[k]);
+        PRECICE_DEBUG("preconditioner scaling factor[" << k << "] = " << 1 / _residualSum[k]);
       }
       offset += _subVectorSizes[k];
     }

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -47,13 +47,12 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
     sum = std::sqrt(sum);
     //PRECICE_CHECK(not math::equals(sum, 0.0), "All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum <<
     //                                          "). This indicates that the data values exchanged between two succesive iterations did not change."
-    //                                          " Your simulation probably got unstable, e.g. produces NAN values. Please check the data values exchanged" 
+    //                                          " Your simulation probably got unstable, e.g. produces NAN values. Please check the data values exchanged"
     //                                          " between the solvers.");
     if (math::equals(sum, 0.0)) {
-      PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum <<
-                                              "). This indicates that the data values exchanged between two succesive iterations did not change."
-                                              " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged" 
-                                              " between the solvers is not identical between iterations.");
+      PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum << "). This indicates that the data values exchanged between two succesive iterations did not change."
+                                                                                                                         " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged"
+                                                                                                                         " between the solvers is not identical between iterations.");
     }
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
@@ -63,19 +62,18 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
       //                                                      " if the coupling values of one solver is zero in the first iterations. "
       //                                                      " . Please try freezing the preconditioner weights or the value preconditioner instead.");
       if (math::equals(_residualSum[k], 0.0)) {
-        PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( residualSum = " << _residualSum[k] <<
-                                                            ") . If this occured directly after the second iteration, check that the initial-relaxation"
-                                                            " factor is not equal to 1.0 if the coupling values of one solver"
-                                                            " is zero in the first iteration."
-                                                            " Please try freezing the preconditioner weights when using residual-sum"
-                                                            " or use the value preconditioner instead.");
+        PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( residualSum = " << _residualSum[k] << ") . If this occured directly after the second iteration, check that the initial-relaxation"
+                                                                                                                                      " factor is not equal to 1.0 if the coupling values of one solver"
+                                                                                                                                      " is zero in the first iteration."
+                                                                                                                                      " Please try freezing the preconditioner weights when using residual-sum"
+                                                                                                                                      " or use the value preconditioner instead.");
       }
     }
 
     offset = 0;
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      if (!math::equals(_residualSum[k], 0.0)){
-      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+      if (!math::equals(_residualSum[k], 0.0)) {
+        for (size_t i = 0; i < _subVectorSizes[k]; i++) {
           _weights[i + offset]    = 1 / _residualSum[k];
           _invWeights[i + offset] = _residualSum[k];
         }

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -45,10 +45,6 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
       norms[k] = std::sqrt(norms[k]);
     }
     sum = std::sqrt(sum);
-    //PRECICE_CHECK(not math::equals(sum, 0.0), "All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum <<
-    //                                          "). This indicates that the data values exchanged between two succesive iterations did not change."
-    //                                          " Your simulation probably got unstable, e.g. produces NAN values. Please check the data values exchanged"
-    //                                          " between the solvers.");
     if (math::equals(sum, 0.0)) {
       PRECICE_WARN("All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = " << sum << "). This indicates that the data values exchanged between two succesive iterations did not change."
                                                                                                                          " The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged"
@@ -57,10 +53,6 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       _residualSum[k] += norms[k] / sum;
-      //PRECICE_CHECK(not math::equals(_residualSum[k], 0.0), "A sub-vector in the residual-sum preconditioner became numerically zero ( residualSum = " << _residualSum[k] <<
-      //                                                      ") . If this occured during the first iteration, check that the initial-relaxation factor is not equal to 1.0"
-      //                                                      " if the coupling values of one solver is zero in the first iterations. "
-      //                                                      " . Please try freezing the preconditioner weights or the value preconditioner instead.");
       if (math::equals(_residualSum[k], 0.0)) {
         PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( residualSum = " << _residualSum[k] << ") . If this occured directly after the second iteration, check that the initial-relaxation"
                                                                                                                                       " factor is not equal to 1.0 if the coupling values of one solver"


### PR DESCRIPTION
Closes https://github.com/precice/precice/issues/882
This PR improves the error message when a zero sub-vector occurs for the residual-sum preconditioner. A new default method starts using a weight of 1 for each sub-vector, and does not change the weights if a sub-vector is found. In this case, only a warning is provided instead of an error.