### PR TITLE
Merge read/write function calls in SolverInterfaceImpl

### DIFF
--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1053,10 +1053,10 @@ void SolverInterfaceImpl::mapReadDataTo(
 }
 
 template <int dataDimension>
-void SolverInterfaceImpl::readBlockVectorDataImpl(const int  dataID,
-                                                  const int  size,
-                                                  const int *valueIndices,
-                                                  double *   values) const
+void SolverInterfaceImpl::readBlockDataImpl(const int  dataID,
+                                            const int  size,
+                                            const int *valueIndices,
+                                            double *   values) const
 
 {
   PRECICE_TRACE(dataID, size);
@@ -1095,10 +1095,10 @@ void SolverInterfaceImpl::readBlockVectorDataImpl(const int  dataID,
 }
 
 template <int dataDimension>
-void SolverInterfaceImpl::writeBlockVectorDataImpl(const int     dataID,
-                                                   const int     size,
-                                                   const int *   valueIndices,
-                                                   const double *values)
+void SolverInterfaceImpl::writeBlockDataImpl(const int     dataID,
+                                             const int     size,
+                                             const int *   valueIndices,
+                                             const double *values)
 {
   PRECICE_TRACE(dataID, size);
 
@@ -1147,9 +1147,9 @@ void SolverInterfaceImpl::writeBlockVectorData(
 {
   PRECICE_VALIDATE_DATA_ID(dataID);
   if (_accessor->dataContext(dataID).fromData->getDimensions() == 2)
-    writeBlockVectorDataImpl<2>(dataID, size, valueIndices, values);
+    writeBlockDataImpl<2>(dataID, size, valueIndices, values);
   else
-    writeBlockVectorDataImpl<3>(dataID, size, valueIndices, values);
+    writeBlockDataImpl<3>(dataID, size, valueIndices, values);
 }
 
 void SolverInterfaceImpl::writeVectorData(
@@ -1159,9 +1159,9 @@ void SolverInterfaceImpl::writeVectorData(
 {
   PRECICE_VALIDATE_DATA_ID(dataID);
   if (_accessor->dataContext(dataID).fromData->getDimensions() == 2)
-    writeBlockVectorDataImpl<2>(dataID, 1, &valueIndex, value);
+    writeBlockDataImpl<2>(dataID, 1, &valueIndex, value);
   else
-    writeBlockVectorDataImpl<3>(dataID, 1, &valueIndex, value);
+    writeBlockDataImpl<3>(dataID, 1, &valueIndex, value);
 }
 
 void SolverInterfaceImpl::writeBlockScalarData(
@@ -1170,7 +1170,7 @@ void SolverInterfaceImpl::writeBlockScalarData(
     const int *   valueIndices,
     const double *values)
 {
-  writeBlockVectorDataImpl<1>(dataID, size, valueIndices, values);
+  writeBlockDataImpl<1>(dataID, size, valueIndices, values);
 }
 
 void SolverInterfaceImpl::writeScalarData(
@@ -1178,7 +1178,7 @@ void SolverInterfaceImpl::writeScalarData(
     int    valueIndex,
     double value)
 {
-  writeBlockVectorDataImpl<1>(dataID, 1, &valueIndex, &value);
+  writeBlockDataImpl<1>(dataID, 1, &valueIndex, &value);
 }
 
 void SolverInterfaceImpl::readBlockVectorData(
@@ -1189,9 +1189,9 @@ void SolverInterfaceImpl::readBlockVectorData(
 {
   PRECICE_VALIDATE_DATA_ID(dataID);
   if (_accessor->dataContext(dataID).toData->getDimensions() == 2)
-    readBlockVectorDataImpl<2>(dataID, size, valueIndices, values);
+    readBlockDataImpl<2>(dataID, size, valueIndices, values);
   else
-    readBlockVectorDataImpl<3>(dataID, size, valueIndices, values);
+    readBlockDataImpl<3>(dataID, size, valueIndices, values);
 }
 
 void SolverInterfaceImpl::readVectorData(
@@ -1201,9 +1201,9 @@ void SolverInterfaceImpl::readVectorData(
 {
   PRECICE_VALIDATE_DATA_ID(dataID);
   if (_accessor->dataContext(dataID).toData->getDimensions() == 2)
-    readBlockVectorDataImpl<2>(dataID, 1, &valueIndex, value);
+    readBlockDataImpl<2>(dataID, 1, &valueIndex, value);
   else
-    readBlockVectorDataImpl<3>(dataID, 1, &valueIndex, value);
+    readBlockDataImpl<3>(dataID, 1, &valueIndex, value);
 }
 
 void SolverInterfaceImpl::readBlockScalarData(
@@ -1212,7 +1212,7 @@ void SolverInterfaceImpl::readBlockScalarData(
     const int *valueIndices,
     double *   values) const
 {
-  readBlockVectorDataImpl<1>(dataID, size, valueIndices, values);
+  readBlockDataImpl<1>(dataID, size, valueIndices, values);
 }
 
 void SolverInterfaceImpl::readScalarData(
@@ -1220,7 +1220,7 @@ void SolverInterfaceImpl::readScalarData(
     int     valueIndex,
     double &value) const
 {
-  readBlockVectorDataImpl<1>(dataID, 1, &valueIndex, &value);
+  readBlockDataImpl<1>(dataID, 1, &valueIndex, &value);
 }
 
 void SolverInterfaceImpl::exportMesh(

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -635,6 +635,40 @@ private:
   void mapReadData();
 
   /**
+   * @brief Generich implementation in order to write data
+   *
+   * @tparam dataDimension dimension of the associated data.
+   *         Equals one for scalar data and dim for vector-valued data
+   *
+   * @param[in] dataID dataID of the associated data
+   * @param[in] size size of data seeds to write
+   * @param[in] valueIndices pointer to the value associated data indices
+   * @param[in] values pointer to the data to write
+   */
+  template <int dataDimension>
+  void writeBlockVectorDataImpl(const int     dataID,
+                                const int     size,
+                                const int *   valueIndices,
+                                const double *values);
+
+  /**
+   * @brief Generich implementation in order to read data
+   *
+   * @tparam dataDimension dimension of the associated data.
+   *         Equals one for scalar data and dim for vector-valued data
+   *
+   * @param[in]  dataID dataID of the associated data
+   * @param[in]  size size of data seeds to read
+   * @param[in]  valueIndices pointer to the value associated data indices
+   * @param[out] values pointer to the data to read
+   */
+  template <int dataDimension>
+  void readBlockVectorDataImpl(const int  dataID,
+                               const int  size,
+                               const int *valueIndices,
+                               double *   values) const;
+
+  /**
    * @brief Performs all data actions with given timing.
    *
    * @param[in] dt Last timestep length computed by solver.

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -635,7 +635,7 @@ private:
   void mapReadData();
 
   /**
-   * @brief Generich implementation in order to write data
+   * @brief Generic implementation in order to write data
    *
    * @tparam dataDimension dimension of the associated data.
    *         Equals one for scalar data and dim for vector-valued data
@@ -646,13 +646,13 @@ private:
    * @param[in] values pointer to the data to write
    */
   template <int dataDimension>
-  void writeBlockVectorDataImpl(const int     dataID,
-                                const int     size,
-                                const int *   valueIndices,
-                                const double *values);
+  void writeBlockDataImpl(const int     dataID,
+                          const int     size,
+                          const int *   valueIndices,
+                          const double *values);
 
   /**
-   * @brief Generich implementation in order to read data
+   * @brief Generic implementation in order to read data
    *
    * @tparam dataDimension dimension of the associated data.
    *         Equals one for scalar data and dim for vector-valued data
@@ -663,10 +663,10 @@ private:
    * @param[out] values pointer to the data to read
    */
   template <int dataDimension>
-  void readBlockVectorDataImpl(const int  dataID,
-                               const int  size,
-                               const int *valueIndices,
-                               double *   values) const;
+  void readBlockDataImpl(const int  dataID,
+                         const int  size,
+                         const int *valueIndices,
+                         double *   values) const;
 
   /**
    * @brief Performs all data actions with given timing.


### PR DESCRIPTION
## Main changes of this PR
This PR merges the implementation of our `read(Block)Scalar/VectorData` and `write(Block)Scalar/VectorData` into a single implementation for each task. 

## Motivation and additional information
We have quite some duplication in all these functions and changing the mapping might require changes in these functions. Changing it in all places is tedious. This PR would centralize the implementation.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)