### PR TITLE
Remove normals from primitives

### DIFF
--- a/docs/changelog/1000.md
+++ b/docs/changelog/1000.md
@@ -1,0 +1,5 @@
+- Deprecated vertex normals in the `vertexCallback()` of the python actions. preCICE will pass `None` if the normal parameter is defined.
+- Deprecated the `flip-normals` attribute of meshes. This is not functional anymore.
+- Removed vertex normals from the vtk exporters.
+- Changed edge and triangle normals to be computed on-demand.
+- Improved mesh memory usage of vertices by ~41% and of connectivity by ~55%.

--- a/src/acceleration/test/AccelerationMasterSlaveTest.cpp
+++ b/src/acceleration/test/AccelerationMasterSlaveTest.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(testVIQNILSpp)
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
   std::vector<int>  vertexOffsets{4, 8, 8, 10};
 
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJpp)
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
   std::vector<int>  vertexOffsets{4, 8, 8, 10};
 
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -507,7 +507,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp)
   PtrPreconditioner _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(-1));
   std::vector<int>  vertexOffsets{0, 11, 22, 22};
 
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("dummyMesh", 2, false, testing::nextMeshID()));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("dummyMesh", 2, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
@@ -977,7 +977,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLogging)
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
   std::vector<int>  vertexOffsets{2, 3, 3, 4};
 
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration acc(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -32,6 +32,8 @@ BOOST_FIXTURE_TEST_SUITE(AccelerationSerialTests, AccelerationSerialTestsFixture
 BOOST_AUTO_TEST_CASE(testMVQNPP)
 {
   PRECICE_TEST(1_rank);
+  using namespace precice::cplscheme;
+
   //use two vectors and see if underrelaxation works
   double           initialRelaxation        = 0.01;
   int              maxIterationsUsed        = 50;
@@ -131,8 +133,9 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
 BOOST_AUTO_TEST_CASE(testVIQNPP)
 {
   PRECICE_TEST(1_rank);
-  //use two vectors and see if underrelaxation works
+  using namespace precice::cplscheme;
 
+  //use two vectors and see if underrelaxation works
   double           initialRelaxation        = 0.01;
   int              maxIterationsUsed        = 50;
   int              timestepsReused          = 6;
@@ -187,8 +190,8 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   PtrCouplingData fpcd(new CouplingData(forces, dummyMesh, false));
 
   DataMap data;
-  data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
-  data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
+  data.insert(std::pair<int, cplscheme::PtrCouplingData>(0, dpcd));
+  data.insert(std::pair<int, cplscheme::PtrCouplingData>(1, fpcd));
 
   pp.initialize(data);
 

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   int              timestepsReused          = 6;
   int              reusedTimestepsAtRestart = 0;
   int              chunkSize                = 0;
-  int              filter                   = Acceleration::QR1FILTER;
-  int              restartType              = MVQNAcceleration::NO_RESTART;
+  int              filter                   = acceleration::Acceleration::QR1FILTER;
+  int              restartType              = acceleration::MVQNAcceleration::NO_RESTART;
   double           singularityLimit         = 1e-10;
   double           svdTruncationEps         = 0.0;
   bool             enforceInitialRelaxation = false;
@@ -49,12 +49,12 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   dataIDs.push_back(1);
   std::vector<double> factors;
   factors.resize(2, 1.0);
-  impl::PtrPreconditioner prec(new impl::ConstantPreconditioner(factors));
-  mesh::PtrMesh           dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
+  acceleration::impl::PtrPreconditioner prec(new acceleration::impl::ConstantPreconditioner(factors));
+  mesh::PtrMesh                         dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
 
-  MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                      timestepsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
-                      restartType, chunkSize, reusedTimestepsAtRestart, svdTruncationEps);
+  acceleration::MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
+                                    timestepsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
+                                    restartType, chunkSize, reusedTimestepsAtRestart, svdTruncationEps);
 
   Eigen::VectorXd dcol1;
   Eigen::VectorXd fcol1;
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   utils::append(dcol1, 1.0);
   utils::append(dcol1, 1.0);
 
-  cplscheme::PtrCouplingData dpcd(new cplscheme::CouplingData(displacements, dummyMesh, false));
+  PtrCouplingData dpcd(new CouplingData(displacements, dummyMesh, false));
 
   //init forces
   utils::append(forces->values(), 0.1);
@@ -86,11 +86,11 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   utils::append(fcol1, 0.2);
   utils::append(fcol1, 0.2);
 
-  cplscheme::PtrCouplingData fpcd(new cplscheme::CouplingData(forces, dummyMesh, false));
+  PtrCouplingData fpcd(new CouplingData(forces, dummyMesh, false));
 
   DataMap data;
-  data.insert(std::pair<int, cplscheme::PtrCouplingData>(0, dpcd));
-  data.insert(std::pair<int, cplscheme::PtrCouplingData>(1, fpcd));
+  data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+  data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
   pp.initialize(data);
 
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   std::map<int, double> scalings;
   scalings.insert(std::make_pair(0, 1.0));
   scalings.insert(std::make_pair(1, 1.0));
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
 
   acceleration::IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                                       timestepsReused, filter, singularityLimit, dataIDs, prec);
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   utils::append(dcol1, 1.0);
   utils::append(dcol1, 1.0);
 
-  cplscheme::PtrCouplingData dpcd(new cplscheme::CouplingData(displacements, dummyMesh, false));
+  PtrCouplingData dpcd(new CouplingData(displacements, dummyMesh, false));
 
   //init forces
   utils::append(forces->values(), 0.1);
@@ -184,11 +184,11 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   utils::append(fcol1, 0.2);
   utils::append(fcol1, 0.2);
 
-  cplscheme::PtrCouplingData fpcd(new cplscheme::CouplingData(forces, dummyMesh, false));
+  PtrCouplingData fpcd(new CouplingData(forces, dummyMesh, false));
 
   DataMap data;
-  data.insert(std::pair<int, cplscheme::PtrCouplingData>(0, dpcd));
-  data.insert(std::pair<int, cplscheme::PtrCouplingData>(1, fpcd));
+  data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+  data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
 
   pp.initialize(data);
 

--- a/src/action/ComputeCurvatureAction.cpp
+++ b/src/action/ComputeCurvatureAction.cpp
@@ -55,7 +55,7 @@ void ComputeCurvatureAction::performAction(
     Eigen::Vector3d contribution;
 
     for (mesh::Triangle &tri : getMesh()->triangles()) {
-      normal = tri.getNormal();
+      normal = tri.computeNormal();
       for (int i = 0; i < 3; i++) {
         mesh::Vertex &v0 = tri.vertex(i);
         mesh::Vertex &v1 = tri.vertex((i + 1) % 3);

--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -143,6 +143,7 @@ void PythonAction::performAction(double time,
       PRECICE_CHECK(pythonCoords != nullptr, "Creating python coords failed. Please check that the python-actions mesh name is correct.");
       PyTuple_SetItem(vertexArgs, 0, pythonID);
       PyTuple_SetItem(vertexArgs, 1, pythonCoords);
+      PyTuple_SetItem(vertexArgs, 2, Py_None);
       PyObject_CallObject(_vertexCallback, vertexArgs);
       if (PyErr_Occurred()) {
         PRECICE_ERROR("Error occurred during call of function vertexCallback() in python module \"{}\". "

--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -62,7 +62,7 @@ PyObject *getfullargspec()
   return getfullargspec_function;
 }
 
-/// Returns the argument names of of a callable
+/// Returns the argument names of a callable
 std::vector<std::string> python_func_args(PyObject *const func)
 {
   PyObject *const getfullargspec_function = getfullargspec();

--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -51,7 +51,7 @@ std::string python_error_as_string()
   }
 }
 
-/// Fetches the function inpect.getfullargspec().
+/// Fetches the function inspect.getfullargspec().
 PyObject *getfullargspec()
 {
   PyObject *const inspect_module_name     = PyUnicode_DecodeFSDefault("inspect");

--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -133,21 +133,16 @@ void PythonAction::performAction(double time,
     PyObject *      vertexArgs = PyTuple_New(3);
     mesh::PtrMesh   mesh       = getMesh();
     Eigen::VectorXd coords(mesh->getDimensions());
-    Eigen::VectorXd normal(mesh->getDimensions());
     for (mesh::Vertex &vertex : mesh->vertices()) {
       npy_intp vdim[]        = {mesh->getDimensions()};
       int      id            = vertex.getID();
       coords                 = vertex.getCoords();
-      normal                 = vertex.getNormal();
       PyObject *pythonID     = PyLong_FromLong(id);
       PyObject *pythonCoords = PyArray_SimpleNewFromData(1, vdim, NPY_DOUBLE, coords.data());
-      PyObject *pythonNormal = PyArray_SimpleNewFromData(1, vdim, NPY_DOUBLE, coords.data());
       PRECICE_CHECK(pythonID != nullptr, "Creating python ID failed. Please check that the python-actions mesh name is correct.");
       PRECICE_CHECK(pythonCoords != nullptr, "Creating python coords failed. Please check that the python-actions mesh name is correct.");
-      PRECICE_CHECK(pythonNormal != nullptr, "Creating python normal failed. Please check that the python-actions mesh name is correct.");
       PyTuple_SetItem(vertexArgs, 0, pythonID);
       PyTuple_SetItem(vertexArgs, 1, pythonCoords);
-      PyTuple_SetItem(vertexArgs, 2, pythonNormal);
       PyObject_CallObject(_vertexCallback, vertexArgs);
       if (PyErr_Occurred()) {
         PRECICE_ERROR("Error occurred during call of function vertexCallback() in python module \"{}\". "

--- a/src/action/PythonAction.hpp
+++ b/src/action/PythonAction.hpp
@@ -58,6 +58,8 @@ private:
 
   PyObject *_vertexCallback = nullptr;
 
+  int _vertexCallbackArgs = 0;
+
   PyObject *_postAction = nullptr;
 
   void initialize();

--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_SUITE(Python)
 BOOST_AUTO_TEST_CASE(AllMethods)
 {
   PRECICE_TEST(1_rank);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector3d::Constant(1.0));
   mesh->createVertex(Eigen::Vector3d::Constant(2.0));
   mesh->createVertex(Eigen::Vector3d::Constant(3.0));
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
     action.performAction(0.0, 0.0, 0.0, 0.0);
   }
   {
-    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
     mesh::PtrData data = mesh->createData("TargetData", 1);
     mesh->allocateDataValues();
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
     action.performAction(0.0, 0.0, 0.0, 0.0);
   }
   {
-    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
     mesh::PtrData data = mesh->createData("SourceData", 1);
     mesh->allocateDataValues();
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(DeprecatedNormal)
   PRECICE_TEST(1_rank);
   std::string path = testing::getPathToSources() + "/action/tests/";
   {
-    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
     mesh::PtrData data = mesh->createData("TargetData", 1);
     mesh->allocateDataValues();

--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -69,6 +69,20 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
   }
 }
 
+BOOST_AUTO_TEST_CASE(DeprecatedNormal)
+{
+  PRECICE_TEST(1_rank);
+  std::string path = testing::getPathToSources() + "/action/tests/";
+  {
+    mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+    mesh->createVertex(Eigen::Vector3d::Zero());
+    mesh::PtrData data = mesh->createData("TargetData", 1);
+    mesh->allocateDataValues();
+    PythonAction action(PythonAction::WRITE_MAPPING_PRIOR, path, "TestDeprecatedAction", mesh, data->getID(), -1);
+    action.performAction(0.0, 0.0, 0.0, 0.0);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Python
 BOOST_AUTO_TEST_SUITE_END() // ActionTest
 

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(DivideByArea)
 {
   PRECICE_TEST(1_rank);
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 2, true, testing::nextMeshID()));
+  PtrMesh mesh(new Mesh("Mesh", 2, testing::nextMeshID()));
   PtrData data   = mesh->createData("test-data", 1);
   int     dataID = data->getID();
   Vertex &v0     = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(ScaleByTimeStepSizeToTimeWindowSize)
 {
   PRECICE_TEST(1_rank);
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::nextMeshID()));
+  PtrMesh mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
   PtrData sourceData   = mesh->createData("SourceData", 1);
   PtrData targetData   = mesh->createData("TargetData", 1);
   int     sourceDataID = sourceData->getID();
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(ScaleByComputedTimeWindowPart)
 {
   PRECICE_TEST(1_rank);
   using namespace mesh;
-  PtrMesh mesh(new Mesh("Mesh", 3, true, testing::nextMeshID()));
+  PtrMesh mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
   PtrData sourceData   = mesh->createData("SourceData", 1);
   PtrData targetData   = mesh->createData("TargetData", 1);
   int     sourceDataID = sourceData->getID();

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -41,7 +41,6 @@ BOOST_AUTO_TEST_CASE(DivideByArea)
   Vertex &v2     = mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
   mesh->createEdge(v0, v1);
   mesh->createEdge(v1, v2);
-  mesh->computeState();
   mesh->allocateDataValues();
   auto &values = data->values();
   values << 2.0, 3.0, 4.0;

--- a/src/action/tests/SummationActionTest.cpp
+++ b/src/action/tests/SummationActionTest.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(SummationOneDimensional)
 {
   PRECICE_TEST(1_rank);
   using namespace mesh;
-  PtrMesh          mesh(new Mesh("Mesh", 3, true, testing::nextMeshID()));
+  PtrMesh          mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
   int              dimension   = 1;
   PtrData          sourceData1 = mesh->createData("SourceData1", dimension);
   PtrData          sourceData2 = mesh->createData("SourceData2", dimension);
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(SummationThreeDimensional)
   PRECICE_TEST(1_rank);
   using namespace mesh;
   int              dimension = 3;
-  PtrMesh          mesh(new Mesh("Mesh", dimension, true, testing::nextMeshID()));
+  PtrMesh          mesh(new Mesh("Mesh", dimension, testing::nextMeshID()));
   PtrData          sourceData1 = mesh->createData("SourceData1", dimension);
   PtrData          sourceData2 = mesh->createData("SourceData2", dimension);
   PtrData          targetData  = mesh->createData("TargetData", dimension);

--- a/src/action/tests/TestAllAction.py
+++ b/src/action/tests/TestAllAction.py
@@ -20,7 +20,7 @@ def performAction(time, timeWindowSize, sourceData, targetData):
 # This function is called for every vertex in the configured mesh. It is called
 # after performAction, and can also be omitted.
 #
-def vertexCallback(id, coords, normal):
+def vertexCallback(id, coords):
     global mySourceData
     global myTargetData
     # Usage example:

--- a/src/action/tests/TestDeprecatedAction.py
+++ b/src/action/tests/TestDeprecatedAction.py
@@ -1,0 +1,2 @@
+def vertexCallback(id, coords, normal):
+    print("vertex callback ...")

--- a/src/action/tests/TestOmitAction2.py
+++ b/src/action/tests/TestOmitAction2.py
@@ -2,7 +2,7 @@
 def performAction(time, timeWindowSize, targetData):
     pass
     
-def vertexCallback(id, coords, normal):
+def vertexCallback(id, coords):
     pass
     
 #def postAction():

--- a/src/action/tests/TestOmitAction3.py
+++ b/src/action/tests/TestOmitAction3.py
@@ -2,7 +2,7 @@
 def performAction(time, timeWindowSize, sourceData):
     pass
     
-#def vertexCallback(id, coords, normal):
+#def vertexCallback(id, coords):
 #    print "vertex callback ..."
     
 #def postAction():

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh)
   auto m2n = context.connectMasters("A", "B");
 
   for (int dim = 2; dim <= 3; dim++) {
-    mesh::Mesh    sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
+    mesh::Mesh    sendMesh("Sent Mesh", dim, testing::nextMeshID());
     mesh::Vertex &v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
     mesh::Vertex &v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
     mesh::Vertex &v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh)
       comMesh.sendMesh(sendMesh, 0);
     } else {
       // receiveMesh can also deal with delta meshes
-      mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
+      mesh::Mesh recvMesh("Received Mesh", dim, testing::nextMeshID());
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       comMesh.receiveMesh(recvMesh, 0);
       BOOST_TEST(recvMesh.vertices().size() == 4);
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh)
   auto m2n = context.connectMasters("A", "B");
 
   int             dim = 3;
-  mesh::Mesh      sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
+  mesh::Mesh      sendMesh("Sent Mesh", dim, testing::nextMeshID());
   mesh::Vertex &  v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
   mesh::Vertex &  v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
   mesh::Vertex &  v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh)
   if (context.isNamed("A")) {
     comMesh.sendMesh(sendMesh, 0);
   } else {
-    mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
+    mesh::Mesh recvMesh("Received Mesh", dim, testing::nextMeshID());
     // receiveMesh can also deal with delta meshes
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     comMesh.receiveMesh(recvMesh, 0);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh)
   PRECICE_TEST(""_on(2_ranks).setupMasterSlaves(), Require::Events);
 
   int             dim = 3;
-  mesh::Mesh      sendMesh("Sent Mesh", dim, false, testing::nextMeshID());
+  mesh::Mesh      sendMesh("Sent Mesh", dim, testing::nextMeshID());
   mesh::Vertex &  v0 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 0));
   mesh::Vertex &  v1 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 1));
   mesh::Vertex &  v2 = sendMesh.createVertex(Eigen::VectorXd::Constant(dim, 2));
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh)
   if (context.isMaster()) {
     comMesh.broadcastSendMesh(sendMesh);
   } else {
-    mesh::Mesh recvMesh("Received Mesh", dim, false, testing::nextMeshID());
+    mesh::Mesh recvMesh("Received Mesh", dim, testing::nextMeshID());
     // receiveMesh can also deal with delta meshes
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     comMesh.broadcastReceiveMesh(recvMesh);

--- a/src/cplscheme/cplscheme.dox
+++ b/src/cplscheme/cplscheme.dox
@@ -44,8 +44,7 @@ Data data ( dataName, dataType, dataID );
 
 // Create a mesh (in a real example, it has to be filled with Vertices, ...)
 std::string meshName ( "MyMesh" );
-bool flipNormals = false;
-Mesh mesh ( meshName, flipNormals );
+Mesh mesh ( meshName );
 mesh.setVertexData ( data );
 
 // Create explicit coupling scheme object

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
   dataConfig->addData("Data0", 1);
   dataConfig->addData("Data1", 3);
   mesh::MeshConfiguration meshConfig(root, dataConfig);
-  mesh::PtrMesh           mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh           mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
   mesh->createData("Data0", 1);
   mesh->createData("Data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -591,7 +591,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
   dataConfig->addData("Data1", 3);
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
   mesh->createData("Data0", 1);
   mesh->createData("Data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
   const auto    dataID0 = mesh->createData("Data0", 1)->getID();
   const auto    dataID1 = mesh->createData("Data1", 3)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   PRECICE_TEST(1_rank);
   using namespace mesh;
 
-  PtrMesh mesh(new Mesh("MyMesh", 3, false, testing::nextMeshID()));
+  PtrMesh mesh(new Mesh("MyMesh", 3, testing::nextMeshID()));
   PtrData data   = mesh->createData("MyData", 1);
   int     dataID = data->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -534,7 +534,7 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
 
   MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
   mesh->createData("data0", 1);
   mesh->createData("data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
   mesh->createData("data0", 1);
   mesh->createData("data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -689,7 +689,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
   mesh->createData("data0", 1);
   mesh->createData("data1", 3);
   mesh->createVertex(Eigen::Vector3d::Zero());
@@ -750,7 +750,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, false, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
   const auto    dataID0 = mesh->createData("Data0", 1)->getID();
   const auto    dataID1 = mesh->createData("Data1", 3)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());

--- a/src/io/ExportContext.hpp
+++ b/src/io/ExportContext.hpp
@@ -15,27 +15,13 @@ struct ExportContext {
   std::string location;
 
   // @brief Exporting every N time windows (equals -1 when not set).
-  int everyNTimeWindows;
+  int everyNTimeWindows = -1;
 
   // @brief If true, export is done in every iteration (also implicit).
-  bool everyIteration;
+  bool everyIteration = false;
 
   // @brief type of the exporter (e.g. vtk).
   std::string type;
-
-  // @brief If true, normals are plotted.
-  bool plotNormals;
-
-  /**
-   * @brief Constructor.
-   */
-  ExportContext()
-      : exporter(),
-        location(),
-        everyNTimeWindows(-1),
-        everyIteration(false),
-        type(),
-        plotNormals(false) {}
 };
 
 } // namespace io

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -18,7 +18,8 @@
 namespace precice {
 namespace io {
 
-ExportVTK::ExportVTK() : Export() {}
+ExportVTK::ExportVTK()
+    : Export() {}
 
 int ExportVTK::getType() const
 {

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -18,9 +18,6 @@
 namespace precice {
 namespace io {
 
-ExportVTK::ExportVTK()
-    : Export() {}
-
 int ExportVTK::getType() const
 {
   return constants::exportVTK();

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -18,9 +18,7 @@
 namespace precice {
 namespace io {
 
-ExportVTK::ExportVTK(bool writeNormals)
-    : Export(),
-      _writeNormals(writeNormals) {}
+ExportVTK::ExportVTK() : Export() {}
 
 int ExportVTK::getType() const
 {
@@ -100,37 +98,6 @@ void ExportVTK::exportMesh(std::ofstream &outFile, mesh::Mesh const &mesh)
 void ExportVTK::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
 {
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
-
-  if (_writeNormals) { // Plot vertex normals
-    outFile << "VECTORS VertexNormals double\n\n";
-    for (auto const &vertex : mesh.vertices()) {
-      int i = 0;
-      for (; i < mesh.getDimensions(); i++) {
-        outFile << vertex.getNormal()[i] << ' ';
-      }
-      if (i < 3) {
-        outFile << '0';
-      }
-      outFile << '\n';
-    }
-    outFile << '\n';
-
-    // Plot edge normals
-    //    if(_plotNormals) {
-    //      VTKTextFileWriter vtkWriterEdgeNormals; //(fileName + "-edgenormals.vtk");
-    //      PtrVertexWriter normalsOriginWriter (vtkWriterEdgeNormals.createVertexWriter());
-    //      PtrVertexDataWriter normalsWriter (
-    //          vtkWriterEdgeNormals.createVertexDataWriter("EdgeNormals", utils::Def::DIM));
-    //      for (mesh::Edge & edge : mesh.edges()) {
-    //  //      int vertexID = normalsOriginWriter.getNextFreeVertexNumber ();
-    //        int vertexID = normalsOriginWriter->plotVertex(edge.getCenter());
-    //        normalsWriter->plotVertex(vertexID, edge.getNormal());
-    //      }
-    //      vtkWriterEdgeNormals.writeToFile(fileName + "-edgenormals.vtk");
-    //  //    vtkWriterEdgeNormals.plotVertices(normalsOriginWriter);
-    //  //    vtkWriterEdgeNormals.plotPointData(normalsWriter);
-    //    }
-  }
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
     Eigen::VectorXd &values = data->values();

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -18,7 +18,7 @@ namespace io {
 /// Writes polygonal, or triangle meshes to vtk files.
 class ExportVTK : public Export {
 public:
-  explicit ExportVTK(bool exportNormals);
+  explicit ExportVTK();
 
   /// Returns the VTK type ID.
   virtual int getType() const;
@@ -48,9 +48,6 @@ public:
 
 private:
   logging::Logger _log{"io::ExportVTK"};
-
-  /// By default set true: plot vertex normals, false: no normals plotting
-  bool _writeNormals;
 
   void openFile(
       std::ofstream &    outFile,

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -18,8 +18,6 @@ namespace io {
 /// Writes polygonal, or triangle meshes to vtk files.
 class ExportVTK : public Export {
 public:
-  explicit ExportVTK();
-
   /// Returns the VTK type ID.
   virtual int getType() const;
 

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -21,10 +21,8 @@
 namespace precice {
 namespace io {
 
-ExportVTKXML::ExportVTKXML(
-    bool writeNormals)
+ExportVTKXML::ExportVTKXML()
     : Export(),
-      _writeNormals(writeNormals),
       _meshDimensions(-1)
 {
 }
@@ -57,9 +55,6 @@ void ExportVTKXML::processDataNamesAndDimensions(mesh::Mesh const &mesh)
   _meshDimensions = mesh.getDimensions();
   _vectorDataNames.clear();
   _scalarDataNames.clear();
-  if (_writeNormals) {
-    _vectorDataNames.emplace_back("VertexNormals");
-  }
   for (const mesh::PtrData &data : mesh.data()) {
     int dataDimensions = data->getDimensions();
     PRECICE_ASSERT(dataDimensions >= 1);
@@ -249,26 +244,6 @@ void ExportVTKXML::exportData(
   }
   outFile << "\">\n";
 
-  // Print VertexNormals
-  if (_writeNormals) {
-    const auto dimensions = mesh.getDimensions();
-    outFile << "            <DataArray type=\"Float64\" Name=\"VertexNormals\" NumberOfComponents=\"";
-    outFile << std::max(3, dimensions) << "\" format=\"ascii\">\n";
-    outFile << "               ";
-    for (const auto &vertex : mesh.vertices()) {
-      const auto &normal = vertex.getNormal();
-      for (int i = 0; i < std::max(3, dimensions); i++) {
-        if (i < dimensions) {
-          outFile << normal[i] << ' ';
-        } else {
-          outFile << "0.0 ";
-        }
-        outFile << ' ';
-      }
-    }
-    outFile << '\n'
-            << "            </DataArray>\n";
-  }
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
     Eigen::VectorXd &values         = data->values();
     int              dataDimensions = data->getDimensions();

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -21,12 +21,6 @@
 namespace precice {
 namespace io {
 
-ExportVTKXML::ExportVTKXML()
-    : Export(),
-      _meshDimensions(-1)
-{
-}
-
 int ExportVTKXML::getType() const
 {
   return constants::exportVTKXML();
@@ -52,7 +46,6 @@ void ExportVTKXML::doExport(
 
 void ExportVTKXML::processDataNamesAndDimensions(mesh::Mesh const &mesh)
 {
-  _meshDimensions = mesh.getDimensions();
   _vectorDataNames.clear();
   _scalarDataNames.clear();
   for (const mesh::PtrData &data : mesh.data()) {
@@ -134,7 +127,7 @@ void ExportVTKXML::writeSubFile(
 {
   int numPoints = mesh.vertices().size(); // number of vertices
   int numCells;                           // number of cells
-  if (_meshDimensions == 2) {
+  if (mesh.getDimensions() == 2) {
     numCells = mesh.edges().size();
   } else {
     numCells = mesh.triangles().size();
@@ -178,7 +171,7 @@ void ExportVTKXML::exportMesh(
     std::ofstream &   outFile,
     mesh::Mesh const &mesh)
 {
-  if (_meshDimensions == 2) { // write edges as cells
+  if (mesh.getDimensions() == 2) { // write edges as cells
     outFile << "         <Cells>\n";
     outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
     outFile << "               ";

--- a/src/io/ExportVTKXML.hpp
+++ b/src/io/ExportVTKXML.hpp
@@ -23,10 +23,8 @@ class ExportVTKXML : public Export {
 public:
   /**
    * @brief Standard constructor
-   *
-   * @param[in] writeNormals write normals to file?
    */
-  ExportVTKXML(bool writeNormals);
+  ExportVTKXML();
 
   /// Returns the VTK type ID.
   virtual int getType() const;
@@ -56,9 +54,6 @@ public:
 
 private:
   logging::Logger _log{"io::ExportVTKXML"};
-
-  /// By default set true: plot vertex normals, false: no normals plotting
-  bool _writeNormals;
 
   /// dimensions of mesh
   int _meshDimensions;

--- a/src/io/ExportVTKXML.hpp
+++ b/src/io/ExportVTKXML.hpp
@@ -21,11 +21,6 @@ namespace io {
 /// Writes meshes to xml-vtk files. Only for parallel usage. Serial usage (coupling mode) should still use ExportVTK
 class ExportVTKXML : public Export {
 public:
-  /**
-   * @brief Standard constructor
-   */
-  ExportVTKXML();
-
   /// Returns the VTK type ID.
   virtual int getType() const;
 
@@ -54,9 +49,6 @@ public:
 
 private:
   logging::Logger _log{"io::ExportVTKXML"};
-
-  /// dimensions of mesh
-  int _meshDimensions;
 
   /// List of names of all scalar data on mesh
   std::vector<std::string> _scalarDataNames;

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -44,8 +44,8 @@ void ExportConfiguration::xmlTagCallback(
     xml::XMLTag &                    tag)
 {
   if (tag.getBooleanAttributeValue(ATTR_NORMALS)) {
-    PRECICE_WARNING("You explicitly requrested to export the vertex normals. "
-                    "This is deprecated and the attribute will be removed in a future release.");
+    PRECICE_WARN("You explicitly requrested to export the vertex normals. "
+                 "This is deprecated and the attribute will be removed in a future release.");
   }
   if (tag.getNamespace() == TAG) {
     ExportContext econtext;

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -24,8 +24,8 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
   auto attrEveryNTimeWindows = makeXMLAttribute(ATTR_EVERY_N_TIME_WINDOWS, 1)
                                    .setDocumentation("preCICE does an export every X time windows. Choose -1 for no exports.");
 
-  auto attrNormals = makeXMLAttribute(ATTR_NORMALS, true)
-                         .setDocumentation("If set to on/yes, mesh normals (if available) are added to the export.");
+  auto attrNormals = makeXMLAttribute(ATTR_NORMALS, false)
+                         .setDocumentation("Deprecated");
 
   auto attrEveryIteration = makeXMLAttribute(ATTR_EVERY_ITERATION, false)
                                 .setDocumentation("Exports in every coupling (sub)iteration. For debug purposes.");
@@ -43,11 +43,14 @@ void ExportConfiguration::xmlTagCallback(
     const xml::ConfigurationContext &context,
     xml::XMLTag &                    tag)
 {
+  if (tag.getBooleanAttributeValue(ATTR_NORMALS)) {
+    PRECICE_WARNING("You explicitly requrested to export the vertex normals. "
+                    "This is deprecated and the attribute will be removed in a future release.");
+  }
   if (tag.getNamespace() == TAG) {
     ExportContext econtext;
     econtext.location          = tag.getStringAttributeValue(ATTR_LOCATION);
     econtext.everyNTimeWindows = tag.getIntAttributeValue(ATTR_EVERY_N_TIME_WINDOWS);
-    econtext.plotNormals       = tag.getBooleanAttributeValue(ATTR_NORMALS);
     econtext.everyIteration    = tag.getBooleanAttributeValue(ATTR_EVERY_ITERATION);
     econtext.type              = tag.getName();
     _contexts.push_back(econtext);

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -45,7 +45,7 @@ void ExportConfiguration::xmlTagCallback(
 {
   if (tag.getBooleanAttributeValue(ATTR_NORMALS)) {
     PRECICE_WARN("You explicitly requrested to export the vertex normals. "
-                 "This is deprecated and the attribute will be removed in a future release.");
+                 "This is deprecated, no longer functional, and the attribute will be removed in a future release.");
   }
   if (tag.getNamespace() == TAG) {
     ExportContext econtext;

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -36,7 +36,6 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-
   io::ExportVTK exportVTK;
   std::string   filename = "io-VTKExport-ExportPolygonalMesh";
   std::string   location = "";

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -37,8 +37,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   mesh.createEdge(v3, v1);
 
 
-  bool          exportNormals = true;
-  io::ExportVTK exportVTK(exportNormals);
+  io::ExportVTK exportVTK;
   std::string   filename = "io-VTKExport-ExportPolygonalMesh";
   std::string   location = "";
   exportVTK.doExport(filename, location, mesh);
@@ -61,8 +60,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   mesh::Edge &e3 = mesh.createEdge(v3, v1);
   mesh.createTriangle(e1, e2, e3);
 
-  bool          exportNormals = true;
-  io::ExportVTK exportVTK(exportNormals);
+  io::ExportVTK exportVTK;
   std::string   filename = "io-VTKExport-ExportTriangulatedMesh";
   std::string   location = "";
   exportVTK.doExport(filename, location, mesh);

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -24,8 +24,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(1_rank);
   int             dim           = 2;
-  bool            invertNormals = false;
-  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
+  mesh::Mesh      mesh("MyMesh", dim, testing::nextMeshID());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Constant(dim, 0.0);
@@ -46,8 +45,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(1_rank);
   int             dim           = 3;
-  bool            invertNormals = false;
-  mesh::Mesh      mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
+  mesh::Mesh      mesh("MyMesh", dim, testing::nextMeshID());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
   Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -36,7 +36,6 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  mesh.computeState();
 
   bool          exportNormals = true;
   io::ExportVTK exportVTK(exportNormals);
@@ -61,7 +60,6 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   mesh::Edge &e2 = mesh.createEdge(v2, v3);
   mesh::Edge &e3 = mesh.createEdge(v3, v1);
   mesh.createTriangle(e1, e2, e3);
-  mesh.computeState();
 
   bool          exportNormals = true;
   io::ExportVTK exportVTK(exportNormals);

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -23,7 +23,7 @@ using namespace precice;
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(1_rank);
-  int             dim           = 2;
+  int             dim = 2;
   mesh::Mesh      mesh("MyMesh", dim, testing::nextMeshID());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(1_rank);
-  int             dim           = 3;
+  int             dim = 3;
   mesh::Mesh      mesh("MyMesh", dim, testing::nextMeshID());
   mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
   mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -45,8 +45,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
   int        dim           = 2;
-  bool       invertNormals = false;
-  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));
@@ -88,8 +87,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
   int        dim           = 3;
-  bool       invertNormals = false;
-  mesh::Mesh mesh("MyMesh", dim, invertNormals, testing::nextMeshID());
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {
     mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Zero(dim));

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_SUITE(VTKXMLExport)
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
-  int        dim           = 2;
+  int        dim = 2;
   mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
-  int        dim           = 3;
+  int        dim = 3;
   mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
 
   if (utils::Parallel::getProcessRank() == 0) {

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -78,7 +78,6 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::VectorXd::Constant(dim, 3.0));
   }
 
-
   io::ExportVTKXML exportVTKXML;
   std::string      filename = "io-ExportVTKXMLTest-testExportPolygonalMesh";
   std::string      location = "";
@@ -124,7 +123,6 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   } else if (utils::Parallel::getProcessRank() == 3) {
     mesh.createVertex(Eigen::VectorXd::Constant(dim, 3.0));
   }
-
 
   io::ExportVTKXML exportVTKXML;
   std::string      filename = "io-ExportVTKXMLTest-testExportTriangulatedMesh";

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -79,8 +79,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   }
 
 
-  bool             exportNormals = true;
-  io::ExportVTKXML exportVTKXML(exportNormals);
+  io::ExportVTKXML exportVTKXML;
   std::string      filename = "io-ExportVTKXMLTest-testExportPolygonalMesh";
   std::string      location = "";
   exportVTKXML.doExport(filename, location, mesh);
@@ -127,8 +126,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   }
 
 
-  bool             exportNormals = false;
-  io::ExportVTKXML exportVTKXML(exportNormals);
+  io::ExportVTKXML exportVTKXML;
   std::string      filename = "io-ExportVTKXMLTest-testExportTriangulatedMesh";
   std::string      location = "";
   exportVTKXML.doExport(filename, location, mesh);

--- a/src/io/tests/ExportVTKXMLTest.cpp
+++ b/src/io/tests/ExportVTKXMLTest.cpp
@@ -78,7 +78,6 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::VectorXd::Constant(dim, 3.0));
   }
 
-  mesh.computeState();
 
   bool             exportNormals = true;
   io::ExportVTKXML exportVTKXML(exportNormals);
@@ -127,7 +126,6 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::VectorXd::Constant(dim, 3.0));
   }
 
-  mesh.computeState();
 
   bool             exportNormals = false;
   io::ExportVTKXML exportVTKXML(exportNormals);

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -23,12 +23,11 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
 
   int             dimensions       = 2;
   int             numberOfVertices = 6;
-  bool            flipNormals      = false;
   int             valueDimension   = 1;
   Eigen::VectorXd offset           = Eigen::VectorXd::Zero(dimensions);
 
   if (context.isNamed("Part1")) {
-    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
     m2n->createDistributedCommunication(pMesh);
 
     pMesh->setGlobalNumberOfVertices(numberOfVertices);
@@ -54,7 +53,7 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
 
   } else {
     BOOST_TEST(context.isNamed("Part2"));
-    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pMesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
     m2n->createDistributedCommunication(pMesh);
     m2n->requestSlavesConnection("Part1", "Part2");
 

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -47,7 +47,7 @@ void runP2PComTest1(const TestContext &context, com::PtrCommunicationFactory cf)
 {
   BOOST_TEST(context.hasSize(2));
 
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, testing::nextMeshID()));
 
   m2n::PointToPointCommunication c(cf, mesh);
 
@@ -123,7 +123,7 @@ void runP2PComTest1(const TestContext &context, com::PtrCommunicationFactory cf)
 void runP2PComTest2(const TestContext &context, com::PtrCommunicationFactory cf)
 {
   BOOST_TEST(context.hasSize(2));
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, true, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 2, testing::nextMeshID()));
 
   m2n::PointToPointCommunication c(cf, mesh);
 

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -199,7 +199,7 @@ void runSameConnectionTest(const TestContext &context, com::PtrCommunicationFact
 
   BOOST_TEST(context.hasSize(2));
 
-  int           dimensions  = 2;
+  int           dimensions = 2;
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
@@ -255,7 +255,7 @@ void runCrossConnectionTest(const TestContext &context, com::PtrCommunicationFac
 
   BOOST_TEST(context.hasSize(2));
 
-  int           dimensions  = 2;
+  int           dimensions = 2;
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
@@ -310,7 +310,7 @@ void runEmptyConnectionTest(const TestContext &context, com::PtrCommunicationFac
 {
   BOOST_TEST(context.hasSize(2));
 
-  int           dimensions  = 2;
+  int           dimensions = 2;
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
@@ -354,7 +354,7 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
 {
   BOOST_TEST(context.hasSize(2));
 
-  int           dimensions  = 2;
+  int           dimensions = 2;
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
@@ -421,7 +421,7 @@ void runP2PComLocalCommunicationMapTest(const TestContext &context, com::PtrComm
 {
   BOOST_TEST(context.hasSize(2));
 
-  int                             dimensions  = 2;
+  int                             dimensions = 2;
   mesh::PtrMesh                   mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
   const auto                      expectedId = mesh->getID();
   std::map<int, std::vector<int>> localCommunicationMap;

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -200,8 +200,7 @@ void runSameConnectionTest(const TestContext &context, com::PtrCommunicationFact
   BOOST_TEST(context.hasSize(2));
 
   int           dimensions  = 2;
-  bool          flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
     if (context.isMaster()) {
@@ -257,8 +256,7 @@ void runCrossConnectionTest(const TestContext &context, com::PtrCommunicationFac
   BOOST_TEST(context.hasSize(2));
 
   int           dimensions  = 2;
-  bool          flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
     if (context.isMaster()) {
@@ -313,8 +311,7 @@ void runEmptyConnectionTest(const TestContext &context, com::PtrCommunicationFac
   BOOST_TEST(context.hasSize(2));
 
   int           dimensions  = 2;
-  bool          flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
     if (context.isMaster()) {
@@ -358,8 +355,7 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
   BOOST_TEST(context.hasSize(2));
 
   int           dimensions  = 2;
-  bool          flipNormals = false;
-  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
 
   if (context.isNamed("A")) {
     if (context.isMaster()) {
@@ -426,8 +422,7 @@ void runP2PComLocalCommunicationMapTest(const TestContext &context, com::PtrComm
   BOOST_TEST(context.hasSize(2));
 
   int                             dimensions  = 2;
-  bool                            flipNormals = false;
-  mesh::PtrMesh                   mesh(new mesh::Mesh("Mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh                   mesh(new mesh::Mesh("Mesh", dimensions, testing::nextMeshID()));
   const auto                      expectedId = mesh->getID();
   std::map<int, std::vector<int>> localCommunicationMap;
 

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -11,6 +11,7 @@ Polation::Polation(const mesh::Vertex &element)
 
 Polation::Polation(const Eigen::VectorXd &location, const mesh::Edge &element)
 {
+  PRECICE_ASSERT(location.size() == element.getDimensions(), location.size(), element.getDimensions());
   const auto &A = element.vertex(0);
   const auto &B = element.vertex(1);
 
@@ -27,6 +28,7 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Edge &element)
 
 Polation::Polation(const Eigen::VectorXd &location, const mesh::Triangle &element)
 {
+  PRECICE_ASSERT(location.size() == element.getDimensions(), location.size(), element.getDimensions());
   auto &A = element.vertex(0);
   auto &B = element.vertex(1);
   auto &C = element.vertex(2);

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -17,7 +17,7 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Edge &element)
   const auto bcoords = math::barycenter::calcBarycentricCoordsForEdge(
                            A.getCoords(),
                            B.getCoords(),
-                           element.getNormal(),
+                           element.computeNormal(),
                            location)
                            .barycentricCoords;
 
@@ -35,7 +35,7 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Triangle &elemen
                            A.getCoords(),
                            B.getCoords(),
                            C.getCoords(),
-                           element.getNormal(),
+                           element.computeNormal(),
                            location)
                            .barycentricCoords;
 

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -152,7 +152,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   if (utils::MasterSlave::isSlave()) {
 
     // Input mesh may have overlaps
-    mesh::Mesh filteredInMesh("filteredInMesh", inMesh->getDimensions(), inMesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+    mesh::Mesh filteredInMesh("filteredInMesh", inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
     mesh::filterMesh(filteredInMesh, *inMesh, [&](const mesh::Vertex &v) { return v.isOwner(); });
 
     // Send the mesh
@@ -161,13 +161,13 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
 
   } else { // Parallel Master or Serial
 
-    mesh::Mesh globalInMesh("globalInMesh", inMesh->getDimensions(), inMesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
-    mesh::Mesh globalOutMesh("globalOutMesh", outMesh->getDimensions(), outMesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+    mesh::Mesh globalInMesh("globalInMesh", inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
+    mesh::Mesh globalOutMesh("globalOutMesh", outMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
 
     if (utils::MasterSlave::isMaster()) {
       {
         // Input mesh may have overlaps
-        mesh::Mesh filteredInMesh("filteredInMesh", inMesh->getDimensions(), inMesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+        mesh::Mesh filteredInMesh("filteredInMesh", inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
         mesh::filterMesh(filteredInMesh, *inMesh, [&](const mesh::Vertex &v) { return v.isOwner(); });
         globalInMesh.addMesh(filteredInMesh);
         globalOutMesh.addMesh(*outMesh);
@@ -175,11 +175,11 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
 
       // Receive mesh
       for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); ++rankSlave) {
-        mesh::Mesh slaveInMesh(inMesh->getName(), inMesh->getDimensions(), inMesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+        mesh::Mesh slaveInMesh(inMesh->getName(), inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
         com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(slaveInMesh, rankSlave);
         globalInMesh.addMesh(slaveInMesh);
 
-        mesh::Mesh slaveOutMesh(outMesh->getName(), outMesh->getDimensions(), outMesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+        mesh::Mesh slaveOutMesh(outMesh->getName(), outMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
         com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(slaveOutMesh, rankSlave);
         globalOutMesh.addMesh(slaveOutMesh);
       }

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   using testing::equals;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inDataScalar   = inMesh->createData("InDataScalar", 1);
   PtrData inDataVector   = inMesh->createData("InDataVector", 2);
   int     inDataScalarID = inDataScalar->getID();
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   inValuesVector << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1);
   PtrData outDataVector   = outMesh->createData("OutDataVector", 2);
   int     outDataScalarID = outDataScalar->getID();
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData    = inMesh->createData("InData", 1);
   int     inDataID  = inData->getID();
   Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
   inValues(1)               = 2.0;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData    = outMesh->createData("OutData", 1);
   int     outDataID  = outData->getID();
   Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentNonIncremental)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData    = inMesh->createData("InData", 1);
   int     inDataID  = inData->getID();
   Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentNonIncremental)
   inValues(3)               = 4.0;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData    = outMesh->createData("OutData", 1);
   int     outDataID  = outData->getID();
   Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   int dimensions = 2;
 
   // Setup geometry to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, true, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData   = outMesh->createData("Data", 1);
   int     outDataID = outData->getID();
   Vertex &v1        = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   {
     // Setup mapping with mapping coordinates and geometry used
     mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-    PtrMesh                           inMesh(new Mesh("InMesh0", dimensions, false, testing::nextMeshID()));
+    PtrMesh                           inMesh(new Mesh("InMesh0", dimensions, testing::nextMeshID()));
     PtrData                           inData   = inMesh->createData("Data0", 1);
     int                               inDataID = inData->getID();
 
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   {
     // Setup mapping with mapping coordinates and geometry used
     mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
-    PtrMesh                           inMesh(new Mesh("InMesh1", dimensions, false, testing::nextMeshID()));
+    PtrMesh                           inMesh(new Mesh("InMesh1", dimensions, testing::nextMeshID()));
     PtrData                           inData   = inMesh->createData("Data1", 1);
     int                               inDataID = inData->getID();
 
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData   = inMesh->createData("InData", 1);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
   {
     // Create mesh to map to
-    PtrMesh outMesh(new Mesh("OutMesh0", dimensions, false, testing::nextMeshID()));
+    PtrMesh outMesh(new Mesh("OutMesh0", dimensions, testing::nextMeshID()));
     PtrData outData   = outMesh->createData("OutData", 1);
     int     outDataID = outData->getID();
 
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
   {
     // Create mesh to map to
-    PtrMesh outMesh(new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()));
+    PtrMesh outMesh(new Mesh("OutMesh1", dimensions, testing::nextMeshID()));
     PtrData outData   = outMesh->createData("OutData", 1);
     int     outDataID = outData->getID();
 
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase1)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData   = inMesh->createData("InData", 1);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase1)
 
   auto inputIntegral = mesh::integrate(inMesh, inData);
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh0", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh0", dimensions, testing::nextMeshID()));
   PtrData outData   = outMesh->createData("OutData", 1);
   int     outDataID = outData->getID();
   auto &  outValues = outData->values();
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase2)
   int dimensions = 2;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData   = inMesh->createData("InData", 1);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase2)
   auto inputIntegral = mesh::integrate(inMesh, inData);
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh1", dimensions, testing::nextMeshID()));
   PtrData outData   = outMesh->createData("OutData", 1);
   int     outDataID = outData->getID();
   auto &  outValues = outData->values();
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   int dimensions = 3;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData   = inMesh->createData("InData", 1);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
 
   {
     // Create mesh to map to
-    PtrMesh outMesh(new Mesh("OutMesh1", dimensions, false, testing::nextMeshID()));
+    PtrMesh outMesh(new Mesh("OutMesh1", dimensions, testing::nextMeshID()));
     PtrData outData   = outMesh->createData("OutData1", 1);
     int     outDataID = outData->getID();
 
@@ -400,7 +400,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   }
   {
     // Create mesh to map to
-    PtrMesh outMesh(new Mesh("OutMesh2", dimensions, false, testing::nextMeshID()));
+    PtrMesh outMesh(new Mesh("OutMesh2", dimensions, testing::nextMeshID()));
     PtrData outData   = outMesh->createData("OutData2", 1);
     int     outDataID = outData->getID();
 
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
   int dimensions = 3;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData   = inMesh->createData("InData", 1);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
   values(2)                     = valueVertex3;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData   = outMesh->createData("OutData", 1);
   int     outDataID = outData->getID();
 
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
   int dimensions = 3;
 
   // Create mesh to map from
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData   = inMesh->createData("InData", 1);
   int     inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
   values(2)                     = valueVertex3;
 
   // Create mesh to map to
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData   = outMesh->createData("OutData", 1);
   int     outDataID = outData->getID();
 
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   constexpr int dimensions = 3;
 
   // Create mesh to map from with Triangles ABD and BDC
-  PtrMesh inMesh(new Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   Vertex &inVA   = inMesh->createVertex(Eigen::Vector3d{0, 0, 0});
   Vertex &inVB   = inMesh->createVertex(Eigen::Vector3d{0, 1, 0});
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   inData->values() << 1.0, 1.0, 1.0, 1.0;
 
   // Create mesh to map to with one vertex per defined traingle
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{0.33, 0.33, 0});
   outMesh->createVertex(Eigen::Vector3d{0.66, 0.66, 0});
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
   PtrData      inData = inMesh->createData("InData", 1);
   const double z1     = 0.1;
   const double z2     = -0.1;
@@ -629,7 +629,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   inMesh->allocateDataValues();
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
   outMesh->allocateDataValues();
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
   PtrData      inData = inMesh->createData("InData", 1);
   const double z1     = 0.1;
   const double z2     = -0.1;
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
   inMesh->allocateDataValues();
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   auto &  outV1   = outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
   auto &  outV2   = outMesh->createVertex(Eigen::Vector3d{0.5, 0.0, 0.05});
@@ -743,7 +743,7 @@ BOOST_AUTO_TEST_CASE(AvoidClosestTriangle)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   // Close triangle - extrapolating
   auto &vc0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
@@ -760,7 +760,7 @@ BOOST_AUTO_TEST_CASE(AvoidClosestTriangle)
   inMesh->allocateDataValues();
   inData->values() << 0, 0, 0, 1, 1, 1;
 
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{2, 1, 0});
   outMesh->allocateDataValues();
@@ -776,7 +776,7 @@ BOOST_AUTO_TEST_CASE(PickClosestTriangle)
   PRECICE_TEST(1_rank);
   using namespace precice::mesh;
 
-  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   // Far triangle - interpolating
   auto &vf0 = inMesh->createVertex(Eigen::Vector3d(0, 0, -1));
@@ -793,7 +793,7 @@ BOOST_AUTO_TEST_CASE(PickClosestTriangle)
   inMesh->allocateDataValues();
   inData->values() << 1, 1, 1, 0, 0, 0;
 
-  PtrMesh outMesh(new Mesh("OutMesh", 3, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", 3, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 0});
   outMesh->allocateDataValues();
@@ -810,7 +810,7 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
   // Close edge
   auto &vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -826,7 +826,7 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
   inMesh->allocateDataValues();
   inData->values() << 0, 0, 1, 1, 1;
 
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 1});
   outMesh->allocateDataValues();
@@ -843,7 +843,7 @@ BOOST_AUTO_TEST_CASE(TriangleDistances)
   using namespace precice::mesh;
   constexpr int dimensions = 3;
 
-  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, false, testing::nextMeshID()));
+  PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1);
 
   // Close triangle
@@ -861,7 +861,7 @@ BOOST_AUTO_TEST_CASE(TriangleDistances)
   inMesh->allocateDataValues();
   inData->values() << 1, 1, 1, 0, 0, 0;
 
-  PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 1});
   outMesh->allocateDataValues();

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -38,7 +38,6 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
   Vertex &v1        = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2        = outMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
   outMesh->createEdge(v1, v2);
-  outMesh->computeState();
   outMesh->allocateDataValues();
 
   // Base-value for tests
@@ -62,7 +61,6 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
     inMesh->createVertex(Eigen::Vector2d(1.5, 1.5));
 
     inMesh->allocateDataValues();
-    inMesh->computeState();
 
     //assign(inData->values()) = value;
     inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
@@ -91,7 +89,6 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
     inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
     inMesh->allocateDataValues();
-    inMesh->computeState();
 
     //assign(inData->values()) = value;
     inData->values() = Eigen::VectorXd::Constant(inData->values().size(), value);
@@ -134,7 +131,6 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
   inMesh->createEdge(v1, v2);
-  inMesh->computeState();
   inMesh->allocateDataValues();
   double           valueVertex1 = 1.0;
   double           valueVertex2 = 2.0;
@@ -227,7 +223,6 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase1)
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
   inMesh->createEdge(v1, v2);
-  inMesh->computeState();
   inMesh->allocateDataValues();
   double           valueVertex1 = 1.0;
   double           valueVertex2 = 2.0;
@@ -287,7 +282,6 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase2)
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
   inMesh->createEdge(v1, v2);
-  inMesh->computeState();
   inMesh->allocateDataValues();
   double           valueVertex1 = 1.0;
   double           valueVertex2 = 2.0;
@@ -354,7 +348,6 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   Edge &  e31      = inMesh->createEdge(v3, v1);
   inMesh->createTriangle(e12, e23, e31);
 
-  inMesh->computeState();
   inMesh->allocateDataValues();
   double           valueVertex1 = 1.0;
   double           valueVertex2 = 2.0;
@@ -465,7 +458,6 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
   inMesh->createEdge(v2, v3);
   inMesh->createEdge(v3, v1);
 
-  inMesh->computeState();
   inMesh->allocateDataValues();
   double           valueVertex1 = 1.0;
   double           valueVertex2 = 2.0;
@@ -518,7 +510,6 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
   inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
 
-  inMesh->computeState();
   inMesh->allocateDataValues();
   double           valueVertex1 = 1.0;
   double           valueVertex2 = 2.0;
@@ -580,7 +571,6 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   inMesh->createTriangle(inEAB, inEBD, inEDA);
   inMesh->createTriangle(inEBD, inEDC, inECB);
   inMesh->allocateDataValues();
-  inMesh->computeState();
   inData->values() << 1.0, 1.0, 1.0, 1.0;
 
   // Create mesh to map to with one vertex per defined traingle
@@ -589,7 +579,6 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
   outMesh->createVertex(Eigen::Vector3d{0.33, 0.33, 0});
   outMesh->createVertex(Eigen::Vector3d{0.66, 0.66, 0});
   outMesh->allocateDataValues();
-  outMesh->computeState();
   outData->values() << 0.0, 0.0;
 
   // Setup mapping with mapping coordinates and geometry used
@@ -638,14 +627,12 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   inMesh->createTriangle(erd, erb, err);
 
   inMesh->allocateDataValues();
-  inMesh->computeState();
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
   outMesh->allocateDataValues();
-  outMesh->computeState();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
 
   // Setup mapping with mapping coordinates and geometry used
@@ -695,7 +682,6 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
   inMesh->createTriangle(erd, erb, err);
 
   inMesh->allocateDataValues();
-  inMesh->computeState();
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
@@ -708,7 +694,6 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
   auto &  outE3   = outMesh->createEdge(outV1, outV3);
   outMesh->createTriangle(outE1, outE2, outE3);
   outMesh->allocateDataValues();
-  outMesh->computeState();
   outData->values() = Eigen::VectorXd::Constant(3, 0.0);
 
   // Setup mapping with mapping coordinates and geometry used
@@ -773,14 +758,12 @@ BOOST_AUTO_TEST_CASE(AvoidClosestTriangle)
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   inMesh->allocateDataValues();
-  inMesh->computeState();
   inData->values() << 0, 0, 0, 1, 1, 1;
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{2, 1, 0});
   outMesh->allocateDataValues();
-  outMesh->computeState();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
 
   const auto &values = runNPMapping(mapping::Mapping::CONSISTENT, inMesh, inData, outMesh, outData);
@@ -808,14 +791,12 @@ BOOST_AUTO_TEST_CASE(PickClosestTriangle)
   makeTriangle(inMesh, vc0, vc1, vc2);
 
   inMesh->allocateDataValues();
-  inMesh->computeState();
   inData->values() << 1, 1, 1, 0, 0, 0;
 
   PtrMesh outMesh(new Mesh("OutMesh", 3, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 0});
   outMesh->allocateDataValues();
-  outMesh->computeState();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
 
   const auto &values = runNPMapping(mapping::Mapping::CONSISTENT, inMesh, inData, outMesh, outData);
@@ -843,14 +824,12 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   inMesh->allocateDataValues();
-  inMesh->computeState();
   inData->values() << 0, 0, 1, 1, 1;
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 1});
   outMesh->allocateDataValues();
-  outMesh->computeState();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
 
   const auto &values = runNPMapping(mapping::Mapping::CONSISTENT, inMesh, inData, outMesh, outData);
@@ -880,14 +859,12 @@ BOOST_AUTO_TEST_CASE(TriangleDistances)
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   inMesh->allocateDataValues();
-  inMesh->computeState();
   inData->values() << 1, 1, 1, 0, 0, 0;
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 1});
   outMesh->allocateDataValues();
-  outMesh->computeState();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
 
   const auto &values = runNPMapping(mapping::Mapping::CONSISTENT, inMesh, inData, outMesh, outData);

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -133,13 +133,13 @@ void testDistributed(const TestContext &    context,
   int meshDimension  = inMeshSpec.at(0).position.size();
   int valueDimension = inMeshSpec.at(0).value.size();
 
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", valueDimension);
   int           inDataID = inData->getID();
 
   getDistributedMesh(context, inMeshSpec, inMesh, inData, inGlobalIndexOffset);
 
-  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", valueDimension);
   int           outDataID = outData->getID();
 

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -1019,11 +1019,11 @@ void testTagging(const TestContext &context,
   int meshDimension  = inMeshSpec.at(0).position.size();
   int valueDimension = inMeshSpec.at(0).value.size();
 
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
   getDistributedMesh(context, inMeshSpec, inMesh, inData);
 
-  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData outData = outMesh->createData("OutData", valueDimension);
   getDistributedMesh(context, outMeshSpec, outMesh, outData);
   BOOST_TEST_MESSAGE("Mesh sizes in: " << inMesh->vertices().size() << " out: " << outMesh->vertices().size());
@@ -1142,7 +1142,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1156,7 +1156,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
@@ -1237,7 +1237,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 2);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1251,7 +1251,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   values << 1.0, 4.0, 2.0, 5.0, 2.0, 5.0, 1.0, 4.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 2);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
@@ -1349,7 +1349,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -1367,7 +1367,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   values << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector3d::Zero());
@@ -1483,7 +1483,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1503,7 +1503,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
   inValues << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1532,7 +1532,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -1557,7 +1557,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
   inValues << 1.0, 2.0, 4.0, 6.0, 8.0, 9.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -1588,7 +1588,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
@@ -1598,7 +1598,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1656,7 +1656,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 2);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
@@ -1666,7 +1666,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 2);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1728,7 +1728,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector3d(0, 0, 0));
@@ -1738,7 +1738,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -1959,7 +1959,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 1.0));
@@ -1973,7 +1973,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
@@ -2007,7 +2007,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector3d(0.0, 3.0, 0.0));
@@ -2021,7 +2021,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   values << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 2.9, 0.0));
@@ -2058,7 +2058,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
                                                      xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 1.0));
@@ -2071,7 +2071,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
   inData->values() << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0, 3));
@@ -2109,7 +2109,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(1, 1));
@@ -2121,7 +2121,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(3, 3)); // Point is outside the inMesh
@@ -2174,7 +2174,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0, 0));
@@ -2186,7 +2186,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.4, 0));
@@ -2254,13 +2254,13 @@ BOOST_AUTO_TEST_CASE(NoMapping)
 
   {
     // Call only computeMapping
-    mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", 2, false, testing::nextMeshID()));
+    mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", 2, testing::nextMeshID()));
     mesh::PtrData inData = inMesh->createData("InData", 1);
     inMesh->createVertex(Eigen::Vector2d(0, 0));
     inMesh->allocateDataValues();
     addGlobalIndex(inMesh);
 
-    mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", 2, false, testing::nextMeshID()));
+    mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", 2, testing::nextMeshID()));
     mesh::PtrData outData = outMesh->createData("OutData", 1);
     outMesh->createVertex(Eigen::Vector2d(0, 0));
     outMesh->allocateDataValues();
@@ -2285,7 +2285,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   Gaussian fct(1); // supportRadius = 4.55
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(1, 1)).setGlobalIndex(2);
@@ -2297,7 +2297,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
   inData->values() << 1, 1, 1, 1;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.5, 0.5));

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -120,13 +120,13 @@ void testDistributed(const TestContext &    context,
   int meshDimension  = inMeshSpec.at(0).position.size();
   int valueDimension = inMeshSpec.at(0).value.size();
 
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", valueDimension);
   int           inDataID = inData->getID();
 
   getDistributedMesh(context, inMeshSpec, inMesh, inData, inGlobalIndexOffset);
 
-  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", valueDimension);
   int           outDataID = outData->getID();
 

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -1006,11 +1006,11 @@ void testTagging(const TestContext &context,
   int meshDimension  = inMeshSpec.at(0).position.size();
   int valueDimension = inMeshSpec.at(0).value.size();
 
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData inData = inMesh->createData("InData", valueDimension);
   getDistributedMesh(context, inMeshSpec, inMesh, inData);
 
-  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData outData = outMesh->createData("OutData", valueDimension);
   getDistributedMesh(context, outMeshSpec, outMesh, outData);
 
@@ -1099,7 +1099,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1113,7 +1113,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
@@ -1194,7 +1194,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 2);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1208,7 +1208,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   values << 1.0, 4.0, 2.0, 5.0, 2.0, 5.0, 1.0, 4.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 2);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
@@ -1306,7 +1306,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -1324,7 +1324,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   values << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector3d::Zero());
@@ -1440,7 +1440,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1460,7 +1460,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
   inValues << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1489,7 +1489,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -1514,7 +1514,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
   inValues << 1.0, 2.0, 4.0, 6.0, 8.0, 9.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -1545,7 +1545,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
@@ -1555,7 +1555,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1613,7 +1613,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
   using Eigen::Vector2d;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 2);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
@@ -1623,7 +1623,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 2);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
@@ -1685,7 +1685,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
   int dimensions = 3;
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector3d(0, 0, 0));
@@ -1695,7 +1695,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
   addGlobalIndex(inMesh);
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -1916,7 +1916,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
                                                   xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 1.0));
@@ -1930,7 +1930,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
   values << 1.0, 2.0, 2.0, 1.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
@@ -1964,7 +1964,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   Mapping mapping(Mapping::CONSISTENT, dimensions, fct, xDead, yDead, zDead);
 
   // Create mesh to map from
-  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector3d(0.0, 3.0, 0.0));
@@ -1978,7 +1978,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
   values << 1.0, 2.0, 3.0, 4.0;
 
   // Create mesh to map to
-  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, false, testing::nextMeshID()));
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", 1);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 2.9, 0.0));

--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -21,9 +21,9 @@ BarycentricCoordsAndProjected calcBarycentricCoordsForEdge(
   using Eigen::VectorXd;
 
   const int dimensions = edgeA.size();
-  PRECICE_ASSERT(dimensions == edgeB.size(), "The inputs need to have the same dimensions.", dimensions, edgeB.size());
-  PRECICE_ASSERT(dimensions == edgeNormal.size(), "The inputs need to have the same dimensions.", dimensions, edgeNormal.size());
-  PRECICE_ASSERT(dimensions == location.size(), "The inputs need to have the same dimensions.", dimensions, location.size());
+  PRECICE_ASSERT(dimensions == edgeB.size(), "A and B need to have the same dimensions.", dimensions, edgeB.size());
+  PRECICE_ASSERT(dimensions == edgeNormal.size(), "A and the normal need to have the same dimensions.", dimensions, edgeNormal.size());
+  PRECICE_ASSERT(dimensions == location.size(), "A and the location need to have the same dimensions.", dimensions, location.size());
   PRECICE_ASSERT((dimensions == 2) || (dimensions == 3), dimensions);
 
   Vector2d barycentricCoords;
@@ -142,10 +142,10 @@ BarycentricCoordsAndProjected calcBarycentricCoordsForTriangle(
 
   const int dimensions = a.size();
   PRECICE_ASSERT(dimensions == 3, dimensions);
-  PRECICE_ASSERT(dimensions == b.size(), "The inputs need to have the same dimensions.", dimensions, b.size());
-  PRECICE_ASSERT(dimensions == c.size(), "The inputs need to have the same dimensions.", dimensions, c.size());
-  PRECICE_ASSERT(dimensions == normal.size(), "The inputs need to have the same dimensions.", dimensions, normal.size());
-  PRECICE_ASSERT(dimensions == location.size(), "The inputs need to have the same dimensions.", dimensions, location.size());
+  PRECICE_ASSERT(dimensions == b.size(), "A and B need to have the same dimensions.", dimensions, b.size());
+  PRECICE_ASSERT(dimensions == c.size(), "A and C need to have the same dimensions.", dimensions, c.size());
+  PRECICE_ASSERT(dimensions == normal.size(), "A and the normal need to have the same dimensions.", dimensions, normal.size());
+  PRECICE_ASSERT(dimensions == location.size(), "A and the location need to have the same dimensions.", dimensions, location.size());
 
   // Parametric representation for triangle plane:
   // (x, y, z) * normal = d

--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -21,8 +21,9 @@ BarycentricCoordsAndProjected calcBarycentricCoordsForEdge(
   using Eigen::VectorXd;
 
   const int dimensions = edgeA.size();
-  PRECICE_ASSERT(dimensions == edgeB.size() && dimensions == edgeNormal.size() && dimensions == location.size(),
-                 "The inputs need to have the same dimensions.");
+  PRECICE_ASSERT(dimensions == edgeB.size(), "The inputs need to have the same dimensions.", dimensions, edgeB.size());
+  PRECICE_ASSERT(dimensions == edgeNormal.size(), "The inputs need to have the same dimensions.", dimensions, edgeNormal.size());
+  PRECICE_ASSERT(dimensions == location.size(), "The inputs need to have the same dimensions.", dimensions, location.size());
   PRECICE_ASSERT((dimensions == 2) || (dimensions == 3), dimensions);
 
   Vector2d barycentricCoords;
@@ -138,6 +139,13 @@ BarycentricCoordsAndProjected calcBarycentricCoordsForTriangle(
 {
   using Eigen::Vector2d;
   using Eigen::Vector3d;
+
+  const int dimensions = a.size();
+  PRECICE_ASSERT(dimensions == 3, dimensions);
+  PRECICE_ASSERT(dimensions == b.size(), "The inputs need to have the same dimensions.", dimensions, b.size());
+  PRECICE_ASSERT(dimensions == c.size(), "The inputs need to have the same dimensions.", dimensions, c.size());
+  PRECICE_ASSERT(dimensions == normal.size(), "The inputs need to have the same dimensions.", dimensions, normal.size());
+  PRECICE_ASSERT(dimensions == location.size(), "The inputs need to have the same dimensions.", dimensions, location.size());
 
   // Parametric representation for triangle plane:
   // (x, y, z) * normal = d

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -12,7 +12,54 @@ using namespace precice::math::barycenter;
 BOOST_AUTO_TEST_SUITE(MathTests)
 BOOST_AUTO_TEST_SUITE(Barycenter)
 
-BOOST_AUTO_TEST_CASE(BarycenterEdge)
+BOOST_AUTO_TEST_CASE(BarycenterEdge2D)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector2d;
+  using Eigen::Vector3d;
+  using precice::testing::equals;
+  Vector2d a(0.0, 0.0);
+  Vector2d b(1.0, 0.0);
+  Vector2d n(0.0, 1.0);
+  {
+    Vector2d l(0.5, 0.0);
+    Vector2d coords(0.5, 0.5);
+    auto     ret = calcBarycentricCoordsForEdge(
+        a, b, n, l);
+    BOOST_TEST(equals(ret.projected, l));
+    BOOST_TEST(ret.barycentricCoords.sum() == 1.0);
+    BOOST_TEST(equals(ret.barycentricCoords, coords));
+  }
+  {
+    Vector2d l(0.0, 0.0);
+    Vector2d coords(1.0, 0.0);
+    auto     ret = calcBarycentricCoordsForEdge(
+        a, b, n, l);
+    BOOST_TEST(equals(ret.projected, l));
+    BOOST_TEST(ret.barycentricCoords.sum() == 1.0);
+    BOOST_TEST(equals(ret.barycentricCoords, coords));
+  }
+  {
+    Vector2d l(1.0, 0.0);
+    Vector2d coords(0, 1.0);
+    auto     ret = calcBarycentricCoordsForEdge(
+        a, b, n, l);
+    BOOST_TEST(equals(ret.projected, l));
+    BOOST_TEST(ret.barycentricCoords.sum() == 1.0);
+    BOOST_TEST(equals(ret.barycentricCoords, coords));
+  }
+  {
+    Vector2d l(0.75, 1.0);
+    Vector2d projected(0.75, 0.0);
+    Vector2d coords(0.25, 0.75);
+    auto     ret = calcBarycentricCoordsForEdge(a, b, n, l);
+    BOOST_TEST(equals(ret.projected, projected));
+    BOOST_TEST(ret.barycentricCoords.sum() == 1.0);
+    BOOST_TEST(equals(ret.barycentricCoords, coords), "Coords are " << ret.barycentricCoords << " but should be " << coords);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(BarycenterEdge3D)
 {
   PRECICE_TEST(1_rank);
   using Eigen::Vector2d;

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -40,7 +40,7 @@ Eigen::VectorXd Edge::computeNormal() const
   normal[1]              = edgeVector[0];
 
   // Handle vectors along the z axis
-  if(normal.size() == 3 && normal.isApproxToConstant(0.0)) {
+  if (normal.size() == 3 && normal.isApproxToConstant(0.0)) {
     normal[0] = 1.0;
   }
 

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -33,10 +33,16 @@ Eigen::VectorXd Edge::computeNormal(bool flip) const
 {
   // Compute normal
   Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
+
   // In 3D, use a normal on the plane z=0
   Eigen::VectorXd normal = Eigen::VectorXd::Zero(edgeVector.size());
   normal[0]              = -edgeVector[1];
   normal[1]              = edgeVector[0];
+
+  // Handle vectors along the z axis
+  if(normal.size() == 3 && normal.isApproxToConstant(0.0)) {
+    normal[0] = 1.0;
+  }
 
   if (not flip) {
     normal *= -1.0; // Invert direction if counterclockwise

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -37,8 +37,7 @@ Eigen::VectorXd Edge::computeNormal(bool flip) const
   if (not flip) {
     normal *= -1.0; // Invert direction if counterclockwise
   }
- // Scale normal vector to length 1, then weight by length
-  return normal.normalized() * getEnclosingRadius() * 2.0; 
+  return normal.normalized();
 }
 
 const Eigen::VectorXd Edge::getCenter() const

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -12,8 +12,7 @@ Edge::Edge(
     Vertex &vertexTwo,
     int     id)
     : _vertices({&vertexOne, &vertexTwo}),
-      _id(id),
-      _normal(Eigen::VectorXd::Constant(vertexOne.getDimensions(), 0.0))
+      _id(id)
 {
   PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),
                  vertexOne.getDimensions(), vertexTwo.getDimensions());
@@ -30,7 +29,7 @@ double Edge::getLength() const
   return length;
 }
 
-const Eigen::VectorXd Edge::computeNormal(bool flip)
+Eigen::VectorXd Edge::computeNormal(bool flip) const
 {
   // Compute normal
   Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
@@ -38,9 +37,8 @@ const Eigen::VectorXd Edge::computeNormal(bool flip)
   if (not flip) {
     normal *= -1.0; // Invert direction if counterclockwise
   }
-  _normal = normal.normalized(); // Scale normal vector to length 1
-
-  return normal * getEnclosingRadius() * 2.0; // Weight by length
+ // Scale normal vector to length 1, then weight by length
+  return normal.normalized() * getEnclosingRadius() * 2.0; 
 }
 
 const Eigen::VectorXd Edge::getCenter() const
@@ -60,8 +58,7 @@ bool Edge::connectedTo(const Edge &other) const
 
 bool Edge::operator==(const Edge &other) const
 {
-  return math::equals(_normal, other._normal) &&
-         std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin(),
+  return std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin(),
                              [](const Vertex *a, const Vertex *b) { return *a == *b; });
 }
 bool Edge::operator!=(const Edge &other) const

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -33,7 +33,11 @@ Eigen::VectorXd Edge::computeNormal(bool flip) const
 {
   // Compute normal
   Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
-  Eigen::VectorXd normal     = Eigen::Vector2d(-edgeVector[1], edgeVector[0]);
+  // In 3D, use a normal on the plane z=0
+  Eigen::VectorXd normal = Eigen::VectorXd::Zero(edgeVector.size());
+  normal[0] = -edgeVector[1];
+  normal[1] = edgeVector[0];
+
   if (not flip) {
     normal *= -1.0; // Invert direction if counterclockwise
   }

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -29,7 +29,7 @@ double Edge::getLength() const
   return length;
 }
 
-Eigen::VectorXd Edge::computeNormal(bool flip) const
+Eigen::VectorXd Edge::computeNormal() const
 {
   // Compute normal
   Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
@@ -44,9 +44,6 @@ Eigen::VectorXd Edge::computeNormal(bool flip) const
     normal[0] = 1.0;
   }
 
-  if (not flip) {
-    normal *= -1.0; // Invert direction if counterclockwise
-  }
   return normal.normalized();
 }
 

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -35,8 +35,8 @@ Eigen::VectorXd Edge::computeNormal(bool flip) const
   Eigen::VectorXd edgeVector = vertex(1).getCoords() - vertex(0).getCoords();
   // In 3D, use a normal on the plane z=0
   Eigen::VectorXd normal = Eigen::VectorXd::Zero(edgeVector.size());
-  normal[0] = -edgeVector[1];
-  normal[1] = edgeVector[0];
+  normal[0]              = -edgeVector[1];
+  normal[1]              = edgeVector[0];
 
   if (not flip) {
     normal *= -1.0; // Invert direction if counterclockwise

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -39,12 +39,8 @@ public:
   /// Returns the edge's vertex as const object with index 0 or 1.
   const Vertex &vertex(int i) const;
 
-  /// Sets the normal of the edge.
-  template <typename VECTOR_T>
-  void setNormal(const VECTOR_T &normal);
-
   /// Computes and sets the normal of the edge, returns the area-weighted normal.
-  const Eigen::VectorXd computeNormal(bool flip = false);
+  Eigen::VectorXd computeNormal(bool flip = false) const;
 
   /// Returns the (among edges) unique ID of the edge.
   int getID() const;
@@ -53,7 +49,7 @@ public:
   double getLength() const;
 
   /// Returns the normal of the edge.
-  const Eigen::VectorXd &getNormal() const;
+  const Eigen::VectorXd getNormal() const;
 
   /// Returns the center of the edge.
   const Eigen::VectorXd getCenter() const;
@@ -81,9 +77,6 @@ private:
 
   /// Unique (among edges) ID of the edge.
   int _id;
-
-  /// Normal of the edge.
-  Eigen::VectorXd _normal;
 };
 
 // ------------------------------------------------------ HEADER IMPLEMENTATION
@@ -107,18 +100,9 @@ inline int Edge::getDimensions() const
   return _vertices[0]->getDimensions();
 }
 
-template <typename VECTOR_T>
-void Edge::setNormal(
-    const VECTOR_T &normal)
+inline const Eigen::VectorXd Edge::getNormal() const
 {
-  PRECICE_ASSERT(normal.size() == _vertices[0]->getDimensions(), normal,
-                 _vertices[0]->getDimensions());
-  _normal = normal;
-}
-
-inline const Eigen::VectorXd &Edge::getNormal() const
-{
-  return _normal;
+  return computeNormal();
 }
 
 std::ostream &operator<<(std::ostream &stream, const Edge &edge);

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -39,7 +39,7 @@ public:
   /// Returns the edge's vertex as const object with index 0 or 1.
   const Vertex &vertex(int i) const;
 
-  /// Computes and sets the normal of the edge, returns the area-weighted normal.
+  /// Computes the normal of the edge
   Eigen::VectorXd computeNormal(bool flip = false) const;
 
   /// Returns the (among edges) unique ID of the edge.
@@ -47,9 +47,6 @@ public:
 
   /// Returns the length of the edge
   double getLength() const;
-
-  /// Returns the normal of the edge.
-  const Eigen::VectorXd getNormal() const;
 
   /// Returns the center of the edge.
   const Eigen::VectorXd getCenter() const;
@@ -63,8 +60,8 @@ public:
   /**
    * @brief Compares two Edges for equality
    *
-   * Two Edges are equal if their normal vector is equal AND
-   * if the two vertices are equal, whereas the order of vertices is NOT important.
+   * Two Edges are equal if the two vertices are equal,
+   * whereas the order of vertices is NOT important.
    */
   bool operator==(const Edge &other) const;
 
@@ -98,11 +95,6 @@ inline const Vertex &Edge::vertex(
 inline int Edge::getDimensions() const
 {
   return _vertices[0]->getDimensions();
-}
-
-inline const Eigen::VectorXd Edge::getNormal() const
-{
-  return computeNormal();
 }
 
 std::ostream &operator<<(std::ostream &stream, const Edge &edge);

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -40,7 +40,7 @@ public:
   const Vertex &vertex(int i) const;
 
   /// Computes the normal of the edge
-  Eigen::VectorXd computeNormal(bool flip = false) const;
+  Eigen::VectorXd computeNormal() const;
 
   /// Returns the (among edges) unique ID of the edge.
   int getID() const;

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -23,11 +23,9 @@ namespace mesh {
 Mesh::Mesh(
     std::string name,
     int         dimensions,
-    bool        flipNormals,
     int         id)
     : _name(std::move(name)),
       _dimensions(dimensions),
-      _flipNormals(flipNormals),
       _id(id),
       _boundingBox(dimensions)
 {
@@ -162,17 +160,6 @@ const PtrData &Mesh::data(
 const std::string &Mesh::getName() const
 {
   return _name;
-}
-
-bool Mesh::isFlipNormals() const
-{
-  return _flipNormals;
-}
-
-void Mesh::setFlipNormals(
-    bool flipNormals)
-{
-  _flipNormals = flipNormals;
 }
 
 int Mesh::getID() const

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -155,17 +155,6 @@ public:
   /// Allocates memory for the vertex data values.
   void allocateDataValues();
 
-  /**
-   * @brief Necessary before any geom. operations can be performed on the mesh.
-   *
-   * If no edges (in 2d) or triangles(in 3d) are
-   * given, no normals are computed in order to avoid dividing by zero on
-   * normalization of the vertex normals.
-   *
-   * Circumcircles of edges and triangles are computed.
-   */
-  void computeState();
-
   /// Computes the boundingBox for the vertices.
   void computeBoundingBox();
 
@@ -219,7 +208,6 @@ public:
    * @brief Returns the bounding box of the mesh.
    *
    * BoundingBox is a vector of pairs (min, max), one pair for each dimension.
-   * computeState() has to be called after setting the mesh.
    */
   const BoundingBox &getBoundingBox() const;
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -61,13 +61,11 @@ public:
    *
    * @param[in] name Unique name of the mesh.
    * @param[in] dimensions Dimensionalty of the mesh.
-   * @param[in] flipNormals Inverts the standard direction of normals.
    * @param[in] id The id of this mesh
    */
   Mesh(
       std::string name,
       int         dimensions,
-      bool        flipNormals,
       int         id);
 
   /// Destructor, deletes created objects.
@@ -138,10 +136,6 @@ public:
 
   /// Returns the name of the mesh, as set in the config file.
   const std::string &getName() const;
-
-  bool isFlipNormals() const;
-
-  void setFlipNormals(bool flipNormals);
 
   /// Returns the base ID of the mesh.
   int getID() const;
@@ -223,9 +217,6 @@ private:
 
   /// Dimension of mesh.
   int _dimensions;
-
-  /// Flag for flipping normals direction.
-  bool _flipNormals;
 
   /// The ID of this mesh.
   int _id;

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -80,16 +80,12 @@ double Triangle::getArea() const
   return math::geometry::triangleArea(vertex(0).getCoords(), vertex(1).getCoords(), vertex(2).getCoords());
 }
 
-Eigen::VectorXd Triangle::computeNormal(bool flip) const
+Eigen::VectorXd Triangle::computeNormal() const
 {
   Eigen::Vector3d vectorA = edge(1).getCenter() - edge(0).getCenter();
   Eigen::Vector3d vectorB = edge(2).getCenter() - edge(0).getCenter();
   // Compute cross-product of vector A and vector B
-  auto normal = vectorA.cross(vectorB);
-  if (flip) {
-    normal *= -1.0; // Invert direction if counterclockwise
-  }
-  return normal.normalized();
+  return vectorA.cross(vectorB).normalized();
 }
 
 int Triangle::getDimensions() const

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -25,8 +25,7 @@ Triangle::Triangle(
     Edge &edgeThree,
     int   id)
     : _edges({&edgeOne, &edgeTwo, &edgeThree}),
-      _id(id),
-      _normal(Eigen::VectorXd::Zero(edgeOne.getDimensions()))
+      _id(id)
 {
   PRECICE_ASSERT(edgeOne.getDimensions() == edgeTwo.getDimensions(),
                  edgeOne.getDimensions(), edgeTwo.getDimensions());
@@ -81,7 +80,7 @@ double Triangle::getArea() const
   return math::geometry::triangleArea(vertex(0).getCoords(), vertex(1).getCoords(), vertex(2).getCoords());
 }
 
-const Eigen::VectorXd Triangle::computeNormal(bool flip)
+Eigen::VectorXd Triangle::computeNormal(bool flip) const
 {
   Eigen::Vector3d vectorA = edge(1).getCenter() - edge(0).getCenter();
   Eigen::Vector3d vectorB = edge(2).getCenter() - edge(0).getCenter();
@@ -90,8 +89,7 @@ const Eigen::VectorXd Triangle::computeNormal(bool flip)
   if (flip) {
     normal *= -1.0; // Invert direction if counterclockwise
   }
-  _normal = normal.normalized();
-  return normal;
+  return normal.normalized();
 }
 
 int Triangle::getDimensions() const
@@ -99,9 +97,9 @@ int Triangle::getDimensions() const
   return _edges[0]->getDimensions();
 }
 
-const Eigen::VectorXd &Triangle::getNormal() const
+Eigen::VectorXd Triangle::getNormal() const
 {
-  return _normal;
+  return computeNormal();
 }
 
 const Eigen::VectorXd Triangle::getCenter() const
@@ -119,8 +117,7 @@ double Triangle::getEnclosingRadius() const
 
 bool Triangle::operator==(const Triangle &other) const
 {
-  return math::equals(_normal, other._normal) &&
-         std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin(),
+  return std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin(),
                              [](const Edge *e1, const Edge *e2) { return *e1 == *e2; });
 }
 

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -97,11 +97,6 @@ int Triangle::getDimensions() const
   return _edges[0]->getDimensions();
 }
 
-Eigen::VectorXd Triangle::getNormal() const
-{
-  return computeNormal();
-}
-
 const Eigen::VectorXd Triangle::getCenter() const
 {
   return (_edges[0]->getCenter() + _edges[1]->getCenter() + _edges[2]->getCenter()) / 3.0;

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -94,7 +94,11 @@ public:
 
   ///@}
 
-  /// Computes and sets the normal of the triangle, returns the area-weighted normal.
+  /**
+   * @brief Computes the normal of the triangle.
+   *
+   * @pre The normal has to be computed and set from outside before.
+   */
   Eigen::VectorXd computeNormal(bool flip = false) const;
 
   /// Returns a among triangles globally unique ID.
@@ -102,13 +106,6 @@ public:
 
   /// Returns the surface area of the triangle
   double getArea() const;
-
-  /**
-   * @brief Returns the outer normal of the triangle.
-   *
-   * @pre The normal has to be computed and set from outside before.
-   */
-  Eigen::VectorXd getNormal() const;
 
   /// Returns the barycenter of the triangle.
   const Eigen::VectorXd getCenter() const;

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -94,12 +94,8 @@ public:
 
   ///@}
 
-  /// Sets the outer normal of the triangle.
-  template <typename VECTOR_T>
-  void setNormal(const VECTOR_T &normal);
-
   /// Computes and sets the normal of the triangle, returns the area-weighted normal.
-  const Eigen::VectorXd computeNormal(bool flip = false);
+  Eigen::VectorXd computeNormal(bool flip = false) const;
 
   /// Returns a among triangles globally unique ID.
   int getID() const;
@@ -112,7 +108,7 @@ public:
    *
    * @pre The normal has to be computed and set from outside before.
    */
-  const Eigen::VectorXd &getNormal() const;
+  Eigen::VectorXd getNormal() const;
 
   /// Returns the barycenter of the triangle.
   const Eigen::VectorXd getCenter() const;
@@ -140,9 +136,6 @@ private:
 
   /// ID of the edge.
   int _id;
-
-  /// Normal vector of the triangle.
-  Eigen::VectorXd _normal;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS
@@ -197,14 +190,6 @@ inline Triangle::const_iterator Triangle::cbegin() const
 inline Triangle::const_iterator Triangle::cend() const
 {
   return end();
-}
-
-template <typename VECTOR_T>
-void Triangle::setNormal(
-    const VECTOR_T &normal)
-{
-  PRECICE_ASSERT(normal.size() == getDimensions(), normal.size(), getDimensions());
-  _normal = normal;
 }
 
 inline int Triangle::getID() const

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -94,12 +94,8 @@ public:
 
   ///@}
 
-  /**
-   * @brief Computes the normal of the triangle.
-   *
-   * @pre The normal has to be computed and set from outside before.
-   */
-  Eigen::VectorXd computeNormal(bool flip = false) const;
+  /// Computes the normal of the triangle.
+  Eigen::VectorXd computeNormal() const;
 
   /// Returns a among triangles globally unique ID.
   int getID() const;

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -10,11 +10,6 @@ int Vertex::getDimensions() const
   return _dim;
 }
 
-const Eigen::VectorXd &Vertex::getNormal() const
-{
-  return _normal;
-}
-
 int Vertex::getGlobalIndex() const
 {
   return _globalIndex;

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -29,14 +29,6 @@ public:
   template <typename VECTOR_T>
   void setCoords(const VECTOR_T &coordinates);
 
-  /// Sets the normal of the vertex.
-  template <typename VECTOR_T>
-  void setNormal(const VECTOR_T &normal);
-
-  /// Sets the normal of the vertex, rvalue variant
-  template <typename VECTOR_T>
-  void setNormal(VECTOR_T &&normal);
-
   /// Returns the unique (among vertices of one mesh on one processor) ID of the vertex.
   int getID() const;
 
@@ -45,9 +37,6 @@ public:
 
   /// Direct access to the coordinates
   const RawCoords &rawCoords() const;
-
-  /// Returns the normal of the vertex.
-  const Eigen::VectorXd &getNormal() const;
 
   /// Globally unique index
   int getGlobalIndex() const;
@@ -76,9 +65,6 @@ private:
   /// Unique (among vertices in one mesh) ID of the vertex.
   int _id;
 
-  /// Normal of the vertex.
-  Eigen::VectorXd _normal;
-
   /// global (unique) index for parallel simulations
   int _globalIndex = -1;
 
@@ -96,8 +82,7 @@ Vertex::Vertex(
     const VECTOR_T &coordinates,
     int             id)
     : _dim(coordinates.size()),
-      _id(id),
-      _normal(Eigen::VectorXd::Constant(_dim, 0.0))
+      _id(id)
 {
   PRECICE_ASSERT(_dim == 2 || _dim == 3, _dim);
   _coords[0] = coordinates[0];
@@ -113,22 +98,6 @@ void Vertex::setCoords(
   _coords[0] = coordinates[0];
   _coords[1] = coordinates[1];
   _coords[2] = (_dim == 3) ? coordinates[2] : 0.0;
-}
-
-template <typename VECTOR_T>
-void Vertex::setNormal(
-    const VECTOR_T &normal)
-{
-  PRECICE_ASSERT(normal.size() == _normal.size(), normal.size(), _normal.size());
-  _normal = normal;
-}
-
-template <typename VECTOR_T>
-void Vertex::setNormal(
-    VECTOR_T &&normal)
-{
-  PRECICE_ASSERT(normal.size() == _normal.size(), normal.size(), _normal.size());
-  _normal = std::forward<VECTOR_T>(normal);
 }
 
 inline int Vertex::getID() const

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -74,9 +74,14 @@ void MeshConfiguration::xmlTagCallback(
   if (tag.getName() == TAG) {
     PRECICE_ASSERT(_dimensions != 0);
     std::string name        = tag.getStringAttributeValue(ATTR_NAME);
-    bool        flipNormals = tag.getBooleanAttributeValue(ATTR_FLIP_NORMALS);
+    if(tag.hasAttribute(ATTR_FLIP_NORMALS)) {
+      PRECICE_WARN("You used the attribute \"{}\" when configuring mesh \"\". "
+          "This attribute is deprecated and will be removed in the next major release. "
+          "Please remove the attribute to silence this warning.",
+          ATTR_FLIP_NORMALS, name);
+    }
     PRECICE_ASSERT(_meshIdManager);
-    _meshes.push_back(std::make_shared<Mesh>(name, _dimensions, flipNormals, _meshIdManager->getFreeID()));
+    _meshes.push_back(std::make_shared<Mesh>(name, _dimensions, _meshIdManager->getFreeID()));
   } else if (tag.getName() == TAG_DATA) {
     std::string name  = tag.getStringAttributeValue(ATTR_NAME);
     bool        found = false;

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -73,12 +73,12 @@ void MeshConfiguration::xmlTagCallback(
   PRECICE_TRACE(tag.getName());
   if (tag.getName() == TAG) {
     PRECICE_ASSERT(_dimensions != 0);
-    std::string name        = tag.getStringAttributeValue(ATTR_NAME);
-    if(tag.hasAttribute(ATTR_FLIP_NORMALS)) {
+    std::string name = tag.getStringAttributeValue(ATTR_NAME);
+    if (tag.hasAttribute(ATTR_FLIP_NORMALS)) {
       PRECICE_WARN("You used the attribute \"{}\" when configuring mesh \"\". "
-          "This attribute is deprecated and will be removed in the next major release. "
-          "Please remove the attribute to silence this warning.",
-          ATTR_FLIP_NORMALS, name);
+                   "This attribute is deprecated and will be removed in the next major release. "
+                   "Please remove the attribute to silence this warning.",
+                   ATTR_FLIP_NORMALS, name);
     }
     PRECICE_ASSERT(_meshIdManager);
     _meshes.push_back(std::make_shared<Mesh>(name, _dimensions, _meshIdManager->getFreeID()));

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -44,8 +44,7 @@ MeshConfiguration::MeshConfiguration(
                       .setDocumentation("Unique name for the mesh.");
   tag.addAttribute(attrName);
 
-  auto attrFlipNormals = makeXMLAttribute(ATTR_FLIP_NORMALS, false)
-                             .setDocumentation("Flips mesh normal vector directions.");
+  auto attrFlipNormals = makeXMLAttribute(ATTR_FLIP_NORMALS, false).setDocumentation("Deprectated.");
   tag.addAttribute(attrFlipNormals);
 
   XMLTag subtagData(*this, TAG_DATA, XMLTag::OCCUR_ARBITRARY);

--- a/src/mesh/mesh.dox
+++ b/src/mesh/mesh.dox
@@ -20,8 +20,7 @@ An example on how to create a triangulated mesh data structure is given here:
 #include "utils/Dimensions.hpp" // defines utils::Vector
  
 // A mesh is the simplest way to create all needed objects
-bool invertNormals = false;
-Mesh mesh ( "MyMesh", invertNormals );
+Mesh mesh ( "MyMesh" );
 
 // A mesh can assign properties to created vertices automatically
 std::string dataName ( "Forces" );

--- a/src/mesh/mesh.dox
+++ b/src/mesh/mesh.dox
@@ -45,9 +45,6 @@ Edge & e3 = mesh.createEdge ( v3, v1 );
 // Triangles are setup from three edges
 Triangle & t = mesh.createTriangle ( e1, e2, e3 );
 
-// In order to operate on a mesh, it has to have a valid state
-mesh.computeState ();
-
 @endcode
 
 */

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -9,6 +9,7 @@
 
 using namespace precice;
 using namespace precice::mesh;
+using namespace Eigen;
 
 BOOST_AUTO_TEST_SUITE(MeshTests)
 BOOST_AUTO_TEST_SUITE(EdgeTests)
@@ -16,40 +17,62 @@ BOOST_AUTO_TEST_SUITE(EdgeTests)
 BOOST_AUTO_TEST_CASE(Edges)
 {
   PRECICE_TEST(1_rank);
-  Vertex v1(Eigen::Vector3d::Constant(0.0), 0);
-  Vertex v2(Eigen::Vector3d::Constant(1.0), 1);
+  Vertex v1(Vector3d::Constant(0.0), 0);
+  Vertex v2(Vector3d::Constant(1.0), 1);
   Edge   edge(v1, v2, 0);
 
-  Eigen::VectorXd coords1 = edge.vertex(0).getCoords();
-  Eigen::VectorXd coords2 = edge.vertex(1).getCoords();
-  BOOST_TEST(coords1 == Eigen::Vector3d::Constant(0.0));
-  BOOST_TEST(coords2 == Eigen::Vector3d::Constant(1.0));
+  BOOST_TEST(edge.getDimensions() == 3);
+  VectorXd coords1 = edge.vertex(0).getCoords();
+  VectorXd coords2 = edge.vertex(1).getCoords();
+  BOOST_TEST(coords1 == Vector3d::Constant(0.0));
+  BOOST_TEST(coords2 == Vector3d::Constant(1.0));
+
+  double expectedLenght = std::sqrt(3.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), (coords1+coords2)/2));
+  BOOST_TEST(edge.computeNormal().dot(coords1-coords2) == 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(Dimensions2D)
 {
   PRECICE_TEST(1_rank);
-  Vertex v1(Eigen::Vector2d::Constant(0.0), 0);
-  Vertex v2(Eigen::Vector2d::Constant(1.0), 1);
+  Vertex v1(Vector2d::Constant(0.0), 0);
+  Vertex v2(Vector2d::Constant(1.0), 1);
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 2);
+
+  double expectedLenght = std::sqrt(2.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0.5,0.5}));
+  BOOST_TEST(edge.computeNormal().dot(Vector2d{0.5, 0.5}) == 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(Dimensions3D)
 {
   PRECICE_TEST(1_rank);
-  Vertex v1(Eigen::Vector3d::Constant(0.0), 0);
-  Vertex v2(Eigen::Vector3d::Constant(1.0), 1);
+  Vertex v1(Vector3d::Constant(0.0), 0);
+  Vertex v2(Vector3d::Constant(1.0), 1);
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 3);
+
+  double expectedLenght = std::sqrt(3.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector3d::Constant(0.5)));
+  BOOST_TEST(edge.computeNormal().dot(Vector3d::Constant(0.3333)) == 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeEquality)
 {
   PRECICE_TEST(1_rank);
-  Vertex v1(Eigen::Vector3d(0, 0, 0), 0);
-  Vertex v2(Eigen::Vector3d(0, 0, 1), 0);
-  Vertex v3(Eigen::Vector3d(0, 0, 2), 0);
+  Vertex v1(Vector3d(0, 0, 0), 0);
+  Vertex v2(Vector3d(0, 0, 1), 0);
+  Vertex v3(Vector3d(0, 0, 2), 0);
   Edge   edge1(v1, v2, 0);
   Edge   edge2(v2, v1, 1);
   Edge   edge3(v1, v3, 0);
@@ -62,15 +85,15 @@ BOOST_AUTO_TEST_CASE(EdgeEquality)
 BOOST_AUTO_TEST_CASE(ComputeNormal2D_Unit)
 {
   PRECICE_TEST(1_rank);
-  Vertex v1(Eigen::Vector2d{0.0, 0.0}, 0);
-  Vertex v2(Eigen::Vector2d{1.0, 0.0}, 1);
+  Vertex v1(Vector2d{0.0, 0.0}, 0);
+  Vertex v2(Vector2d{1.0, 0.0}, 1);
   Edge   edge(v1, v2, 0);
 
   auto normal = edge.computeNormal(false);
   BOOST_TEST(normal.size() == 2);
   BOOST_TEST(normal.norm() == 1.0);
-  Eigen::Vector2d a{0.0, 1.0};
-  Eigen::Vector2d b{0.0, -1.0};
+  Vector2d a{0.0, 1.0};
+  Vector2d b{0.0, -1.0};
   BOOST_TEST((normal == a || normal == b));
 
   auto flipped = edge.computeNormal(true);
@@ -80,8 +103,8 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D_Unit)
 BOOST_AUTO_TEST_CASE(ComputeNormal2D)
 {
   PRECICE_TEST(1_rank);
-  Eigen::Vector2d a{-0.5, 1.0};
-  Eigen::Vector2d b{1.25, -1.1};
+  Vector2d a{-0.5, 1.0};
+  Vector2d b{1.25, -1.1};
   Vertex          v1(a, 0);
   Vertex          v2(b, 1);
   Edge            edge(v1, v2, 0);
@@ -98,8 +121,8 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D)
 BOOST_AUTO_TEST_CASE(ComputeNormal3D_Unit)
 {
   PRECICE_TEST(1_rank);
-  Eigen::Vector3d a{0.0, 0.0, 1.0};
-  Eigen::Vector3d b{1.0, 0.0, 1.0};
+  Vector3d a{0.0, 0.0, 1.0};
+  Vector3d b{1.0, 0.0, 1.0};
   Vertex          v1(a, 0);
   Vertex          v2(b, 1);
   Edge            edge(v1, v2, 0);
@@ -116,15 +139,15 @@ BOOST_AUTO_TEST_CASE(ComputeNormal3D_Unit)
 BOOST_AUTO_TEST_CASE(EdgeWKTPrint)
 {
   PRECICE_TEST(1_rank);
-  Vertex            v1(Eigen::Vector2d(1., 2.), 0);
-  Vertex            v2(Eigen::Vector2d(2., 3.), 0);
+  Vertex            v1(Vector2d(1., 2.), 0);
+  Vertex            v2(Vector2d(2., 3.), 0);
   Edge              e1(v1, v2, 0);
   std::stringstream e1stream;
   e1stream << e1;
   std::string e1str("LINESTRING (1 2, 2 3)");
   BOOST_TEST(e1str == e1stream.str());
-  Vertex            v3(Eigen::Vector3d(1., 2., 3.), 0);
-  Vertex            v4(Eigen::Vector3d(3., 2., 1.), 0);
+  Vertex            v3(Vector3d(1., 2., 3.), 0);
+  Vertex            v4(Vector3d(3., 2., 1.), 0);
   Edge              e2(v3, v4, 0);
   std::stringstream e2stream;
   e2stream << e2;
@@ -135,10 +158,10 @@ BOOST_AUTO_TEST_CASE(EdgeWKTPrint)
 BOOST_AUTO_TEST_CASE(EdgeConnectedTo)
 {
   PRECICE_TEST(1_rank);
-  Vertex v1(Eigen::Vector3d(0, 0, 1), 0);
-  Vertex v2(Eigen::Vector3d(0, 0, 2), 0);
-  Vertex v3(Eigen::Vector3d(0, 0, 3), 0);
-  Vertex v4(Eigen::Vector3d(0, 0, 4), 0);
+  Vertex v1(Vector3d(0, 0, 1), 0);
+  Vertex v2(Vector3d(0, 0, 2), 0);
+  Vertex v3(Vector3d(0, 0, 3), 0);
+  Vertex v4(Vector3d(0, 0, 4), 0);
 
   Edge edge1(v1, v2, 0);
   Edge edge2(v2, v3, 0);

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -177,15 +177,12 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D_Unit)
   Vertex v2(Vector2d{1.0, 0.0}, 1);
   Edge   edge(v1, v2, 0);
 
-  auto normal = edge.computeNormal(false);
+  auto normal = edge.computeNormal();
   BOOST_TEST(normal.size() == 2);
   BOOST_TEST(normal.norm() == 1.0);
   Vector2d a{0.0, 1.0};
   Vector2d b{0.0, -1.0};
   BOOST_TEST((normal == a || normal == b));
-
-  auto flipped = edge.computeNormal(true);
-  BOOST_TEST(normal == -flipped);
 }
 
 BOOST_AUTO_TEST_CASE(ComputeNormal2D)
@@ -197,13 +194,10 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D)
   Vertex          v2(b, 1);
   Edge            edge(v1, v2, 0);
 
-  auto normal = edge.computeNormal(false);
+  auto normal = edge.computeNormal();
   BOOST_TEST(normal.size() == 2);
   BOOST_TEST(normal.norm() == 1.0);
   BOOST_TEST(normal.dot(b - a) == 0.0);
-
-  auto flipped = edge.computeNormal(true);
-  BOOST_TEST(normal == -flipped);
 }
 
 
@@ -216,13 +210,10 @@ BOOST_AUTO_TEST_CASE(ComputeNormal3D_Unit)
   Vertex          v2(b, 1);
   Edge            edge(v1, v2, 0);
 
-  auto normal = edge.computeNormal(false);
+  auto normal = edge.computeNormal();
   BOOST_TEST(normal.size() == 3);
   BOOST_TEST(normal.norm() == 1.0);
   BOOST_TEST(normal.dot(b - a) == 0.0);
-
-  auto flipped = edge.computeNormal(true);
-  BOOST_TEST(normal == -flipped);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeWKTPrint)

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -28,12 +28,12 @@ BOOST_AUTO_TEST_CASE(Edges)
   BOOST_TEST(coords1 == Vector3d::Constant(0.0));
   BOOST_TEST(coords2 == Vector3d::Constant(1.0));
 
-  double expectedLenght = std::sqrt(3.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(3.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
-  BOOST_TEST(testing::equals(edge.getCenter(), (coords1+coords2)/2));
-  BOOST_TEST(edge.computeNormal().dot(coords1-coords2) == 0.0);
+  BOOST_TEST(testing::equals(edge.getCenter(), (coords1 + coords2) / 2));
+  BOOST_TEST(edge.computeNormal().dot(coords1 - coords2) == 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(Dimensions2D)
@@ -44,11 +44,11 @@ BOOST_AUTO_TEST_CASE(Dimensions2D)
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 2);
 
-  double expectedLenght = std::sqrt(2.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(2.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
-  BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0.5,0.5}));
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0.5, 0.5}));
   BOOST_TEST(edge.computeNormal().dot(Vector2d{0.5, 0.5}) == 0.0);
 }
 
@@ -60,11 +60,11 @@ BOOST_AUTO_TEST_CASE(Dimensions2DX)
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 2);
 
-  double expectedLenght = std::sqrt(1.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(1.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
-  BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0.5,0}));
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0.5, 0}));
   BOOST_TEST(edge.computeNormal().dot(Vector2d{1, 0}) == 0.0);
 }
 
@@ -76,14 +76,13 @@ BOOST_AUTO_TEST_CASE(Dimensions2DY)
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 2);
 
-  double expectedLenght = std::sqrt(1.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(1.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
   BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0, 0.5}));
   BOOST_TEST(edge.computeNormal().dot(Vector2d{0, 1}) == 0.0);
 }
-
 
 BOOST_AUTO_TEST_CASE(Dimensions3DX)
 {
@@ -93,8 +92,8 @@ BOOST_AUTO_TEST_CASE(Dimensions3DX)
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 3);
 
-  double expectedLenght = std::sqrt(1.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(1.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
   BOOST_TEST(testing::equals(edge.getCenter(), Vector3d{0.5, 0, 0}));
@@ -111,8 +110,8 @@ BOOST_AUTO_TEST_CASE(Dimensions3DY)
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 3);
 
-  double expectedLenght = std::sqrt(1.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(1.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
   BOOST_TEST(testing::equals(edge.getCenter(), Vector3d{0, 0.5, 0}));
@@ -129,8 +128,8 @@ BOOST_AUTO_TEST_CASE(Dimensions3DZ)
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 3);
 
-  double expectedLenght = std::sqrt(1.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(1.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
   BOOST_TEST(testing::equals(edge.getCenter(), Vector3d{0, 0, 0.5}));
@@ -147,8 +146,8 @@ BOOST_AUTO_TEST_CASE(Dimensions3D)
   Edge   edge(v1, v2, 0);
   BOOST_TEST(edge.getDimensions() == 3);
 
-  double expectedLenght = std::sqrt(3.0); 
-  double expectedRadius = expectedLenght/2.0;
+  double expectedLenght = std::sqrt(3.0);
+  double expectedRadius = expectedLenght / 2.0;
   BOOST_TEST(edge.getLength() == expectedLenght);
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
   BOOST_TEST(testing::equals(edge.getCenter(), Vector3d::Constant(0.5)));
@@ -190,9 +189,9 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D)
   PRECICE_TEST(1_rank);
   Vector2d a{-0.5, 1.0};
   Vector2d b{1.25, -1.1};
-  Vertex          v1(a, 0);
-  Vertex          v2(b, 1);
-  Edge            edge(v1, v2, 0);
+  Vertex   v1(a, 0);
+  Vertex   v2(b, 1);
+  Edge     edge(v1, v2, 0);
 
   auto normal = edge.computeNormal();
   BOOST_TEST(normal.size() == 2);
@@ -200,15 +199,14 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D)
   BOOST_TEST(normal.dot(b - a) == 0.0);
 }
 
-
 BOOST_AUTO_TEST_CASE(ComputeNormal3D_Unit)
 {
   PRECICE_TEST(1_rank);
   Vector3d a{0.0, 0.0, 1.0};
   Vector3d b{1.0, 0.0, 1.0};
-  Vertex          v1(a, 0);
-  Vertex          v2(b, 1);
-  Edge            edge(v1, v2, 0);
+  Vertex   v1(a, 0);
+  Vertex   v2(b, 1);
+  Edge     edge(v1, v2, 0);
 
   auto normal = edge.computeNormal();
   BOOST_TEST(normal.size() == 3);

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -82,14 +82,14 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D)
   PRECICE_TEST(1_rank);
   Eigen::Vector2d a{-0.5, 1.0};
   Eigen::Vector2d b{1.25, -1.1};
-  Vertex v1(a, 0);
-  Vertex v2(b, 1);
-  Edge   edge(v1, v2, 0);
+  Vertex          v1(a, 0);
+  Vertex          v2(b, 1);
+  Edge            edge(v1, v2, 0);
 
   auto normal = edge.computeNormal(false);
   BOOST_TEST(normal.size() == 2);
   BOOST_TEST(normal.norm() == 1.0);
-  BOOST_TEST(normal.dot(b-a) == 0.0);
+  BOOST_TEST(normal.dot(b - a) == 0.0);
 
   auto flipped = edge.computeNormal(true);
   BOOST_TEST(normal == -flipped);
@@ -100,19 +100,18 @@ BOOST_AUTO_TEST_CASE(ComputeNormal3D_Unit)
   PRECICE_TEST(1_rank);
   Eigen::Vector3d a{0.0, 0.0, 1.0};
   Eigen::Vector3d b{1.0, 0.0, 1.0};
-  Vertex v1(a, 0);
-  Vertex v2(b, 1);
-  Edge   edge(v1, v2, 0);
+  Vertex          v1(a, 0);
+  Vertex          v2(b, 1);
+  Edge            edge(v1, v2, 0);
 
   auto normal = edge.computeNormal(false);
   BOOST_TEST(normal.size() == 3);
   BOOST_TEST(normal.norm() == 1.0);
-  BOOST_TEST(normal.dot(b-a) == 0.0);
+  BOOST_TEST(normal.dot(b - a) == 0.0);
 
   auto flipped = edge.computeNormal(true);
   BOOST_TEST(normal == -flipped);
 }
-
 
 BOOST_AUTO_TEST_CASE(EdgeWKTPrint)
 {

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -1,4 +1,5 @@
 #include <Eigen/Core>
+#include <Eigen/src/Core/Matrix.h>
 #include <iosfwd>
 #include <string>
 #include "logging/Logger.hpp"
@@ -49,6 +50,93 @@ BOOST_AUTO_TEST_CASE(Dimensions2D)
   BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
   BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0.5,0.5}));
   BOOST_TEST(edge.computeNormal().dot(Vector2d{0.5, 0.5}) == 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(Dimensions2DX)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Vector2d::Constant(0.0), 0);
+  Vertex v2(Vector2d{1, 0}, 1);
+  Edge   edge(v1, v2, 0);
+  BOOST_TEST(edge.getDimensions() == 2);
+
+  double expectedLenght = std::sqrt(1.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0.5,0}));
+  BOOST_TEST(edge.computeNormal().dot(Vector2d{1, 0}) == 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(Dimensions2DY)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Vector2d::Constant(0.0), 0);
+  Vertex v2(Vector2d{0, 1}, 1);
+  Edge   edge(v1, v2, 0);
+  BOOST_TEST(edge.getDimensions() == 2);
+
+  double expectedLenght = std::sqrt(1.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector2d{0, 0.5}));
+  BOOST_TEST(edge.computeNormal().dot(Vector2d{0, 1}) == 0.0);
+}
+
+
+BOOST_AUTO_TEST_CASE(Dimensions3DX)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Vector3d::Constant(0.0), 0);
+  Vertex v2(Vector3d{1, 0, 0}, 1);
+  Edge   edge(v1, v2, 0);
+  BOOST_TEST(edge.getDimensions() == 3);
+
+  double expectedLenght = std::sqrt(1.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector3d{0.5, 0, 0}));
+  const Vector3d normal = edge.computeNormal();
+  BOOST_TEST(normal.norm() == 1.0);
+  BOOST_TEST(normal.dot(Vector3d{1, 0, 0}) == 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(Dimensions3DY)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Vector3d::Constant(0.0), 0);
+  Vertex v2(Vector3d{0, 1, 0}, 1);
+  Edge   edge(v1, v2, 0);
+  BOOST_TEST(edge.getDimensions() == 3);
+
+  double expectedLenght = std::sqrt(1.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector3d{0, 0.5, 0}));
+  const Vector3d normal = edge.computeNormal();
+  BOOST_TEST(normal.norm() == 1.0);
+  BOOST_TEST(normal.dot(Vector3d{0, 1, 0}) == 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(Dimensions3DZ)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Vector3d::Constant(0.0), 0);
+  Vertex v2(Vector3d{0, 0, 1}, 1);
+  Edge   edge(v1, v2, 0);
+  BOOST_TEST(edge.getDimensions() == 3);
+
+  double expectedLenght = std::sqrt(1.0); 
+  double expectedRadius = expectedLenght/2.0;
+  BOOST_TEST(edge.getLength() == expectedLenght);
+  BOOST_TEST(edge.getEnclosingRadius() == expectedRadius);
+  BOOST_TEST(testing::equals(edge.getCenter(), Vector3d{0, 0, 0.5}));
+  const Vector3d normal = edge.computeNormal();
+  BOOST_TEST(normal.norm() == 1.0);
+  BOOST_TEST(normal.dot(Vector3d{0, 0, 1}) == 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(Dimensions3D)
@@ -117,6 +205,7 @@ BOOST_AUTO_TEST_CASE(ComputeNormal2D)
   auto flipped = edge.computeNormal(true);
   BOOST_TEST(normal == -flipped);
 }
+
 
 BOOST_AUTO_TEST_CASE(ComputeNormal3D_Unit)
 {

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -26,6 +26,24 @@ BOOST_AUTO_TEST_CASE(Edges)
   BOOST_TEST(coords2 == Eigen::Vector3d::Constant(1.0));
 }
 
+BOOST_AUTO_TEST_CASE(Dimensions2D)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Eigen::Vector2d::Constant(0.0), 0);
+  Vertex v2(Eigen::Vector2d::Constant(1.0), 1);
+  Edge   edge(v1, v2, 0);
+  BOOST_TEST(edge.getDimensions() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(Dimensions3D)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Eigen::Vector3d::Constant(0.0), 0);
+  Vertex v2(Eigen::Vector3d::Constant(1.0), 1);
+  Edge   edge(v1, v2, 0);
+  BOOST_TEST(edge.getDimensions() == 3);
+}
+
 BOOST_AUTO_TEST_CASE(EdgeEquality)
 {
   PRECICE_TEST(1_rank);
@@ -38,8 +56,63 @@ BOOST_AUTO_TEST_CASE(EdgeEquality)
   Edge   edge4(v1, v3, 0);
   BOOST_TEST(edge1 == edge2);
   BOOST_TEST(edge1 != edge3);
-  BOOST_TEST(edge3 != edge4);
+  BOOST_TEST(edge3 == edge4);
 }
+
+BOOST_AUTO_TEST_CASE(ComputeNormal2D_Unit)
+{
+  PRECICE_TEST(1_rank);
+  Vertex v1(Eigen::Vector2d{0.0, 0.0}, 0);
+  Vertex v2(Eigen::Vector2d{1.0, 0.0}, 1);
+  Edge   edge(v1, v2, 0);
+
+  auto normal = edge.computeNormal(false);
+  BOOST_TEST(normal.size() == 2);
+  BOOST_TEST(normal.norm() == 1.0);
+  Eigen::Vector2d a{0.0, 1.0};
+  Eigen::Vector2d b{0.0, -1.0};
+  BOOST_TEST((normal == a || normal == b));
+
+  auto flipped = edge.computeNormal(true);
+  BOOST_TEST(normal == -flipped);
+}
+
+BOOST_AUTO_TEST_CASE(ComputeNormal2D)
+{
+  PRECICE_TEST(1_rank);
+  Eigen::Vector2d a{-0.5, 1.0};
+  Eigen::Vector2d b{1.25, -1.1};
+  Vertex v1(a, 0);
+  Vertex v2(b, 1);
+  Edge   edge(v1, v2, 0);
+
+  auto normal = edge.computeNormal(false);
+  BOOST_TEST(normal.size() == 2);
+  BOOST_TEST(normal.norm() == 1.0);
+  BOOST_TEST(normal.dot(b-a) == 0.0);
+
+  auto flipped = edge.computeNormal(true);
+  BOOST_TEST(normal == -flipped);
+}
+
+BOOST_AUTO_TEST_CASE(ComputeNormal3D_Unit)
+{
+  PRECICE_TEST(1_rank);
+  Eigen::Vector3d a{0.0, 0.0, 1.0};
+  Eigen::Vector3d b{1.0, 0.0, 1.0};
+  Vertex v1(a, 0);
+  Vertex v2(b, 1);
+  Edge   edge(v1, v2, 0);
+
+  auto normal = edge.computeNormal(false);
+  BOOST_TEST(normal.size() == 3);
+  BOOST_TEST(normal.norm() == 1.0);
+  BOOST_TEST(normal.dot(b-a) == 0.0);
+
+  auto flipped = edge.computeNormal(true);
+  BOOST_TEST(normal == -flipped);
+}
+
 
 BOOST_AUTO_TEST_CASE(EdgeWKTPrint)
 {

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -36,7 +36,6 @@ BOOST_AUTO_TEST_CASE(EdgeEquality)
   Edge   edge2(v2, v1, 1);
   Edge   edge3(v1, v3, 0);
   Edge   edge4(v1, v3, 0);
-  edge4.setNormal(Eigen::Vector3d(Eigen::Vector3d(0, 1, 0)));
   BOOST_TEST(edge1 == edge2);
   BOOST_TEST(edge1 != edge3);
   BOOST_TEST(edge3 != edge4);

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
   Eigen::Vector2d coords1(-1, 4);
   Eigen::Vector2d coords2(0, 1);
 
-  mesh::Mesh mesh("2D Testmesh", 2, false, testing::nextMeshID());
+  mesh::Mesh mesh("2D Testmesh", 2, testing::nextMeshID());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(BoundingBoxCOG_3D)
   Eigen::Vector3d coords2(0, 1, -2);
   Eigen::Vector3d coords3(3.5, 2, -2);
 
-  mesh::Mesh mesh("3D Testmesh", 3, false, testing::nextMeshID());
+  mesh::Mesh mesh("3D Testmesh", 3, testing::nextMeshID());
   mesh.createVertex(coords0);
   mesh.createVertex(coords1);
   mesh.createVertex(coords2);
@@ -100,12 +100,10 @@ BOOST_AUTO_TEST_CASE(Demonstration)
   for (int dim = 2; dim <= 3; dim++) {
     // Create mesh object
     std::string         meshName("MyMesh");
-    bool                flipNormals = false; // The normals of triangles, edges, vertices
-    precice::mesh::Mesh mesh(meshName, dim, flipNormals, testing::nextMeshID());
+    precice::mesh::Mesh mesh(meshName, dim, testing::nextMeshID());
 
     // Validate mesh object state
     BOOST_TEST(mesh.getName() == meshName);
-    BOOST_TEST(mesh.isFlipNormals() == flipNormals);
 
     // Create mesh vertices
     Eigen::VectorXd coords0(dim);
@@ -205,9 +203,8 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
   PRECICE_TEST(1_rank);
   int                   dim = 3;
   Mesh                  mesh1("Mesh1", dim, false, testing::nextMeshID());
-  Mesh                  mesh1flipped("Mesh1flipped", dim, true, testing::nextMeshID());
   Mesh                  mesh2("Mesh2", dim, false, testing::nextMeshID());
-  std::array<Mesh *, 3> meshes = {&mesh1, &mesh1flipped, &mesh2};
+  std::array<Mesh *, 3> meshes = {&mesh1, &mesh2};
   for (auto ptr : meshes) {
     auto &          mesh = *ptr;
     Eigen::VectorXd coords0(dim);
@@ -229,14 +226,13 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
     mesh.createEdge(v3, v2);              // LINESTRING (1 0 1, 0 0 1)
     mesh.createTriangle(e0, e1, e2);
   }
-  BOOST_TEST(mesh1 == mesh1flipped);
   BOOST_TEST(mesh1 == mesh2);
 }
 
 BOOST_AUTO_TEST_CASE(MeshWKTPrint)
 {
   PRECICE_TEST(1_rank);
-  Mesh    mesh("WKTMesh", 3, false, testing::nextMeshID());
+  Mesh    mesh("WKTMesh", 3, testing::nextMeshID());
   Vertex &v0 = mesh.createVertex(Eigen::Vector3d(0., 0., 0.));
   Vertex &v1 = mesh.createVertex(Eigen::Vector3d(1., 0., 0.));
   Vertex &v2 = mesh.createVertex(Eigen::Vector3d(0., 0., 1.));
@@ -263,7 +259,7 @@ BOOST_AUTO_TEST_CASE(CreateUniqueEdge)
 {
   PRECICE_TEST(1_rank);
   int             dim = 3;
-  Mesh            mesh1("Mesh1", dim, false, testing::nextMeshID());
+  Mesh            mesh1("Mesh1", dim, testing::nextMeshID());
   auto &          mesh = mesh1;
   Eigen::VectorXd coords0(dim);
   Eigen::VectorXd coords1(dim);
@@ -292,7 +288,7 @@ BOOST_AUTO_TEST_CASE(CreateUniqueEdge)
 BOOST_AUTO_TEST_CASE(ResizeDataGrow)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   const auto &        values = mesh.createData("Data", 1)->values();
 
   // Create mesh
@@ -315,7 +311,7 @@ BOOST_AUTO_TEST_CASE(ResizeDataGrow)
 BOOST_AUTO_TEST_CASE(ResizeDataShrink)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, true, testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   const auto &        values = mesh.createData("Data", 1)->values();
 
   // Create mesh

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -202,9 +202,9 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
 {
   PRECICE_TEST(1_rank);
   int                   dim = 3;
-  Mesh                  mesh1("Mesh1", dim, false, testing::nextMeshID());
-  Mesh                  mesh2("Mesh2", dim, false, testing::nextMeshID());
-  std::array<Mesh *, 3> meshes = {&mesh1, &mesh2};
+  Mesh                  mesh1("Mesh1", dim, testing::nextMeshID());
+  Mesh                  mesh2("Mesh2", dim, testing::nextMeshID());
+  std::array<Mesh *, 2> meshes = {&mesh1, &mesh2};
   for (auto ptr : meshes) {
     auto &          mesh = *ptr;
     Eigen::VectorXd coords0(dim);
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_SUITE(Utils)
 BOOST_AUTO_TEST_CASE(AsChain)
 {
   PRECICE_TEST(1_rank);
-  Mesh mesh("Mesh1", 3, false, testing::nextMeshID());
+  Mesh mesh("Mesh1", 3, testing::nextMeshID());
   mesh.createData("Data", 1);
 
   Eigen::Vector3d coords0;
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(AsChain)
 BOOST_AUTO_TEST_CASE(ShareVertex)
 {
   PRECICE_TEST(1_rank);
-  Mesh mesh("Mesh1", 3, false, testing::nextMeshID());
+  Mesh mesh("Mesh1", 3, testing::nextMeshID());
   mesh.createData("Data", 1);
 
   Eigen::Vector3d coords0;
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(EdgeLength)
 BOOST_AUTO_TEST_CASE(VertexPtrsFor)
 {
   PRECICE_TEST(1_rank);
-  Mesh mesh("Mesh1", 3, false, testing::nextMeshID());
+  Mesh mesh("Mesh1", 3, testing::nextMeshID());
   mesh.createData("Data", 1);
 
   Eigen::Vector3d coords0;
@@ -463,7 +463,7 @@ BOOST_AUTO_TEST_CASE(VertexPtrsFor)
 BOOST_AUTO_TEST_CASE(CoordsForIDs)
 {
   PRECICE_TEST(1_rank);
-  Mesh mesh("Mesh1", 3, false, testing::nextMeshID());
+  Mesh mesh("Mesh1", 3, testing::nextMeshID());
   mesh.createData("Data", 1);
 
   Eigen::Vector3d coords0;
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE(CoordsForIDs)
 BOOST_AUTO_TEST_CASE(CoordsForPtrs)
 {
   PRECICE_TEST(1_rank);
-  Mesh mesh("Mesh1", 3, false, testing::nextMeshID());
+  Mesh mesh("Mesh1", 3, testing::nextMeshID());
   mesh.createData("Data", 1);
 
   Eigen::Vector3d coords0;
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(CoordsForPtrs)
 BOOST_AUTO_TEST_CASE(Integrate2DScalarData)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, false, testing::nextMeshID());
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
   mesh->createData("Data", 1);
 
   auto &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE(Integrate2DScalarData)
 BOOST_AUTO_TEST_CASE(Integrate2DVectorData)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, false, testing::nextMeshID());
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
   mesh->createData("Data", 2);
 
   auto &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -578,7 +578,7 @@ BOOST_AUTO_TEST_CASE(Integrate2DVectorData)
 BOOST_AUTO_TEST_CASE(Integrate3DScalarData)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, false, testing::nextMeshID());
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
   mesh->createData("Data", 1);
 
   auto &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -610,7 +610,7 @@ BOOST_AUTO_TEST_CASE(Integrate3DScalarData)
 BOOST_AUTO_TEST_CASE(Integrate3DVectorData)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, false, testing::nextMeshID());
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
   mesh->createData("Data", 2);
 
   auto &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
     mesh.createEdge(v3, v2);              // LINESTRING (1 0 1, 0 0 1)
     mesh.createTriangle(e0, e1, e2);
   }
-  BOOST_TEST(mesh1 != mesh1flipped);
+  BOOST_TEST(mesh1 == mesh1flipped);
   BOOST_TEST(mesh1 == mesh2);
 }
 

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -51,11 +51,8 @@ BOOST_AUTO_TEST_CASE(ComputeState_2D)
   BOOST_TEST(equals(e2.getCenter(), Vector2d(1.0, 0.5)));
   BOOST_TEST(e1.getEnclosingRadius() == 0.5);
   BOOST_TEST(e2.getEnclosingRadius() == 0.5);
-  BOOST_TEST(equals(e1.getNormal(), Vector2d(0.0, 1.0)));
-  BOOST_TEST(equals(e2.getNormal(), Vector2d(-1.0, 0.0)));
-  BOOST_TEST(equals(v1.getNormal(), Vector2d(0.0, 1.0)));
-  BOOST_TEST(equals(v2.getNormal(), Vector2d(-std::sqrt(0.5), std::sqrt(0.5))));
-  BOOST_TEST(equals(v3.getNormal(), Vector2d(-1.0, 0.0)));
+  BOOST_TEST(equals(e1.computeNormal(), Vector2d(0.0, 1.0)));
+  BOOST_TEST(equals(e2.computeNormal(), Vector2d(-1.0, 0.0)));
 }
 
 BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
@@ -103,18 +100,14 @@ BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
   Vector3d normal(1.0, 0.0, -1.0);
   normal = normal.normalized();
   BOOST_TEST(normal.norm() == 1.0);
-  BOOST_TEST(equals(t1.getNormal(), normal));
-  BOOST_TEST(equals(t2.getNormal(), normal));
+  BOOST_TEST(equals(t1.computeNormal(), normal));
+  BOOST_TEST(equals(t2.computeNormal(), normal));
 
-  BOOST_TEST(equals(e1.getNormal(), normal));
-  BOOST_TEST(equals(e2.getNormal(), normal));
-  BOOST_TEST(equals(e3.getNormal(), normal));
-  BOOST_TEST(equals(e4.getNormal(), normal));
-  BOOST_TEST(equals(e5.getNormal(), normal));
-  BOOST_TEST(equals(v1.getNormal(), normal));
-  BOOST_TEST(equals(v2.getNormal(), normal));
-  BOOST_TEST(equals(v3.getNormal(), normal));
-  BOOST_TEST(equals(v4.getNormal(), normal));
+  BOOST_TEST(equals(e1.computeNormal(), normal));
+  BOOST_TEST(equals(e2.computeNormal(), normal));
+  BOOST_TEST(equals(e3.computeNormal(), normal));
+  BOOST_TEST(equals(e4.computeNormal(), normal));
+  BOOST_TEST(equals(e5.computeNormal(), normal));
 }
 
 BOOST_AUTO_TEST_CASE(BoundingBoxCOG_2D)
@@ -419,10 +412,6 @@ BOOST_AUTO_TEST_CASE(ComputeStateOfNotFullyConnectedMesh)
 
   mesh.allocateDataValues();
   BOOST_TEST(mesh.data().size() == 1);
-
-  for (const auto &vertex : mesh.vertices()) {
-    BOOST_TEST(vertex.getNormal().allFinite());
-  }
 }
 
 BOOST_AUTO_TEST_CASE(ResizeDataGrow)

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -45,7 +45,6 @@ BOOST_AUTO_TEST_CASE(ComputeState_2D)
   //     *  <---
   // *****
   Edge &e2 = mesh.createEdge(v2, v3);
-  mesh.computeState();
 
   // Perform test validations
   BOOST_TEST(equals(e1.getCenter(), Vector2d(0.5, 0.0)));
@@ -84,7 +83,6 @@ BOOST_AUTO_TEST_CASE(ComputeState_3D_Triangle)
   //   *   *   *
   // *************
   Triangle &t2 = mesh.createTriangle(e4, e5, e2);
-  mesh.computeState();
 
   // Perform test validations
   BOOST_TEST(equals(e1.getCenter(), Vector3d(0.5, 0.0, 0.5)));
@@ -264,8 +262,7 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     std::string dataName("MyData");
     int         dataDimensions = dim;
     // Add a data set to the mesh. Every data value is associated to a vertex in
-    // the mesh via the vertex ID. The data values are created when
-    // Mesh::computeState() is called by the mesh holding the data.
+    // the mesh via the vertex ID.
     PtrData data = mesh.createData(dataName, dataDimensions);
 
     // Validate data state
@@ -277,7 +274,6 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     BOOST_TEST(mesh.data().at(0)->getName() == dataName);
 
     // Compute the state of the mesh elements (vertices, edges, triangles)
-    mesh.computeState();
 
     // Allocate memory for the data values of set data. Before data value access
     // leads to assertions.
@@ -322,7 +318,6 @@ BOOST_AUTO_TEST_CASE(MeshEquality)
     mesh.createEdge(v1, v3);              // LINESTRING (1 0 0, 1 0 1)
     mesh.createEdge(v3, v2);              // LINESTRING (1 0 1, 0 0 1)
     mesh.createTriangle(e0, e1, e2);
-    mesh.computeState();
   }
   BOOST_TEST(mesh1 != mesh1flipped);
   BOOST_TEST(mesh1 == mesh2);
@@ -342,7 +337,6 @@ BOOST_AUTO_TEST_CASE(MeshWKTPrint)
   mesh.createEdge(v1, v3);              // LINESTRING (1 0 0, 1 0 1)
   mesh.createEdge(v3, v2);              // LINESTRING (1 0 1, 0 0 1)
   mesh.createTriangle(e0, e1, e2);
-  mesh.computeState();
   std::stringstream sstream;
   sstream << mesh;
   std::string reference(
@@ -425,7 +419,6 @@ BOOST_AUTO_TEST_CASE(ComputeStateOfNotFullyConnectedMesh)
 
   mesh.allocateDataValues();
   BOOST_TEST(mesh.data().size() == 1);
-  mesh.computeState();
 
   for (const auto &vertex : mesh.vertices()) {
     BOOST_TEST(vertex.getNormal().allFinite());

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -56,11 +56,11 @@ BOOST_AUTO_TEST_CASE(DirectionalEdges)
   BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
-  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
-  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3 - coords1).dot(normal) == 0.0);
 
   Vector3d center = triangle.getCenter();
-  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+  BOOST_TEST(testing::equals(center, (coords1 + coords2 + coords3) / 3));
 
   constexpr double expectedRadius = 0.74535599249993001;
   BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);
@@ -108,11 +108,11 @@ BOOST_AUTO_TEST_CASE(SecondFlipped)
   BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
-  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
-  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3 - coords1).dot(normal) == 0.0);
 
   Vector3d center = triangle.getCenter();
