### PR TITLE
Implement ownership and global indexing for edges and triangles

### DIFF
--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -58,11 +58,14 @@ void CommunicateMesh::sendMesh(
     _communication->send(vertexIDs, rankReceiver);
 
     std::vector<int> edgeIDs(numberOfEdges * 2);
+    std::vector<int> globalEdgeIDs(numberOfEdges);
     for (int i = 0; i < numberOfEdges; i++) {
       edgeIDs[i * 2]     = mesh.edges()[i].vertex(0).getID();
       edgeIDs[i * 2 + 1] = mesh.edges()[i].vertex(1).getID();
+      globalEdgeIDs[i]   = mesh.edges()[i].getGlobalIndex();
     }
     _communication->send(edgeIDs, rankReceiver);
+    _communication->send(globalEdgeIDs, rankReceiver);
   }
 
   if (dim == 3) {
@@ -78,12 +81,15 @@ void CommunicateMesh::sendMesh(
       _communication->send(edgeIDs, rankReceiver);
 
       std::vector<int> triangleIDs(numberOfTriangles * 3);
+      std::vector<int> globalTriangleIDs(numberOfTriangles);
       for (int i = 0; i < numberOfTriangles; i++) {
         triangleIDs[i * 3]     = mesh.triangles()[i].edge(0).getID();
         triangleIDs[i * 3 + 1] = mesh.triangles()[i].edge(1).getID();
         triangleIDs[i * 3 + 2] = mesh.triangles()[i].edge(2).getID();
+        globalTriangleIDs[i]   = mesh.triangles()[i].getGlobalIndex();
       }
       _communication->send(triangleIDs, rankReceiver);
+      _communication->send(globalTriangleIDs, rankReceiver);
     }
   }
 }
@@ -133,12 +139,15 @@ void CommunicateMesh::receiveMesh(
     }
 
     std::vector<int> edgeIDs;
+    std::vector<int> globalEdgeIDs;
     _communication->receive(edgeIDs, rankSender);
+    _communication->receive(globalEdgeIDs, rankSender);
     for (int i = 0; i < numberOfEdges; i++) {
       PRECICE_ASSERT(vertexMap.count((edgeIDs[i * 2])) == 1);
       PRECICE_ASSERT(vertexMap.count(edgeIDs[i * 2 + 1]) == 1);
       PRECICE_ASSERT(edgeIDs[i * 2] != edgeIDs[i * 2 + 1]);
       mesh::Edge &e = mesh.createEdge(*vertexMap[edgeIDs[i * 2]], *vertexMap[edgeIDs[i * 2 + 1]]);
+      e.setGlobalIndex(globalEdgeIDs[i]);
       edges.push_back(&e);
     }
   }
@@ -159,8 +168,9 @@ void CommunicateMesh::receiveMesh(
       }
 
       std::vector<int> triangleIDs;
+      std::vector<int> globalTriangleIDs;
       _communication->receive(triangleIDs, rankSender);
-
+      _communication->receive(globalTriangleIDs, rankSender);
       for (int i = 0; i < numberOfTriangles; i++) {
         PRECICE_ASSERT(edgeMap.count(triangleIDs[i * 3]) == 1);
         PRECICE_ASSERT(edgeMap.count(triangleIDs[i * 3 + 1]) == 1);
@@ -168,7 +178,8 @@ void CommunicateMesh::receiveMesh(
         PRECICE_ASSERT(triangleIDs[i * 3] != triangleIDs[i * 3 + 1]);
         PRECICE_ASSERT(triangleIDs[i * 3 + 1] != triangleIDs[i * 3 + 2]);
         PRECICE_ASSERT(triangleIDs[i * 3 + 2] != triangleIDs[i * 3]);
-        mesh.createTriangle(*edgeMap[triangleIDs[i * 3]], *edgeMap[triangleIDs[i * 3 + 1]], *edgeMap[triangleIDs[i * 3 + 2]]);
+        auto &t = mesh.createTriangle(*edgeMap[triangleIDs[i * 3]], *edgeMap[triangleIDs[i * 3 + 1]], *edgeMap[triangleIDs[i * 3 + 2]]);
+        t.setGlobalIndex(globalTriangleIDs[i]);
       }
     }
   }
