### PR TITLE
Disable macos ci

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -1,9 +1,8 @@
 name: Build and Test macOS
 on:
   push:
-    branches:
-      - master
-      - develop
+    branches-ignore:
+      - '**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Main changes of this PR
macOS runner currently not set properly. Until then, disable macOS workflows.

## Motivation and additional information

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)