### PR TITLE
GitHub actions for macOS CI

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -1,0 +1,65 @@
+name: Build and Test macOS
+on:
+  push:
+    branches:
+      - master
+      - develop
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }}
+    runs-on: [self-hosted, macOS]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - CONFIG: MPIPETSc
+            CXX: 'clang++'
+            TYPE: Debug
+          - CONFIG: MPIPETSc
+            CXX: 'clang++'
+            TYPE: Release
+    steps:
+    - name: Generate build directory
+      run: mkdir -p build
+    - name: Configure
+      working-directory: build
+      env:
+        CXX: ${{ matrix.CXX }}
+        CXXFLAGS: "-Wall"
+        MPI: ${{ contains(matrix.CONFIG, 'MPI') }}
+        PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
+      run: |
+        cmake --version
+        cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_MPICommunication=${{ env.MPI }} -DPRECICE_PETScMapping=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }} CMakeCache 
+        path: build/CMakeCache.txt
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }} CMakeLogs 
+        path: 'build/CMakeFiles/*.log'
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }} CompileCommands 
+        path: build/compile_commands.json
+    - name: Compile
+      working-directory: build
+      run: |
+        make -j $(sysctl -n hw.ncpu)
+    - name: Tests
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+      working-directory: build
+      run: make test
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }} TestOutput 
+        path: build/TestOutput/
+      


### PR DESCRIPTION
## Main changes of this PR
Adds Bare, MPI and PETSc + MPI builds for macOS which runs on the self-hosted runner. For the security purposes, macOS runs are limited to the pushes to `master` and `develop` branches. Closing #884 

## Motivation and additional information

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)