### PR TITLE
Support building as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,11 +498,6 @@ write_basic_package_version_file("preciceConfigVersion.cmake"
   COMPATIBILITY SameMajorVersion
   )
 
-# Install the Config and the ConfigVersion files
-install(FILES "cmake/preciceConfig.cmake" "${preCICE_BINARY_DIR}/preciceConfigVersion.cmake"
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/precice
-  )
-
 # Setup the config in the build directory
 set(_precice_bin_dir ${CMAKE_BINARY_DIR})
 set(_precice_lib_dir ${CMAKE_BINARY_DIR})
@@ -511,13 +506,25 @@ if(PRECICE_ENABLE_C)
   set(_precice_include_dirs ${_precice_include_dirs} "${preCICE_SOURCE_DIR}/extras/bindings/c/include")
 endif()
 set(_precice_pre_petsc_hook "list(APPEND CMAKE_MODULE_PATH ${preCICE_SOURCE_DIR}/cmake/modules)")
-
 configure_file("cmake/preciceConfig.cmake.in" "${preCICE_BINARY_DIR}/preciceConfig.cmake" @ONLY)
 
+# Setup the config for the install directory
+set(_precice_bin_dir ${CMAKE_INSTALL_FULL_BINDIR})
+set(_precice_lib_dir ${CMAKE_INSTALL_FULL_LIBDIR})
+set(_precice_include_dirs "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(_precice_pre_petsc_hook "list(APPEND CMAKE_MODULE_PATH \${CMAKE_CURRENT_LIST_DIR})")
+configure_file("cmake/preciceConfig.cmake.in" "${preCICE_BINARY_DIR}/cmake/preciceConfig.cmake" @ONLY)
+
+# Cleanup
 unset(_precice_include_dirs)
 unset(_precice_pre_petsc_hook)
 unset(_precice_lib_dir)
 unset(_precice_bin_dir)
+
+# Install the Config and the ConfigVersion files
+install(FILES "${preCICE_BINARY_DIR}/cmake/preciceConfig.cmake" "${preCICE_BINARY_DIR}/preciceConfigVersion.cmake" "cmake/modules/FindPETSc.cmake"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/precice
+  )
 
 # Add an alias to allow subprojects to use the namespaced name
 add_library(precice::precice ALIAS precice)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "=== DISABLED FEATURES ===" Q
 print_section("DEPENDENCIES")
 
 find_package (Threads REQUIRED)
+set(_precice_boost_libs filesystem log log_setup program_options system thread unit_test_framework)
 
 if(TPL_ENABLE_BOOST)
   xsdk_tpl_require(BOOST BOOST_ROOT)
@@ -150,7 +151,7 @@ if(TPL_ENABLE_BOOST)
   unset(ENV{BOOST_ROOT})
 endif()
 find_package(Boost 1.65.1 REQUIRED
-  COMPONENTS filesystem log log_setup program_options system thread unit_test_framework
+  COMPONENTS ${_precice_boost_libs}
   )
 
 # Eigen
@@ -503,11 +504,20 @@ install(FILES "cmake/preciceConfig.cmake" "${preCICE_BINARY_DIR}/preciceConfigVe
   )
 
 # Setup the config in the build directory
-export(EXPORT preciceTargets
-  NAMESPACE precice::
-  FILE "preciceTargets.cmake")
-file(COPY "cmake/preciceConfig.cmake"
-  DESTINATION "${preCICE_BINARY_DIR}")
+set(_precice_bin_dir ${CMAKE_BINARY_DIR})
+set(_precice_lib_dir ${CMAKE_BINARY_DIR})
+set(_precice_include_dirs "${preCICE_SOURCE_DIR}/src" "${preCICE_BINARY_DIR}/src")
+if(PRECICE_ENABLE_C)
+  set(_precice_include_dirs ${_precice_include_dirs} "${preCICE_SOURCE_DIR}/extras/bindings/c/include")
+endif()
+set(_precice_pre_petsc_hook "list(APPEND CMAKE_MODULE_PATH ${preCICE_SOURCE_DIR}/cmake/modules)")
+
+configure_file("cmake/preciceConfig.cmake.in" "${preCICE_BINARY_DIR}/preciceConfig.cmake" @ONLY)
+
+unset(_precice_include_dirs)
+unset(_precice_pre_petsc_hook)
+unset(_precice_lib_dir)
+unset(_precice_bin_dir)
 
 # Add an alias to allow subprojects to use the namespaced name
 add_library(precice::precice ALIAS precice)

--- a/cmake/preciceConfig.cmake
+++ b/cmake/preciceConfig.cmake
@@ -1,5 +1,0 @@
-include(CMakeFindDependencyMacro)
-
-find_dependency(Threads)
-
-include("${CMAKE_CURRENT_LIST_DIR}/preciceTargets.cmake")

--- a/cmake/preciceConfig.cmake.in
+++ b/cmake/preciceConfig.cmake.in
@@ -45,6 +45,7 @@ set(_precice_build_type @CMAKE_BUILD_TYPE@)
 
 set(_precice_include_dirs @_precice_include_dirs@)
 set(_precice_bin_dir @_precice_bin_dir@)
+unset(_precice_lib CACHE)
 find_library(_precice_lib NAMES precice PATHS @_precice_lib_dir@ NO_DEFAULT_PATH)
 
 # Create imported target precice::precice

--- a/cmake/preciceConfig.cmake.in
+++ b/cmake/preciceConfig.cmake.in
@@ -43,11 +43,8 @@ set(_precice_is_shared @BUILD_SHARED_LIBS@)
 set(_precice_build_type @CMAKE_BUILD_TYPE@)
 
 set(_precice_include_dirs @_precice_include_dirs@)
-set(_precice_lib_dir @_precice_lib_dir@)
 set(_precice_bin_dir @_precice_bin_dir@)
-
-
-set(_precice_lib_name @_precice_lib_name@) # libprecice.a
+find_library(_precice_lib NAMES precice PATHS @_precice_lib_dir@ NO_DEFAULT_PATH)
 
 # Create imported target precice::precice
 set(_precice_lib_type)
@@ -60,12 +57,19 @@ add_library(precice::precice ${_precice_lib_type} IMPORTED)
 unset(_precice_lib_type)
 
 include(CMakeFindDependencyMacro)
-# find_dependency(Threads)
-find_dependency(Boost)
-set_target_properties(precice::precice 
-  INTERFACE_LINK_LIBRARIES Boost
+enable_language(CXX) # Otherwise the boost config errors
+find_dependency(Boost COMPONENTS @_precice_boost_libs@)
+
+set_target_properties(precice::precice PROPERTIES
+  INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS}
   INTERFACE_INCLUDE_DIRECTORIES "${_precice_include_dirs}"
   )
+
+
+foreach(_boost_lib @_precice_boost_libs@)
+  set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES Boost::${_boost_lib})
+endforeach()
+
 
 if(NOT _precice_is_shared)
   find_dependency(LibXml2)
