### PR TITLE
Use possibly cached index trees in watch-point

### DIFF
--- a/docs/changelog/965.md
+++ b/docs/changelog/965.md
@@ -1,0 +1,1 @@
+* Changed the watch-point calculation algorithm to use already built index trees 

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -54,7 +54,7 @@ void NearestNeighborMapping::computeMapping()
     const mesh::Mesh::VertexContainer &    inputVertices = input()->vertices();
     // Search for the output vertex inside the input mesh and add index to _vertexIndices
     for (size_t i = 0; i < verticesSize; i++) {
-      auto matchedVertex = indexTree.getClosestVertex(inputVertices[i]);
+      auto matchedVertex = indexTree.getClosestVertex(inputVertices[i].getCoords());
       _vertexIndices[i]  = matchedVertex.index;
       distanceStatistics(matchedVertex.distance);
     }
@@ -73,7 +73,7 @@ void NearestNeighborMapping::computeMapping()
     utils::statistics::DistanceAccumulator distanceStatistics;
     const mesh::Mesh::VertexContainer &    outputVertices = output()->vertices();
     for (size_t i = 0; i < verticesSize; i++) {
-      auto matchedVertex = indexTree.getClosestVertex(outputVertices[i]);
+      auto matchedVertex = indexTree.getClosestVertex(outputVertices[i].getCoords());
       _vertexIndices[i]  = matchedVertex.index;
       distanceStatistics(matchedVertex.distance);
     }

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -761,15 +761,15 @@ BOOST_AUTO_TEST_CASE(AvoidClosestTriangle)
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   // Close triangle - extrapolating
-  auto &       vc0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
-  auto &       vc1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 0));
-  auto &       vc2 = inMesh->createVertex(Eigen::Vector3d(4, 1, 0));
+  auto &vc0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
+  auto &vc1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 0));
+  auto &vc2 = inMesh->createVertex(Eigen::Vector3d(4, 1, 0));
   makeTriangle(inMesh, vc0, vc1, vc2);
 
   // Far triangle - interpolating
-  auto &       vf0 = inMesh->createVertex(Eigen::Vector3d(0, 0, -1));
-  auto &       vf1 = inMesh->createVertex(Eigen::Vector3d(0, 2, -1));
-  auto &       vf2 = inMesh->createVertex(Eigen::Vector3d(0, 1, 1));
+  auto &vf0 = inMesh->createVertex(Eigen::Vector3d(0, 0, -1));
+  auto &vf1 = inMesh->createVertex(Eigen::Vector3d(0, 2, -1));
+  auto &vf2 = inMesh->createVertex(Eigen::Vector3d(0, 1, 1));
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   inMesh->allocateDataValues();
@@ -796,15 +796,15 @@ BOOST_AUTO_TEST_CASE(PickClosestTriangle)
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   // Far triangle - interpolating
-  auto &       vf0 = inMesh->createVertex(Eigen::Vector3d(0, 0, -1));
-  auto &       vf1 = inMesh->createVertex(Eigen::Vector3d(0, 1, 1));
-  auto &       vf2 = inMesh->createVertex(Eigen::Vector3d(0, 2, -1));
+  auto &vf0 = inMesh->createVertex(Eigen::Vector3d(0, 0, -1));
+  auto &vf1 = inMesh->createVertex(Eigen::Vector3d(0, 1, 1));
+  auto &vf2 = inMesh->createVertex(Eigen::Vector3d(0, 2, -1));
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   // Close triangle - extrapolating
-  auto &       vc0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
-  auto &       vc1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 0));
-  auto &       vc2 = inMesh->createVertex(Eigen::Vector3d(4, 1, 0));
+  auto &vc0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
+  auto &vc1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 0));
+  auto &vc2 = inMesh->createVertex(Eigen::Vector3d(4, 1, 0));
   makeTriangle(inMesh, vc0, vc1, vc2);
 
   inMesh->allocateDataValues();
