### PR TITLE
Add bindings to CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,7 @@ on:
       - 'src/**'
       - 'thirdparty/**'
       - 'CMakeLists.txt'
+      - 'extras/bindings/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Main changes of this PR
Triggers our build and test CI pipeline in case there are changes in the native bindings (C/fortran).

## Motivation and additional information
Might be very rarely, but in case there are changes in the bindings only, the CI is not triggered. Related to #1044 
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)