-  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+  BOOST_TEST(testing::equals(center, (coords1 + coords2 + coords3) / 3));
 
   constexpr double expectedRadius = 0.74535599249993001;
   BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);
@@ -161,11 +161,11 @@ BOOST_AUTO_TEST_CASE(ReversedFirstFlipped)
   BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
-  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
-  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3 - coords1).dot(normal) == 0.0);
 
   Vector3d center = triangle.getCenter();
-  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+  BOOST_TEST(testing::equals(center, (coords1 + coords2 + coords3) / 3));
 
   constexpr double expectedRadius = 0.74535599249993001;
   BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);
@@ -214,11 +214,11 @@ BOOST_AUTO_TEST_CASE(ReversedLastFlipped)
   BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
-  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
-  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3 - coords1).dot(normal) == 0.0);
 
   Vector3d center = triangle.getCenter();
-  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+  BOOST_TEST(testing::equals(center, (coords1 + coords2 + coords3) / 3));
 
   constexpr double expectedRadius = 0.74535599249993001;
   BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -204,7 +204,6 @@ BOOST_AUTO_TEST_CASE(TriangleEquality)
   //    ****
   Triangle triangle3(e2, e4, e5, 0);
   Triangle triangle4(e2, e4, e5, 0);
-  triangle4.setNormal(Vector3d(0., 0., 1.));
   BOOST_TEST(triangle1 == triangle2);
   BOOST_TEST(triangle1 != triangle3);
   BOOST_TEST(triangle4 != triangle3);

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -16,160 +16,274 @@ using namespace precice::mesh;
 BOOST_AUTO_TEST_SUITE(MeshTests)
 BOOST_AUTO_TEST_SUITE(TriangleTests)
 
