### PR TITLE
Improve PETSc usability

### DIFF
--- a/docs/changelog/961.md
+++ b/docs/changelog/961.md
@@ -1,0 +1,2 @@
+- Added convergence information for linear solvers of PETSc-based RBF mappings. Reports of converged solvers are logged as DEBUG, stopped solvers as WARNING and diverged solvers as ERROR messages.
+- Changed linear solvers of PETSc-based RBF mappings now issue a warning when they reach the maximum iterations. This used to result in am ERROR.

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -552,6 +552,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     PCSetType(pc, PCNONE);
     KSPSetType(_QRsolver, KSPLSQR);
     KSPSetOperators(_QRsolver, _matrixQ, _matrixQ);
+    KSPSetTolerances(_QRsolver, _solverRtol, PETSC_DEFAULT, 1e30, PETSC_DEFAULT);
   }
 
   // -- CONFIGURE SOLVER FOR SYSTEM MATRIX --

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -552,7 +552,6 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     PCSetType(pc, PCNONE);
     KSPSetType(_QRsolver, KSPLSQR);
     KSPSetOperators(_QRsolver, _matrixQ, _matrixQ);
-    KSPSetTolerances(_QRsolver, _solverRtol, PETSC_DEFAULT, 1e30, PETSC_DEFAULT);
   }
 
   // -- CONFIGURE SOLVER FOR SYSTEM MATRIX --
@@ -840,22 +839,22 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
       case (petsc::KSPSolver::SolverResult::Converged):
         PRECICE_DEBUG("The linear system of the RBF mapping from mesh "
                       << input()->getName() << " to mesh " << output()->getName()
-                      << " converged. " << _QRsolver.summaryFor(in));
+                      << " converged. " << _solver.summaryFor(in));
         break;
       case (petsc::KSPSolver::SolverResult::Stopped):
         PRECICE_WARN("The linear system of the RBF mapping from mesh "
                      << input()->getName() << " to mesh " << output()->getName()
                      << " has not converged. This means most probably that the mapping problem is not well-posed or your relative tolerance is too conservative. "
                      << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                     << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(in));
+                     << "by marking perpendicular axes as dead? " << _solver.summaryFor(in));
         break;
       case (petsc::KSPSolver::SolverResult::Diverged):
-        KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
+        KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
         PRECICE_ERROR("The linear system of the RBF mapping from mesh "
                       << input()->getName() << " to mesh " << output()->getName()
                       << " has diverged. This means most probably that the mapping problem is not well-posed. "
                       << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                      << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(in));
