### PR TITLE
Use PKG_CONFIG_ALLOW_SYSTEM_CFLAGS in FindPETSc

### DIFF
--- a/cmake/modules/FindPETSc.cmake
+++ b/cmake/modules/FindPETSc.cmake
@@ -143,9 +143,17 @@ if(PKG_CONFIG_FOUND)
     endif()
   endif()
 
+  # Set PKG_CONFIG_ALLOW_SYSTEM_CFLAGS
+  set(_petsc_prev_allow_system_cflags $ENV{PKG_CONFIG_ALLOW_SYSTEM_CFLAGS})
+  set(ENV{PKG_CONFIG_ALLOW_SYSTEM_CFLAGS} 1)
+
   # Use pkg-config to find PETSc
   set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH "YES")
   pkg_check_modules(PC_PETSc ${_petsc_quiet_arg} "PETSc${_pkg_version_spec}")
+
+  # Restore/Reset PKG_CONFIG_USE_CMAKE_PREFIX_PATH
+  set(ENV{PKG_CONFIG_ALLOW_SYSTEM_CFLAGS} ${_petsc_prev_allow_system_cflags})
+
   unset(PKG_CONFIG_USE_CMAKE_PREFIX_PATH)
   unset(_pkg_version_spec)
 

--- a/docs/changelog/993.md
+++ b/docs/changelog/993.md
@@ -1,0 +1,1 @@
+- Fixed FindPETSc to also find PETSc if the include directory is in CPATH, which occured with some versions of `pkg-config`.


### PR DESCRIPTION
## Main changes of this PR

Use `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS` to find PETSc flags even if they are in system dirs.

## Motivation and additional information

Fixes #972

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
