### PR TITLE
Fix FindNumpy use of find_path

### DIFF
--- a/cmake/modules/FindNumPy.cmake
+++ b/cmake/modules/FindNumPy.cmake
@@ -43,8 +43,8 @@ if(NOT NumPy_FOUND)
       ERROR_QUIET
       )
     find_path(NumPy_INCLUDE_DIR
-      numpy/arrayobject.h
-      PATH "${_numpy_include_dir}"
+      NAMES numpy/arrayobject.h
+      PATHS "${_numpy_include_dir}"
       NO_DEFAULT_PATH
       )
     unset(_numpy_include_dir)

--- a/docs/changelog/970.md
+++ b/docs/changelog/970.md
@@ -1,0 +1,1 @@
+- Fixed FindNumPy using fallback of `find_path`


### PR DESCRIPTION
## Main changes of this PR

Fixes a typo in FindNumPy which lead to using the fallback syntax of `find_path`.
This does not impact functionality.

