### PR TITLE
Adds initial write data to previousIteration values

### DIFF
--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -81,6 +81,7 @@ void SerialCouplingScheme::exchangeInitialData()
   } else { // second participant
     PRECICE_ASSERT(not receivesInitializedData(), "Only first participant can receive data during initialization.");
     if (sendsInitializedData()) {
+      storeIteration();
       // The second participant sends the initialized data to the first participant
       // here, which receives the data on call of initialize().
       sendData(getM2N(), getSendData());


### PR DESCRIPTION
## Main changes of this PR

Adds the `storeIteration()` function to add the initial write data to `previousIteration()`.

## Motivation and additional information

Closes https://github.com/precice/precice/issues/1034


## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?