-BOOST_AUTO_TEST_CASE(Triangles)
+BOOST_AUTO_TEST_CASE(DirectionalEdges)
 {
   PRECICE_TEST(1_rank);
   using Eigen::Vector3d;
   Vector3d coords1(0.0, 0.0, 0.0);
   Vector3d coords2(1.0, 0.0, 0.0);
   Vector3d coords3(1.0, 1.0, 0.0);
+
+  Vertex v1(coords1, 0);
+  Vertex v2(coords2, 1);
+  Vertex v3(coords3, 2);
+
+  Edge e1(v1, v2, 0);
+  Edge e2(v2, v3, 1);
+  Edge e3(v3, v1, 2);
+
+  Triangle triangle(e1, e2, e3, 0);
+
+  Vertex &v1ref = triangle.vertex(0);
+  BOOST_TEST(v1ref.getID() == v1.getID());
+
+  Vertex &v2ref = triangle.vertex(1);
+  BOOST_TEST(v2ref.getID() == v2.getID());
+
+  Vertex &v3ref = triangle.vertex(2);
+  BOOST_TEST(v3ref.getID() == v3.getID());
+
+  Edge &e1ref = triangle.edge(0);
+  BOOST_TEST(e1ref.getID() == e1.getID());
+
+  Edge &e2ref = triangle.edge(1);
+  BOOST_TEST(e2ref.getID() == e2.getID());
+
+  Edge &e3ref = triangle.edge(2);
+  BOOST_TEST(e3ref.getID() == e3.getID());
+
+  int id = triangle.getID();
+  BOOST_TEST(id == 0);
+
+  Vector3d normal = triangle.computeNormal();
+  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+
+  Vector3d center = triangle.getCenter();
+  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+
+  constexpr double expectedRadius = 0.74535599249993001;
+  BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);
+
+  constexpr double expectedArea = 0.5;
+  BOOST_TEST(triangle.getArea() == expectedArea);
+}
+
+BOOST_AUTO_TEST_CASE(SecondFlipped)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector3d;
+  Vector3d coords1(0.0, 0.0, 0.0);
+  Vector3d coords2(1.0, 0.0, 0.0);
+  Vector3d coords3(1.0, 1.0, 0.0);
+  Vertex   v1(coords1, 0);
+  Vertex   v2(coords2, 1);
+  Vertex   v3(coords3, 2);
+
+  Edge e1(v1, v2, 0);
+  Edge e2(v3, v2, 1);
+  Edge e3(v3, v1, 2);
+
+  Triangle triangle(e1, e2, e3, 0);
+
+  Vertex &v1ref = triangle.vertex(0);
+  BOOST_TEST(v1ref.getID() == v1.getID());
+
+  Vertex &v2ref = triangle.vertex(1);
+  BOOST_TEST(v2ref.getID() == v2.getID());
+
+  Vertex &v3ref = triangle.vertex(2);
+  BOOST_TEST(v3ref.getID() == v3.getID());
+
+  Edge &e1ref = triangle.edge(0);
+  BOOST_TEST(e1ref.getID() == e1.getID());
+
+  Edge &e2ref = triangle.edge(1);
+  BOOST_TEST(e2ref.getID() == e2.getID());
+
+  Edge &e3ref = triangle.edge(2);
+  BOOST_TEST(e3ref.getID() == e3.getID());
+
+  int id = triangle.getID();
+  BOOST_TEST(id == 0);
+
+  Vector3d normal = triangle.computeNormal();
+  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+
+  Vector3d center = triangle.getCenter();
+  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+
+  constexpr double expectedRadius = 0.74535599249993001;
+  BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);
+
+  constexpr double expectedArea = 0.5;
+  BOOST_TEST(triangle.getArea() == expectedArea);
+}
+
+BOOST_AUTO_TEST_CASE(ReversedFirstFlipped)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector3d;
+  Vector3d coords1(0.0, 0.0, 0.0);
+  Vector3d coords2(1.0, 0.0, 0.0);
+  Vector3d coords3(1.0, 1.0, 0.0);
+
+  Vertex v1(coords1, 0);
+  Vertex v2(coords2, 1);
+  Vertex v3(coords3, 2);
+
+  Edge e1(v1, v2, 0);
+  Edge e2(v3, v2, 1);
+  Edge e3(v1, v3, 2);
+
+  Triangle triangle(e1, e2, e3, 0);
+
+  Vertex &v1ref = triangle.vertex(0);
+  BOOST_TEST(v1ref.getID() == v1.getID());
+
+  Vertex &v2ref = triangle.vertex(1);
+  BOOST_TEST(v2ref.getID() == v2.getID());
+
+  Vertex &v3ref = triangle.vertex(2);
+  BOOST_TEST(v3ref.getID() == v3.getID());
+
+  Edge &e1ref = triangle.edge(0);
+  BOOST_TEST(e1ref.getID() == e1.getID());
+
+  Edge &e2ref = triangle.edge(1);
+  BOOST_TEST(e2ref.getID() == e2.getID());
+
+  Edge &e3ref = triangle.edge(2);
+  BOOST_TEST(e3ref.getID() == e3.getID());
+
+  int id = triangle.getID();
+  BOOST_TEST(id == 0);
+
+  Vector3d normal = triangle.computeNormal();
+  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+
+  Vector3d center = triangle.getCenter();
+  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+
+  constexpr double expectedRadius = 0.74535599249993001;
+  BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);
+
+  constexpr double expectedArea = 0.5;
+  BOOST_TEST(triangle.getArea() == expectedArea);
+}
+
+BOOST_AUTO_TEST_CASE(ReversedLastFlipped)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector3d;
+  Vector3d coords1(0.0, 0.0, 0.0);
+  Vector3d coords2(1.0, 0.0, 0.0);
+  Vector3d coords3(1.0, 1.0, 0.0);
+
+  Vertex v1(coords1, 0);
+  Vertex v2(coords2, 1);
+  Vertex v3(coords3, 2);
+
+  Edge e1(v1, v2, 0);
+  Edge e2(v3, v2, 1);
+  Edge e3(v3, v1, 2);
+
+  Triangle triangle(e1, e3, e2, 0);
+
+  Vertex &v1ref = triangle.vertex(0);
+  BOOST_TEST(v1ref.getID() == v2.getID());
+
+  Vertex &v2ref = triangle.vertex(1);
+  BOOST_TEST(v2ref.getID() == v1.getID());
+
+  Vertex &v3ref = triangle.vertex(2);
+  BOOST_TEST(v3ref.getID() == v3.getID());
+
+  Edge &e1ref = triangle.edge(0);
+  BOOST_TEST(e1ref.getID() == e1.getID());
+
+  Edge &e2ref = triangle.edge(1);
+  BOOST_TEST(e2ref.getID() == e3.getID());
+
+  Edge &e3ref = triangle.edge(2);
+  BOOST_TEST(e3ref.getID() == e2.getID());
+
+  int id = triangle.getID();
+  BOOST_TEST(id == 0);
+
+  Vector3d normal = triangle.computeNormal();
+  BOOST_TEST((coords2-coords1).dot(normal) == 0.0);
+  BOOST_TEST((coords3-coords1).dot(normal) == 0.0);
+
+  Vector3d center = triangle.getCenter();
+  BOOST_TEST(testing::equals(center, (coords1+coords2+coords3)/3));
+
+  constexpr double expectedRadius = 0.74535599249993001;
+  BOOST_TEST(triangle.getEnclosingRadius() == expectedRadius);
+
+  constexpr double expectedArea = 0.5;
+  BOOST_TEST(triangle.getArea() == expectedArea);
+}
+
+BOOST_AUTO_TEST_CASE(RangeAccess)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector3d;
+  Vector3d coords1(0.0, 0.0, 0.0);
+  Vector3d coords2(1.0, 0.0, 0.0);
+  Vector3d coords3(1.0, 1.0, 0.0);
+
+  Vertex v0(coords1, 0);
+  Vertex v1(coords2, 1);
+  Vertex v2(coords3, 2);
+
+  Edge e0(v0, v1, 0);
+  Edge e1(v1, v2, 1);
+  Edge e2(v2, v0, 2);
+
+  Triangle triangle(e0, e1, e2, 0);
+
   {
-    Vertex v1(coords1, 0);
-    Vertex v2(coords2, 1);
-    Vertex v3(coords3, 2);
-
-    Edge e1(v1, v2, 0);
-    Edge e2(v3, v2, 1);
-    Edge e3(v3, v1, 2);
-
-    Triangle triangle(e1, e2, e3, 0);
-
-    Vertex &v1ref = triangle.vertex(0);
-    BOOST_TEST(v1ref.getID() == v1.getID());
-
-    Vertex &v2ref = triangle.vertex(1);
-    BOOST_TEST(v2ref.getID() == v2.getID());
-
-    Vertex &v3ref = triangle.vertex(2);
-    BOOST_TEST(v3ref.getID() == v3.getID());
-
-    Edge &e1ref = triangle.edge(0);
-    BOOST_TEST(e1ref.getID() == e1.getID());
-
-    Edge &e2ref = triangle.edge(1);
-    BOOST_TEST(e2ref.getID() == e2.getID());
-
-    Edge &e3ref = triangle.edge(2);
-    BOOST_TEST(e3ref.getID() == e3.getID());
-
-    int id = triangle.getID();
-    BOOST_TEST(id == 0);
+    // Test begin(), end()
+    auto       ibegin = triangle.begin();
+    const auto iend   = triangle.end();
+    BOOST_TEST(std::distance(ibegin, iend) == 3);
+    BOOST_TEST(*ibegin == v0.rawCoords());
+    ++ibegin;
+    BOOST_TEST(*ibegin == v1.rawCoords());
+    ++ibegin;
+    BOOST_TEST(*ibegin == v2.rawCoords());
+    ++ibegin;
+    BOOST_TEST((ibegin == iend));
   }
   {
-    Vertex v1(coords1, 0);
-    Vertex v2(coords2, 1);
-    Vertex v3(coords3, 2);
-
-    Edge e1(v1, v2, 0);
-    Edge e2(v3, v2, 1);
-    Edge e3(v1, v3, 2);
-
-    Triangle triangle(e1, e2, e3, 0);
-
-    Vertex &v1ref = triangle.vertex(0);
-    BOOST_TEST(v1ref.getID() == v1.getID());
-
-    Vertex &v2ref = triangle.vertex(1);
-    BOOST_TEST(v2ref.getID() == v2.getID());
-
-    Vertex &v3ref = triangle.vertex(2);
-    BOOST_TEST(v3ref.getID() == v3.getID());
-
-    Edge &e1ref = triangle.edge(0);
-    BOOST_TEST(e1ref.getID() == e1.getID());
-
-    Edge &e2ref = triangle.edge(1);
-    BOOST_TEST(e2ref.getID() == e2.getID());
-
-    Edge &e3ref = triangle.edge(2);
-    BOOST_TEST(e3ref.getID() == e3.getID());
-
-    int id = triangle.getID();
-    BOOST_TEST(id == 0);
+    // Test begin(), end() for const
+    const Triangle &ctriangle = triangle;
+    auto            ibegin    = ctriangle.begin();
+    const auto      iend      = ctriangle.end();
+    BOOST_TEST(std::distance(ibegin, iend) == 3);
+    BOOST_TEST(*ibegin == v0.rawCoords());
+    ++ibegin;
+    BOOST_TEST(*ibegin == v1.rawCoords());
+    ++ibegin;
+    BOOST_TEST(*ibegin == v2.rawCoords());
+    ++ibegin;
+    BOOST_TEST((ibegin == iend));
   }
   {
-    Vertex v1(coords1, 0);
-    Vertex v2(coords2, 1);
-    Vertex v3(coords3, 2);
-
-    Edge e1(v1, v2, 0);
-    Edge e2(v3, v2, 1);
-    Edge e3(v3, v1, 2);
-
-    Triangle triangle(e1, e3, e2, 0);
-
-    Vertex &v1ref = triangle.vertex(0);
-    BOOST_TEST(v1ref.getID() == v2.getID());
-
-    Vertex &v2ref = triangle.vertex(1);
-    BOOST_TEST(v2ref.getID() == v1.getID());
-
-    Vertex &v3ref = triangle.vertex(2);
-    BOOST_TEST(v3ref.getID() == v3.getID());
-
-    Edge &e1ref = triangle.edge(0);
-    BOOST_TEST(e1ref.getID() == e1.getID());
-
-    Edge &e2ref = triangle.edge(1);
-    BOOST_TEST(e2ref.getID() == e3.getID());
-
-    Edge &e3ref = triangle.edge(2);
-    BOOST_TEST(e3ref.getID() == e2.getID());
-
-    int id = triangle.getID();
-    BOOST_TEST(id == 0);
-  }
-  {
-    Vertex v0(coords1, 0);
-    Vertex v1(coords2, 1);
-    Vertex v2(coords3, 2);
-
-    Edge e0(v0, v1, 0);
-    Edge e1(v1, v2, 1);
-    Edge e2(v2, v0, 2);
-
-    Triangle triangle(e0, e1, e2, 0);
-
-    {
-      // Test begin(), end()
-      auto       ibegin = triangle.begin();
-      const auto iend   = triangle.end();
-      BOOST_TEST(std::distance(ibegin, iend) == 3);
-      BOOST_TEST(*ibegin == v0.rawCoords());
-      ++ibegin;
-      BOOST_TEST(*ibegin == v1.rawCoords());
-      ++ibegin;
-      BOOST_TEST(*ibegin == v2.rawCoords());
-      ++ibegin;
-      BOOST_TEST((ibegin == iend));
-    }
-    {
-      // Test begin(), end() for const
-      const Triangle &ctriangle = triangle;
-      auto            ibegin    = ctriangle.begin();
-      const auto      iend      = ctriangle.end();
-      BOOST_TEST(std::distance(ibegin, iend) == 3);
-      BOOST_TEST(*ibegin == v0.rawCoords());
-      ++ibegin;
-      BOOST_TEST(*ibegin == v1.rawCoords());
-      ++ibegin;
-      BOOST_TEST(*ibegin == v2.rawCoords());
-      ++ibegin;
-      BOOST_TEST((ibegin == iend));
-    }
-    {
-      // Test cbegin(), cend()
-      auto       ibegin = triangle.cbegin();
-      const auto iend   = triangle.cend();
-      BOOST_TEST(std::distance(ibegin, iend) == 3);
-      BOOST_TEST(*ibegin == v0.rawCoords());
-      ++ibegin;
-      BOOST_TEST(*ibegin == v1.rawCoords());
-      ++ibegin;
-      BOOST_TEST(*ibegin == v2.rawCoords());
-      ++ibegin;
-      BOOST_TEST((ibegin == iend));
-    }
+    // Test cbegin(), cend()
+    auto       ibegin = triangle.cbegin();
+    const auto iend   = triangle.cend();
+    BOOST_TEST(std::distance(ibegin, iend) == 3);
+    BOOST_TEST(*ibegin == v0.rawCoords());
+    ++ibegin;
+    BOOST_TEST(*ibegin == v1.rawCoords());
+    ++ibegin;
+    BOOST_TEST(*ibegin == v2.rawCoords());
+    ++ibegin;
+    BOOST_TEST((ibegin == iend));
   }
 }
 

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(TriangleEquality)
   Triangle triangle4(e2, e4, e5, 0);
   BOOST_TEST(triangle1 == triangle2);
   BOOST_TEST(triangle1 != triangle3);
