### PR TITLE
Simplify MasterSlave use-cases

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -124,7 +124,7 @@ void BaseQNAcceleration::initialize(
    *  last entry _dimOffsets[MasterSlave::getSize()] holds the global dimension, global,n
    */
   std::stringstream ss;
-  if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
+  if (utils::MasterSlave::isParallel()) {
     PRECICE_ASSERT(utils::MasterSlave::_communication.get() != nullptr);
     PRECICE_ASSERT(utils::MasterSlave::_communication->isConnected());
 
@@ -506,7 +506,7 @@ void BaseQNAcceleration::iterationsConverged(
 {
   PRECICE_TRACE();
 
-  if (utils::MasterSlave::isMaster() || (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()))
+  if (utils::MasterSlave::isMaster() || !utils::MasterSlave::isParallel())
     _infostringstream << "# time window " << tWindows << " converged #\n iterations: " << its
                       << "\n used cols: " << getLSSystemCols() << "\n del cols: " << _nbDelCols << '\n';
 
@@ -655,7 +655,7 @@ int BaseQNAcceleration::getLSSystemCols() const
 
 int BaseQNAcceleration::getLSSystemRows()
 {
-  if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
+  if (utils::MasterSlave::isParallel()) {
     return _dimOffsets.back();
   }
   return _residuals.size();
@@ -664,7 +664,7 @@ int BaseQNAcceleration::getLSSystemRows()
 void BaseQNAcceleration::writeInfo(
     std::string s, bool allProcs)
 {
-  if (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()) {
+  if (not utils::MasterSlave::isParallel()) {
     // serial acceleration mode
     _infostringstream << s;
 

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -78,7 +78,7 @@ public:
   virtual ~BaseQNAcceleration()
   {
     // not necessary for user, only for developer, if needed, this should be configurable
-    //     if (utils::MasterSlave::isMaster() || (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave())){
+    //     if (utils::MasterSlave::isMaster() || !utils::MasterSlave::isParallel()) {
     //       _infostream.open("precice-accelerationInfo.log", std::ios_base::out);
     //       _infostream << std::setprecision(16);
     //       _infostream << _infostringstream.str();

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -161,7 +161,7 @@ void IQNILSAcceleration::computeQNUpdate(Acceleration::DataMap &cplData, Eigen::
   utils::append(c, (Eigen::VectorXd) Eigen::VectorXd::Zero(_local_b.size()));
 
   // compute rhs Q^T*res in parallel
-  if (! utils::MasterSlave::isParallel()) {
+  if (!utils::MasterSlave::isParallel()) {
     PRECICE_ASSERT(Q.cols() == getLSSystemCols(), Q.cols(), getLSSystemCols());
     // back substitution
     c = R.triangularView<Eigen::Upper>().solve<Eigen::OnTheLeft>(_local_b);

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -86,7 +86,7 @@ void MVQNAcceleration::initialize(
   int entries  = _residuals.size();
   int global_n = 0;
 
-  if (! utils::MasterSlave::isParallel()) {
+  if (!utils::MasterSlave::isParallel()) {
     global_n = entries;
   } else {
     global_n = _dimOffsets.back();

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -86,7 +86,7 @@ void MVQNAcceleration::initialize(
   int entries  = _residuals.size();
   int global_n = 0;
 
-  if (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()) {
+  if (! utils::MasterSlave::isParallel()) {
     global_n = entries;
   } else {
     global_n = _dimOffsets.back();
@@ -105,9 +105,10 @@ void MVQNAcceleration::initialize(
   }
   _Wtil = Eigen::MatrixXd::Zero(entries, 0);
 
-  if (utils::MasterSlave::isMaster() || (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()))
+  if (utils::MasterSlave::isMaster() || !utils::MasterSlave::isParallel()) {
     _infostringstream << " IMVJ restart mode: " << _imvjRestart << "\n chunk size: " << _chunkSize << "\n trunc eps: " << _svdJ.getThreshold() << "\n R_RS: " << _RSLSreusedTimeWindows << "\n--------\n"
                       << '\n';
+  }
 }
 
 // ==================================================================================
@@ -553,9 +554,10 @@ void MVQNAcceleration::restartIMVJ()
 
     PRECICE_DEBUG("MVJ-RESTART, mode=SVD. Rank of truncated SVD of Jacobian {}, new modes: {}, truncated modes: {} avg rank: {}", rankAfter, rankAfter - rankBefore, waste, _avgRank / _nbRestarts);
     //double percentage = 100.0*used_storage/(double)theoreticalJ_storage;
-    if (utils::MasterSlave::isMaster() || (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()))
+    if (utils::MasterSlave::isMaster() || !utils::MasterSlave::isParallel()) {
       _infostringstream << " - MVJ-RESTART " << _nbRestarts << ", mode= SVD -\n  new modes: " << rankAfter - rankBefore << "\n  rank svd: " << rankAfter << "\n  avg rank: " << _avgRank / _nbRestarts << "\n  truncated modes: " << waste << "\n"
                         << '\n';
+    }
 
     //        ------------ RESTART LEAST SQUARES ------------
   } else if (_imvjRestartType == MVQNAcceleration::RS_LS) {
@@ -630,9 +632,10 @@ void MVQNAcceleration::restartIMVJ()
     }
 
     PRECICE_DEBUG("MVJ-RESTART, mode=LS. Restart with {} columns from {} time windows.", _matrixV_RSLS.cols(), _RSLSreusedTimeWindows);
-    if (utils::MasterSlave::isMaster() || (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()))
+    if (utils::MasterSlave::isMaster() || !utils::MasterSlave::isParallel()) {
       _infostringstream << " - MVJ-RESTART" << _nbRestarts << ", mode= LS -\n  used cols: " << _matrixV_RSLS.cols() << "\n  R_RS: " << _RSLSreusedTimeWindows << "\n"
                         << '\n';
+    }
 
     //            ------------ RESTART ZERO ------------
   } else if (_imvjRestartType == MVQNAcceleration::RS_ZERO) {

--- a/src/acceleration/impl/ParallelMatrixOperations.cpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.cpp
@@ -11,7 +11,7 @@ void ParallelMatrixOperations::initialize(const bool needCyclicComm)
 {
   PRECICE_TRACE();
 
-  if (needCyclicComm && (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave())) {
+  if (needCyclicComm && utils::MasterSlave::isParallel()) {
     _needCyclicComm = true;
     establishCircularCommunication();
   } else {

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -41,7 +41,7 @@ public:
     PRECICE_ASSERT(leftMatrix.cols() == rightMatrix.rows(), leftMatrix.cols(), rightMatrix.rows());
 
     // if serial computation on single processor, i.e, no master-slave mode
-    if (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()) {
+    if (!utils::MasterSlave::isParallel()) {
       result.noalias() = leftMatrix * rightMatrix;
 
       // if parallel computation on p processors, i.e., master-slave mode
@@ -101,7 +101,7 @@ public:
     localResult.noalias() = leftMatrix * rightMatrix;
 
     // if serial computation on single processor, i.e, no master-slave mode
-    if (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()) {
+    if (! utils::MasterSlave::isParallel()) {
       result = localResult;
     } else {
       utils::MasterSlave::allreduceSum(localResult.data(), result.data(), localResult.size());

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -291,7 +291,7 @@ private:
       // distribute blocks of summarizedBlocks (result of multiplication) to corresponding slaves
       result = summarizedBlocks.block(0, 0, offsets[1], r);
 
-      for (int rankSlave : utils::MasterSlave::slaves()) {
+      for (int rankSlave : utils::MasterSlave::allSlaves()) {
         int off       = offsets[rankSlave];
         int send_rows = offsets[rankSlave + 1] - offsets[rankSlave];
 

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -291,7 +291,7 @@ private:
       // distribute blocks of summarizedBlocks (result of multiplication) to corresponding slaves
       result = summarizedBlocks.block(0, 0, offsets[1], r);
 
-      for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+      for (int rankSlave : utils::MasterSlave::slaves()) {
         int off       = offsets[rankSlave];
         int send_rows = offsets[rankSlave + 1] - offsets[rankSlave];
 

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -101,7 +101,7 @@ public:
     localResult.noalias() = leftMatrix * rightMatrix;
 
     // if serial computation on single processor, i.e, no master-slave mode
-    if (! utils::MasterSlave::isParallel()) {
+    if (!utils::MasterSlave::isParallel()) {
       result = localResult;
     } else {
       utils::MasterSlave::allreduceSum(localResult.data(), result.data(), localResult.size());

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -587,7 +587,7 @@ int QRFactorization::orthogonalize_stable(
         v = Eigen::VectorXd::Zero(_rows);
 
         // insert rho1 at position k with smallest u(i) = Q(i,:) * Q(i,:)
-        if (! utils::MasterSlave::isParallel()) {
+        if (!utils::MasterSlave::isParallel()) {
           v(k) = rho1;
         } else {
           if (utils::MasterSlave::getRank() == rank)

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -565,7 +565,7 @@ int QRFactorization::orthogonalize_stable(
 
         if (utils::MasterSlave::isMaster()) {
           global_uk = u(k);
-          for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+          for (int rankSlave : utils::MasterSlave::slaves()) {
             utils::MasterSlave::_communication->receive(local_k, rankSlave);
             utils::MasterSlave::_communication->receive(local_uk, rankSlave);
             if (local_uk < global_uk) {

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -318,7 +318,7 @@ int QRFactorization::orthogonalize(
 {
   PRECICE_TRACE();
 
-  if (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()) {
+  if (!utils::MasterSlave::isParallel()) {
     PRECICE_ASSERT(_globalRows == _rows, _globalRows, _rows);
   }
 
@@ -434,7 +434,7 @@ int QRFactorization::orthogonalize_stable(
   PRECICE_TRACE();
 
   // serial case
-  if (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()) {
+  if (!utils::MasterSlave::isParallel()) {
     PRECICE_ASSERT(_globalRows == _rows, _globalRows, _rows);
   }
 
@@ -587,7 +587,7 @@ int QRFactorization::orthogonalize_stable(
         v = Eigen::VectorXd::Zero(_rows);
 
         // insert rho1 at position k with smallest u(i) = Q(i,:) * Q(i,:)
-        if (not utils::MasterSlave::isMaster() && not utils::MasterSlave::isSlave()) {
+        if (! utils::MasterSlave::isParallel()) {
           v(k) = rho1;
         } else {
           if (utils::MasterSlave::getRank() == rank)

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -565,7 +565,7 @@ int QRFactorization::orthogonalize_stable(
 
         if (utils::MasterSlave::isMaster()) {
           global_uk = u(k);
-          for (int rankSlave : utils::MasterSlave::slaves()) {
+          for (int rankSlave : utils::MasterSlave::allSlaves()) {
             utils::MasterSlave::_communication->receive(local_k, rankSlave);
             utils::MasterSlave::_communication->receive(local_uk, rankSlave);
             if (local_uk < global_uk) {

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -32,7 +32,7 @@ void ExportVTKXML::doExport(
     mesh::Mesh &       mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
-  PRECICE_ASSERT(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster());
+  PRECICE_ASSERT(utils::MasterSlave::isParallel());
   processDataNamesAndDimensions(mesh);
   if (not location.empty())
     boost::filesystem::create_directories(location);

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -80,7 +80,7 @@ void BoundM2N::cleanupEstablishment()
 void BoundM2N::waitForSlaves()
 {
   if (utils::MasterSlave::isMaster()) {
-    for (int rank : utils::MasterSlave::slaves()) {
+    for (int rank : utils::MasterSlave::allSlaves()) {
       int item = 0;
       utils::MasterSlave::_communication->receive(item, rank);
       PRECICE_ASSERT(item > 0);

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -80,7 +80,7 @@ void BoundM2N::cleanupEstablishment()
 void BoundM2N::waitForSlaves()
 {
   if (utils::MasterSlave::isMaster()) {
-    for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+    for (int rank : utils::MasterSlave::slaves()) {
       int item = 0;
       utils::MasterSlave::_communication->receive(item, rank);
       PRECICE_ASSERT(item > 0);

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -87,7 +87,7 @@ void GatherScatterCommunication::send(
     }
 
     // Slaves data
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       PRECICE_ASSERT(utils::MasterSlave::_communication.get() != nullptr);
       PRECICE_ASSERT(utils::MasterSlave::_communication->isConnected());
 
@@ -145,7 +145,7 @@ void GatherScatterCommunication::receive(
     }
 
     // Slaves data
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       PRECICE_ASSERT(utils::MasterSlave::_communication.get() != nullptr);
       PRECICE_ASSERT(utils::MasterSlave::_communication->isConnected());
 

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -87,7 +87,7 @@ void GatherScatterCommunication::send(
     }
 
     // Slaves data
-    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+    for (int rankSlave : utils::MasterSlave::slaves()) {
       PRECICE_ASSERT(utils::MasterSlave::_communication.get() != nullptr);
       PRECICE_ASSERT(utils::MasterSlave::_communication->isConnected());
 
@@ -145,7 +145,7 @@ void GatherScatterCommunication::receive(
     }
 
     // Slaves data
-    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+    for (int rankSlave : utils::MasterSlave::slaves()) {
       PRECICE_ASSERT(utils::MasterSlave::_communication.get() != nullptr);
       PRECICE_ASSERT(utils::MasterSlave::_communication->isConnected());
 

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -234,7 +234,7 @@ void M2N::send(double itemToSend)
 void M2N::broadcastSendMesh(mesh::Mesh &mesh)
 {
   int meshID = mesh.getID();
-  PRECICE_ASSERT(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster(),
+  PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
   PRECICE_ASSERT(_areSlavesConnected);
   PRECICE_ASSERT(_distComs.find(meshID) != _distComs.end());
@@ -245,7 +245,7 @@ void M2N::broadcastSendMesh(mesh::Mesh &mesh)
 void M2N::scatterAllCommunicationMap(std::map<int, std::vector<int>> &localCommunicationMap,
                                      mesh::Mesh &                     mesh)
 {
-  PRECICE_ASSERT(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster(),
+  PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
   int meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
@@ -254,7 +254,7 @@ void M2N::scatterAllCommunicationMap(std::map<int, std::vector<int>> &localCommu
 
 void M2N::broadcastSend(int &itemToSend, mesh::Mesh &mesh)
 {
-  PRECICE_ASSERT(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster(),
+  PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
   int meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
@@ -314,7 +314,7 @@ void M2N::receive(double &itemToReceive)
 
 void M2N::broadcastReceiveAll(std::vector<int> &itemToReceive, mesh::Mesh &mesh)
 {
-  PRECICE_ASSERT(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster(),
+  PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
   int meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
@@ -323,7 +323,7 @@ void M2N::broadcastReceiveAll(std::vector<int> &itemToReceive, mesh::Mesh &mesh)
 
 void M2N::broadcastReceiveAllMesh(mesh::Mesh &mesh)
 {
-  PRECICE_ASSERT(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster(),
+  PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
   int meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
@@ -334,7 +334,7 @@ void M2N::broadcastReceiveAllMesh(mesh::Mesh &mesh)
 
 void M2N::gatherAllCommunicationMap(std::map<int, std::vector<int>> &localCommunicationMap, mesh::Mesh &mesh)
 {
-  PRECICE_ASSERT(utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster(),
+  PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
   int meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -114,7 +114,7 @@ void print(std::map<int, std::vector<int>> const &m)
 
     std::string s;
 
-    for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+    for (int rank : utils::MasterSlave::slaves()) {
       utils::MasterSlave::_communication->receive(s, rank);
 
       oss << s;
@@ -140,7 +140,7 @@ void printCommunicationPartnerCountStats(std::map<int, std::vector<int>> const &
       count++;
     }
 
-    for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+    for (int rank : utils::MasterSlave::slaves()) {
       utils::MasterSlave::_communication->receive(size, rank);
 
       total += size;
@@ -196,7 +196,7 @@ void printLocalIndexCountStats(std::map<int, std::vector<int>> const &m)
       count++;
     }
 
-    for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+    for (int rank : utils::MasterSlave::slaves()) {
       utils::MasterSlave::_communication->receive(size, rank);
 
       total += size;

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -114,7 +114,7 @@ void print(std::map<int, std::vector<int>> const &m)
 
     std::string s;
 
-    for (int rank : utils::MasterSlave::slaves()) {
+    for (int rank : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(s, rank);
 
       oss << s;
@@ -140,7 +140,7 @@ void printCommunicationPartnerCountStats(std::map<int, std::vector<int>> const &
       count++;
     }
 
-    for (int rank : utils::MasterSlave::slaves()) {
+    for (int rank : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(size, rank);
 
       total += size;
@@ -196,7 +196,7 @@ void printLocalIndexCountStats(std::map<int, std::vector<int>> const &m)
       count++;
     }
 
-    for (int rank : utils::MasterSlave::slaves()) {
+    for (int rank : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(size, rank);
 
       total += size;

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -174,7 +174,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       }
 
       // Receive mesh
-      for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); ++rankSlave) {
+      for (int rankSlave : utils::MasterSlave::slaves()) {
         mesh::Mesh slaveInMesh(inMesh->getName(), inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
         com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(slaveInMesh, rankSlave);
         globalInMesh.addMesh(slaveInMesh);
@@ -297,7 +297,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(int inputDa
     {
       std::vector<double> slaveBuffer;
       int                 slaveOutputValueSize;
-      for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+      for (int rank : utils::MasterSlave::slaves()) {
         utils::MasterSlave::_communication->receive(slaveBuffer, rank);
         globalInValues.insert(globalInValues.end(), slaveBuffer.begin(), slaveBuffer.end());
 
@@ -347,7 +347,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(int inputDa
 
       // Data scattering to slaves
       int beginPoint = outputValueSizes.at(0);
-      for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+      for (int rank : utils::MasterSlave::slaves()) {
         utils::MasterSlave::_communication->send(outputValues.data() + beginPoint, outputValueSizes.at(rank), rank);
         beginPoint += outputValueSizes.at(rank);
       }
@@ -408,7 +408,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(int inputData
 
       std::vector<double> slaveBuffer;
 
-      for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+      for (int rank : utils::MasterSlave::slaves()) {
         utils::MasterSlave::_communication->receive(slaveBuffer, rank);
         std::copy(slaveBuffer.begin(), slaveBuffer.end(), globalInValues.begin() + inputSizeCounter);
         inputSizeCounter += slaveBuffer.size();
@@ -456,7 +456,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(int inputData
     int beginPoint = outValuesSize.at(0);
 
     if (utils::MasterSlave::isMaster()) {
-      for (int rank = 1; rank < utils::MasterSlave::getSize(); ++rank) {
+      for (int rank : utils::MasterSlave::slaves()) {
         utils::MasterSlave::_communication->send(outputValues.data() + beginPoint, outValuesSize.at(rank), rank);
         beginPoint += outValuesSize.at(rank);
       }

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -174,7 +174,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       }
 
       // Receive mesh
-      for (int rankSlave : utils::MasterSlave::slaves()) {
+      for (int rankSlave : utils::MasterSlave::allSlaves()) {
         mesh::Mesh slaveInMesh(inMesh->getName(), inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
         com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(slaveInMesh, rankSlave);
         globalInMesh.addMesh(slaveInMesh);
@@ -297,7 +297,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(int inputDa
     {
       std::vector<double> slaveBuffer;
       int                 slaveOutputValueSize;
-      for (int rank : utils::MasterSlave::slaves()) {
+      for (int rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->receive(slaveBuffer, rank);
         globalInValues.insert(globalInValues.end(), slaveBuffer.begin(), slaveBuffer.end());
 
@@ -347,7 +347,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(int inputDa
 
       // Data scattering to slaves
       int beginPoint = outputValueSizes.at(0);
-      for (int rank : utils::MasterSlave::slaves()) {
+      for (int rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->send(outputValues.data() + beginPoint, outputValueSizes.at(rank), rank);
         beginPoint += outputValueSizes.at(rank);
       }
@@ -408,7 +408,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(int inputData
 
       std::vector<double> slaveBuffer;
 
-      for (int rank : utils::MasterSlave::slaves()) {
+      for (int rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->receive(slaveBuffer, rank);
         std::copy(slaveBuffer.begin(), slaveBuffer.end(), globalInValues.begin() + inputSizeCounter);
         inputSizeCounter += slaveBuffer.size();
@@ -456,7 +456,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(int inputData
     int beginPoint = outValuesSize.at(0);
 
     if (utils::MasterSlave::isMaster()) {
-      for (int rank : utils::MasterSlave::slaves()) {
+      for (int rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->send(outputValues.data() + beginPoint, outValuesSize.at(rank), rank);
         beginPoint += outValuesSize.at(rank);
       }

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -88,7 +88,7 @@ void ProvidedPartition::communicate()
           PRECICE_ASSERT(utils::MasterSlave::getRank() == 0);
           PRECICE_ASSERT(utils::MasterSlave::getSize() > 1);
 
-          for (int rankSlave : utils::MasterSlave::slaves()) {
+          for (int rankSlave : utils::MasterSlave::allSlaves()) {
             com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(globalMesh, rankSlave);
             PRECICE_DEBUG("Received sub-mesh, from slave: {}, global vertexCount: {}", rankSlave, globalMesh.vertices().size());
           }
@@ -134,7 +134,7 @@ void ProvidedPartition::prepare()
     int globalNumberOfVertices   = numberOfVertices;
 
     // receive number of slave vertices and fill vertex offsets
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       int numberOfSlaveVertices = -1;
       utils::MasterSlave::_communication->receive(numberOfSlaveVertices, rankSlave);
       _mesh->getVertexOffsets()[rankSlave] = numberOfSlaveVertices + _mesh->getVertexOffsets()[rankSlave - 1];
@@ -159,7 +159,7 @@ void ProvidedPartition::prepare()
         for (int i = 0; i < _mesh->getVertexOffsets()[0]; i++) {
           localIds.push_back(i);
         }
-        for (int rankSlave : utils::MasterSlave::slaves()) {
+        for (int rankSlave : utils::MasterSlave::allSlaves()) {
           // This always creates an entry for each slave
           auto &slaveIds = _mesh->getVertexDistribution()[rankSlave];
           for (int i = _mesh->getVertexOffsets()[rankSlave - 1]; i < _mesh->getVertexOffsets()[rankSlave]; i++) {
@@ -250,7 +250,7 @@ void ProvidedPartition::compareBoundingBoxes()
     PRECICE_ASSERT(!bbm.empty(), "The bounding box of the local mesh is invalid!");
 
     // master receives bbs from slaves and stores them in bbm
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       // initialize bbm
       bbm.emplace(rankSlave, bb);
       com::CommunicateBoundingBox(utils::MasterSlave::_communication).receiveBoundingBox(bbm.at(rankSlave), rankSlave);

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -88,7 +88,7 @@ void ProvidedPartition::communicate()
           PRECICE_ASSERT(utils::MasterSlave::getRank() == 0);
           PRECICE_ASSERT(utils::MasterSlave::getSize() > 1);
 
-          for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+          for (int rankSlave : utils::MasterSlave::slaves()) {
             com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(globalMesh, rankSlave);
             PRECICE_DEBUG("Received sub-mesh, from slave: {}, global vertexCount: {}", rankSlave, globalMesh.vertices().size());
           }
@@ -134,7 +134,7 @@ void ProvidedPartition::prepare()
     int globalNumberOfVertices   = numberOfVertices;
 
     // receive number of slave vertices and fill vertex offsets
-    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+    for (int rankSlave : utils::MasterSlave::slaves()) {
       int numberOfSlaveVertices = -1;
       utils::MasterSlave::_communication->receive(numberOfSlaveVertices, rankSlave);
       _mesh->getVertexOffsets()[rankSlave] = numberOfSlaveVertices + _mesh->getVertexOffsets()[rankSlave - 1];
@@ -159,7 +159,7 @@ void ProvidedPartition::prepare()
         for (int i = 0; i < _mesh->getVertexOffsets()[0]; i++) {
           localIds.push_back(i);
         }
-        for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+        for (int rankSlave : utils::MasterSlave::slaves()) {
           // This always creates an entry for each slave
           auto &slaveIds = _mesh->getVertexDistribution()[rankSlave];
           for (int i = _mesh->getVertexOffsets()[rankSlave - 1]; i < _mesh->getVertexOffsets()[rankSlave]; i++) {
@@ -250,7 +250,7 @@ void ProvidedPartition::compareBoundingBoxes()
     PRECICE_ASSERT(!bbm.empty(), "The bounding box of the local mesh is invalid!");
 
     // master receives bbs from slaves and stores them in bbm
-    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+    for (int rankSlave : utils::MasterSlave::slaves()) {
       // initialize bbm
       bbm.emplace(rankSlave, bb);
       com::CommunicateBoundingBox(utils::MasterSlave::_communication).receiveBoundingBox(bbm.at(rankSlave), rankSlave);

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -91,7 +91,7 @@ void ReceivedPartition::compute()
   PRECICE_TRACE();
 
   // handle coupling mode first (i.e. serial participant)
-  if (not utils::MasterSlave::isSlave() && not utils::MasterSlave::isMaster()) { //coupling mode
+  if (! utils::MasterSlave::isParallel()) { //coupling mode
     PRECICE_DEBUG("Handle partition data structures for serial participant");
     int vertexCounter = 0;
     for (mesh::Vertex &v : _mesh->vertices()) {

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -192,7 +192,7 @@ void ReceivedPartition::compute()
       }
       _mesh->getVertexDistribution()[0] = std::move(vertexIDs);
 
-      for (int rankSlave : utils::MasterSlave::slaves()) {
+      for (int rankSlave : utils::MasterSlave::allSlaves()) {
         int numberOfSlaveVertices = -1;
         utils::MasterSlave::_communication->receive(numberOfSlaveVertices, rankSlave);
         PRECICE_ASSERT(numberOfSlaveVertices >= 0);
@@ -225,7 +225,7 @@ void ReceivedPartition::compute()
     _mesh->getVertexOffsets()[0] = _mesh->vertices().size();
 
     // receive number of slave vertices and fill vertex offsets
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       int numberOfSlaveVertices = -1;
       utils::MasterSlave::_communication->receive(numberOfSlaveVertices, rankSlave);
       _mesh->getVertexOffsets()[rankSlave] = numberOfSlaveVertices + _mesh->getVertexOffsets()[rankSlave - 1];
@@ -287,7 +287,7 @@ void ReceivedPartition::filterByBoundingBox()
       PRECICE_ASSERT(utils::MasterSlave::getRank() == 0);
       PRECICE_ASSERT(utils::MasterSlave::getSize() > 1);
 
-      for (int rankSlave : utils::MasterSlave::slaves()) {
+      for (int rankSlave : utils::MasterSlave::allSlaves()) {
         mesh::BoundingBox slaveBB(_bb.getDimension());
         com::CommunicateBoundingBox(utils::MasterSlave::_communication).receiveBoundingBox(slaveBB, rankSlave);
 
@@ -404,7 +404,7 @@ void ReceivedPartition::compareBoundingBoxes()
     }
 
     // receive connected ranks from slaves and add them to the connection map
-    for (int rank : utils::MasterSlave::slaves()) {
+    for (int rank : utils::MasterSlave::allSlaves()) {
       std::vector<int> slaveConnectedRanks;
       int              connectedRanksSize = -1;
       utils::MasterSlave::_communication->receive(connectedRanksSize, rank);
@@ -535,7 +535,7 @@ void ReceivedPartition::createOwnerInformation()
     if (masterAtInterface)
       ranksAtInterface++;
 
-    for (int rank : utils::MasterSlave::slaves()) {
+    for (int rank : utils::MasterSlave::allSlaves()) {
       int localNumberOfVertices = -1;
       utils::MasterSlave::_communication->receive(localNumberOfVertices, rank);
       PRECICE_DEBUG("Rank {} has {} vertices.", rank, localNumberOfVertices);
@@ -585,7 +585,7 @@ void ReceivedPartition::createOwnerInformation()
     }
 
     // Send information back to slaves
-    for (int rank : utils::MasterSlave::slaves()) {
+    for (int rank : utils::MasterSlave::allSlaves()) {
       if (not slaveTags[rank].empty()) {
         PRECICE_DEBUG("Send owner information to slave rank {}", rank);
         utils::MasterSlave::_communication->send(slaveOwnerVecs[rank], rank);

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -91,7 +91,7 @@ void ReceivedPartition::compute()
   PRECICE_TRACE();
 
   // handle coupling mode first (i.e. serial participant)
-  if (! utils::MasterSlave::isParallel()) { //coupling mode
+  if (!utils::MasterSlave::isParallel()) { //coupling mode
     PRECICE_DEBUG("Handle partition data structures for serial participant");
     int vertexCounter = 0;
     for (mesh::Vertex &v : _mesh->vertices()) {

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -559,7 +559,7 @@ void ReceivedPartition::createOwnerInformation()
     PRECICE_ASSERT(ranksAtInterface != 0);
     int localGuess = _mesh->getGlobalNumberOfVertices() / ranksAtInterface; // Guess for a decent load balancing
     // First round: every slave gets localGuess vertices
-    for (int rank : utils::MasterSlave::ranks()) {
+    for (int rank : utils::MasterSlave::allRanks()) {
       int counter = 0;
       for (size_t i = 0; i < slaveOwnerVecs[rank].size(); i++) {
         // Vertex has no owner yet and rank could be owner
@@ -575,7 +575,7 @@ void ReceivedPartition::createOwnerInformation()
 
     // Second round: distribute all other vertices in a greedy way
     PRECICE_DEBUG("Decide owners, second round in greedy way");
-    for (int rank : utils::MasterSlave::ranks()) {
+    for (int rank : utils::MasterSlave::allRanks()) {
       for (size_t i = 0; i < slaveOwnerVecs[rank].size(); i++) {
         if (globalOwnerVec[slaveGlobalIDs[rank][i]] == 0 && slaveTags[rank][i] == 1) {
           slaveOwnerVecs[rank][i]                 = 1;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -222,7 +222,7 @@ void SolverInterfaceImpl::configure(
   utils::EventRegistry::instance().initialize("precice-" + _accessorName, "", utils::Parallel::current()->comm);
 
   PRECICE_DEBUG("Initialize master-slave communication");
-  if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
+  if (utils::MasterSlave::isParallel()) {
     initializeMasterSlaveCommunication();
   }
 
@@ -385,7 +385,7 @@ double SolverInterfaceImpl::advance(
 
 #ifndef NDEBUG
   PRECICE_DEBUG("Synchronize timestep length");
-  if (utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave()) {
+  if (utils::MasterSlave::isParallel()) {
     syncTimestep(computedTimestepLength);
   }
 #endif
@@ -492,7 +492,7 @@ void SolverInterfaceImpl::finalize()
 
   // Close Connections
   PRECICE_DEBUG("Close master-slave communication");
-  if (utils::MasterSlave::isSlave() || utils::MasterSlave::isMaster()) {
+  if (utils::MasterSlave::isParallel()) {
     utils::MasterSlave::_communication->closeConnection();
     utils::MasterSlave::_communication = nullptr;
   }
@@ -1654,11 +1654,12 @@ void SolverInterfaceImpl::initializeMasterSlaveCommunication()
 
 void SolverInterfaceImpl::syncTimestep(double computedTimestepLength)
 {
-  PRECICE_ASSERT(utils::MasterSlave::isMaster() || utils::MasterSlave::isSlave());
+  PRECICE_ASSERT(utils::MasterSlave::isParallel());
   if (utils::MasterSlave::isSlave()) {
     utils::MasterSlave::_communication->send(computedTimestepLength, 0);
-  } else if (utils::MasterSlave::isMaster()) {
-    for (int rankSlave = 1; rankSlave < _accessorCommunicatorSize; rankSlave++) {
+  } else {
+    PRECICE_ASSERT(utils::MasterSlave::isMaster());
+    for (int rankSlave : utils::MasterSlave::slaves()) {
       double dt;
       utils::MasterSlave::_communication->receive(dt, rankSlave);
       PRECICE_CHECK(math::equals(dt, computedTimestepLength),

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1659,7 +1659,7 @@ void SolverInterfaceImpl::syncTimestep(double computedTimestepLength)
     utils::MasterSlave::_communication->send(computedTimestepLength, 0);
   } else {
     PRECICE_ASSERT(utils::MasterSlave::isMaster());
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       double dt;
       utils::MasterSlave::_communication->receive(dt, rankSlave);
       PRECICE_CHECK(math::equals(dt, computedTimestepLength),

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -74,7 +74,7 @@ void WatchPoint::initialize()
     int    closestRank           = 0;
     double closestDistanceGlobal = _shortestDistance;
     double closestDistanceLocal  = std::numeric_limits<double>::max();
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(closestDistanceLocal, rankSlave);
       if (closestDistanceLocal < closestDistanceGlobal) {
         closestDistanceGlobal = closestDistanceLocal;
@@ -82,7 +82,7 @@ void WatchPoint::initialize()
       }
     }
     _isClosest = closestRank == 0;
-    for (int rankSlave : utils::MasterSlave::slaves()) {
+    for (int rankSlave : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->send(closestRank == rankSlave, rankSlave);
     }
   }

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -74,7 +74,7 @@ void WatchPoint::initialize()
     int    closestRank           = 0;
     double closestDistanceGlobal = _shortestDistance;
     double closestDistanceLocal  = std::numeric_limits<double>::max();
-    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+    for (int rankSlave : utils::MasterSlave::slaves()) {
       utils::MasterSlave::_communication->receive(closestDistanceLocal, rankSlave);
       if (closestDistanceLocal < closestDistanceGlobal) {
         closestDistanceGlobal = closestDistanceLocal;
@@ -82,7 +82,7 @@ void WatchPoint::initialize()
       }
     }
     _isClosest = closestRank == 0;
-    for (int rankSlave = 1; rankSlave < utils::MasterSlave::getSize(); rankSlave++) {
+    for (int rankSlave : utils::MasterSlave::slaves()) {
       utils::MasterSlave::_communication->send(closestRank == rankSlave, rankSlave);
     }
   }

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup)
   }
 
   { // slaves
-    auto             slaves = utils::MasterSlave::slaves();
+    auto             slaves = utils::MasterSlave::allSlaves();
     std::vector<int> ranks(slaves.begin(), slaves.end());
     BOOST_TEST(ranks.size() == 3);
     BOOST_TEST(std::is_sorted(ranks.begin(), ranks.end()));

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -45,13 +45,36 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup)
   if (context.isMaster()) {
     BOOST_TEST(utils::MasterSlave::isMaster() == true);
     BOOST_TEST(utils::MasterSlave::isSlave() == false);
+    BOOST_TEST(utils::MasterSlave::isParallel() == true);
   } else {
     BOOST_TEST(utils::MasterSlave::isMaster() == false);
     BOOST_TEST(utils::MasterSlave::isSlave() == true);
+    BOOST_TEST(utils::MasterSlave::isParallel() == true);
   }
 
   BOOST_TEST(utils::MasterSlave::getRank() == context.rank);
   BOOST_TEST(utils::MasterSlave::getSize() == context.size);
+
+  { // ranks
+    auto             ranksRange = utils::MasterSlave::ranks();
+    std::vector<int> ranks(ranksRange.begin(), ranksRange.end());
+    BOOST_TEST(ranks.size() == 4);
+    BOOST_TEST(std::is_sorted(ranks.begin(), ranks.end()));
+    BOOST_TEST(ranks.front() == 0);
+    auto lastUnique = std::unique(ranks.begin(), ranks.end());
+    BOOST_TEST((lastUnique == ranks.end()));
+  }
+
+  { // slaves
+    auto             slaves = utils::MasterSlave::slaves();
+    std::vector<int> ranks(slaves.begin(), slaves.end());
+    BOOST_TEST(ranks.size() == 3);
+    BOOST_TEST(std::is_sorted(ranks.begin(), ranks.end()));
+    BOOST_TEST(ranks.front() == 1);
+    auto lastUnique = std::unique(ranks.begin(), ranks.end());
+    BOOST_TEST((lastUnique == ranks.end()));
+  }
+
   BOOST_TEST(utils::MasterSlave::_communication.use_count() > 0);
   BOOST_TEST(utils::MasterSlave::_communication->isConnected());
 }

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup)
   BOOST_TEST(utils::MasterSlave::getSize() == context.size);
 
   { // ranks
-    auto             ranksRange = utils::MasterSlave::ranks();
+    auto             ranksRange = utils::MasterSlave::allRanks();
     std::vector<int> ranks(ranksRange.begin(), ranksRange.end());
     BOOST_TEST(ranks.size() == 4);
     BOOST_TEST(std::is_sorted(ranks.begin(), ranks.end()));

--- a/src/utils/MasterSlave.cpp
+++ b/src/utils/MasterSlave.cpp
@@ -53,6 +53,11 @@ bool MasterSlave::isSlave()
   return _isSlave;
 }
 
+bool MasterSlave::isParallel()
+{
+  return _isMaster || _isSlave;
+}
+
 double MasterSlave::l2norm(const Eigen::VectorXd &vec)
 {
   PRECICE_TRACE();

--- a/src/utils/MasterSlave.hpp
+++ b/src/utils/MasterSlave.hpp
@@ -34,7 +34,7 @@ public:
   }
 
   /// Returns an iterable range over all ranks [0, _size)
-  static auto ranks()
+  static auto allRanks()
   {
     return boost::irange(0, _size);
   }

--- a/src/utils/MasterSlave.hpp
+++ b/src/utils/MasterSlave.hpp
@@ -3,6 +3,7 @@
 #include <Eigen/Core>
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
+#include "boost/range/irange.hpp"
 
 namespace precice {
 namespace logging {
@@ -26,11 +27,26 @@ public:
   /// Number of ranks. This includes ranks from both participants, e.g. minimal size is 2.
   static int getSize();
 
+  /// Returns an iterable range over salve ranks [1, _size)
+  static auto slaves()
+  {
+    return boost::irange(1, _size);
+  }
+
+  /// Returns an iterable range over all ranks [0, _size)
+  static auto ranks()
+  {
+    return boost::irange(0, _size);
+  }
+
   /// True if this process is running the master.
   static bool isMaster();
 
   /// True if this process is running a slave.
   static bool isSlave();
+
+  /// True if this process is running in parallel
+  static bool isParallel();
 
   /// The l2 norm of a vector is calculated on distributed data.
   static double l2norm(const Eigen::VectorXd &vec);

--- a/src/utils/MasterSlave.hpp
+++ b/src/utils/MasterSlave.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <Eigen/Core>
+#include "boost/range/irange.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
-#include "boost/range/irange.hpp"
 
 namespace precice {
 namespace logging {

--- a/src/utils/MasterSlave.hpp
+++ b/src/utils/MasterSlave.hpp
@@ -28,7 +28,7 @@ public:
   static int getSize();
 
   /// Returns an iterable range over salve ranks [1, _size)
-  static auto slaves()
+  static auto allSlaves()
   {
     return boost::irange(1, _size);
   }


### PR DESCRIPTION
## Main changes of this PR

- Add range access for all ranks and slave ranks simplifing some loops
- Add isParallel which is equivalent to `isMaster() || isSlave()`.

## Motivation and additional information

We often need to implement functionality for the cases:
* Parallel
* Not parallel
* Master
* Slave

The frist two did not have an explicit query. Now one can use `utils::MasterSlave::isParallel()`.

Another error-prone part was the iteration over all ranks, or the ranks of all slaves.
This PR now proves integer ranges to simplify this.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
