### PR TITLE
Add Keys for Version and Revision

### DIFF
--- a/docs/changelog/1001.md
+++ b/docs/changelog/1001.md
@@ -1,0 +1,1 @@
+- Changed output of `SolverInterface::getVersionInformation()` to return a list of key-value pairs separated by a `;`.

--- a/src/precice/impl/versions.cpp.in
+++ b/src/precice/impl/versions.cpp.in
@@ -1,4 +1,4 @@
 #include "precice/impl/versions.hpp"
 
 const char * const precice::preciceRevision = "@preCICE_REVISION@";
-const char * const precice::versionInformation = "@preCICE_VERSION@;@preCICE_REVISION@;@preCICE_VERSION_INFORMATION@";
+const char * const precice::versionInformation = "PRECICE_version=@preCICE_VERSION@;PRECICE_revision=@preCICE_REVISION@;@preCICE_VERSION_INFORMATION@";


### PR DESCRIPTION
## Main changes of this PR


## Motivation and additional information

This changes the string returned by https://github.com/precice/precice/blob/34688da733169cdbea87fd9c66dd74362496f9ad/src/precice/SolverInterface.hpp#L800

from 

```
'2.2.0;v2.2.0-dirty;PRECICE_MPICommunication=Y;PRECICE_PETScMapping=Y;PRECICE_PythonActions=N;PRECICE_ENABLE_C=Y;PRECICE_ENABLE_FORTRAN=Y;CXX=GNU;CXXFLAGS= -g;LDFAGS='
```

to

```
'PRECICE_version=2.2.0;PRECICE_revision=v2.2.0-dirty;PRECICE_MPICommunication=Y;PRECICE_PETScMapping=Y;PRECICE_PythonActions=N;PRECICE_ENABLE_C=Y;PRECICE_ENABLE_FORTRAN=Y;CXX=GNU;CXXFLAGS= -g;LDFAGS='
```

This makes it easier to reformat the string in a key-value fashion. Here is a short example in python:

```
python3 -c "import precice; print({item.split('=')[0]:item.split('=')[1] for item in str(precice.get_version_information()).split(';')})"
```

`item.split('=')[1]` currently breaks, since there is no `=` in the first two items of the list separated by `;`.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
* [x] (more questions/tasks)