### PR TITLE
Port communication backend to using span

### DIFF
--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -179,7 +179,7 @@ void IQNILSAcceleration::computeQNUpdate(Acceleration::DataMap &cplData, Eigen::
     utils::append(_global_b, (Eigen::VectorXd) Eigen::VectorXd::Zero(_local_b.size()));
 
     // do a reduce operation to sum up all the _local_b vectors
-    utils::MasterSlave::reduceSum(_local_b, _global_b); // size = getLSSystemCols() = _local_b.size()
+    utils::MasterSlave::reduceSum(_local_b, _global_b);
 
     // back substitution R*c = b only in master node
     if (utils::MasterSlave::isMaster()) {

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -179,7 +179,7 @@ void IQNILSAcceleration::computeQNUpdate(Acceleration::DataMap &cplData, Eigen::
     utils::append(_global_b, (Eigen::VectorXd) Eigen::VectorXd::Zero(_local_b.size()));
 
     // do a reduce operation to sum up all the _local_b vectors
-    utils::MasterSlave::reduceSum(_local_b.data(), _global_b.data(), _local_b.size()); // size = getLSSystemCols() = _local_b.size()
+    utils::MasterSlave::reduceSum(_local_b, _global_b); // size = getLSSystemCols() = _local_b.size()
 
     // back substitution R*c = b only in master node
     if (utils::MasterSlave::isMaster()) {
@@ -187,7 +187,7 @@ void IQNILSAcceleration::computeQNUpdate(Acceleration::DataMap &cplData, Eigen::
     }
 
     // broadcast coefficients c to all slaves
-    utils::MasterSlave::broadcast(c.data(), c.size());
+    utils::MasterSlave::broadcast(c);
   }
 
   PRECICE_DEBUG("   Apply Newton factors");

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -106,12 +106,12 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations)
   int    iaa   = (int) a;
   int    ires1 = 0, ires2 = 0;
 
-  utils::MasterSlave::allreduceSum(a, res1, 1);
-  utils::MasterSlave::allreduceSum(iaa, ires2, 1);
-  utils::MasterSlave::allreduceSum(aa.data(), res2.data(), 2);
+  utils::MasterSlave::allreduceSum(a, res1);
+  utils::MasterSlave::allreduceSum(iaa, ires2);
+  utils::MasterSlave::allreduceSum(aa, res2);
 
-  utils::MasterSlave::reduceSum(aa.data(), res3.data(), 2);
-  utils::MasterSlave::reduceSum(iaa, ires1, 1);
+  utils::MasterSlave::reduceSum(aa, res3);
+  utils::MasterSlave::reduceSum(iaa, ires1);
 
   BOOST_TEST(testing::equals(res1, 10.));
   BOOST_TEST(testing::equals(ires2, 10));

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -47,7 +47,7 @@ void Communication::reduceSum(precice::span<double const> itemsToSend, precice::
   std::vector<double> received(itemsToReceive.size());
   // receive local results from slaves
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aReceive({received}, rank + _rankOffset);
+    auto request = aReceive(received, rank + _rankOffset);
     request->wait();
     for (size_t i = 0; i < itemsToReceive.size(); i++) {
       itemsToReceive[i] += received[i];
@@ -96,7 +96,7 @@ void Communication::allreduceSum(precice::span<double const> itemsToSend, precic
 
   // send reduced result to all slaves
   std::vector<PtrRequest> requests;
-  requests.resize(getRemoteCommunicatorSize());
+  requests.reserve(getRemoteCommunicatorSize());
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     requests.push_back(aSend(itemsToReceive, rank + _rankOffset));
   }

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -6,6 +6,7 @@
 #include "Request.hpp"
 #include "logging/LogMacros.hpp"
 #include "precice/types.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace com {
@@ -41,6 +42,7 @@ void Communication::connectMasterSlaves(std::string const &participantName,
 void Communication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
   PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
 
   std::copy(itemsToSend.begin(), itemsToSend.end(), itemsToReceive.begin());
 
@@ -58,6 +60,7 @@ void Communication::reduceSum(precice::span<double const> itemsToSend, precice::
 void Communication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
   PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
 
   auto request = aSend(itemsToSend, rankMaster);
   request->wait();
@@ -91,6 +94,7 @@ void Communication::reduceSum(int itemToSend, int &itemToReceive, Rank rankMaste
 void Communication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
   PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
 
   reduceSum(itemsToSend, itemsToReceive);
 
@@ -109,6 +113,7 @@ void Communication::allreduceSum(precice::span<double const> itemsToSend, precic
 void Communication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
   PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
 
   reduceSum(itemsToSend, itemsToReceive, rankMaster);
   // receive reduced data from master

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -38,28 +38,28 @@ void Communication::connectMasterSlaves(std::string const &participantName,
 /**
  * @attention This method modifies the input buffer.
  */
-void Communication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size)
+void Communication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
 
-  std::copy(itemsToSend, itemsToSend + size, itemsToReceive);
+  std::copy(itemsToSend.begin(), itemsToSend.end(), itemsToReceive.begin());
 
-  std::vector<double> received(size);
+  std::vector<double> received(itemsToReceive.size());
   // receive local results from slaves
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aReceive(received.data(), size, rank + _rankOffset);
+    auto request = aReceive({received}, rank + _rankOffset);
     request->wait();
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0; i < itemsToReceive.size(); i++) {
       itemsToReceive[i] += received[i];
     }
   }
 }
 
-void Communication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
+void Communication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
 
-  auto request = aSend(itemsToSend, size, rankMaster);
+  auto request = aSend(itemsToSend, rankMaster);
   request->wait();
 }
 
@@ -81,34 +81,24 @@ void Communication::reduceSum(int itemToSend, int &itemToReceive, Rank rankMaste
 {
   PRECICE_TRACE();
 
-  auto request = aSend(&itemToSend, 1, rankMaster);
+  auto request = aSend(itemToSend, rankMaster);
   request->wait();
 }
 
 /**
  * @attention This method modifies the input buffer.
  */
-void Communication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size)
+void Communication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
 
-  std::copy(itemsToSend, itemsToSend + size, itemsToReceive);
-
-  std::vector<double> received(size);
-  // receive local results from slaves
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aReceive(received.data(), size, rank + _rankOffset);
-    request->wait();
-    for (int i = 0; i < size; i++) {
-      itemsToReceive[i] += received[i];
-    }
-  }
+  reduceSum(itemsToSend, itemsToReceive);
 
   // send reduced result to all slaves
-  std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
+  std::vector<PtrRequest> requests;
+  requests.resize(getRemoteCommunicatorSize());
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request   = aSend(itemsToReceive, size, rank + _rankOffset);
-    requests[rank] = request;
+    requests.push_back(aSend(itemsToReceive, rank + _rankOffset));
   }
   Request::wait(requests);
 }
@@ -116,14 +106,13 @@ void Communication::allreduceSum(double const *itemsToSend, double *itemsToRecei
 /**
  * @attention This method modifies the input buffer.
  */
-void Communication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
+void Communication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size(), itemsToReceive.size());
 
-  auto request = aSend(itemsToSend, size, rankMaster);
-  request->wait();
+  reduceSum(itemsToSend, itemsToReceive, rankMaster);
   // receive reduced data from master
-  receive(itemsToReceive, size, rankMaster + _rankOffset);
+  receive(itemsToReceive, rankMaster + _rankOffset);
 }
 
 void Communication::allreduceSum(double itemToSend, double &itemToReceive)
@@ -134,7 +123,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
 
   // receive local results from slaves
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request = aReceive(&itemToSend, 1, rank + _rankOffset);
+    auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
     itemToReceive += itemToSend;
   }
@@ -142,7 +131,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request   = aSend(&itemToReceive, 1, rank + _rankOffset);
+    auto request   = aSend(itemToReceive, rank + _rankOffset);
     requests[rank] = request;
   }
   Request::wait(requests);
@@ -152,10 +141,10 @@ void Communication::allreduceSum(double itemToSend, double &itemsToReceive, Rank
 {
   PRECICE_TRACE();
 
-  auto request = aSend(&itemToSend, 1, rankMaster);
+  auto request = aSend(itemToSend, rankMaster);
   request->wait();
   // receive reduced data from master
-  receive(&itemsToReceive, 1, rankMaster + _rankOffset);
+  receive(itemsToReceive, rankMaster + _rankOffset);
 }
 
 void Communication::allreduceSum(int itemToSend, int &itemToReceive)
@@ -174,7 +163,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request   = aSend(&itemToReceive, 1, rank + _rankOffset);
+    auto request   = aSend(itemToReceive, rank + _rankOffset);
     requests[rank] = request;
   }
   Request::wait(requests);
@@ -184,31 +173,31 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive, Rank rankMa
 {
   PRECICE_TRACE();
 
-  auto request = aSend(&itemToSend, 1, rankMaster);
+  auto request = aSend(itemToSend, rankMaster);
   request->wait();
   // receive reduced data from master
-  receive(&itemToReceive, 1, rankMaster + _rankOffset);
+  receive(itemToReceive, rankMaster + _rankOffset);
 }
 
-void Communication::broadcast(const int *itemsToSend, int size)
+void Communication::broadcast(precice::span<const int> itemsToSend)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size());
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request   = aSend(itemsToSend, size, rank + _rankOffset);
+    auto request   = aSend(itemsToSend, rank + _rankOffset);
     requests[rank] = request;
   }
 
   Request::wait(requests);
 }
 
-void Communication::broadcast(int *itemsToReceive, int size, Rank rankBroadcaster)
+void Communication::broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToReceive.size());
 
-  receive(itemsToReceive, size, rankBroadcaster + _rankOffset);
+  receive(itemsToReceive, rankBroadcaster + _rankOffset);
 }
 
 void Communication::broadcast(int itemToSend)
@@ -231,26 +220,25 @@ void Communication::broadcast(int &itemToReceive, Rank rankBroadcaster)
   receive(itemToReceive, rankBroadcaster + _rankOffset);
 }
 
-void Communication::broadcast(const double *itemsToSend, int size)
+void Communication::broadcast(precice::span<const double> itemsToSend)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size());
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
   for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
-    auto request   = aSend(itemsToSend, size, rank + _rankOffset);
+    auto request   = aSend(itemsToSend, rank + _rankOffset);
     requests[rank] = request;
   }
 
   Request::wait(requests);
 }
 
-void Communication::broadcast(double *itemsToReceive,
-                              int     size,
-                              int     rankBroadcaster)
+void Communication::broadcast(precice::span<double> itemsToReceive,
+                              int                   rankBroadcaster)
 {
-  PRECICE_TRACE(size);
-  receive(itemsToReceive, size, rankBroadcaster + _rankOffset);
+  PRECICE_TRACE(itemsToReceive.size());
+  receive(itemsToReceive, rankBroadcaster + _rankOffset);
 }
 
 void Communication::broadcast(double itemToSend)