@@ -832,14 +832,14 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   // Close edge
-  auto &       vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
-  auto &       vc1 = inMesh->createVertex(Eigen::Vector3d(0, 2, 0));
-  inMesh->createEdge(vc0,vc1);
+  auto &vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
+  auto &vc1 = inMesh->createVertex(Eigen::Vector3d(0, 2, 0));
+  inMesh->createEdge(vc0, vc1);
 
   // Far triangle - interpolating
-  auto &       vf0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
-  auto &       vf1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 2));
-  auto &       vf2 = inMesh->createVertex(Eigen::Vector3d(3, 1, 0));
+  auto &vf0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
+  auto &vf1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 2));
+  auto &vf2 = inMesh->createVertex(Eigen::Vector3d(3, 1, 0));
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   inMesh->allocateDataValues();
@@ -868,15 +868,15 @@ BOOST_AUTO_TEST_CASE(TriangleDistances)
   PtrData inData = inMesh->createData("InData", 1);
 
   // Close triangle
-  auto &       vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
-  auto &       vc1 = inMesh->createVertex(Eigen::Vector3d(0, 2, 2));
-  auto &       vc2 = inMesh->createVertex(Eigen::Vector3d(0, 1, 0));
+  auto &vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
+  auto &vc1 = inMesh->createVertex(Eigen::Vector3d(0, 2, 2));
+  auto &vc2 = inMesh->createVertex(Eigen::Vector3d(0, 1, 0));
   makeTriangle(inMesh, vc0, vc1, vc2);
 
   // Far triangle
-  auto &       vf0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
-  auto &       vf1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 2));
-  auto &       vf2 = inMesh->createVertex(Eigen::Vector3d(3, 1, 0));
+  auto &vf0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
+  auto &vf1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 2));
+  auto &vf2 = inMesh->createVertex(Eigen::Vector3d(3, 1, 0));
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   inMesh->allocateDataValues();

