### PR TITLE
Introduce named types

### DIFF
--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -1,12 +1,13 @@
 #ifndef PRECICE_NO_MPI
 
-#include "acceleration/MVQNAcceleration.hpp"
 #include <Eigen/Core>
 #include <algorithm>
 #include <fstream>
 #include <map>
 #include <memory>
 #include <string>
+
+#include "acceleration/MVQNAcceleration.hpp"
 #include "acceleration/impl/ParallelMatrixOperations.hpp"
 #include "acceleration/impl/Preconditioner.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
@@ -15,6 +16,7 @@
 #include "cplscheme/CouplingData.hpp"
 #include "cplscheme/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Event.hpp"
 #include "utils/MasterSlave.hpp"
@@ -508,7 +510,7 @@ void MVQNAcceleration::restartIMVJ()
     }
     // |===================                            ===|
 
-    int rankBefore = _svdJ.isSVDinitialized() ? _svdJ.rank() : 0;
+    Rank rankBefore = _svdJ.isSVDinitialized() ? _svdJ.rank() : 0;
 
     // if it is the first time window, there is no initial SVD, so take all Wtil, Z matrices
     // otherwise, the first element of each container holds the decomposition of the current
@@ -540,8 +542,8 @@ void MVQNAcceleration::restartIMVJ()
       for (int j = 0; j < (int) Z.cols(); j++)
         Z(i, j) = phi(j, i) * sigma[i];
 
-    int rankAfter = _svdJ.rank();
-    int waste     = _svdJ.getWaste();
+    Rank rankAfter = _svdJ.rank();
+    int  waste     = _svdJ.getWaste();
     _avgRank += rankAfter;
 
     // store factorized truncated SVD of J

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -7,12 +7,14 @@
 #include <stddef.h>
 #include <string>
 #include <vector>
+
 #include "com/Communication.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "com/Request.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
 