@@ -82,8 +86,12 @@ if(NOT _precice_is_shared)
   endif()
 
   if(PRECICE_PETScMapping)
+    #set(_old_modules ${CMAKE_MODULE_PATH})
+    @_precice_pre_petsc_hook@
     find_dependency(PETSc)
     set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES PETSc::PETSc)
+    #set(CMAKE_MODULE_PATH ${_old_modules})
+    #unset(_old_modules)
   endif()
 
 endif()
@@ -95,7 +103,7 @@ set_target_properties(precice::precice PROPERTIES
   # IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
   # IMPORTED_LOCATION_DEBUG "/home/simonis/dev/precice/second/bs/libprecice.a"
   IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-  IMPORTED_LOCATION "${_precice_lib_dir}/${_precice_lib_name}"
+  IMPORTED_LOCATION "${_precice_lib}"
   )
 
 # Create imported target precice::binprecice

--- a/cmake/preciceConfig.cmake.in
+++ b/cmake/preciceConfig.cmake.in
@@ -1,0 +1,112 @@
+if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.5)
+   message(FATAL_ERROR "CMake >= 2.6.0 required")
+endif()
+cmake_policy(PUSH)
+cmake_policy(VERSION 2.6...3.17)
+
+# Commands may need to know the format version.
+set(CMAKE_IMPORT_FILE_VERSION 1)
+
+# Protect against multiple inclusion, which would fail when already imported targets are added once more.
+set(_targetsDefined)
+set(_targetsNotDefined)
+set(_expectedTargets)
+foreach(_expectedTarget precice::precice precice::binprecice)
+  list(APPEND _expectedTargets ${_expectedTarget})
+  if(NOT TARGET ${_expectedTarget})
+    list(APPEND _targetsNotDefined ${_expectedTarget})
+  endif()
+  if(TARGET ${_expectedTarget})
+    list(APPEND _targetsDefined ${_expectedTarget})
+  endif()
+endforeach()
+if("${_targetsDefined}" STREQUAL "${_expectedTargets}")
+  unset(_targetsDefined)
+  unset(_targetsNotDefined)
+  unset(_expectedTargets)
+  set(CMAKE_IMPORT_FILE_VERSION)
+  cmake_policy(POP)
+  return()
+endif()
+if(NOT "${_targetsDefined}" STREQUAL "")
+  message(FATAL_ERROR "Some (but not all) targets in this export set were already defined.\nTargets Defined: ${_targetsDefined}\nTargets not yet defined: ${_targetsNotDefined}\n")
+endif()
+unset(_targetsDefined)
+unset(_targetsNotDefined)
+unset(_expectedTargets)
+
+set(PRECICE_MPICommunication @PRECICE_MPICommunication@)
+set(PRECICE_PETScMapping @PRECICE_PETScMapping@)
+set(PRECICE_PythonActions @PRECICE_PythonActions@)
+
+set(_precice_is_shared @BUILD_SHARED_LIBS@)
+set(_precice_build_type @CMAKE_BUILD_TYPE@)
+
+set(_precice_include_dirs @_precice_include_dirs@)
+set(_precice_lib_dir @_precice_lib_dir@)
+set(_precice_bin_dir @_precice_bin_dir@)
+
+
+set(_precice_lib_name @_precice_lib_name@) # libprecice.a
+
+# Create imported target precice::precice
+set(_precice_lib_type)
+if(_precice_is_shared)
+  set(_precice_lib_type SHARED)
+else()
+  set(_precice_lib_type STATIC)
+endif()
+add_library(precice::precice ${_precice_lib_type} IMPORTED)
+unset(_precice_lib_type)
+
+include(CMakeFindDependencyMacro)
+# find_dependency(Threads)
+find_dependency(Boost)
+set_target_properties(precice::precice 
+  INTERFACE_LINK_LIBRARIES Boost
+  INTERFACE_INCLUDE_DIRECTORIES "${_precice_include_dirs}"
+  )
+
+if(NOT _precice_is_shared)
+  find_dependency(LibXml2)
+  set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${LIBXML2_LIBRARIES})
+
+  if(PRECICE_PythonActions)
+    find_dependency(PythonLibs)
+    set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${PYTHON_LIBRARIES})
+  endif()
+
+  if(PRECICE_MPICommunication)
+    find_dependency(MPI)
+    set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES MPI::MPI_CXX)
+  endif()
+
+  if(PRECICE_PETScMapping)
+    find_dependency(PETSc)
+    set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES PETSc::PETSc)
+  endif()
+
+endif()
+
+
+# Import target "precice::precice" for configuration "Debug"
+# set_property(TARGET precice::precice APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+set_target_properties(precice::precice PROPERTIES
+  # IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
+  # IMPORTED_LOCATION_DEBUG "/home/simonis/dev/precice/second/bs/libprecice.a"
+  IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+  IMPORTED_LOCATION "${_precice_lib_dir}/${_precice_lib_name}"
+  )
+
+# Create imported target precice::binprecice
+add_executable(precice::binprecice IMPORTED)
+set_target_properties(precice::binprecice PROPERTIES
+  IMPORTED_LOCATION "${_precice_bin_dir}/binprecice"
+  )
+
+# This file does not depend on other imported targets which have
+# been exported from the same project but in a separate export set.
+
+# Commands beyond this point should not need to know the version.
+set(CMAKE_IMPORT_FILE_VERSION)
+cmake_policy(POP)

