### PR TITLE
Improve vertex coordinate representation

### DIFF
--- a/docs/changelog/1008.md
+++ b/docs/changelog/1008.md
@@ -1,0 +1,1 @@
+- Improved memory consumption and data locality of vertices.

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -29,31 +29,30 @@ void CommunicateMesh::sendMesh(
     int               rankReceiver)
 {
   PRECICE_TRACE(mesh.getName(), rankReceiver);
-  int dim = mesh.getDimensions();
+  const int dim = mesh.getDimensions();
 
-  int numberOfVertices = mesh.vertices().size();
+  const auto &meshVertices     = mesh.vertices();
+  const int   numberOfVertices = meshVertices.size();
   _communication->send(numberOfVertices, rankReceiver);
   if (not mesh.vertices().empty()) {
     std::vector<double> coords(static_cast<size_t>(numberOfVertices) * dim);
     std::vector<int>    globalIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
-      for (int d = 0; d < dim; d++) {
-        coords[i * dim + d] = mesh.vertices()[i].getCoords()[d];
-      }
-      globalIDs[i] = mesh.vertices()[i].getGlobalIndex();
+      std::copy_n(meshVertices[i].rawCoords().begin(), dim, &coords[i * dim]);
+      globalIDs[i] = meshVertices[i].getGlobalIndex();
     }
     _communication->send(coords, rankReceiver);
     _communication->send(globalIDs, rankReceiver);
   }
 
-  int numberOfEdges = mesh.edges().size();
+  const int numberOfEdges = mesh.edges().size();
   _communication->send(numberOfEdges, rankReceiver);
   if (not mesh.edges().empty()) {
     //we need to send the vertexIDs first such that the right edges can be created later
     //contrary to the normal sendMesh, this variant must also work for adding delta meshes
     std::vector<int> vertexIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
-      vertexIDs[i] = mesh.vertices()[i].getID();
+      vertexIDs[i] = meshVertices[i].getID();
     }
     _communication->send(vertexIDs, rankReceiver);
 
@@ -106,8 +105,8 @@ void CommunicateMesh::receiveMesh(
     std::vector<int>    globalIDs;
     _communication->receive(vertexCoords, rankSender);
     _communication->receive(globalIDs, rankSender);
+    Eigen::VectorXd coords(dim);
     for (int i = 0; i < numberOfVertices; i++) {
-      Eigen::VectorXd coords(dim);
       for (int d = 0; d < dim; d++) {
         coords[d] = vertexCoords[i * dim + d];
       }
@@ -179,16 +178,15 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
   PRECICE_TRACE(mesh.getName());
   int dim = mesh.getDimensions();
 
-  int numberOfVertices = mesh.vertices().size();
+  const auto &meshVertices     = mesh.vertices();
+  const int   numberOfVertices = meshVertices.size();
   _communication->broadcast(numberOfVertices);
   if (numberOfVertices > 0) {
     std::vector<double> coords(static_cast<size_t>(numberOfVertices) * dim);
     std::vector<int>    globalIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
-      for (int d = 0; d < dim; d++) {
-        coords[i * dim + d] = mesh.vertices()[i].getCoords()[d];
-      }
-      globalIDs[i] = mesh.vertices()[i].getGlobalIndex();
+      std::copy_n(meshVertices[i].rawCoords().begin(), dim, &coords[i * dim]);
+      globalIDs[i] = meshVertices[i].getGlobalIndex();
     }
     _communication->broadcast(coords);
     _communication->broadcast(globalIDs);
@@ -201,14 +199,15 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
     //contrary to the normal sendMesh, this variant must also work for adding delta meshes
     std::vector<int> vertexIDs(numberOfVertices);
     for (int i = 0; i < numberOfVertices; i++) {
-      vertexIDs[i] = mesh.vertices()[i].getID();
+      vertexIDs[i] = meshVertices[i].getID();
     }
     _communication->broadcast(vertexIDs);
 
     std::vector<int> edgeIDs(numberOfEdges * 2);
+    const auto &     meshEdges = mesh.edges();
     for (int i = 0; i < numberOfEdges; i++) {
-      edgeIDs[i * 2]     = mesh.edges()[i].vertex(0).getID();
-      edgeIDs[i * 2 + 1] = mesh.edges()[i].vertex(1).getID();
+      edgeIDs[i * 2]     = meshEdges[i].vertex(0).getID();
+      edgeIDs[i * 2 + 1] = meshEdges[i].vertex(1).getID();
     }
     _communication->broadcast(edgeIDs);
   }
@@ -226,10 +225,11 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
       _communication->broadcast(edgeIDs);
 
       std::vector<int> triangleIDs(numberOfTriangles * 3);
+      const auto &     meshTriangles = mesh.triangles();
       for (int i = 0; i < numberOfTriangles; i++) {
-        triangleIDs[i * 3]     = mesh.triangles()[i].edge(0).getID();
-        triangleIDs[i * 3 + 1] = mesh.triangles()[i].edge(1).getID();
-        triangleIDs[i * 3 + 2] = mesh.triangles()[i].edge(2).getID();
+        triangleIDs[i * 3]     = meshTriangles[i].edge(0).getID();
+        triangleIDs[i * 3 + 1] = meshTriangles[i].edge(1).getID();
+        triangleIDs[i * 3 + 2] = meshTriangles[i].edge(2).getID();
       }
       _communication->broadcast(triangleIDs);
     }