@@ -226,7 +228,7 @@ private:
   {
     PRECICE_TRACE();
     for (int i = 0; i < leftMatrix.rows(); i++) {
-      int rank = 0;
+      Rank rank = 0;
       // find rank of processor that stores the result
       // the second while is necessary if processors with no vertices are present
       // Note: the >'=' here is crucial: In case some procs do not have any vertices,
@@ -291,7 +293,7 @@ private:
       // distribute blocks of summarizedBlocks (result of multiplication) to corresponding slaves
       result = summarizedBlocks.block(0, 0, offsets[1], r);
 
-      for (int rankSlave : utils::MasterSlave::allSlaves()) {
+      for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
         int off       = offsets[rankSlave];
         int send_rows = offsets[rankSlave + 1] - offsets[rankSlave];
 

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -1,4 +1,4 @@
-#include "acceleration/impl/QRFactorization.hpp"
+
 #include <Eigen/Core>
 #include <algorithm> // std::sort
 #include <cmath>
@@ -6,12 +6,14 @@
 #include <iostream>
 #include <memory>
 #include <utility>
-
 #include <vector>
+
 #include "acceleration/Acceleration.hpp"
+#include "acceleration/impl/QRFactorization.hpp"
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
 
@@ -565,7 +567,7 @@ int QRFactorization::orthogonalize_stable(
 
         if (utils::MasterSlave::isMaster()) {
           global_uk = u(k);
-          for (int rankSlave : utils::MasterSlave::allSlaves()) {
+          for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
             utils::MasterSlave::_communication->receive(local_k, rankSlave);
             utils::MasterSlave::_communication->receive(local_uk, rankSlave);
             if (local_uk < global_uk) {

--- a/src/acceleration/impl/SVDFactorization.cpp
+++ b/src/acceleration/impl/SVDFactorization.cpp
@@ -295,7 +295,7 @@ int SVDFactorization::rows()
   return _rows;
 }
 
-int SVDFactorization::rank()
+Rank SVDFactorization::rank()
 {
   return _cols;
 }

--- a/src/acceleration/impl/SVDFactorization.hpp
+++ b/src/acceleration/impl/SVDFactorization.hpp
@@ -13,12 +13,14 @@
 #include <fstream>
 #include <memory>
 #include <string>
+
 #include "acceleration/impl/ParallelMatrixOperations.hpp"
 #include "acceleration/impl/Preconditioner.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 // ------- CLASS DEFINITION
@@ -208,7 +210,7 @@ public:
   int rows();
 
   /// @brief: returns the rank of the truncated SVD factorization
-  int rank();
+  Rank rank();
 
   /// @brief: returns the total number of truncated modes since last call to this method
   int getWaste();

--- a/src/com/CommunicateBoundingBox.cpp
+++ b/src/com/CommunicateBoundingBox.cpp
@@ -1,10 +1,12 @@
-#include "CommunicateBoundingBox.hpp"
 #include <cstddef>
 #include <memory>
 #include <utility>
+
+#include "CommunicateBoundingBox.hpp"
 #include "Communication.hpp"
 #include "logging/LogMacros.hpp"
 #include "mesh/BoundingBox.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -88,7 +90,7 @@ void CommunicateBoundingBox::receiveConnectionMap(
   std::vector<int> connected_ranks;
 
   for (size_t i = 0; i < fbm.size(); ++i) {
-    int rank;
+    Rank rank;
     _communication->receive(rank, rankSender);
     _communication->receive(connected_ranks, rankSender);
     fbm[rank] = connected_ranks;

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -247,7 +247,7 @@ void CommunicateMesh::broadcastReceiveMesh(
   Rank rankBroadcaster = 0;
 
   std::vector<mesh::Vertex *>   vertices;
-  std::map<int, mesh::Vertex *> vertexMap;
+  std::map<VertexID, mesh::Vertex *> vertexMap;
   int                           numberOfVertices = 0;
   _communication->broadcast(numberOfVertices, rankBroadcaster);
 

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -1,4 +1,3 @@
-#include "CommunicateMesh.hpp"
 #include <Eigen/Core>
 #include <algorithm>
 #include <boost/container/flat_map.hpp>
@@ -8,14 +7,16 @@
 #include <memory>
 #include <ostream>
 #include <utility>
-
 #include <vector>
+
+#include "CommunicateMesh.hpp"
 #include "Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -242,8 +243,8 @@ void CommunicateMesh::broadcastReceiveMesh(
     mesh::Mesh &mesh)
 {
   PRECICE_TRACE(mesh.getName());
-  int dim             = mesh.getDimensions();
-  int rankBroadcaster = 0;
+  int  dim             = mesh.getDimensions();
+  Rank rankBroadcaster = 0;
 
   std::vector<mesh::Vertex *>   vertices;
   std::map<int, mesh::Vertex *> vertexMap;

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -246,9 +246,9 @@ void CommunicateMesh::broadcastReceiveMesh(
   int  dim             = mesh.getDimensions();
   Rank rankBroadcaster = 0;
 
-  std::vector<mesh::Vertex *>   vertices;
+  std::vector<mesh::Vertex *>        vertices;
   std::map<VertexID, mesh::Vertex *> vertexMap;
-  int                           numberOfVertices = 0;
+  int                                numberOfVertices = 0;
   _communication->broadcast(numberOfVertices, rankBroadcaster);
 
   if (numberOfVertices > 0) {

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -1,9 +1,11 @@
-#include "Communication.hpp"
 #include <algorithm>
 #include <memory>
 #include <ostream>
+
+#include "Communication.hpp"
 #include "Request.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace com {
@@ -19,8 +21,8 @@ void Communication::connectMasterSlaves(std::string const &participantName,
   std::string masterName = participantName + "Master";
   std::string slaveName  = participantName + "Slave";
 
-  constexpr int rankOffset = 1;
-  int           slavesSize = size - rankOffset;
+  constexpr Rank rankOffset = 1;
+  int            slavesSize = size - rankOffset;
   if (rank == 0) {
     PRECICE_INFO("Connecting Master to {} Slaves", slavesSize);
     prepareEstablishment(masterName, slaveName);
@@ -53,7 +55,7 @@ void Communication::reduceSum(double const *itemsToSend, double *itemsToReceive,
   }
 }
 
-void Communication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster)
+void Communication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
 {
   PRECICE_TRACE(size);
 
@@ -75,7 +77,7 @@ void Communication::reduceSum(int itemToSend, int &itemToReceive)
   }
 }
 
-void Communication::reduceSum(int itemToSend, int &itemToReceive, int rankMaster)
+void Communication::reduceSum(int itemToSend, int &itemToReceive, Rank rankMaster)
 {
   PRECICE_TRACE();
 
@@ -114,7 +116,7 @@ void Communication::allreduceSum(double const *itemsToSend, double *itemsToRecei
 /**
  * @attention This method modifies the input buffer.
  */
-void Communication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster)
+void Communication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
 {
   PRECICE_TRACE(size);
 
@@ -146,7 +148,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
   Request::wait(requests);
 }
 
-void Communication::allreduceSum(double itemToSend, double &itemsToReceive, int rankMaster)
+void Communication::allreduceSum(double itemToSend, double &itemsToReceive, Rank rankMaster)
 {
   PRECICE_TRACE();
 
@@ -178,7 +180,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
   Request::wait(requests);
 }
 
-void Communication::allreduceSum(int itemToSend, int &itemToReceive, int rankMaster)
+void Communication::allreduceSum(int itemToSend, int &itemToReceive, Rank rankMaster)
 {
   PRECICE_TRACE();
 
@@ -202,7 +204,7 @@ void Communication::broadcast(const int *itemsToSend, int size)
   Request::wait(requests);
 }
 
-void Communication::broadcast(int *itemsToReceive, int size, int rankBroadcaster)
+void Communication::broadcast(int *itemsToReceive, int size, Rank rankBroadcaster)
 {
   PRECICE_TRACE(size);
 
@@ -223,7 +225,7 @@ void Communication::broadcast(int itemToSend)
   Request::wait(requests);
 }
 
-void Communication::broadcast(int &itemToReceive, int rankBroadcaster)
+void Communication::broadcast(int &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
   receive(itemToReceive, rankBroadcaster + _rankOffset);
@@ -265,7 +267,7 @@ void Communication::broadcast(double itemToSend)
   Request::wait(requests);
 }
 
-void Communication::broadcast(double &itemToReceive, int rankBroadcaster)
+void Communication::broadcast(double &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
   receive(itemToReceive, rankBroadcaster + _rankOffset);
@@ -278,7 +280,7 @@ void Communication::broadcast(bool itemToSend)
   broadcast(item);
 }
 
-void Communication::broadcast(bool &itemToReceive, int rankBroadcaster)
+void Communication::broadcast(bool &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
   int item;
@@ -292,7 +294,7 @@ void Communication::broadcast(std::vector<int> const &v)
   broadcast(const_cast<int *>(v.data()), v.size()); // make it send vector
 }
 
-void Communication::broadcast(std::vector<int> &v, int rankBroadcaster)
+void Communication::broadcast(std::vector<int> &v, Rank rankBroadcaster)
 {
   v.clear();
   int size = 0;
@@ -307,7 +309,7 @@ void Communication::broadcast(std::vector<double> const &v)
   broadcast(v.data(), v.size()); // make it send vector
 }
 
-void Communication::broadcast(std::vector<double> &v, int rankBroadcaster)
+void Communication::broadcast(std::vector<double> &v, Rank rankBroadcaster)
 {
   v.clear();
   int size = 0;
@@ -316,7 +318,7 @@ void Communication::broadcast(std::vector<double> &v, int rankBroadcaster)
   broadcast(v.data(), size, rankBroadcaster);
 }
 
-int Communication::adjustRank(int rank) const
+int Communication::adjustRank(Rank rank) const
 {
   return rank - _rankOffset;
 }

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -4,9 +4,11 @@
 #include <stddef.h>
 #include <string>
 #include <vector>
+
 #include "Request.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace com {
@@ -196,20 +198,20 @@ public:
   /// @{
 
   /// Performs a reduce summation on the rank given by rankMaster
-  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster);
+  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster);
   /// Performs a reduce summation on the master, every other rank has to call reduceSum
   virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size);
 
-  virtual void reduceSum(int itemToSend, int &itemToReceive, int rankMaster);
+  virtual void reduceSum(int itemToSend, int &itemToReceive, Rank rankMaster);
   virtual void reduceSum(int itemsToSend, int &itemsToReceive);
 
-  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster);
+  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster);
   virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size);
 
-  virtual void allreduceSum(double itemToSend, double &itemToReceive, int rankMaster);
+  virtual void allreduceSum(double itemToSend, double &itemToReceive, Rank rankMaster);
   virtual void allreduceSum(double itemToSend, double &itemToReceive);
 
-  virtual void allreduceSum(int itemToSend, int &itemToReceive, int rankMaster);
+  virtual void allreduceSum(int itemToSend, int &itemToReceive, Rank rankMaster);
   virtual void allreduceSum(int itemToSend, int &itemToReceive);
 
   /// @}
@@ -218,25 +220,25 @@ public:
   /// @{
 
   virtual void broadcast(const int *itemsToSend, int size);
-  virtual void broadcast(int *itemsToReceive, int size, int rankBroadcaster);
+  virtual void broadcast(int *itemsToReceive, int size, Rank rankBroadcaster);
 
   virtual void broadcast(int itemToSend);
-  virtual void broadcast(int &itemToReceive, int rankBroadcaster);
+  virtual void broadcast(int &itemToReceive, Rank rankBroadcaster);
 
   virtual void broadcast(const double *itemsToSend, int size);
-  virtual void broadcast(double *itemsToReceive, int size, int rankBroadcaster);
+  virtual void broadcast(double *itemsToReceive, int size, Rank rankBroadcaster);
 
   virtual void broadcast(double itemToSend);
-  virtual void broadcast(double &itemToReceive, int rankBroadcaster);
+  virtual void broadcast(double &itemToReceive, Rank rankBroadcaster);
 
   virtual void broadcast(bool itemToSend);
-  virtual void broadcast(bool &itemToReceive, int rankBroadcaster);
+  virtual void broadcast(bool &itemToReceive, Rank rankBroadcaster);
 
   virtual void broadcast(std::vector<int> const &v);
-  virtual void broadcast(std::vector<int> &v, int rankBroadcaster);
+  virtual void broadcast(std::vector<int> &v, Rank rankBroadcaster);
 
   virtual void broadcast(std::vector<double> const &v);
-  virtual void broadcast(std::vector<double> &v, int rankBroadcaster);
+  virtual void broadcast(std::vector<double> &v, Rank rankBroadcaster);
 
   /// @}
 
@@ -244,45 +246,45 @@ public:
   /// @{
 
   /// Sends a std::string to process with given rank.
-  virtual void send(std::string const &itemToSend, int rankReceiver) = 0;
+  virtual void send(std::string const &itemToSend, Rank rankReceiver) = 0;
 
   /// Sends an array of integer values.
-  virtual void send(const int *itemsToSend, int size, int rankReceiver) = 0;
+  virtual void send(const int *itemsToSend, int size, Rank rankReceiver) = 0;
 
   /// Asynchronously sends an array of integer values.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const int *itemsToSend, int size, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const int *itemsToSend, int size, Rank rankReceiver) = 0;
 
   /// Sends an array of double values.
-  virtual void send(const double *itemsToSend, int size, int rankReceiver) = 0;
+  virtual void send(const double *itemsToSend, int size, Rank rankReceiver) = 0;
 
   /// Asynchronously sends an array of double values.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const double *itemsToSend, int size, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const double *itemsToSend, int size, Rank rankReceiver) = 0;
 
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, Rank rankReceiver) = 0;
 
   /// Sends a double to process with given rank.
-  virtual void send(double itemToSend, int rankReceiver) = 0;
+  virtual void send(double itemToSend, Rank rankReceiver) = 0;
 
   /// Asynchronously sends a double to process with given rank.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const double &itemToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const double &itemToSend, Rank rankReceiver) = 0;
 
   /// Sends an int to process with given rank.
-  virtual void send(int itemToSend, int rankReceiver) = 0;
+  virtual void send(int itemToSend, Rank rankReceiver) = 0;
 
   /// Asynchronously sends an int to process with given rank.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const int &itemToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const int &itemToSend, Rank rankReceiver) = 0;
 
   /// Sends a bool to process with given rank.
-  virtual void send(bool itemToSend, int rankReceiver) = 0;
+  virtual void send(bool itemToSend, Rank rankReceiver) = 0;
 
   /// Asynchronously sends a bool to process with given rank.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const bool &itemToSend, int rankReceiver) = 0;
+  virtual PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) = 0;
 
   /// @}
 
@@ -290,13 +292,13 @@ public:
   /// @{
 
   /// Receives a std::string from process with given rank.
-  virtual void receive(std::string &itemToReceive, int rankSender) = 0;
+  virtual void receive(std::string &itemToReceive, Rank rankSender) = 0;
 
   /// Receives an array of integer values.
-  virtual void receive(int *itemsToReceive, int size, int rankSender) = 0;
+  virtual void receive(int *itemsToReceive, int size, Rank rankSender) = 0;
 
   /// Receives an array of double values.
-  virtual void receive(double *itemsToReceive, int size, int rankSender) = 0;
+  virtual void receive(double *itemsToReceive, int size, Rank rankSender) = 0;
 
   /// Asynchronously receives an array of double values.
   virtual PtrRequest aReceive(double *itemsToReceive,
@@ -307,38 +309,38 @@ public:
   /*
    * @attention All asynchronous receives methods require the vector to be appropriately sized
    */
-  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, int rankSender) = 0;
+  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, Rank rankSender) = 0;
 
   /// Receives a double from process with given rank.
-  virtual void receive(double &itemToReceive, int rankSender) = 0;
+  virtual void receive(double &itemToReceive, Rank rankSender) = 0;
 
   /// Asynchronously receives a double from process with given rank.
-  virtual PtrRequest aReceive(double &itemToReceive, int rankSender) = 0;
+  virtual PtrRequest aReceive(double &itemToReceive, Rank rankSender) = 0;
 
   /// Receives an int from process with given rank.
-  virtual void receive(int &itemToReceive, int rankSender) = 0;
+  virtual void receive(int &itemToReceive, Rank rankSender) = 0;
 
   /// Asynchronously receives an int from process with given rank.
-  virtual PtrRequest aReceive(int &itemToReceive, int rankSender) = 0;
+  virtual PtrRequest aReceive(int &itemToReceive, Rank rankSender) = 0;
 
   /// Receives a bool from process with given rank.
-  virtual void receive(bool &itemToReceive, int rankSender) = 0;
+  virtual void receive(bool &itemToReceive, Rank rankSender) = 0;
 
   /// Asynchronously receives a bool from process with given rank.
-  virtual PtrRequest aReceive(bool &itemToReceive, int rankSender) = 0;
+  virtual PtrRequest aReceive(bool &itemToReceive, Rank rankSender) = 0;
 
-  virtual void send(std::vector<int> const &v, int rankReceiver) = 0;
+  virtual void send(std::vector<int> const &v, Rank rankReceiver) = 0;
   /// Receives an std::vector of ints. The vector will be resized accordingly.
-  virtual void receive(std::vector<int> &v, int rankSender) = 0;
+  virtual void receive(std::vector<int> &v, Rank rankSender) = 0;
 
-  virtual void send(std::vector<double> const &v, int rankReceiver) = 0;
+  virtual void send(std::vector<double> const &v, Rank rankReceiver) = 0;
   /// Receives an std::vector of doubles. The vector will be resized accordingly.
-  virtual void receive(std::vector<double> &v, int rankSender) = 0;
+  virtual void receive(std::vector<double> &v, Rank rankSender) = 0;
 
   /// @}
 
   /// Set rank offset.
-  void setRankOffset(int rankOffset)
+  void setRankOffset(Rank rankOffset)
   {
     _rankOffset = rankOffset;
   }
@@ -350,7 +352,7 @@ protected:
   bool _isConnected = false;
 
   /// Adjusts the given rank bases on the _rankOffset
-  virtual int adjustRank(int rank) const;
+  virtual int adjustRank(Rank rank) const;
 
 private:
   logging::Logger _log{"com::Communication"};

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -1,4 +1,3 @@
-#include "ConnectionInfoPublisher.hpp"
 #include <algorithm>
 #include <boost/filesystem.hpp>
 #include <boost/uuid/name_generator.hpp>
@@ -7,12 +6,15 @@
 #include <chrono>
 #include <istream>
 #include <thread>
+
+#include "ConnectionInfoPublisher.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace com {
 
-std::string impl::hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &tag, int rank)
+std::string impl::hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &tag, Rank rank)
 {
   using namespace boost::filesystem;
 

--- a/src/com/ConnectionInfoPublisher.hpp
+++ b/src/com/ConnectionInfoPublisher.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <string>
 #include <utility>
+
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace com {
@@ -12,7 +14,7 @@ namespace impl {
    * It has the form first two letters from hash of 
    * (acceptorName, requesterName, mesh, rank)/rest of hash.
    */
-std::string hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &meshName, int rank);
+std::string hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &meshName, Rank rank);
 
 /** Returns the local directory which is the root for storing connection information.
    * It has the form addressDirectory/precice-run/acceptorName-requesterName

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -1,10 +1,12 @@
 #ifndef PRECICE_NO_MPI
 
-#include "MPICommunication.hpp"
 #include <cstddef>
 #include <ostream>
+
+#include "MPICommunication.hpp"
 #include "MPIRequest.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 
 template <size_t>
 struct MPI_Select_unsigned_integer_datatype;
@@ -39,7 +41,7 @@ namespace precice {
 namespace com {
 MPICommunication::MPICommunication() = default;
 
-void MPICommunication::send(std::string const &itemToSend, int rankReceiver)
+void MPICommunication::send(std::string const &itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
@@ -52,7 +54,7 @@ void MPICommunication::send(std::string const &itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-void MPICommunication::send(const int *itemsToSend, int size, int rankReceiver)
+void MPICommunication::send(const int *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size);
   rankReceiver = adjustRank(rankReceiver);
@@ -64,7 +66,7 @@ void MPICommunication::send(const int *itemsToSend, int size, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const int *itemsToSend, int size, int rankReceiver)
+PtrRequest MPICommunication::aSend(const int *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size);
   rankReceiver = adjustRank(rankReceiver);
@@ -81,7 +83,7 @@ PtrRequest MPICommunication::aSend(const int *itemsToSend, int size, int rankRec
   return PtrRequest(new MPIRequest(request));
 }
 
-void MPICommunication::send(const double *itemsToSend, int size, int rankReceiver)
+void MPICommunication::send(const double *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size);
   rankReceiver = adjustRank(rankReceiver);
@@ -93,7 +95,7 @@ void MPICommunication::send(const double *itemsToSend, int size, int rankReceive
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const double *itemsToSend, int size, int rankReceiver)
+PtrRequest MPICommunication::aSend(const double *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size, rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
@@ -110,7 +112,7 @@ PtrRequest MPICommunication::aSend(const double *itemsToSend, int size, int rank
   return PtrRequest(new MPIRequest(request));
 }
 
-PtrRequest MPICommunication::aSend(std::vector<double> const &itemsToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(std::vector<double> const &itemsToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(rankReceiver, itemsToSend.size(), itemsToSend);
   rankReceiver = adjustRank(rankReceiver);
@@ -127,7 +129,7 @@ PtrRequest MPICommunication::aSend(std::vector<double> const &itemsToSend, int r
   return PtrRequest(new MPIRequest(request));
 }
 
-void MPICommunication::send(double itemToSend, int rankReceiver)
+void MPICommunication::send(double itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
@@ -139,12 +141,12 @@ void MPICommunication::send(double itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const double &itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const double &itemToSend, Rank rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
 
-void MPICommunication::send(int itemToSend, int rankReceiver)
+void MPICommunication::send(int itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
@@ -156,12 +158,12 @@ void MPICommunication::send(int itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const int &itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const int &itemToSend, Rank rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
 
-void MPICommunication::send(bool itemToSend, int rankReceiver)
+void MPICommunication::send(bool itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
@@ -173,7 +175,7 @@ void MPICommunication::send(bool itemToSend, int rankReceiver)
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const bool &itemToSend, int rankReceiver)
+PtrRequest MPICommunication::aSend(const bool &itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE();
   rankReceiver = adjustRank(rankReceiver);
@@ -190,7 +192,7 @@ PtrRequest MPICommunication::aSend(const bool &itemToSend, int rankReceiver)
   return PtrRequest(new MPIRequest(request));
 }
 
-void MPICommunication::receive(std::string &itemToReceive, int rankSender)
+void MPICommunication::receive(std::string &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(itemToReceive, rankSender);
   rankSender = adjustRank(rankSender);
@@ -210,7 +212,7 @@ void MPICommunication::receive(std::string &itemToReceive, int rankSender)
   PRECICE_DEBUG("Received \"{}\" from rank {}", itemToReceive, rankSender);
 }
 
-void MPICommunication::receive(int *itemsToReceive, int size, int rankSender)
+void MPICommunication::receive(int *itemsToReceive, int size, Rank rankSender)
 {
   PRECICE_TRACE(size);
   rankSender = adjustRank(rankSender);
@@ -225,7 +227,7 @@ void MPICommunication::receive(int *itemsToReceive, int size, int rankSender)
            &status);
 }
 
-void MPICommunication::receive(double *itemsToReceive, int size, int rankSender)
+void MPICommunication::receive(double *itemsToReceive, int size, Rank rankSender)
 {
   PRECICE_TRACE(size);
   rankSender = adjustRank(rankSender);
@@ -240,7 +242,7 @@ void MPICommunication::receive(double *itemsToReceive, int size, int rankSender)
            &status);
 }
 
-PtrRequest MPICommunication::aReceive(double *itemsToReceive, int size, int rankSender)
+PtrRequest MPICommunication::aReceive(double *itemsToReceive, int size, Rank rankSender)
 {
   PRECICE_TRACE(size);
   rankSender = adjustRank(rankSender);
@@ -257,7 +259,7 @@ PtrRequest MPICommunication::aReceive(double *itemsToReceive, int size, int rank
   return PtrRequest(new MPIRequest(request));
 }
 
-PtrRequest MPICommunication::aReceive(std::vector<double> &itemsToReceive, int rankSender)
+PtrRequest MPICommunication::aReceive(std::vector<double> &itemsToReceive, Rank rankSender)
 {
   PRECICE_TRACE(itemsToReceive.size());
   rankSender = adjustRank(rankSender);
@@ -274,7 +276,7 @@ PtrRequest MPICommunication::aReceive(std::vector<double> &itemsToReceive, int r
   return PtrRequest(new MPIRequest(request));
 }
 
-void MPICommunication::receive(double &itemToReceive, int rankSender)
+void MPICommunication::receive(double &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
@@ -290,12 +292,12 @@ void MPICommunication::receive(double &itemToReceive, int rankSender)
   PRECICE_DEBUG("Received {} from rank {}", itemToReceive, rankSender);
 }
 
-PtrRequest MPICommunication::aReceive(double &itemToReceive, int rankSender)
+PtrRequest MPICommunication::aReceive(double &itemToReceive, Rank rankSender)
 {
   return aReceive(&itemToReceive, 1, rankSender);
 }
 
-void MPICommunication::receive(int &itemToReceive, int rankSender)
+void MPICommunication::receive(int &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
@@ -311,7 +313,7 @@ void MPICommunication::receive(int &itemToReceive, int rankSender)
   PRECICE_DEBUG("Received {} from rank {}", itemToReceive, rankSender);
 }
 
-PtrRequest MPICommunication::aReceive(int &itemToReceive, int rankSender)
+PtrRequest MPICommunication::aReceive(int &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
@@ -328,7 +330,7 @@ PtrRequest MPICommunication::aReceive(int &itemToReceive, int rankSender)
   return PtrRequest(new MPIRequest(request));
 }
 
-void MPICommunication::receive(bool &itemToReceive, int rankSender)
+void MPICommunication::receive(bool &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
@@ -344,7 +346,7 @@ void MPICommunication::receive(bool &itemToReceive, int rankSender)
   PRECICE_DEBUG("Received {} from rank {}", itemToReceive, rankSender);
 }
 
-PtrRequest MPICommunication::aReceive(bool &itemToReceive, int rankSender)
+PtrRequest MPICommunication::aReceive(bool &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
@@ -361,7 +363,7 @@ PtrRequest MPICommunication::aReceive(bool &itemToReceive, int rankSender)
   return PtrRequest(new MPIRequest(request));
 }
 
-void MPICommunication::send(std::vector<int> const &v, int rankReceiver)
+void MPICommunication::send(std::vector<int> const &v, Rank rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
@@ -369,7 +371,7 @@ void MPICommunication::send(std::vector<int> const &v, int rankReceiver)
            rank(rankReceiver), 0, communicator(rankReceiver));
 }
 
-void MPICommunication::receive(std::vector<int> &v, int rankSender)
+void MPICommunication::receive(std::vector<int> &v, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender        = adjustRank(rankSender);
@@ -382,7 +384,7 @@ void MPICommunication::receive(std::vector<int> &v, int rankSender)
            0, communicator(rankSender), MPI_STATUS_IGNORE);
 }
 
-void MPICommunication::send(std::vector<double> const &v, int rankReceiver)
+void MPICommunication::send(std::vector<double> const &v, Rank rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
@@ -390,7 +392,7 @@ void MPICommunication::send(std::vector<double> const &v, int rankReceiver)
            rank(rankReceiver), 0, communicator(rankReceiver));
 }
 
-void MPICommunication::receive(std::vector<double> &v, int rankSender)
+void MPICommunication::receive(std::vector<double> &v, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
   rankSender        = adjustRank(rankSender);

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -5,9 +5,11 @@
 #include <mpi.h>
 #include <string>
 #include <vector>
+
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace com {
@@ -31,113 +33,113 @@ public:
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(std::string const &itemToSend, int rankReceiver) override;
+  virtual void send(std::string const &itemToSend, Rank rankReceiver) override;
 
   /// Sends an array of integer values.
-  virtual void send(const int *itemsToSend, int size, int rankReceiver) override;
+  virtual void send(const int *itemsToSend, int size, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of integer values.
-  virtual PtrRequest aSend(const int *itemsToSend, int size, int rankReceiver) override;
+  virtual PtrRequest aSend(const int *itemsToSend, int size, Rank rankReceiver) override;
 
   /// Sends an array of double values.
-  virtual void send(const double *itemsToSend, int size, int rankReceiver) override;
+  virtual void send(const double *itemsToSend, int size, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of double values.
-  virtual PtrRequest aSend(const double *itemsToSend, int size, int rankReceiver) override;
+  virtual PtrRequest aSend(const double *itemsToSend, int size, Rank rankReceiver) override;
 
-  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, Rank rankReceiver) override;
 
   /**
    * @brief Sends a double to process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(double itemToSend, int rankReceiver) override;
+  virtual void send(double itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(const double &itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
 
   /**
    * @brief Sends an int to process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(int itemToSend, int rankReceiver) override;
+  virtual void send(int itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(const int &itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
 
   /**
    * @brief Sends a bool to process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(bool itemToSend, int rankReceiver) override;
+  virtual void send(bool itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(const bool &itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
 
   /**
    * @brief Receives a std::string from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(std::string &itemToReceive, int rankSender) override;
+  virtual void receive(std::string &itemToReceive, Rank rankSender) override;
 
   /// Receives an array of integer values.
-  virtual void receive(int *itemsToReceive, int size, int rankSender) override;
+  virtual void receive(int *itemsToReceive, int size, Rank rankSender) override;
 
   /// Receives an array of double values.
-  virtual void receive(double *itemsToReceive, int size, int rankSender) override;
+  virtual void receive(double *itemsToReceive, int size, Rank rankSender) override;
 
   /// Asynchronously receives an array of double values.
   virtual PtrRequest aReceive(double *itemsToReceive,
                               int     size,
                               int     rankSender) override;
 
-  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, Rank rankSender) override;
 
   /**
    * @brief Receives a double from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(double &itemToReceive, int rankSender) override;
+  virtual void receive(double &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a double from process with given rank.
-  virtual PtrRequest aReceive(double &itemToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
 
   /**
    * @brief Receives an int from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(int &itemToReceive, int rankSender) override;
+  virtual void receive(int &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an int from process with given rank.
-  virtual PtrRequest aReceive(int &itemToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
 
   /**
    * @brief Receives a bool from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(bool &itemToReceive, int rankSender) override;
+  virtual void receive(bool &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a bool from process with given rank.
-  virtual PtrRequest aReceive(bool &itemToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
 
-  void send(std::vector<int> const &v, int rankReceiver) override;
-  void receive(std::vector<int> &v, int rankSender) override;
+  void send(std::vector<int> const &v, Rank rankReceiver) override;
+  void receive(std::vector<int> &v, Rank rankSender) override;
 
-  void send(std::vector<double> const &v, int rankReceiver) override;
-  void receive(std::vector<double> &v, int rankSender) override;
+  void send(std::vector<double> const &v, Rank rankReceiver) override;
+  void receive(std::vector<double> &v, Rank rankSender) override;
 
 protected:
   /// Returns the communicator.
-  virtual MPI_Comm &communicator(int rank) = 0;
+  virtual MPI_Comm &communicator(Rank rank) = 0;
 
-  virtual int rank(int rank) = 0;
+  virtual Rank rank(int rank) = 0;
 
 private:
   logging::Logger _log{"com::MPICommunication"};

--- a/src/com/MPIDirectCommunication.cpp
+++ b/src/com/MPIDirectCommunication.cpp
@@ -1,8 +1,10 @@
 #ifndef PRECICE_NO_MPI
 
-#include "MPIDirectCommunication.hpp"
 #include <memory>
+
+#include "MPIDirectCommunication.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
 
@@ -77,11 +79,11 @@ void MPIDirectCommunication::requestConnection(std::string const &acceptorName,
 void MPIDirectCommunication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size)
 {
   PRECICE_TRACE(size);
-  int rank = _commState->rank();
+  Rank rank = _commState->rank();
   MPI_Reduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, rank, _commState->comm);
 }
 
-void MPIDirectCommunication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster)
+void MPIDirectCommunication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
 {
   PRECICE_TRACE(size);
   MPI_Reduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, rankMaster, _commState->comm);
@@ -90,11 +92,11 @@ void MPIDirectCommunication::reduceSum(double const *itemsToSend, double *itemsT
 void MPIDirectCommunication::reduceSum(int itemToSend, int &itemsToReceive)
 {
   PRECICE_TRACE();
-  int rank = _commState->rank();
+  Rank rank = _commState->rank();
   MPI_Reduce(&itemToSend, &itemsToReceive, 1, MPI_INT, MPI_SUM, rank, _commState->comm);
 }
 
-void MPIDirectCommunication::reduceSum(int itemToSend, int &itemsToReceive, int rankMaster)
+void MPIDirectCommunication::reduceSum(int itemToSend, int &itemsToReceive, Rank rankMaster)
 {
   PRECICE_TRACE();
   MPI_Reduce(&itemToSend, &itemsToReceive, 1, MPI_INT, MPI_SUM, rankMaster, _commState->comm);
@@ -106,7 +108,7 @@ void MPIDirectCommunication::allreduceSum(double const *itemsToSend, double *ite
   MPI_Allreduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, _commState->comm);
 }
 
-void MPIDirectCommunication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster)
+void MPIDirectCommunication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
 {
   PRECICE_TRACE(size);
   MPI_Allreduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, _commState->comm);
@@ -118,7 +120,7 @@ void MPIDirectCommunication::allreduceSum(double itemToSend, double &itemToRecei
   MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_DOUBLE, MPI_SUM, _commState->comm);
 }
 
-void MPIDirectCommunication::allreduceSum(double itemToSend, double &itemToReceive, int rankMaster)
+void MPIDirectCommunication::allreduceSum(double itemToSend, double &itemToReceive, Rank rankMaster)
 {
   PRECICE_TRACE();
   MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_DOUBLE, MPI_SUM, _commState->comm);
@@ -130,7 +132,7 @@ void MPIDirectCommunication::allreduceSum(int itemToSend, int &itemToReceive)
   MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_INT, MPI_SUM, _commState->comm);
 }
 
-void MPIDirectCommunication::allreduceSum(int itemToSend, int &itemToReceive, int rankMaster)
+void MPIDirectCommunication::allreduceSum(int itemToSend, int &itemToReceive, Rank rankMaster)
 {
   PRECICE_TRACE();
   MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_INT, MPI_SUM, _commState->comm);
@@ -156,7 +158,7 @@ void MPIDirectCommunication::broadcast(int itemToSend)
   broadcast(&itemToSend, 1);
 }
 
-void MPIDirectCommunication::broadcast(int &itemToReceive, int rankBroadcaster)
+void MPIDirectCommunication::broadcast(int &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
   broadcast(&itemToReceive, 1, rankBroadcaster);
@@ -182,7 +184,7 @@ void MPIDirectCommunication::broadcast(double itemToSend)
   broadcast(&itemToSend, 1);
 }
 
-void MPIDirectCommunication::broadcast(double &itemToReceive, int rankBroadcaster)
+void MPIDirectCommunication::broadcast(double &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
   broadcast(&itemToReceive, 1, rankBroadcaster);
@@ -195,7 +197,7 @@ void MPIDirectCommunication::broadcast(bool itemToSend)
   broadcast(item);
 }
 
-void MPIDirectCommunication::broadcast(bool &itemToReceive, int rankBroadcaster)
+void MPIDirectCommunication::broadcast(bool &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
   int item;
@@ -203,18 +205,18 @@ void MPIDirectCommunication::broadcast(bool &itemToReceive, int rankBroadcaster)
   itemToReceive = item;
 }
 
-MPI_Comm &MPIDirectCommunication::communicator(int rank)
+MPI_Comm &MPIDirectCommunication::communicator(Rank rank)
 {
   return _commState->comm;
 }
 
-int MPIDirectCommunication::rank(int rank)
+int MPIDirectCommunication::rank(Rank rank)
 {
   // Correct _rankOffset if we are on master
   return rank;
 }
 
-int MPIDirectCommunication::adjustRank(int rank) const
+int MPIDirectCommunication::adjustRank(Rank rank) const
 {
   return rank;
 }

--- a/src/com/MPIDirectCommunication.hpp
+++ b/src/com/MPIDirectCommunication.hpp
@@ -6,8 +6,10 @@
 #include <set>
 #include <stddef.h>
 #include <string>
+
 #include "MPICommunication.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
 
@@ -80,50 +82,50 @@ public:
   /// See precice::com::Communication::closeConnection().
   virtual void closeConnection() override;
 
-  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster) override;
+  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster) override;
 
   virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size) override;
 
-  virtual void reduceSum(int itemToSend, int &itemsToReceive, int rankMaster) override;
+  virtual void reduceSum(int itemToSend, int &itemsToReceive, Rank rankMaster) override;
 
   virtual void reduceSum(int itemToSend, int &itemsToReceive) override;
 
-  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, int rankMaster) override;
+  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster) override;
 
   virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size) override;
 
-  virtual void allreduceSum(double itemToSend, double &itemsToReceive, int rankMaster) override;
+  virtual void allreduceSum(double itemToSend, double &itemsToReceive, Rank rankMaster) override;
 
   virtual void allreduceSum(double itemToSend, double &itemsToReceive) override;
 
-  virtual void allreduceSum(int itemToSend, int &itemsToReceive, int rankMaster) override;
+  virtual void allreduceSum(int itemToSend, int &itemsToReceive, Rank rankMaster) override;
 
   virtual void allreduceSum(int itemToSend, int &itemsToReceive) override;
 
   virtual void broadcast(const int *itemsToSend, int size) override;
 
-  virtual void broadcast(int *itemsToReceive, int size, int rankBroadcaster) override;
+  virtual void broadcast(int *itemsToReceive, int size, Rank rankBroadcaster) override;
 
   virtual void broadcast(int itemToSend) override;
 
-  virtual void broadcast(int &itemToReceive, int rankBroadcaster) override;
+  virtual void broadcast(int &itemToReceive, Rank rankBroadcaster) override;
 
   virtual void broadcast(const double *itemsToSend, int size) override;
 
-  virtual void broadcast(double *itemsToReceive, int size, int rankBroadcaster) override;
+  virtual void broadcast(double *itemsToReceive, int size, Rank rankBroadcaster) override;
 
   virtual void broadcast(double itemToSend) override;
 
-  virtual void broadcast(double &itemToReceive, int rankBroadcaster) override;
+  virtual void broadcast(double &itemToReceive, Rank rankBroadcaster) override;
 
   virtual void broadcast(bool itemToSend) override;
 
-  virtual void broadcast(bool &itemToReceive, int rankBroadcaster) override;
+  virtual void broadcast(bool &itemToReceive, Rank rankBroadcaster) override;
 
 private:
-  virtual MPI_Comm &communicator(int rank = 0) override;
+  virtual MPI_Comm &communicator(Rank rank = 0) override;
 
-  virtual int rank(int rank) override;
+  virtual Rank rank(int rank) override;
 
   logging::Logger _log{"com::MPIDirectCommunication"};
 
@@ -132,7 +134,7 @@ private:
 
 protected:
   /// Turn the rank adjustment into a noop for direct communication
-  virtual int adjustRank(int rank) const override;
+  virtual int adjustRank(Rank rank) const override;
 };
 
 } // namespace com

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -1,11 +1,13 @@
 #ifndef PRECICE_NO_MPI
 
-#include "MPIPortsCommunication.hpp"
 #include <boost/filesystem.hpp>
 #include <ostream>
 #include <utility>
+
 #include "ConnectionInfoPublisher.hpp"
+#include "MPIPortsCommunication.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -241,14 +243,14 @@ void MPIPortsCommunication::cleanupEstablishment(std::string const &acceptorName
   }
 }
 
-MPI_Comm &MPIPortsCommunication::communicator(int rank)
+MPI_Comm &MPIPortsCommunication::communicator(Rank rank)
 {
   PRECICE_TRACE(rank, _communicators.size(), _isAcceptor);
   // Use bounds checking here, because a std::map otherwise creates element
   return _communicators.at(rank);
 }
 
-int MPIPortsCommunication::rank(int rank)
+int MPIPortsCommunication::rank(Rank rank)
 {
   return 0;
 }

--- a/src/com/MPIPortsCommunication.hpp
+++ b/src/com/MPIPortsCommunication.hpp
@@ -6,8 +6,10 @@
 #include <set>
 #include <stddef.h>
 #include <string>
+
 #include "MPICommunication.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace com {
@@ -58,9 +60,9 @@ public:
                                     std::string const &requesterName) override;
 
 private:
-  virtual MPI_Comm &communicator(int rank) override;
+  virtual MPI_Comm &communicator(Rank rank) override;
 
-  virtual int rank(int rank) override;
+  virtual Rank rank(int rank) override;
 
   logging::Logger _log{"com::MPIPortsCommunication"};
 

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -1,13 +1,15 @@
 #ifndef PRECICE_NO_MPI
 
-#include "MPISinglePortsCommunication.hpp"
 #include <boost/filesystem.hpp>
 #include <memory>
 #include <mpi.h>
 #include <ostream>
 #include <utility>
+
 #include "ConnectionInfoPublisher.hpp"
+#include "MPISinglePortsCommunication.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
@@ -107,7 +109,7 @@ void MPISinglePortsCommunication::acceptConnectionAsServer(std::string const &ac
 
   _isAcceptor = true;
 
-  const int rank = utils::Parallel::current()->rank();
+  const Rank rank = utils::Parallel::current()->rank();
 
   if (rank == 0) { // only master opens a port
     ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
@@ -213,7 +215,7 @@ void MPISinglePortsCommunication::closeConnection()
   _isConnected     = false;
 }
 
-MPI_Comm &MPISinglePortsCommunication::communicator(int rank)
+MPI_Comm &MPISinglePortsCommunication::communicator(Rank rank)
 {
   if (_global != MPI_COMM_NULL) {
     // Always prefer the global communicator
@@ -224,7 +226,7 @@ MPI_Comm &MPISinglePortsCommunication::communicator(int rank)
   }
 }
 
-int MPISinglePortsCommunication::rank(int rank)
+int MPISinglePortsCommunication::rank(Rank rank)
 {
   if (_global != MPI_COMM_NULL) {
     // Always prefer the global communicator

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -6,8 +6,10 @@
 #include <set>
 #include <stddef.h>
 #include <string>
+
 #include "MPICommunication.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace com {
@@ -72,9 +74,9 @@ public:
   virtual void closeConnection() override;
 
 private:
-  virtual MPI_Comm &communicator(int rank) override;
+  virtual MPI_Comm &communicator(Rank rank) override;
 
-  virtual int rank(int rank) override;
+  virtual Rank rank(int rank) override;
 
   logging::Logger _log{"com::MPISinglePortsCommunication"};
 

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -1,4 +1,3 @@
-#include "SocketCommunication.hpp"
 #include <algorithm>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
@@ -6,9 +5,12 @@
 #include <sstream>
 #include <stdexcept>
 #include <utility>
+
 #include "ConnectionInfoPublisher.hpp"
+#include "SocketCommunication.hpp"
 #include "SocketRequest.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 #include "utils/networking.hpp"
 
@@ -338,7 +340,7 @@ void SocketCommunication::closeConnection()
   _isConnected = false;
 }
 
-void SocketCommunication::send(std::string const &itemToSend, int rankReceiver)
+void SocketCommunication::send(std::string const &itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
 
@@ -356,7 +358,7 @@ void SocketCommunication::send(std::string const &itemToSend, int rankReceiver)
   }
 }
 
-void SocketCommunication::send(const int *itemsToSend, int size, int rankReceiver)
+void SocketCommunication::send(const int *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size, rankReceiver);
 
@@ -398,7 +400,7 @@ void SocketCommunication::cleanupEstablishment(std::string const &acceptorName,
   }
 }
 
-PtrRequest SocketCommunication::aSend(const int *itemsToSend, int size, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const int *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size, rankReceiver);
 
@@ -417,7 +419,7 @@ PtrRequest SocketCommunication::aSend(const int *itemsToSend, int size, int rank
   return request;
 }
 
-void SocketCommunication::send(const double *itemsToSend, int size, int rankReceiver)
+void SocketCommunication::send(const double *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size, rankReceiver);
 
@@ -433,7 +435,7 @@ void SocketCommunication::send(const double *itemsToSend, int size, int rankRece
   }
 }
 
-PtrRequest SocketCommunication::aSend(const double *itemsToSend, int size, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const double *itemsToSend, int size, Rank rankReceiver)
 {
   PRECICE_TRACE(size, rankReceiver);
 
@@ -452,7 +454,7 @@ PtrRequest SocketCommunication::aSend(const double *itemsToSend, int size, int r
   return request;
 }
 
-PtrRequest SocketCommunication::aSend(std::vector<double> const &itemsToSend, int rankReceiver)
+PtrRequest SocketCommunication::aSend(std::vector<double> const &itemsToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
 
@@ -471,7 +473,7 @@ PtrRequest SocketCommunication::aSend(std::vector<double> const &itemsToSend, in
   return request;
 }
 
-void SocketCommunication::send(double itemToSend, int rankReceiver)
+void SocketCommunication::send(double itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
 
@@ -487,12 +489,12 @@ void SocketCommunication::send(double itemToSend, int rankReceiver)
   }
 }
 
-PtrRequest SocketCommunication::aSend(const double &itemToSend, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const double &itemToSend, Rank rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
 
-void SocketCommunication::send(int itemToSend, int rankReceiver)
+void SocketCommunication::send(int itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
 
@@ -508,12 +510,12 @@ void SocketCommunication::send(int itemToSend, int rankReceiver)
   }
 }
 
-PtrRequest SocketCommunication::aSend(const int &itemToSend, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const int &itemToSend, Rank rankReceiver)
 {
   return aSend(&itemToSend, 1, rankReceiver);
 }
 
-void SocketCommunication::send(bool itemToSend, int rankReceiver)
+void SocketCommunication::send(bool itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(itemToSend, rankReceiver);
 
@@ -529,7 +531,7 @@ void SocketCommunication::send(bool itemToSend, int rankReceiver)
   }
 }
 
-PtrRequest SocketCommunication::aSend(const bool &itemToSend, int rankReceiver)
+PtrRequest SocketCommunication::aSend(const bool &itemToSend, Rank rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
 
@@ -548,7 +550,7 @@ PtrRequest SocketCommunication::aSend(const bool &itemToSend, int rankReceiver)
   return request;
 }
 
-void SocketCommunication::receive(std::string &itemToReceive, int rankSender)
+void SocketCommunication::receive(std::string &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -569,7 +571,7 @@ void SocketCommunication::receive(std::string &itemToReceive, int rankSender)
   }
 }
 
-void SocketCommunication::receive(int *itemsToReceive, int size, int rankSender)
+void SocketCommunication::receive(int *itemsToReceive, int size, Rank rankSender)
 {
   PRECICE_TRACE(size, rankSender);
 
@@ -585,7 +587,7 @@ void SocketCommunication::receive(int *itemsToReceive, int size, int rankSender)
   }
 }
 
-void SocketCommunication::receive(double *itemsToReceive, int size, int rankSender)
+void SocketCommunication::receive(double *itemsToReceive, int size, Rank rankSender)
 {
   PRECICE_TRACE(size, rankSender);
 
@@ -627,7 +629,7 @@ PtrRequest SocketCommunication::aReceive(double *itemsToReceive,
   return request;
 }
 
-PtrRequest SocketCommunication::aReceive(std::vector<double> &itemsToReceive, int rankSender)
+PtrRequest SocketCommunication::aReceive(std::vector<double> &itemsToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -651,7 +653,7 @@ PtrRequest SocketCommunication::aReceive(std::vector<double> &itemsToReceive, in
   return request;
 }
 
-void SocketCommunication::receive(double &itemToReceive, int rankSender)
+void SocketCommunication::receive(double &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -667,12 +669,12 @@ void SocketCommunication::receive(double &itemToReceive, int rankSender)
   }
 }
 
-PtrRequest SocketCommunication::aReceive(double &itemToReceive, int rankSender)
+PtrRequest SocketCommunication::aReceive(double &itemToReceive, Rank rankSender)
 {
   return aReceive(&itemToReceive, 1, rankSender);
 }
 
-void SocketCommunication::receive(int &itemToReceive, int rankSender)
+void SocketCommunication::receive(int &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -688,7 +690,7 @@ void SocketCommunication::receive(int &itemToReceive, int rankSender)
   }
 }
 
-PtrRequest SocketCommunication::aReceive(int &itemToReceive, int rankSender)
+PtrRequest SocketCommunication::aReceive(int &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -713,7 +715,7 @@ PtrRequest SocketCommunication::aReceive(int &itemToReceive, int rankSender)
   return request;
 }
 
-void SocketCommunication::receive(bool &itemToReceive, int rankSender)
+void SocketCommunication::receive(bool &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -729,7 +731,7 @@ void SocketCommunication::receive(bool &itemToReceive, int rankSender)
   }
 }
 
-PtrRequest SocketCommunication::aReceive(bool &itemToReceive, int rankSender)
+PtrRequest SocketCommunication::aReceive(bool &itemToReceive, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -753,7 +755,7 @@ PtrRequest SocketCommunication::aReceive(bool &itemToReceive, int rankSender)
   return request;
 }
 
-void SocketCommunication::send(std::vector<int> const &v, int rankReceiver)
+void SocketCommunication::send(std::vector<int> const &v, Rank rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
 
@@ -771,7 +773,7 @@ void SocketCommunication::send(std::vector<int> const &v, int rankReceiver)
   }
 }
 
-void SocketCommunication::receive(std::vector<int> &v, int rankSender)
+void SocketCommunication::receive(std::vector<int> &v, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 
@@ -791,7 +793,7 @@ void SocketCommunication::receive(std::vector<int> &v, int rankSender)
   }
 }
 
-void SocketCommunication::send(std::vector<double> const &v, int rankReceiver)
+void SocketCommunication::send(std::vector<double> const &v, Rank rankReceiver)
 {
   PRECICE_TRACE(rankReceiver);
 
@@ -809,7 +811,7 @@ void SocketCommunication::send(std::vector<double> const &v, int rankReceiver)
   }
 }
 
-void SocketCommunication::receive(std::vector<double> &v, int rankSender)
+void SocketCommunication::receive(std::vector<double> &v, Rank rankSender)
 {
   PRECICE_TRACE(rankSender);
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -8,10 +8,12 @@
 #include <string>
 #include <thread>
 #include <vector>
+
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "com/SocketSendQueue.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 #include "utils/networking.hpp"
 
 namespace precice {
@@ -57,79 +59,79 @@ public:
   virtual void closeConnection() override;
 
   /// Sends a std::string to process with given rank.
-  virtual void send(std::string const &itemToSend, int rankReceiver) override;
+  virtual void send(std::string const &itemToSend, Rank rankReceiver) override;
 
   /// Sends an array of integer values.
-  virtual void send(const int *itemsToSend, int size, int rankReceiver) override;
+  virtual void send(const int *itemsToSend, int size, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of integer values.
-  virtual PtrRequest aSend(const int *itemsToSend, int size, int rankReceiver) override;
+  virtual PtrRequest aSend(const int *itemsToSend, int size, Rank rankReceiver) override;
 
   /// Sends an array of double values.
-  virtual void send(const double *itemsToSend, int size, int rankReceiver) override;
+  virtual void send(const double *itemsToSend, int size, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of double values.
-  virtual PtrRequest aSend(const double *itemsToSend, int size, int rankReceiver) override;
+  virtual PtrRequest aSend(const double *itemsToSend, int size, Rank rankReceiver) override;
 
-  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(std::vector<double> const &itemsToSend, Rank rankReceiver) override;
 
   /// Sends a double to process with given rank.
-  virtual void send(double itemToSend, int rankReceiver) override;
+  virtual void send(double itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(const double &itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
 
   /// Sends an int to process with given rank.
-  virtual void send(int itemToSend, int rankReceiver) override;
+  virtual void send(int itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(const int &itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
 
   /// Sends a bool to process with given rank.
-  virtual void send(bool itemToSend, int rankReceiver) override;
+  virtual void send(bool itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(const bool &itemToSend, int rankReceiver) override;
+  virtual PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
 
   /// Receives a std::string from process with given rank.
-  virtual void receive(std::string &itemToReceive, int rankSender) override;
+  virtual void receive(std::string &itemToReceive, Rank rankSender) override;
 
   /// Receives an array of integer values.
-  virtual void receive(int *itemsToReceive, int size, int rankSender) override;
+  virtual void receive(int *itemsToReceive, int size, Rank rankSender) override;
 
   /// Receives an array of double values.
-  virtual void receive(double *itemsToReceive, int size, int rankSender) override;
+  virtual void receive(double *itemsToReceive, int size, Rank rankSender) override;
 
   /// Asynchronously receives an array of double values.
   virtual PtrRequest aReceive(double *itemsToReceive,
                               int     size,
                               int     rankSender) override;
 
-  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, Rank rankSender) override;
 
   /// Receives a double from process with given rank.
-  virtual void receive(double &itemToReceive, int rankSender) override;
+  virtual void receive(double &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a double from process with given rank.
-  virtual PtrRequest aReceive(double &itemToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
 
   /// Receives an int from process with given rank.
-  virtual void receive(int &itemToReceive, int rankSender) override;
+  virtual void receive(int &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an int from process with given rank.
-  virtual PtrRequest aReceive(int &itemToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
 
   /// Receives a bool from process with given rank.
-  virtual void receive(bool &itemToReceive, int rankSender) override;
+  virtual void receive(bool &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a bool from process with given rank.
-  virtual PtrRequest aReceive(bool &itemToReceive, int rankSender) override;
+  virtual PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
 
-  void send(std::vector<int> const &v, int rankReceiver) override;
-  void receive(std::vector<int> &v, int rankSender) override;
+  void send(std::vector<int> const &v, Rank rankReceiver) override;
+  void receive(std::vector<int> &v, Rank rankSender) override;
 
-  void send(std::vector<double> const &v, int rankReceiver) override;
-  void receive(std::vector<double> &v, int rankSender) override;
+  void send(std::vector<double> const &v, Rank rankReceiver) override;
+  void receive(std::vector<double> &v, Rank rankSender) override;
 
   virtual void prepareEstablishment(std::string const &acceptorName,
                                     std::string const &requesterName) override;

--- a/src/com/tests/CommunicateBoundingBoxTest.cpp
+++ b/src/com/tests/CommunicateBoundingBoxTest.cpp
@@ -2,11 +2,13 @@
 #include <map>
 #include <memory>
 #include <vector>
+
 #include "com/CommunicateBoundingBox.hpp"
 #include "com/SharedPointer.hpp"
 #include "m2n/M2N.hpp"
 #include "mesh/BoundingBox.hpp"
 #include "mesh/Mesh.hpp"
+#include "precice/types.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 #include "utils/MasterSlave.hpp"
@@ -53,7 +55,7 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveBoundingBoxMap)
   for (int dim = 2; dim <= 3; dim++) {
     mesh::Mesh::BoundingBoxMap bbm;
 
-    for (int rank = 0; rank < 3; rank++) {
+    for (Rank rank = 0; rank < 3; rank++) {
       std::vector<double> bounds;
       for (int i = 0; i < dim; i++) {
         bounds.push_back(rank * i);
@@ -78,7 +80,7 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveBoundingBoxMap)
 
       comBB.receiveBoundingBoxMap(bbmCompare, 0);
 
-      for (int rank = 0; rank < 3; rank++) {
+      for (Rank rank = 0; rank < 3; rank++) {
         BOOST_TEST(bbm.at(rank) == bbmCompare.at(rank));
       }
     }
@@ -92,7 +94,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveBoundingBoxMap)
   // Build BB/BBMap to communicate
   int                        dimension = 3;
   mesh::Mesh::BoundingBoxMap bbm;
-  for (int rank = 0; rank < 3; rank++) {
+  for (Rank rank = 0; rank < 3; rank++) {
     std::vector<double> bounds;
     for (int i = 0; i < dimension; i++) {
       bounds.push_back(rank * i);
@@ -115,7 +117,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveBoundingBoxMap)
     }
     comBB.broadcastReceiveBoundingBoxMap(bbmCompare);
     BOOST_TEST((int) bbmCompare.size() == 3);
-    for (int rank = 0; rank < 3; rank++) {
+    for (Rank rank = 0; rank < 3; rank++) {
       BOOST_TEST(bbm.at(rank) == bbmCompare.at(rank));
     }
   }
@@ -129,7 +131,7 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveConnectionMap)
   std::vector<int>                fb;
   std::map<int, std::vector<int>> fbm;
 
-  for (int rank = 0; rank < 3; rank++) {
+  for (Rank rank = 0; rank < 3; rank++) {
 
     for (int i = 0; i < 3; i++) {
       fb.push_back(i + 1);
@@ -148,7 +150,7 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveConnectionMap)
     std::vector<int>                fbCompare;
     std::map<int, std::vector<int>> fbmCompare;
 
-    for (int rank = 0; rank < 3; rank++) {
+    for (Rank rank = 0; rank < 3; rank++) {
 
       for (int i = 0; i < 3; i++) {
         fbCompare.push_back(-1);
@@ -160,7 +162,7 @@ BOOST_AUTO_TEST_CASE(SendAndReceiveConnectionMap)
 
     comBB.receiveConnectionMap(fbmCompare, 0);
 
-    for (int rank = 0; rank < 3; rank++) {
+    for (Rank rank = 0; rank < 3; rank++) {
 
       BOOST_TEST(fbm.at(rank) == fbmCompare.at(rank));
     }
@@ -174,7 +176,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveConnectionMap)
   std::vector<int>                fb;
   std::map<int, std::vector<int>> fbm;
 
-  for (int rank = 0; rank < 3; rank++) {
+  for (Rank rank = 0; rank < 3; rank++) {
 
     for (int i = 0; i < 3; i++) {
       fb.push_back(i + 1);
@@ -193,7 +195,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveConnectionMap)
     std::vector<int>                fbCompare;
     std::map<int, std::vector<int>> fbmCompare;
 
-    for (int rank = 0; rank < 3; rank++) {
+    for (Rank rank = 0; rank < 3; rank++) {
       for (int i = 0; i < 3; i++) {
         fbCompare.push_back(-1);
       }
@@ -203,7 +205,7 @@ BOOST_AUTO_TEST_CASE(BroadcastSendAndReceiveConnectionMap)
 
     comBB.broadcastReceiveConnectionMap(fbmCompare);
 
-    for (int rank = 0; rank < 3; rank++) {
+    for (Rank rank = 0; rank < 3; rank++) {
 
       BOOST_TEST(fbm.at(rank) == fbmCompare.at(rank));
     }

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -1,10 +1,11 @@
-#include "BaseCouplingScheme.hpp"
 #include <Eigen/Core>
 #include <cmath>
 #include <cstddef>
 #include <limits>
 #include <sstream>
 #include <utility>
+
+#include "BaseCouplingScheme.hpp"
 #include "acceleration/Acceleration.hpp"
 #include "cplscheme/Constants.hpp"
 #include "cplscheme/CouplingData.hpp"
@@ -16,6 +17,7 @@
 #include "math/differences.hpp"
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
+#include "precice/types.hpp"
 #include "time/Waveform.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/MasterSlave.hpp"
@@ -131,7 +133,7 @@ void BaseCouplingScheme::initialize(double startTime, int startTimeWindow)
                     "an implicit coupling scheme.");
       // setup convergence measures
       for (ConvergenceMeasureContext &convergenceMeasure : _convergenceMeasures) {
-        int dataID = convergenceMeasure.couplingData->getDataID();
+        DataID dataID = convergenceMeasure.couplingData->getDataID();
         assignDataToConvergenceMeasure(&convergenceMeasure, dataID);
       }
       // reserve memory and initialize data with zero
@@ -636,7 +638,7 @@ bool BaseCouplingScheme::doImplicitStep()
   return convergence;
 }
 
-void BaseCouplingScheme::assignDataToConvergenceMeasure(ConvergenceMeasureContext *convergenceMeasure, int dataID)
+void BaseCouplingScheme::assignDataToConvergenceMeasure(ConvergenceMeasureContext *convergenceMeasure, DataID dataID)
 {
   PRECICE_TRACE(dataID);
   DataMap::iterator iter = _allData.find(dataID);

--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -1,10 +1,11 @@
-#include "BiCouplingScheme.hpp"
 #include <algorithm>
 #include <map>
 #include <memory>
 #include <ostream>
 #include <type_traits>
 #include <utility>
+
+#include "BiCouplingScheme.hpp"
 #include "cplscheme/BaseCouplingScheme.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "cplscheme/SharedPointer.hpp"
@@ -12,6 +13,7 @@
 #include "m2n/M2N.hpp"
 #include "m2n/SharedPointer.hpp"
 #include "mesh/Data.hpp"
+#include "precice/types.hpp"
 #include "utils/Helpers.hpp"
 
 namespace precice {
@@ -97,7 +99,7 @@ std::vector<std::string> BiCouplingScheme::getCouplingPartners() const
 }
 
 CouplingData *BiCouplingScheme::getSendData(
-    int dataID)
+    DataID dataID)
 {
   PRECICE_TRACE(dataID);
   DataMap::iterator iter = _sendData.find(dataID);
@@ -108,7 +110,7 @@ CouplingData *BiCouplingScheme::getSendData(
 }
 
 CouplingData *BiCouplingScheme::getReceiveData(
-    int dataID)
+    DataID dataID)
 {
   PRECICE_TRACE(dataID);
   DataMap::iterator iter = _receiveData.find(dataID);

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -2,11 +2,13 @@
 
 #include <string>
 #include <vector>
+
 #include "BaseCouplingScheme.hpp"
 #include "cplscheme/Constants.hpp"
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 // Forward declaration to friend the boost test struct
@@ -72,7 +74,7 @@ public:
   /**
    * @returns true, if coupling scheme has sendData with given DataID
    */
-  bool hasSendData(int dataID)
+  bool hasSendData(DataID dataID)
   {
     return getSendData(dataID) != nullptr;
   }
@@ -91,10 +93,10 @@ protected:
   }
 
   /// Sets the values