-  BOOST_TEST(triangle4 != triangle3);
+  BOOST_TEST(triangle4 == triangle3);
 }
 
 BOOST_AUTO_TEST_CASE(TriangleWKTPrint)

--- a/src/mesh/tests/VertexTest.cpp
+++ b/src/mesh/tests/VertexTest.cpp
@@ -21,9 +21,6 @@ BOOST_AUTO_TEST_CASE(Vertices)
 
   int id = vertex.getID();
   BOOST_TEST(id == 0);
-
-  Eigen::Vector3d normal = vertex.getNormal();
-  BOOST_TEST(testing::equals(normal, Eigen::Vector3d::Zero()));
 }
 
 BOOST_AUTO_TEST_CASE(VertexEquality)

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -43,7 +43,7 @@ void ProvidedPartition::communicate()
     return;
 
   // Temporary globalMesh such that the master also keeps his local mesh
-  mesh::Mesh globalMesh(_mesh->getName(), _mesh->getDimensions(), _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+  mesh::Mesh globalMesh(_mesh->getName(), _mesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
   bool       hasMeshBeenGathered = false;
 
   bool twoLevelInitAlreadyUsed = false;

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -131,7 +131,7 @@ void ReceivedPartition::compute()
   // (5) Filter mesh according to tag
   PRECICE_INFO("Filter mesh {} by mappings", _mesh->getName());
   Event      e5("partition.filterMeshMappings" + _mesh->getName(), precice::syncMode);
-  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+  mesh::Mesh filteredMesh("FilteredMesh", _dimensions, mesh::Mesh::MESH_ID_UNDEFINED);
   mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return v.isTagged(); });
   PRECICE_DEBUG("Mapping filter, filtered from {} to {} vertices, {} to {} edges, and {} to {} triangles.",
                 _mesh->vertices().size(), filteredMesh.vertices().size(),
@@ -287,14 +287,14 @@ void ReceivedPartition::filterByBoundingBox()
         com::CommunicateBoundingBox(utils::MasterSlave::_communication).receiveBoundingBox(slaveBB, rankSlave);
 
         PRECICE_DEBUG("From slave {}, bounding mesh: {}", rankSlave, slaveBB);
-        mesh::Mesh slaveMesh("SlaveMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+        mesh::Mesh slaveMesh("SlaveMesh", _dimensions, mesh::Mesh::MESH_ID_UNDEFINED);
         mesh::filterMesh(slaveMesh, *_mesh, [&slaveBB](const mesh::Vertex &v) { return slaveBB.contains(v); });
         PRECICE_DEBUG("Send filtered mesh to slave: {}", rankSlave);
         com::CommunicateMesh(utils::MasterSlave::_communication).sendMesh(slaveMesh, rankSlave);
       }
 
       // Now also filter the remaining master mesh
-      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, mesh::Mesh::MESH_ID_UNDEFINED);
       mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return _bb.contains(v); });
       PRECICE_DEBUG("Master mesh, filtered from {} to {} vertices, {} to {} edges, and {} to {} triangles.",
                     _mesh->vertices().size(), filteredMesh.vertices().size(),
@@ -324,7 +324,7 @@ void ReceivedPartition::filterByBoundingBox()
       PRECICE_INFO("Filter mesh {} by bounding box on slaves", _mesh->getName());
       Event e("partition.filterMeshBB." + _mesh->getName(), precice::syncMode);
 
-      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, _mesh->isFlipNormals(), mesh::Mesh::MESH_ID_UNDEFINED);
+      mesh::Mesh filteredMesh("FilteredMesh", _dimensions, mesh::Mesh::MESH_ID_UNDEFINED);
       mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return _bb.contains(v); });
 
       if (isAnyProvidedMeshNonEmpty()) {

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -117,7 +117,6 @@ void ReceivedPartition::compute()
 
   // (2) Tag vertices 1st round (i.e. who could be owned by this rank)
   PRECICE_DEBUG("Tag vertices for filtering: 1st round.");
-  _mesh->computeState(); // normals need to be ready for NP mapping
   // go to both meshes, vertex is tagged if already one mesh tags him
   tagMeshFirstRound();
 

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -93,7 +93,6 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
       pSolidzMesh->createEdge(v5, v6);
     }
     pSolidzMesh->computeBoundingBox();