@@ -253,8 +253,8 @@ void CommunicateMesh::broadcastReceiveMesh(
     std::vector<int>    globalIDs;
     _communication->broadcast(vertexCoords, rankBroadcaster);
     _communication->broadcast(globalIDs, rankBroadcaster);
+    Eigen::VectorXd coords(dim);
     for (int i = 0; i < numberOfVertices; i++) {
-      Eigen::VectorXd coords(dim);
       for (int d = 0; d < dim; d++) {
         coords[d] = vertexCoords[i * dim + d];
       }

--- a/src/mesh/BoundingBox.cpp
+++ b/src/mesh/BoundingBox.cpp
@@ -55,8 +55,9 @@ bool BoundingBox::empty() const
 bool BoundingBox::contains(const mesh::Vertex &vertex) const
 {
   PRECICE_ASSERT(_dimensions == vertex.getDimensions(), "Vertex with different dimensions than bounding box cannot be checked.");
+  const auto &coords = vertex.rawCoords();
   for (int d = 0; d < _dimensions; d++) {
-    if (vertex.getCoords()[d] < _bounds.at(2 * d) || vertex.getCoords()[d] > _bounds.at(2 * d + 1)) {
+    if (coords[d] < _bounds.at(2 * d) || coords[d] > _bounds.at(2 * d + 1)) {
       return false;
     }
   }
@@ -122,9 +123,10 @@ void BoundingBox::expandBy(const BoundingBox &otherBB)
 void BoundingBox::expandBy(const Vertex &vertices)
 {
   PRECICE_ASSERT(_dimensions == vertices.getDimensions(), "Vertex with different dimensions than bounding box cannot be used to expand bounding box");
+  const auto coords = vertices.rawCoords();
   for (int d = 0; d < _dimensions; ++d) {
-    _bounds.at(2 * d)     = std::min(vertices.getCoords()[d], _bounds.at(2 * d));
-    _bounds.at(2 * d + 1) = std::max(vertices.getCoords()[d], _bounds.at(2 * d + 1));
+    _bounds.at(2 * d)     = std::min(coords[d], _bounds.at(2 * d));
+    _bounds.at(2 * d + 1) = std::max(coords[d], _bounds.at(2 * d + 1));
   }
 }
 

--- a/src/mesh/RangeAccessor.hpp
+++ b/src/mesh/RangeAccessor.hpp
@@ -23,14 +23,14 @@ public:
 
   const Value &dereference() const
   {
-    using Coord = decltype(src_->vertex(idx_).getCoords());
+    using Coord = decltype(src_->vertex(idx_).rawCoords());
     static_assert(
         std::is_reference<Coord>::value,
         "Coordinate type must be a reference!");
     static_assert(
         std::is_convertible<Coord, Value>::value,
         "Exposed and accessed types must match!");
-    return static_cast<const Value &>(src_->vertex(idx_).getCoords());
+    return static_cast<const Value &>(src_->vertex(idx_).rawCoords());
   }
 
   size_t equal(const IndexRangeIterator<Source, Value> &other) const

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -29,13 +29,13 @@ public:
    * The returned value is the forwarded result of Vertex::getCoords.
    * It is thus a read-only random-access iterator.
    */
-  using const_iterator = IndexRangeIterator<const Triangle, const Eigen::VectorXd>;
+  using const_iterator = IndexRangeIterator<const Triangle, const Vertex::RawCoords>;
 
   /// Type of the read-only random access vertex iterator
   using iterator = const_iterator;
 
   /// Fix for the Boost.Test versions 1.65.1 - 1.67
-  using value_type = Eigen::VectorXd;
+  using value_type = Vertex::RawCoords;
 
   /// Constructor, the order of edges defines the outer normal direction.
   Triangle(

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -7,7 +7,7 @@ namespace mesh {
 
 int Vertex::getDimensions() const
 {
-  return _coords.size();
+  return _dim;
 }
 
 const Eigen::VectorXd &Vertex::getNormal() const

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -100,10 +100,9 @@ Vertex::Vertex(
       _normal(Eigen::VectorXd::Constant(_dim, 0.0))
 {
   PRECICE_ASSERT(_dim == 2 || _dim == 3, _dim);
-  std::copy_n(coordinates.data(), _dim, _coords.begin());
-  if (_dim == 2) {
-    _coords[2] = 0.0;
-  };
+  _coords[0] = coordinates[0];
+  _coords[1] = coordinates[1];
+  _coords[2] = (_dim == 3) ? coordinates[2] : 0.0;
 }
 
 template <typename VECTOR_T>
@@ -111,10 +110,9 @@ void Vertex::setCoords(
     const VECTOR_T &coordinates)
 {
   PRECICE_ASSERT(coordinates.size() == _dim, coordinates.size(), _dim);
-  std::copy_n(coordinates.data(), _dim, _coords.begin());
-  if (_dim == 2) {
-    _coords[2] = 0.0;
-  };
+  _coords[0] = coordinates[0];
+  _coords[1] = coordinates[1];
+  _coords[2] = (_dim == 3) ? coordinates[2] : 0.0;
 }
 
 template <typename VECTOR_T>

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -135,11 +135,11 @@ BOOST_AUTO_TEST_CASE(Triangles)
       auto       ibegin = triangle.begin();
       const auto iend   = triangle.end();
       BOOST_TEST(std::distance(ibegin, iend) == 3);
-      BOOST_TEST(*ibegin == v0.getCoords());
+      BOOST_TEST(*ibegin == v0.rawCoords());
       ++ibegin;
-      BOOST_TEST(*ibegin == v1.getCoords());
+      BOOST_TEST(*ibegin == v1.rawCoords());
       ++ibegin;
-      BOOST_TEST(*ibegin == v2.getCoords());
+      BOOST_TEST(*ibegin == v2.rawCoords());
       ++ibegin;
       BOOST_TEST((ibegin == iend));
     }
@@ -149,11 +149,11 @@ BOOST_AUTO_TEST_CASE(Triangles)
       auto            ibegin    = ctriangle.begin();
       const auto      iend      = ctriangle.end();
       BOOST_TEST(std::distance(ibegin, iend) == 3);
-      BOOST_TEST(*ibegin == v0.getCoords());
+      BOOST_TEST(*ibegin == v0.rawCoords());
       ++ibegin;
-      BOOST_TEST(*ibegin == v1.getCoords());
+      BOOST_TEST(*ibegin == v1.rawCoords());
       ++ibegin;
-      BOOST_TEST(*ibegin == v2.getCoords());
+      BOOST_TEST(*ibegin == v2.rawCoords());
       ++ibegin;
       BOOST_TEST((ibegin == iend));
     }
@@ -162,11 +162,11 @@ BOOST_AUTO_TEST_CASE(Triangles)
       auto       ibegin = triangle.cbegin();
       const auto iend   = triangle.cend();
       BOOST_TEST(std::distance(ibegin, iend) == 3);
-      BOOST_TEST(*ibegin == v0.getCoords());
+      BOOST_TEST(*ibegin == v0.rawCoords());
       ++ibegin;
-      BOOST_TEST(*ibegin == v1.getCoords());
+      BOOST_TEST(*ibegin == v1.rawCoords());
       ++ibegin;
-      BOOST_TEST(*ibegin == v2.getCoords());
+      BOOST_TEST(*ibegin == v2.rawCoords());
       ++ibegin;
       BOOST_TEST((ibegin == iend));
     }

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -1,4 +1,6 @@
 #include "Index.hpp"
+#include <Eigen/src/Core/Matrix.h>
+#include <algorithm>
 #include <boost/range/irange.hpp>
 #include "impl/Indexer.hpp"
 #include "logging/LogMacros.hpp"
@@ -92,8 +94,8 @@ std::vector<size_t> Index::getVerticesInsideBox(const mesh::Vertex &centerVertex
   }
 
   // Prepare boost::geometry box
-  auto &          coords = centerVertex.getCoords();
-  query::RTreeBox searchBox{coords.array() - radius, coords.array() + radius};
+  auto coords    = centerVertex.getCoords();
+  auto searchBox = query::makeBox(coords.array() - radius, coords.array() + radius);
 
   std::vector<size_t> matches;
   _pimpl->indices.vertexRTree->query(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertices()[i]) <= radius; }),
@@ -111,7 +113,7 @@ std::vector<size_t> Index::getVerticesInsideBox(const mesh::BoundingBox &bb)
     event.stop();
   }
   std::vector<size_t> matches;
-  _pimpl->indices.vertexRTree->query(bgi::intersects(query::RTreeBox{bb.minCorner(), bb.maxCorner()}), std::back_inserter(matches));
+  _pimpl->indices.vertexRTree->query(bgi::intersects(query::makeBox(bb.minCorner(), bb.maxCorner())), std::back_inserter(matches));
   return matches;
 }
 