-  CouplingData *getSendData(int dataID);
+  CouplingData *getSendData(DataID dataID);
 
   /// Returns all data to be received with data ID as given.
-  CouplingData *getReceiveData(int dataID);
+  CouplingData *getReceiveData(DataID dataID);
 
   /// @return Communication device to the other coupling participant.
   m2n::PtrM2N getM2N() const

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -1,4 +1,3 @@
-#include "CouplingSchemeConfiguration.hpp"
 #include <algorithm>
 #include <cstddef>
 #include <memory>
@@ -6,6 +5,8 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
+
+#include "CouplingSchemeConfiguration.hpp"
 #include "acceleration/Acceleration.hpp"
 #include "acceleration/AitkenAcceleration.hpp"
 #include "acceleration/config/AccelerationConfiguration.hpp"
@@ -27,6 +28,7 @@
 #include "mesh/Mesh.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
 #include "precice/impl/SharedPointer.hpp"
+#include "precice/types.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/assertion.hpp"
 #include "xml/ConfigParser.hpp"
@@ -829,7 +831,7 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialImplicitCouplingSchem
   setSerialAcceleration(scheme, first, second);
 
   if (scheme->doesFirstStep() && _accelerationConfig->getAcceleration() && not _accelerationConfig->getAcceleration()->getDataIDs().empty()) {
-    int dataID = *(_accelerationConfig->getAcceleration()->getDataIDs().begin());
+    DataID dataID = *(_accelerationConfig->getAcceleration()->getDataIDs().begin());
     PRECICE_CHECK(not scheme->hasSendData(dataID),
                   "In case of serial coupling, acceleration can be defined for data of second participant only!");
   }
