### PR TITLE
Masterslave in serial

### DIFF
--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -38,50 +38,6 @@ struct ParallelTestFixture : testing::WhiteboxAccessor {
 BOOST_AUTO_TEST_SUITE(PreciceTests)
 BOOST_FIXTURE_TEST_SUITE(Parallel, ParallelTestFixture)
 
-BOOST_AUTO_TEST_CASE(TestMasterSlaveSetup)
-{
-  PRECICE_TEST("SolverOne"_on(4_ranks));
-  std::string     configFilename = _pathToTests + "config1.xml";
-  SolverInterface interface(context.name, configFilename, context.rank, context.size);
-  BOOST_TEST(interface.getDimensions() == 3);
-
-  if (context.isMaster()) {
-    BOOST_TEST(utils::MasterSlave::isMaster() == true);
-    BOOST_TEST(utils::MasterSlave::isSlave() == false);
-    BOOST_TEST(utils::MasterSlave::isParallel() == true);
-  } else {
-    BOOST_TEST(utils::MasterSlave::isMaster() == false);
-    BOOST_TEST(utils::MasterSlave::isSlave() == true);
-    BOOST_TEST(utils::MasterSlave::isParallel() == true);
-  }
-
-  BOOST_TEST(utils::MasterSlave::getRank() == context.rank);
-  BOOST_TEST(utils::MasterSlave::getSize() == context.size);
-
-  { // ranks
-    auto             ranksRange = utils::MasterSlave::allRanks();
-    std::vector<int> ranks(ranksRange.begin(), ranksRange.end());
-    BOOST_TEST(ranks.size() == 4);
-    BOOST_TEST(std::is_sorted(ranks.begin(), ranks.end()));
-    BOOST_TEST(ranks.front() == 0);
-    auto lastUnique = std::unique(ranks.begin(), ranks.end());
-    BOOST_TEST((lastUnique == ranks.end()));
-  }
-
-  { // slaves
-    auto             slaves = utils::MasterSlave::allSlaves();
-    std::vector<int> ranks(slaves.begin(), slaves.end());
-    BOOST_TEST(ranks.size() == 3);
-    BOOST_TEST(std::is_sorted(ranks.begin(), ranks.end()));
-    BOOST_TEST(ranks.front() == 1);
-    auto lastUnique = std::unique(ranks.begin(), ranks.end());
-    BOOST_TEST((lastUnique == ranks.end()));
-  }
-
-  BOOST_TEST(utils::MasterSlave::_communication.use_count() > 0);
-  BOOST_TEST(utils::MasterSlave::_communication->isConnected());
-}
-
 BOOST_AUTO_TEST_CASE(TestFinalize)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -239,11 +239,13 @@ target_sources(precice
     src/precice/impl/WatchPoint.cpp
     src/precice/impl/WatchPoint.hpp
     src/precice/impl/versions.hpp
+    src/precice/types.hpp
     src/query/Index.cpp
     src/query/Index.hpp
     src/query/impl/Indexer.cpp
     src/query/impl/Indexer.hpp
     src/query/impl/RTreeAdapter.hpp
+    src/time/SharedPointer.hpp
     src/time/Waveform.cpp
     src/time/Waveform.hpp
     src/utils/ArgumentFormatter.hpp
@@ -282,6 +284,8 @@ target_sources(precice
     src/utils/fmtSTL.hpp
     src/utils/networking.cpp
     src/utils/networking.hpp
+    src/utils/span.hpp
+    src/utils/span_tools.hpp
     src/utils/stacktrace.cpp
     src/utils/stacktrace.hpp
     src/utils/traits.hpp
@@ -302,4 +306,5 @@ target_sources(precice
 
 set_property(TARGET precice PROPERTY PUBLIC_HEADER
     src/precice/SolverInterface.hpp
+    src/precice/types.hpp
     )

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -172,15 +172,11 @@ void TestContext::initializeMasterSlave()
   if (invalid)
     return;
 
-  if (_initMS && hasSize(1)) {
-    throw std::runtime_error{
-        "Initializing a Master Slave communication does not make sense for serial participant \"" + name + "\"!"};
-  }
-
   // Establish a consistent state for all tests
   utils::MasterSlave::configure(rank, size);
+  utils::MasterSlave::_communication.reset();
 
-  if (!_initMS)
+  if (!_initMS || hasSize(1))
     return;
 
 #ifndef PRECICE_NO_MPI

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -70,6 +70,7 @@ target_sources(testprecice
     src/utils/tests/DimensionsTest.cpp
     src/utils/tests/EigenHelperFunctionsTest.cpp
     src/utils/tests/ManageUniqueIDsTest.cpp
+    src/utils/tests/MasterSlaveTest.cpp
     src/utils/tests/MultiLockTest.cpp
     src/utils/tests/ParallelTest.cpp
     src/utils/tests/PointerVectorTest.cpp

--- a/src/utils/MasterSlave.cpp
+++ b/src/utils/MasterSlave.cpp
@@ -154,6 +154,7 @@ void MasterSlave::reduceSum(precice::span<const double> sendData, precice::span<
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
+    std::copy(sendData.begin(), sendData.end(), rcvData.begin());
     return;
   }
 
@@ -183,6 +184,7 @@ void MasterSlave::reduceSum(const int &sendData, int &rcvData)
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
+    rcvData = sendData;
     return;
   }
 
@@ -205,6 +207,7 @@ void MasterSlave::allreduceSum(precice::span<const double> sendData, precice::sp
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
+    std::copy(sendData.begin(), sendData.end(), rcvData.begin());
     return;
   }
 
@@ -227,6 +230,7 @@ void MasterSlave::allreduceSum(double &sendData, double &rcvData)
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
+    rcvData = sendData;
     return;
   }
 
@@ -249,6 +253,7 @@ void MasterSlave::allreduceSum(int &sendData, int &rcvData)
   PRECICE_TRACE();
 
   if (not _isMaster && not _isSlave) {
+    rcvData = sendData;
     return;
   }
 

--- a/src/utils/tests/MasterSlaveTest.cpp
+++ b/src/utils/tests/MasterSlaveTest.cpp
@@ -1,0 +1,350 @@
+#include <boost/test/tools/context.hpp>
+#include "testing/Testing.hpp"
+#include "utils/MasterSlave.hpp"
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(UtilsTests)
+
+BOOST_AUTO_TEST_SUITE(MasterSlave)
+
+BOOST_AUTO_TEST_CASE(SerialConfig)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+
+  BOOST_TEST(!utils::MasterSlave::isMaster());
+  BOOST_TEST(!utils::MasterSlave::isSlave());
+  BOOST_TEST(!utils::MasterSlave::isParallel());
+
+  BOOST_TEST(utils::MasterSlave::getRank() == context.rank);
+  BOOST_TEST(utils::MasterSlave::getSize() == context.size);
+
+  { // ranks
+    auto             ranksRange = utils::MasterSlave::allRanks();
+    std::vector<int> ranks(ranksRange.begin(), ranksRange.end());
+    BOOST_TEST(ranks.size() == 1);
+    BOOST_TEST(ranks.front() == 0);
+  }
+
+  { // slaves
+    auto slaves = utils::MasterSlave::allSlaves();
+    BOOST_TEST((slaves.begin() == slaves.end()));
+  }
+
+  BOOST_TEST(!static_cast<bool>(utils::MasterSlave::_communication));
+}
+
+BOOST_AUTO_TEST_CASE(ParallelConfig)
+{
+  PRECICE_TEST(""_on(3_ranks).setupMasterSlaves());
+
+  BOOST_TEST(utils::MasterSlave::isMaster() == context.isMaster());
+  BOOST_TEST(utils::MasterSlave::isSlave() != context.isMaster());
+  BOOST_TEST(utils::MasterSlave::isParallel());
+
+  BOOST_TEST(utils::MasterSlave::getRank() == context.rank);
+  BOOST_TEST(utils::MasterSlave::getSize() == context.size);
+
+  { // ranks
+    auto             ranksRange = utils::MasterSlave::allRanks();
+    std::vector<int> ranks(ranksRange.begin(), ranksRange.end());
+    std::vector<int> expected{0, 1, 2};
+    BOOST_TEST(ranks == expected, boost::test_tools::per_element());
+  }
+
+  { // slaves
+    auto             slaves = utils::MasterSlave::allSlaves();
+    std::vector<int> ranks(slaves.begin(), slaves.end());
+    std::vector<int> expected{1, 2};
+    BOOST_TEST(ranks == expected, boost::test_tools::per_element());
+  }
+
+  BOOST_TEST(static_cast<bool>(utils::MasterSlave::_communication));
+}
+
+BOOST_AUTO_TEST_CASE(Parallell2norm)
+{
+  PRECICE_TEST(""_on(3_ranks).setupMasterSlaves());
+
+  const double norm = 16.881943016134134;
+  if (context.isMaster()) {
+    Eigen::VectorXd v(3);
+    v << 1, 2, 3;
+    BOOST_TEST(utils::MasterSlave::l2norm(v) == norm);
+  }
+  if (context.isRank(1)) {
+    Eigen::VectorXd v(2);
+    v << 4, 5;
+    BOOST_TEST(utils::MasterSlave::l2norm(v) == norm);
+  }
+  if (context.isRank(2)) {
+    Eigen::VectorXd v(4);
+    v << 6, 7, 8, 9;
+    BOOST_TEST(utils::MasterSlave::l2norm(v) == norm);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Seriall2norm)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+
+  const double    norm = 16.881943016134134;
+  Eigen::VectorXd v(9);
+  v << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  BOOST_TEST(utils::MasterSlave::l2norm(v) == norm);
+}
+
+BOOST_AUTO_TEST_CASE(Paralleldot)
+{
+  PRECICE_TEST(""_on(3_ranks).setupMasterSlaves());
+
+  if (context.isMaster()) {
+    Eigen::VectorXd u(3), v(3);
+    u << 1, 2, 3;
+    v << 9, 8, 7;
+    BOOST_TEST(utils::MasterSlave::dot(u, v) == 165);
+  }
+  if (context.isRank(1)) {
+    Eigen::VectorXd u(2), v(2);
+    u << 4, 5;
+    v << 6, 5;
+    BOOST_TEST(utils::MasterSlave::dot(u, v) == 165);
+  }
+  if (context.isRank(2)) {
+    Eigen::VectorXd u(4), v(4);
+    u << 6, 7, 8, 9;
+    v << 4, 3, 2, 1;
+    BOOST_TEST(utils::MasterSlave::dot(u, v) == 165);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Serialdot)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+
+  Eigen::VectorXd u(9), v(9);
+  u << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  v << 9, 8, 7, 6, 5, 4, 3, 2, 1;
+  BOOST_TEST(utils::MasterSlave::dot(u, v) == 165);
+}
+
+BOOST_AUTO_TEST_CASE(ParallelReduceSum)
+{
+  PRECICE_TEST(""_on(3_ranks).setupMasterSlaves());
+
+  if (context.isMaster()) {
+    {
+      std::vector<double> in{1, 2, 3}, out{-1, -1, -1};
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == (std::vector<double>{12, 15, 18}), boost::test_tools::per_element());
+    }
+    {
+      int in = 1, out = -1;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == 9);
+    }
+    {
+      double in = 1.1, out = -1;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == 9.9);
+    }
+  }
+  if (context.isRank(1)) {
+    {
+      std::vector<double> in{4, 5, 6}, out{-1, -1, -1};
+      auto                expected = out;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == expected, boost::test_tools::per_element());
+    }
+    {
+      int in = 3, out = -1;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == -1);
+    }
+    {
+      double in = 3.3, out = -1;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == -1);
+    }
+  }
+  if (context.isRank(2)) {
+    {
+      std::vector<double> in{7, 8, 9}, out{-1, -1, -1};
+      auto                expected = out;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == expected, boost::test_tools::per_element());
+    }
+    {
+      int in = 5, out = -1;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == -1);
+    }
+    {
+      double in = 5.5, out = -1;
+      utils::MasterSlave::reduceSum(in, out);
+      BOOST_TEST(out == -1);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SerialReduceSum)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+
+  {
+    std::vector<double> in{1, 2, 3}, out{-1, -1, -1};
+    utils::MasterSlave::reduceSum(in, out);
+    BOOST_TEST(out == in, boost::test_tools::per_element());
+  }
+  {
+    int in = 1, out = -1;
+    utils::MasterSlave::reduceSum(in, out);
+    BOOST_TEST(out == in);
+  }
+  {
+    double in = 1.1, out = -1;
+    utils::MasterSlave::reduceSum(in, out);
+    BOOST_TEST(out == in);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ParallelAllReduceSum)
+{
+  PRECICE_TEST(""_on(3_ranks).setupMasterSlaves());
+
+  if (context.isMaster()) {
+    {
+      std::vector<double> in{1, 2, 3}, out{-1, -1, -1};
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == (std::vector<double>{12, 15, 18}), boost::test_tools::per_element());
+    }
+    {
+      int in = 1, out = -1;
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == 9);
+    }
+    {
+      double in = 1.1, out = -1;
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == 9.9);
+    }
+  }
+  if (context.isRank(1)) {
+    {
+      std::vector<double> in{4, 5, 6}, out{-1, -1, -1};
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == (std::vector<double>{12, 15, 18}), boost::test_tools::per_element());
+    }
+    {
+      int in = 3, out = -1;
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == 9);
+    }
+    {
+      double in = 3.3, out = -1;
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == 9.9);
+    }
+  }
+  if (context.isRank(2)) {
+    {
+      std::vector<double> in{7, 8, 9}, out{-1, -1, -1};
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == (std::vector<double>{12, 15, 18}), boost::test_tools::per_element());
+    }
+    {
+      int in = 5, out = -1;
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == 9);
+    }
+    {
+      double in = 5.5, out = -1;
+      utils::MasterSlave::allreduceSum(in, out);
+      BOOST_TEST(out == 9.9);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SerialAllReduceSum)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+
+  {
+    std::vector<double> in{1, 2, 3}, out{-1, -1, -1};
+    utils::MasterSlave::allreduceSum(in, out);
+    BOOST_TEST(out == in, boost::test_tools::per_element());
+  }
+  {
+    int in = 1, out = -1;
+    utils::MasterSlave::allreduceSum(in, out);
+    BOOST_TEST(out == in);
+  }
+  {
+    double in = 1.1, out = -1;
+    utils::MasterSlave::allreduceSum(in, out);
+    BOOST_TEST(out == in);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ParallelBroadcast)
+{
+  PRECICE_TEST(""_on(3_ranks).setupMasterSlaves());
+
+  if (context.isMaster()) {
+    {
+      std::vector<double> in{1, 2, 3};
+      utils::MasterSlave::broadcast(in);
+      BOOST_TEST(in == (std::vector<double>{1, 2, 3}), boost::test_tools::per_element());
+    }
+    {
+      bool in = true;
+      utils::MasterSlave::broadcast(in);
+      BOOST_TEST(in);
+    }
+    {
+      double in = 9.9;
+      utils::MasterSlave::broadcast(in);
+      BOOST_TEST(in == 9.9);
+    }
+  } else {
+    {
+      std::vector<double> out{-1, -1, -1};
+      utils::MasterSlave::broadcast(out);
+      BOOST_TEST(out == (std::vector<double>{1, 2, 3}), boost::test_tools::per_element());
+    }
+    {
+      bool out = false;
+      utils::MasterSlave::broadcast(out);
+      BOOST_TEST(out);
+    }
+    {
+      double out = 9.9;
+      utils::MasterSlave::broadcast(out);
+      BOOST_TEST(out == 9.9);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SerialBroadcast)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+  {
+    std::vector<double> in{1, 2, 3};
+    utils::MasterSlave::broadcast(in);
+    BOOST_TEST(in == (std::vector<double>{1, 2, 3}), boost::test_tools::per_element());
+  }
+  {
+    bool in = true;
+    utils::MasterSlave::broadcast(in);
+    BOOST_TEST(in);
+  }
+  {
+    double in = 9.9;
+    utils::MasterSlave::broadcast(in);
+    BOOST_TEST(in == 9.9);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Main changes of this PR

Adds tests for the MasterSlave (name to be changed #1026) construct.
Fixes the behaviour of reduction functionality when using a serial participant.
They used to simply exit, but now they copy the input to the output.

## Motivation and additional information

I ran into this while working on the adaptive meshes.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)