--- a/src/query/tests/RTreeAdapterTests.cpp
+++ b/src/query/tests/RTreeAdapterTests.cpp
@@ -17,6 +17,7 @@
 
 using namespace precice;
 using namespace precice::mesh;
+using namespace precice::query;
 
 namespace bg  = boost::geometry;
 namespace bgi = boost::geometry::index;
@@ -33,8 +34,6 @@ BOOST_AUTO_TEST_CASE(VectorAdapter)
   BOOST_TEST(bg::get<0>(vec) == 1);
   BOOST_TEST(bg::get<1>(vec) == 2);
   BOOST_TEST(bg::get<2>(vec) == 0);
-  bg::set<1>(vec, 5);
-  BOOST_TEST(bg::get<1>(vec) == 5);
 }
 
 BOOST_AUTO_TEST_CASE(VertexAdapter)
@@ -45,8 +44,20 @@ BOOST_AUTO_TEST_CASE(VertexAdapter)
   BOOST_TEST(bg::get<0>(v) == 1);
   BOOST_TEST(bg::get<1>(v) == 2);
   BOOST_TEST(bg::get<2>(v) == 0);
+}
+
+BOOST_AUTO_TEST_CASE(RawCoordinateAdapter)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex::RawCoords v{1, 2, 3};
+  BOOST_TEST(bg::get<0>(v) == 1);
+  BOOST_TEST(bg::get<1>(v) == 2);
+  BOOST_TEST(bg::get<2>(v) == 3);
   bg::set<1>(v, 5);