@@ -206,11 +217,14 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
     _communication->broadcast(vertexIDs);
 
     std::vector<int> edgeIDs(numberOfEdges * 2);
+    std::vector<int> globalEdgeIDs(numberOfEdges);
     for (int i = 0; i < numberOfEdges; i++) {
       edgeIDs[i * 2]     = mesh.edges()[i].vertex(0).getID();
       edgeIDs[i * 2 + 1] = mesh.edges()[i].vertex(1).getID();
+      globalEdgeIDs[i]   = mesh.edges()[i].getGlobalIndex();
     }
     _communication->broadcast(edgeIDs);
+    _communication->broadcast(globalEdgeIDs);
   }
 
   if (dim == 3) {
@@ -226,12 +240,15 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
       _communication->broadcast(edgeIDs);
 
       std::vector<int> triangleIDs(numberOfTriangles * 3);
+      std::vector<int> globalTriangleIDs(numberOfTriangles);
       for (int i = 0; i < numberOfTriangles; i++) {
         triangleIDs[i * 3]     = mesh.triangles()[i].edge(0).getID();
         triangleIDs[i * 3 + 1] = mesh.triangles()[i].edge(1).getID();
         triangleIDs[i * 3 + 2] = mesh.triangles()[i].edge(2).getID();
+        globalTriangleIDs[i]   = mesh.triangles()[i].getGlobalIndex();
       }
       _communication->broadcast(triangleIDs);
+      _communication->broadcast(globalTriangleIDs);
     }
   }
 }
@@ -276,12 +293,15 @@ void CommunicateMesh::broadcastReceiveMesh(
     }
 
     std::vector<int> edgeIDs;
+    std::vector<int> globalEdgeIDs;
     _communication->broadcast(edgeIDs, rankBroadcaster);
+    _communication->broadcast(globalEdgeIDs, rankBroadcaster);
     for (int i = 0; i < numberOfEdges; i++) {
       PRECICE_ASSERT(vertexMap.find(edgeIDs[i * 2]) != vertexMap.end());
       PRECICE_ASSERT(vertexMap.find(edgeIDs[i * 2 + 1]) != vertexMap.end());
       PRECICE_ASSERT(edgeIDs[i * 2] != edgeIDs[i * 2 + 1]);
       mesh::Edge &e = mesh.createEdge(*vertexMap[edgeIDs[i * 2]], *vertexMap[edgeIDs[i * 2 + 1]]);
+      e.setGlobalIndex(globalEdgeIDs[i]);
       edges.push_back(&e);
     }
   }
@@ -299,7 +319,9 @@ void CommunicateMesh::broadcastReceiveMesh(
       }
 
       std::vector<int> triangleIDs;
+      std::vector<int> globalTriangleIDs;
       _communication->broadcast(triangleIDs, rankBroadcaster);
+      _communication->broadcast(globalTriangleIDs, rankBroadcaster);
 
       for (int i = 0; i < numberOfTriangles; i++) {
         PRECICE_ASSERT(edgeMap.find(triangleIDs[i * 3]) != edgeMap.end());
@@ -308,7 +330,8 @@ void CommunicateMesh::broadcastReceiveMesh(
         PRECICE_ASSERT(triangleIDs[i * 3] != triangleIDs[i * 3 + 1]);
         PRECICE_ASSERT(triangleIDs[i * 3 + 1] != triangleIDs[i * 3 + 2]);
         PRECICE_ASSERT(triangleIDs[i * 3 + 2] != triangleIDs[i * 3]);
-        mesh.createTriangle(*edgeMap[triangleIDs[i * 3]], *edgeMap[triangleIDs[i * 3 + 1]], *edgeMap[triangleIDs[i * 3 + 2]]);
+        auto &t = mesh.createTriangle(*edgeMap[triangleIDs[i * 3]], *edgeMap[triangleIDs[i * 3 + 1]], *edgeMap[triangleIDs[i * 3 + 2]]);
+        t.setGlobalIndex(globalTriangleIDs[i]);
       }
     }
   }

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -69,6 +69,26 @@ bool Edge::operator!=(const Edge &other) const
   return !(*this == other);
 }
 