--- a/src/precice/impl/WatchPoint.hpp
+++ b/src/precice/impl/WatchPoint.hpp
@@ -8,6 +8,7 @@
 #include "io/TXTTableWriter.hpp"
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "query/FindClosest.hpp"
 
 namespace precice {
 namespace mesh {
@@ -55,9 +56,7 @@ private:
 
   double _shortestDistance = std::numeric_limits<double>::max();
 
-  std::vector<double> _weights;
-
-  std::vector<mesh::Vertex *> _vertices;
+  query::InterpolationElements _interpolationElements;
 
   std::vector<mesh::PtrData> _dataToExport;
 

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -210,6 +210,7 @@ BOOST_AUTO_TEST_CASE(Reinitalize)
     // Change Mesh and data
     mesh::Vertex &v4 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
     mesh->createEdge(v3, v4);
+    mesh->meshChanged(*mesh);
     mesh->allocateDataValues();
     mesh->computeState();
     doubleValues.setConstant(1.0);

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -1,5 +1,6 @@
 #include "Index.hpp"
 #include <boost/range/irange.hpp>
+#include "FindClosest.hpp"
 #include "impl/Indexer.hpp"
 #include "logging/LogMacros.hpp"
 #include "utils/Event.hpp"
@@ -27,7 +28,7 @@ Index::~Index()
 {
 }
 
-VertexMatch Index::getClosestVertex(const mesh::Vertex &sourceVertex)
+VertexMatch Index::getClosestVertex(const Eigen::VectorXd &sourceCoord)
 {
   PRECICE_TRACE();
   // Add tree to the local cache
@@ -37,32 +38,14 @@ VertexMatch Index::getClosestVertex(const mesh::Vertex &sourceVertex)
     event.stop();
   }
 
-  std::vector<VertexMatch> matches;
-  _pimpl->indices.vertexRTree->query(bgi::nearest(sourceVertex, 1), boost::make_function_output_iterator([&](size_t matchID) {
-                                       matches.emplace_back(bg::distance(sourceVertex, _mesh->vertices()[matchID]), matchID);
+  VertexMatch match;
+  _pimpl->indices.vertexRTree->query(bgi::nearest(sourceCoord, 1), boost::make_function_output_iterator([&](size_t matchID) {
+                                       match = VertexMatch(bg::distance(sourceCoord, _mesh->vertices()[matchID]), matchID);
                                      }));
-  return matches.back();
+  return match;
 }
 
-std::vector<VertexMatch> Index::getClosestVertices(const mesh::Vertex &sourceVertex, int n)
-{
-  PRECICE_TRACE();
-  // Add tree to the local cache
-  if (not _pimpl->indices.vertexRTree) {
-    precice::utils::Event event("query.index.getVertexIndexTree." + _mesh->getName(), precice::syncMode);
-    _pimpl->indices.vertexRTree = impl::Indexer::instance()->getVertexRTree(_mesh);
-    event.stop();
-  }
-
-  std::vector<VertexMatch> matches;
-  _pimpl->indices.vertexRTree->query(bgi::nearest(sourceVertex, n), boost::make_function_output_iterator([&](size_t matchID) {
-                                       matches.emplace_back(bg::distance(sourceVertex, _mesh->vertices()[matchID]), matchID);
-                                     }));
-  std::sort(matches.begin(), matches.end());
-  return matches;
-}
-
-std::vector<EdgeMatch> Index::getClosestEdges(const mesh::Vertex &sourceVertex, int n)
+std::vector<EdgeMatch> Index::getClosestEdges(const Eigen::VectorXd &sourceCoord, int n)
 {
   PRECICE_TRACE();
   // Add tree to the local cache
@@ -73,14 +56,14 @@ std::vector<EdgeMatch> Index::getClosestEdges(const mesh::Vertex &sourceVertex, 
   }
 
   std::vector<EdgeMatch> matches;
-  _pimpl->indices.edgeRTree->query(bgi::nearest(sourceVertex, n), boost::make_function_output_iterator([&](size_t matchID) {
-                                     matches.emplace_back(bg::distance(sourceVertex, _mesh->edges()[matchID]), matchID);
+  _pimpl->indices.edgeRTree->query(bgi::nearest(sourceCoord, n), boost::make_function_output_iterator([&](size_t matchID) {
+                                     matches.emplace_back(bg::distance(sourceCoord, _mesh->edges()[matchID]), matchID);
                                    }));
   std::sort(matches.begin(), matches.end());
   return matches;
 }
 
-std::vector<TriangleMatch> Index::getClosestTriangles(const mesh::Vertex &sourceVertex, int n)
+std::vector<TriangleMatch> Index::getClosestTriangles(const Eigen::VectorXd &sourceCoord, int n)
 {
   PRECICE_TRACE();
   // Add tree to the local cache
@@ -91,12 +74,27 @@ std::vector<TriangleMatch> Index::getClosestTriangles(const mesh::Vertex &source
   }
 
   std::vector<TriangleMatch> matches;
-  _pimpl->indices.triangleRTree->query(bgi::nearest(sourceVertex, n),
+  _pimpl->indices.triangleRTree->query(bgi::nearest(sourceCoord, n),
                                        boost::make_function_output_iterator([&](impl::TriangleTraits::IndexType const &match) {
-                                         matches.emplace_back(bg::distance(sourceVertex, _mesh->triangles()[match.second]), match.second);
+                                         matches.emplace_back(bg::distance(sourceCoord, _mesh->triangles()[match.second]), match.second);
                                        }));
   std::sort(matches.begin(), matches.end());
   return matches;
+}
+
+VertexMatch Index::getClosestVertex(const mesh::Vertex &sourceVertex)
+{
+  return getClosestVertex(sourceVertex.getCoords());
+}
+
+std::vector<EdgeMatch> Index::getClosestEdges(const mesh::Vertex &sourceVertex, int n)
+{
+  return getClosestEdges(sourceVertex.getCoords(), n);
+}
+
+std::vector<TriangleMatch> Index::getClosestTriangles(const mesh::Vertex &sourceVertex, int n)
+{
+  return getClosestTriangles(sourceVertex.getCoords(), n);
 }
 
 std::vector<size_t> Index::getVerticesInsideBox(const mesh::Vertex &centerVertex, double radius)
@@ -131,6 +129,47 @@ std::vector<size_t> Index::getVerticesInsideBox(const mesh::BoundingBox &bb)
   std::vector<size_t> matches;
   _pimpl->indices.vertexRTree->query(bgi::intersects(query::RTreeBox{bb.minCorner(), bb.maxCorner()}), std::back_inserter(matches));
   return matches;
+}
+
+std::pair<InterpolationElements, double> Index::findNearestProjection(const mesh::Vertex &sourceVertex, int n)
+{
+  if (_mesh->getDimensions() == 2) {
+    return findEdgeProjection(sourceVertex, n);
+  } else {
+    return findTriangleProjection(sourceVertex, n);
+  }
+}
+
+std::pair<InterpolationElements, double> Index::findVertexProjection(const mesh::Vertex &sourceVertex)
+{
+  auto match = getClosestVertex(sourceVertex.getCoords());
+  return std::pair<InterpolationElements, double>(generateInterpolationElements(sourceVertex, _mesh->vertices()[match.index]), match.distance);
+}
+
+std::pair<InterpolationElements, double> Index::findEdgeProjection(const mesh::Vertex &sourceVertex, int n)
+{
+  auto matchedEdges = getClosestEdges(sourceVertex.getCoords(), n);
+  for (const auto &match : matchedEdges) {
+    auto weights = query::generateInterpolationElements(sourceVertex, _mesh->edges()[match.index]);
+    if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const &elem) { return elem.weight >= 0.0; })) {
+      return std::pair<InterpolationElements, double>(weights, match.distance);
+    }
+  }
+  // Could not find edge projection element, fall back to vertex projection
+  return findVertexProjection(sourceVertex);
+}
+
+std::pair<InterpolationElements, double> Index::findTriangleProjection(const mesh::Vertex &sourceVertex, int n)
+{
+  auto matchedTriangles = getClosestTriangles(sourceVertex.getCoords(), n);
+  for (const auto &match : matchedTriangles) {
+    auto weights = query::generateInterpolationElements(sourceVertex, _mesh->triangles()[match.index]);
+    if (std::all_of(weights.begin(), weights.end(), [](query::InterpolationElement const &elem) { return elem.weight >= 0.0; })) {
+      return std::pair<InterpolationElements, double>(weights, match.distance);
+    }
+  }
+  // Could not triangle find projection element, fall back to edge projection
+  return findEdgeProjection(sourceVertex, n);
 }
 
 void clearCache()

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include "FindClosest.hpp"
 #include "logging/Logger.hpp"
 #include "mesh/BoundingBox.hpp"
 #include "mesh/Edge.hpp"
@@ -17,7 +18,6 @@ template <class Tag>
 struct MatchType {
   double distance;
   int    index;
-
   MatchType() = default;
   MatchType(double d, int i)
       : distance(d), index(i){};
@@ -28,6 +28,7 @@ struct MatchType {
 };
 
 /// Match tags for each primitive type
+using GenericMatch  = MatchType<struct GenericMatchTag>;
 using VertexMatch   = MatchType<struct VertexMatchTag>;
 using EdgeMatch     = MatchType<struct EdgeMatchTag>;
 using TriangleMatch = MatchType<struct TriangleTag>;
@@ -41,15 +42,15 @@ public:
 
   /// Get n number of closest vertices to the given vertex
   VertexMatch getClosestVertex(const mesh::Vertex &sourceVertex);
-
-  /// Get n number of closest vertices to the given vertex
-  std::vector<VertexMatch> getClosestVertices(const mesh::Vertex &sourceVertex, int n);
+  VertexMatch getClosestVertex(const Eigen::VectorXd &sourceCoord);
 
   /// Get n number of closest edges to the given vertex
-  std::vector<EdgeMatch> getClosestEdges(const mesh::Vertex &sourcesVertex, int n);
+  std::vector<EdgeMatch> getClosestEdges(const mesh::Vertex &sourceVertex, int n);
+  std::vector<EdgeMatch> getClosestEdges(const Eigen::VectorXd &sourceCoord, int n);
 
   /// Get n number of closest triangles to the given vertex
   std::vector<TriangleMatch> getClosestTriangles(const mesh::Vertex &sourceVertex, int n);
+  std::vector<TriangleMatch> getClosestTriangles(const Eigen::VectorXd &sourceCoord, int n);
 
   /// Return all the vertices inside the box formed by vertex and radius
   std::vector<size_t> getVerticesInsideBox(const mesh::Vertex &centerVertex, double radius);
@@ -57,12 +58,33 @@ public:
   /// Return all the vertices inside a bounding box
   std::vector<size_t> getVerticesInsideBox(const mesh::BoundingBox &bb);
 
+  /**
+   * @brief Find the closest interpolation element to a vertex. 
+   * If exists, triangle or edge projection element is returned. If not vertex projection element, which is the neares neighbor is returned.
+   * 
+   * param[in] sourceVertex 
+   * param[in] n how many nearest edges/faces are going to be checked
+   * 
+   * param[out] pair of interpolation elements and the distance to corresponding vertex/edge/triangle
+   *
+  */
+  std::pair<InterpolationElements, double> findNearestProjection(const mesh::Vertex &sourceVertex, int n);
+
 private:
   struct IndexImpl;
   std::unique_ptr<IndexImpl> _pimpl;
 
   const mesh::PtrMesh             _mesh;
   static precice::logging::Logger _log;
+
+  /// Closest vertex projection element is always the nearest neighbor
+  std::pair<InterpolationElements, double> findVertexProjection(const mesh::Vertex &sourceVertex);
+
+  /// Find closest edge interpolation element. If cannot be found, it falls back to vertex projection
+  std::pair<InterpolationElements, double> findEdgeProjection(const mesh::Vertex &sourceVertex, int n);
+
+  /// Find closest face interpolation element. If cannot be found, it falls back to first edge interpolation element, then vertex if necessary
+  std::pair<InterpolationElements, double> findTriangleProjection(const mesh::Vertex &sourceVertex, int n);
 };
 
 /// Clear all the cache

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -106,11 +106,6 @@ BOOST_AUTO_TEST_CASE(Query2DVertex)
   auto result = indexTree.getClosestVertex(searchVertex);
   BOOST_TEST(mesh->vertices().at(result.index).getCoords() == Eigen::Vector2d(0, 1));
   BOOST_TEST(result.distance == 0.28284271247461906);
-
-  auto results = indexTree.getClosestVertices(searchVertex, 2);
-  BOOST_TEST(results.size() == 2);
-  BOOST_TEST(mesh->vertices().at(results.at(0).index).getCoords() == Eigen::Vector2d(0, 1));
-  BOOST_TEST(mesh->vertices().at(results.at(1).index).getCoords() == Eigen::Vector2d(0, 0));
 }
 
 BOOST_AUTO_TEST_CASE(Query3DVertex)
@@ -123,11 +118,6 @@ BOOST_AUTO_TEST_CASE(Query3DVertex)
   auto result = indexTree.getClosestVertex(searchVertex);
   BOOST_TEST(mesh->vertices().at(result.index).getCoords() == Eigen::Vector3d(1, 0, 1));
   BOOST_TEST(result.distance == 0.28284271247461906);
-
-  auto results = indexTree.getClosestVertices(searchVertex, 2);
-  BOOST_TEST(results.size() == 2);
-  BOOST_TEST(mesh->vertices().at(results.at(0).index).getCoords() == Eigen::Vector3d(1, 0, 1));
-  BOOST_TEST(mesh->vertices().at(results.at(1).index).getCoords() == Eigen::Vector3d(1, 0, 0));
 }
 
 BOOST_AUTO_TEST_CASE(Query3DFullVertex)


### PR DESCRIPTION
## Main changes of this PR
- Change closest find functions to use already cached index trees
- Use same functionality as nearest-projection mapping for interpolation

## Motivation and additional information
For the calculation of the watch point, we use closest point/edge/triangle finding. For nearest-projection and nearest-neighbor mappings index trees are possibly built up therefore we can use them to efficiently get the corresponding primitives.

Additionally, nearest-projection mapping and watch-point calculation involves similar operations, both using interpolation to determine the value. Therefore, using consistent functions across the same operation helps to improve maintainability.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)