### PR TITLE
Add Rank as data in parallel vtk exports

### DIFF
--- a/docs/changelog/1058.md
+++ b/docs/changelog/1058.md
@@ -1,0 +1,1 @@
+- Added the `Rank` of partitions in parallel VTK exports

--- a/docs/changelog/1058.md
+++ b/docs/changelog/1058.md
@@ -1,1 +1,1 @@
-- Added the `Rank` of partitions in parallel VTK exports
+- Added the `Rank` of partitions in VTK exports

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -97,6 +97,10 @@ void ExportVTK::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
 {
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
 
+  outFile << "SCALARS Rank unsigned_int\n";
+  std::fill_n(std::ostream_iterator<char const *>(outFile), mesh.vertices().size(), "0 ");
+  outFile << "\n\n";
+
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
     Eigen::VectorXd &values = data->values();
     if (data->getDimensions() > 1) {

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -240,7 +240,7 @@ void ExportVTKXML::exportData(
   outFile << "\">\n";
 
   // Export the current rank
-  outFile << "            <DataArray type=\"Int32\" Name=\"Rank\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "            <DataArray type=\"UInt32\" Name=\"Rank\" NumberOfComponents=\"1\" format=\"ascii\">\n";
   const auto rank = utils::MasterSlave::getRank();
   for (size_t count = 0; count < mesh.vertices().size(); ++count) {
     outFile << rank << ' ';

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -88,7 +88,7 @@ void ExportVTKXML::writeMasterFile(
   outMasterFile << "      </PCells>\n";
 
   // write scalar data names
-  outMasterFile << "      <PPointData Scalars=\"";
+  outMasterFile << "      <PPointData Scalars=\"Rank ";
   for (const auto &scalarDataName : _scalarDataNames) {
     outMasterFile << scalarDataName << ' ';
   }
@@ -98,6 +98,8 @@ void ExportVTKXML::writeMasterFile(
     outMasterFile << vectorDataName << ' ';
   }
   outMasterFile << "\">\n";
+
+  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"Rank\" NumberOfComponents=\"1\"/>\n";
 
   for (const auto &scalarDataName : _scalarDataNames) {
     outMasterFile << "         <PDataArray type=\"Float64\" Name=\"" << scalarDataName << "\" NumberOfComponents=\"" << 1 << "\"/>\n";
@@ -227,7 +229,7 @@ void ExportVTKXML::exportData(
     std::ofstream &outFile,
     mesh::Mesh &   mesh)
 {
-  outFile << "         <PointData Scalars=\"";
+  outFile << "         <PointData Scalars=\"Rank ";
   for (const auto &scalarDataName : _scalarDataNames) {
     outFile << scalarDataName << ' ';
   }
@@ -236,6 +238,14 @@ void ExportVTKXML::exportData(
     outFile << vectorDataName << ' ';
   }
   outFile << "\">\n";
+
+  // Export the current rank
+  outFile << "            <DataArray type=\"Int32\" Name=\"Rank\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  const auto rank = utils::MasterSlave::getRank();
+  for (size_t count = 0; count < mesh.vertices().size(); ++count) {
+    outFile << rank << ' ';
+  }
+  outFile << "\n            </DataArray>\n";
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
     Eigen::VectorXd &values         = data->values();


### PR DESCRIPTION
## Main changes of this PR

When exporting vtk in parallel participant, this PR adds the additional scalar data `Rank`, which contains the rank of the partition.

Open questions:
* Is the name `Rank` too general?
* Could the name collide with a user-data name? Shall we use something longer like `preCICERank`?
* Shall we reserve that name via the configuration?
* Should also the non-parallel vtk file include this data as a constant?

## Motivation and additional information

This simplifies debugging vtk exports from parallel solvers, as loading the master file now contains the partitioning information. This was not obvious in the absence of connectivity information. Now using a point gaussian with the rank colouring shows the partitions for such cases.

This also simplifies processing vtk files in external tools, such as ASTE.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist


* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