+int Edge::getGlobalIndex() const
+{
+  return _globalIndex;
+}
+
+void Edge::setGlobalIndex(int globalIndex)
+{
+  _globalIndex = globalIndex;
+}
+
+bool Edge::isOwner() const
+{
+  return _owner;
+}
+
+void Edge::setOwner(bool owner)
+{
+  _owner = owner;
+}
+
 std::ostream &operator<<(std::ostream &stream, const Edge &edge)
 {
   using utils::eigenio::wkt;

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -49,6 +49,15 @@ public:
   /// Returns the (among edges) unique ID of the edge.
   int getID() const;
 
+  /// Globally unique index
+  int getGlobalIndex() const;
+
+  void setGlobalIndex(int globalIndex);
+
+  bool isOwner() const;
+
+  void setOwner(bool owner);
+
   /// Returns the length of the edge
   double getLength() const;
 
@@ -84,6 +93,12 @@ private:
 
   /// Normal of the edge.
   Eigen::VectorXd _normal;
+
+  /// global (unique) index for parallel simulations
+  int _globalIndex = -1;
+
+  /// true if this processors is the owner of the triangle (for parallel simulations)
+  bool _owner = true;
 };
 
 // ------------------------------------------------------ HEADER IMPLEMENTATION

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -325,6 +325,26 @@ void Mesh::setGlobalNumberOfVertices(int num)
   _globalNumberOfVertices = num;
 }
 
+int Mesh::getGlobalNumberOfEdges() const
+{
+  return _globalNumberOfEdges;
+}
+
+void Mesh::setGlobalNumberOfEdges(int num)
+{
+  _globalNumberOfEdges = num;
+}
+
+int Mesh::getGlobalNumberOfTriangles() const
+{
+  return _globalNumberOfTriangles;
+}
+
+void Mesh::setGlobalNumberOfTriangles(int num)
+{
+  _globalNumberOfTriangles = num;
+}
+
 Eigen::VectorXd Mesh::getOwnedVertexData(int dataID)
 {
 
@@ -382,7 +402,9 @@ void Mesh::addMesh(
     int vertexIndex2 = edge.vertex(1).getID();
     PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
                    (vertexMap.count(vertexIndex2) == 1));
-    Edge &e               = createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
+    Edge &e = createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
+    e.setGlobalIndex(edge.getGlobalIndex());
+    e.setOwner(edge.isOwner());
     edgeMap[edge.getID()] = &e;
   }
 
@@ -394,7 +416,9 @@ void Mesh::addMesh(
       PRECICE_ASSERT((edgeMap.count(edgeIndex1) == 1) &&
                      (edgeMap.count(edgeIndex2) == 1) &&
                      (edgeMap.count(edgeIndex3) == 1));
-      createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
+      Triangle &t = createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
+      t.setGlobalIndex(triangle.getGlobalIndex());
+      t.setOwner(triangle.isOwner());
     }
   }
   meshChanged(*this);

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -200,6 +200,14 @@ public:
 
   void setGlobalNumberOfVertices(int num);
 
+  int getGlobalNumberOfEdges() const;
+
+  void setGlobalNumberOfEdges(int num);
+
+  int getGlobalNumberOfTriangles() const;
+
+  void setGlobalNumberOfTriangles(int num);
+
   // Get the data of owned vertices for given data ID
   Eigen::VectorXd getOwnedVertexData(int dataID);
 
