### PR TITLE
Fix bug in ReceivedPartition

### DIFF
--- a/docs/changelog/948.md
+++ b/docs/changelog/948.md
@@ -1,1 +1,1 @@
-- Fixed a bug in ReceivedPartition which let to problems when coupling multiple participants.
+- Fixed a bug in ReceivedPartition which led to problems when coupling multiple participants.

--- a/docs/changelog/948.md
+++ b/docs/changelog/948.md
@@ -1,0 +1,1 @@
+- Fixed a bug in ReceivedPartition which let to problems when coupling multiple participants.

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -493,6 +493,7 @@ void ReceivedPartition::createOwnerInformation()
       std::vector<int> ownerVec(numberOfVertices, -1);
       utils::MasterSlave::_communication->receive(ownerVec, 0);
       PRECICE_DEBUG("My owner information: " << ownerVec);
+      PRECICE_ASSERT(ownerVec.size() == numberOfVertices);
       setOwnerInformation(ownerVec);
     }
   }
@@ -580,9 +581,10 @@ void ReceivedPartition::createOwnerInformation()
 
     // Send information back to slaves
     for (int rank = 1; rank < utils::MasterSlave::getSize(); rank++) {
-      if (not slaveTags[rank].empty())
+      if (not slaveTags[rank].empty()) {
         PRECICE_DEBUG("Send owner information to slave rank " << rank);
-      utils::MasterSlave::_communication->send(slaveOwnerVecs[rank], rank);
+        utils::MasterSlave::_communication->send(slaveOwnerVecs[rank], rank);
+      }
     }
     // Master data
     PRECICE_DEBUG("My owner information: " << slaveOwnerVecs[0]);


### PR DESCRIPTION
## Main changes of this PR

Fixes a bug in `ReceivedPartition` which let two mixed up receive calls if multiple communication partners were present. Fixes #919 

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
* [x] Does the two-flap tutorial work for you as well?