-    pSolidzMesh->computeState();
 
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
@@ -174,7 +173,6 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
       pSolidzMesh->createTriangle(e4, e5, e3);
     }
     pSolidzMesh->computeBoundingBox();
-    pSolidzMesh->computeState();
 
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
@@ -261,7 +259,6 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
     position << 4.0, 0.0;
     pMesh->createVertex(position);
   }
-  pMesh->computeState();
   pMesh->computeBoundingBox();
 
   ProvidedPartition part(pMesh);
@@ -355,7 +352,6 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
       pSolidzMesh->createEdge(v5, v6);
     }
     pSolidzMesh->computeBoundingBox();
-    pSolidzMesh->computeState();
 
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
@@ -464,7 +460,6 @@ BOOST_AUTO_TEST_CASE(TestSendBoundingBoxes3D)
       mesh::Vertex &v6 = pSolidzMesh->createVertex(position);
       pSolidzMesh->createEdge(v5, v6);
     }
-    pSolidzMesh->computeState();
     pSolidzMesh->computeBoundingBox();
 
     ProvidedPartition part(pSolidzMesh);
@@ -568,7 +563,6 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
     }
   }
   mesh->computeBoundingBox();
-  mesh->computeState();
 
   if (context.isNamed("Solid")) {
     m2n->createDistributedCommunication(mesh);
@@ -694,7 +688,6 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning2D)
       mesh->createVertex(position);
     }
   }
