### PR TITLE
Simplify for loop in summation action and formatting

### DIFF
--- a/src/action/SummationAction.cpp
+++ b/src/action/SummationAction.cpp
@@ -40,10 +40,7 @@ void SummationAction::performAction(
   targetValues.setZero();
 
   for (const auto &sourceData : _sourceDataVector) {
-    auto sourceValues = sourceData->values();
-    for (int i = 0; i < targetValues.size(); ++i) {
-      targetValues[i] += sourceValues[i];
-    }
+    targetValues += sourceData->values();
   }
 }
 

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     action::ActionConfiguration config(tag, meshConfig);
     xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
-    auto& action = config.actions().front();
+    auto &action = config.actions().front();
     BOOST_TEST(static_cast<bool>(action));
   }
   {
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     action::ActionConfiguration config(tag, meshConfig);
     xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
-    auto& action = config.actions().front();
+    auto &action = config.actions().front();
     BOOST_TEST(static_cast<bool>(action));
   }
   {
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     action::ActionConfiguration config(tag, meshConfig);
     xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
-    auto& action = config.actions().front();
+    auto &action = config.actions().front();
     BOOST_TEST(static_cast<bool>(action));
   }
   {
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
     action::ActionConfiguration config(tag, meshConfig);
     xml::configure(tag, xml::ConfigurationContext{}, filename);
     BOOST_TEST(config.actions().size() == 1);
-    auto& action = config.actions().front();
+    auto &action = config.actions().front();
     BOOST_TEST(static_cast<bool>(action));
   }
 }

--- a/src/action/tests/SummationActionTest.cpp
+++ b/src/action/tests/SummationActionTest.cpp
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(Configuration)
   action::ActionConfiguration config(tag, meshConfig);
   xml::configure(tag, xml::ConfigurationContext{}, filename);
   BOOST_TEST(config.actions().size() == 1);
-  auto& action = config.actions().front();
+  auto &action = config.actions().front();
   BOOST_TEST(static_cast<bool>(action));
 }
 


### PR DESCRIPTION
## Main changes of this PR
Replace for loop with the simple summation compound operator. Bonus: there are some accidental formatting fixes too

## Motivation and additional information
Same functionality, cleaner code and [more possibility for optimization](https://eigen.tuxfamily.org/dox/group__TutorialMatrixArithmetic.html)

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes. (Not necessary)
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
* [ ] (more questions/tasks)