### PR TITLE
Remove syncmode in indexing

### DIFF
--- a/docs/changelog/1022.md
+++ b/docs/changelog/1022.md
@@ -1,0 +1,1 @@
+- Fixed a bug leading to freezed when using `sync-mode` with lazy indexing.

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -34,9 +34,8 @@ VertexMatch Index::getClosestVertex(const Eigen::VectorXd &sourceCoord)
   PRECICE_TRACE();
   // Add tree to the local cache
   if (not _pimpl->indices.vertexRTree) {
-    precice::utils::Event event("query.index.getVertexIndexTree." + _mesh->getName(), precice::syncMode);
+    precice::utils::Event e("query.index.getVertexIndexTree." + _mesh->getName());
     _pimpl->indices.vertexRTree = impl::Indexer::instance()->getVertexRTree(_mesh);
-    event.stop();
   }
 
   PRECICE_ASSERT(not _mesh->vertices().empty(), _mesh->getName());
@@ -52,9 +51,8 @@ std::vector<EdgeMatch> Index::getClosestEdges(const Eigen::VectorXd &sourceCoord
   PRECICE_TRACE();
   // Add tree to the local cache
   if (not _pimpl->indices.edgeRTree) {
-    precice::utils::Event event("query.index.getEdgeIndexTree." + _mesh->getName(), precice::syncMode);
+    precice::utils::Event e("query.index.getEdgeIndexTree." + _mesh->getName());
     _pimpl->indices.edgeRTree = impl::Indexer::instance()->getEdgeRTree(_mesh);
-    event.stop();
   }
 
   std::vector<EdgeMatch> matches;
@@ -70,9 +68,8 @@ std::vector<TriangleMatch> Index::getClosestTriangles(const Eigen::VectorXd &sou
   PRECICE_TRACE();
   // Add tree to the local cache
   if (not _pimpl->indices.triangleRTree) {
-    precice::utils::Event event("query.index.getTriangleIndexTree." + _mesh->getName(), precice::syncMode);
+    precice::utils::Event e("query.index.getTriangleIndexTree." + _mesh->getName());
     _pimpl->indices.triangleRTree = impl::Indexer::instance()->getTriangleRTree(_mesh);
-    event.stop();
   }
 
   std::vector<TriangleMatch> matches;
@@ -89,9 +86,8 @@ std::vector<size_t> Index::getVerticesInsideBox(const mesh::Vertex &centerVertex
   PRECICE_TRACE();
   // Add tree to the local cache
   if (_pimpl->indices.vertexRTree == nullptr) {
-    precice::utils::Event event("query.index.getVertexIndexTree." + _mesh->getName(), precice::syncMode);
+    precice::utils::Event e("query.index.getVertexIndexTree." + _mesh->getName());
     _pimpl->indices.vertexRTree = impl::Indexer::instance()->getVertexRTree(_mesh);
-    event.stop();
   }
 
   // Prepare boost::geometry box
@@ -109,9 +105,8 @@ std::vector<size_t> Index::getVerticesInsideBox(const mesh::BoundingBox &bb)
   PRECICE_TRACE();
   // Add tree to the local cache
   if (not _pimpl->indices.vertexRTree) {
-    precice::utils::Event event("query.index.getVertexIndexTree." + _mesh->getName(), precice::syncMode);
+    precice::utils::Event e("query.index.getVertexIndexTree." + _mesh->getName());
     _pimpl->indices.vertexRTree = impl::Indexer::instance()->getVertexRTree(_mesh);
-    event.stop();
   }
   std::vector<size_t> matches;
   _pimpl->indices.vertexRTree->query(bgi::intersects(query::makeBox(bb.minCorner(), bb.maxCorner())), std::back_inserter(matches));


### PR DESCRIPTION
## Main changes of this PR

This PR removes the syncmode of events in the indexing logic.
Indexing is done lazily and will lead to ranks partially synchronizing at barriers.
This fix will be backported to version 2.2.1.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