-  mesh->computeState();
   mesh->computeBoundingBox();
 
   if (context.isNamed("Solid")) {
@@ -826,7 +819,6 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning3D)
       mesh->createVertex(position);
     }
   }
-  mesh->computeState();
   mesh->computeBoundingBox();
 
   if (context.isNamed("Solid")) {

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -50,10 +50,9 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
   auto m2n = context.connectMasters("NASTIN", "SOLIDZ");
 
   int  dimensions  = 2;
-  bool flipNormals = false;
 
   if (context.isNamed("NASTIN")) { //NASTIN
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     double safetyFactor = 0.1;
 
@@ -68,7 +67,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
       BOOST_TEST(pSolidzMesh->vertices().at(i).getGlobalIndex() == i);
     }
   } else { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     if (context.isMaster()) { //Master
       Eigen::VectorXd position(dimensions);
@@ -124,10 +123,9 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
   auto m2n = context.connectMasters("NASTIN", "SOLIDZ");
 
   int  dimensions  = 3;
-  bool flipNormals = false;
 
   if (context.isNamed("NASTIN")) { //NASTIN
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     double safetyFactor = 0.1;
 
@@ -143,7 +141,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
       BOOST_TEST(pSolidzMesh->vertices().at(i).getGlobalIndex() == i);
     }
   } else { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     if (context.isMaster()) { //Master
       Eigen::VectorXd position(dimensions);
@@ -238,8 +236,7 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
   // Create mesh object
   std::string   meshName("MyMesh");
   int           dim         = 2;
-  bool          flipNormals = false; // The normals of triangles, edges, vertices
-  mesh::PtrMesh pMesh(new mesh::Mesh(meshName, dim, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh pMesh(new mesh::Mesh(meshName, dim, testing::nextMeshID()));
 
   if (context.isMaster()) { //Master
     Eigen::VectorXd position(dim);
@@ -318,11 +315,10 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
   auto m2n                 = context.connectMasters("NASTIN", "SOLIDZ", options);
 
   int  dimensions  = 2;
-  bool flipNormals = true;
 
   if (context.isNamed("SOLIDZ")) { //SOLIDZ
 
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     if (context.isMaster()) { //Master
       Eigen::VectorXd position(dimensions);
@@ -427,11 +423,10 @@ BOOST_AUTO_TEST_CASE(TestSendBoundingBoxes3D)
   auto m2n                 = context.connectMasters("NASTIN", "SOLIDZ", options);
 
   int  dimensions  = 3;
-  bool flipNormals = true;
 
   if (context.isNamed("SOLIDZ")) { //SOLIDZ
 
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     if (context.isMaster()) { //Master
       Eigen::VectorXd position(dimensions);
@@ -509,9 +504,8 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
   PRECICE_TEST("Solid"_on(2_ranks).setupMasterSlaves(), "Fluid"_on(2_ranks).setupMasterSlaves(), Require::Events);
   //mesh creation
   int           dimensions   = 2;
-  bool          flipNormals  = true;
   double        safetyFactor = 0.1;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, testing::nextMeshID()));
 
   testing::ConnectionOptions options;
   options.useOnlyMasterCom = false;
@@ -609,10 +603,9 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning2D)
   PRECICE_TEST("Solid"_on(2_ranks).setupMasterSlaves(), "Fluid"_on(2_ranks).setupMasterSlaves(), Require::Events);
   //mesh creation
   int           dimensions   = 2;
-  bool          flipNormals  = true;
   double        safetyFactor = 0;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
-  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, testing::nextMeshID()));
+  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, testing::nextMeshID()));
 
   testing::ConnectionOptions options;
   options.useOnlyMasterCom = false;
@@ -750,10 +743,9 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning3D)
 
   //mesh creation
   int           dimensions   = 3;
-  bool          flipNormals  = true;
   double        safetyFactor = 0.0;
-  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
-  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, flipNormals, testing::nextMeshID()));
+  mesh::PtrMesh mesh(new mesh::Mesh("mesh", dimensions, testing::nextMeshID()));
+  mesh::PtrMesh receivedMesh(new mesh::Mesh("mesh", dimensions, testing::nextMeshID()));
 
   // create the communicator for m2n mesh and communciation map exchange
   testing::ConnectionOptions options;

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
   PRECICE_TEST("NASTIN"_on(1_rank), "SOLIDZ"_on(3_ranks).setupMasterSlaves(), Require::Events);
   auto m2n = context.connectMasters("NASTIN", "SOLIDZ");
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("NASTIN")) { //NASTIN
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
   PRECICE_TEST("NASTIN"_on(1_rank), "SOLIDZ"_on(3_ranks).setupMasterSlaves(), Require::Events);
   auto m2n = context.connectMasters("NASTIN", "SOLIDZ");
 
-  int  dimensions  = 3;
+  int dimensions = 3;
 
   if (context.isNamed("NASTIN")) { //NASTIN
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
   PRECICE_TEST("NASTIN"_on(4_ranks).setupMasterSlaves(), Require::Events);
   // Create mesh object
   std::string   meshName("MyMesh");
-  int           dim         = 2;
+  int           dim = 2;
   mesh::PtrMesh pMesh(new mesh::Mesh(meshName, dim, testing::nextMeshID()));
 
   if (context.isMaster()) { //Master
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
   options.useTwoLevelInit  = true;
   auto m2n                 = context.connectMasters("NASTIN", "SOLIDZ", options);
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("SOLIDZ")) { //SOLIDZ
 
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(TestSendBoundingBoxes3D)
   options.useTwoLevelInit  = true;
   auto m2n                 = context.connectMasters("NASTIN", "SOLIDZ", options);
 
-  int  dimensions  = 3;
+  int dimensions = 3;
 
   if (context.isNamed("SOLIDZ")) { //SOLIDZ
 

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -78,7 +78,6 @@ void createSolidzMesh2D(mesh::PtrMesh pSolidzMesh)
   pSolidzMesh->createEdge(v3, v4);
   pSolidzMesh->createEdge(v4, v5);
   pSolidzMesh->createEdge(v5, v6);
-  pSolidzMesh->computeState();
   pSolidzMesh->computeBoundingBox();
 }
 
@@ -97,7 +96,6 @@ void createSolidzMesh2DSmall(mesh::PtrMesh pSolidzMesh)
   mesh::Vertex &v3 = pSolidzMesh->createVertex(position);
   pSolidzMesh->createEdge(v1, v2);
   pSolidzMesh->createEdge(v2, v3);
-  pSolidzMesh->computeState();
   pSolidzMesh->computeBoundingBox();
 }
 
@@ -122,7 +120,6 @@ void createNastinMesh2D(mesh::PtrMesh pNastinMesh, int rank)
     position << 0.0, 6.0;
     pNastinMesh->createVertex(position);
   }
-  pNastinMesh->computeState();
   pNastinMesh->computeBoundingBox();
 }
 
