### PR TITLE
Remove output zeroing before data mapping

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1004,7 +1004,6 @@ void SolverInterfaceImpl::mapWriteDataFrom(
         continue;
       }
 
-      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
                                   << "\" from mesh \"" << context.mesh->getName() << "\"");
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
@@ -1040,7 +1039,7 @@ void SolverInterfaceImpl::mapReadDataTo(
       if (context.mesh->getID() != toMeshID) {
         continue;
       }
-      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
+
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
                                   << "\" to mesh \"" << context.mesh->getName() << "\"");
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext.mapping);
@@ -1485,17 +1484,18 @@ void SolverInterfaceImpl::mapWrittenData()
 
   // Map data
   for (impl::DataContext &context : _accessor->writeDataContexts()) {
-    timing          = context.mappingContext.timing;
-    bool hasMapping = context.mappingContext.mapping.get() != nullptr;
-    bool rightTime  = timing == MappingConfiguration::ON_ADVANCE;
+    timing         = context.mappingContext.timing;
+    bool rightTime = timing == MappingConfiguration::ON_ADVANCE;
     rightTime |= timing == MappingConfiguration::INITIAL;
-    bool hasMapped = context.mappingContext.hasMappedData;
+    const bool hasMapping = context.mappingContext.mapping.get() != nullptr;
+    const bool hasMapped  = context.mappingContext.hasMappedData;
+
     if (hasMapping && rightTime && (not hasMapped)) {
-      int inDataID  = context.fromData->getID();
-      int outDataID = context.toData->getID();
+      const int inDataID  = context.fromData->getID();
+      const int outDataID = context.toData->getID();
+
       PRECICE_DEBUG("Map data \"" << context.fromData->getName()
                                   << "\" from mesh \"" << context.mesh->getName() << "\"");
-      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
       PRECICE_DEBUG("Map from dataID " << inDataID << " to dataID: " << outDataID);
       context.mappingContext.mapping->map(inDataID, outDataID);
       PRECICE_DEBUG("Mapped values = " << utils::previewRange(3, context.toData->values()));
@@ -1538,12 +1538,13 @@ void SolverInterfaceImpl::mapReadData()
     timing      = context.mappingContext.timing;
     bool mapNow = timing == mapping::MappingConfiguration::ON_ADVANCE;
     mapNow |= timing == mapping::MappingConfiguration::INITIAL;
-    bool hasMapping = context.mappingContext.mapping.get() != nullptr;
-    bool hasMapped  = context.mappingContext.hasMappedData;
+    const bool hasMapping = context.mappingContext.mapping.get() != nullptr;
+    const bool hasMapped  = context.mappingContext.hasMappedData;
+
     if (mapNow && hasMapping && (not hasMapped)) {
-      int inDataID             = context.fromData->getID();
-      int outDataID            = context.toData->getID();
-      context.toData->values() = Eigen::VectorXd::Zero(context.toData->values().size());
+      const int inDataID  = context.fromData->getID();
+      const int outDataID = context.toData->getID();
+
       PRECICE_DEBUG("Map read data \"" << context.fromData->getName()
                                        << "\" to mesh \"" << context.mesh->getName() << "\"");
       context.mappingContext.mapping->map(inDataID, outDataID);
@@ -1552,7 +1553,7 @@ void SolverInterfaceImpl::mapReadData()
   }
   // Clear non-initial, non-incremental mappings
   for (impl::MappingContext &context : _accessor->readMappingContexts()) {
-    bool isStationary = context.timing == mapping::MappingConfiguration::INITIAL;
+    const bool isStationary = context.timing == mapping::MappingConfiguration::INITIAL;
     if (not isStationary) {
       context.mapping->clear();
     }


### PR DESCRIPTION
## Motivation and additional information
We currently zero out the data vector on the output mesh before performing any mapping. I don't get the rationale behind this. I guess it is a secure action with no further purpose, but maybe I am overlooking something. However, we would like to be able to directly access data on the output mesh without performing a mapping in preCICE (solver mapping) and this doesn't work if we zero out the data vector before performing the mapping and sending the data (in case of the 'solver mapping' the `map` function would of course be a 'do nothing' mapping in preCICE, but we need the function call nevertheless for compatibility reasons).
All tests pass locally.