### PR TITLE
Simplify reinitialization

### DIFF
--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -102,6 +102,7 @@ void NearestProjectionMapping::computeMapping()
   query::Index                           indexTree(searchSpace);
   utils::statistics::DistanceAccumulator distanceStatistics;
 
+  _interpolations.clear();
   _interpolations.reserve(fVertices.size());
 
   for (const auto &fVertex : fVertices) {

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -240,6 +240,16 @@ void Mesh::clear()
   }
 }
 
+/// @todo this should be handled by the Parition
+void Mesh::clearPartitioning()
+{
+  _connectedRanks.clear();
+  _communicationMap.clear();
+  _vertexDistribution.clear();
+  _vertexOffsets.clear();
+  _globalNumberOfVertices = 0;
+}
+
 Mesh::VertexDistribution &Mesh::getVertexDistribution()
 {
   return _vertexDistribution;

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -172,6 +172,9 @@ public:
    */
   void clear();
 
+  /// Clears the partitioning information
+  void clearPartitioning();
+
   /// Returns a mapping from rank to used (not necessarily owned) vertex IDs
   VertexDistribution &getVertexDistribution();
 

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -230,6 +230,8 @@ void ProvidedPartition::compareBoundingBoxes()
   if (_m2ns.empty())
     return;
 
+  _mesh->clearPartitioning();
+
   //@todo coupling mode
 
   //@todo treatment of multiple m2ns
@@ -290,6 +292,7 @@ void ProvidedPartition::compareBoundingBoxes()
     }
 
     // master checks which ranks are connected to it