@@ -148,7 +145,6 @@ void createNastinMesh2D2(mesh::PtrMesh pNastinMesh, int rank)
     position << 2.9, 2.9;
     pNastinMesh->createVertex(position);
   }
-  pNastinMesh->computeState();
   pNastinMesh->computeBoundingBox();
 }
 
@@ -182,7 +178,6 @@ void createSolidzMesh3D(mesh::PtrMesh pSolidzMesh)
   mesh::Edge &e6 = pSolidzMesh->createEdge(v5, v1);
   pSolidzMesh->createTriangle(e1, e2, e3);
   pSolidzMesh->createTriangle(e4, e5, e6);
-  pSolidzMesh->computeState();
   pSolidzMesh->computeBoundingBox();
 }
 
@@ -207,7 +202,6 @@ void createNastinMesh3D(mesh::PtrMesh pNastinMesh, int rank)
     position << 0.5, 0.5, 0.0;
     pNastinMesh->createVertex(position);
   }
-  pNastinMesh->computeState();
   pNastinMesh->computeBoundingBox();
 }
 
@@ -233,7 +227,6 @@ void createNastinMesh3D2(mesh::PtrMesh pNastinMesh, int rank)
     position << 2.9, 2.9, 2.1;
     pNastinMesh->createVertex(position);
   }