+  bg::set<2>(v, 1);
+  BOOST_TEST(bg::get<0>(v) == 1);
   BOOST_TEST(bg::get<1>(v) == 5);
+  BOOST_TEST(bg::get<2>(v) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeAdapter)
@@ -62,8 +73,6 @@ BOOST_AUTO_TEST_CASE(EdgeAdapter)
   BOOST_TEST((bg::get<1, 0>(e)) == 3.0);
   BOOST_TEST((bg::get<1, 1>(e)) == 4.0);
   BOOST_TEST((bg::get<1, 2>(e)) == 0.0);
-  bg::set<1, 1>(e, 5.0);
-  BOOST_TEST((bg::get<1, 1>(e)) == 5.0);
 }
 
 BOOST_AUTO_TEST_CASE(TriangleAdapter)
@@ -78,14 +87,14 @@ BOOST_AUTO_TEST_CASE(TriangleAdapter)
   auto &              e3 = mesh.createEdge(v3, v1);
   auto &              t  = mesh.createTriangle(e1, e2, e3);
 
-  std::vector<Eigen::VectorXd> vertices(t.begin(), t.end());
-  std::vector<Eigen::VectorXd> refs{v1.getCoords(), v2.getCoords(), v3.getCoords()};
+  std::vector<Vertex::RawCoords> vertices(t.begin(), t.end());
+  std::vector<Vertex::RawCoords> refs{v1.rawCoords(), v2.rawCoords(), v3.rawCoords()};
   BOOST_TEST(vertices.size() == refs.size());
   BOOST_TEST((std::is_permutation(
       vertices.begin(), vertices.end(),
       refs.begin(),
-      [](const Eigen::VectorXd &lhs, const Eigen::VectorXd &rhs) {
-        return precice::math::equals(lhs, rhs);
+      [](const auto &lhs, const auto &rhs) {
+        return precice::math::equals(rawToEigen(lhs), rawToEigen(rhs));
       })));
 }
 
