### PR TITLE
Simplify Mesh

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -78,6 +78,14 @@ int Mesh::getDimensions() const
   return _dimensions;
 }
 
+Vertex &Mesh::createVertex(const Eigen::VectorXd &coords)
+{
+  PRECICE_ASSERT(coords.size() == _dimensions, coords.size(), _dimensions);
+  auto nextID = _vertices.size();
+  _vertices.emplace_back(coords, nextID);
+  return _vertices.back();
+}
+
 Edge &Mesh::createEdge(
     Vertex &vertexOne,
     Vertex &vertexTwo)

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -82,7 +82,8 @@ Edge &Mesh::createEdge(
     Vertex &vertexOne,
     Vertex &vertexTwo)
 {
-  _edges.emplace_back(vertexOne, vertexTwo, _manageEdgeIDs.getFreeID());
+  auto nextID = _edges.size();
+  _edges.emplace_back(vertexOne, vertexTwo, nextID);
   return _edges.back();
 }
 
@@ -113,7 +114,8 @@ Triangle &Mesh::createTriangle(
       edgeOne.connectedTo(edgeTwo) &&
       edgeTwo.connectedTo(edgeThree) &&
       edgeThree.connectedTo(edgeOne));
-  _triangles.emplace_back(edgeOne, edgeTwo, edgeThree, _manageTriangleIDs.getFreeID());
+  auto nextID = _triangles.size();
+  _triangles.emplace_back(edgeOne, edgeTwo, edgeThree, nextID);
   return _triangles.back();
 }
 
@@ -278,10 +280,6 @@ void Mesh::clear()
   _triangles.clear();
   _edges.clear();
   _vertices.clear();
-
-  _manageTriangleIDs.resetIDs();
-  _manageEdgeIDs.resetIDs();
-  _manageVertexIDs.resetIDs();
 
   meshChanged(*this);
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -194,7 +194,7 @@ void Mesh::allocateDataValues()
   PRECICE_TRACE(_vertices.size());
   const auto expectedCount = _vertices.size();
   using SizeType           = std::remove_cv<decltype(expectedCount)>::type;
-  for (PtrData data : _data) {
+  for (PtrData &data : _data) {
     const SizeType expectedSize = expectedCount * data->getDimensions();
     const auto     actualSize   = static_cast<SizeType>(data->values().size());
     // Shrink Buffer
@@ -291,7 +291,7 @@ void Mesh::clear()
 
   meshChanged(*this);
 
-  for (mesh::PtrData data : _data) {
+  for (mesh::PtrData &data : _data) {
     data->values().resize(0);
   }
 }

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -97,7 +97,8 @@ public:
   Vertex &createVertex(const VECTOR_T &coords)
   {
     PRECICE_ASSERT(coords.size() == _dimensions, coords.size(), _dimensions);
-    _vertices.emplace_back(coords, _manageVertexIDs.getFreeID());
+    auto nextID = _vertices.size();
+    _vertices.emplace_back(coords, nextID);
     return _vertices.back();
   }
 
@@ -254,12 +255,6 @@ private:
 
   /// Data hold by the vertices of the mesh.
   DataContainer _data;
-
-  utils::ManageUniqueIDs _manageVertexIDs;
-
-  utils::ManageUniqueIDs _manageEdgeIDs;
-
-  utils::ManageUniqueIDs _manageTriangleIDs;
 
   /**
    * @brief Vertex distribution for the master, holding for each slave all vertex IDs it owns.

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -93,14 +93,8 @@ public:
 
   int getDimensions() const;
 
-  template <typename VECTOR_T>
-  Vertex &createVertex(const VECTOR_T &coords)
-  {
-    PRECICE_ASSERT(coords.size() == _dimensions, coords.size(), _dimensions);
-    auto nextID = _vertices.size();
-    _vertices.emplace_back(coords, nextID);
-    return _vertices.back();
-  }
+  /// Creates and initializes a Vertex object.
+  Vertex &createVertex(const Eigen::VectorXd &coords);
 
   /**
    * @brief Creates and initializes an Edge object.


### PR DESCRIPTION
## Main changes of this PR

- Remove id management for mesh primitives
- Use EigenXd in mesh interface
- Prevent smartpointer copies

## Motivation and additional information

The id management is not necessary anymore. The ID of a vertex needs to be the index in the mesh. The following needs to hold for `_vertices`, `_edges`, and `_triangles` of a mesh:
```cpp
for (int i = 0; i < _vertices.size(); ++i) {
  assert(i == _vertices.at(i).getID());
}
```

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