+    _mesh->getConnectedRanks().clear();
     for (auto &remoteRank : remoteConnectionMap) {
       for (auto &includedRank : remoteRank.second) {
         if (utils::MasterSlave::getRank() == includedRank) {
@@ -309,6 +312,7 @@ void ProvidedPartition::compareBoundingBoxes()
       com::CommunicateBoundingBox(utils::MasterSlave::_communication).broadcastReceiveConnectionMap(remoteConnectionMap);
     }
 
+    _mesh->getConnectedRanks().clear();
     for (const auto &remoteRank : remoteConnectionMap) {
       for (int includedRanks : remoteRank.second) {
         if (utils::MasterSlave::getRank() == includedRanks) {

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -354,6 +354,8 @@ void ReceivedPartition::compareBoundingBoxes()
 {
   PRECICE_TRACE();
 
+  _mesh->clearPartitioning();
+
   // @todo handle coupling mode (i.e. serial participant)
   // @todo treatment of multiple m2ns
   PRECICE_ASSERT(_m2ns.size() == 1);
@@ -395,6 +397,7 @@ void ReceivedPartition::compareBoundingBoxes()
     std::vector<int>                connectedRanksList; // local ranks with any connection
 
     // connected ranks for master
+    _mesh->getConnectedRanks().clear();
     for (auto &remoteBB : remoteBBMap) {
       if (_bb.overlapping(remoteBB.second)) {
         _mesh->getConnectedRanks().push_back(remoteBB.first); //connected remote ranks for this rank
@@ -428,6 +431,7 @@ void ReceivedPartition::compareBoundingBoxes()
   } else {
     PRECICE_ASSERT(utils::MasterSlave::isSlave());
 
+    _mesh->getConnectedRanks().clear();
     for (const auto &remoteBB : remoteBBMap) {
       if (_bb.overlapping(remoteBB.second)) {
         _mesh->getConnectedRanks().push_back(remoteBB.first);

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -247,11 +247,16 @@ double SolverInterfaceImpl::initialize()
 
   PRECICE_INFO("Setting up master communication to coupling partner/s");
   for (auto &m2nPair : _m2ns) {
-    auto &bm2n = m2nPair.second;
-    PRECICE_DEBUG((bm2n.isRequesting ? "Awaiting master connection from {}" : "Establishing master connection to {}"), bm2n.remoteName);
-    bm2n.prepareEstablishment();
-    bm2n.connectMasters();
-    PRECICE_DEBUG("Established master connection {} {}", (bm2n.isRequesting ? "from " : "to "), bm2n.remoteName);
+    auto &bm2n       = m2nPair.second;
+    bool  requesting = bm2n.isRequesting;
+    if (bm2n.m2n->isConnected()) {
+      PRECICE_DEBUG("Master connection {} {} already connected.", (requesting ? "from" : "to"), bm2n.remoteName);
+    } else {
+      PRECICE_DEBUG((requesting ? "Awaiting master connection from {}" : "Establishing master connection to {}"), bm2n.remoteName);
+      bm2n.prepareEstablishment();
+      bm2n.connectMasters();
+      PRECICE_DEBUG("Established master connection {} {}", (requesting ? "from " : "to "), bm2n.remoteName);
+    }
   }
 
   PRECICE_INFO("Masters are connected");

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -680,6 +680,15 @@ private:
   /// Syncs the timestep between slaves and master (all timesteps should be the same!)
   void syncTimestep(double computedTimestepLength);
 
+  /// Which channels to close in closeCommunicationChannels()
+  enum class CloseChannels : bool {
+    All         = false,
+    Distributed = true
+  };
+
+  /// Syncs the masters of all connected participants
+  void closeCommunicationChannels(CloseChannels cc);
+
   /// To allow white box tests.
   friend struct PreciceTests::Serial::TestConfigurationPeano;
   friend struct PreciceTests::Serial::TestConfigurationComsol;

--- a/src/utils/MultiLock.hpp
+++ b/src/utils/MultiLock.hpp
@@ -29,6 +29,9 @@ public:
   /// The type of the key
   using key_type = Key;
 
+  /// The size type
+  using size_type = std::size_t;
+
   /** @brief Adds a lock with a given state
    *
    * Adding an already existent lock does nothing.
@@ -127,9 +130,29 @@ public:
     return _locks.find(name) != _locks.end();
   }
 
+  /// Returns the total count of locks
+  size_type size() const noexcept
+  {
+    return _locks.size();
+  }
+
+  /// Returns the count of locked locks
+  size_t countLocked() const
+  {
+    return std::count_if(_locks.begin(), _locks.end(), [](typename map_type::value_type const &kv) { return kv.second; });
+  }
+
+  /// Returns the count of unlocked locks
+  size_t countUnlocked() const
+  {
+    return std::count_if(_locks.begin(), _locks.end(), [](typename map_type::value_type const &kv) { return not kv.second; });
+  }
+
 private:
+  using map_type = typename std::map<Key, bool>;
+
   /// The map that keeps track of the locks and their state.
-  std::map<Key, bool> _locks;
+  map_type _locks;
 };
 } // namespace utils
 } // namespace precice

--- a/src/utils/tests/MultiLockTest.cpp
+++ b/src/utils/tests/MultiLockTest.cpp
@@ -22,33 +22,49 @@ BOOST_AUTO_TEST_CASE(MultiLockTest)
   BOOST_CHECK_THROW(mlock.check("A"), LockNotFoundException);
   BOOST_CHECK_THROW(mlock.lock("A"), LockNotFoundException);
   BOOST_CHECK_THROW(mlock.unlock("A"), LockNotFoundException);
+  BOOST_TEST(mlock.size() == 0);
+  BOOST_TEST(mlock.countUnlocked() == 0);
+  BOOST_TEST(mlock.countLocked() == 0);
 
   mlock.add("A", true);
   BOOST_TEST(mlock.contains("A"));
   BOOST_TEST(!mlock.contains("B"));
   BOOST_TEST(mlock.check("A"));
   BOOST_TEST(mlock.checkAll());
+  BOOST_TEST(mlock.size() == 1);
+  BOOST_TEST(mlock.countUnlocked() == 0);
+  BOOST_TEST(mlock.countLocked() == 1);
 
   mlock.add("B", false);
   BOOST_TEST(mlock.check("A"));
   BOOST_TEST(mlock.contains("B"));
   BOOST_TEST(!mlock.check("B"));
   BOOST_TEST(!mlock.checkAll());
+  BOOST_TEST(mlock.size() == 2);
+  BOOST_TEST(mlock.countUnlocked() == 1);
+  BOOST_TEST(mlock.countLocked() == 1);
 
   mlock.lock("B");
   BOOST_TEST(mlock.check("A"));
   BOOST_TEST(mlock.check("B"));
   BOOST_TEST(mlock.checkAll());
+  BOOST_TEST(mlock.size() == 2);
+  BOOST_TEST(mlock.countUnlocked() == 0);
+  BOOST_TEST(mlock.countLocked() == 2);
 
   mlock.unlockAll();
   BOOST_TEST(!mlock.check("A"));
   BOOST_TEST(!mlock.check("B"));
   BOOST_TEST(!mlock.checkAll());
+  BOOST_TEST(mlock.countUnlocked() == 2);
+  BOOST_TEST(mlock.countLocked() == 0);
 
   mlock.lockAll();
   BOOST_TEST(mlock.check("A"));
   BOOST_TEST(mlock.check("B"));
   BOOST_TEST(mlock.checkAll());
+  BOOST_TEST(mlock.countUnlocked() == 0);
+  BOOST_TEST(mlock.countLocked() == 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Main changes of this PR

This PR adds a bunch of minor changes that simplify the implementation of the reinitialization. This affects:
* Paritioning
* (NP) Mapping 
Real additions are:
* MultiLock queries
* Refactoring of the SolverInterface participant synchronisation
* Splitting M2N `closeConnections()` into close master-master and distributed


## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)