### PR TITLE
Introduce named types for preCICE own data structures

### DIFF
--- a/src/utils/types.hpp
+++ b/src/utils/types.hpp
@@ -1,0 +1,38 @@
+#pragma once
+/**
+ * A namespace in which all relevant types used throughout the code base
+ * are decalred.
+ */
+namespace types {
+
+/**
+ * Type used for the IDs of vertices
+ */
+using vertexID = unsigned int;
+
+/**
+ * Type used for the IDs of edges
+ */
+using edgeID = unsigned int;
+
+/**
+ * Type used for the IDs of triangles
+ */
+using triangleID = unsigned int;
+
+/**
+ * Type used for the IDs of matching entities
+ */
+using matchID = unsigned int;
+
+/**
+ * Type used for the IDs of data
+ */
+using dataID = unsigned int;
+
+/**
+ * Type used for the IDs of meshes
+ */
+using meshID = int;
+
+} // namespace types


### PR DESCRIPTION
## Main changes of this PR
I would like to push the development of https://github.com/precice/precice/issues/248 a bit forward. By now, I just added the most obvious IDs and how I would declare them. Any feedback is very welcome. In the long run, we can potentially just switch from 32 to 64 bit indices. This PR does not touch anything of the code base yet.

## Motivation and additional information
See https://github.com/precice/precice/issues/248
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)