### PR TITLE
Assert that user provided  writeData is finite

### DIFF
--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -31,7 +31,9 @@
 #define PRECICE_TRACE(...) \
   {                        \
   }
-
+#define PRECICE_IS_FINITE(...) \
+  {                            \
+  }
 #else // NDEBUG
 
 #include "logging/Tracer.hpp"
@@ -43,5 +45,7 @@
 #define PRECICE_TRACE(...)                                       \
   precice::logging::Tracer _tracer_(_log, PRECICE_LOG_LOCATION); \
   _log.trace(PRECICE_LOG_LOCATION, std::string{"Entering "} + __func__ + PRECICE_LOG_ARGUMENTS(__VA_ARGS__))
+
+#define PRECICE_IS_FINITE(value) PRECICE_CHECK(std::isfinite(value), "The given value is either plus or minus infinity or NaN.");
 
 #endif // ! NDEBUG

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -31,9 +31,6 @@
 #define PRECICE_TRACE(...) \
   {                        \
   }
-#define PRECICE_IS_FINITE(...) \
-  {                            \
-  }
 #else // NDEBUG
 
 #include "logging/Tracer.hpp"
@@ -45,7 +42,5 @@
 #define PRECICE_TRACE(...)                                       \
   precice::logging::Tracer _tracer_(_log, PRECICE_LOG_LOCATION); \
   _log.trace(PRECICE_LOG_LOCATION, std::string{"Entering "} + __func__ + PRECICE_LOG_ARGUMENTS(__VA_ARGS__))
-
-#define PRECICE_IS_FINITE(value) PRECICE_CHECK(std::isfinite(value), "The given value is either plus or minus infinity or NaN.");
 
 #endif // ! NDEBUG

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -31,6 +31,7 @@
 #define PRECICE_TRACE(...) \
   {                        \
   }
+
 #else // NDEBUG
 
 #include "logging/Tracer.hpp"

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1076,6 +1076,8 @@ void SolverInterfaceImpl::writeBlockVectorData(
   PRECICE_CHECK(data.getDimensions() == _dimensions,
                 "You cannot call writeBlockVectorData on the scalar data type \"{0}\". Use writeBlockScalarData or change the data type for \"{0}\" to vector.",
                 data.getName());
+  PRECICE_VALIDATE_DATA(values, size * _dimensions);
+
   auto &     valuesInternal = data.values();
   const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
@@ -1083,13 +1085,12 @@ void SolverInterfaceImpl::writeBlockVectorData(
     PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                   "Cannot write data \"{}\" to invalid Vertex ID ({}). Please make sure you only use the results from calls to setMeshVertex/Vertices().",
                   data.getName(), valueIndex);
-    int offsetInternal = valueIndex * _dimensions;
-    int offset         = i * _dimensions;
+    const int offsetInternal = valueIndex * _dimensions;
+    const int offset         = i * _dimensions;
     for (int dim = 0; dim < _dimensions; dim++) {
       PRECICE_ASSERT(offset + dim < valuesInternal.size(),
                      offset + dim, valuesInternal.size());
       valuesInternal[offsetInternal + dim] = values[offset + dim];
-      PRECICE_IS_FINITE(values[offset + dim]);
     }
   }
 }
@@ -1110,15 +1111,16 @@ void SolverInterfaceImpl::writeVectorData(
   PRECICE_CHECK(data.getDimensions() == _dimensions,
                 "You cannot call writeVectorData on the scalar data type \"{0}\". Use writeScalarData or change the data type for \"{0}\" to vector.",
                 data.getName());
+  PRECICE_VALIDATE_DATA(value, _dimensions);
+
   auto &     values      = data.values();
   const auto vertexCount = values.size() / data.getDimensions();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot write data \"{}\" to invalid Vertex ID ({}). Please make sure you only use the results from calls to setMeshVertex/Vertices().",
                 data.getName(), valueIndex);
-  int offset = valueIndex * _dimensions;
+  const int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     values[offset + dim] = value[dim];
-    PRECICE_IS_FINITE(value[dim]);
   }
 }
 
@@ -1142,6 +1144,8 @@ void SolverInterfaceImpl::writeBlockScalarData(
   PRECICE_CHECK(data.getDimensions() == 1,
                 "You cannot call writeBlockScalarData on the vector data type \"{}\". Use writeBlockVectorData or change the data type for \"{}\" to scalar.",
                 data.getName(), data.getName());
+  PRECICE_VALIDATE_DATA(values, size);
+
   auto &     valuesInternal = data.values();
   const auto vertexCount    = valuesInternal.size() / data.getDimensions();
   for (int i = 0; i < size; i++) {
@@ -1150,7 +1154,6 @@ void SolverInterfaceImpl::writeBlockScalarData(
                   "Cannot write data \"{}\" to invalid Vertex ID ({}). Please make sure you only use the results from calls to setMeshVertex/Vertices().",
                   data.getName(), valueIndex);
     valuesInternal[valueIndex] = values[i];
-    PRECICE_IS_FINITE(values[i]);
   }
 }
 