@@ -1017,7 +1019,7 @@ void CouplingSchemeConfiguration::addMultiDataToBeExchanged(
 }
 
 void CouplingSchemeConfiguration::checkIfDataIsExchanged(
-    int dataID) const
+    DataID dataID) const
 {
   const auto match = std::find_if(_config.exchanges.begin(),
                                   _config.exchanges.end(),
@@ -1092,7 +1094,7 @@ void CouplingSchemeConfiguration::setSerialAcceleration(
     for (std::string &neededMesh : _accelerationConfig->getNeededMeshes()) {
       _meshConfig->addNeededMesh(second, neededMesh);
     }
-    for (const int dataID : _accelerationConfig->getAcceleration()->getDataIDs()) {
+    for (const DataID dataID : _accelerationConfig->getAcceleration()->getDataIDs()) {
       checkSerialImplicitAccelerationData(dataID, first, second);
     }
     scheme->setAcceleration(_accelerationConfig->getAcceleration());
@@ -1107,7 +1109,7 @@ void CouplingSchemeConfiguration::setParallelAcceleration(
     for (std::string &neededMesh : _accelerationConfig->getNeededMeshes()) {
       _meshConfig->addNeededMesh(participant, neededMesh);
     }
-    for (const int dataID : _accelerationConfig->getAcceleration()->getDataIDs()) {
+    for (const DataID dataID : _accelerationConfig->getAcceleration()->getDataIDs()) {
       checkIfDataIsExchanged(dataID);
     }
     scheme->setAcceleration(_accelerationConfig->getAcceleration());

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+
 #include "acceleration/SharedPointer.hpp"
 #include "cplscheme/Constants.hpp"
 #include "cplscheme/CouplingScheme.hpp"
@@ -15,6 +16,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "precice/config/SharedPointer.hpp"
 #include "precice/impl/MeshContext.hpp"
+#include "precice/types.hpp"
 #include "xml/XMLTag.hpp"
 
 namespace precice {
@@ -258,10 +260,10 @@ private:
       const std::string &  accessor) const;
 
   void checkIfDataIsExchanged(
-      int dataID) const;
+      DataID dataID) const;
 
   void checkSerialImplicitAccelerationData(
-      int dataID, const std::string &first, const std::string &second) const;
+      DataID dataID, const std::string &first, const std::string &second) const;
 
   void addConvergenceMeasures(
       BaseCouplingScheme *                           scheme,

--- a/src/cplscheme/cplscheme.dox
+++ b/src/cplscheme/cplscheme.dox
@@ -39,7 +39,7 @@ std::string nameOtherSolver ( "OtherSolverName" );
 // Create one data
 std::string dataName ( "MyData" );
 Data::DataTypeConstants dataType ( Data::TYPE_VECTOR );
-int dataID ( 1 );
+DataID dataID ( 1 );
 Data data ( dataName, dataType, dataID );
 
 // Create a mesh (in a real example, it has to be filled with Vertices, ...)

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -1,9 +1,11 @@
-#include "m2n/BoundM2N.hpp"
 #include <memory>
+
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
+#include "m2n/BoundM2N.hpp"
 #include "m2n/M2N.hpp"
+#include "precice/types.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
 
@@ -80,7 +82,7 @@ void BoundM2N::cleanupEstablishment()
 void BoundM2N::waitForSlaves()
 {
   if (utils::MasterSlave::isMaster()) {
-    for (int rank : utils::MasterSlave::allSlaves()) {
+    for (Rank rank : utils::MasterSlave::allSlaves()) {
       int item = 0;
       utils::MasterSlave::_communication->receive(item, rank);
       PRECICE_ASSERT(item > 0);

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -1,14 +1,15 @@
-#include "GatherScatterCommunication.hpp"
 #include <algorithm>
 #include <map>
 #include <memory>
 #include <ostream>
 #include <utility>
 
+#include "GatherScatterCommunication.hpp"
 #include "com/Communication.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/DistributedCommunication.hpp"
 #include "mesh/Mesh.hpp"
+#include "precice/types.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
 
@@ -87,7 +88,7 @@ void GatherScatterCommunication::send(
     }
 
     // Slaves data
-    for (int rankSlave : utils::MasterSlave::allSlaves()) {
+    for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
       PRECICE_ASSERT(utils::MasterSlave::_communication.get() != nullptr);
       PRECICE_ASSERT(utils::MasterSlave::_communication->isConnected());
 
@@ -145,7 +146,7 @@ void GatherScatterCommunication::receive(
     }
 
     // Slaves data
-    for (int rankSlave : utils::MasterSlave::allSlaves()) {
+    for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
       PRECICE_ASSERT(utils::MasterSlave::_communication.get() != nullptr);
       PRECICE_ASSERT(utils::MasterSlave::_communication->isConnected());
 

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -1,10 +1,12 @@
-#include "M2N.hpp"
 #include <utility>
+
 #include "DistributedComFactory.hpp"
 #include "DistributedCommunication.hpp"
+#include "M2N.hpp"
 #include "com/Communication.hpp"
 #include "logging/LogMacros.hpp"
 #include "mesh/Mesh.hpp"
+#include "precice/types.hpp"
 #include "utils/Event.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
@@ -233,7 +235,7 @@ void M2N::send(double itemToSend)
 
 void M2N::broadcastSendMesh(mesh::Mesh &mesh)
 {
-  int meshID = mesh.getID();
+  MeshID meshID = mesh.getID();
   PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
   PRECICE_ASSERT(_areSlavesConnected);
@@ -247,7 +249,7 @@ void M2N::scatterAllCommunicationMap(std::map<int, std::vector<int>> &localCommu
 {
   PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
-  int meshID = mesh.getID();
+  MeshID meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
   _distComs[meshID]->scatterAllCommunicationMap(localCommunicationMap);
 }
@@ -256,7 +258,7 @@ void M2N::broadcastSend(int &itemToSend, mesh::Mesh &mesh)
 {
   PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
-  int meshID = mesh.getID();
+  MeshID meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
   _distComs[meshID]->broadcastSend(itemToSend);
 }
@@ -316,7 +318,7 @@ void M2N::broadcastReceiveAll(std::vector<int> &itemToReceive, mesh::Mesh &mesh)
 {
   PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
-  int meshID = mesh.getID();
+  MeshID meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
   _distComs[meshID]->broadcastReceiveAll(itemToReceive);
 }
@@ -325,7 +327,7 @@ void M2N::broadcastReceiveAllMesh(mesh::Mesh &mesh)
 {
   PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
-  int meshID = mesh.getID();
+  MeshID meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
   PRECICE_ASSERT(_distComs.find(meshID) != _distComs.end());
   PRECICE_ASSERT(_distComs[meshID].get() != nullptr);
@@ -336,7 +338,7 @@ void M2N::gatherAllCommunicationMap(std::map<int, std::vector<int>> &localCommun
 {
   PRECICE_ASSERT(utils::MasterSlave::isParallel(),
                  "This method can only be used for parallel participants");
-  int meshID = mesh.getID();
+  MeshID meshID = mesh.getID();
   PRECICE_ASSERT(_areSlavesConnected);
   _distComs[meshID]->gatherAllCommunicationMap(localCommunicationMap);
 }

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -1,4 +1,3 @@
-#include "PointToPointCommunication.hpp"
 #include <algorithm>
 #include <boost/container/flat_map.hpp>
 #include <functional>
@@ -9,8 +8,9 @@
 #include <set>
 #include <thread>
 #include <utility>
-
 #include <vector>
+
+#include "PointToPointCommunication.hpp"
 #include "com/CommunicateMesh.hpp"
 #include "com/Communication.hpp"
 #include "com/CommunicationFactory.hpp"
@@ -18,6 +18,7 @@
 #include "logging/LogMacros.hpp"
 #include "m2n/DistributedCommunication.hpp"
 #include "mesh/Mesh.hpp"
+#include "precice/types.hpp"
 #include "utils/Event.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
@@ -51,7 +52,7 @@ void receive(mesh::Mesh::VertexDistribution &m,
   communication->receive(size, rankSender);
 
   while (size--) {
-    int rank = -1;
+    Rank rank = -1;
     communication->receive(rank, rankSender);
     communication->receive(m[rank], rankSender);
   }
@@ -79,7 +80,7 @@ void broadcastReceive(mesh::Mesh::VertexDistribution &m,
   communication->broadcast(size, rankBroadcaster);
 
   while (size--) {
-    int rank = -1;
+    Rank rank = -1;
     communication->broadcast(rank, rankBroadcaster);
     communication->broadcast(m[rank], rankBroadcaster);
   }
@@ -114,7 +115,7 @@ void print(std::map<int, std::vector<int>> const &m)
 
     std::string s;
 
-    for (int rank : utils::MasterSlave::allSlaves()) {
+    for (Rank rank : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(s, rank);
 
       oss << s;
@@ -140,7 +141,7 @@ void printCommunicationPartnerCountStats(std::map<int, std::vector<int>> const &
       count++;
     }
 
-    for (int rank : utils::MasterSlave::allSlaves()) {
+    for (Rank rank : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(size, rank);
 
       total += size;
@@ -196,7 +197,7 @@ void printLocalIndexCountStats(std::map<int, std::vector<int>> const &m)
       count++;
     }
 
-    for (int rank : utils::MasterSlave::allSlaves()) {
+    for (Rank rank : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(size, rank);
 
       total += size;

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "Mapping.hpp"
-
 #include <Eigen/Core>
 #include <Eigen/QR>
 
 #include "com/CommunicateMesh.hpp"
 #include "com/Communication.hpp"
 #include "impl/BasisFunctions.hpp"
+#include "mapping/Mapping.hpp"
 #include "mesh/Filter.hpp"
+#include "precice/types.hpp"
 #include "query/Index.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Event.hpp"
@@ -174,7 +174,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       }
 
       // Receive mesh
-      for (int rankSlave : utils::MasterSlave::allSlaves()) {
+      for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
         mesh::Mesh slaveInMesh(inMesh->getName(), inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
         com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(slaveInMesh, rankSlave);
         globalInMesh.addMesh(slaveInMesh);
@@ -297,7 +297,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(int inputDa
     {
       std::vector<double> slaveBuffer;
       int                 slaveOutputValueSize;
-      for (int rank : utils::MasterSlave::allSlaves()) {
+      for (Rank rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->receive(slaveBuffer, rank);
         globalInValues.insert(globalInValues.end(), slaveBuffer.begin(), slaveBuffer.end());
 
@@ -347,7 +347,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(int inputDa
 
       // Data scattering to slaves
       int beginPoint = outputValueSizes.at(0);
-      for (int rank : utils::MasterSlave::allSlaves()) {
+      for (Rank rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->send(outputValues.data() + beginPoint, outputValueSizes.at(rank), rank);
         beginPoint += outputValueSizes.at(rank);
       }
@@ -408,7 +408,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(int inputData
 
       std::vector<double> slaveBuffer;
 
-      for (int rank : utils::MasterSlave::allSlaves()) {
+      for (Rank rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->receive(slaveBuffer, rank);
         std::copy(slaveBuffer.begin(), slaveBuffer.end(), globalInValues.begin() + inputSizeCounter);
         inputSizeCounter += slaveBuffer.size();
@@ -456,7 +456,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(int inputData
     int beginPoint = outValuesSize.at(0);
 
     if (utils::MasterSlave::isMaster()) {
-      for (int rank : utils::MasterSlave::allSlaves()) {
+      for (Rank rank : utils::MasterSlave::allSlaves()) {
         utils::MasterSlave::_communication->send(outputValues.data() + beginPoint, outValuesSize.at(rank), rank);
         beginPoint += outValuesSize.at(rank);
       }

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -19,7 +20,7 @@ Data::Data()
 
 Data::Data(
     std::string name,
-    int         id,
+    DataID      id,
     int         dimensions)
     : _values(),
       _name(std::move(name)),
@@ -50,7 +51,7 @@ const std::string &Data::getName() const
   return _name;
 }
 
-int Data::getID() const
+DataID Data::getID() const
 {
   return _id;
 }

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -3,7 +3,9 @@
 #include <Eigen/Core>
 #include <stddef.h>
 #include <string>
+
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace mesh {
@@ -59,7 +61,7 @@ public:
    */
   Data(
       std::string name,
-      int         id,
+      DataID      id,
       int         dimension);
 
   /// Destructor, decrements data count.
@@ -75,7 +77,7 @@ public:
   const std::string &getName() const;
 
   /// Returns the ID of the data set (supposed to be unique).
-  int getID() const;
+  DataID getID() const;
 
   /**
    * @brief Returns the type constant of the data set.
@@ -100,7 +102,7 @@ private:
   std::string _name;
 
   /// ID of the data set (supposed to be unique).
-  int _id;
+  DataID _id;
 
   //  // @brief Type of data (scalar or vector).
   //  DataType _type;

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -1,7 +1,9 @@
-#include "Edge.hpp"
 #include <Eigen/Core>
 #include <algorithm>
+
+#include "Edge.hpp"
 #include "math/differences.hpp"
+#include "precice/types.hpp"
 #include "utils/EigenIO.hpp"
 
 namespace precice {
@@ -10,7 +12,7 @@ namespace mesh {
 Edge::Edge(
     Vertex &vertexOne,
     Vertex &vertexTwo,
-    int     id)
+    EdgeID  id)
     : _vertices({&vertexOne, &vertexTwo}),
       _id(id)
 {
@@ -18,7 +20,7 @@ Edge::Edge(
                  vertexOne.getDimensions(), vertexTwo.getDimensions());
 }
 
-int Edge::getID() const
+EdgeID Edge::getID() const
 {
   return _id;
 }

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -3,8 +3,10 @@
 #include <Eigen/Core>
 #include <array>
 #include <iostream>
+
 #include "math/differences.hpp"
 #include "mesh/Vertex.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -28,7 +30,7 @@ public:
   Edge(
       Vertex &vertexOne,
       Vertex &vertexTwo,
-      int     id);
+      EdgeID  id);
 
   /// Returns number of spatial dimensions (2 or 3) the edge is embedded to.
   int getDimensions() const;
@@ -43,7 +45,7 @@ public:
   Eigen::VectorXd computeNormal() const;
 
   /// Returns the (among edges) unique ID of the edge.
-  int getID() const;
+  EdgeID getID() const;
 
   /// Returns the length of the edge
   double getLength() const;

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <boost/container/flat_map.hpp>
+
 #include "mesh/Mesh.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace mesh {
@@ -16,7 +18,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
 {
   // Create a flat_map which can contain all vertices of the original mesh.
   // This prevents resizes during the map build-up.
-  boost::container::flat_map<int, Vertex *> vertexMap;
+  boost::container::flat_map<VertexID, Vertex *> vertexMap;
   vertexMap.reserve(source.vertices().size());
 
   for (const Vertex &vertex : source.vertices()) {
@@ -32,13 +34,13 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
 
   // Create a flat_map which can contain all edges of the original mesh.
   // This prevents resizes during the map build-up.
-  boost::container::flat_map<int, Edge *> edgeMap;
+  boost::container::flat_map<EdgeID, Edge *> edgeMap;
   edgeMap.reserve(source.edges().size());
 
   // Add all edges formed by the contributing vertices
   for (const Edge &edge : source.edges()) {
-    int vertexIndex1 = edge.vertex(0).getID();
-    int vertexIndex2 = edge.vertex(1).getID();
+    VertexID vertexIndex1 = edge.vertex(0).getID();
+    VertexID vertexIndex2 = edge.vertex(1).getID();
     if (vertexMap.count(vertexIndex1) == 1 &&
         vertexMap.count(vertexIndex2) == 1) {
       Edge &e               = destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
@@ -49,9 +51,9 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
   // Add all triangles formed by the contributing edges
   if (source.getDimensions() == 3) {
     for (const Triangle &triangle : source.triangles()) {
-      int edgeIndex1 = triangle.edge(0).getID();
-      int edgeIndex2 = triangle.edge(1).getID();
-      int edgeIndex3 = triangle.edge(2).getID();
+      EdgeID edgeIndex1 = triangle.edge(0).getID();
+      EdgeID edgeIndex2 = triangle.edge(1).getID();
+      EdgeID edgeIndex3 = triangle.edge(2).getID();
       if (edgeMap.count(edgeIndex1) == 1 &&
           edgeMap.count(edgeIndex2) == 1 &&
           edgeMap.count(edgeIndex3) == 1) {

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -1,4 +1,3 @@
-#include "Mesh.hpp"
 #include <Eigen/Core>
 #include <algorithm>
 #include <array>
@@ -9,11 +8,14 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+
 #include "Edge.hpp"
+#include "Mesh.hpp"
 #include "Triangle.hpp"
 #include "logging/LogMacros.hpp"
 #include "math/geometry.hpp"
 #include "mesh/Data.hpp"
+#include "precice/types.hpp"
 #include "query/Index.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 
@@ -23,7 +25,7 @@ namespace mesh {
 Mesh::Mesh(
     std::string name,
     int         dimensions,
-    int         id)
+    MeshID      id)
     : _name(std::move(name)),
       _dimensions(dimensions),
       _id(id),
@@ -97,11 +99,11 @@ Edge &Mesh::createUniqueEdge(
     Vertex &vertexOne,
     Vertex &vertexTwo)
 {
-  const std::array<int, 2> vids{vertexOne.getID(), vertexTwo.getID()};
-  const auto               eend = edges().end();
-  auto                     pos  = std::find_if(edges().begin(), eend,
+  const std::array<VertexID, 2> vids{vertexOne.getID(), vertexTwo.getID()};
+  const auto                    eend = edges().end();
+  auto                          pos  = std::find_if(edges().begin(), eend,
                           [&vids](const Edge &e) -> bool {
-                            const std::array<int, 2> eids{e.vertex(0).getID(), e.vertex(1).getID()};
+                            const std::array<VertexID, 2> eids{e.vertex(0).getID(), e.vertex(1).getID()};
                             return std::is_permutation(vids.begin(), vids.end(), eids.begin());
                           });
   if (pos != eend) {
@@ -147,7 +149,7 @@ const Mesh::DataContainer &Mesh::data() const
   return _data;
 }
 
-const PtrData &Mesh::data(int dataID) const
+const PtrData &Mesh::data(DataID dataID) const
 {
   auto iter = std::find_if(_data.begin(), _data.end(), [dataID](const auto &dptr) {
     return dptr->getID() == dataID;
@@ -170,17 +172,17 @@ const std::string &Mesh::getName() const
   return _name;
 }
 
-int Mesh::getID() const
+MeshID Mesh::getID() const
 {
   return _id;
 }
 
-bool Mesh::isValidVertexID(int vertexID) const
+bool Mesh::isValidVertexID(VertexID vertexID) const
 {
   return (0 <= vertexID) && (static_cast<size_t>(vertexID) < vertices().size());
 }
 
-bool Mesh::isValidEdgeID(int edgeID) const
+bool Mesh::isValidEdgeID(EdgeID edgeID) const
 {
   return (0 <= edgeID) && (static_cast<size_t>(edgeID) < edges().size());
 }
@@ -265,7 +267,7 @@ void Mesh::setGlobalNumberOfVertices(int num)
   _globalNumberOfVertices = num;
 }
 
-Eigen::VectorXd Mesh::getOwnedVertexData(int dataID)
+Eigen::VectorXd Mesh::getOwnedVertexData(DataID dataID)
 {
 
   std::vector<double> ownedDataVector;
@@ -298,7 +300,7 @@ void Mesh::addMesh(
   PRECICE_TRACE();
   PRECICE_ASSERT(_dimensions == deltaMesh.getDimensions());
 
-  boost::container::flat_map<int, Vertex *> vertexMap;
+  boost::container::flat_map<VertexID, Vertex *> vertexMap;
   vertexMap.reserve(deltaMesh.vertices().size());
   Eigen::VectorXd coords(_dimensions);
   for (const Vertex &vertex : deltaMesh.vertices()) {
@@ -312,14 +314,14 @@ void Mesh::addMesh(
     vertexMap[vertex.getID()] = &v;
   }
 
-  boost::container::flat_map<int, Edge *> edgeMap;
+  boost::container::flat_map<EdgeID, Edge *> edgeMap;
   edgeMap.reserve(deltaMesh.edges().size());
   // you cannot just take the vertices from the edge and add them,
   // since you need the vertices from the new mesh
   // (which may differ in IDs)
   for (const Edge &edge : deltaMesh.edges()) {
-    int vertexIndex1 = edge.vertex(0).getID();
-    int vertexIndex2 = edge.vertex(1).getID();
+    VertexID vertexIndex1 = edge.vertex(0).getID();
+    VertexID vertexIndex2 = edge.vertex(1).getID();
     PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
                    (vertexMap.count(vertexIndex2) == 1));
     Edge &e               = createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
@@ -328,9 +330,9 @@ void Mesh::addMesh(
 
   if (_dimensions == 3) {
     for (const Triangle &triangle : deltaMesh.triangles()) {
-      int edgeIndex1 = triangle.edge(0).getID();
-      int edgeIndex2 = triangle.edge(1).getID();
-      int edgeIndex3 = triangle.edge(2).getID();
+      EdgeID edgeIndex1 = triangle.edge(0).getID();
+      EdgeID edgeIndex2 = triangle.edge(1).getID();
+      EdgeID edgeIndex3 = triangle.edge(2).getID();
       PRECICE_ASSERT((edgeMap.count(edgeIndex1) == 1) &&
                      (edgeMap.count(edgeIndex2) == 1) &&
                      (edgeMap.count(edgeIndex3) == 1));

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include "logging/Logger.hpp"
 #include "mesh/BoundingBox.hpp"
 #include "mesh/Data.hpp"
@@ -15,6 +16,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
+#include "precice/types.hpp"
 #include "utils/ManageUniqueIDs.hpp"
 #include "utils/PointerVector.hpp"
 #include "utils/assertion.hpp"
@@ -42,10 +44,10 @@ public:
   using BoundingBoxMap    = std::map<int, BoundingBox>;
 
   /// A mapping from rank to used (not necessarily owned) vertex IDs
-  using VertexDistribution = std::map<int, std::vector<int>>;
+  using VertexDistribution = std::map<Rank, std::vector<VertexID>>;
 
   /// A mapping from remote local ranks to the IDs that must be communicated
-  using CommunicationMap = std::map<int, std::vector<int>>;
+  using CommunicationMap = std::map<Rank, std::vector<VertexID>>;
 
   /// Signal is emitted when the mesh is changed
   boost::signals2::signal<void(Mesh &)> meshChanged;
@@ -54,7 +56,7 @@ public:
   boost::signals2::signal<void(Mesh &)> meshDestroyed;
 
   /// Use if the id of the mesh is not necessary
-  static constexpr int MESH_ID_UNDEFINED{-1};
+  static constexpr MeshID MESH_ID_UNDEFINED{-1};
 
   /**
    * @brief Constructor.
@@ -66,7 +68,7 @@ public:
   Mesh(
       std::string name,
       int         dimensions,
-      int         id);
+      MeshID      id);
 
   /// Destructor, deletes created objects.
   ~Mesh();
@@ -134,7 +136,7 @@ public:
   const DataContainer &data() const;
 
   /// Returns the data with the matching ID
-  const PtrData &data(int dataID) const;
+  const PtrData &data(DataID dataID) const;
 
   /// Returns the data with the matching name
   const PtrData &data(const std::string &dataName) const;
@@ -143,13 +145,13 @@ public:
   const std::string &getName() const;
 
   /// Returns the base ID of the mesh.
-  int getID() const;
+  MeshID getID() const;
 
   /// Returns true if the given vertexID is valid
-  bool isValidVertexID(int vertexID) const;
+  bool isValidVertexID(VertexID vertexID) const;
 
   /// Returns true if the given edgeID is valid
-  bool isValidEdgeID(int edgeID) const;
+  bool isValidEdgeID(EdgeID edgeID) const;
 
   /// Allocates memory for the vertex data values.
   void allocateDataValues();
@@ -184,13 +186,13 @@ public:
   void setGlobalNumberOfVertices(int num);
 
   // Get the data of owned vertices for given data ID
-  Eigen::VectorXd getOwnedVertexData(int dataID);
+  Eigen::VectorXd getOwnedVertexData(DataID dataID);
 
   // Tag all the vertices
   void tagAll();
 
   /// Returns a vector of connected ranks
-  std::vector<int> &getConnectedRanks()
+  std::vector<Rank> &getConnectedRanks()
   {
     return _connectedRanks;
   }
@@ -224,7 +226,7 @@ private:
   int _dimensions;
 
   /// The ID of this mesh.
-  int _id;
+  MeshID _id;
 
   /// Holds vertices, edges, and triangles.
   VertexContainer   _vertices;
@@ -259,7 +261,7 @@ private:
    * @brief each rank stores list of connected remote ranks.
    * In the m2n package, this is used to create the initial communication channels.
    */
-  std::vector<int> _connectedRanks;
+  std::vector<Rank> _connectedRanks;
 
   /**
    * @brief each rank stores list of connected ranks and corresponding vertex IDs here.

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -4,9 +4,11 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+
 #include "math/differences.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/RangeAccessor.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -39,10 +41,10 @@ public:
 
   /// Constructor, the order of edges defines the outer normal direction.
   Triangle(
-      Edge &edgeOne,
-      Edge &edgeTwo,
-      Edge &edgeThree,
-      int   id);
+      Edge &     edgeOne,
+      Edge &     edgeTwo,
+      Edge &     edgeThree,
+      TriangleID id);
 
   /// Returns dimensionalty of space the triangle is embedded in.
   int getDimensions() const;
@@ -98,7 +100,7 @@ public:
   Eigen::VectorXd computeNormal() const;
 
   /// Returns a among triangles globally unique ID.
-  int getID() const;
+  TriangleID getID() const;
 
   /// Returns the surface area of the triangle
   double getArea() const;
@@ -127,8 +129,8 @@ private:
   /// Decider for choosing unique vertices from _edges.
   std::array<bool, 3> _vertexMap;
 
-  /// ID of the edge.
-  int _id;
+  /// ID of the triangle.
+  TriangleID _id;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS
@@ -185,7 +187,7 @@ inline Triangle::const_iterator Triangle::cend() const
   return end();
 }
 
-inline int Triangle::getID() const
+inline TriangleID Triangle::getID() const
 {
   return _id;
 }

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -65,7 +65,7 @@ private:
   short _dim;
 
   /// Unique (among vertices in one mesh) ID of the vertex.
-  int _id;
+  VertexID _id;
 
   /// global (unique) index for parallel simulations
   int _globalIndex = -1;
@@ -102,7 +102,7 @@ void Vertex::setCoords(
   _coords[2] = (_dim == 3) ? coordinates[2] : 0.0;
 }
 
-inline int Vertex::getID() const
+inline VertexID Vertex::getID() const
 {
   return _id;
 }

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -4,7 +4,9 @@
 #include <array>
 #include <iostream>
 #include <utility>
+
 #include "math/differences.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -20,7 +22,7 @@ public:
   template <typename VECTOR_T>
   Vertex(
       const VECTOR_T &coordinates,
-      int             id);
+      VertexID        id);
 
   /// Returns spatial dimensionality of vertex.
   int getDimensions() const;
@@ -30,7 +32,7 @@ public:
   void setCoords(const VECTOR_T &coordinates);
 
   /// Returns the unique (among vertices of one mesh on one processor) ID of the vertex.
-  int getID() const;
+  VertexID getID() const;
 
   /// Returns the coordinates of the vertex.
   Eigen::VectorXd getCoords() const;

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -1,10 +1,10 @@
-#include "partition/ProvidedPartition.hpp"
 #include <algorithm>
 #include <map>
 #include <memory>
 #include <ostream>
 #include <utility>
 #include <vector>
+
 #include "com/CommunicateBoundingBox.hpp"
 #include "com/CommunicateMesh.hpp"
 #include "com/Communication.hpp"
@@ -16,6 +16,8 @@
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
 #include "partition/Partition.hpp"
+#include "partition/ProvidedPartition.hpp"
+#include "precice/types.hpp"
 #include "utils/Event.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
@@ -88,7 +90,7 @@ void ProvidedPartition::communicate()
           PRECICE_ASSERT(utils::MasterSlave::getRank() == 0);
           PRECICE_ASSERT(utils::MasterSlave::getSize() > 1);
 
-          for (int rankSlave : utils::MasterSlave::allSlaves()) {
+          for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
             com::CommunicateMesh(utils::MasterSlave::_communication).receiveMesh(globalMesh, rankSlave);
             PRECICE_DEBUG("Received sub-mesh, from slave: {}, global vertexCount: {}", rankSlave, globalMesh.vertices().size());
           }
@@ -134,7 +136,7 @@ void ProvidedPartition::prepare()
     int globalNumberOfVertices   = numberOfVertices;
 
     // receive number of slave vertices and fill vertex offsets
-    for (int rankSlave : utils::MasterSlave::allSlaves()) {
+    for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
       int numberOfSlaveVertices = -1;
       utils::MasterSlave::_communication->receive(numberOfSlaveVertices, rankSlave);
       _mesh->getVertexOffsets()[rankSlave] = numberOfSlaveVertices + _mesh->getVertexOffsets()[rankSlave - 1];
@@ -159,7 +161,7 @@ void ProvidedPartition::prepare()
         for (int i = 0; i < _mesh->getVertexOffsets()[0]; i++) {
           localIds.push_back(i);
         }
-        for (int rankSlave : utils::MasterSlave::allSlaves()) {
+        for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
           // This always creates an entry for each slave
           auto &slaveIds = _mesh->getVertexDistribution()[rankSlave];
           for (int i = _mesh->getVertexOffsets()[rankSlave - 1]; i < _mesh->getVertexOffsets()[rankSlave]; i++) {
@@ -250,7 +252,7 @@ void ProvidedPartition::compareBoundingBoxes()
     PRECICE_ASSERT(!bbm.empty(), "The bounding box of the local mesh is invalid!");
 
     // master receives bbs from slaves and stores them in bbm
-    for (int rankSlave : utils::MasterSlave::allSlaves()) {
+    for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
       // initialize bbm
       bbm.emplace(rankSlave, bb);
       com::CommunicateBoundingBox(utils::MasterSlave::_communication).receiveBoundingBox(bbm.at(rankSlave), rankSlave);
@@ -301,7 +303,7 @@ void ProvidedPartition::compareBoundingBoxes()
     utils::MasterSlave::_communication->broadcast(connectedRanksList, 0);
 
     if (!connectedRanksList.empty()) {
-      for (int rank : connectedRanksList) {
+      for (Rank rank : connectedRanksList) {
         remoteConnectionMap[rank] = {-1};
       }
       com::CommunicateBoundingBox(utils::MasterSlave::_communication).broadcastReceiveConnectionMap(remoteConnectionMap);

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "com/CommunicateBoundingBox.hpp"
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
@@ -26,6 +27,7 @@
 #include "partition/ProvidedPartition.hpp"
 #include "partition/ReceivedPartition.hpp"
 #include "precice/impl/versions.hpp"
+#include "precice/types.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 #include "utils/assertion.hpp"
@@ -99,7 +101,7 @@ void createSolidzMesh2DSmall(mesh::PtrMesh pSolidzMesh)
   pSolidzMesh->computeBoundingBox();
 }
 
-void createNastinMesh2D(mesh::PtrMesh pNastinMesh, int rank)
+void createNastinMesh2D(mesh::PtrMesh pNastinMesh, Rank rank)
 {
   int dimensions = 2;
   BOOST_TEST(pNastinMesh);
@@ -123,7 +125,7 @@ void createNastinMesh2D(mesh::PtrMesh pNastinMesh, int rank)
   pNastinMesh->computeBoundingBox();
 }
 
-void createNastinMesh2D2(mesh::PtrMesh pNastinMesh, int rank)
+void createNastinMesh2D2(mesh::PtrMesh pNastinMesh, Rank rank)
 {
   int dimensions = 2;
   PRECICE_ASSERT(pNastinMesh.use_count() > 0);
@@ -181,7 +183,7 @@ void createSolidzMesh3D(mesh::PtrMesh pSolidzMesh)
   pSolidzMesh->computeBoundingBox();
 }
 
-void createNastinMesh3D(mesh::PtrMesh pNastinMesh, int rank)
+void createNastinMesh3D(mesh::PtrMesh pNastinMesh, Rank rank)
 {
   int dimensions = 3;
   BOOST_TEST(pNastinMesh);
@@ -205,7 +207,7 @@ void createNastinMesh3D(mesh::PtrMesh pNastinMesh, int rank)
   pNastinMesh->computeBoundingBox();
 }
 
-void createNastinMesh3D2(mesh::PtrMesh pNastinMesh, int rank)
+void createNastinMesh3D2(mesh::PtrMesh pNastinMesh, Rank rank)
 {
   int dimensions = 3;
   PRECICE_ASSERT(pNastinMesh.use_count() > 0);

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <ostream>
 #include <utility>
+
 #include "DataContext.hpp"
 #include "MappingContext.hpp"
 #include "MeshContext.hpp"
@@ -14,6 +15,7 @@
 #include "mesh/config/DataConfiguration.hpp"
 #include "mesh/config/MeshConfiguration.hpp"
 #include "precice/impl/SharedPointer.hpp"
+#include "precice/types.hpp"
 #include "utils/ManageUniqueIDs.hpp"
 #include "utils/assertion.hpp"
 
@@ -143,14 +145,14 @@ void Participant::addWriteMappingContext(
 
 // Data queries
 
-const DataContext &Participant::dataContext(int dataID) const
+const DataContext &Participant::dataContext(DataID dataID) const
 {
   PRECICE_ASSERT((dataID >= 0) && (dataID < (int) _dataContexts.size()));
   PRECICE_ASSERT(_dataContexts[dataID] != nullptr);
   return *_dataContexts[dataID];
 }
 
-DataContext &Participant::dataContext(int dataID)
+DataContext &Participant::dataContext(DataID dataID)
 {
   PRECICE_TRACE(dataID, _dataContexts.size());
   PRECICE_ASSERT((dataID >= 0) && (dataID < (int) _dataContexts.size()));
@@ -178,7 +180,7 @@ utils::ptr_vector<DataContext> &Participant::readDataContexts()
   return _readDataContexts;
 }
 
-bool Participant::hasData(int dataID) const
+bool Participant::hasData(DataID dataID) const
 {
   return std::any_of(
       _meshContexts.begin(), _meshContexts.end(),
@@ -193,41 +195,41 @@ bool Participant::hasData(int dataID) const
       });
 }
 
-bool Participant::isDataUsed(const std::string &dataName, int meshID) const
+bool Participant::isDataUsed(const std::string &dataName, MeshID meshID) const
 {
   const auto &meshData = meshContext(meshID).mesh->data();
   const auto  match    = std::find_if(meshData.begin(), meshData.end(), [&dataName](auto &dptr) { return dptr->getName() == dataName; });
   return match != meshData.end();
 }
 
-bool Participant::isDataUsed(int dataID) const
+bool Participant::isDataUsed(DataID dataID) const
 {
   PRECICE_ASSERT((dataID >= 0) && (dataID < (int) _dataContexts.size()), dataID, (int) _dataContexts.size());
   return _dataContexts[dataID] != nullptr;
 }
 
-bool Participant::isDataRead(int dataID) const
+bool Participant::isDataRead(DataID dataID) const
 {
   return std::any_of(_readDataContexts.begin(), _readDataContexts.end(), [dataID](const DataContext &context) {
     return context.toData->getID() == dataID;
   });
 }
 
-bool Participant::isDataWrite(int dataID) const
+bool Participant::isDataWrite(DataID dataID) const
 {
   return std::any_of(_writeDataContexts.begin(), _writeDataContexts.end(), [dataID](const DataContext &context) {
     return context.fromData->getID() == dataID;
   });
 }
 
-int Participant::getUsedDataID(const std::string &dataName, int meshID) const
+int Participant::getUsedDataID(const std::string &dataName, MeshID meshID) const
 {
   const auto &dptr = usedMeshContext(meshID).mesh->data(dataName);
   PRECICE_ASSERT(dptr != nullptr);
   return dptr->getID();
 }
 
-std::string Participant::getDataName(int dataID) const
+std::string Participant::getDataName(DataID dataID) const
 {
   for (const MeshContext *mcptr : _meshContexts) {
     if (mcptr) {
@@ -244,14 +246,14 @@ std::string Participant::getDataName(int dataID) const
 
 /// Mesh queries
 
-const MeshContext &Participant::meshContext(int meshID) const
+const MeshContext &Participant::meshContext(MeshID meshID) const
 {
   PRECICE_ASSERT((meshID >= 0) && (meshID < (int) _meshContexts.size()));
   PRECICE_ASSERT(_meshContexts[meshID] != nullptr);
   return *_meshContexts[meshID];
 }
 
-MeshContext &Participant::meshContext(int meshID)
+MeshContext &Participant::meshContext(MeshID meshID)
 {
   PRECICE_TRACE(meshID, _meshContexts.size());
   PRECICE_ASSERT((meshID >= 0) && (meshID < (int) _meshContexts.size()),
@@ -270,7 +272,7 @@ std::vector<MeshContext *> &Participant::usedMeshContexts()
   return _usedMeshContexts;
 }
 
-MeshContext &Participant::usedMeshContext(int meshID)
+MeshContext &Participant::usedMeshContext(MeshID meshID)
 {
   auto pos = std::find_if(_usedMeshContexts.begin(), _usedMeshContexts.end(),
                           [meshID](MeshContext const *context) {
@@ -280,7 +282,7 @@ MeshContext &Participant::usedMeshContext(int meshID)
   return **pos;
 }
 
-MeshContext const &Participant::usedMeshContext(int meshID) const
+MeshContext const &Participant::usedMeshContext(MeshID meshID) const
 {
   auto pos = std::find_if(_usedMeshContexts.begin(), _usedMeshContexts.end(),
                           [meshID](MeshContext const *context) {
@@ -310,7 +312,7 @@ MeshContext const &Participant::usedMeshContext(const std::string &name) const
   return **pos;
 }
 
-bool Participant::hasMesh(int meshID) const
+bool Participant::hasMesh(MeshID meshID) const
 {
   return meshID < static_cast<int>(_meshContexts.size()) && _meshContexts.at(meshID) != nullptr;
 }
@@ -324,7 +326,7 @@ bool Participant::hasMesh(const std::string &meshName) const
       });
 }
 
-bool Participant::isMeshUsed(int meshID) const
+bool Participant::isMeshUsed(MeshID meshID) const
 {
   return std::any_of(
       _usedMeshContexts.begin(), _usedMeshContexts.end(),
@@ -342,7 +344,7 @@ bool Participant::isMeshUsed(const std::string &meshName) const
       });
 }
 
-bool Participant::isMeshProvided(int meshID) const
+bool Participant::isMeshProvided(MeshID meshID) const
 {
   PRECICE_ASSERT((meshID >= 0) && (meshID < (int) _meshContexts.size()));
   auto context = _meshContexts[meshID];
@@ -354,12 +356,12 @@ int Participant::getUsedMeshID(const std::string &meshName) const
   return usedMeshContext(meshName).mesh->getID();
 }
 
-std::string Participant::getMeshName(int meshID) const
+std::string Participant::getMeshName(MeshID meshID) const
 {
   return meshContext(meshID).mesh->getName();
 }
 
-std::string Participant::getMeshNameFromData(int dataID) const
+std::string Participant::getMeshNameFromData(DataID dataID) const
 {
   for (const MeshContext *mcptr : _meshContexts) {
     for (const auto &dptr : mcptr->mesh->data()) {

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "SharedPointer.hpp"
 #include "action/SharedPointer.hpp"
 #include "cplscheme/SharedPointer.hpp"
@@ -15,6 +16,7 @@
 #include "mapping/SharedPointer.hpp"
 #include "mesh/SharedPointer.hpp"
 #include "partition/ReceivedPartition.hpp"
+#include "precice/types.hpp"
 #include "utils/ManageUniqueIDs.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/PointerVector.hpp"
@@ -117,12 +119,12 @@ public:
   /** Provides access to both write and read \ref DataContext
    * @pre there exists a \ref DataContext for \ref dataID
    */
-  const DataContext &dataContext(int dataID) const;
+  const DataContext &dataContext(DataID dataID) const;
 
   /** Provides access to both write and read \ref DataContext
    * @pre there exists a \ref DataContext for \ref dataID
    */
-  DataContext &dataContext(int dataID);
+  DataContext &dataContext(DataID dataID);
 
   /** Provides access to write \ref DataContext
    * @remarks does not contain nullptr.
@@ -145,25 +147,25 @@ public:
   utils::ptr_vector<DataContext> &readDataContexts();
 
   /// Is the dataID know to preCICE?
-  bool hasData(int dataID) const;
+  bool hasData(DataID dataID) const;
 
   /// Is the data used by this participant?
-  bool isDataUsed(int dataID) const;
+  bool isDataUsed(DataID dataID) const;
 
   /// Is the data used by this participant?
-  bool isDataUsed(const std::string &dataName, int meshId) const;
+  bool isDataUsed(const std::string &dataName, MeshID meshId) const;
 
   /// Is the participant allowed to read the data?
-  bool isDataRead(int dataID) const;
+  bool isDataRead(DataID dataID) const;
 
   /// Is the participant allowed to write the data?
-  bool isDataWrite(int dataID) const;
+  bool isDataWrite(DataID dataID) const;
 
   /// What is the dataID of the used data from a used mesh given the meshid and the data name?
-  int getUsedDataID(const std::string &dataName, int meshID) const;
+  int getUsedDataID(const std::string &dataName, MeshID meshID) const;
 
   /// What is the name of the given data id
-  std::string getDataName(int dataID) const;
+  std::string getDataName(DataID dataID) const;
   /// @}
 
   /// @name Mesh queries
@@ -173,14 +175,14 @@ public:
    * @returns a reference to the matching \ref MeshContext
    * @pre the \ref Mesh with \ref meshID is used by the Participant
    */
-  const MeshContext &meshContext(int meshID) const;
+  const MeshContext &meshContext(MeshID meshID) const;
 
   /*** Provides direct access to a \ref MeshContext given the \ref meshid
    * @param[in] meshID the id of the \ref Mesh
    * @returns a reference to the matching \ref MeshContext
    * @pre the \ref Mesh with \ref meshID is used by the Participant
    */
-  MeshContext &meshContext(int meshID);
+  MeshContext &meshContext(MeshID meshID);
 
   /** Provides unordered access to all \ref MeshContext.used by this \ref Participant
    * @remarks The sequence does not contain nullptr
@@ -211,38 +213,38 @@ public:
    * @return a reference to the MeshContext
    * @pre there is a matching mesh
    */
-  MeshContext &usedMeshContext(int meshID);
+  MeshContext &usedMeshContext(MeshID meshID);
 
   /** Looks for a used MeshContext with a given meshID
    * @param[in] meshID the id of the \ref Mesh
    * @return a reference to the MeshContext
    * @pre there is a matching mesh
    */
-  MeshContext const &usedMeshContext(int meshID) const;
+  MeshContext const &usedMeshContext(MeshID meshID) const;
 
   /// Does preCICE know a mesh with this meshID?
-  bool hasMesh(int meshID) const;
+  bool hasMesh(MeshID meshID) const;
 
   /// Does preCICE know a mesh with this name?
   bool hasMesh(const std::string &meshName) const;
 
   /// Is a mesh with this id used by this participant?
-  bool isMeshUsed(int meshID) const;
+  bool isMeshUsed(MeshID meshID) const;
 
   /// Is a mesh with this name used by this participant?
   bool isMeshUsed(const std::string &meshID) const;
 
   /// Is a mesh with this id provided?
-  bool isMeshProvided(int meshID) const;
+  bool isMeshProvided(MeshID meshID) const;
 
   /// Get the used mesh id of a mesh with this name.
   int getUsedMeshID(const std::string &meshName) const;
 
   /// Get the name of a mesh given by its id.
-  std::string getMeshName(int meshID) const;
+  std::string getMeshName(MeshID meshID) const;
 
   /// Get a mesh name which uses the given data id.
-  std::string getMeshNameFromData(int dataID) const;
+  std::string getMeshNameFromData(DataID dataID) const;
   /// @}
 
   /// @name Other queries

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1,4 +1,3 @@
-#include "SolverInterfaceImpl.hpp"
 #include <Eigen/Core>
 #include <algorithm>
 #include <array>
@@ -11,6 +10,8 @@
 #include <sstream>
 #include <tuple>
 #include <utility>
+
+#include "SolverInterfaceImpl.hpp"
 #include "action/SharedPointer.hpp"
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
@@ -54,6 +55,7 @@
 #include "precice/impl/WatchIntegral.hpp"
 #include "precice/impl/WatchPoint.hpp"
 #include "precice/impl/versions.hpp"
+#include "precice/types.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/EigenIO.hpp"
 #include "utils/Event.hpp"
@@ -616,7 +618,7 @@ std::set<int> SolverInterfaceImpl::getMeshIDs() const
 }
 
 bool SolverInterfaceImpl::hasData(
-    const std::string &dataName, int meshID) const
+    const std::string &dataName, MeshID meshID) const
 {
   PRECICE_TRACE(dataName, meshID);
   PRECICE_VALIDATE_MESH_ID(meshID);
@@ -624,7 +626,7 @@ bool SolverInterfaceImpl::hasData(
 }
 
 int SolverInterfaceImpl::getDataID(
-    const std::string &dataName, int meshID) const
+    const std::string &dataName, MeshID meshID) const
 {
   PRECICE_TRACE(dataName, meshID);
   PRECICE_VALIDATE_MESH_ID(meshID);
@@ -636,7 +638,7 @@ int SolverInterfaceImpl::getDataID(
 }
 
 int SolverInterfaceImpl::getMeshVertexSize(
-    int meshID) const
+    MeshID meshID) const
 {
   PRECICE_TRACE(meshID);
   PRECICE_REQUIRE_MESH_USE(meshID);
@@ -647,7 +649,7 @@ int SolverInterfaceImpl::getMeshVertexSize(
 
 /// @todo Currently not supported as we would need to re-compute the re-partition
 void SolverInterfaceImpl::resetMesh(
-    int meshID)
+    MeshID meshID)
 {
   PRECICE_TRACE(meshID);
   PRECICE_VALIDATE_MESH_ID(meshID);
@@ -761,9 +763,9 @@ void SolverInterfaceImpl::getMeshVertexIDsFromPositions(
 }
 
 int SolverInterfaceImpl::setMeshEdge(
-    int meshID,
-    int firstVertexID,
-    int secondVertexID)
+    MeshID meshID,
+    int    firstVertexID,
+    int    secondVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID, secondVertexID);
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
@@ -781,10 +783,10 @@ int SolverInterfaceImpl::setMeshEdge(
 }
 
 void SolverInterfaceImpl::setMeshTriangle(
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID)
+    MeshID meshID,
+    int    firstEdgeID,
+    int    secondEdgeID,
+    int    thirdEdgeID)
 {
   PRECICE_TRACE(meshID, firstEdgeID,
                 secondEdgeID, thirdEdgeID);
@@ -812,10 +814,10 @@ void SolverInterfaceImpl::setMeshTriangle(
 }
 
 void SolverInterfaceImpl::setMeshTriangleWithEdges(
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID)
+    MeshID meshID,
+    int    firstVertexID,
+    int    secondVertexID,
+    int    thirdVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID,
                 secondVertexID, thirdVertexID);
@@ -850,11 +852,11 @@ void SolverInterfaceImpl::setMeshTriangleWithEdges(
 }
 
 void SolverInterfaceImpl::setMeshQuad(
-    int meshID,
-    int firstEdgeID,
-    int secondEdgeID,
-    int thirdEdgeID,
-    int fourthEdgeID)
+    MeshID meshID,
+    int    firstEdgeID,
+    int    secondEdgeID,
+    int    thirdEdgeID,
+    int    fourthEdgeID)
 {
   PRECICE_TRACE(meshID, firstEdgeID, secondEdgeID, thirdEdgeID,
                 fourthEdgeID);
@@ -910,11 +912,11 @@ void SolverInterfaceImpl::setMeshQuad(
 }
 
 void SolverInterfaceImpl::setMeshQuadWithEdges(
-    int meshID,
-    int firstVertexID,
-    int secondVertexID,
-    int thirdVertexID,
-    int fourthVertexID)
+    MeshID meshID,
+    int    firstVertexID,
+    int    secondVertexID,
+    int    thirdVertexID,
+    int    fourthVertexID)
 {
   PRECICE_TRACE(meshID, firstVertexID,
                 secondVertexID, thirdVertexID, fourthVertexID);
@@ -1637,7 +1639,7 @@ void SolverInterfaceImpl::syncTimestep(double computedTimestepLength)
     utils::MasterSlave::_communication->send(computedTimestepLength, 0);
   } else {
     PRECICE_ASSERT(utils::MasterSlave::isMaster());
-    for (int rankSlave : utils::MasterSlave::allSlaves()) {
+    for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
       double dt;
       utils::MasterSlave::_communication->receive(dt, rankSlave);
       PRECICE_CHECK(math::equals(dt, computedTimestepLength),

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <string>
 #include <vector>
+
 #include "action/Action.hpp"
 #include "boost/noncopyable.hpp"
 #include "com/Communication.hpp"
@@ -16,6 +17,7 @@
 #include "precice/SolverInterface.hpp"
 #include "precice/impl/DataContext.hpp"
 #include "precice/impl/SharedPointer.hpp"
+#include "precice/types.hpp"
 #include "utils/MultiLock.hpp"
 
 namespace precice {
@@ -242,13 +244,13 @@ public:
   std::set<int> getMeshIDs() const;
 
   /// Returns true, if the data with given name is used in the given mesh.
-  bool hasData(const std::string &dataName, int meshID) const;
+  bool hasData(const std::string &dataName, MeshID meshID) const;
 
   /// Returns data id corresponding to the given name (from configuration) and mesh.
-  int getDataID(const std::string &dataName, int meshID) const;
+  int getDataID(const std::string &dataName, MeshID meshID) const;
 
   /// Returns the number of nodes of a mesh.
-  int getMeshVertexSize(int meshID) const;
+  int getMeshVertexSize(MeshID meshID) const;
 
   /**
    * @brief Resets mesh with given ID.
@@ -257,7 +259,7 @@ public:
    * changes. Only has an effect, if the mapping used is non-stationary and
    * non-incremental.
    */
-  void resetMesh(int meshID);
+  void resetMesh(MeshID meshID);
 
   /**
    * @brief Set the position of a solver mesh vertex.
@@ -310,39 +312,39 @@ public:
    * @return Index of the edge to be used when setting a triangle.
    */
   int setMeshEdge(
-      int meshID,
-      int firstVertexID,
-      int secondVertexID);
+      MeshID meshID,
+      int    firstVertexID,
+      int    secondVertexID);
 
   /// Set a triangle of a solver mesh.
   void setMeshTriangle(
-      int meshID,
-      int firstEdgeID,
-      int secondEdgeID,
-      int thirdEdgeID);
+      MeshID meshID,
+      int    firstEdgeID,
+      int    secondEdgeID,
+      int    thirdEdgeID);
 
   /// Sets a triangle and creates/sets edges automatically of a solver mesh.
   void setMeshTriangleWithEdges(
-      int meshID,
-      int firstVertexID,
-      int secondVertexID,
-      int thirdVertexID);
+      MeshID meshID,
+      int    firstVertexID,
+      int    secondVertexID,
+      int    thirdVertexID);
 
   /// Set a quadrangle of a solver mesh.
   void setMeshQuad(
-      int meshID,
-      int firstEdgeID,
-      int secondEdgeID,
-      int thirdEdgeID,
-      int fourthEdgeID);
+      MeshID meshID,
+      int    firstEdgeID,
+      int    secondEdgeID,
+      int    thirdEdgeID,
+      int    fourthEdgeID);
 
   /// Sets a quadrangle and creates/sets edges automatically of a solver mesh.
   void setMeshQuadWithEdges(
-      int meshID,
-      int firstVertexID,
-      int secondVertexID,
-      int thirdVertexID,
-      int fourthVertexID);
+      MeshID meshID,
+      int    firstVertexID,
+      int    secondVertexID,
+      int    thirdVertexID,
+      int    fourthVertexID);
 
   /**
    * @brief Computes and maps all write data mapped from mesh with given ID.

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -1,10 +1,11 @@
-#include "WatchPoint.hpp"
 #include <Eigen/Core>
 #include <algorithm>
 #include <limits>
 #include <memory>
 #include <ostream>
 #include <utility>
+
+#include "WatchPoint.hpp"
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
@@ -14,6 +15,7 @@
 #include "mesh/Mesh.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
+#include "precice/types.hpp"
 #include "query/Index.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/assertion.hpp"
@@ -74,7 +76,7 @@ void WatchPoint::initialize()
     int    closestRank           = 0;
     double closestDistanceGlobal = _shortestDistance;
     double closestDistanceLocal  = std::numeric_limits<double>::max();
-    for (int rankSlave : utils::MasterSlave::allSlaves()) {
+    for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->receive(closestDistanceLocal, rankSlave);
       if (closestDistanceLocal < closestDistanceGlobal) {
         closestDistanceGlobal = closestDistanceLocal;
@@ -82,7 +84,7 @@ void WatchPoint::initialize()
       }
     }
     _isClosest = closestRank == 0;
-    for (int rankSlave : utils::MasterSlave::allSlaves()) {
+    for (Rank rankSlave : utils::MasterSlave::allSlaves()) {
       utils::MasterSlave::_communication->send(closestRank == rankSlave, rankSlave);
     }
   }

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -1,10 +1,12 @@
 #ifndef PRECICE_NO_MPI
+
 #include <Eigen/Core>
 #include <algorithm>
 #include <memory>
 #include <mpi.h>
 #include <string>
 #include <vector>
+
 #include "com/Communication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
@@ -14,6 +16,7 @@
 #include "precice/SolverInterface.hpp"
 #include "precice/config/Configuration.hpp"
 #include "precice/impl/SolverInterfaceImpl.hpp"
+#include "precice/types.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 #include "utils/MasterSlave.hpp"
@@ -251,10 +254,10 @@ void runTestEnforceGatherScatter(std::vector<double> masterPartition, std::strin
     BOOST_REQUIRE(context.isNamed("SerialSolver"));
     SolverInterface interface(context.name, configFilename, context.rank, context.size);
     // Get IDs
-    const int meshID      = interface.getMeshID("SerialMesh");
-    const int writeDataID = interface.getDataID("MyData2", meshID);
-    const int readDataID  = interface.getDataID("MyData1", meshID);
-    const int dim         = interface.getDimensions();
+    const MeshID meshID      = interface.getMeshID("SerialMesh");
+    const int    writeDataID = interface.getDataID("MyData2", meshID);
+    const int    readDataID  = interface.getDataID("MyData1", meshID);
+    const int    dim         = interface.getDimensions();
     BOOST_TEST(interface.getDimensions() == 2);
 
     // Define the interface
@@ -438,7 +441,7 @@ void runTestQN(std::string const &config, TestContext const &context)
   int             writeDataID = interface.getDataID(writeDataName, meshID);
   int             readDataID  = interface.getDataID(readDataName, meshID);
 
-  int vertexIDs[4];
+  VertexID vertexIDs[4];
 
   // meshes for rank 0 and rank 1, we use matching meshes for both participants
   double positions0[8] = {1.0, 0.0, 1.0, 0.5, 1.0, 1.0, 1.0, 1.5};
@@ -538,7 +541,7 @@ void runTestQNEmptyPartition(std::string const &config, TestContext const &conte
   int             writeDataID = interface.getDataID(writeDataName, meshID);
   int             readDataID  = interface.getDataID(readDataName, meshID);
 
-  int vertexIDs[4];
+  VertexID vertexIDs[4];
 
   // meshes for rank 0 and rank 1, we use matching meshes for both participants
   double positions0[8] = {1.0, 0.0, 1.0, 0.5, 1.0, 1.0, 1.0, 1.5};
@@ -726,7 +729,7 @@ void runTestDistributedCommunication(std::string const &config, TestContext cons
 
   std::vector<int> vertexIDs;
   for (int i = i1; i < i2; i++) {
-    int vertexID = precice.setMeshVertex(meshID, positions[i].data());
+    VertexID vertexID = precice.setMeshVertex(meshID, positions[i].data());
     vertexIDs.push_back(vertexID);
   }
 
@@ -836,12 +839,12 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitialization)
   std::string     configFilename = _pathToTests + "BB-sockets-explicit-oneway.xml";
   SolverInterface precice(context.name, configFilename, context.rank, context.size);
 
-  int meshID   = precice.getMeshID(context.name + "Mesh");
-  int forcesID = precice.getDataID("Forces", meshID);
+  MeshID meshID   = precice.getMeshID(context.name + "Mesh");
+  int    forcesID = precice.getDataID("Forces", meshID);
 
   std::vector<int> vertexIDs;
   for (int i = i1; i < i2; i++) {
-    int vertexID = precice.setMeshVertex(meshID, positions[i].data());
+    VertexID vertexID = precice.setMeshVertex(meshID, positions[i].data());
     vertexIDs.push_back(vertexID);
   }
 
@@ -932,13 +935,13 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationTwoWay)
   std::string     configFilename = _pathToTests + "BB-sockets-explicit-twoway.xml";
   SolverInterface precice(context.name, configFilename, context.rank, context.size);
 
-  int meshID       = precice.getMeshID(context.name + "Mesh");
-  int forcesID     = precice.getDataID("Forces", meshID);
-  int velocitiesID = precice.getDataID("Velocities", meshID);
+  MeshID meshID       = precice.getMeshID(context.name + "Mesh");
+  int    forcesID     = precice.getDataID("Forces", meshID);
+  int    velocitiesID = precice.getDataID("Velocities", meshID);
 
   std::vector<int> vertexIDs;
   for (int i = i1; i < i2; i++) {
-    int vertexID = precice.setMeshVertex(meshID, positions[i].data());
+    VertexID vertexID = precice.setMeshVertex(meshID, positions[i].data());
     vertexIDs.push_back(vertexID);
   }
 
@@ -995,8 +998,8 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning)
       interface.advance(1.0);
       interface.finalize();
     } else {
-      const int meshID     = interface.getMeshID("CellCenters");
-      const int dimensions = 3;
+      const MeshID meshID     = interface.getMeshID("CellCenters");
+      const int    dimensions = 3;
       BOOST_TEST(interface.getDimensions() == dimensions);
 
       const int                 numberOfVertices = 65;

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -1,4 +1,5 @@
 #ifndef PRECICE_NO_MPI
+
 #include <Eigen/Core>
 #include <algorithm>
 #include <deque>
@@ -9,6 +10,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
+
 #include "action/RecorderAction.hpp"
 #include "logging/LogMacros.hpp"
 #include "math/constants.hpp"
@@ -23,6 +25,7 @@
 #include "precice/impl/Participant.hpp"
 #include "precice/impl/SharedPointer.hpp"
 #include "precice/impl/SolverInterfaceImpl.hpp"
+#include "precice/types.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 
@@ -204,12 +207,12 @@ void runTestExplicit(std::string const &configurationFileName, TestContext const
 
   //was necessary to replace pre-defined geometries
   if (context.isNamed("SolverOne") && couplingInterface.hasMesh("MeshOne")) {
-    int meshID = couplingInterface.getMeshID("MeshOne");
+    MeshID meshID = couplingInterface.getMeshID("MeshOne");
     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
   }
   if (context.isNamed("SolverTwo") && couplingInterface.hasMesh("Test-Square")) {
-    int meshID = couplingInterface.getMeshID("Test-Square");
+    MeshID meshID = couplingInterface.getMeshID("Test-Square");
     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
   }
@@ -268,7 +271,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling)
     BOOST_TEST(timestep == 20);
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
-    int meshID = precice.getMeshID("Test-Square");
+    MeshID meshID = precice.getMeshID("Test-Square");
     precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     precice.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     double maxDt     = precice.initialize();
@@ -339,7 +342,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
     cplInterface.finalize();
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
-    int meshID = cplInterface.getMeshID("Test-Square");
+    MeshID meshID = cplInterface.getMeshID("Test-Square");
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 1.0, 0.0).data());
@@ -520,12 +523,12 @@ BOOST_AUTO_TEST_CASE(testExplicitWithBlockDataExchange)
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
 
-    int squareID       = cplInterface.getMeshID("Test-Square");
-    int forcesID       = cplInterface.getDataID("Forces", squareID);
-    int pressuresID    = cplInterface.getDataID("Pressures", squareID);
-    int velocitiesID   = cplInterface.getDataID("Velocities", squareID);
-    int temperaturesID = cplInterface.getDataID("Temperatures", squareID);
-    int meshID         = cplInterface.getMeshID("Test-Square");
+    int    squareID       = cplInterface.getMeshID("Test-Square");
+    int    forcesID       = cplInterface.getDataID("Forces", squareID);
+    int    pressuresID    = cplInterface.getDataID("Pressures", squareID);
+    int    velocitiesID   = cplInterface.getDataID("Velocities", squareID);
+    int    temperaturesID = cplInterface.getDataID("Temperatures", squareID);
+    MeshID meshID         = cplInterface.getMeshID("Test-Square");
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     cplInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 1.0, 0.0).data());
@@ -588,7 +591,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry)
   BOOST_TEST(couplingInterface.getDimensions() == 3);
   if (context.isNamed("SolverOne")) {
     //was necessary to replace pre-defined geometries
-    int meshID = couplingInterface.getMeshID("MeshOne");
+    MeshID meshID = couplingInterface.getMeshID("MeshOne");
     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
 
@@ -601,13 +604,13 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSolverGeometry)
     couplingInterface.finalize();
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
-    int meshID = couplingInterface.getMeshID("SolverGeometry");
-    int i0     = couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-    int i1     = couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
-    int i2     = couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 1.0, 0.0).data());
-    int e0     = couplingInterface.setMeshEdge(meshID, i0, i1);
-    int e1     = couplingInterface.setMeshEdge(meshID, i1, i2);
-    int e2     = couplingInterface.setMeshEdge(meshID, i2, i0);
+    MeshID meshID = couplingInterface.getMeshID("SolverGeometry");
+    int    i0     = couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+    int    i1     = couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    int    i2     = couplingInterface.setMeshVertex(meshID, Eigen::Vector3d(0.0, 1.0, 0.0).data());
+    int    e0     = couplingInterface.setMeshEdge(meshID, i0, i1);
+    int    e1     = couplingInterface.setMeshEdge(meshID, i1, i2);
+    int    e2     = couplingInterface.setMeshEdge(meshID, i2, i0);
     couplingInterface.setMeshTriangle(meshID, e0, e1, e2);
     double dt = couplingInterface.initialize();
 
@@ -641,7 +644,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling)
   std::vector<int>    ids       = {0, 0, 0, 0};
 
   if (context.isNamed("SolverOne")) {
-    int meshID = cplInterface.getMeshID("Test-Square-One");
+    MeshID meshID = cplInterface.getMeshID("Test-Square-One");
     cplInterface.setMeshVertices(meshID, 4, positions.data(), ids.data());
     for (int i = 0; i < 4; i++)
       cplInterface.setMeshEdge(meshID, ids.at(i), ids.at((i + 1) % 4));
@@ -659,7 +662,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataScaling)
     cplInterface.finalize();
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
-    int meshID = cplInterface.getMeshID("Test-Square-Two");
+    MeshID meshID = cplInterface.getMeshID("Test-Square-Two");
     cplInterface.setMeshVertices(meshID, 4, positions.data(), ids.data());
     for (int i = 0; i < 4; i++)
       cplInterface.setMeshEdge(meshID, ids.at(i), ids.at((i + 1) % 4));
@@ -1012,10 +1015,10 @@ BOOST_AUTO_TEST_CASE(testBug)
   if (context.isNamed("Flite")) {
     SolverInterface precice("Flite", configName, 0, 1);
 
-    int meshID             = precice.getMeshID("FliteNodes");
-    int forcesID           = precice.getDataID("Forces", meshID);
-    int displacementsID    = precice.getDataID("Displacements", meshID);
-    int oldDisplacementsID = precice.getDataID("OldDisplacements", meshID);
+    MeshID meshID             = precice.getMeshID("FliteNodes");
+    int    forcesID           = precice.getDataID("Forces", meshID);
+    int    displacementsID    = precice.getDataID("Displacements", meshID);
+    int    oldDisplacementsID = precice.getDataID("OldDisplacements", meshID);
     BOOST_TEST(precice.getDimensions() == 3);
     for (Vector3d &coord : coords) {
       precice.setMeshVertex(meshID, coord.data());
@@ -1042,7 +1045,7 @@ BOOST_AUTO_TEST_CASE(testBug)
     BOOST_TEST(context.isNamed("Calculix"));
     SolverInterface precice("Calculix", configName, 0, 1);
 
-    int meshID = precice.getMeshID("CalculixNodes");
+    MeshID meshID = precice.getMeshID("CalculixNodes");
     for (Vector3d &coord : coords) {
       precice.setMeshVertex(meshID, coord.data());
     }
@@ -1108,7 +1111,7 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
   } else if (context.isNamed("SolverTwo")) {
     SolverInterface precice(context.name, config, 0, 1);
 
-    int meshID = precice.getMeshID("MeshC");
+    MeshID meshID = precice.getMeshID("MeshC");
     precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
     double dt = precice.initialize();
 
@@ -1133,7 +1136,7 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
     BOOST_TEST(context.isNamed("SolverThree"));
     SolverInterface precice(context.name, config, 0, 1);
 
-    int meshID = precice.getMeshID("MeshD");
+    MeshID meshID = precice.getMeshID("MeshD");
     precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
     double dt = precice.initialize();
 
@@ -1229,9 +1232,9 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
   if (context.isNamed("SOLIDZ1") ||
       context.isNamed("SOLIDZ2") ||
       context.isNamed("SOLIDZ3")) {
-    int meshID      = -1;
-    int dataWriteID = -1;
-    int dataReadID  = -1;
+    MeshID meshID      = -1;
+    int    dataWriteID = -1;
+    int    dataReadID  = -1;
 
     SolverInterface precice(context.name, _pathToTests + "/multi.xml", 0, 1);
     BOOST_TEST(precice.getDimensions() == 2);
@@ -1290,12 +1293,12 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
     BOOST_TEST(context.isNamed("NASTIN"));
     SolverInterface precice("NASTIN", _pathToTests + "/multi.xml", 0, 1);
     BOOST_TEST(precice.getDimensions() == 2);
-    int meshID1      = precice.getMeshID("NASTIN_Mesh1");
-    int meshID2      = precice.getMeshID("NASTIN_Mesh2");
-    int meshID3      = precice.getMeshID("NASTIN_Mesh3");
-    int dataWriteID1 = precice.getDataID("Forces1", meshID1);
-    int dataWriteID2 = precice.getDataID("Forces2", meshID2);
-    int dataWriteID3 = precice.getDataID("Forces3", meshID3);
+    MeshID meshID1      = precice.getMeshID("NASTIN_Mesh1");
+    MeshID meshID2      = precice.getMeshID("NASTIN_Mesh2");
+    MeshID meshID3      = precice.getMeshID("NASTIN_Mesh3");
+    int    dataWriteID1 = precice.getDataID("Forces1", meshID1);
+    int    dataWriteID2 = precice.getDataID("Forces2", meshID2);
+    int    dataWriteID3 = precice.getDataID("Forces3", meshID3);
 
     std::vector<int> vertexIDs1;
     int              vertexID = -1;
@@ -1483,13 +1486,13 @@ BOOST_AUTO_TEST_CASE(SendMeshToMultipleParticipants)
 
   SolverInterface cplInterface(context.name, configFile, 0, 1);
 
-  const int meshID = cplInterface.getMeshID(meshName);
+  const MeshID meshID = cplInterface.getMeshID(meshName);
 
-  int vertexID = cplInterface.setMeshVertex(meshID, vertex.data());
+  VertexID vertexID = cplInterface.setMeshVertex(meshID, vertex.data());
 
   double maxDt = cplInterface.initialize();
 
-  int dataID = cplInterface.getDataID("Data", meshID);
+  DataID dataID = cplInterface.getDataID("Data", meshID);
 
   if (context.isNamed("SolverOne")) {
     cplInterface.writeScalarData(dataID, vertexID, value);
@@ -1523,7 +1526,7 @@ BOOST_AUTO_TEST_CASE(PreconditionerBug)
 
   Vector2d vertex{0.0, 0.0};
 
-  int vertexID = cplInterface.setMeshVertex(meshID, vertex.data());
+  VertexID vertexID = cplInterface.setMeshVertex(meshID, vertex.data());
 
   cplInterface.initialize();
   int numberOfAdvanceCalls = 0;
@@ -1535,7 +1538,7 @@ BOOST_AUTO_TEST_CASE(PreconditionerBug)
       cplInterface.markActionFulfilled(actionReadIterationCheckpoint());
 
     if (context.isNamed("SolverTwo")) {
-      int dataID = cplInterface.getDataID("DataOne", meshID);
+      DataID dataID = cplInterface.getDataID("DataOne", meshID);
       // to get convergence in first timestep (everything 0), but not in second timestep
       Vector2d value{0.0, 2.0 + numberOfAdvanceCalls * numberOfAdvanceCalls};
       cplInterface.writeVectorData(dataID, vertexID, value.data());
@@ -1566,7 +1569,7 @@ void testSummationAction(const std::string &configFile, TestContext const &conte
     Vector3d coordC{1.0, 1.0, 0.3};
     Vector3d coordD{0.0, 1.0, 0.3};
 
-    const int meshID = cplInterface.getMeshID("MeshTarget");
+    const MeshID meshID = cplInterface.getMeshID("MeshTarget");
 
     int idA = cplInterface.setMeshVertex(meshID, coordA.data());
     int idB = cplInterface.setMeshVertex(meshID, coordB.data());
@@ -1606,7 +1609,7 @@ void testSummationAction(const std::string &configFile, TestContext const &conte
     Vector3d coordC{1.0, 1.0, 0.3};
     Vector3d coordD{0.0, 1.0, 0.3};
 
-    const int meshID = cplInterface.getMeshID("MeshOne");
+    const MeshID meshID = cplInterface.getMeshID("MeshOne");
 
     int idA = cplInterface.setMeshVertex(meshID, coordA.data());
     int idB = cplInterface.setMeshVertex(meshID, coordB.data());
@@ -1642,7 +1645,7 @@ void testSummationAction(const std::string &configFile, TestContext const &conte
     Vector3d coordC{1.0, 1.0, 0.3};
     Vector3d coordD{0.0, 1.0, 0.3};
 
-    const int meshID = cplInterface.getMeshID("MeshTwo");
+    const MeshID meshID = cplInterface.getMeshID("MeshTwo");
 
     int idA = cplInterface.setMeshVertex(meshID, coordA.data());
     int idB = cplInterface.setMeshVertex(meshID, coordB.data());
@@ -1695,7 +1698,7 @@ void testWatchIntegral(const std::string &configFile, TestContext &context)
     Vector2d coordB{1.0, 0.0};
     Vector2d coordC{1.0, 2.0};
 
-    const int meshID = cplInterface.getMeshID("MeshOne");
+    const MeshID meshID = cplInterface.getMeshID("MeshOne");
 
     int idA = cplInterface.setMeshVertex(meshID, coordA.data());
     int idB = cplInterface.setMeshVertex(meshID, coordB.data());
@@ -2095,7 +2098,7 @@ void testConvergenceMeasures(const std::string configFile, TestContext const &co
 
   std::vector<double> writeValues = {1.0, 1.01, 2.0, 2.5, 2.8, 2.81};
 
-  int vertexID = cplInterface.setMeshVertex(meshID, vertex.data());
+  VertexID vertexID = cplInterface.setMeshVertex(meshID, vertex.data());
 
   cplInterface.initialize();
   int numberOfAdvanceCalls = 0;
@@ -2109,7 +2112,7 @@ void testConvergenceMeasures(const std::string configFile, TestContext const &co
     }
 
     if (context.isNamed("SolverTwo")) {
-      int dataID = cplInterface.getDataID("Data2", meshID);
+      DataID dataID = cplInterface.getDataID("Data2", meshID);
       cplInterface.writeScalarData(dataID, vertexID, writeValues.at(numberOfAdvanceCalls));
     }
 
@@ -2381,12 +2384,12 @@ BOOST_AUTO_TEST_CASE(MultipleFromMappings)
   Vector2d        vertex{0.0, 0.0};
 
   if (context.isNamed("A")) {
-    const int meshIDTop      = interface.getMeshID("MeshATop");
-    const int meshIDBottom   = interface.getMeshID("MeshABottom");
-    int       vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
-    int       vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
-    int       dataIDTop      = interface.getDataID("Pressure", meshIDTop);
-    int       dataIDBottom   = interface.getDataID("Pressure", meshIDBottom);
+    const MeshID meshIDTop      = interface.getMeshID("MeshATop");
+    const MeshID meshIDBottom   = interface.getMeshID("MeshABottom");
+    int          vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
+    int          vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
+    int          dataIDTop      = interface.getDataID("Pressure", meshIDTop);
+    int          dataIDBottom   = interface.getDataID("Pressure", meshIDBottom);
 
     double dt = interface.initialize();
     interface.advance(dt);
@@ -2401,9 +2404,9 @@ BOOST_AUTO_TEST_CASE(MultipleFromMappings)
 
   } else {
     BOOST_TEST(context.isNamed("B"));
-    const int meshID   = interface.getMeshID("MeshB");
-    int       vertexID = interface.setMeshVertex(meshID, vertex.data());
-    int       dataID   = interface.getDataID("Pressure", meshID);
+    const MeshID meshID   = interface.getMeshID("MeshB");
+    int          vertexID = interface.setMeshVertex(meshID, vertex.data());
+    int          dataID   = interface.getDataID("Pressure", meshID);
 
     double dt       = interface.initialize();
     double pressure = 1.0;
@@ -2427,12 +2430,12 @@ BOOST_AUTO_TEST_CASE(MultipleToMappings)
   Vector2d        vertex{0.0, 0.0};
 
   if (context.isNamed("A")) {
-    const int meshIDTop      = interface.getMeshID("MeshATop");
-    const int meshIDBottom   = interface.getMeshID("MeshABottom");
-    int       vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
-    int       vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
-    int       dataIDTop      = interface.getDataID("DisplacementTop", meshIDTop);
-    int       dataIDBottom   = interface.getDataID("DisplacementBottom", meshIDBottom);
+    const MeshID meshIDTop      = interface.getMeshID("MeshATop");
+    const MeshID meshIDBottom   = interface.getMeshID("MeshABottom");
+    int          vertexIDTop    = interface.setMeshVertex(meshIDTop, vertex.data());
+    int          vertexIDBottom = interface.setMeshVertex(meshIDBottom, vertex.data());
+    int          dataIDTop      = interface.getDataID("DisplacementTop", meshIDTop);
+    int          dataIDBottom   = interface.getDataID("DisplacementBottom", meshIDBottom);
 
     double dt              = interface.initialize();
     double displacementTop = 1.0;
@@ -2445,9 +2448,9 @@ BOOST_AUTO_TEST_CASE(MultipleToMappings)
 
   } else {
     BOOST_TEST(context.isNamed("B"));
-    const int meshID   = interface.getMeshID("MeshB");
-    int       vertexID = interface.setMeshVertex(meshID, vertex.data());
-    int       dataID   = interface.getDataID("DisplacementSum", meshID);
+    const MeshID meshID   = interface.getMeshID("MeshB");
+    int          vertexID = interface.setMeshVertex(meshID, vertex.data());
+    int          dataID   = interface.getDataID("DisplacementSum", meshID);
 
     double dt = interface.initialize();
     interface.advance(dt);
@@ -2472,9 +2475,9 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
   Vector2d        vertex{0.0, 0.0};
 
   if (context.isNamed("A")) {
-    const int meshID   = interface.getMeshID("A-Mesh");
-    int       vertexID = interface.setMeshVertex(meshID, vertex.data());
-    int       dataID   = interface.getDataID("Data", meshID);
+    const MeshID meshID   = interface.getMeshID("A-Mesh");
+    int          vertexID = interface.setMeshVertex(meshID, vertex.data());
+    int          dataID   = interface.getDataID("Data", meshID);
 
     double dt    = interface.initialize();
     double value = 1.0;
@@ -2489,9 +2492,9 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
 
   } else {
     BOOST_TEST(context.isNamed("B"));
-    const int meshID   = interface.getMeshID("B-Mesh");
-    int       vertexID = interface.setMeshVertex(meshID, vertex.data());
-    int       dataID   = interface.getDataID("Data", meshID);
+    const MeshID meshID   = interface.getMeshID("B-Mesh");
+    int          vertexID = interface.setMeshVertex(meshID, vertex.data());
+    int          dataID   = interface.getDataID("Data", meshID);
 
     double dt = interface.initialize();
     interface.markActionFulfilled(actionWriteIterationCheckpoint());

--- a/src/precice/types.hpp
+++ b/src/precice/types.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace precice {
+
+/**
+ * Type used for the IDs of vertices
+ */
+using VertexID = int;
+
+/**
+ * Type used for the IDs of edges
+ */
+using EdgeID = int;
+
+/**
+ * Type used for the IDs of triangles
+ */
+using TriangleID = int;
+
+/**
+ * Type used for the IDs of matching entities
+ */
+using MatchID = int;
+
+/**
+ * Type used for the IDs of data
+ */
+using DataID = int;
+
+/**
+ * Type used for the IDs of meshes
+ */
+using MeshID = int;
+
+using Rank = int;
+
+} // namespace precice

--- a/src/precice/types.hpp
+++ b/src/precice/types.hpp
@@ -18,11 +18,6 @@ using EdgeID = int;
 using TriangleID = int;
 
 /**
- * Type used for the IDs of matching entities
- */
-using MatchID = int;
-
-/**
  * Type used for the IDs of data
  */
 using DataID = int;

--- a/src/precice/types.hpp
+++ b/src/precice/types.hpp
@@ -27,6 +27,11 @@ using DataID = int;
  */
 using MeshID = int;
 
+/**
+ * Type used to represent local ranks of a parallel participant.
+ *
+ * The primary participant has Rank 0.
+ */
 using Rank = int;
 
 } // namespace precice

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -1,11 +1,12 @@
-#include "Index.hpp"
-#include <Eigen/src/Core/Matrix.h>
+#include <Eigen/Core>
 #include <algorithm>
 #include <boost/range/irange.hpp>
 #include <utility>
 
+#include "Index.hpp"
 #include "impl/Indexer.hpp"
 #include "logging/LogMacros.hpp"
+#include "precice/types.hpp"
 #include "utils/Event.hpp"
 
 namespace precice {
@@ -160,7 +161,7 @@ void clearCache()
   impl::Indexer::instance()->clearCache();
 }
 
-void clearCache(int meshID)
+void clearCache(MeshID meshID)
 {
   impl::Indexer::instance()->clearCache(meshID);
 }

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+
 #include "logging/Logger.hpp"
 #include "mapping/Polation.hpp"
 #include "mesh/BoundingBox.hpp"
@@ -9,6 +10,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace query {
@@ -90,7 +92,7 @@ private:
 void clearCache();
 
 /// Clear the cache of given mesh
-void clearCache(int meshID);
+void clearCache(MeshID meshID);
 
 /// Clear the cache of given mesh
 void clearCache(mesh::Mesh &mesh);

--- a/src/query/impl/Indexer.cpp
+++ b/src/query/impl/Indexer.cpp
@@ -1,6 +1,8 @@
-#include "Indexer.hpp"
 #include <boost/range/irange.hpp>
+
+#include "Indexer.hpp"
 #include "mesh/BoundingBox.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace query {
@@ -12,7 +14,7 @@ std::shared_ptr<Indexer> Indexer::instance()
   return indexer;
 }
 
-MeshIndices &Indexer::cacheEntry(int meshID)
+MeshIndices &Indexer::cacheEntry(MeshID meshID)
 {
   auto result = _cachedTrees.emplace(std::make_pair(meshID, MeshIndices{}));
   return result.first->second;
@@ -95,7 +97,7 @@ void Indexer::clearCache()
   _cachedTrees.clear();
 }
 
-void Indexer::clearCache(int meshID)
+void Indexer::clearCache(MeshID meshID)
 {
   _cachedTrees.erase(meshID);
 }

--- a/src/query/impl/Indexer.hpp
+++ b/src/query/impl/Indexer.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <map>
-#include "RTreeAdapter.hpp"
+
+#include "precice/types.hpp"
+#include "query/impl/RTreeAdapter.hpp"
 
 namespace precice {
 namespace query {
@@ -40,11 +42,11 @@ public:
   void clearCache();
 
   /// Clear the cache only for the given mesh
-  void clearCache(int meshID);
+  void clearCache(MeshID meshID);
 
 private:
   Indexer(){};
-  MeshIndices &              cacheEntry(int meshID);
+  MeshIndices &              cacheEntry(MeshID meshID);
   std::map<int, MeshIndices> _cachedTrees;
 };
 

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -1,10 +1,10 @@
-#include "testing/TestContext.hpp"
 #include <algorithm>
 #include <exception>
 #include <memory>
 #include <numeric>
 #include <ostream>
 #include <utility>
+
 #include "com/Communication.hpp"
 #include "com/MPIDirectCommunication.hpp"
 #include "com/SharedPointer.hpp"
@@ -15,7 +15,9 @@
 #include "m2n/M2N.hpp"
 #include "m2n/PointToPointComFactory.hpp"
 #include "mesh/Data.hpp"
+#include "precice/types.hpp"
 #include "query/Index.hpp"
+#include "testing/TestContext.hpp"
 #include "utils/EventUtils.hpp"
 #include "utils/MasterSlave.hpp"
 #include "utils/Parallel.hpp"
@@ -63,7 +65,7 @@ bool TestContext::isNamed(const std::string &name) const
   return this->name == name;
 }
 
-bool TestContext::isRank(int rank) const
+bool TestContext::isRank(Rank rank) const
 {
   if (rank >= size) {
     throw std::runtime_error("The requested Rank does not exist!");
@@ -102,7 +104,7 @@ void TestContext::handleOption(Participants &participants, Participant participa
   participants.emplace_back(std::move(participant));
 }
 
-void TestContext::setContextFrom(const Participant &p, int rank)
+void TestContext::setContextFrom(const Participant &p, Rank rank)
 {
   this->name         = p.name;
   this->size         = p.size;

--- a/src/testing/TestContext.hpp
+++ b/src/testing/TestContext.hpp
@@ -5,8 +5,10 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+
 #include "m2n/M2N.hpp"
 #include "m2n/SharedPointer.hpp"
+#include "precice/types.hpp"
 #include "utils/Parallel.hpp"
 
 namespace precice {
@@ -156,7 +158,7 @@ public:
   std::string name;
 
   /// the rank of the current participant
-  int rank = 0;
+  Rank rank = 0;
 
   /// the size of the Communicator of the current participant
   int size = 1;
@@ -232,7 +234,7 @@ public:
   bool isNamed(const std::string &name) const;
 
   /// Check wheater this context has a given rank inside the Partiticipant
-  bool isRank(int rank) const;
+  bool isRank(Rank rank) const;
 
   /** Check wheater this context is the master of a Participants
    * @note This is equivalent to `isRank(0)`
@@ -294,7 +296,7 @@ private:
   /** set the context from a Participants and a given rank
    * Both uniquely identify a context.
    */
-  void setContextFrom(const Participant &p, int rank);
+  void setContextFrom(const Participant &p, Rank rank);
 
   /// @{
   /// @name Initialization

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -290,7 +290,7 @@ void EventRegistry::printAll() const
 
 void EventRegistry::writeSummary(std::ostream &out) const
 {
-  Rank rank, size;
+  int rank, size;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
 
@@ -411,7 +411,7 @@ void EventRegistry::collect()
   MPI_Type_create_struct(4, blocklengths, displacements, types, &MPI_EVENTDATA);
   MPI_Type_commit(&MPI_EVENTDATA);
 
-  Rank rank, MPIsize;
+  int rank, MPIsize;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &MPIsize);
 

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -290,7 +290,7 @@ void EventRegistry::printAll() const
 
 void EventRegistry::writeSummary(std::ostream &out) const
 {
-  int rank, size;
+  Rank rank, size;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
 
@@ -411,7 +411,7 @@ void EventRegistry::collect()
   MPI_Type_create_struct(4, blocklengths, displacements, types, &MPI_EVENTDATA);
   MPI_Type_commit(&MPI_EVENTDATA);
 
-  int rank, MPIsize;
+  Rank rank, MPIsize;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &MPIsize);
 

--- a/src/utils/MasterSlave.cpp
+++ b/src/utils/MasterSlave.cpp
@@ -1,20 +1,22 @@
 //#ifndef PRECICE_NO_MPI
 
-#include "MasterSlave.hpp"
 #include <Eigen/Core>
 #include <cmath>
 #include <memory>
 #include <ostream>
 #include <string>
+
+#include "MasterSlave.hpp"
 #include "com/Communication.hpp"
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
 namespace utils {
 
-int                   MasterSlave::_rank     = -1;
+Rank                  MasterSlave::_rank     = -1;
 int                   MasterSlave::_size     = -1;
 bool                  MasterSlave::_isMaster = false;
 bool                  MasterSlave::_isSlave  = false;
@@ -22,7 +24,7 @@ com::PtrCommunication MasterSlave::_communication;
 
 logging::Logger MasterSlave::_log("utils::MasterSlave");
 
-void MasterSlave::configure(int rank, int size)
+void MasterSlave::configure(Rank rank, int size)
 {
   PRECICE_TRACE(rank, size);
   _rank = rank;
@@ -33,7 +35,7 @@ void MasterSlave::configure(int rank, int size)
   PRECICE_DEBUG("isSlave: {}, isMaster: {}", _isSlave, _isMaster);
 }
 
-int MasterSlave::getRank()
+Rank MasterSlave::getRank()
 {
   return _rank;
 }
@@ -84,11 +86,11 @@ double MasterSlave::l2norm(const Eigen::VectorXd &vec)
   }
   if(_isMaster){
     globalSum2 += localSum2;
-    for(int rankSlave = 1; rankSlave < _size; rankSlave++){
+    for(Rank rankSlave = 1; rankSlave < _size; rankSlave++){
       _communication->receive(localSum2, rankSlave);
       globalSum2 += localSum2;
     }
-    for(int rankSlave = 1; rankSlave < _size; rankSlave++){
+    for(Rank rankSlave = 1; rankSlave < _size; rankSlave++){
       _communication->send(globalSum2, rankSlave);
     }
   }
@@ -125,11 +127,11 @@ double MasterSlave::dot(const Eigen::VectorXd &vec1, const Eigen::VectorXd &vec2
   }
   if(_isMaster){
     globalSum += localSum;
-    for(int rankSlave = 1; rankSlave < _size; rankSlave++){
+    for(Rank rankSlave = 1; rankSlave < _size; rankSlave++){
       _communication->receive(localSum, rankSlave);
       globalSum += localSum;
     }
-    for(int rankSlave = 1; rankSlave < _size; rankSlave++){
+    for(Rank rankSlave = 1; rankSlave < _size; rankSlave++){
       _communication->send(globalSum, rankSlave);
     }
   }

--- a/src/utils/MasterSlave.hpp
+++ b/src/utils/MasterSlave.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <Eigen/Core>
+
 #include "boost/range/irange.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace logging {
@@ -19,10 +21,10 @@ public:
   static com::PtrCommunication _communication;
 
   /// Configures the master-slave communication.
-  static void configure(int rank, int size);
+  static void configure(Rank rank, int size);
 
   /// Current rank
-  static int getRank();
+  static Rank getRank();
 
   /// Number of ranks. This includes ranks from both participants, e.g. minimal size is 2.
   static int getSize();
@@ -76,7 +78,7 @@ private:
   static logging::Logger _log;
 
   /// Current rank
-  static int _rank;
+  static Rank _rank;
 
   /// Number of ranks. This includes ranks from both participants, e.g. minimal size is 2.
   static int _size;

--- a/src/utils/Parallel.hpp
+++ b/src/utils/Parallel.hpp
@@ -4,7 +4,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "logging/Logger.hpp"
+#include "precice/types.hpp"
 
 #ifndef PRECICE_NO_MPI
 #include <mpi.h>
@@ -101,7 +103,7 @@ public:
     /// @{
 
     /// Returns the current rank in comm
-    int rank() const;
+    Rank rank() const;
 
     /// Returns size of comm
     int size() const;
@@ -226,7 +228,7 @@ public:
 
   /// Returns the global process rank.
   //@todo remove
-  static int getProcessRank();
+  static Rank getProcessRank();
 
   /**
    * @brief Returns the local process rank.
@@ -234,7 +236,7 @@ public:
    * If only one accessor group is present, returns getProcessRank().
    */
   //@todo remove
-  static int getLocalProcessRank();
+  static Rank getLocalProcessRank();
 
   /// Returns the number of processes in the global communicator.
   //@todo remove


### PR DESCRIPTION
## Main changes of this PR

Introduces a header providing named types for common internals.
The current use-case is to make types and locations more readable.

Related to #248 #1045

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)