@@ -214,7 +223,6 @@ BOOST_AUTO_TEST_CASE(DistanceTestSlopedTriangle)
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
 {
   PRECICE_TEST(1_rank);
-  using precice::testing::equals;
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto &              v1  = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto &              v2  = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
@@ -224,14 +232,19 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleClockWise)
   auto &              e3  = mesh.createEdge(v3, v1);
   auto &              t   = mesh.createTriangle(e1, e2, e3);
   auto                box = bg::return_envelope<precice::query::RTreeBox>(t);
-  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0, 0, 0}));
-  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1, 1, 1}));
+  auto                min = box.min_corner();
+  BOOST_TEST(min[0] == 0.0);
+  BOOST_TEST(min[1] == 0.0);
+  BOOST_TEST(min[2] == 0.0);
+  auto max = box.max_corner();
+  BOOST_TEST(max[0] == 1.0);
+  BOOST_TEST(max[1] == 1.0);
+  BOOST_TEST(max[2] == 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
 {
   PRECICE_TEST(1_rank);
-  using precice::testing::equals;
   precice::mesh::Mesh mesh("MyMesh", 3, false, testing::nextMeshID());
   auto &              v1  = mesh.createVertex(Eigen::Vector3d(0, 1, 0));
   auto &              v2  = mesh.createVertex(Eigen::Vector3d(1, 1, 1));
@@ -241,8 +254,14 @@ BOOST_AUTO_TEST_CASE(EnvelopeTriangleCounterclockWise)
   auto &              e3  = mesh.createEdge(v2, v1);
   auto &              t   = mesh.createTriangle(e1, e2, e3);
   auto                box = bg::return_envelope<precice::query::RTreeBox>(t);
-  BOOST_TEST(equals(box.min_corner(), Eigen::Vector3d{0, 0, 0}));
-  BOOST_TEST(equals(box.max_corner(), Eigen::Vector3d{1, 1, 1}));
+  auto                min = box.min_corner();
+  BOOST_TEST(min[0] == 0.0);
+  BOOST_TEST(min[1] == 0.0);
+  BOOST_TEST(min[2] == 0.0);
+  auto max = box.max_corner();
+  BOOST_TEST(max[0] == 1.0);
+  BOOST_TEST(max[1] == 1.0);
+  BOOST_TEST(max[2] == 1.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // BG Adapters


### PR DESCRIPTION
## Main changes of this PR

In a nutshell, this PR changes the coordinate representation of vertices from an `Eigen::VectorXd` to an `std::array<double,3>` plus a `short dim`.

The primary motivation is to reduce the memory footprint as already discussed in #483.
What used to be a 16B object plus 16B/24B dynamic allocation for 2D/3D is now a 24B array plus ~8B for the dimension.
In theory, this leads to no change for 2D and an 8B saving for 3D; in practise, the compiler packs the dimension with the other members resulting in a gain even for ~~3D~~ 2D.
As a bonus, this change reduces dynamic allocations by `Eigen::VectorXd` and improves data locality.

The `mesh::Vertex` now offers two ways to access the coordinate:
```cpp
// Direct access to the coordinate buffer.
// Use getDimensions() to get the dimensionality
const std::array<double, 3> & Vertex::rawCoords() const;

// Constructs and returns Eigen::VectorXd.
Eigen::VectorXd Vertex::getCoords() const;
```

## Motivation and additional information

The memory overhead of meshes unnecessarily big!
See #483 for more details.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