@@ -1174,6 +1177,7 @@ void SolverInterfaceImpl::writeScalarData(
                 "You cannot call writeScalarData on the vector data type \"{0}\". "
                 "Use writeVectorData or change the data type for \"{0}\" to scalar.",
                 data.getName());
+  PRECICE_VALIDATE_DATA(static_cast<double *>(&value), 1);
 
   auto &     values      = data.values();
   const auto vertexCount = values.size() / data.getDimensions();
@@ -1182,7 +1186,6 @@ void SolverInterfaceImpl::writeScalarData(
                 "Please make sure you only use the results from calls to setMeshVertex/Vertices().",
                 data.getName(), valueIndex);
   values[valueIndex] = value;
-  PRECICE_IS_FINITE(value);
 }
 
 void SolverInterfaceImpl::readBlockVectorData(

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1089,6 +1089,7 @@ void SolverInterfaceImpl::writeBlockVectorData(
       PRECICE_ASSERT(offset + dim < valuesInternal.size(),
                      offset + dim, valuesInternal.size());
       valuesInternal[offsetInternal + dim] = values[offset + dim];
+      PRECICE_IS_FINITE(values[offset + dim]);
     }
   }
 }
@@ -1117,6 +1118,7 @@ void SolverInterfaceImpl::writeVectorData(
   int offset = valueIndex * _dimensions;
   for (int dim = 0; dim < _dimensions; dim++) {
     values[offset + dim] = value[dim];
+    PRECICE_IS_FINITE(value[dim]);
   }
 }
 
@@ -1148,6 +1150,7 @@ void SolverInterfaceImpl::writeBlockScalarData(
                   "Cannot write data \"{}\" to invalid Vertex ID ({}). Please make sure you only use the results from calls to setMeshVertex/Vertices().",
                   data.getName(), valueIndex);
     valuesInternal[valueIndex] = values[i];
+    PRECICE_IS_FINITE(values[i]);
   }
 }
 
@@ -1179,6 +1182,7 @@ void SolverInterfaceImpl::writeScalarData(
                 "Please make sure you only use the results from calls to setMeshVertex/Vertices().",
                 data.getName(), valueIndex);
   values[valueIndex] = value;
+  PRECICE_IS_FINITE(value);
 }
 
 void SolverInterfaceImpl::readBlockVectorData(

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -142,3 +142,20 @@
     const auto id = (dataID);              \
     PRECICE_REQUIRE_DATA_WRITE_IMPL(id)    \
   } while (false)
+
+//
+// DATA VALUE VALIDATION
+//
+#ifdef NDEBUG
+
+#define PRECICE_VALIDATE_DATA(data, size) \
+  {                                       \
+  }
+#else //NDEBUG
+
+#define PRECICE_VALIDATE_DATA(data, size)                                                                                                                                       \
+  do {                                                                                                                                                                          \
+    PRECICE_CHECK(std::all_of(data, data + size, [](const auto &val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN."); \
+  } while (false)
+
+#endif

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -154,6 +154,6 @@
 #else //NDEBUG
 
 #define PRECICE_VALIDATE_DATA(data, size) \
-  PRECICE_CHECK(std::all_of(data, data + size, [](const double val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN.");
+  PRECICE_CHECK(std::all_of(data, data + size, [](double val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN.");
 
 #endif

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -153,6 +153,7 @@
   }
 #else //NDEBUG
 
-#define PRECICE_VALIDATE_DATA(data, size)                                                                                                                                      \
-  PRECICE_CHECK(std::all_of(data, data + size, [](const double val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN."); \
+#define PRECICE_VALIDATE_DATA(data, size) \
+  PRECICE_CHECK(std::all_of(data, data + size, [](const double val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN.");
+
 #endif

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -153,9 +153,6 @@
   }
 #else //NDEBUG
 
-#define PRECICE_VALIDATE_DATA(data, size)                                                                                                                                       \
-  do {                                                                                                                                                                          \
-    PRECICE_CHECK(std::all_of(data, data + size, [](const auto &val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN."); \
-  } while (false)
-
+#define PRECICE_VALIDATE_DATA(data, size)                                                                                                                                      \
+  PRECICE_CHECK(std::all_of(data, data + size, [](const double val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN."); \
 #endif


### PR DESCRIPTION

## Motivation and additional information
A simple Assert in order to prevent accidental passing of nan values to preCICE. We could do the same for the reading data functions, but I guess we hit the writeData first.