--- a/cmake/preciceConfig.cmake.in
+++ b/cmake/preciceConfig.cmake.in
@@ -35,6 +35,7 @@ unset(_targetsDefined)
 unset(_targetsNotDefined)
 unset(_expectedTargets)
 
+# Information about the configuration etc
 set(PRECICE_MPICommunication @PRECICE_MPICommunication@)
 set(PRECICE_PETScMapping @PRECICE_PETScMapping@)
 set(PRECICE_PythonActions @PRECICE_PythonActions@)
@@ -56,21 +57,26 @@ endif()
 add_library(precice::precice ${_precice_lib_type} IMPORTED)
 unset(_precice_lib_type)
 
-include(CMakeFindDependencyMacro)
-enable_language(CXX) # Otherwise the boost config errors
-find_dependency(Boost COMPONENTS @_precice_boost_libs@)
-
+# Set some initial properties
 set_target_properties(precice::precice PROPERTIES
   INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS}
   INTERFACE_INCLUDE_DIRECTORIES "${_precice_include_dirs}"
+  IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+  IMPORTED_LOCATION "${_precice_lib}"
   )
 
+# Start finding dependencies
+include(CMakeFindDependencyMacro)
 
+# Find required boost libraries 
+# The CMake config shipped with Boost fails if CXX is not enabled. (state: 1.75.0)
+enable_language(CXX)
+find_dependency(Boost COMPONENTS @_precice_boost_libs@)
 foreach(_boost_lib @_precice_boost_libs@)
   set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES Boost::${_boost_lib})
 endforeach()
 