@@ -281,6 +289,20 @@ private:
    * Duplicated vertices are only accounted once.
    */
   int _globalNumberOfVertices = -1;
+
+  /**
+   * @brief Number of unique edges for complete distributed mesh.
+   *
+   * Duplicated edges are only accounted once.
+   */
+  int _globalNumberOfEdges = -1;
+
+  /**
+   * @brief Number of unique triangles for complete distributed mesh.
+   *
+   * Duplicated triangles are only accounted once.
+   */
+  int _globalNumberOfTriangles = -1;
 
   /**
    * @brief each rank stores list of connected remote ranks.

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -132,6 +132,26 @@ bool Triangle::operator!=(const Triangle &other) const
   return !(*this == other);
 }
 
+int Triangle::getGlobalIndex() const
+{
+  return _globalIndex;
+}
+
+void Triangle::setGlobalIndex(int globalIndex)
+{
+  _globalIndex = globalIndex;
+}
+
+bool Triangle::isOwner() const
+{
+  return _owner;
+}
+
+void Triangle::setOwner(bool owner)
+{
+  _owner = owner;
+}
+
 std::ostream &operator<<(std::ostream &os, const Triangle &t)
 {
   using utils::eigenio::wkt;

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -104,6 +104,15 @@ public:
   /// Returns a among triangles globally unique ID.
   int getID() const;
 
+  /// Globally unique index
+  int getGlobalIndex() const;
+
+  void setGlobalIndex(int globalIndex);
+
+  bool isOwner() const;
+
+  void setOwner(bool owner);
+
   /// Returns the surface area of the triangle
   double getArea() const;
 
@@ -143,6 +152,12 @@ private:
 
   /// Normal vector of the triangle.
   Eigen::VectorXd _normal;
+
+  /// global (unique) index for parallel simulations
+  int _globalIndex = -1;
+
+  /// true if this processors is the owner of the triangle (for parallel simulations)
+  bool _owner = true;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS

--- a/src/partition/ProvidedPartition.hpp
+++ b/src/partition/ProvidedPartition.hpp
@@ -32,6 +32,9 @@ public:
 private:
   void prepare();
 
+  void prepareEdges();
+  void prepareTriangles();
+
   logging::Logger _log{"partition::ProvidedPartition"};
 };
 

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -74,8 +74,18 @@ private:
 
   void createOwnerInformation();
 
+  void createEdgeOwnerInformation();
+
+  void createTriangleOwnerInformation();
+
   /// Helper function for 'createOwnerFunction' to set local owner information
   void setOwnerInformation(const std::vector<int> &ownerVec);
+
+  /// Helper function for 'createOwnerFunction' to set local owner information
+  void setEdgeOwnerInformation(const std::vector<int> &ownerVec);
+
+  /// Helper function for 'createOwnerFunction' to set local owner information
+  void setTriangleOwnerInformation(const std::vector<int> &ownerVec);
 
   /// Is the local other (i.e. provided) bounding box already prepared (i.e. has prepareBoundingBox() been called)
   bool _boundingBoxPrepared = false;
@@ -87,6 +97,8 @@ private:
   int _dimensions;
 
   double _safetyFactor;
+
+  int _ranksAtInterface = 0;
 
   logging::Logger _log{"partition::ReceivedPartition"};
 


### PR DESCRIPTION
## Main changes of this PR
Similar to the vertex ownership and global indexing, this PR implements ownership and global indexing for other two primitives.
* Define setters and getters
* Extend communication for global indices of edges and triangles
* Extend partitioning to account for these changes

## Motivation and additional information
This PR is part of #962 . For connectivity based mappings, there is no way to know exactly which connectivity element is defined on which rank and which are defined twice/overlapping for a received partition.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)