### PR TITLE
Parallel participant support for scaled-consistent mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ docs/source-code-documentation/
 CMakeFiles
 Makefile
 src/versions.hpp
+.idea

--- a/docs/changelog/906.md
+++ b/docs/changelog/906.md
@@ -1,0 +1,1 @@
+- Added the constraint `scaled-consistent` to mapping methods, which scales a consistent mapping such that the surface integral is equal on both sides of the interface.

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -1,6 +1,8 @@
 #include "Mapping.hpp"
 #include <boost/config.hpp>
 #include <ostream>
+#include "mesh/Utils.hpp"
+#include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -76,6 +78,43 @@ void Mapping::setOutputRequirement(
 int Mapping::getDimensions() const
 {
   return _dimensions;
+}
+
+void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
+{
+  // Only serial participant is supported for scale-consistent mapping
+  PRECICE_ASSERT((not utils::MasterSlave::isMaster()) and (not utils::MasterSlave::isSlave()));
+
+  // If rank is not empty and do not contain connectivity information, raise error
+  if ((input()->edges().empty() and (not input()->vertices().empty())) or
+      (((input()->getDimensions() == 3) and input()->triangles().empty()) and (not input()->vertices().empty()))) {
+    logging::Logger _log{"mapping::Mapping"};
+    PRECICE_ERROR("Connectivity information is missing for the mesh " << input()->getName() << ". Scaled consistent mapping requires connectivity information.");
+  }
+  if ((output()->edges().empty() and (not output()->vertices().empty())) or
+      (((output()->getDimensions() == 3) and output()->triangles().empty()) and (not output()->vertices().empty()))) {
+    logging::Logger _log{"mapping::Mapping"};
+    PRECICE_ERROR("Connectivity information is missing for the mesh " << output()->getName() << ". Scaled consistent mapping requires connectivity information.");
+  }
+
+  auto &outputValues    = output()->data(outputDataID)->values();
+  int   valueDimensions = input()->data(inputDataID)->getDimensions();
+
+  // Integral is calculated on each direction separately
+  auto integralInput  = mesh::integrate(input(), input()->data(inputDataID));
+  auto integralOutput = mesh::integrate(output(), output()->data(outputDataID));
+
+  // Create reshape the output values vector to matrix
+  Eigen::Map<Eigen::MatrixXd> outputValuesMatrix(outputValues.data(), valueDimensions, outputValues.size() / valueDimensions);
+
+  // Scale in each direction
+  Eigen::VectorXd scalingFactor = integralInput.array() / integralOutput.array();
+  outputValuesMatrix.array().colwise() *= scalingFactor.array();
+}
+
+bool Mapping::hasConstraint(const Constraint &constraint) const
+{
+  return (getConstraint() == constraint);
 }
 
 bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs)

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -17,13 +17,16 @@ public:
    *
    * A consistent mapping retains mean values. When mapping displacements, e.g.
    * rigid body motions are retained. A conservative mapping retains the sum of
-   * the values. Values integrated over some area should be mapped conservative,
-   * while area independent values such as pressure or stresses should be mapped
-   * consistent.
+   * the values. The scaled-consistent mapping first map the values consistently,
+   * then scales the mapped such that the integrals on both sides of the interface
+   * are equal. Values integrated over some area should be mapped conservative or 
+   * scaled-consistent, while area independent values such as pressure or stresses 
+   * should be mapped consistent.
    */
   enum Constraint {
     CONSISTENT,
-    CONSERVATIVE
+    CONSERVATIVE,
+    SCALEDCONSISTENT
   };
 
   /**
@@ -84,6 +87,9 @@ public:
    */
   virtual bool hasComputedMapping() const = 0;
 
+  /// Checks whether the mapping has the given constraint or not
+  virtual bool hasConstraint(const Constraint &constraint) const;
+
   /// Removes a computed mapping.
   virtual void clear() = 0;
 
@@ -105,6 +111,15 @@ public:
 
   /// Method used by partition. Tags vertices that can be filtered out.
   virtual void tagMeshSecondRound() = 0;
+
+  /**
+   * @brief Scales the consistently mapped output data such that the surface integral
+   * of the values on input mesh and output mesh are equal
+   *
+   * 
+   * @pre Input and output mesh should have full connectivity information.
+   */
+  virtual void scaleConsistentMapping(int inputDataID, int outputDataID) const;
 
 protected:
   /// Returns pointer to input mesh.

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -32,8 +32,13 @@ NearestNeighborMapping::NearestNeighborMapping(
     int        dimensions)
     : Mapping(constraint, dimensions)
 {
-  setInputRequirement(Mapping::MeshRequirement::VERTEX);
-  setOutputRequirement(Mapping::MeshRequirement::VERTEX);
+  if (hasConstraint(SCALEDCONSISTENT)) {
+    setInputRequirement(Mapping::MeshRequirement::FULL);
+    setOutputRequirement(Mapping::MeshRequirement::FULL);
+  } else {
+    setInputRequirement(Mapping::MeshRequirement::VERTEX);
+    setOutputRequirement(Mapping::MeshRequirement::VERTEX);
+  }
 }
 
 void NearestNeighborMapping::computeMapping()
@@ -46,32 +51,7 @@ void NearestNeighborMapping::computeMapping()
   const std::string     baseEvent = "map.nn.computeMapping.From" + input()->getName() + "To" + output()->getName();
   precice::utils::Event e(baseEvent, precice::syncMode);
 