-
+# Most dependencies are only required if preCICE is build as a static library
 if(NOT _precice_is_shared)
   find_dependency(LibXml2)
   set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${LIBXML2_LIBRARIES})
@@ -86,34 +92,17 @@ if(NOT _precice_is_shared)
   endif()
 
   if(PRECICE_PETScMapping)
-    #set(_old_modules ${CMAKE_MODULE_PATH})
     @_precice_pre_petsc_hook@
     find_dependency(PETSc)
     set_property(TARGET precice::precice APPEND PROPERTY INTERFACE_LINK_LIBRARIES PETSc::PETSc)
-    #set(CMAKE_MODULE_PATH ${_old_modules})
-    #unset(_old_modules)
   endif()
-
 endif()
-
-
-# Import target "precice::precice" for configuration "Debug"
-# set_property(TARGET precice::precice APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-set_target_properties(precice::precice PROPERTIES
-  # IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
-  # IMPORTED_LOCATION_DEBUG "/home/simonis/dev/precice/second/bs/libprecice.a"
-  IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-  IMPORTED_LOCATION "${_precice_lib}"
-  )
 
 # Create imported target precice::binprecice
 add_executable(precice::binprecice IMPORTED)
 set_target_properties(precice::binprecice PROPERTIES
   IMPORTED_LOCATION "${_precice_bin_dir}/binprecice"
   )
-
-# This file does not depend on other imported targets which have
-# been exported from the same project but in a separate export set.
 
 # Commands beyond this point should not need to know the version.
 set(CMAKE_IMPORT_FILE_VERSION)

--- a/docs/changelog/973.md
+++ b/docs/changelog/973.md
@@ -1,0 +1,1 @@
+- Added support for using preCICE as a static library from CMake


### PR DESCRIPTION
## Main changes of this PR

This PR adds support for CMake to build preCICE as a static library.
The main change is a custom `preciceConfig.cmake`, which is based on the auto-generated one.

## Motivation and additional information

Building CMake as a static library and then using it via the `preciceConfig.cmake` was not properly supported.
The auto-generated config lists all header-only/interface libraries as link dependencies. This is required as they themself may depend on a static/shared library.
Thus, this required to find dependencies such as jsoncpp, prettyprint, Eigen, NumPy etc.

Related to #801, #677

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)