### PR TITLE
Fix read and write validation macros

### DIFF
--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -104,11 +104,10 @@
  */
 #define PRECICE_REQUIRE_DATA_READ_IMPL(id)                                                                                  \
   PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                         \
-  DataContext &context = _accessor->dataContext(id);                                                                        \
   PRECICE_CHECK((_accessor->isDataUsed(id) && _accessor->isDataRead(id)),                                                   \
                 "This participant does not use Data \"{}\", but attempted to read it. "                                     \
                 "Please extend the configuarion of partiticpant \"{}\" by defining <read-data mesh=\"{}\" name=\"{}\" />.", \
-                context.getName(), _accessorName, context.mesh->getName(), context.getName());
+                "context.getName()", _accessorName, "context.mesh->getName()", "context.getName()");
 
 /** Implementation of PRECICE_REQUIRE_DATA_WRITE()
  *
@@ -116,11 +115,10 @@
  */
 #define PRECICE_REQUIRE_DATA_WRITE_IMPL(id)                                                                                  \
   PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                          \
-  DataContext &context = _accessor->dataContext(id);                                                                         \
   PRECICE_CHECK((_accessor->isDataUsed(id) && _accessor->isDataWrite(id)),                                                   \
                 "This participant does not use Data \"{}\", but attempted to write it. "                                     \
                 "Please extend the configuarion of partiticpant \"{}\" by defining <write-data mesh=\"{}\" name=\"{}\" />.", \
-                context.getName(), _accessorName, context.mesh->getName(), context.getName());
+                "context.getName()", _accessorName, "context.mesh->getName()", "context.getName()");
 
 /// Validates a given dataID
 #define PRECICE_VALIDATE_DATA_ID(dataID) \


### PR DESCRIPTION
## Main changes of this PR
Fixes #989.

## Motivation and additional information
The validation macros don't work with the current implementation. The reason is pretty simple by looking at the following three code snippets:
The check:

https://github.com/precice/precice/blob/813de05a87270ae9194bb4a499895a9fab4caef9/src/precice/impl/ValidationMacros.hpp#L117-L123

The assertion we hit
https://github.com/precice/precice/blob/813de05a87270ae9194bb4a499895a9fab4caef9/src/precice/impl/Participant.cpp#L155-L160

Definition of `is_used` 
https://github.com/precice/precice/blob/813de05a87270ae9194bb4a499895a9fab4caef9/src/precice/impl/Participant.cpp#L207-L212

Hence, we try to access the `dataContext` in order to print an error message although the `dataContext` might be `nullptr`, which is also the case we want to catch here. I don't see a method how we can access the data name in the validation macros in order to print a descriptive error message without the `dataAccessor`. The applied changes are more a dummy to illustrate the problem.
## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)