### PR TITLE
Fix macOS runner tag

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -4,12 +4,13 @@ on:
     branches:
       - master
       - develop
+      - fix-macos-ci
   workflow_dispatch:
 
 jobs:
   build:
     name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }}
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, OSX]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Main changes of this PR
Apparently, I have used the wrong tag to identify the runner. Probably it should be `OSX`. It would be good if it can be confirmed since I cannot see the runner tags.

## Motivation and additional information


## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)