### PR TITLE
remove bits/c++config.h

### DIFF
--- a/src/utils/fmtSTL.hpp
+++ b/src/utils/fmtSTL.hpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <bits/c++config.h>
 #include <deque>
 #include <fmt/format.h>
 #include <map>


### PR DESCRIPTION
## Main changes of this PR
This include causes macOS build to fail and seems unnecessary anyways. See #1011 

## Motivation and additional information

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)