+                      << "by marking perpendicular axes as dead? " << _solver.summaryFor(in));
         break;
       }
 

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -592,7 +592,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     rhs.assemble();
     switch (_solver.solve(rhs, rescalingCoeffs)) {
     case (petsc::KSPSolver::SolverResult::Converged):
-      PRECICE_INFO("Using rescaling, " << _solver.summaryFor(rhs));
+      PRECICE_INFO("Using rescaling. " << _solver.summaryFor(rhs));
       break;
     case (petsc::KSPSolver::SolverResult::Stopped):
       PRECICE_WARN("Using rescaling, but beware. " << _solver.summaryFor(rhs));

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -590,10 +590,19 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     auto                  rescalingCoeffs = petsc::Vector::allocate(_matrixC);
     VecSet(rhs, 1);
     rhs.assemble();
-    if (not _solver.solve(rhs, rescalingCoeffs)) {
-      PRECICE_WARN("RBF rescaling linear system has not converged. Deactivating rescaling!");
+    switch (_solver.solve(rhs, rescalingCoeffs)) {
+    case (petsc::KSPSolver::SolverResult::Converged):
+      PRECICE_INFO("Using rescaling, " << _solver.summaryFor(rhs));
+      break;
+    case (petsc::KSPSolver::SolverResult::Stopped):
+      PRECICE_WARN("Using rescaling, but beware. " << _solver.summaryFor(rhs));
+      break;
+    case (petsc::KSPSolver::SolverResult::Diverged):
+      PRECICE_WARN("Deactivating rescaling! " << _solver.summaryFor(rhs));
       useRescaling = false;
+      break;
     }
+
     eRescaling.addData("Iterations", _solver.getIterationNumber());
     ierr = MatCreateVecs(_matrixA, nullptr, &oneInterpolant.vector);
     CHKERRV(ierr);
@@ -692,28 +701,63 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
         ierr     = MatMultTransposeAdd(_matrixQ, mu, epsilon, tau);
         CHKERRV(ierr);
         auto sigma = petsc::Vector::allocate(_matrixQ, "sigma", petsc::Vector::LEFT);
-        if (not _QRsolver.solveTranspose(tau, sigma)) {
+
+        switch (_QRsolver.solveTranspose(tau, sigma)) {
+        case (petsc::KSPSolver::SolverResult::Converged):
+          PRECICE_DEBUG("The polynomial linear system of the RBF mapping from mesh "
+                        << input()->getName() << " to mesh "
+                        << output()->getName() << " converged. " << _QRsolver.summaryFor(tau));
+          break;
+        case (petsc::KSPSolver::SolverResult::Stopped):
+          PRECICE_WARN("The polynomial linear system of the RBF mapping from mesh "
+                       << input()->getName() << " to mesh "
+                       << output()->getName() << " has not converged. This means most probably that the mapping problem is not well-posed or your relative tolerance is too conservative. "
+                       << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                       << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(tau));
+          break;
+        case (petsc::KSPSolver::SolverResult::Diverged):
           KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
-          PRECICE_ERROR("The polynomial linear system of the RBF mapping from mesh " << input()->getName() << " to mesh "
-                                                                                     << output()->getName() << " has not converged. This means most probably that the mapping problem is not well-posed. "
-                                                                                     << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                                                                                     << "by marking perpendicular axes as dead?");
+          PRECICE_ERROR("The polynomial linear system of the RBF mapping from mesh "
+                        << input()->getName() << " to mesh "
+                        << output()->getName() << " has diverged. This means most probably that the mapping problem is not well-posed. "
+                        << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                        << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(tau));
+          break;
         }
+
         VecWAXPY(out, -1, sigma, mu);
       } else {
         ierr = MatMultTranspose(_matrixA, in, au);
         CHKERRV(ierr);
         utils::Event eSolve("map.pet.solveConservative.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
-        if (not _solver.solve(au, out)) {
-          KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
-          PRECICE_ERROR("The linear system of the RBF mapping from mesh " << input()->getName() << " to mesh "
-                                                                          << output()->getName() << " has not converged. This means most probably that the mapping problem is not well-posed. "
-                                                                          << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                                                                          << "by marking perpendicular axes as dead?");
-        }
+        const auto   solverResult = _solver.solve(au, out);
         eSolve.addData("Iterations", _solver.getIterationNumber());
         eSolve.stop();
+
+        switch (solverResult) {
+        case (petsc::KSPSolver::SolverResult::Converged):
+          PRECICE_DEBUG("The linear system of the RBF mapping from mesh "
+                        << input()->getName() << " to mesh "
+                        << output()->getName() << " converged. " << _solver.summaryFor(au));
+          break;
+        case (petsc::KSPSolver::SolverResult::Stopped):
+          PRECICE_WARN("The linear system of the RBF mapping from mesh "
+                       << input()->getName() << " to mesh "
+                       << output()->getName() << " has not converged. This means most probably that the mapping problem is not well-posed or your relative tolerance is too conservative. "
+                       << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                       << "by marking perpendicular axes as dead? " << _solver.summaryFor(au));
+          break;
+        case (petsc::KSPSolver::SolverResult::Diverged):
+          KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
+          PRECICE_ERROR("The linear system of the RBF mapping from mesh "
+                        << input()->getName() << " to mesh "
+                        << output()->getName() << " has diverged. This means most probably that the mapping problem is not well-posed. "
+                        << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                        << "by marking perpendicular axes as dead? " << _solver.summaryFor(au));
+          break;
+        }
       }
+
       VecChop(out, 1e-9);
 
       // Copy mapped data to output data values
@@ -759,13 +803,29 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
       in.assemble();
 
       if (_polynomial == Polynomial::SEPARATE) {
-        if (not _QRsolver.solve(in, a)) {
+        switch (_QRsolver.solve(in, a)) {
+        case (petsc::KSPSolver::SolverResult::Converged):
+          PRECICE_DEBUG("The polynomial QR system of the RBF mapping from mesh "
+                        << input()->getName() << " to mesh " << output()->getName()
+                        << " converged. " << _QRsolver.summaryFor(in));
+          break;
+        case (petsc::KSPSolver::SolverResult::Stopped):
+          PRECICE_WARN("The polynomial QR system of the RBF mapping from mesh "
+                       << input()->getName() << " to mesh " << output()->getName()
+                       << " has not converged. This means most probably that the mapping problem is not well-posed or your relative tolerance is too conservative. "
+                       << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                       << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(in));
+          break;
+        case (petsc::KSPSolver::SolverResult::Diverged):
           KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
-          PRECICE_ERROR("The polynomial QR system of the RBF mapping from mesh " << input()->getName() << " to mesh "
-                                                                                 << output()->getName() << " has not converged. This means most probably that the mapping problem is not well-posed. "
-                                                                                 << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                                                                                 << "by marking perpendicular axes as dead?");
+          PRECICE_ERROR("The polynomial QR system of the RBF mapping from mesh "
+                        << input()->getName() << " to mesh " << output()->getName()
+                        << " has diverged. This means most probably that the mapping problem is not well-posed. "
+                        << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                        << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(in));
+          break;
         }
+
         VecScale(a, -1);
         MatMultAdd(_matrixQ, a, in, in); // Subtract the polynomial from the input values
       }
@@ -777,15 +837,32 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
                              ->second;
 
       utils::Event eSolve("map.pet.solveConsistent.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
-      if (not _solver.solve(in, p)) {
-        KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
-        PRECICE_ERROR("The linear system of the RBF mapping from mesh " << input()->getName() << " to mesh "
-                                                                        << output()->getName() << " has not converged. This means most probably that the mapping problem is not well-posed. "
-                                                                        << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                                                                        << "by marking perpendicular axes as dead?");
-      }
+      const auto   solverResult = _solver.solve(in, p);
       eSolve.addData("Iterations", _solver.getIterationNumber());
       eSolve.stop();
+
+      switch (solverResult) {
+      case (petsc::KSPSolver::SolverResult::Converged):
+        PRECICE_WARN("The linear system of the RBF mapping from mesh "
+                     << input()->getName() << " to mesh " << output()->getName()
+                     << " converged. " << _QRsolver.summaryFor(in));
+        break;
+      case (petsc::KSPSolver::SolverResult::Stopped):
+        PRECICE_WARN("The linear system of the RBF mapping from mesh "
+                     << input()->getName() << " to mesh " << output()->getName()
+                     << " has not converged. This means most probably that the mapping problem is not well-posed or your relative tolerance is too conservative. "
+                     << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                     << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(in));
+        break;
+      case (petsc::KSPSolver::SolverResult::Diverged):
+        KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
+        PRECICE_ERROR("The linear system of the RBF mapping from mesh "
+                      << input()->getName() << " to mesh " << output()->getName()
+                      << " has diverged. This means most probably that the mapping problem is not well-posed. "
+                      << "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                      << "by marking perpendicular axes as dead? " << _QRsolver.summaryFor(in));
+        break;
+      }
 
       ierr = MatMult(_matrixA, p, out);
       CHKERRV(ierr);

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -590,17 +590,11 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     auto                  rescalingCoeffs = petsc::Vector::allocate(_matrixC);
     VecSet(rhs, 1);
     rhs.assemble();
-    switch (_solver.solve(rhs, rescalingCoeffs)) {
-    case (petsc::KSPSolver::SolverResult::Converged):
+    if (_solver.solve(rhs, rescalingCoeffs) == petsc::KSPSolver::SolverResult::Converged) {
       PRECICE_INFO("Using rescaling. " << _solver.summaryFor(rhs));
-      break;
-    case (petsc::KSPSolver::SolverResult::Stopped):
-      PRECICE_WARN("Using rescaling, but beware. " << _solver.summaryFor(rhs));
-      break;
-    case (petsc::KSPSolver::SolverResult::Diverged):
+    } else {
       PRECICE_WARN("Deactivating rescaling! " << _solver.summaryFor(rhs));
       useRescaling = false;
-      break;
     }
 
     eRescaling.addData("Iterations", _solver.getIterationNumber());

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -843,9 +843,9 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::map(int inputDataID, int
 
       switch (solverResult) {
       case (petsc::KSPSolver::SolverResult::Converged):
-        PRECICE_WARN("The linear system of the RBF mapping from mesh "
-                     << input()->getName() << " to mesh " << output()->getName()
-                     << " converged. " << _QRsolver.summaryFor(in));
+        PRECICE_DEBUG("The linear system of the RBF mapping from mesh "
+                      << input()->getName() << " to mesh " << output()->getName()
+                      << " converged. " << _QRsolver.summaryFor(in));
         break;
       case (petsc::KSPSolver::SolverResult::Stopped):
         PRECICE_WARN("The linear system of the RBF mapping from mesh "

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -7,19 +7,19 @@
 #include <memory>
 #include <mpi.h>
 #include <numeric>
+#include <sstream>
 #include <type_traits>
 #include <utility>
 #include <vector>
-#include <sstream>
 
 #include "logging/LogMacros.hpp"
 #include "petsc.h"
 #include "petscdrawtypes.h"
 #include "petscis.h"
-#include "petscviewertypes.h"
-#include "utils/Parallel.hpp"
 #include "petscksp.h"
 #include "petscsystypes.h"
+#include "petscviewertypes.h"
+#include "utils/Parallel.hpp"
 
 #endif // not PRECICE_NO_PETSC
 
@@ -639,10 +639,11 @@ void KSPSolver::reset()
   CHKERRV(ierr);
 }
 
-KSPSolver::SolverResult KSPSolver::getSolverResult() {
+KSPSolver::SolverResult KSPSolver::getSolverResult()
+{
   KSPConvergedReason convReason;
-  PetscErrorCode ierr = 0;
-  ierr = KSPGetConvergedReason(ksp, &convReason);
+  PetscErrorCode     ierr = 0;
+  ierr                    = KSPGetConvergedReason(ksp, &convReason);
   if (ierr != 0) {
     return SolverResult::Diverged;
   }
@@ -667,7 +668,6 @@ KSPSolver::SolverResult KSPSolver::solveTranspose(Vector &b, Vector &x)
   KSPSolveTranspose(ksp, b, x);
   return getSolverResult();
 }
-
 
 std::string KSPSolver::summaryFor(Vector &b)
 {

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -1,7 +1,4 @@
 #include "Petsc.hpp"
-#include <petscksp.h>
-#include <petscsystypes.h>
-#include <sstream>
 
 // A logger is always required
 #include "logging/Logger.hpp"
@@ -13,6 +10,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <sstream>
 
 #include "logging/LogMacros.hpp"
 #include "petsc.h"
@@ -20,6 +18,9 @@
 #include "petscis.h"
 #include "petscviewertypes.h"
 #include "utils/Parallel.hpp"
+#include "petscksp.h"
+#include "petscsystypes.h"
+
 #endif // not PRECICE_NO_PETSC
 
 namespace precice {

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -718,7 +718,7 @@ std::string KSPSolver::summaryFor(Vector &b)
   double dlim  = bnorm * dtol;
   double rlim  = bnorm * rtol;
 
-  oss << ". Last residual norm: " << getResidualNorm() << ", limits: relative " << rlim << " (rtol " << rtol << "), absolute " << atol << ", divergence " << dlim << "(dtol "<< dtol << ')';
+  oss << ". Last residual norm: " << getResidualNorm() << ", limits: relative " << rlim << " (rtol " << rtol << "), absolute " << atol << ", divergence " << dlim << "(dtol " << dtol << ')';
 
   return oss.str();
 }

--- a/src/utils/Petsc.hpp
+++ b/src/utils/Petsc.hpp
@@ -259,8 +259,8 @@ public:
   /// The state of the KSP after returning from solve()
   enum struct SolverResult {
     Converged, ///< The solver converged
-    Stopped, ///< The solver reached the maximum iterations
-    Diverged ///< The solver diverged 
+    Stopped,   ///< The solver reached the maximum iterations
+    Diverged   ///< The solver diverged
   };
 
   /// Returns the current convergence reason as a SolverRestult
@@ -277,7 +277,7 @@ public:
 
   /// Returns the iteration number of solver, either during or after the solve call.
   PetscInt getIterationNumber();
-  
+
   /// Returns the relavtive tolerance of the KSP
   PetscReal getRealtiveTolerance();
 

--- a/src/utils/Petsc.hpp
+++ b/src/utils/Petsc.hpp
@@ -151,6 +151,9 @@ public:
 
   /// Prints the vector
   void view() const;
+
+  /// returns the l2-norm of the vector
+  double l2norm() const;
 };
 
 void swap(Vector &lhs, Vector &rhs) noexcept;
@@ -253,14 +256,33 @@ public:
   /// Destroys and recreates the ksp on the same communicator
   void reset();
 
+  /// The state of the KSP after returning from solve()
+  enum struct SolverResult {
+    Converged, ///< The solver converged
+    Stopped, ///< The solver reached the maximum iterations
+    Diverged ///< The solver diverged 
+  };
+
+  /// Returns the current convergence reason as a SolverRestult
+  SolverResult getSolverResult();
+
   /// Solves the linear system, returns false it not converged
-  bool solve(Vector &b, Vector &x);
+  SolverResult solve(Vector &b, Vector &x);
 
   /// Solves the transposed linear system, returns false it not converged
-  bool solveTranspose(Vector &b, Vector &x);
+  SolverResult solveTranspose(Vector &b, Vector &x);
+
+  /// Returns a summary the KSP solving for b
+  std::string summaryFor(Vector &b);
 
   /// Returns the iteration number of solver, either during or after the solve call.
   PetscInt getIterationNumber();
+  
+  /// Returns the relavtive tolerance of the KSP
+  PetscReal getRealtiveTolerance();
+
+  /// Returns the last residual norm of the KSP
+  PetscReal getResidualNorm();
 };
 
 /// Destroys an KSP, if ksp is not null and PetscIsInitialized


### PR DESCRIPTION
## Main changes of this PR

Added 3 result states for KSP solve:
* Converged
* Diverged (nan or inf in residual, method break down, diverged residual)
* Stopped (reached max iterations)

The parallel implementation of RBF with PETSc now only displays an error if a solver diverged.

It displays a warning for `Stopped` solvers

It also displays a `DEBUG` output if the solver converges. Note that this is the default case and does not exist in release binaries.

## Examples

### `computeMapping()`

Success
```
21:25:03.266496||0|mapping::PetRadialBasisFctMapping|l595|computeMapping|Using rescaling, Solver converged after 1 of 10000 iterations due to sufficient absolute convergence. Residual norm: 0, limits: relative 1.73205e-09, absolute 1e-50, divergence 1.73205e+30
21:25:03.267326||0|mapping::PetRadialBasisFctMapping|l709|map|The polynomial linear system of the RBF mapping from mesh InMesh to mesh OutMesh converged. Solver converged after 3 of 10000 iterations due to sufficient relative convergence. Residual norm: 1.24855e-08, limits: relative 2.97685e-05, absolute 1e-50, divergence 29768.5
```

Breakdown
```
21:25:03.275108||0|mapping::PetRadialBasisFctMapping|l601|computeMapping|WARNING: Deactivating rescaling! Solver diverged after 1 of 10000 iterations due to a generic breakdown of the method. Residual norm: 8.18836e+13, limits: relative 1e-09, absolute 1e-50, divergence 1e+30
```

### `map()`
Success
```
21:25:03.284225||0|utils::Events|l59|stop|Stopped event map.pet.computeMapping.FromInMeshToOutMesh
21:25:03.284311||0|utils::Events|l40|start|Started event map.pet.mapData.FromInMeshToOutMesh
21:25:03.284398||0|mapping::PetRadialBasisFctMapping|l976|printMappingInfo|Mapping InData consistent from InMesh (ID 114) to OutMesh (ID 115) for dimension 0) with polynomial set to separate
21:25:03.284550||0|mapping::PetRadialBasisFctMapping|l810|map|The polynomial QR system of the RBF mapping from mesh InMesh to mesh OutMesh converged. Solver converged after 2 of 10000 iterations due to sufficient relative convergence. Residual norm: 3.00571e-15, limits: relative 2e-05, absolute 1e-50, divergence 20000
21:25:03.284644||0|utils::Events|l40|start|Started event map.pet.solveConsistent.FromInMeshToOutMesh
21:25:03.284769||0|utils::Events|l59|stop|Stopped event map.pet.solveConsistent.FromInMeshToOutMesh
21:25:03.284830||0|mapping::PetRadialBasisFctMapping|l848|map|The linear system of the RBF mapping from mesh InMesh to mesh OutMesh converged. Solver converged after 2 of 10000 iterations due to sufficient relative convergence. Residual norm: 3.00571e-15, limits: relative 3.29626e-20, absolute 1e-50, divergence 3.29626e-11
21:25:03.284916||0|utils::Events|l59|stop|Stopped event map.pet.mapData.FromInMeshToOutMesh
```

## Motivation and additional information

See #960

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