-  if (getConstraint() == CONSISTENT) {
-    PRECICE_DEBUG("Compute consistent mapping");
-    precice::utils::Event e2(baseEvent + ".getIndexOnVertices", precice::syncMode);
-    auto                  rtree = query::rtree::getVertexRTree(input());
-    e2.stop();
-    size_t verticesSize = output()->vertices().size();
-    _vertexIndices.resize(verticesSize);
-    utils::statistics::DistanceAccumulator distanceStatistics;
-    const mesh::Mesh::VertexContainer &    outputVertices = output()->vertices();
-    for (size_t i = 0; i < verticesSize; i++) {
-      const Eigen::VectorXd &coords = outputVertices[i].getCoords();
-      // Search for the output vertex inside the input mesh and add index to _vertexIndices
-      rtree->query(boost::geometry::index::nearest(coords, 1),
-                   boost::make_function_output_iterator([&](size_t const &val) {
-                     const auto &match = input()->vertices()[val];
-                     _vertexIndices[i] = match.getID();
-                     distanceStatistics(bg::distance(match, coords));
-                   }));
-    }
-    if (distanceStatistics.empty()) {
-      PRECICE_INFO("Mapping distance not available due to empty partition.");
-    } else {
-      PRECICE_INFO("Mapping distance " << distanceStatistics);
-    }
-  } else {
-    PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
+  if (hasConstraint(CONSERVATIVE)) {
     PRECICE_DEBUG("Compute conservative mapping");
     precice::utils::Event e2(baseEvent + ".getIndexOnVertices", precice::syncMode);
     auto                  rtree = query::rtree::getVertexRTree(output());
@@ -86,6 +66,30 @@ void NearestNeighborMapping::computeMapping()
       rtree->query(boost::geometry::index::nearest(coords, 1),
                    boost::make_function_output_iterator([&](size_t const &val) {
                      const auto &match = output()->vertices()[val];
+                     _vertexIndices[i] = match.getID();
+                     distanceStatistics(bg::distance(match, coords));
+                   }));
+    }
+    if (distanceStatistics.empty()) {
+      PRECICE_INFO("Mapping distance not available due to empty partition.");
+    } else {
+      PRECICE_INFO("Mapping distance " << distanceStatistics);
+    }
+  } else {
+    PRECICE_DEBUG("Compute consistent mapping");
+    precice::utils::Event e2(baseEvent + ".getIndexOnVertices", precice::syncMode);
+    auto                  rtree = query::rtree::getVertexRTree(input());
+    e2.stop();
+    size_t verticesSize = output()->vertices().size();
+    _vertexIndices.resize(verticesSize);
+    utils::statistics::DistanceAccumulator distanceStatistics;
+    const mesh::Mesh::VertexContainer &    outputVertices = output()->vertices();
+    for (size_t i = 0; i < verticesSize; i++) {
+      const Eigen::VectorXd &coords = outputVertices[i].getCoords();
+      // Search for the output vertex inside the input mesh and add index to _vertexIndices
+      rtree->query(boost::geometry::index::nearest(coords, 1),
+                   boost::make_function_output_iterator([&](size_t const &val) {
+                     const auto &match = input()->vertices()[val];
                      _vertexIndices[i] = match.getID();
                      distanceStatistics(bg::distance(match, coords));
                    }));
@@ -110,7 +114,7 @@ void NearestNeighborMapping::clear()
   PRECICE_TRACE();
   _vertexIndices.clear();
   _hasComputedMapping = false;
-  if (getConstraint() == CONSISTENT) {
+  if (hasConstraint(CONSISTENT)) {
     query::rtree::clear(*input());
   } else {
     query::rtree::clear(*output());
@@ -135,7 +139,16 @@ void NearestNeighborMapping::map(
                  inputValues.size(), valueDimensions, input()->vertices().size());
   PRECICE_ASSERT(outputValues.size() / valueDimensions == (int) output()->vertices().size(),
                  outputValues.size(), valueDimensions, output()->vertices().size());
-  if (getConstraint() == CONSISTENT) {
+  if (hasConstraint(CONSERVATIVE)) {
+    PRECICE_DEBUG("Map conservative");
+    size_t const inSize = input()->vertices().size();
+    for (size_t i = 0; i < inSize; i++) {
+      int const outputIndex = _vertexIndices[i] * valueDimensions;
+      for (int dim = 0; dim < valueDimensions; dim++) {
+        outputValues(outputIndex + dim) += inputValues((i * valueDimensions) + dim);
+      }
+    }
+  } else {
     PRECICE_DEBUG("Map consistent");
     size_t const outSize = output()->vertices().size();
     for (size_t i = 0; i < outSize; i++) {
@@ -144,15 +157,8 @@ void NearestNeighborMapping::map(
         outputValues((i * valueDimensions) + dim) = inputValues(inputIndex + dim);
       }
     }
-  } else {
-    PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
-    PRECICE_DEBUG("Map conservative");
-    size_t const inSize = input()->vertices().size();
-    for (size_t i = 0; i < inSize; i++) {
-      int const outputIndex = _vertexIndices[i] * valueDimensions;
-      for (int dim = 0; dim < valueDimensions; dim++) {
-        outputValues(outputIndex + dim) += inputValues((i * valueDimensions) + dim);
-      }
+    if (hasConstraint(SCALEDCONSISTENT)) {
+      scaleConsistentMapping(inputDataID, outputDataID);
     }
   }
 }
@@ -167,14 +173,14 @@ void NearestNeighborMapping::tagMeshFirstRound()
   // Lookup table of all indices used in the mapping
   const boost::container::flat_set<int> indexSet(_vertexIndices.begin(), _vertexIndices.end());
 
-  if (getConstraint() == CONSISTENT) {
-    for (mesh::Vertex &v : input()->vertices()) {
+  if (hasConstraint(CONSERVATIVE)) {
+    PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
+    for (mesh::Vertex &v : output()->vertices()) {
       if (indexSet.count(v.getID()) != 0)
         v.tag();
     }
   } else {
-    PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
-    for (mesh::Vertex &v : output()->vertices()) {
+    for (mesh::Vertex &v : input()->vertices()) {
       if (indexSet.count(v.getID()) != 0)
         v.tag();
     }

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -136,8 +136,8 @@ MappingConfiguration::MappingConfiguration(
                         .setDocumentation("The mesh to map the data to.");
 
   auto attrConstraint = XMLAttribute<std::string>(ATTR_CONSTRAINT)
-                            .setDocumentation("Use conservative to conserve the quantity of the data over the interface such as force or mass. Use consistent for normalized quantities such as temperature or pressure.")
-                            .setOptions({VALUE_CONSERVATIVE, VALUE_CONSISTENT});
+                            .setDocumentation("Use conservative to conserve the nodal sum of the data over the interface (needed e.g. for force mapping).  Use consistent for normalized quantities such as temperature or pressure. Use scaled-consistent for normalized quantities where conservation of integral values is needed (e.g. velocities when the mass flow rate needs to be conserved). Mesh connectivity is required to use scaled-consistent.")
+                            .setOptions({VALUE_CONSERVATIVE, VALUE_CONSISTENT, VALUE_SCALED_CONSISTENT});
 
   auto attrTiming = makeXMLAttribute(ATTR_TIMING, VALUE_TIMING_INITIAL)
                         .setDocumentation("This allows to defer the mapping of the data to advance or to a manual call to mapReadDataTo and mapWriteDataFrom.")
@@ -283,6 +283,8 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
     constraintValue = Mapping::CONSERVATIVE;
   } else if (constraint == VALUE_CONSISTENT) {
     constraintValue = Mapping::CONSISTENT;
+  } else if (constraint == VALUE_SCALED_CONSISTENT) {
+    constraintValue = Mapping::SCALEDCONSISTENT;
   } else {
     PRECICE_ASSERT(false, "Unknown mapping constraint \"" << constraint << "\". Please check the documentation for available options.");
   }

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -115,10 +115,11 @@ private:
   const std::string ATTR_Z_DEAD         = "z-dead";
   const std::string ATTR_USE_QR         = "use-qr-decomposition";
 
-  const std::string VALUE_WRITE        = "write";
-  const std::string VALUE_READ         = "read";
-  const std::string VALUE_CONSISTENT   = "consistent";
-  const std::string VALUE_CONSERVATIVE = "conservative";
+  const std::string VALUE_WRITE             = "write";
+  const std::string VALUE_READ              = "read";
+  const std::string VALUE_CONSISTENT        = "consistent";
+  const std::string VALUE_CONSERVATIVE      = "conservative";
+  const std::string VALUE_SCALED_CONSISTENT = "scaled-consistent";
 
   const std::string VALUE_NEAREST_NEIGHBOR      = "nearest-neighbor";
   const std::string VALUE_NEAREST_PROJECTION    = "nearest-projection";

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -8,6 +8,7 @@
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "mesh/Utils.hpp"
 #include "mesh/Vertex.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
@@ -164,6 +165,74 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   BOOST_TEST(mapping.hasComputedMapping() == true);
   BOOST_TEST(outValues(0) == inValues(0) + inValues(1));
   BOOST_TEST(outValues(1) == 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(ScaledConsistentNonIncremental)
+{
+  PRECICE_TEST(1_rank);
+  int dimensions = 2;
+
+  // Create mesh to map from
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrData inData    = inMesh->createData("InData", 1);
+  int     inDataID  = inData->getID();
+  Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &inVertex1 = inMesh->createVertex(Eigen::Vector2d{1.0, 0.0});
+  Vertex &inVertex2 = inMesh->createVertex(Eigen::Vector2d{3.0, 0.0});
+  Vertex &inVertex3 = inMesh->createVertex(Eigen::Vector2d{6.0, 0.0});
+
+  inMesh->createEdge(inVertex0, inVertex1);
+  inMesh->createEdge(inVertex1, inVertex2);
+  inMesh->createEdge(inVertex2, inVertex3);
+
+  inMesh->allocateDataValues();
+  Eigen::VectorXd &inValues = inData->values();
+  inValues(0)               = 1.0;
+  inValues(1)               = 2.0;
+  inValues(2)               = 3.0;
+  inValues(3)               = 4.0;
+
+  // Create mesh to map to
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrData outData    = outMesh->createData("OutData", 1);
+  int     outDataID  = outData->getID();
+  Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &outVertex1 = outMesh->createVertex(Eigen::Vector2d(0.8, 0.0));
+  Vertex &outVertex2 = outMesh->createVertex(Eigen::Vector2d(3.0, 0.0));
+  Vertex &outVertex3 = outMesh->createVertex(Eigen::Vector2d(6.2, 0.0));
+
+  outMesh->createEdge(outVertex0, outVertex1);
+  outMesh->createEdge(outVertex1, outVertex2);
+  outMesh->createEdge(outVertex2, outVertex3);
+
+  outMesh->allocateDataValues();
+
+  // Setup mapping with mapping coordinates and geometry used
+  precice::mapping::NearestNeighborMapping mapping(mapping::Mapping::SCALEDCONSISTENT, dimensions);
+
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+
+  Eigen::VectorXd &outValues = outData->values();
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+
+  auto inputIntegral  = mesh::integrate(inMesh, inData);
+  auto outputIntegral = mesh::integrate(outMesh, outData);
+
+  for (int dim = 0; dim < inputIntegral.size(); ++dim) {
+    BOOST_TEST(inputIntegral(dim) == outputIntegral(dim));
+  }
+
+  double scaleFactor = outValues(0) / inValues(0);
+  BOOST_TEST(scaleFactor != 1.0);
+
+  BOOST_TEST(inValues(0) * scaleFactor == outValues(0));
+  BOOST_TEST(inValues(1) * scaleFactor == outValues(1));
+  BOOST_TEST(inValues(2) * scaleFactor == outValues(2));
+  BOOST_TEST(inValues(3) * scaleFactor == outValues(3));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -8,6 +8,7 @@
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "mesh/Utils.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 #include "utils/assertion.hpp"
@@ -211,6 +212,128 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
     BOOST_TEST(outData->values()(1) == valueVertex2);
     BOOST_TEST(outData->values()(2) == (valueVertex1 + valueVertex2) * 0.5);
   }
+}
+
+BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase1)
+{
+  PRECICE_TEST(1_rank);
+  using namespace mesh;
+  int dimensions = 2;
+
+  // Create mesh to map from
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrData inData   = inMesh->createData("InData", 1);
+  int     inDataID = inData->getID();
+  Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  inMesh->createEdge(v1, v2);
+  inMesh->computeState();
+  inMesh->allocateDataValues();
+  double           valueVertex1 = 1.0;
+  double           valueVertex2 = 2.0;
+  Eigen::VectorXd &inValues     = inData->values();
+  inValues(0)                   = valueVertex1;
+  inValues(1)                   = valueVertex2;
+
+  auto inputIntegral = mesh::integrate(inMesh, inData);
+  // Create mesh to map to
+  PtrMesh outMesh(new Mesh("OutMesh0", dimensions, false, testing::nextMeshID()));
+  PtrData outData   = outMesh->createData("OutData", 1);
+  int     outDataID = outData->getID();
+  auto &  outValues = outData->values();
+  // Setup mapping with mapping coordinates and geometry used
+  mapping::NearestProjectionMapping mapping(mapping::Mapping::SCALEDCONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  Vertex &outV1 = outMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
+  Vertex &outV2 = outMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
+  Vertex &outV3 = outMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
+
+  outMesh->createEdge(outV1, outV2);
+  outMesh->createEdge(outV1, outV3);
+
+  outMesh->allocateDataValues();
+  outValues = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+
+  // Compute and perform mapping
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+
+  auto   outputIntegral = mesh::integrate(outMesh, outData);
+  double scaleFactor    = outValues(1) / inValues(0);
+  BOOST_TEST(scaleFactor != 1.0);
+
+  // Validate results
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  for (int dim = 0; dim < inputIntegral.size(); ++dim) {
+    BOOST_TEST(inputIntegral(dim) == outputIntegral(dim));
+  }
+  BOOST_TEST(outValues(0) == (inValues(0) + inValues(1)) * 0.5 * scaleFactor);
+  BOOST_TEST(outValues(1) == inValues(0) * scaleFactor);
+  BOOST_TEST(outValues(2) == inValues(1) * scaleFactor);
+}
+
+BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase2)
+{
+  PRECICE_TEST(1_rank);
+  using namespace mesh;
+  int dimensions = 2;
+
+  // Create mesh to map from
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrData inData   = inMesh->createData("InData", 1);
+  int     inDataID = inData->getID();
+  Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  inMesh->createEdge(v1, v2);
+  inMesh->computeState();
+  inMesh->allocateDataValues();
+  double           valueVertex1 = 1.0;
+  double           valueVertex2 = 2.0;
+  Eigen::VectorXd &inValues     = inData->values();
+  inValues(0)                   = valueVertex1;
+  inValues(1)                   = valueVertex2;
+
+  auto inputIntegral = mesh::integrate(inMesh, inData);
+
+  // Create mesh to map to
+  PtrMesh outMesh(new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()));
+  PtrData outData   = outMesh->createData("OutData", 1);
+  int     outDataID = outData->getID();
+  auto &  outValues = outData->values();
+
+  // Setup mapping with mapping coordinates and geometry used
+  mapping::NearestProjectionMapping mapping(mapping::Mapping::SCALEDCONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  Vertex &outV1 = outMesh->createVertex(Eigen::Vector2d(-0.5, -0.5));
+  Vertex &outV2 = outMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
+  Vertex &outV3 = outMesh->createVertex(Eigen::Vector2d(0.5, 0.5));
+
+  outMesh->createEdge(outV3, outV1);
+  outMesh->createEdge(outV3, outV2);
+
+  outMesh->allocateDataValues();
+
+  //assign(outData->values()) = 0.0;
+  outValues = Eigen::VectorXd::Constant(outData->values().size(), 0.0);
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+
+  auto   outputIntegral = mesh::integrate(outMesh, outData);
+  double scaleFactor    = outValues(0) / inValues(0);
+  BOOST_TEST(scaleFactor != 1.0);
+
+  // Validate results
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  for (int dim = 0; dim < inputIntegral.size(); ++dim) {
+    BOOST_TEST(inputIntegral(dim) == outputIntegral(dim));
+  }
+  BOOST_TEST(outValues(0) == inValues(0) * scaleFactor);
+  BOOST_TEST(outValues(1) == inValues(1) * scaleFactor);
+  BOOST_TEST(outValues(2) == (inValues(0) + inValues(1)) * 0.5 * scaleFactor);
 }
 
 BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
@@ -538,6 +661,72 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   mapping.map(inData->getID(), outData->getID());
   BOOST_TEST_INFO("Out Data after Mapping:" << outData->values());
   BOOST_TEST(outData->values()(0) == 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
+{
+  PRECICE_TEST(1_rank);
+  using namespace precice::mesh;
+  constexpr int dimensions = 3;
+
+  PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrData      inData = inMesh->createData("InData", 1);
+  const double z1     = 0.1;
+  const double z2     = -0.1;
+  auto &       v00    = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
+  auto &       v01    = inMesh->createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &       v10    = inMesh->createVertex(Eigen::Vector3d(1, 0, z1));
+  auto &       v11    = inMesh->createVertex(Eigen::Vector3d(1, 1, z1));
+  auto &       v20    = inMesh->createVertex(Eigen::Vector3d(2, 0, z2));
+  auto &       v21    = inMesh->createVertex(Eigen::Vector3d(2, 1, z2));
+  auto &       ell    = inMesh->createEdge(v00, v01);
+  auto &       elt    = inMesh->createEdge(v01, v11);
+  auto &       elr    = inMesh->createEdge(v11, v10);
+  auto &       elb    = inMesh->createEdge(v10, v00);
+  auto &       eld    = inMesh->createEdge(v00, v11);
+  auto &       erl    = elr;
+  auto &       ert    = inMesh->createEdge(v11, v21);
+  auto &       err    = inMesh->createEdge(v21, v20);
+  auto &       erb    = inMesh->createEdge(v20, v10);
+  auto &       erd    = inMesh->createEdge(v10, v21);
+  inMesh->createTriangle(ell, elt, eld);
+  inMesh->createTriangle(eld, elb, elr);
+  inMesh->createTriangle(erl, ert, erd);
+  inMesh->createTriangle(erd, erb, err);
+
+  inMesh->allocateDataValues();
+  inMesh->computeState();
+  inData->values() = Eigen::VectorXd::Constant(6, 1.0);
+
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrData outData = outMesh->createData("OutData", 1);
+  auto &  outV1   = outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
+  auto &  outV2   = outMesh->createVertex(Eigen::Vector3d{0.5, 0.0, 0.05});
+  auto &  outV3   = outMesh->createVertex(Eigen::Vector3d{0.5, 0.0, 0.0});
+  auto &  outE1   = outMesh->createEdge(outV1, outV2);
+  auto &  outE2   = outMesh->createEdge(outV2, outV3);
+  auto &  outE3   = outMesh->createEdge(outV1, outV3);
+  outMesh->createTriangle(outE1, outE2, outE3);
+  outMesh->allocateDataValues();
+  outMesh->computeState();
+  outData->values() = Eigen::VectorXd::Constant(3, 0.0);
+
+  // Setup mapping with mapping coordinates and geometry used
+  precice::mapping::NearestProjectionMapping mapping(mapping::Mapping::SCALEDCONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  mapping.computeMapping();
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+
+  mapping.map(inData->getID(), outData->getID());
+
+  auto inputIntegral  = mesh::integrate(inMesh, inData);
+  auto outputIntegral = mesh::integrate(outMesh, outData);
+
+  for (int dim = 0; dim < inputIntegral.size(); ++dim) {
+    BOOST_TEST(inputIntegral(dim) == outputIntegral(dim));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -12,6 +12,7 @@
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "mesh/Utils.hpp"
 #include "mesh/Vertex.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
@@ -19,6 +20,7 @@
 using namespace precice;
 using namespace precice::mesh;
 using namespace precice::mapping;
+using namespace precice::testing;
 using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(MappingTests)
@@ -28,6 +30,16 @@ void addGlobalIndex(mesh::PtrMesh &mesh, int offset = 0)
 {
   for (mesh::Vertex &v : mesh->vertices()) {
     v.setGlobalIndex(v.getID() + offset);
+  }
+}
+
+void testSerialScaledConsistent(mesh::PtrMesh inMesh, mesh::PtrMesh outMesh, mesh::PtrData inData, mesh::PtrData outData)
+{
+  auto inputIntegral  = mesh::integrate(inMesh, inData);
+  auto outputIntegral = mesh::integrate(outMesh, outData);
+
+  for (int dim = 0; dim < inputIntegral.size(); ++dim) {
+    BOOST_TEST(inputIntegral(dim) == outputIntegral(dim));
   }
 }
 
@@ -1422,6 +1434,110 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   BOOST_TEST(value == 1.5);
 }
 
+void perform2DTestScaledConsistentMapping(Mapping &mapping)
+{
+  int dimensions = 2;
+  using Eigen::Vector2d;
+
+  // Create mesh to map from
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  auto &        inV1     = inMesh->createVertex(Vector2d(0.0, 0.0));
+  auto &        inV2     = inMesh->createVertex(Vector2d(1.0, 0.0));
+  auto &        inV3     = inMesh->createVertex(Vector2d(1.0, 1.0));
+  auto &        inV4     = inMesh->createVertex(Vector2d(0.0, 1.0));
+
+  inMesh->createEdge(inV1, inV2);
+  inMesh->createEdge(inV2, inV3);
+  inMesh->createEdge(inV3, inV4);
+  inMesh->createEdge(inV1, inV4);
+
+  inMesh->allocateDataValues();
+  addGlobalIndex(inMesh);
+
+  auto &inValues = inData->values();
+  inValues << 1.0, 2.0, 2.0, 1.0;
+
+  // Create mesh to map to
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  auto &        outV1     = outMesh->createVertex(Vector2d(0.0, 0.0));
+  auto &        outV2     = outMesh->createVertex(Vector2d(0.0, 1.0));
+  auto &        outV3     = outMesh->createVertex(Vector2d(1.1, 1.1));
+  auto &        outV4     = outMesh->createVertex(Vector2d(0.1, 1.1));
+  outMesh->createEdge(outV1, outV2);
+  outMesh->createEdge(outV2, outV3);
+  outMesh->createEdge(outV3, outV4);
+  outMesh->createEdge(outV1, outV4);
+  outMesh->allocateDataValues();
+  addGlobalIndex(outMesh);
+
+  // Setup mapping with mapping coordinates and geometry used
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+
+  testSerialScaledConsistent(inMesh, outMesh, inData, outData);
+}
+
+void perform3DTestScaledConsistentMapping(Mapping &mapping)
+{
+  int dimensions = 3;
+
+  // Create mesh to map from
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  int           inDataID = inData->getID();
+  auto &        inV1     = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &        inV2     = inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  auto &        inV3     = inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.5));
+  auto &        inV4     = inMesh->createVertex(Eigen::Vector3d(2.0, 0.0, 0.0));
+  auto &        inV5     = inMesh->createVertex(Eigen::Vector3d(0.0, 2.0, 0.0));
+  auto &        inV6     = inMesh->createVertex(Eigen::Vector3d(0.0, 2.0, 1.0));
+  auto &        inE1     = inMesh->createEdge(inV1, inV2);
+  auto &        inE2     = inMesh->createEdge(inV2, inV3);
+  auto &        inE3     = inMesh->createEdge(inV1, inV3);
+  auto &        inE4     = inMesh->createEdge(inV4, inV5);
+  auto &        inE5     = inMesh->createEdge(inV5, inV6);
+  auto &        inE6     = inMesh->createEdge(inV4, inV6);
+  inMesh->createTriangle(inE1, inE2, inE3);
+  inMesh->createTriangle(inE4, inE5, inE6);
+
+  inMesh->allocateDataValues();
+  addGlobalIndex(inMesh);
+
+  auto &inValues = inData->values();
+  inValues << 1.0, 2.0, 4.0, 6.0, 8.0, 9.0;
+
+  // Create mesh to map to
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  int           outDataID = outData->getID();
+  auto &        outV1     = outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &        outV2     = outMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  auto &        outV3     = outMesh->createVertex(Eigen::Vector3d(0.0, 1.1, 0.6));
+  auto &        outE1     = outMesh->createEdge(outV1, outV2);
+  auto &        outE2     = outMesh->createEdge(outV2, outV3);
+  auto &        outE3     = outMesh->createEdge(outV1, outV3);
+  outMesh->createTriangle(outE1, outE2, outE3);
+
+  outMesh->allocateDataValues();
+  addGlobalIndex(outMesh);
+
+  // Setup mapping with mapping coordinates and geometry used
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+  mapping.computeMapping();
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+  mapping.map(inDataID, outDataID);
+
+  testSerialScaledConsistent(inMesh, outMesh, inData, outData);
+}
+
 void perform2DTestConservativeMapping(Mapping &mapping)
 {
   const int    dimensions = 2;
@@ -1620,6 +1736,10 @@ BOOST_AUTO_TEST_CASE(MapThinPlateSplines)
   perform2DTestConsistentMappingVector(consistentMap2DVector);
   RadialBasisFctMapping<ThinPlateSplines> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  RadialBasisFctMapping<ThinPlateSplines> scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  RadialBasisFctMapping<ThinPlateSplines> scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   RadialBasisFctMapping<ThinPlateSplines> conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   RadialBasisFctMapping<ThinPlateSplines> conservativeMap2DVector(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
@@ -1639,6 +1759,10 @@ BOOST_AUTO_TEST_CASE(MapMultiquadrics)
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<Multiquadrics> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  RadialBasisFctMapping<Multiquadrics> scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  RadialBasisFctMapping<Multiquadrics> scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   RadialBasisFctMapping<Multiquadrics> conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   RadialBasisFctMapping<Multiquadrics> conservativeMap3D(Mapping::CONSERVATIVE, 3, fct, xDead, yDead, zDead);
@@ -1656,6 +1780,10 @@ BOOST_AUTO_TEST_CASE(MapInverseMultiquadrics)
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<InverseMultiquadrics> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  RadialBasisFctMapping<InverseMultiquadrics> scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  RadialBasisFctMapping<InverseMultiquadrics> scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   RadialBasisFctMapping<InverseMultiquadrics> conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   RadialBasisFctMapping<InverseMultiquadrics> conservativeMap3D(Mapping::CONSERVATIVE, 3, fct, xDead, yDead, zDead);
@@ -1673,6 +1801,10 @@ BOOST_AUTO_TEST_CASE(MapVolumeSplines)
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<VolumeSplines> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  RadialBasisFctMapping<VolumeSplines> scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  RadialBasisFctMapping<VolumeSplines> scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   RadialBasisFctMapping<VolumeSplines> conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   RadialBasisFctMapping<VolumeSplines> conservativeMap3D(Mapping::CONSERVATIVE, 3, fct, xDead, yDead, zDead);
@@ -1690,6 +1822,10 @@ BOOST_AUTO_TEST_CASE(MapGaussian)
   perform2DTestConsistentMapping(consistentMap2D);
   RadialBasisFctMapping<Gaussian> consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  RadialBasisFctMapping<Gaussian> scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  RadialBasisFctMapping<Gaussian> scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   RadialBasisFctMapping<Gaussian> conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   RadialBasisFctMapping<Gaussian> conservativeMap3D(Mapping::CONSERVATIVE, 3, fct, xDead, yDead, zDead);
@@ -1709,6 +1845,10 @@ BOOST_AUTO_TEST_CASE(MapCompactThinPlateSplinesC2)
   perform2DTestConsistentMapping(consistentMap2D);
   Mapping consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  Mapping scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  Mapping scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   Mapping conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   Mapping conservativeMap3D(Mapping::CONSERVATIVE, 3, fct, xDead, yDead, zDead);
@@ -1728,6 +1868,10 @@ BOOST_AUTO_TEST_CASE(MapPetCompactPolynomialC0)
   perform2DTestConsistentMapping(consistentMap2D);
   Mapping consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  Mapping scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  Mapping scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   Mapping conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   Mapping conservativeMap3D(Mapping::CONSERVATIVE, 3, fct, xDead, yDead, zDead);
@@ -1747,6 +1891,10 @@ BOOST_AUTO_TEST_CASE(MapPetCompactPolynomialC6)
   perform2DTestConsistentMapping(consistentMap2D);
   Mapping consistentMap3D(Mapping::CONSISTENT, 3, fct, xDead, yDead, zDead);
   perform3DTestConsistentMapping(consistentMap3D);
+  Mapping scaledConsistentMap2D(Mapping::SCALEDCONSISTENT, 2, fct, xDead, yDead, zDead);
+  perform2DTestScaledConsistentMapping(scaledConsistentMap2D);
+  Mapping scaledConsistentMap3D(Mapping::SCALEDCONSISTENT, 3, fct, xDead, yDead, zDead);
+  perform3DTestScaledConsistentMapping(scaledConsistentMap3D);
   Mapping conservativeMap2D(Mapping::CONSERVATIVE, 2, fct, xDead, yDead, zDead);
   perform2DTestConservativeMapping(conservativeMap2D);
   Mapping conservativeMap3D(Mapping::CONSERVATIVE, 3, fct, xDead, yDead, zDead);

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -6,6 +6,7 @@
 #include <boost/concept/assert.hpp>
 #include <boost/range/concepts.hpp>
 #include "math/differences.hpp"
+#include "math/geometry.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
 #include "utils/EigenIO.hpp"
@@ -77,11 +78,7 @@ Triangle::Triangle(
 
 double Triangle::getArea() const
 {
-  Eigen::Vector3d vectorA = edge(1).vertex(1).getCoords() - edge(1).vertex(0).getCoords();
-  Eigen::Vector3d vectorB = edge(0).vertex(1).getCoords() - edge(0).vertex(0).getCoords();
-  // Compute cross-product of vector A and vector B
-  auto normal = vectorA.cross(vectorB);
-  return (0.5 * normal.norm());
+  return math::geometry::triangleArea(vertex(0).getCoords(), vertex(1).getCoords(), vertex(2).getCoords());
 }
 
 const Eigen::VectorXd Triangle::computeNormal(bool flip)

--- a/src/mesh/Utils.cpp
+++ b/src/mesh/Utils.cpp
@@ -1,0 +1,40 @@
+#include <Eigen/Core>
+#include <mesh/Edge.hpp>
+#include <mesh/Mesh.hpp>
+#include <utils/MasterSlave.hpp>
+
+namespace precice {
+namespace mesh {
+
+/// Given the data and the mesh, this function returns the surface integral. Assumes no overlap exists for the mesh
+Eigen::VectorXd integrate(PtrMesh mesh, PtrData data)
+{
+  const int       valueDimensions = data->getDimensions();
+  const int       meshDimensions  = mesh->getDimensions();
+  const auto &    values          = data->values();
+  Eigen::VectorXd integral        = Eigen::VectorXd::Zero(valueDimensions);
+
+  if (meshDimensions == 2) {
+    for (const auto &edge : mesh->edges()) {
+      int vertex1 = edge.vertex(0).getID() * valueDimensions;
+      int vertex2 = edge.vertex(1).getID() * valueDimensions;
+      for (int dim = 0; dim < valueDimensions; ++dim) {
+        integral(dim) += 0.5 * edge.getLength() * (values(vertex1 + dim) + values(vertex2 + dim));
+      }
+    }
+  } else {
+    for (const auto &face : mesh->triangles()) {
+      int vertex1 = face.vertex(0).getID() * valueDimensions;
+      int vertex2 = face.vertex(1).getID() * valueDimensions;
+      int vertex3 = face.vertex(2).getID() * valueDimensions;
+
+      for (int dim = 0; dim < valueDimensions; ++dim) {
+        integral(dim) += (face.getArea() / 3.0) * (values(vertex1 + dim) + values(vertex2 + dim) + values(vertex3 + dim));
+      }
+    }
+  }
+  return integral;
+}
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Utils.hpp
+++ b/src/mesh/Utils.hpp
@@ -132,5 +132,8 @@ std::array<Eigen::VectorXd, n> coordsFor(const std::array<Vertex *, n> &vertexPt
   return coords;
 }
 
+/// Given the data and the mesh, this function returns the surface integral. Assumes no overlap exists for the mesh
+Eigen::VectorXd integrate(PtrMesh mesh, PtrData data);
+
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -666,6 +666,134 @@ BOOST_AUTO_TEST_CASE(CoordsForPtrs)
   BOOST_TEST(result == expected);
 }
 
+BOOST_AUTO_TEST_CASE(Integrate2DScalarData)
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, false, testing::nextMeshID());
+  mesh->createData("Data", 1);
+
+  auto &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  auto &v2 = mesh->createVertex(Eigen::Vector2d(0.0, 0.5));
+  auto &v3 = mesh->createVertex(Eigen::Vector2d(0.0, 1.5));
+  auto &v4 = mesh->createVertex(Eigen::Vector2d(0.0, 3.5));
+  mesh->allocateDataValues();
+
+  mesh->createEdge(v1, v2); // Length = 0.5
+  mesh->createEdge(v2, v3); // Length = 1.0
+  mesh->createEdge(v3, v4); // Length = 2.0
+
+  mesh->data(0)->values()(0) = 1.0;
+  mesh->data(0)->values()(1) = 3.0;
+  mesh->data(0)->values()(2) = 5.0;
+  mesh->data(0)->values()(3) = 7.0;
+
+  auto   result   = mesh::integrate(mesh, mesh->data(0));
+  double expected = 17.0;
+  BOOST_REQUIRE(result.size() == 1);
+  BOOST_TEST(result(0) == expected);
+}
+
+BOOST_AUTO_TEST_CASE(Integrate2DVectorData)
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, false, testing::nextMeshID());
+  mesh->createData("Data", 2);
+
+  auto &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  auto &v2 = mesh->createVertex(Eigen::Vector2d(0.0, 0.5));
+  auto &v3 = mesh->createVertex(Eigen::Vector2d(0.0, 1.5));
+  auto &v4 = mesh->createVertex(Eigen::Vector2d(0.0, 3.5));
+  mesh->allocateDataValues();
+
+  mesh->createEdge(v1, v2); // Length = 0.5
+  mesh->createEdge(v2, v3); // Length = 1.0
+  mesh->createEdge(v3, v4); // Length = 2.0
+
+  mesh->data(0)->values()(0) = 1.0;
+  mesh->data(0)->values()(1) = 2.0;
+  mesh->data(0)->values()(2) = 3.0;
+  mesh->data(0)->values()(3) = 4.0;
+  mesh->data(0)->values()(4) = 5.0;
+  mesh->data(0)->values()(5) = 6.0;
+  mesh->data(0)->values()(6) = 7.0;
+  mesh->data(0)->values()(7) = 8.0;
+
+  auto            result = mesh::integrate(mesh, mesh->data(0));
+  Eigen::Vector2d expected(17.0, 20.5);
+  BOOST_REQUIRE(result.size() == 2);
+  BOOST_TEST(result(0) == expected(0));
+  BOOST_TEST(result(1) == expected(1));
+}
+
+BOOST_AUTO_TEST_CASE(Integrate3DScalarData)
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, false, testing::nextMeshID());
+  mesh->createData("Data", 1);
+
+  auto &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
+  auto &v3 = mesh->createVertex(Eigen::Vector3d(3.0, 4.0, 0.0));
+  auto &v4 = mesh->createVertex(Eigen::Vector3d(0.0, 8.0, 0.0));
+  mesh->allocateDataValues();
+
+  auto &e1 = mesh->createEdge(v1, v2);
+  auto &e2 = mesh->createEdge(v2, v3);
+  auto &e3 = mesh->createEdge(v3, v4);
+  auto &e4 = mesh->createEdge(v1, v4);
+  auto &e5 = mesh->createEdge(v1, v3);
+
+  mesh->createTriangle(e1, e2, e5); // Area = 6.0
+  mesh->createTriangle(e3, e4, e5); // Area = 12.0
+
+  mesh->data(0)->values()(0) = 1.0;
+  mesh->data(0)->values()(1) = 3.0;
+  mesh->data(0)->values()(2) = 5.0;
+  mesh->data(0)->values()(3) = 7.0;
+
+  auto   result   = mesh::integrate(mesh, mesh->data(0));
+  double expected = 70.0;
+  BOOST_REQUIRE(result.size() == 1);
+  BOOST_TEST(result(0) == expected);
+}
+
+BOOST_AUTO_TEST_CASE(Integrate3DVectorData)
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, false, testing::nextMeshID());
+  mesh->createData("Data", 2);
+
+  auto &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
+  auto &v3 = mesh->createVertex(Eigen::Vector3d(3.0, 4.0, 0.0));
+  auto &v4 = mesh->createVertex(Eigen::Vector3d(0.0, 8.0, 0.0));
+  mesh->allocateDataValues();
+
+  auto &e1 = mesh->createEdge(v1, v2);
+  auto &e2 = mesh->createEdge(v2, v3);
+  auto &e3 = mesh->createEdge(v3, v4);
+  auto &e4 = mesh->createEdge(v1, v4);
+  auto &e5 = mesh->createEdge(v1, v3);
+
+  mesh->createTriangle(e1, e2, e5); // Area = 6.0
+  mesh->createTriangle(e3, e4, e5); // Area = 12.0
+
+  mesh->data(0)->values()(0) = 1.0;
+  mesh->data(0)->values()(1) = 2.0;
+  mesh->data(0)->values()(2) = 3.0;
+  mesh->data(0)->values()(3) = 4.0;
+  mesh->data(0)->values()(4) = 5.0;
+  mesh->data(0)->values()(5) = 6.0;
+  mesh->data(0)->values()(6) = 7.0;
+  mesh->data(0)->values()(7) = 8.0;
+
+  auto            result = mesh::integrate(mesh, mesh->data(0));
+  Eigen::Vector2d expected(70.0, 88.0);
+  BOOST_REQUIRE(result.size() == 2);
+  BOOST_TEST(result(0) == expected(0));
+  BOOST_TEST(result(1) == expected(1));
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Utils
 
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -413,6 +413,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
         PRECICE_ERROR(
             "For a parallel participant, only the mapping"
             << " combinations read-consistent and write-conservative are allowed");
+      } else if (confMapping.mapping->getConstraint() == mapping::Mapping::SCALEDCONSISTENT) {
+        PRECICE_ERROR("Scaled consistent mapping is not yet supported for a parallel participant. You could run in serial or use a plain (read-)consistent mapping instead.");
       }
     }
 

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -9,6 +9,7 @@
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "math/constants.hpp"
+#include "math/geometry.hpp"
 #include "mesh/Mesh.hpp"
 #include "precice/SolverInterface.hpp"
 #include "precice/config/Configuration.hpp"

--- a/src/precice/tests/mapping-scaled-consistent-onA.xml
+++ b/src/precice/tests/mapping-scaled-consistent-onA.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="DataOne" />
+
+    <mesh name="MeshOne">
+      <use-data name="DataOne" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="DataOne" />
+    </mesh>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshTwo" provide="on" />
+      <read-data name="DataOne" mesh="MeshTwo" />
+    </participant>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <use-mesh name="MeshTwo" from="SolverTwo" />
+      <write-data name="DataOne" mesh="MeshOne" />
+      <mapping:nearest-projection
+        direction="write"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="scaled-consistent"
+        timing="initial" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="1" />
+      <time-window-size value="1.0" />
+      <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/precice/tests/mapping-scaled-consistent-onB.xml
+++ b/src/precice/tests/mapping-scaled-consistent-onB.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="DataOne" />
+
+    <mesh name="MeshOne">
+      <use-data name="DataOne" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="DataOne" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <write-data name="DataOne" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshTwo" provide="on" />
+      <mapping:nearest-projection
+        direction="read"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="scaled-consistent"
+        timing="initial" />
+      <read-data name="DataOne" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="1" />
+      <time-window-size value="1.0" />
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -198,6 +198,7 @@ target_sources(precice
     src/mesh/SharedPointer.hpp
     src/mesh/Triangle.cpp
     src/mesh/Triangle.hpp
+    src/mesh/Utils.cpp
     src/mesh/Utils.hpp
     src/mesh/Vertex.cpp
     src/mesh/Vertex.hpp


### PR DESCRIPTION
## Main changes of this PR
In #906 scaled-consistent mapping is introduced only for serial participants. This PR expands it for parallel participants too. There are a few things to accomplish first.

## Motivation and additional information
Currently, scaled-consistent mapping is only supported for serial participants.

## Author's checklist

* [ ] Add ownership information for `Edge` and `Triangle`
* [ ] Introduce more aggressive repartioning to consider connectivity information
* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)