@@ -291,31 +279,33 @@ void Communication::broadcast(bool &itemToReceive, Rank rankBroadcaster)
 void Communication::broadcast(std::vector<int> const &v)
 {
   broadcast(static_cast<int>(v.size()));
-  broadcast(const_cast<int *>(v.data()), v.size()); // make it send vector
+  broadcast(precice::span<const int>{v});
 }
 
 void Communication::broadcast(std::vector<int> &v, Rank rankBroadcaster)
 {
-  v.clear();
   int size = 0;
   broadcast(size, rankBroadcaster);
+
+  v.clear();
   v.resize(size);
-  broadcast(v.data(), size, rankBroadcaster);
+  broadcast(precice::span<int>{v}, rankBroadcaster);
 }
 
 void Communication::broadcast(std::vector<double> const &v)
 {
   broadcast(static_cast<int>(v.size()));
-  broadcast(v.data(), v.size()); // make it send vector
+  broadcast(precice::span<const double>{v});
 }
 
 void Communication::broadcast(std::vector<double> &v, Rank rankBroadcaster)
 {
-  v.clear();
   int size = 0;
   broadcast(size, rankBroadcaster);
+
+  v.clear();
   v.resize(size);
-  broadcast(v.data(), size, rankBroadcaster);
+  broadcast(precice::span<double>{v}, rankBroadcaster);
 }
 
 int Communication::adjustRank(Rank rank) const

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -48,7 +48,7 @@ void Communication::reduceSum(precice::span<double const> itemsToSend, precice::
 
   std::vector<double> received(itemsToReceive.size());
   // receive local results from slaves
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(received, rank + _rankOffset);
     request->wait();
     for (size_t i = 0; i < itemsToReceive.size(); i++) {
@@ -73,7 +73,7 @@ void Communication::reduceSum(int itemToSend, int &itemToReceive)
   itemToReceive = itemToSend;
 
   // receive local results from slaves
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
     itemToReceive += itemToSend;
@@ -101,7 +101,7 @@ void Communication::allreduceSum(precice::span<double const> itemsToSend, precic
   // send reduced result to all slaves
   std::vector<PtrRequest> requests;
   requests.reserve(getRemoteCommunicatorSize());
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     requests.push_back(aSend(itemsToReceive, rank + _rankOffset));
   }
   Request::wait(requests);
@@ -127,7 +127,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
   itemToReceive = itemToSend;
 
   // receive local results from slaves
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
     itemToReceive += itemToSend;
@@ -135,7 +135,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
 
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request   = aSend(itemToReceive, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -159,7 +159,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
   itemToReceive = itemToSend;
 
   // receive local results from slaves
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
     itemToReceive += itemToSend;
@@ -167,7 +167,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
 
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request   = aSend(itemToReceive, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -190,7 +190,7 @@ void Communication::broadcast(precice::span<const int> itemsToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request   = aSend(itemsToSend, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -211,7 +211,7 @@ void Communication::broadcast(int itemToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request   = aSend(itemToSend, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -231,7 +231,7 @@ void Communication::broadcast(precice::span<const double> itemsToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request   = aSend(itemsToSend, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -252,7 +252,7 @@ void Communication::broadcast(double itemToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank : remoteCommunicatorRanks()) {
     auto request   = aSend(itemToSend, rank + _rankOffset);
     requests[rank] = request;
   }

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -48,7 +48,7 @@ void Communication::reduceSum(precice::span<double const> itemsToSend, precice::
 
   std::vector<double> received(itemsToReceive.size());
   // receive local results from slaves
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request = aReceive(received, rank + _rankOffset);
     request->wait();
     for (size_t i = 0; i < itemsToReceive.size(); i++) {
@@ -73,7 +73,7 @@ void Communication::reduceSum(int itemToSend, int &itemToReceive)
   itemToReceive = itemToSend;
 
   // receive local results from slaves
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
     itemToReceive += itemToSend;
@@ -101,7 +101,7 @@ void Communication::allreduceSum(precice::span<double const> itemsToSend, precic
   // send reduced result to all slaves
   std::vector<PtrRequest> requests;
   requests.reserve(getRemoteCommunicatorSize());
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     requests.push_back(aSend(itemsToReceive, rank + _rankOffset));
   }
   Request::wait(requests);
@@ -127,7 +127,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
   itemToReceive = itemToSend;
 
   // receive local results from slaves
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
     itemToReceive += itemToSend;
@@ -135,7 +135,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
 
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request   = aSend(itemToReceive, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -159,7 +159,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
   itemToReceive = itemToSend;
 
   // receive local results from slaves
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
     itemToReceive += itemToSend;
@@ -167,7 +167,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
 
   // send reduced result to all slaves
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request   = aSend(itemToReceive, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -190,7 +190,7 @@ void Communication::broadcast(precice::span<const int> itemsToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request   = aSend(itemsToSend, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -211,7 +211,7 @@ void Communication::broadcast(int itemToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request   = aSend(itemToSend, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -231,7 +231,7 @@ void Communication::broadcast(precice::span<const double> itemsToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request   = aSend(itemsToSend, rank + _rankOffset);
     requests[rank] = request;
   }
@@ -252,7 +252,7 @@ void Communication::broadcast(double itemToSend)
 
   std::vector<PtrRequest> requests(getRemoteCommunicatorSize());
 
-  for (size_t rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
+  for (Rank rank = 0; rank < getRemoteCommunicatorSize(); ++rank) {
     auto request   = aSend(itemToSend, rank + _rankOffset);
     requests[rank] = request;
   }

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -9,6 +9,7 @@
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "precice/types.hpp"
+#include "utils/span.hpp"
 
 namespace precice {
 namespace com {
@@ -198,15 +199,15 @@ public:
   /// @{
 
   /// Performs a reduce summation on the rank given by rankMaster
-  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster);
+  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster);
   /// Performs a reduce summation on the master, every other rank has to call reduceSum
-  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size);
+  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive);
 
   virtual void reduceSum(int itemToSend, int &itemToReceive, Rank rankMaster);
   virtual void reduceSum(int itemsToSend, int &itemsToReceive);
 
-  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster);
-  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size);
+  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster);
+  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive);
 
   virtual void allreduceSum(double itemToSend, double &itemToReceive, Rank rankMaster);
   virtual void allreduceSum(double itemToSend, double &itemToReceive);
@@ -219,14 +220,14 @@ public:
   /// @name Broadcast
   /// @{
 
-  virtual void broadcast(const int *itemsToSend, int size);
-  virtual void broadcast(int *itemsToReceive, int size, Rank rankBroadcaster);
+  virtual void broadcast(precice::span<const int> itemsToSend);
+  virtual void broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster);
 
   virtual void broadcast(int itemToSend);
   virtual void broadcast(int &itemToReceive, Rank rankBroadcaster);
 
-  virtual void broadcast(const double *itemsToSend, int size);
-  virtual void broadcast(double *itemsToReceive, int size, Rank rankBroadcaster);
+  virtual void broadcast(precice::span<const double> itemsToSend);
+  virtual void broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster);
 
   virtual void broadcast(double itemToSend);
   virtual void broadcast(double &itemToReceive, Rank rankBroadcaster);
@@ -249,18 +250,18 @@ public:
   virtual void send(std::string const &itemToSend, Rank rankReceiver) = 0;
 
   /// Sends an array of integer values.
-  virtual void send(const int *itemsToSend, int size, Rank rankReceiver) = 0;
+  virtual void send(precice::span<const int> itemsToSend, Rank rankReceiver) = 0;
 
   /// Asynchronously sends an array of integer values.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const int *itemsToSend, int size, Rank rankReceiver) = 0;
+  virtual PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) = 0;
 
   /// Sends an array of double values.
-  virtual void send(const double *itemsToSend, int size, Rank rankReceiver) = 0;
+  virtual void send(precice::span<const double> itemsToSend, Rank rankReceiver) = 0;
 
   /// Asynchronously sends an array of double values.
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
-  virtual PtrRequest aSend(const double *itemsToSend, int size, Rank rankReceiver) = 0;
+  virtual PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) = 0;
 
   /// @attention The caller must guarantee that the lifetime of the item extends to the completion of the request!
   virtual PtrRequest aSend(std::vector<double> const &itemsToSend, Rank rankReceiver) = 0;
@@ -295,15 +296,13 @@ public:
   virtual void receive(std::string &itemToReceive, Rank rankSender) = 0;
 
   /// Receives an array of integer values.
-  virtual void receive(int *itemsToReceive, int size, Rank rankSender) = 0;
+  virtual void receive(precice::span<int> itemsToReceive, Rank rankSender) = 0;
 
   /// Receives an array of double values.
-  virtual void receive(double *itemsToReceive, int size, Rank rankSender) = 0;
+  virtual void receive(precice::span<double> itemsToReceive, Rank rankSender) = 0;
 
   /// Asynchronously receives an array of double values.
-  virtual PtrRequest aReceive(double *itemsToReceive,
-                              int     size,
-                              int     rankSender) = 0;
+  virtual PtrRequest aReceive(precice::span<double> itemsToReceive, int rankSender) = 0;
 
   /// Asynchronously receives a vector of double values.
   /*

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -10,6 +10,7 @@
 #include "logging/Logger.hpp"
 #include "precice/types.hpp"
 #include "utils/span.hpp"
+#include "boost/range/irange.hpp"
 
 namespace precice {
 namespace com {
@@ -72,6 +73,18 @@ public:
    * @pre A connection to the remote participant has been set up.
    */
   virtual size_t getRemoteCommunicatorSize() = 0;
+
+  /**
+   * @brief Returns a range over all valid remote ranks.
+   *
+   * @pre A connection to the remote participant has been set up.
+   *
+   * @see getRemoteCommunicatorSize()
+   */
+  auto remoteCommunicatorRanks()
+  {
+    return boost::irange<Rank>(0, static_cast<Rank>(getRemoteCommunicatorSize()));
+  }
 
   /**
    * @brief Accepts connection from another communicator, which has to call requestConnection().

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -6,11 +6,11 @@
 #include <vector>
 
 #include "Request.hpp"
+#include "boost/range/irange.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "precice/types.hpp"
 #include "utils/span.hpp"
-#include "boost/range/irange.hpp"
 
 namespace precice {
 namespace com {

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -7,6 +7,7 @@
 #include "MPIRequest.hpp"
 #include "logging/LogMacros.hpp"
 #include "precice/types.hpp"
+#include "utils/span_tools.hpp"
 
 template <size_t>
 struct MPI_Select_unsigned_integer_datatype;
@@ -143,7 +144,7 @@ void MPICommunication::send(double itemToSend, Rank rankReceiver)
 
 PtrRequest MPICommunication::aSend(const double &itemToSend, Rank rankReceiver)
 {
-  return aSend(precice::span<const double>{&itemToSend, 1}, rankReceiver);
+  return aSend(precice::refToSpan<const double>(itemToSend), rankReceiver);
 }
 
 void MPICommunication::send(int itemToSend, Rank rankReceiver)
@@ -160,7 +161,7 @@ void MPICommunication::send(int itemToSend, Rank rankReceiver)
 
 PtrRequest MPICommunication::aSend(const int &itemToSend, Rank rankReceiver)
 {
-  return aSend(precice::span<const int>{&itemToSend, 1}, rankReceiver);
+  return aSend(precice::refToSpan<const int>(itemToSend), rankReceiver);
 }
 
 void MPICommunication::send(bool itemToSend, Rank rankReceiver)
@@ -282,7 +283,7 @@ void MPICommunication::receive(double &itemToReceive, Rank rankSender)
 
 PtrRequest MPICommunication::aReceive(double &itemToReceive, Rank rankSender)
 {
-  return aReceive(precice::span<double>{&itemToReceive, 1}, rankSender);
+  return aReceive(precice::refToSpan<double>(itemToReceive), rankSender);
 }
 
 void MPICommunication::receive(int &itemToReceive, Rank rankSender)

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -54,26 +54,26 @@ void MPICommunication::send(std::string const &itemToSend, Rank rankReceiver)
            communicator(rankReceiver));
 }
 
-void MPICommunication::send(const int *itemsToSend, int size, Rank rankReceiver)
+void MPICommunication::send(precice::span<const int> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size());
   rankReceiver = adjustRank(rankReceiver);
-  MPI_Send(const_cast<int *>(itemsToSend),
-           size,
+  MPI_Send(const_cast<int *>(itemsToSend.data()),
+           itemsToSend.size(),
            MPI_INT,
            rank(rankReceiver),
            0,
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const int *itemsToSend, int size, Rank rankReceiver)
+PtrRequest MPICommunication::aSend(precice::span<const int> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size());
   rankReceiver = adjustRank(rankReceiver);
 
   MPI_Request request;
-  MPI_Isend(const_cast<int *>(itemsToSend),
-            size,
+  MPI_Isend(const_cast<int *>(itemsToSend.data()),
+            itemsToSend.size(),
             MPI_INT,
             rank(rankReceiver),
             0,
@@ -83,26 +83,26 @@ PtrRequest MPICommunication::aSend(const int *itemsToSend, int size, Rank rankRe
   return PtrRequest(new MPIRequest(request));
 }
 
-void MPICommunication::send(const double *itemsToSend, int size, Rank rankReceiver)
+void MPICommunication::send(precice::span<const double> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size());
   rankReceiver = adjustRank(rankReceiver);
-  MPI_Send(const_cast<double *>(itemsToSend),
-           size,
+  MPI_Send(const_cast<double *>(itemsToSend.data()),
+           itemsToSend.size(),
            MPI_DOUBLE,
            rank(rankReceiver),
            0,
            communicator(rankReceiver));
 }
 
-PtrRequest MPICommunication::aSend(const double *itemsToSend, int size, Rank rankReceiver)
+PtrRequest MPICommunication::aSend(precice::span<const double> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size, rankReceiver);
+  PRECICE_TRACE(itemsToSend.size(), rankReceiver);
   rankReceiver = adjustRank(rankReceiver);
 
   MPI_Request request;
-  MPI_Isend(const_cast<double *>(itemsToSend),
-            size,
+  MPI_Isend(const_cast<double *>(itemsToSend.data()),
+            itemsToSend.size(),
             MPI_DOUBLE,
             rank(rankReceiver),
             0,
@@ -143,7 +143,7 @@ void MPICommunication::send(double itemToSend, Rank rankReceiver)
 
 PtrRequest MPICommunication::aSend(const double &itemToSend, Rank rankReceiver)
 {
-  return aSend(&itemToSend, 1, rankReceiver);
+  return aSend(precice::span<const double>{&itemToSend, 1}, rankReceiver);
 }
 
 void MPICommunication::send(int itemToSend, Rank rankReceiver)
@@ -160,7 +160,7 @@ void MPICommunication::send(int itemToSend, Rank rankReceiver)
 
 PtrRequest MPICommunication::aSend(const int &itemToSend, Rank rankReceiver)
 {
-  return aSend(&itemToSend, 1, rankReceiver);
+  return aSend(precice::span<const int>{&itemToSend, 1}, rankReceiver);
 }
 
 void MPICommunication::send(bool itemToSend, Rank rankReceiver)
@@ -212,14 +212,14 @@ void MPICommunication::receive(std::string &itemToReceive, Rank rankSender)
   PRECICE_DEBUG("Received \"{}\" from rank {}", itemToReceive, rankSender);
 }
 
-void MPICommunication::receive(int *itemsToReceive, int size, Rank rankSender)
+void MPICommunication::receive(precice::span<int> itemsToReceive, Rank rankSender)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToReceive.size());
   rankSender = adjustRank(rankSender);
 
   MPI_Status status;
-  MPI_Recv(itemsToReceive,
-           size,
+  MPI_Recv(itemsToReceive.data(),
+           itemsToReceive.size(),
            MPI_INT,
            rank(rankSender),
            0,
@@ -227,14 +227,14 @@ void MPICommunication::receive(int *itemsToReceive, int size, Rank rankSender)
            &status);
 }
 
-void MPICommunication::receive(double *itemsToReceive, int size, Rank rankSender)
+void MPICommunication::receive(precice::span<double> itemsToReceive, Rank rankSender)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToReceive.size());
   rankSender = adjustRank(rankSender);
 
   MPI_Status status;
-  MPI_Recv(itemsToReceive,
-           size,
+  MPI_Recv(itemsToReceive.data(),
+           itemsToReceive.size(),
            MPI_DOUBLE,
            rank(rankSender),
            0,
@@ -242,24 +242,7 @@ void MPICommunication::receive(double *itemsToReceive, int size, Rank rankSender
            &status);
 }
 
-PtrRequest MPICommunication::aReceive(double *itemsToReceive, int size, Rank rankSender)
-{
-  PRECICE_TRACE(size);
-  rankSender = adjustRank(rankSender);
-
-  MPI_Request request;
-  MPI_Irecv(itemsToReceive,
-            size,
-            MPI_DOUBLE,
-            rank(rankSender),
-            0,
-            communicator(rankSender),
-            &request);
-
-  return PtrRequest(new MPIRequest(request));
-}
-
-PtrRequest MPICommunication::aReceive(std::vector<double> &itemsToReceive, Rank rankSender)
+PtrRequest MPICommunication::aReceive(precice::span<double> itemsToReceive, Rank rankSender)
 {
   PRECICE_TRACE(itemsToReceive.size());
   rankSender = adjustRank(rankSender);
@@ -274,6 +257,11 @@ PtrRequest MPICommunication::aReceive(std::vector<double> &itemsToReceive, Rank 
             &request);
 
   return PtrRequest(new MPIRequest(request));
+}
+
+PtrRequest MPICommunication::aReceive(std::vector<double> &itemsToReceive, Rank rankSender)
+{
+  return aReceive(precice::span<double>{itemsToReceive}, rankSender);
 }
 
 void MPICommunication::receive(double &itemToReceive, Rank rankSender)
@@ -294,7 +282,7 @@ void MPICommunication::receive(double &itemToReceive, Rank rankSender)
 
 PtrRequest MPICommunication::aReceive(double &itemToReceive, Rank rankSender)
 {
-  return aReceive(&itemToReceive, 1, rankSender);
+  return aReceive(precice::span<double>{&itemToReceive, 1}, rankSender);
 }
 
 void MPICommunication::receive(int &itemToReceive, Rank rankSender)

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -36,16 +36,16 @@ public:
   virtual void send(std::string const &itemToSend, Rank rankReceiver) override;
 
   /// Sends an array of integer values.
-  virtual void send(const int *itemsToSend, int size, Rank rankReceiver) override;
+  virtual void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of integer values.
-  virtual PtrRequest aSend(const int *itemsToSend, int size, Rank rankReceiver) override;
+  virtual PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Sends an array of double values.
-  virtual void send(const double *itemsToSend, int size, Rank rankReceiver) override;
+  virtual void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of double values.
-  virtual PtrRequest aSend(const double *itemsToSend, int size, Rank rankReceiver) override;
+  virtual PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   virtual PtrRequest aSend(std::vector<double> const &itemsToSend, Rank rankReceiver) override;
 
@@ -87,15 +87,13 @@ public:
   virtual void receive(std::string &itemToReceive, Rank rankSender) override;
 
   /// Receives an array of integer values.
-  virtual void receive(int *itemsToReceive, int size, Rank rankSender) override;
+  virtual void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
 
   /// Receives an array of double values.
-  virtual void receive(double *itemsToReceive, int size, Rank rankSender) override;
+  virtual void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an array of double values.
-  virtual PtrRequest aReceive(double *itemsToReceive,
-                              int     size,
-                              int     rankSender) override;
+  virtual PtrRequest aReceive(precice::span<double> itemsToReceive, int rankSender) override;
 
   virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, Rank rankSender) override;
 

--- a/src/com/MPIDirectCommunication.cpp
+++ b/src/com/MPIDirectCommunication.cpp
@@ -80,6 +80,7 @@ void MPIDirectCommunication::requestConnection(std::string const &acceptorName,
 void MPIDirectCommunication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
   PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
   Rank rank = _commState->rank();
   MPI_Reduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToSend.size(), MPI_DOUBLE, MPI_SUM, rank, _commState->comm);
 }
@@ -87,6 +88,7 @@ void MPIDirectCommunication::reduceSum(precice::span<double const> itemsToSend, 
 void MPIDirectCommunication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
   PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
   MPI_Reduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToSend.size(), MPI_DOUBLE, MPI_SUM, rankMaster, _commState->comm);
 }
 
@@ -106,12 +108,14 @@ void MPIDirectCommunication::reduceSum(int itemToSend, int &itemsToReceive, Rank
 void MPIDirectCommunication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
   PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
   MPI_Allreduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToSend.size(), MPI_DOUBLE, MPI_SUM, _commState->comm);
 }
 
 void MPIDirectCommunication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
   PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
   MPI_Allreduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToReceive.size(), MPI_DOUBLE, MPI_SUM, _commState->comm);
 }
 

--- a/src/com/MPIDirectCommunication.cpp
+++ b/src/com/MPIDirectCommunication.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #ifndef PRECICE_NO_MPI
 
 #include <memory>
@@ -76,17 +77,17 @@ void MPIDirectCommunication::requestConnection(std::string const &acceptorName,
   PRECICE_ASSERT(requesterCommunicatorSize + 1 == _commState->size());
 }
 
-void MPIDirectCommunication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size)
+void MPIDirectCommunication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
-  PRECICE_TRACE(size);
+  PRECICE_TRACE(itemsToSend.size());
   Rank rank = _commState->rank();
-  MPI_Reduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, rank, _commState->comm);
+  MPI_Reduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToSend.size(), MPI_DOUBLE, MPI_SUM, rank, _commState->comm);
 }
 
-void MPIDirectCommunication::reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
+void MPIDirectCommunication::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
-  PRECICE_TRACE(size);
-  MPI_Reduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, rankMaster, _commState->comm);
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Reduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToSend.size(), MPI_DOUBLE, MPI_SUM, rankMaster, _commState->comm);
 }
 
 void MPIDirectCommunication::reduceSum(int itemToSend, int &itemsToReceive)
@@ -102,16 +103,16 @@ void MPIDirectCommunication::reduceSum(int itemToSend, int &itemsToReceive, Rank
   MPI_Reduce(&itemToSend, &itemsToReceive, 1, MPI_INT, MPI_SUM, rankMaster, _commState->comm);
 }
 
-void MPIDirectCommunication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size)
+void MPIDirectCommunication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
 {
-  PRECICE_TRACE(size);
-  MPI_Allreduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, _commState->comm);
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Allreduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToSend.size(), MPI_DOUBLE, MPI_SUM, _commState->comm);
 }
 
-void MPIDirectCommunication::allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster)
+void MPIDirectCommunication::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster)
 {
-  PRECICE_TRACE(size);
-  MPI_Allreduce(const_cast<double *>(itemsToSend), itemsToReceive, size, MPI_DOUBLE, MPI_SUM, _commState->comm);
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Allreduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(), itemsToReceive.size(), MPI_DOUBLE, MPI_SUM, _commState->comm);
 }
 
 void MPIDirectCommunication::allreduceSum(double itemToSend, double &itemToReceive)
@@ -138,56 +139,52 @@ void MPIDirectCommunication::allreduceSum(int itemToSend, int &itemToReceive, Ra
   MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_INT, MPI_SUM, _commState->comm);
 }
 
-void MPIDirectCommunication::broadcast(const int *itemsToSend, int size)
+void MPIDirectCommunication::broadcast(precice::span<const int> itemsToSend)
 {
-  PRECICE_TRACE(size);
-  MPI_Bcast(const_cast<int *>(itemsToSend), size, MPI_INT, 0, _commState->comm);
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Bcast(const_cast<int *>(itemsToSend.data()), itemsToSend.size(), MPI_INT, 0, _commState->comm);
 }
 
-void MPIDirectCommunication::broadcast(int *itemsToReceive,
-                                       int  size,
-                                       int  rankBroadcaster)
+void MPIDirectCommunication::broadcast(precice::span<int> itemsToReceive, int rankBroadcaster)
 {
-  PRECICE_TRACE(size);
-  MPI_Bcast(itemsToReceive, size, MPI_INT, rankBroadcaster, _commState->comm);
+  PRECICE_TRACE(itemsToReceive.size());
+  MPI_Bcast(itemsToReceive.data(), itemsToReceive.size(), MPI_INT, rankBroadcaster, _commState->comm);
 }
 
 void MPIDirectCommunication::broadcast(int itemToSend)
 {
   PRECICE_TRACE();
-  broadcast(&itemToSend, 1);
+  broadcast(precice::span<const int>{&itemToSend, 1});
 }
 
 void MPIDirectCommunication::broadcast(int &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
-  broadcast(&itemToReceive, 1, rankBroadcaster);
+  broadcast(precice::span<int>{&itemToReceive, 1}, rankBroadcaster);
 }
 
-void MPIDirectCommunication::broadcast(const double *itemsToSend, int size)
+void MPIDirectCommunication::broadcast(precice::span<const double> itemsToSend)
 {
-  PRECICE_TRACE(size);
-  MPI_Bcast(const_cast<double *>(itemsToSend), size, MPI_DOUBLE, 0, _commState->comm);
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Bcast(const_cast<double *>(itemsToSend.data()), itemsToSend.size(), MPI_DOUBLE, 0, _commState->comm);
 }
 
-void MPIDirectCommunication::broadcast(double *itemsToReceive,
-                                       int     size,
-                                       int     rankBroadcaster)
+void MPIDirectCommunication::broadcast(precice::span<double> itemsToReceive, int rankBroadcaster)
 {
-  PRECICE_TRACE(size);
-  MPI_Bcast(itemsToReceive, size, MPI_DOUBLE, rankBroadcaster, _commState->comm);
+  PRECICE_TRACE(itemsToReceive.size());
+  MPI_Bcast(itemsToReceive.data(), itemsToReceive.size(), MPI_DOUBLE, rankBroadcaster, _commState->comm);
 }
 
 void MPIDirectCommunication::broadcast(double itemToSend)
 {
   PRECICE_TRACE();
-  broadcast(&itemToSend, 1);
+  broadcast(precice::span<const double>{&itemToSend, 1});
 }
 
 void MPIDirectCommunication::broadcast(double &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
-  broadcast(&itemToReceive, 1, rankBroadcaster);
+  broadcast(precice::span<double>{&itemToReceive, 1}, rankBroadcaster);
 }
 
 void MPIDirectCommunication::broadcast(bool itemToSend)

--- a/src/com/MPIDirectCommunication.cpp
+++ b/src/com/MPIDirectCommunication.cpp
@@ -8,6 +8,7 @@
 #include "precice/types.hpp"
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
+#include "utils/span_tools.hpp"
 
 namespace precice {
 namespace com {
@@ -158,13 +159,13 @@ void MPIDirectCommunication::broadcast(precice::span<int> itemsToReceive, int ra
 void MPIDirectCommunication::broadcast(int itemToSend)
 {
   PRECICE_TRACE();
-  broadcast(precice::span<const int>{&itemToSend, 1});
+  broadcast(precice::refToSpan<const int>(itemToSend));
 }
 
 void MPIDirectCommunication::broadcast(int &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
-  broadcast(precice::span<int>{&itemToReceive, 1}, rankBroadcaster);
+  broadcast(precice::refToSpan<int>(itemToReceive), rankBroadcaster);
 }
 
 void MPIDirectCommunication::broadcast(precice::span<const double> itemsToSend)
@@ -182,13 +183,13 @@ void MPIDirectCommunication::broadcast(precice::span<double> itemsToReceive, int
 void MPIDirectCommunication::broadcast(double itemToSend)
 {
   PRECICE_TRACE();
-  broadcast(precice::span<const double>{&itemToSend, 1});
+  broadcast(precice::refToSpan<const double>(itemToSend));
 }
 
 void MPIDirectCommunication::broadcast(double &itemToReceive, Rank rankBroadcaster)
 {
   PRECICE_TRACE();
-  broadcast(precice::span<double>{&itemToReceive, 1}, rankBroadcaster);
+  broadcast(precice::refToSpan<double>(itemToReceive), rankBroadcaster);
 }
 
 void MPIDirectCommunication::broadcast(bool itemToSend)

--- a/src/com/MPIDirectCommunication.hpp
+++ b/src/com/MPIDirectCommunication.hpp
@@ -82,17 +82,17 @@ public:
   /// See precice::com::Communication::closeConnection().
   virtual void closeConnection() override;
 
-  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster) override;
+  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster) override;
 
-  virtual void reduceSum(double const *itemsToSend, double *itemsToReceive, int size) override;
+  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
 
   virtual void reduceSum(int itemToSend, int &itemsToReceive, Rank rankMaster) override;
 
   virtual void reduceSum(int itemToSend, int &itemsToReceive) override;
 
-  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size, Rank rankMaster) override;
+  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank rankMaster) override;
 
-  virtual void allreduceSum(double const *itemsToSend, double *itemsToReceive, int size) override;
+  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
 
   virtual void allreduceSum(double itemToSend, double &itemsToReceive, Rank rankMaster) override;
 
@@ -102,17 +102,17 @@ public:
 
   virtual void allreduceSum(int itemToSend, int &itemsToReceive) override;
 
-  virtual void broadcast(const int *itemsToSend, int size) override;
+  virtual void broadcast(precice::span<const int> itemsToSend) override;
 
-  virtual void broadcast(int *itemsToReceive, int size, Rank rankBroadcaster) override;
+  virtual void broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster) override;
 
   virtual void broadcast(int itemToSend) override;
 
   virtual void broadcast(int &itemToReceive, Rank rankBroadcaster) override;
 
-  virtual void broadcast(const double *itemsToSend, int size) override;
+  virtual void broadcast(precice::span<const double> itemsToSend) override;
 
-  virtual void broadcast(double *itemsToReceive, int size, Rank rankBroadcaster) override;
+  virtual void broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster) override;
 
   virtual void broadcast(double itemToSend) override;
 

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -13,6 +13,7 @@
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
 #include "utils/networking.hpp"
+#include "utils/span_tools.hpp"
 
 namespace precice {
 namespace com {
@@ -491,7 +492,7 @@ void SocketCommunication::send(double itemToSend, Rank rankReceiver)
 
 PtrRequest SocketCommunication::aSend(const double &itemToSend, Rank rankReceiver)
 {
-  return aSend(precice::span<const double>{&itemToSend, 1}, rankReceiver);
+  return aSend(precice::refToSpan<const double>(itemToSend), rankReceiver);
 }
 
 void SocketCommunication::send(int itemToSend, Rank rankReceiver)
@@ -512,7 +513,7 @@ void SocketCommunication::send(int itemToSend, Rank rankReceiver)
 
 PtrRequest SocketCommunication::aSend(const int &itemToSend, Rank rankReceiver)
 {
-  return aSend(precice::span<const int>{&itemToSend, 1}, rankReceiver);
+  return aSend(precice::refToSpan<const int>(itemToSend), rankReceiver);
 }
 
 void SocketCommunication::send(bool itemToSend, Rank rankReceiver)
@@ -670,7 +671,7 @@ void SocketCommunication::receive(double &itemToReceive, Rank rankSender)
 
 PtrRequest SocketCommunication::aReceive(double &itemToReceive, Rank rankSender)
 {
-  return aReceive(precice::span<double>{&itemToReceive, 1}, rankSender);
+  return aReceive(precice::refToSpan<double>(itemToReceive), rankSender);
 }
 
 void SocketCommunication::receive(int &itemToReceive, Rank rankSender)

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -358,9 +358,9 @@ void SocketCommunication::send(std::string const &itemToSend, Rank rankReceiver)
   }
 }
 
-void SocketCommunication::send(const int *itemsToSend, int size, Rank rankReceiver)
+void SocketCommunication::send(precice::span<const int> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size, rankReceiver);
+  PRECICE_TRACE(itemsToSend.size(), rankReceiver);
 
   rankReceiver = adjustRank(rankReceiver);
 
@@ -368,7 +368,7 @@ void SocketCommunication::send(const int *itemsToSend, int size, Rank rankReceiv
   PRECICE_ASSERT(isConnected());
 
   try {
-    asio::write(*_sockets[rankReceiver], asio::buffer(itemsToSend, size * sizeof(int)));
+    asio::write(*_sockets[rankReceiver], asio::buffer(itemsToSend.data(), itemsToSend.size() * sizeof(int)));
   } catch (std::exception &e) {
     PRECICE_ERROR("Send using sockets failed with system error: {}", e.what());
   }
@@ -400,9 +400,9 @@ void SocketCommunication::cleanupEstablishment(std::string const &acceptorName,
   }
 }
 
-PtrRequest SocketCommunication::aSend(const int *itemsToSend, int size, Rank rankReceiver)
+PtrRequest SocketCommunication::aSend(precice::span<const int> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size, rankReceiver);
+  PRECICE_TRACE(itemsToSend.size(), rankReceiver);
 
   rankReceiver = adjustRank(rankReceiver);
 
@@ -412,16 +412,16 @@ PtrRequest SocketCommunication::aSend(const int *itemsToSend, int size, Rank ran
   PtrRequest request(new SocketRequest);
 
   _queue.dispatch(_sockets[rankReceiver],
-                  asio::buffer(itemsToSend, size * sizeof(int)),
+                  asio::buffer(itemsToSend.data(), itemsToSend.size() * sizeof(int)),
                   [request] {
                     std::static_pointer_cast<SocketRequest>(request)->complete();
                   });
   return request;
 }
 
-void SocketCommunication::send(const double *itemsToSend, int size, Rank rankReceiver)
+void SocketCommunication::send(precice::span<const double> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size, rankReceiver);
+  PRECICE_TRACE(itemsToSend.size(), rankReceiver);
 
   rankReceiver = adjustRank(rankReceiver);
 
@@ -429,15 +429,15 @@ void SocketCommunication::send(const double *itemsToSend, int size, Rank rankRec
   PRECICE_ASSERT(isConnected());
 
   try {
-    asio::write(*_sockets[rankReceiver], asio::buffer(itemsToSend, size * sizeof(double)));
+    asio::write(*_sockets[rankReceiver], asio::buffer(itemsToSend.data(), itemsToSend.size() * sizeof(double)));
   } catch (std::exception &e) {
     PRECICE_ERROR("Send using sockets failed with system error: {}", e.what());
   }
 }
 
-PtrRequest SocketCommunication::aSend(const double *itemsToSend, int size, Rank rankReceiver)
+PtrRequest SocketCommunication::aSend(precice::span<const double> itemsToSend, Rank rankReceiver)
 {
-  PRECICE_TRACE(size, rankReceiver);
+  PRECICE_TRACE(itemsToSend.size(), rankReceiver);
 
   rankReceiver = adjustRank(rankReceiver);
 
@@ -447,7 +447,7 @@ PtrRequest SocketCommunication::aSend(const double *itemsToSend, int size, Rank 
   PtrRequest request(new SocketRequest);
 
   _queue.dispatch(_sockets[rankReceiver],
-                  asio::buffer(itemsToSend, size * sizeof(double)),
+                  asio::buffer(itemsToSend.data(), itemsToSend.size() * sizeof(double)),
                   [request] {
                     std::static_pointer_cast<SocketRequest>(request)->complete();
                   });
@@ -491,7 +491,7 @@ void SocketCommunication::send(double itemToSend, Rank rankReceiver)
 
 PtrRequest SocketCommunication::aSend(const double &itemToSend, Rank rankReceiver)
 {
-  return aSend(&itemToSend, 1, rankReceiver);
+  return aSend(precice::span<const double>{&itemToSend, 1}, rankReceiver);
 }
 
 void SocketCommunication::send(int itemToSend, Rank rankReceiver)
@@ -512,7 +512,7 @@ void SocketCommunication::send(int itemToSend, Rank rankReceiver)
 
 PtrRequest SocketCommunication::aSend(const int &itemToSend, Rank rankReceiver)
 {
-  return aSend(&itemToSend, 1, rankReceiver);
+  return aSend(precice::span<const int>{&itemToSend, 1}, rankReceiver);
 }
 
 void SocketCommunication::send(bool itemToSend, Rank rankReceiver)
@@ -571,9 +571,9 @@ void SocketCommunication::receive(std::string &itemToReceive, Rank rankSender)
   }
 }
 
-void SocketCommunication::receive(int *itemsToReceive, int size, Rank rankSender)
+void SocketCommunication::receive(precice::span<int> itemsToReceive, Rank rankSender)
 {
-  PRECICE_TRACE(size, rankSender);
+  PRECICE_TRACE(itemsToReceive.size(), rankSender);
 
   rankSender = adjustRank(rankSender);
 
@@ -581,15 +581,15 @@ void SocketCommunication::receive(int *itemsToReceive, int size, Rank rankSender
   PRECICE_ASSERT(isConnected());
 
   try {
-    asio::read(*_sockets[rankSender], asio::buffer(itemsToReceive, size * sizeof(int)));
+    asio::read(*_sockets[rankSender], asio::buffer(itemsToReceive.data(), itemsToReceive.size() * sizeof(int)));
   } catch (std::exception &e) {
     PRECICE_ERROR("Receive using sockets failed with system error: {}", e.what());
   }
 }
 
-void SocketCommunication::receive(double *itemsToReceive, int size, Rank rankSender)
+void SocketCommunication::receive(precice::span<double> itemsToReceive, Rank rankSender)
 {
-  PRECICE_TRACE(size, rankSender);
+  PRECICE_TRACE(itemsToReceive.size(), rankSender);
 
   rankSender = adjustRank(rankSender);
 
@@ -597,17 +597,16 @@ void SocketCommunication::receive(double *itemsToReceive, int size, Rank rankSen
   PRECICE_ASSERT(isConnected());
 
   try {
-    asio::read(*_sockets[rankSender], asio::buffer(itemsToReceive, size * sizeof(double)));
+    asio::read(*_sockets[rankSender], asio::buffer(itemsToReceive.data(), itemsToReceive.size() * sizeof(double)));
   } catch (std::exception &e) {
     PRECICE_ERROR("Receive using sockets failed with system error: {}", e.what());
   }
 }
 
-PtrRequest SocketCommunication::aReceive(double *itemsToReceive,
-                                         int     size,
-                                         int     rankSender)
+PtrRequest SocketCommunication::aReceive(precice::span<double> itemsToReceive,
+                                         int                   rankSender)
 {
-  PRECICE_TRACE(size, rankSender);
+  PRECICE_TRACE(itemsToReceive.size(), rankSender);
 
   rankSender = adjustRank(rankSender);
 
@@ -618,7 +617,7 @@ PtrRequest SocketCommunication::aReceive(double *itemsToReceive,
 
   try {
     asio::async_read(*_sockets[rankSender],
-                     asio::buffer(itemsToReceive, size * sizeof(double)),
+                     asio::buffer(itemsToReceive.data(), itemsToReceive.size() * sizeof(double)),
                      [request](boost::system::error_code const &, std::size_t) {
                        std::static_pointer_cast<SocketRequest>(request)->complete();
                      });
@@ -671,7 +670,7 @@ void SocketCommunication::receive(double &itemToReceive, Rank rankSender)
 
 PtrRequest SocketCommunication::aReceive(double &itemToReceive, Rank rankSender)
 {
-  return aReceive(&itemToReceive, 1, rankSender);
+  return aReceive(precice::span<double>{&itemToReceive, 1}, rankSender);
 }
 
 void SocketCommunication::receive(int &itemToReceive, Rank rankSender)

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -62,16 +62,16 @@ public:
   virtual void send(std::string const &itemToSend, Rank rankReceiver) override;
 
   /// Sends an array of integer values.
-  virtual void send(const int *itemsToSend, int size, Rank rankReceiver) override;
+  virtual void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of integer values.
-  virtual PtrRequest aSend(const int *itemsToSend, int size, Rank rankReceiver) override;
+  virtual PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Sends an array of double values.
-  virtual void send(const double *itemsToSend, int size, Rank rankReceiver) override;
+  virtual void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of double values.
-  virtual PtrRequest aSend(const double *itemsToSend, int size, Rank rankReceiver) override;
+  virtual PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   virtual PtrRequest aSend(std::vector<double> const &itemsToSend, Rank rankReceiver) override;
 
@@ -97,15 +97,14 @@ public:
   virtual void receive(std::string &itemToReceive, Rank rankSender) override;
 
   /// Receives an array of integer values.
-  virtual void receive(int *itemsToReceive, int size, Rank rankSender) override;
+  virtual void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
 
   /// Receives an array of double values.
-  virtual void receive(double *itemsToReceive, int size, Rank rankSender) override;
+  virtual void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an array of double values.
-  virtual PtrRequest aReceive(double *itemsToReceive,
-                              int     size,
-                              int     rankSender) override;
+  virtual PtrRequest aReceive(precice::span<double> itemsToReceive,
+                              int                   rankSender) override;
 
   virtual PtrRequest aReceive(std::vector<double> &itemsToReceive, Rank rankSender) override;
 

--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -98,17 +98,17 @@ void TestSendAndReceiveVectors(TestContext const &context)
     com.acceptConnection("process0", "process1", "", 0);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
-      com.receive(msg.data(), msg.size(), 0);
+      com.receive(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector3d::Constant(1)));
       msg = Eigen::Vector3d::Constant(2);
-      com.send(msg.data(), msg.size(), 0);
+      com.send(msg, 0);
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(0);
-      com.receive(msg.data(), msg.size(), 0);
+      com.receive(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector4i::Constant(1)));
       msg = Eigen::Vector4i::Constant(0);
-      com.send(msg.data(), msg.size(), 0);
+      com.send(msg, 0);
     }
     {
       std::vector<int> msg;
@@ -128,14 +128,14 @@ void TestSendAndReceiveVectors(TestContext const &context)
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(1);
-      com.send(msg.data(), msg.size(), 0);
-      com.receive(msg.data(), msg.size(), 0);
+      com.send(msg, 0);
+      com.receive(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector3d::Constant(2)));
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(1);
-      com.send(msg.data(), msg.size(), 0);
-      com.receive(msg.data(), msg.size(), 0);
+      com.send(msg, 0);
+      com.receive(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector4i::Zero()));
     }
     {
@@ -247,41 +247,41 @@ void TestBroadcastVectors(TestContext const &context)
     com.acceptConnection("process0", "process1", "", 0);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(3.1415);
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(21);
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     {
       std::vector<int> msg{2, 3, 5, 8};
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     {
       std::vector<double> msg{1.2, 2.3, 3.5, 4.8};
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     com.closeConnection();
   } else {
     com.requestConnection("process0", "process1", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector3d::Constant(3.1415)));
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(0);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector4i::Constant(21)));
     }
     {
       std::vector<int> msg(4);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(msg == std::vector<int>({2, 3, 5, 8}));
     }
     {
       std::vector<double> msg(4);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(msg == std::vector<double>({1.2, 2.3, 3.5, 4.8}));
     }
     com.closeConnection();
@@ -355,7 +355,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
-      com.reduceSum(msg.data(), rcv.data(), msg.size());
+      com.reduceSum(msg, rcv);
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());
@@ -366,7 +366,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
-      com.allreduceSum(msg.data(), rcv.data(), msg.size());
+      com.allreduceSum(msg, rcv);
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());
@@ -380,7 +380,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
-      com.reduceSum(msg.data(), rcv.data(), msg.size(), 0);
+      com.reduceSum(msg, rcv, 0);
       std::vector<double> msg_expected{1, 2, 3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());
@@ -391,7 +391,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
-      com.allreduceSum(msg.data(), rcv.data(), msg.size(), 0);
+      com.allreduceSum(msg, rcv, 0);
       std::vector<double> msg_expected{1, 2, 3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());
@@ -498,17 +498,17 @@ void TestSendAndReceiveVectors(TestContext const &context)
     com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
-      com.receive(msg.data(), msg.size(), 1);
+      com.receive(msg, 1);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector3d::Constant(1)));
       msg = Eigen::Vector3d::Constant(2);
-      com.send(msg.data(), msg.size(), 1);
+      com.send(msg, 1);
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(0);
-      com.receive(msg.data(), msg.size(), 1);
+      com.receive(msg, 1);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector4i::Constant(1)));
       msg = Eigen::Vector4i::Constant(0);
-      com.send(msg.data(), msg.size(), 1);
+      com.send(msg, 1);
     }
     {
       std::vector<int> msg;
@@ -528,14 +528,14 @@ void TestSendAndReceiveVectors(TestContext const &context)
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(1);
-      com.send(msg.data(), msg.size(), 0);
-      com.receive(msg.data(), msg.size(), 0);
+      com.send(msg, 0);
+      com.receive(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector3d::Constant(2)));
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(1);
-      com.send(msg.data(), msg.size(), 0);
-      com.receive(msg.data(), msg.size(), 0);
+      com.send(msg, 0);
+      com.receive(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector4i::Zero()));
     }
     {
@@ -604,41 +604,41 @@ void TestBroadcastVectors(TestContext const &context)
     com.acceptConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(3.1415);
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(21);
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     {
       std::vector<int> msg{2, 3, 5, 8};
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     {
       std::vector<double> msg{1.2, 2.3, 3.5, 4.8};
-      com.broadcast(msg.data(), msg.size());
+      com.broadcast(msg);
     }
     com.closeConnection();
   } else {
     com.requestConnection("Master", "Slave", "", 0, 1);
     {
       Eigen::Vector3d msg = Eigen::Vector3d::Constant(0);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector3d::Constant(3.1415)));
     }
     {
       Eigen::Vector4i msg = Eigen::Vector4i::Constant(0);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(testing::equals(msg, Eigen::Vector4i::Constant(21)));
     }
     {
       std::vector<int> msg(4);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(msg == std::vector<int>({2, 3, 5, 8}));
     }
     {
       std::vector<double> msg(4);
-      com.broadcast(msg.data(), msg.size(), 0);
+      com.broadcast(msg, 0);
       BOOST_CHECK(msg == std::vector<double>({1.2, 2.3, 3.5, 4.8}));
     }
     com.closeConnection();
@@ -712,7 +712,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
-      com.reduceSum(msg.data(), rcv.data(), msg.size());
+      com.reduceSum(msg, rcv);
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());
@@ -723,7 +723,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{0.1, 0.2, 0.3};
       std::vector<double> rcv{0, 0, 0};
-      com.allreduceSum(msg.data(), rcv.data(), msg.size());
+      com.allreduceSum(msg, rcv);
       std::vector<double> msg_expected{0.1, 0.2, 0.3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());
@@ -737,7 +737,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
-      com.reduceSum(msg.data(), rcv.data(), msg.size(), 0);
+      com.reduceSum(msg, rcv, 0);
       std::vector<double> msg_expected{1, 2, 3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());
@@ -748,7 +748,7 @@ void TestReduceVectors(TestContext const &context)
     {
       std::vector<double> msg{1, 2, 3};
       std::vector<double> rcv{0, 0, 0};
-      com.allreduceSum(msg.data(), rcv.data(), msg.size(), 0);
+      com.allreduceSum(msg, rcv, 0);
       std::vector<double> msg_expected{1, 2, 3};
       BOOST_CHECK_EQUAL_COLLECTIONS(msg.begin(), msg.end(),
                                     msg_expected.begin(), msg_expected.end());

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -77,10 +77,8 @@ void BaseCouplingScheme::sendData(m2n::PtrM2N m2n, DataMap sendData)
   PRECICE_ASSERT(m2n->isConnected());
 
   for (const DataMap::value_type &pair : sendData) {
-    int size = pair.second->values().size();
-
     // Data is actually only send if size>0, which is checked in the derived classes implementaiton
-    m2n->send(pair.second->values().data(), size, pair.second->getMeshID(), pair.second->getDimensions());
+    m2n->send(pair.second->values(), pair.second->getMeshID(), pair.second->getDimensions());
 
     sentDataIDs.push_back(pair.first);
   }
@@ -94,10 +92,8 @@ void BaseCouplingScheme::receiveData(m2n::PtrM2N m2n, DataMap receiveData)
   PRECICE_ASSERT(m2n.get());
   PRECICE_ASSERT(m2n->isConnected());
   for (DataMap::value_type &pair : receiveData) {
-    int size = pair.second->values().size();
-
     // Data is only received on ranks with size>0, which is checked in the derived class implementation
-    m2n->receive(pair.second->values().data(), size, pair.second->getMeshID(), pair.second->getDimensions());
+    m2n->receive(pair.second->values(), pair.second->getMeshID(), pair.second->getDimensions());
 
     receivedDataIDs.push_back(pair.first);
   }

--- a/src/m2n/DistributedCommunication.hpp
+++ b/src/m2n/DistributedCommunication.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "utils/span.hpp"
 
 namespace precice {
 namespace m2n {
@@ -105,16 +106,10 @@ public:
   virtual void closeConnection() = 0;
 
   /// Sends an array of double values from all slaves (different for each slave).
-  virtual void send(
-      double const *itemsToSend,
-      size_t        size,
-      int           valueDimension) = 0;
+  virtual void send(precice::span<double const> itemsToSend, int valueDimension) = 0;
 
   /// All slaves receive an array of doubles (different for each slave).
-  virtual void receive(
-      double *itemsToReceive,
-      size_t  size,
-      int     valueDimension) = 0;
+  virtual void receive(precice::span<double> itemsToReceive, int valueDimension) = 0;
 
   /*
    * A mapping from remote local ranks to the IDs that must be communicated

--- a/src/m2n/GatherScatterCommunication.hpp
+++ b/src/m2n/GatherScatterCommunication.hpp
@@ -82,16 +82,10 @@ public:
   void closeConnection() override;
 
   /// Sends an array of double values from all slaves (different for each slave).
-  void send(
-      double const *itemsToSend,
-      size_t        size,
-      int           valueDimension) override;
+  void send(precice::span<double const> itemsToSend, int valueDimension) override;
 
   /// All slaves receive an array of doubles (different for each slave).
-  void receive(
-      double *itemsToReceive,
-      size_t  size,
-      int     valueDimension) override;
+  void receive(precice::span<double> itemsToReceive, int valueDimension) override;
 
   /// Broadcasts an int to connected ranks on remote participant. Not available for GatherScatterCommunication.
   void broadcastSend(const int &itemToSend) override;

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -193,10 +193,9 @@ void M2N::createDistributedCommunication(mesh::PtrMesh mesh)
 }
 
 void M2N::send(
-    double const *itemsToSend,
-    int           size,
-    int           meshID,
-    int           valueDimension)
+    precice::span<double const> itemsToSend,
+    int                         meshID,
+    int                         valueDimension)
 {
   if (not _useOnlyMasterCom) {
     PRECICE_ASSERT(_areSlavesConnected);
@@ -210,10 +209,10 @@ void M2N::send(
       _masterCom->send(ack, 0);
     }
     Event e("m2n.sendData", precice::syncMode);
-    _distComs[meshID]->send(itemsToSend, size, valueDimension);
+    _distComs[meshID]->send(itemsToSend, valueDimension);
   } else {
     PRECICE_ASSERT(_isMasterConnected);
-    _masterCom->send(itemsToSend, size, 0);
+    _masterCom->send(itemsToSend, 0);
   }
 }
 
@@ -263,10 +262,9 @@ void M2N::broadcastSend(int &itemToSend, mesh::Mesh &mesh)
   _distComs[meshID]->broadcastSend(itemToSend);
 }
 
-void M2N::receive(double *itemsToReceive,
-                  int     size,
-                  int     meshID,
-                  int     valueDimension)
+void M2N::receive(precice::span<double> itemsToReceive,
+                  int                   meshID,
+                  int                   valueDimension)
 {
   if (not _useOnlyMasterCom) {
     PRECICE_ASSERT(_areSlavesConnected);
@@ -283,10 +281,10 @@ void M2N::receive(double *itemsToReceive,
       }
     }
     Event e("m2n.receiveData", precice::syncMode);
-    _distComs[meshID]->receive(itemsToReceive, size, valueDimension);
+    _distComs[meshID]->receive(itemsToReceive, valueDimension);
   } else {
     PRECICE_ASSERT(_isMasterConnected);
-    _masterCom->receive(itemsToReceive, size, 0);
+    _masterCom->receive(itemsToReceive, 0);
   }
 }
 

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -140,10 +140,9 @@ public:
   void createDistributedCommunication(mesh::PtrMesh mesh);
 
   /// Sends an array of double values from all slaves (different for each slave).
-  void send(double const *itemsToSend,
-            int           size,
-            int           meshID,
-            int           valueDimension);
+  void send(precice::span<double const> itemsToSend,
+            int                         meshID,
+            int                         valueDimension);
 
   /**
    * @brief The master sends a bool to the other master, for performance reasons, we
@@ -167,10 +166,9 @@ public:
   void broadcastSend(int &itemToSend, mesh::Mesh &mesh);
 
   /// All slaves receive an array of doubles (different for each slave).
-  void receive(double *itemsToReceive,
-               int     size,
-               int     meshID,
-               int     valueDimension);
+  void receive(precice::span<double> itemsToReceive,
+               int                   meshID,
+               int                   valueDimension);
 
   /// All slaves receive a bool (the same for each slave).
   void receive(bool &itemToReceive);

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -579,12 +579,10 @@ void PointToPointCommunication::closeConnection()
   _isConnected = false;
 }
 
-void PointToPointCommunication::send(double const *itemsToSend,
-                                     size_t        size,
-                                     int           valueDimension)
+void PointToPointCommunication::send(precice::span<double const> itemsToSend, int valueDimension)
 {
 
-  if (_mappings.empty() || size == 0) {
+  if (_mappings.empty() || itemsToSend.empty()) {
     return;
   }
 
@@ -602,15 +600,13 @@ void PointToPointCommunication::send(double const *itemsToSend,
   checkBufferedRequests(false);
 }
 
-void PointToPointCommunication::receive(double *itemsToReceive,
-                                        size_t  size,
-                                        int     valueDimension)
+void PointToPointCommunication::receive(precice::span<double> itemsToReceive, int valueDimension)
 {
-  if (_mappings.empty() || size == 0) {
+  if (_mappings.empty() || itemsToReceive.empty()) {
     return;
   }
 
-  std::fill(itemsToReceive, itemsToReceive + size, 0);
+  std::fill(itemsToReceive.begin(), itemsToReceive.end(), 0.0);
 
   for (auto &mapping : _mappings) {
     // if (not utils::MasterSlave::isMaster())

--- a/src/m2n/PointToPointCommunication.hpp
+++ b/src/m2n/PointToPointCommunication.hpp
@@ -93,15 +93,13 @@ public:
    * @brief Sends a subset of local double values corresponding to local indices
    *        deduced from the current and remote vertex distributions.
    */
-  void send(double const *itemsToSend, size_t size, int valueDimension = 1) override;
+  void send(precice::span<double const> itemsToSend, int valueDimension = 1) override;
 
   /**
    * @brief Receives a subset of local double values corresponding to local
    *        indices deduced from the current and remote vertex distributions.
    */
-  void receive(double *itemsToReceive,
-               size_t  size,
-               int     valueDimension = 1) override;
+  void receive(precice::span<double> itemsToReceive, int valueDimension = 1) override;
 
   /// Broadcasts an int to connected ranks on remote participant
   void broadcastSend(const int &itemToSend) override;

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -41,9 +41,8 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
     m2n->acceptSlavesConnection("Part1", "Part2");
     Eigen::VectorXd values = Eigen::VectorXd::Zero(numberOfVertices);
     values << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
-    m2n->send(values.data(), numberOfVertices, pMesh->getID(), valueDimension);
-    m2n->receive(values.data(), numberOfVertices, pMesh->getID(),
-                 valueDimension);
+    m2n->send(values, pMesh->getID(), valueDimension);
+    m2n->receive(values, pMesh->getID(), valueDimension);
     BOOST_TEST(values(0) == 2.0);
     BOOST_TEST(values(1) == 4.0);
     BOOST_TEST(values(2) == 6.0);
@@ -68,26 +67,26 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
       pMesh->getVertexDistribution()[2].push_back(5);
 
       Eigen::Vector3d values(0.0, 0.0, 0.0);
-      m2n->receive(values.data(), 3, pMesh->getID(), valueDimension);
+      m2n->receive(values, pMesh->getID(), valueDimension);
       BOOST_TEST(values(0) == 1.0);
       BOOST_TEST(values(1) == 2.0);
       BOOST_TEST(values(2) == 4.0);
       values = values * 2;
-      m2n->send(values.data(), 3, pMesh->getID(), valueDimension);
+      m2n->send(values, pMesh->getID(), valueDimension);
     } else if (context.isRank(1)) { // Slave1
       Eigen::VectorXd values;
-      m2n->receive(values.data(), 0, pMesh->getID(), valueDimension);
-      m2n->send(values.data(), 0, pMesh->getID(), valueDimension);
+      m2n->receive({}, pMesh->getID(), valueDimension);
+      m2n->send(values, pMesh->getID(), valueDimension);
     } else {
       BOOST_TEST(context.isRank(2));
       Eigen::Vector4d values(0.0, 0.0, 0.0, 0.0);
-      m2n->receive(values.data(), 4, pMesh->getID(), valueDimension);
+      m2n->receive(values, pMesh->getID(), valueDimension);
       BOOST_TEST(values(0) == 3.0);
       BOOST_TEST(values(1) == 4.0);
       BOOST_TEST(values(2) == 5.0);
       BOOST_TEST(values(3) == 6.0);
       values = values * 2;
-      m2n->send(values.data(), 4, pMesh->getID(), valueDimension);
+      m2n->send(values, pMesh->getID(), valueDimension);
     }
   }
 }

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -105,17 +105,17 @@ void runP2PComTest1(const TestContext &context, com::PtrCommunicationFactory cf)
   if (context.isNamed("A")) {
     c.requestConnection("B", "A");
 
-    c.send(data.data(), data.size());
-    c.receive(data.data(), data.size());
+    c.send(data);
+    c.receive(data);
 
     BOOST_TEST(data == expectedData);
   } else {
     c.acceptConnection("B", "A");
 
-    c.receive(data.data(), data.size());
+    c.receive(data);
     BOOST_TEST(data == expectedData);
     process(data);
-    c.send(data.data(), data.size());
+    c.send(data);
   }
 }
 
@@ -181,16 +181,16 @@ void runP2PComTest2(const TestContext &context, com::PtrCommunicationFactory cf)
   if (context.isNamed("A")) {
     c.requestConnection("B", "A");
 
-    c.send(data.data(), data.size());
-    c.receive(data.data(), data.size());
+    c.send(data);
+    c.receive(data);
     BOOST_TEST(data == expectedData);
   } else {
     c.acceptConnection("B", "A");
 
-    c.receive(data.data(), data.size());
+    c.receive(data);
     BOOST_TEST(data == expectedData);
     process(data);
-    c.send(data.data(), data.size());
+    c.send(data);
   }
 }
 

--- a/src/precice/impl/WatchIntegral.cpp
+++ b/src/precice/impl/WatchIntegral.cpp
@@ -72,7 +72,7 @@ void WatchIntegral::exportIntegralData(
 
     if (utils::MasterSlave::getSize() > 1) {
       Eigen::VectorXd valueRecv = Eigen::VectorXd::Zero(dataDimensions);
-      utils::MasterSlave::reduceSum(integral.data(), valueRecv.data(), integral.size());
+      utils::MasterSlave::reduceSum(integral, valueRecv);
       integral = std::move(valueRecv);
     }
     if (not utils::MasterSlave::isSlave()) {
@@ -91,7 +91,7 @@ void WatchIntegral::exportIntegralData(
     double surfaceArea = calculateSurfaceArea();
     if (utils::MasterSlave::getSize() > 1) {
       double surfaceAreaSum = 0.0;
-      utils::MasterSlave::reduceSum(&surfaceArea, &surfaceAreaSum, 1);
+      utils::MasterSlave::reduceSum(surfaceArea, surfaceAreaSum);
       surfaceArea = surfaceAreaSum;
     }
     if (not utils::MasterSlave::isSlave()) {
@@ -102,7 +102,7 @@ void WatchIntegral::exportIntegralData(
     if (utils::MasterSlave::getSize() > 1) {
       double surfaceArea    = 0.0;
       double surfaceAreaSum = 0.0;
-      utils::MasterSlave::reduceSum(&surfaceArea, &surfaceAreaSum, 1);
+      utils::MasterSlave::reduceSum(surfaceArea, surfaceAreaSum);
     }
   }
 }

--- a/src/utils/MasterSlave.cpp
+++ b/src/utils/MasterSlave.cpp
@@ -78,7 +78,7 @@ double MasterSlave::l2norm(const Eigen::VectorXd &vec)
   }
 
   // localSum is modified, do not use afterwards
-  allreduceSum(localSum2, globalSum2, 1);
+  allreduceSum(localSum2, globalSum2);
   /* old loop over all slaves solution
   if(_isSlave){
     _communication->send(localSum2, 0);
@@ -117,7 +117,7 @@ double MasterSlave::dot(const Eigen::VectorXd &vec1, const Eigen::VectorXd &vec2
   }
 
   // localSum is modified, do not use afterwards
-  allreduceSum(localSum, globalSum, 1);
+  allreduceSum(localSum, globalSum);
 
   // old loop over all slaves solution
   /*
@@ -148,29 +148,7 @@ void MasterSlave::reset()
   _size     = -1;
 }
 
-void MasterSlave::reduceSum(double *sendData, double *rcvData, int size)
-{
-  PRECICE_TRACE();
-
-  if (not _isMaster && not _isSlave) {
-    return;
-  }
-
-  PRECICE_ASSERT(_communication.get() != nullptr);
-  PRECICE_ASSERT(_communication->isConnected());
-
-  if (_isSlave) {
-    // send local result to master
-    _communication->reduceSum(sendData, rcvData, size, 0);
-  }
-
-  if (_isMaster) {
-    // receive local results from slaves, apply SUM
-    _communication->reduceSum(sendData, rcvData, size);
-  }
-}
-
-void MasterSlave::reduceSum(int &sendData, int &rcvData, int size)
+void MasterSlave::reduceSum(precice::span<const double> sendData, precice::span<double> rcvData)
 {
   PRECICE_TRACE();
 
@@ -192,7 +170,14 @@ void MasterSlave::reduceSum(int &sendData, int &rcvData, int size)
   }
 }
 
-void MasterSlave::allreduceSum(double *sendData, double *rcvData, int size)
+void MasterSlave::reduceSum(const double &sendData, double &rcvData)
+{
+  PRECICE_TRACE();
+  reduceSum(precice::span<const double>{&sendData, 1},
+            precice::span<double>{&rcvData, 1});
+}
+
+void MasterSlave::reduceSum(const int &sendData, int &rcvData)
 {
   PRECICE_TRACE();
 
@@ -204,17 +189,17 @@ void MasterSlave::allreduceSum(double *sendData, double *rcvData, int size)
   PRECICE_ASSERT(_communication->isConnected());
 
   if (_isSlave) {
-    // send local result to master, receive reduced result from master
-    _communication->allreduceSum(sendData, rcvData, size, 0);
+    // send local result to master
+    _communication->reduceSum(sendData, rcvData, 0);
   }
 
   if (_isMaster) {
-    // receive local results from slaves, apply SUM, send reduced result to slaves
-    _communication->allreduceSum(sendData, rcvData, size);
+    // receive local results from slaves, apply SUM
+    _communication->reduceSum(sendData, rcvData);
   }
 }
 
-void MasterSlave::allreduceSum(double &sendData, double &rcvData, int size)
+void MasterSlave::allreduceSum(precice::span<const double> sendData, precice::span<double> rcvData)
 {
   PRECICE_TRACE();
 
@@ -236,7 +221,29 @@ void MasterSlave::allreduceSum(double &sendData, double &rcvData, int size)
   }
 }
 
-void MasterSlave::allreduceSum(int &sendData, int &rcvData, int size)
+void MasterSlave::allreduceSum(double &sendData, double &rcvData)
+{
+  PRECICE_TRACE();
+
+  if (not _isMaster && not _isSlave) {
+    return;
+  }
+
+  PRECICE_ASSERT(_communication.get() != nullptr);
+  PRECICE_ASSERT(_communication->isConnected());
+
+  if (_isSlave) {
+    // send local result to master, receive reduced result from master
+    _communication->allreduceSum(sendData, rcvData, 0);
+  }
+
+  if (_isMaster) {
+    // receive local results from slaves, apply SUM, send reduced result to slaves
+    _communication->allreduceSum(sendData, rcvData);
+  }
+}
+
+void MasterSlave::allreduceSum(int &sendData, int &rcvData)
 {
   PRECICE_TRACE();
 
@@ -302,7 +309,7 @@ void MasterSlave::broadcast(double &value)
   }
 }
 
-void MasterSlave::broadcast(double *values, int size)
+void MasterSlave::broadcast(precice::span<double> values)
 {
   PRECICE_TRACE();
 
@@ -315,12 +322,12 @@ void MasterSlave::broadcast(double *values, int size)
 
   if (_isMaster) {
     // Broadcast (send) value.
-    _communication->broadcast(values, size);
+    _communication->broadcast(values);
   }
 
   if (_isSlave) {
     // Broadcast (receive) value.
-    _communication->broadcast(values, size, 0);
+    _communication->broadcast(values, 0);
   }
 }
 

--- a/src/utils/MasterSlave.cpp
+++ b/src/utils/MasterSlave.cpp
@@ -266,6 +266,28 @@ void MasterSlave::allreduceSum(int &sendData, int &rcvData)
   }
 }
 
+void MasterSlave::broadcast(precice::span<double> values)
+{
+  PRECICE_TRACE();
+
+  if (not _isMaster && not _isSlave) {
+    return;
+  }
+
+  PRECICE_ASSERT(_communication.get() != nullptr);
+  PRECICE_ASSERT(_communication->isConnected());
+
+  if (_isMaster) {
+    // Broadcast (send) value.
+    _communication->broadcast(values);
+  }
+
+  if (_isSlave) {
+    // Broadcast (receive) value.
+    _communication->broadcast(values, 0);
+  }
+}
+
 void MasterSlave::broadcast(bool &value)
 {
   PRECICE_TRACE();
@@ -307,28 +329,6 @@ void MasterSlave::broadcast(double &value)
   if (_isSlave) {
     // Broadcast (receive) value.
     _communication->broadcast(value, 0);
-  }
-}
-
-void MasterSlave::broadcast(precice::span<double> values)
-{
-  PRECICE_TRACE();
-
-  if (not _isMaster && not _isSlave) {
-    return;
-  }
-
-  PRECICE_ASSERT(_communication.get() != nullptr);
-  PRECICE_ASSERT(_communication->isConnected());
-
-  if (_isMaster) {
-    // Broadcast (send) value.
-    _communication->broadcast(values);
-  }
-
-  if (_isSlave) {
-    // Broadcast (receive) value.
-    _communication->broadcast(values, 0);
   }
 }
 

--- a/src/utils/MasterSlave.cpp
+++ b/src/utils/MasterSlave.cpp
@@ -12,6 +12,7 @@
 #include "logging/Logger.hpp"
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
+#include "utils/span_tools.hpp"
 
 namespace precice {
 namespace utils {
@@ -173,8 +174,8 @@ void MasterSlave::reduceSum(precice::span<const double> sendData, precice::span<
 void MasterSlave::reduceSum(const double &sendData, double &rcvData)
 {
   PRECICE_TRACE();
-  reduceSum(precice::span<const double>{&sendData, 1},
-            precice::span<double>{&rcvData, 1});
+  reduceSum(precice::refToSpan<const double>(sendData),
+            precice::refToSpan<double>(rcvData));
 }
 
 void MasterSlave::reduceSum(const int &sendData, int &rcvData)

--- a/src/utils/MasterSlave.hpp
+++ b/src/utils/MasterSlave.hpp
@@ -6,6 +6,7 @@
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "precice/types.hpp"
+#include "utils/span.hpp"
 
 namespace precice {
 namespace logging {
@@ -58,21 +59,23 @@ public:
 
   static void reset();
 
-  static void reduceSum(double *sendData, double *rcvData, int size);
+  static void reduceSum(precice::span<const double> sendData, precice::span<double> rcvData);
 
-  static void reduceSum(int &sendData, int &rcvData, int size);
+  static void reduceSum(const int &sendData, int &rcvData);
 
-  static void allreduceSum(double *sendData, double *rcvData, int size);
+  static void reduceSum(const double &sendData, double &rcvData);
 
-  static void allreduceSum(double &sendData, double &rcvData, int size);
+  static void allreduceSum(precice::span<const double> sendData, precice::span<double> rcvData);
 
-  static void allreduceSum(int &sendData, int &rcvData, int size);
+  static void allreduceSum(double &sendData, double &rcvData);
+
+  static void allreduceSum(int &sendData, int &rcvData);
 
   static void broadcast(bool &value);
 
   static void broadcast(double &value);
 
-  static void broadcast(double *values, int size);
+  static void broadcast(precice::span<double> values);
 
 private:
   static logging::Logger _log;

--- a/src/utils/span.hpp
+++ b/src/utils/span.hpp
@@ -1,0 +1,612 @@
+// clang-format off
+/*
+This is an implementation of C++20's std::span
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
+*/
+
+//          Copyright Tristan Brindle 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TCB_SPAN_HPP_INCLUDED
+#define TCB_SPAN_HPP_INCLUDED
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+// Attempt to discover whether we're being compiled with exception support
+#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#define TCB_SPAN_NO_EXCEPTIONS
+#endif
+#endif
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+#include <cstdio>
+#include <stdexcept>
+#endif
+
+// Various feature test macros
+
+#ifndef TCB_SPAN_NAMESPACE_NAME
+#define TCB_SPAN_NAMESPACE_NAME precice
+#endif
+
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define TCB_SPAN_HAVE_CPP17
+#endif
+
+#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define TCB_SPAN_HAVE_CPP14
+#endif
+
+namespace TCB_SPAN_NAMESPACE_NAME {
+
+// Establish default contract checking behavior
+#if !defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION) &&                          \
+    !defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION) &&                      \
+    !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#if defined(NDEBUG) || !defined(TCB_SPAN_HAVE_CPP14)
+#define TCB_SPAN_NO_CONTRACT_CHECKING
+#else
+#define TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION
+#endif
+#endif
+
+#if defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION)
+struct contract_violation_error : std::logic_error {
+    explicit contract_violation_error(const char* msg) : std::logic_error(msg)
+    {}
+};
+
+inline void contract_violation(const char* msg)
+{
+    throw contract_violation_error(msg);
+}
+
+#elif defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION)
+[[noreturn]] inline void contract_violation(const char* /*unused*/)
+{
+    std::terminate();
+}
+#endif
+
+#if !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_STRINGIFY(cond) #cond
+#define TCB_SPAN_EXPECT(cond)                                                  \
+    cond ? (void) 0 : contract_violation("Expected " TCB_SPAN_STRINGIFY(cond))
+#else
+#define TCB_SPAN_EXPECT(cond)
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_inline_variables)
+#define TCB_SPAN_INLINE_VAR inline
+#else
+#define TCB_SPAN_INLINE_VAR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14) ||                                            \
+    (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
+#define TCB_SPAN_HAVE_CPP14_CONSTEXPR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR)
+#define TCB_SPAN_CONSTEXPR14 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR) &&                                  \
+    (!defined(_MSC_VER) || _MSC_VER > 1900)
+#define TCB_SPAN_CONSTEXPR_ASSIGN constexpr
+#else
+#define TCB_SPAN_CONSTEXPR_ASSIGN
+#endif
+
+#if defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_CONSTEXPR11 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR11 TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_deduction_guides)
+#define TCB_SPAN_HAVE_DEDUCTION_GUIDES
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_byte)
+#define TCB_SPAN_HAVE_STD_BYTE
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_array_constexpr)
+#define TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
+#endif
+
+#if defined(TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC)
+#define TCB_SPAN_ARRAY_CONSTEXPR constexpr
+#else
+#define TCB_SPAN_ARRAY_CONSTEXPR
+#endif
+
+#ifdef TCB_SPAN_HAVE_STD_BYTE
+using byte = std::byte;
+#else
+using byte = unsigned char;
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17)
+#define TCB_SPAN_NODISCARD [[nodiscard]]
+#else
+#define TCB_SPAN_NODISCARD
+#endif
+
+TCB_SPAN_INLINE_VAR constexpr std::size_t dynamic_extent = SIZE_MAX;
+
+template <typename ElementType, std::size_t Extent = dynamic_extent>
+class span;
+
+namespace detail {
+
+template <typename E, std::size_t S>
+struct span_storage {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t /*unused*/) noexcept
+       : ptr(p_ptr)
+    {}
+
+    E* ptr = nullptr;
+    static constexpr std::size_t size = S;
+};
+
+template <typename E>
+struct span_storage<E, dynamic_extent> {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t p_size) noexcept
+        : ptr(p_ptr), size(p_size)
+    {}
+
+    E* ptr = nullptr;
+    std::size_t size = 0;
+};
+
+// Reimplementation of C++17 std::size() and std::data()
+#if defined(TCB_SPAN_HAVE_CPP17) ||                                            \
+    defined(__cpp_lib_nonmember_container_access)
+using std::data;
+using std::size;
+#else
+template <class C>
+constexpr auto size(const C& c) -> decltype(c.size())
+{
+    return c.size();
+}
+
+template <class T, std::size_t N>
+constexpr std::size_t size(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto data(C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class C>
+constexpr auto data(const C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class T, std::size_t N>
+constexpr T* data(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class E>
+constexpr const E* data(std::initializer_list<E> il) noexcept
+{
+    return il.begin();
+}
+#endif // TCB_SPAN_HAVE_CPP17
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_void_t)
+using std::void_t;
+#else
+template <typename...>
+using void_t = void;
+#endif
+
+template <typename T>
+using uncvref_t =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+template <typename>
+struct is_span : std::false_type {};
+
+template <typename T, std::size_t S>
+struct is_span<span<T, S>> : std::true_type {};
+
+template <typename>
+struct is_std_array : std::false_type {};
+
+template <typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <typename, typename = void>
+struct has_size_and_data : std::false_type {};
+
+template <typename T>
+struct has_size_and_data<T, void_t<decltype(detail::size(std::declval<T>())),
+                                   decltype(detail::data(std::declval<T>()))>>
+    : std::true_type {};
+
+template <typename C, typename U = uncvref_t<C>>
+struct is_container {
+    static constexpr bool value =
+        !is_span<U>::value && !is_std_array<U>::value &&
+        !std::is_array<U>::value && has_size_and_data<C>::value;
+};
+
+template <typename T>
+using remove_pointer_t = typename std::remove_pointer<T>::type;
+
+template <typename, typename, typename = void>
+struct is_container_element_type_compatible : std::false_type {};
+
+template <typename T, typename E>
+struct is_container_element_type_compatible<
+    T, E,
+    typename std::enable_if<
+        !std::is_same<typename std::remove_cv<decltype(
+                          detail::data(std::declval<T>()))>::type,
+                      void>::value>::type>
+    : std::is_convertible<
+          remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
+          E (*)[]> {};
+
+template <typename, typename = size_t>
+struct is_complete : std::false_type {};
+
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+
+} // namespace detail
+
+template <typename ElementType, std::size_t Extent>
+class span {
+    static_assert(std::is_object<ElementType>::value,
+                  "A span's ElementType must be an object type (not a "
+                  "reference type or void)");
+    static_assert(detail::is_complete<ElementType>::value,
+                  "A span's ElementType must be a complete type (not a forward "
+                  "declaration)");
+    static_assert(!std::is_abstract<ElementType>::value,
+                  "A span's ElementType cannot be an abstract class type");
+
+    using storage_type = detail::span_storage<ElementType, Extent>;
+
+public:
+    // constants and types
+    using element_type = ElementType;
+    using value_type = typename std::remove_cv<ElementType>::type;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
+    using const_reference = const element_type&;
+    using iterator = pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+
+    static constexpr size_type extent = Extent;
+
+    // [span.cons], span constructors, copy, assignment, and destructor
+    template <
+        std::size_t E = Extent,
+        typename std::enable_if<(E == dynamic_extent || E <= 0), int>::type = 0>
+    constexpr span() noexcept
+    {}
+
+    TCB_SPAN_CONSTEXPR11 span(pointer ptr, size_type count)
+        : storage_(ptr, count)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent || count == extent);
+    }
+
+    TCB_SPAN_CONSTEXPR11 span(pointer first_elem, pointer last_elem)
+        : storage_(first_elem, last_elem - first_elem)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                        last_elem - first_elem ==
+                            static_cast<std::ptrdiff_t>(extent));
+    }
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          element_type (&)[N], ElementType>::value,
+                  int>::type = 0>
+    constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N)
+    {}
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          std::array<value_type, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          const std::array<value_type, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(const std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    const Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(const Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    constexpr span(const span& other) noexcept = default;
+
+    template <typename OtherElementType, std::size_t OtherExtent,
+              typename std::enable_if<
+                  (Extent == OtherExtent || Extent == dynamic_extent) &&
+                      std::is_convertible<OtherElementType (*)[],
+                                          ElementType (*)[]>::value,
+                  int>::type = 0>
+    constexpr span(const span<OtherElementType, OtherExtent>& other) noexcept
+        : storage_(other.data(), other.size())
+    {}
+
+    ~span() noexcept = default;
+
+    TCB_SPAN_CONSTEXPR_ASSIGN span&
+    operator=(const span& other) noexcept = default;
+
+    // [span.sub], span subviews
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> first() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data(), Count};
+    }
+
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> last() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data() + (size() - Count), Count};
+    }
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    using subspan_return_t =
+        span<ElementType, Count != dynamic_extent
+                              ? Count
+                              : (Extent != dynamic_extent ? Extent - Offset
+                                                          : dynamic_extent)>;
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    TCB_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
+    {
+        TCB_SPAN_EXPECT(Offset <= size() &&
+                        (Count == dynamic_extent || Offset + Count <= size()));
+        return {data() + Offset,
+                Count != dynamic_extent ? Count : size() - Offset};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    first(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data(), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    last(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data() + (size() - count), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    subspan(size_type offset, size_type count = dynamic_extent) const
+    {
+        TCB_SPAN_EXPECT(offset <= size() &&
+                        (count == dynamic_extent || offset + count <= size()));
+        return {data() + offset,
+                count == dynamic_extent ? size() - offset : count};
+    }
+
+    // [span.obs], span observers
+    constexpr size_type size() const noexcept { return storage_.size; }
+
+    constexpr size_type size_bytes() const noexcept
+    {
+        return size() * sizeof(element_type);
+    }
+
+    TCB_SPAN_NODISCARD constexpr bool empty() const noexcept
+    {
+        return size() == 0;
+    }
+
+    // [span.elem], span element access
+    TCB_SPAN_CONSTEXPR11 reference operator[](size_type idx) const
+    {
+        TCB_SPAN_EXPECT(idx < size());
+        return *(data() + idx);
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference front() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *data();
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference back() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *(data() + (size() - 1));
+    }
+
+    constexpr pointer data() const noexcept { return storage_.ptr; }
+
+    // [span.iterators], span iterator support
+    constexpr iterator begin() const noexcept { return data(); }
+
+    constexpr iterator end() const noexcept { return data() + size(); }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+private:
+    storage_type storage_{};
+};
+
+#ifdef TCB_SPAN_HAVE_DEDUCTION_GUIDES
+
+/* Deduction Guides */
+template <class T, size_t N>
+span(T (&)[N])->span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N>&)->span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N>&)->span<const T, N>;
+
+template <class Container>
+span(Container&)->span<typename Container::value_type>;
+
+template <class Container>
+span(const Container&)->span<const typename Container::value_type>;
+
+#endif // TCB_HAVE_DEDUCTION_GUIDES
+
+template <typename ElementType, std::size_t Extent>
+constexpr span<ElementType, Extent>
+make_span(span<ElementType, Extent> s) noexcept
+{
+    return s;
+}
+
+template <typename T, std::size_t N>
+constexpr span<T, N> make_span(T (&arr)[N]) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<T, N> make_span(std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<const T, N>
+make_span(const std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename Container>
+constexpr span<typename Container::value_type> make_span(Container& cont)
+{
+    return {cont};
+}
+
+template <typename Container>
+constexpr span<const typename Container::value_type>
+make_span(const Container& cont)
+{
+    return {cont};
+}
+
+template <typename ElementType, std::size_t Extent>
+span<const byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                             : sizeof(ElementType) * Extent)>
+as_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
+}
+
+template <
+    class ElementType, size_t Extent,
+    typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
+span<byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                       : sizeof(ElementType) * Extent)>
+as_writable_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
+}
+
+template <std::size_t N, typename E, std::size_t S>
+constexpr auto get(span<E, S> s) -> decltype(s[N])
+{
+    return s[N];
+}
+
+} // namespace TCB_SPAN_NAMESPACE_NAME
+
+namespace std {
+
+template <typename ElementType, size_t Extent>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>>
+    : public integral_constant<size_t, Extent> {};
+
+template <typename ElementType>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<
+    ElementType, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
+
+template <size_t I, typename ElementType, size_t Extent>
+class tuple_element<I, TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>> {
+public:
+    static_assert(Extent != TCB_SPAN_NAMESPACE_NAME::dynamic_extent &&
+                      I < Extent,
+                  "");
+    using type = ElementType;
+};
+
+} // end namespace std
+
+#endif // TCB_SPAN_HPP_INCLUDED

--- a/src/utils/span_tools.hpp
+++ b/src/utils/span_tools.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "utils/span.hpp"
+
+namespace precice {
+
+/// Wraps a single element into a span
+template <typename T>
+auto refToSpan(T &element)
+{
+  return precice::span<T>{&element, 1};
+}
+
+} // namespace precice


### PR DESCRIPTION
## Main changes of this PR

* Added the glorious span implementation from https://github.com/tcbrindle/span  
  This is a drop-in replacement for the C++20 `std::span`
* Ported the entire communication back-end from using `T* data, size_t size` to using `precice::span<T>`.  
  Using the namespace `precice` allows to simply rename it to `std::` once we upgrade to C++20.
* Ported all tests to the new span method.
* Cleaned up the interface considerably.

## Motivation and additional information

Using `T*` + `size` is error prone and verbose. Even worse is using a single size for multiple `T*`, something we frequently do in the communication back-end.
A span is a neat non-owning wrapper around this and provides convenience methods such as `begin(), end(), empty()`.
`std::span` is part of the C++20 standard, so there is no reason not to take advantage of its features right now.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)