### PR TITLE
Add version to the Markdown XML reference

### DIFF
--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -3,6 +3,7 @@
 #include "precice/config/Configuration.hpp"
 #include "utils/assertion.hpp"
 #include "xml/Printer.hpp"
+#include "precice/impl/versions.hpp"
 
 void printUsage()
 {
@@ -49,6 +50,7 @@ int main(int argc, char **argv)
     precice::xml::toDTD(std::cout, config.getXMLTag());
   } else if (runMD) {
     precice::config::Configuration config;
+    std::cout << "<!-- generated with preCICE " PRECICE_VERSION " -->\n";
     precice::xml::toMarkdown(std::cout, config.getXMLTag());
   } else {
     PRECICE_ASSERT(false);

--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -1,9 +1,9 @@
 #include <iostream>
 #include <string>
 #include "precice/config/Configuration.hpp"
+#include "precice/impl/versions.hpp"
 #include "utils/assertion.hpp"
 #include "xml/Printer.hpp"
-#include "precice/impl/versions.hpp"
 
 void printUsage()
 {


### PR DESCRIPTION
## Main changes of this PR

Adds the preCICE version as a comment to the top of the markdown xml reference.

```markdown
<!-- generated with preCICE 2.2.0 -->
# precice-configuration

Main tag containing preCICE configuration.

**Example:**  
```xml
<precice-configuration sync-mode="0">
  <log enabled="1">
    ...
```

## Motivation and additional information

This will make tracking of the xmlreference on the website easier.

Closes #952
