### PR TITLE
Extend mesh filtering considering connectivity elements

### DIFF
--- a/src/mesh/Filter.cpp
+++ b/src/mesh/Filter.cpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "mesh/Filter.hpp"
+
+namespace precice {
+namespace mesh {
+
+void addVertexToMesh(const Vertex &vertex, boost::container::flat_map<int, Vertex *> &vertexMap, Mesh &destination)
+{
+  Vertex &v = destination.createVertex(vertex.getCoords());
+  v.setGlobalIndex(vertex.getGlobalIndex());
+  if (vertex.isTagged()) {
+    v.tag();
+  }
+  v.setOwner(vertex.isOwner());
+  vertexMap[vertex.getID()] = &v;
+}
+
+void addEdgeToMesh(const Edge &edge, boost::container::flat_map<int, Edge *> &edgeMap, boost::container::flat_map<int, Vertex *> &vertexMap, Mesh &destination)
+{
+  if (vertexMap.count(edge.vertex(0).getID()) == 0) {
+    addVertexToMesh(edge.vertex(0), vertexMap, destination);
+  }
+  if (vertexMap.count(edge.vertex(1).getID()) == 0) {
+    addVertexToMesh(edge.vertex(1), vertexMap, destination);
+  }
+  Edge &e               = destination.createEdge(*vertexMap[edge.vertex(0).getID()], *vertexMap[edge.vertex(1).getID()]);
+  edgeMap[edge.getID()] = &e;
+}
+
+void addTriangleToMesh(const Triangle &triangle, boost::container::flat_map<int, Edge *> &edgeMap, boost::container::flat_map<int, Vertex *> &vertexMap, Mesh &destination)
+{
+  if (edgeMap.count(triangle.edge(0).getID()) == 0) {
+    addEdgeToMesh(triangle.edge(0), edgeMap, vertexMap, destination);
+  }
+  if (edgeMap.count(triangle.edge(1).getID()) == 0) {
+    addEdgeToMesh(triangle.edge(1), edgeMap, vertexMap, destination);
+  }
+  if (edgeMap.count(triangle.edge(2).getID()) == 0) {
+    addEdgeToMesh(triangle.edge(2), edgeMap, vertexMap, destination);
+  }
+  Triangle &t = destination.createTriangle(*edgeMap[triangle.edge(0).getID()], *edgeMap[triangle.edge(1).getID()], *edgeMap[triangle.edge(2).getID()]);
+}
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -6,13 +6,17 @@
 namespace precice {
 namespace mesh {
 
+void addVertexToMesh(const Vertex &vertex, boost::container::flat_map<int, Vertex *> &vertexMap, Mesh &destination);
+void addEdgeToMesh(const Edge &edge, boost::container::flat_map<int, Edge *> &edgeMap, boost::container::flat_map<int, Vertex *> &vertexMap, Mesh &destination);
+void addTriangleToMesh(const Triangle &triangle, boost::container::flat_map<int, Edge *> &edgeMap, boost::container::flat_map<int, Vertex *> &vertexMap, Mesh &destination);
+
 /** filters the source Mesh and adds it to the destination Mesh
  * @param[inout] destination the destination mesh to append the filtered Mesh to
  * @param[in] source the source Mesh to filter
  * @param[in] p the filter as a UnaryPredicate on mesh::Vertex 
  */
 template <typename UnaryPredicate>
-void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
+void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p, bool withConnection = false)
 {
   // Create a flat_map which can contain all vertices of the original mesh.
   // This prevents resizes during the map build-up.
@@ -21,12 +25,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
 
   for (const Vertex &vertex : source.vertices()) {
     if (p(vertex)) {
-      Vertex &v = destination.createVertex(vertex.getCoords());
-      v.setGlobalIndex(vertex.getGlobalIndex());
-      if (vertex.isTagged())
-        v.tag();
-      v.setOwner(vertex.isOwner());
-      vertexMap[vertex.getID()] = &v;
+      addVertexToMesh(vertex, vertexMap, destination);
     }
   }
 
@@ -39,10 +38,17 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
   for (const Edge &edge : source.edges()) {
     int vertexIndex1 = edge.vertex(0).getID();
     int vertexIndex2 = edge.vertex(1).getID();
-    if (vertexMap.count(vertexIndex1) == 1 &&
-        vertexMap.count(vertexIndex2) == 1) {
-      Edge &e               = destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
-      edgeMap[edge.getID()] = &e;
+    if (withConnection) {
+      if (vertexMap.count(vertexIndex1) == 1 or
+          vertexMap.count(vertexIndex2) == 1) {
+        addEdgeToMesh(edge, edgeMap, vertexMap, destination);
+      }
+    } else {
+      if (vertexMap.count(vertexIndex1) == 1 &&
+          vertexMap.count(vertexIndex2) == 1) {
+        Edge &e               = destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
+        edgeMap[edge.getID()] = &e;
+      }
     }
   }
 
@@ -52,10 +58,18 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
       int edgeIndex1 = triangle.edge(0).getID();
       int edgeIndex2 = triangle.edge(1).getID();
       int edgeIndex3 = triangle.edge(2).getID();
-      if (edgeMap.count(edgeIndex1) == 1 &&
-          edgeMap.count(edgeIndex2) == 1 &&
-          edgeMap.count(edgeIndex3) == 1) {
-        destination.createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
+      if (withConnection) {
+        if (edgeMap.count(edgeIndex1) == 1 or
+            edgeMap.count(edgeIndex2) == 1 or
+            edgeMap.count(edgeIndex3) == 1) {
+          addTriangleToMesh(triangle, edgeMap, vertexMap, destination);
+        }
+      } else {
+        if (edgeMap.count(edgeIndex1) == 1 &&
+            edgeMap.count(edgeIndex2) == 1 &&
+            edgeMap.count(edgeIndex3) == 1) {
+          destination.createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
+        }
       }
     }
   }

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -192,6 +192,7 @@ target_sources(precice
     src/mesh/Edge.cpp
     src/mesh/Edge.hpp
     src/mesh/Filter.hpp
+    src/mesh/Filter.cpp
     src/mesh/Mesh.cpp
     src/mesh/Mesh.hpp
     src/mesh/RangeAccessor.hpp


### PR DESCRIPTION
## Main changes of this PR
Mesh filtering does not consider the connectivity elements. With this extension, vertices chosen for filtering extended by elements they are connected, therefore connectivity information is not lost.

## Motivation and additional information
This is a useful feature for connectivity-based mappings, and a must for scaled consistently mapping (other alternative is no filtering)


## Author's checklist
* [ ] Add tests
* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)