-  pNastinMesh->computeState();
   pNastinMesh->computeBoundingBox();
 }
 
@@ -807,7 +800,6 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
     position << 2.0, 0.0;
     pMesh->createVertex(position);
 
-    pMesh->computeState();
     pMesh->computeBoundingBox();
 
     ProvidedPartition part(pMesh);
@@ -839,7 +831,6 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
       // no vertices
     }
 
-    pOtherMesh->computeState();
     pOtherMesh->computeBoundingBox();
 
     double            safetyFactor = 20.0;
@@ -1139,11 +1130,8 @@ BOOST_AUTO_TEST_CASE(RePartitionMultipleMappings)
       position << 0.0, 6.0;
       pNastinMesh3->createVertex(position);
     }
-    pNastinMesh1->computeState();
     pNastinMesh1->computeBoundingBox();
-    pNastinMesh2->computeState();
     pNastinMesh2->computeBoundingBox();
-    pNastinMesh3->computeState();
     pNastinMesh3->computeBoundingBox();
 
     double safetyFactor = 0.1;

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -235,8 +235,8 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int             dimensions  = 2;
-  Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
+  int             dimensions = 2;
+  Eigen::VectorXd offset     = Eigen::VectorXd::Zero(dimensions);
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -292,8 +292,8 @@ BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int             dimensions  = 2;
-  Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
+  int             dimensions = 2;
+  Eigen::VectorXd offset     = Eigen::VectorXd::Zero(dimensions);
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events, Require::PETSc);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events, Require::PETSc);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events, Require::PETSc);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events, Require::PETSc);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 3;
+  int dimensions = 3;
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -725,7 +725,7 @@ BOOST_AUTO_TEST_CASE(RePartitionNPBroadcastFilter3D)
   PRECICE_TEST("Fluid"_on(3_ranks).setupMasterSlaves(), "Solid"_on(1_rank), Require::Events);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 3;
+  int dimensions = 3;
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -778,7 +778,7 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -863,7 +863,7 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
   PRECICE_TEST("Fluid"_on(1_rank), "Solid"_on(1_rank), Require::Events);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   if (context.isNamed("Solid")) {
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -935,7 +935,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
   options.useTwoLevelInit  = true;
   auto m2n                 = context.connectMasters("SOLIDZ", "NASTIN", options);
 
-  int  dimensions  = 2;
+  int dimensions = 2;
 
   // construct send global boundingbox
   mesh::Mesh::BoundingBoxMap sendGlobalBB;
@@ -1005,7 +1005,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
   options.useTwoLevelInit  = true;
   auto m2n                 = context.connectMasters("SOLIDZ", "NASTIN", options);
 
-  int  dimensions  = 3;
+  int dimensions = 3;
 
   // construct send global boundingbox
   mesh::Mesh::BoundingBoxMap sendGlobalBB;
@@ -1072,8 +1072,8 @@ BOOST_AUTO_TEST_CASE(RePartitionMultipleMappings)
   PRECICE_TEST("Solid"_on(1_rank), "Fluid"_on(3_ranks).setupMasterSlaves(), Require::Events);
   auto m2n = context.connectMasters("Solid", "Fluid");
 
-  int             dimensions  = 2;
-  Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
+  int             dimensions = 2;
+  Eigen::VectorXd offset     = Eigen::VectorXd::Zero(dimensions);
 
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -236,11 +236,10 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int             dimensions  = 2;
-  bool            flipNormals = false;
   Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     BOOST_TEST(pSolidzMesh->vertices().size() == 6);
     ProvidedPartition part(pSolidzMesh);
@@ -248,8 +247,8 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D)
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -294,19 +293,18 @@ BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int             dimensions  = 2;
-  bool            flipNormals = false;
   Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2DSmall(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -347,18 +345,17 @@ BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 2;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestProjectionMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -402,18 +399,17 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 2;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::PetRadialBasisFctMapping<mapping::ThinPlateSplines>(mapping::Mapping::CONSISTENT, dimensions,
@@ -487,18 +483,17 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 2;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     double supportRadius = 0.25;
 
@@ -562,18 +557,17 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 2;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     double supportRadius = 2.45;
 
@@ -643,18 +637,17 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 3;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh3D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     double supportRadius1 = 1.2;
     double supportRadius2 = 0.2;
@@ -733,18 +726,17 @@ BOOST_AUTO_TEST_CASE(RePartitionNPBroadcastFilter3D)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 3;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh3D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestProjectionMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -787,10 +779,9 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 2;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     Eigen::VectorXd position(dimensions);
     position << 0.0, 0.0;
@@ -808,8 +799,8 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
 
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pMesh(new mesh::Mesh("NastinMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pOtherMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pMesh(new mesh::Mesh("NastinMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pOtherMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -873,10 +864,9 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int  dimensions  = 2;
-  bool flipNormals = false;
 
   if (context.isNamed("Solid")) {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
@@ -902,9 +892,9 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
     BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == true);
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
-    mesh::PtrMesh       pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh       pOtherMesh(new mesh::Mesh("OtherMesh", dimensions, testing::nextMeshID()));
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
     boundingFromMapping->setMeshes(pSolidzMesh, pOtherMesh);
@@ -946,7 +936,6 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
   auto m2n                 = context.connectMasters("SOLIDZ", "NASTIN", options);
 
   int  dimensions  = 2;
-  bool flipNormals = true;
 
   // construct send global boundingbox
   mesh::Mesh::BoundingBoxMap sendGlobalBB;
@@ -963,7 +952,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
     std::vector<int>                connectedRanksList;
     int                             connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     m2n->getMasterCommunication()->send(3, 0);
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0);
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
@@ -983,8 +972,8 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
     BOOST_TEST(receivedConnectionMap.at(2).at(0) == 0);
 
   } else {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -1017,7 +1006,6 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
   auto m2n                 = context.connectMasters("SOLIDZ", "NASTIN", options);
 
   int  dimensions  = 3;
-  bool flipNormals = true;
 
   // construct send global boundingbox
   mesh::Mesh::BoundingBoxMap sendGlobalBB;
@@ -1034,7 +1022,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
     std::vector<int>                connectedRanksList;
     int                             connectionMapSize = 0;
     std::map<int, std::vector<int>> receivedConnectionMap;
-    mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     m2n->getMasterCommunication()->send(3, 0);
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendBoundingBoxMap(sendGlobalBB, 0);
     m2n->getMasterCommunication()->receive(connectedRanksList, 0);
@@ -1054,8 +1042,8 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
     BOOST_TEST(receivedConnectionMap.at(2).at(0) == 0);
 
   } else {
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
@@ -1085,11 +1073,10 @@ BOOST_AUTO_TEST_CASE(RePartitionMultipleMappings)
   auto m2n = context.connectMasters("Solid", "Fluid");
 
   int             dimensions  = 2;
-  bool            flipNormals = false;
   Eigen::VectorXd offset      = Eigen::VectorXd::Zero(dimensions);
 
   if (context.isNamed("Solid")) { //SOLIDZ
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
     BOOST_TEST(pSolidzMesh->vertices().size() == 6);
     ProvidedPartition part(pSolidzMesh);
@@ -1097,10 +1084,10 @@ BOOST_AUTO_TEST_CASE(RePartitionMultipleMappings)
     part.communicate();
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
-    mesh::PtrMesh pNastinMesh1(new mesh::Mesh("NastinMesh1", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pNastinMesh2(new mesh::Mesh("NastinMesh1", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pNastinMesh3(new mesh::Mesh("NastinMesh1", dimensions, flipNormals, testing::nextMeshID()));
-    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, flipNormals, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh1(new mesh::Mesh("NastinMesh1", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh2(new mesh::Mesh("NastinMesh1", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pNastinMesh3(new mesh::Mesh("NastinMesh1", dimensions, testing::nextMeshID()));
+    mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
 
     mapping::PtrMapping boundingFromMapping1 = mapping::PtrMapping(
         new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -548,9 +548,9 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     io::PtrExport exporter;
     if (exportContext.type == VALUE_VTK) {
       if (context.size > 1) {
-        exporter = io::PtrExport(new io::ExportVTKXML(exportContext.plotNormals));
+        exporter = io::PtrExport(new io::ExportVTKXML());
       } else {
-        exporter = io::PtrExport(new io::ExportVTK(exportContext.plotNormals));
+        exporter = io::PtrExport(new io::ExportVTK());
       }
     } else {
       PRECICE_ERROR("Participant {} defines an <export/> tag of unknown type \"{}\".",

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -355,20 +355,6 @@ partition::ReceivedPartition::GeometricFilter ParticipantConfiguration::getGeoFi
   }
 }
 
-/// @todo remove
-mesh::PtrMesh ParticipantConfiguration::copy(
-    const mesh::PtrMesh &mesh) const
-{
-  int         dim = mesh->getDimensions();
-  std::string name(mesh->getName());
-  bool        flipNormals = mesh->isFlipNormals();
-  mesh::Mesh *meshCopy    = new mesh::Mesh("Local_" + name, dim, flipNormals, mesh::Mesh::MESH_ID_UNDEFINED);
-  for (const mesh::PtrData &data : mesh->data()) {
-    meshCopy->createData(data->getName(), data->getDimensions());
-  }
-  return mesh::PtrMesh(meshCopy);
-}
-
 const mesh::PtrData &ParticipantConfiguration::getData(
     const mesh::PtrMesh &mesh,
     const std::string &  nameData) const

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1490,7 +1490,6 @@ void SolverInterfaceImpl::computePartitions()
 
   for (MeshContext *meshContext : contexts) {
     meshContext->partition->compute();
-    meshContext->mesh->computeState();
     if (not meshContext->provideMesh) { // received mesh can only compute their bounding boxes here
       meshContext->mesh->computeBoundingBox();
     }

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 3;
+  int         dimensions = 3;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 3;
+  int         dimensions = 3;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -592,7 +592,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 3;
+  int         dimensions = 3;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 3;
+  int         dimensions = 3;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 3;
+  int         dimensions = 3;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -821,7 +821,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
   PtrData     doubleData   = mesh->createData("DoubleData", 1);
   auto &      doubleValues = doubleData->values();
@@ -912,7 +912,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
   PtrData     doubleData   = mesh->createData("DoubleData", 2);
   auto &      doubleValues = doubleData->values();
@@ -1019,7 +1019,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {
@@ -1124,7 +1124,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 2;
+  int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {
@@ -1245,7 +1245,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 3;
+  int         dimensions = 3;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {
@@ -1348,7 +1348,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  int         dimensions  = 3;
+  int         dimensions = 3;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -58,7 +58,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -123,7 +122,6 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   PtrData doubleData   = mesh->createData("DoubleData", 2);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -198,7 +196,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -263,7 +260,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -328,7 +324,6 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   PtrData doubleData   = mesh->createData("DoubleData", 2);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -401,7 +396,6 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   PtrData doubleData   = mesh->createData("DoubleData", 2);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -481,7 +475,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -555,7 +548,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -629,7 +621,6 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   PtrData doubleData   = mesh->createData("DoubleData", 2);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -711,7 +702,6 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   PtrData doubleData   = mesh->createData("DoubleData", 2);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -793,7 +783,6 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -863,7 +852,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
     mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
   }
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   if (utils::MasterSlave::isMaster()) {
@@ -956,7 +944,6 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
     mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
   }
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   if (utils::MasterSlave::isMaster()) {
@@ -1073,7 +1060,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   if (utils::MasterSlave::isMaster()) {
@@ -1180,7 +1166,6 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
   PtrData doubleData   = mesh->createData("DoubleData", 2);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   if (utils::MasterSlave::isMaster()) {
@@ -1305,7 +1290,6 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
   PtrData doubleData   = mesh->createData("DoubleData", 1);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   if (utils::MasterSlave::isMaster()) {
@@ -1410,7 +1394,6 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
   PtrData doubleData   = mesh->createData("DoubleData", 2);
   auto &  doubleValues = doubleData->values();
 
-  mesh->computeState();
   mesh->allocateDataValues();
 
   if (utils::MasterSlave::isMaster()) {

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -46,9 +46,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
@@ -110,9 +109,8 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
@@ -182,9 +180,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
@@ -246,9 +243,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
@@ -310,9 +306,8 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
@@ -382,9 +377,8 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
@@ -454,9 +448,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 3;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
@@ -527,9 +520,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 3;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
@@ -600,9 +592,8 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 3;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
@@ -681,9 +672,8 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 3;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
@@ -762,9 +752,8 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 3;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
@@ -832,9 +821,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
   PtrData     doubleData   = mesh->createData("DoubleData", 1);
   auto &      doubleValues = doubleData->values();
 
@@ -924,9 +912,8 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
   PtrData     doubleData   = mesh->createData("DoubleData", 2);
   auto &      doubleValues = doubleData->values();
 
@@ -1032,9 +1019,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {
     mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -1138,9 +1124,8 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 2;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {
     mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -1260,9 +1245,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 3;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {
     mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
@@ -1364,9 +1348,8 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
   using namespace mesh;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
   int         dimensions  = 3;
-  PtrMesh     mesh(new Mesh(name, dimensions, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
 
   if (utils::MasterSlave::isMaster()) {
     mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -47,8 +47,7 @@ BOOST_AUTO_TEST_CASE(TimeSeries)
   using Eigen::VectorXd;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
-  PtrMesh     mesh(new Mesh(name, 2, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, 2, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
@@ -164,8 +163,7 @@ BOOST_AUTO_TEST_CASE(Reinitalize)
   using Eigen::VectorXd;
   // Setup geometry
   std::string name("rectangle");
-  bool        flipNormals = false;
-  PtrMesh     mesh(new Mesh(name, 2, flipNormals, testing::nextMeshID()));
+  PtrMesh     mesh(new Mesh(name, 2, testing::nextMeshID()));
 
   mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(0.0, 1.0));

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -58,7 +58,6 @@ BOOST_AUTO_TEST_CASE(TimeSeries)
   PtrData vectorData   = mesh->createData("VectorData", 2);
   auto &  doubleValues = doubleData->values();
   auto &  vectorValues = vectorData->values();
-  mesh->computeState();
   mesh->allocateDataValues();
 
   doubleValues(0) = 1.0;
@@ -177,7 +176,6 @@ BOOST_AUTO_TEST_CASE(Reinitalize)
   PtrData vectorData   = mesh->createData("VectorData", 2);
   auto &  doubleValues = doubleData->values();
   auto &  vectorValues = vectorData->values();
-  mesh->computeState();
   mesh->allocateDataValues();
 
   // v1, v2 carry data 1
@@ -212,7 +210,6 @@ BOOST_AUTO_TEST_CASE(Reinitalize)
     mesh->createEdge(v3, v4);
     mesh->meshChanged(*mesh);
     mesh->allocateDataValues();
-    mesh->computeState();
     doubleValues.setConstant(1.0);
     doubleValues(2) = 2.0;
     doubleValues(3) = 2.0;

--- a/src/query/tests/RTreeAdapterTests.cpp
+++ b/src/query/tests/RTreeAdapterTests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(VectorAdapter)
 BOOST_AUTO_TEST_CASE(VertexAdapter)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 2, precice::testing::nextMeshID());
   auto &              v = mesh.createVertex(Eigen::Vector2d(1, 2));
   BOOST_TEST(bg::get<0>(v) == 1);
   BOOST_TEST(bg::get<1>(v) == 2);
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(RawCoordinateAdapter)
 BOOST_AUTO_TEST_CASE(EdgeAdapter)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 2, false, precice::testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 2, precice::testing::nextMeshID());
   auto &              v1 = mesh.createVertex(Eigen::Vector2d(1, 2));
   auto &              v2 = mesh.createVertex(Eigen::Vector2d(3, 4));
   auto &              e  = mesh.createEdge(v1, v2);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(EdgeAdapter)
 BOOST_AUTO_TEST_CASE(TriangleAdapter)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, false, precice::testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, precice::testing::nextMeshID());
   auto &              v1 = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
   auto &              v2 = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
   auto &              v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(TriangleAdapter)
 BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   auto &              v1 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
   auto &              v2 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto &              v3 = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatSingleTriangle)
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   auto &              lv1 = mesh.createVertex(Eigen::Vector3d(-1, 1, 0.1));
   auto &              lv2 = mesh.createVertex(Eigen::Vector3d(0, -1, 0));
   auto &              lv3 = mesh.createVertex(Eigen::Vector3d(-2, 0, -0.1));
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangle)
 BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   auto &              a = mesh.createVertex(Eigen::Vector3d(0, 0, 0));
   auto &              b = mesh.createVertex(Eigen::Vector3d(1, 0, 0));
   auto &              c = mesh.createVertex(Eigen::Vector3d(1, 1, 0));
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(DistanceTestFlatDoubleTriangleInsideOutside)
 BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   auto &              v1 = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto &              v2 = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto &              v3 = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -223,7 +223,8 @@ BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
+  using precice::testing::equals;
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   auto &              v1  = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto &              v2  = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto &              v3  = mesh.createVertex(Eigen::Vector3d(0, 0, 1));
@@ -245,7 +246,8 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
 {
   PRECICE_TEST(1_rank);
-  precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
+  using precice::testing::equals;
+  precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
   auto &              v1  = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto &              v2  = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
   auto &              v3  = mesh.createVertex(Eigen::Vector3d(0, 0, 1));

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -46,7 +46,6 @@ PtrMesh fullMesh()
   // Triangles
   mesh.createTriangle(e1, e5, e4);
   mesh.createTriangle(e2, e3, e5);
-  mesh.computeState();
   return ptr;
 }
 

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -30,7 +30,7 @@ namespace bgi = boost::geometry::index;
 namespace {
 PtrMesh fullMesh()
 {
-  PtrMesh ptr(new Mesh("MyMesh", 3, false, testing::nextMeshID()));
+  PtrMesh ptr(new Mesh("MyMesh", 3, testing::nextMeshID()));
   auto &  mesh = *ptr;
   auto &  v1   = mesh.createVertex(Eigen::Vector3d(0, 2, 0));
   auto &  v2   = mesh.createVertex(Eigen::Vector3d(2, 1, 0));
@@ -51,7 +51,7 @@ PtrMesh fullMesh()
 
 PtrMesh edgeMesh3D()
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector3d(0, 0, 0));
   mesh->createVertex(Eigen::Vector3d(0, 0, 1));
   mesh->createVertex(Eigen::Vector3d(0, 1, 0));
@@ -66,7 +66,7 @@ PtrMesh edgeMesh3D()
 
 PtrMesh edgeMesh2D()
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, testing::nextMeshID()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
   mesh->createVertex(Eigen::Vector2d(0, 1));
   auto &v1 = mesh->createVertex(Eigen::Vector2d(1, 0));
@@ -77,7 +77,7 @@ PtrMesh edgeMesh2D()
 
 PtrMesh vertexMesh3D()
 {
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector3d(0, 0, 0));
   mesh->createVertex(Eigen::Vector3d(0, 0, 1));
   mesh->createVertex(Eigen::Vector3d(0, 1, 0));
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(Query3DVertex)
 BOOST_AUTO_TEST_CASE(Query3DFullVertex)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh      mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
+  PtrMesh      mesh(new precice::mesh::Mesh("MyMesh", 3, precice::testing::nextMeshID()));
   const double z1  = 0.1;
   const double z2  = -0.1;
   auto &       v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(Query3DEdge)
 BOOST_AUTO_TEST_CASE(Query3DFullEdge)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh      mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
+  PtrMesh      mesh(new precice::mesh::Mesh("MyMesh", 3, precice::testing::nextMeshID()));
   const double z1  = 0.1;
   const double z2  = -0.1;
   auto &       v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(Query3DFullTriangle)
 {
   PRECICE_TEST(1_rank);
 
-  PtrMesh      mesh(new precice::mesh::Mesh("MyMesh", 3, false, precice::testing::nextMeshID()));
+  PtrMesh      mesh(new precice::mesh::Mesh("MyMesh", 3, precice::testing::nextMeshID()));
   const double z1  = 0.1;
   const double z2  = -0.1;
   auto &       v00 = mesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -330,7 +330,7 @@ BOOST_AUTO_TEST_SUITE(Cache)
 BOOST_AUTO_TEST_CASE(ClearOnChange)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, precice::testing::nextMeshID()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
 
   // The Cache should clear whenever a mesh changes
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(ClearOnChange)
 BOOST_AUTO_TEST_CASE(ClearOnDestruction)
 {
   PRECICE_TEST(1_rank);
-  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, false, precice::testing::nextMeshID()));
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 2, precice::testing::nextMeshID()));
   mesh->createVertex(Eigen::Vector2d(0, 0));
 
   // The Cache should clear whenever we destroy the Mesh


### PR DESCRIPTION
## Main changes of this PR

Removes normals from Primitives and computes them on-demand if necessary.

- Remove saved normals from primitives
- Remove vertex normals from vtk exporters
- Remove `Mesh::computeState`
- Compute normals on-demand
- Extended and fixed tests

Deprecated the `normal` argument of the `vertexCallback(id, coords, normal):`.
If there is a 3rd parameter, preCICE will display the following warning and pass `None` as a value:
```
action::PythonAction|l253|initialize|WARNING: Python module "TestDeprecatedAction" defines the function vertexCallback with 3 arguments. The normal argument is deprecated and preCICE will pass None instead. Please use the following definition to silence this warning "def vertexCallback(id, coords):"
```

Primitive | Mem Old | Mem New | Rel
--- | --- | --- | ---
Vertex | 96B | 32B + 24B | ~41%
Edge | 64B | 24B | ~62%
Triangle | 72B | 32B | ~55%

## Motivation and additional information

Normals are saved as `Eigen::VectorXd`, which are `16B` objects with `24B` or `16B` dynamically allocated data.
This memory is used for every Vertex, Edge and Triangle in preCICE.
You can find more information on the memory consumption in #483.

We can compute the Edge and Triangle normals on-demand.
The vertex normals are unused in most cases.
This PR also deprecates the vertex normals in the python actions and removes them from the exporters.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
* [ ] (more questions/tasks)
