### PR TITLE
Fix clang-tidy `performance-unnecessary-value-param`

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -657,7 +657,7 @@ int BaseQNAcceleration::getLSSystemRows()
 }
 
 void BaseQNAcceleration::writeInfo(
-    std::string s, bool allProcs)
+    const std::string &s, bool allProcs)
 {
   if (not utils::MasterSlave::isParallel()) {
     // serial acceleration mode

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -266,7 +266,7 @@ protected:
   virtual void removeMatrixColumn(int columnIndex);
 
   /// Wwrites info to the _infostream (also in parallel)
-  void writeInfo(std::string s, bool allProcs = false);
+  void writeInfo(const std::string &s, bool allProcs = false);
 
   int its = 0, tWindows = 0;
 

--- a/src/acceleration/BroydenAcceleration.cpp
+++ b/src/acceleration/BroydenAcceleration.cpp
@@ -5,6 +5,8 @@
 #include <map>
 #include <memory>
 #include <ostream>
+#include <utility>
+
 #include "acceleration/impl/QRFactorization.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "cplscheme/SharedPointer.hpp"
@@ -26,7 +28,7 @@ BroydenAcceleration::BroydenAcceleration(
     std::vector<int>        dataIDs,
     impl::PtrPreconditioner preconditioner)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, dataIDs, preconditioner),
+                         filter, singularityLimit, std::move(dataIDs), std::move(preconditioner)),
       _maxColumns(maxIterationsUsed)
 {
 }

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <deque>
 #include <memory>
+#include <utility>
+
 #include "acceleration/impl/Preconditioner.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
@@ -33,7 +35,7 @@ IQNILSAcceleration::IQNILSAcceleration(
     std::vector<int>        dataIDs,
     impl::PtrPreconditioner preconditioner)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, dataIDs, preconditioner)
+                         filter, singularityLimit, std::move(dataIDs), std::move(preconditioner))
 {
 }
 

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "acceleration/MVQNAcceleration.hpp"
 #include "acceleration/impl/ParallelMatrixOperations.hpp"
@@ -29,21 +30,21 @@ namespace acceleration {
 
 // ==================================================================================
 MVQNAcceleration::MVQNAcceleration(
-    double                  initialRelaxation,
-    bool                    forceInitialRelaxation,
-    int                     maxIterationsUsed,
-    int                     pastTimeWindowsReused,
-    int                     filter,
-    double                  singularityLimit,
-    std::vector<int>        dataIDs,
-    impl::PtrPreconditioner preconditioner,
-    bool                    alwaysBuildJacobian,
-    int                     imvjRestartType,
-    int                     chunkSize,
-    int                     RSLSreusedTimeWindows,
-    double                  RSSVDtruncationEps)
+    double                         initialRelaxation,
+    bool                           forceInitialRelaxation,
+    int                            maxIterationsUsed,
+    int                            pastTimeWindowsReused,
+    int                            filter,
+    double                         singularityLimit,
+    std::vector<int>               dataIDs,
+    const impl::PtrPreconditioner &preconditioner,
+    bool                           alwaysBuildJacobian,
+    int                            imvjRestartType,
+    int                            chunkSize,
+    int                            RSLSreusedTimeWindows,
+    double                         RSSVDtruncationEps)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, dataIDs, preconditioner),
+                         filter, singularityLimit, std::move(dataIDs), preconditioner),
       //  _secondaryOldXTildes(),
       _invJacobian(),
       _oldInvJacobian(),

--- a/src/acceleration/MVQNAcceleration.hpp
+++ b/src/acceleration/MVQNAcceleration.hpp
@@ -42,19 +42,19 @@ public:
    * @brief Constructor.
    */
   MVQNAcceleration(
-      double                  initialRelaxation,
-      bool                    forceInitialRelaxation,
-      int                     maxIterationsUsed,
-      int                     pastTimeWindowsReused,
-      int                     filter,
-      double                  singularityLimit,
-      std::vector<int>        dataIDs,
-      impl::PtrPreconditioner preconditioner,
-      bool                    alwaysBuildJacobian,
-      int                     imvjRestartType,
-      int                     chunkSize,
-      int                     RSLSreusedTimeWindows,
-      double                  RSSVDtruncationEps);
+      double                         initialRelaxation,
+      bool                           forceInitialRelaxation,
+      int                            maxIterationsUsed,
+      int                            pastTimeWindowsReused,
+      int                            filter,
+      double                         singularityLimit,
+      std::vector<int>               dataIDs,
+      const impl::PtrPreconditioner &preconditioner,
+      bool                           alwaysBuildJacobian,
+      int                            imvjRestartType,
+      int                            chunkSize,
+      int                            RSLSreusedTimeWindows,
+      double                         RSSVDtruncationEps);
 
   /**
     * @brief Destructor, empty.

--- a/src/acceleration/impl/SVDFactorization.cpp
+++ b/src/acceleration/impl/SVDFactorization.cpp
@@ -23,7 +23,7 @@ void SVDFactorization::initialize(
     PtrParMatrixOps parOps,
     int             globalRows)
 {
-  _parMatrixOps = parOps;
+  _parMatrixOps = std::move(parOps);
   _globalRows   = globalRows;
   _initialized  = true;
 }

--- a/src/action/SummationAction.cpp
+++ b/src/action/SummationAction.cpp
@@ -12,10 +12,10 @@ namespace precice {
 namespace action {
 
 SummationAction::SummationAction(
-    Timing               timing,
-    std::vector<int>     sourceDataIDs,
-    int                  targetDataID,
-    const mesh::PtrMesh &mesh)
+    Timing                  timing,
+    const std::vector<int> &sourceDataIDs,
+    int                     targetDataID,
+    const mesh::PtrMesh &   mesh)
     : Action(timing, mesh, mapping::Mapping::MeshRequirement::VERTEX), _targetData(mesh->data(targetDataID))
 {
 

--- a/src/action/SummationAction.hpp
+++ b/src/action/SummationAction.hpp
@@ -21,10 +21,10 @@ public:
 	 * 
 	 */
   SummationAction(
-      Timing               timing,
-      std::vector<int>     sourceDataIDs,
-      int                  targetDataID,
-      const mesh::PtrMesh &mesh);
+      Timing                  timing,
+      const std::vector<int> &sourceDataIDs,
+      int                     targetDataID,
+      const mesh::PtrMesh &   mesh);
 
   virtual ~SummationAction() {}
 

--- a/src/com/SocketSendQueue.cpp
+++ b/src/com/SocketSendQueue.cpp
@@ -23,7 +23,7 @@ void SocketSendQueue::dispatch(std::shared_ptr<Socket>      sock,
                                boost::asio::const_buffers_1 data,
                                std::function<void()>        callback)
 {
-  _itemQueue.push_back({std::move(sock), std::move(data), callback});
+  _itemQueue.push_back({std::move(sock), std::move(data), std::move(callback)});
   process(); // if queue was previously empty, start it now.
 }
 

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -69,7 +69,7 @@ BaseCouplingScheme::BaseCouplingScheme(
   }
 }
 
-void BaseCouplingScheme::sendData(m2n::PtrM2N m2n, DataMap sendData)
+void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData)
 {
   PRECICE_TRACE();
   std::vector<int> sentDataIDs;
@@ -85,7 +85,7 @@ void BaseCouplingScheme::sendData(m2n::PtrM2N m2n, DataMap sendData)
   PRECICE_DEBUG("Number of sent data sets = {}", sentDataIDs.size());
 }
 
-void BaseCouplingScheme::receiveData(m2n::PtrM2N m2n, DataMap receiveData)
+void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData)
 {
   PRECICE_TRACE();
   std::vector<int> receivedDataIDs;
@@ -439,7 +439,7 @@ void BaseCouplingScheme::setupDataMatrices()
 }
 
 void BaseCouplingScheme::setAcceleration(
-    acceleration::PtrAcceleration acceleration)
+    const acceleration::PtrAcceleration &acceleration)
 {
   PRECICE_ASSERT(acceleration.get() != nullptr);
   _acceleration = acceleration;
@@ -642,7 +642,7 @@ void BaseCouplingScheme::assignDataToConvergenceMeasure(ConvergenceMeasureContex
   convergenceMeasure->couplingData = &(*(iter->second));
 }
 
-void BaseCouplingScheme::sendConvergence(m2n::PtrM2N m2n, bool convergence)
+void BaseCouplingScheme::sendConvergence(const m2n::PtrM2N &m2n, bool convergence)
 {
   PRECICE_ASSERT(not doesFirstStep(), "For convergence information the sending participant is never the first one.");
   m2n->send(convergence);

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -91,7 +91,7 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
   std::vector<int> receivedDataIDs;
   PRECICE_ASSERT(m2n.get());
   PRECICE_ASSERT(m2n->isConnected());
-  for (DataMap::value_type &pair : receiveData) {
+  for (const DataMap::value_type &pair : receiveData) {
     // Data is only received on ranks with size>0, which is checked in the derived class implementation
     m2n->receive(pair.second->values(), pair.second->getMeshID(), pair.second->getDimensions());
 

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -235,7 +235,7 @@ public:
       bool                        doesLogging);
 
   /// Set an acceleration technique.
-  void setAcceleration(acceleration::PtrAcceleration acceleration);
+  void setAcceleration(const acceleration::PtrAcceleration &acceleration);
 
   /**
    * @brief Getter for _doesFirstStep
@@ -259,10 +259,10 @@ protected:
   DataMap _allData;
 
   /// Sends data sendDataIDs given in mapCouplingData with communication.
-  void sendData(m2n::PtrM2N m2n, DataMap sendData);
+  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData);
 
   /// Receives data receiveDataIDs given in mapCouplingData with communication.
-  void receiveData(m2n::PtrM2N m2n, DataMap receiveData);
+  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData);
 
   /**
    * @brief Function to determine whether coupling scheme is an explicit coupling scheme
@@ -336,7 +336,7 @@ protected:
    * @param m2n used for sending
    * @param convergence bool that is being sent
    */
-  void sendConvergence(m2n::PtrM2N m2n, bool convergence);
+  void sendConvergence(const m2n::PtrM2N &m2n, bool convergence);
 
   /**
    * @brief receives convergence from other participant via m2n

--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -49,14 +49,14 @@ BiCouplingScheme::BiCouplingScheme(
 }
 
 void BiCouplingScheme::addDataToSend(
-    mesh::PtrData data,
-    mesh::PtrMesh mesh,
-    bool          requiresInitialization)
+    const mesh::PtrData &data,
+    mesh::PtrMesh        mesh,
+    bool                 requiresInitialization)
 {
   PRECICE_TRACE();
   int id = data->getID();
   if (!utils::contained(id, _sendData)) {
-    PtrCouplingData     ptrCplData(new CouplingData(data, mesh, requiresInitialization));
+    PtrCouplingData     ptrCplData(new CouplingData(data, std::move(mesh), requiresInitialization));
     DataMap::value_type pair = std::make_pair(id, ptrCplData);
     PRECICE_ASSERT(_sendData.count(pair.first) == 0, "Key already exists!");
     _sendData.insert(pair);
@@ -68,14 +68,14 @@ void BiCouplingScheme::addDataToSend(
 }
 
 void BiCouplingScheme::addDataToReceive(
-    mesh::PtrData data,
-    mesh::PtrMesh mesh,
-    bool          requiresInitialization)
+    const mesh::PtrData &data,
+    mesh::PtrMesh        mesh,
+    bool                 requiresInitialization)
 {
   PRECICE_TRACE();
   int id = data->getID();
   if (!utils::contained(id, _receiveData)) {
-    PtrCouplingData     ptrCplData(new CouplingData(data, mesh, requiresInitialization));
+    PtrCouplingData     ptrCplData(new CouplingData(data, std::move(mesh), requiresInitialization));
     DataMap::value_type pair = std::make_pair(id, ptrCplData);
     PRECICE_ASSERT(_receiveData.count(pair.first) == 0, "Key already exists!");
     _receiveData.insert(pair);

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -50,15 +50,15 @@ public:
 
   /// Adds data to be sent on data exchange and possibly be modified during coupling iterations.
   void addDataToSend(
-      mesh::PtrData data,
-      mesh::PtrMesh mesh,
-      bool          requiresInitialization);
+      const mesh::PtrData &data,
+      mesh::PtrMesh        mesh,
+      bool                 requiresInitialization);
 
   /// Adds data to be received on data exchange.
   void addDataToReceive(
-      mesh::PtrData data,
-      mesh::PtrMesh mesh,
-      bool          requiresInitialization);
+      const mesh::PtrData &data,
+      mesh::PtrMesh        mesh,
+      bool                 requiresInitialization);
 
   /// returns list of all coupling partners
   std::vector<std::string> getCouplingPartners() const override final;

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -13,7 +13,7 @@ namespace precice {
 namespace cplscheme {
 
 void CompositionalCouplingScheme::addCouplingScheme(
-    PtrCouplingScheme couplingScheme)
+    const PtrCouplingScheme &couplingScheme)
 {
   PRECICE_TRACE();
   _couplingSchemes.emplace_back(couplingScheme);

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -69,7 +69,7 @@ public:
    *
    * @return Pointer to composition of coupling schemes.
    */
-  void addCouplingScheme(PtrCouplingScheme scheme);
+  void addCouplingScheme(const PtrCouplingScheme &scheme);
 
   /**
    * @brief Initializes the coupling scheme and establishes a communication

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -1,4 +1,7 @@
 #include "cplscheme/CouplingData.hpp"
+
+#include <utility>
+
 #include "utils/EigenHelperFunctions.hpp"
 
 namespace precice {
@@ -9,8 +12,8 @@ CouplingData::CouplingData(
     mesh::PtrMesh mesh,
     bool          requiresInitialization)
     : requiresInitialization(requiresInitialization),
-      _data(data),
-      _mesh(mesh)
+      _data(std::move(data)),
+      _mesh(std::move(mesh))
 {
   PRECICE_ASSERT(_data != nullptr);
   PRECICE_ASSERT(_mesh != nullptr);

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -138,14 +138,14 @@ bool MultiCouplingScheme::exchangeDataAndAccelerate()
 }
 
 void MultiCouplingScheme::addDataToSend(
-    mesh::PtrData data,
-    mesh::PtrMesh mesh,
-    bool          initialize,
-    std::string   to)
+    const mesh::PtrData &data,
+    mesh::PtrMesh        mesh,
+    bool                 initialize,
+    const std::string &  to)
 {
   int id = data->getID();
   PRECICE_DEBUG("Configuring send data to {}", to);
-  PtrCouplingData     ptrCplData(new CouplingData(data, mesh, initialize));
+  PtrCouplingData     ptrCplData(new CouplingData(data, std::move(mesh), initialize));
   DataMap::value_type dataPair = std::make_pair(id, ptrCplData);
   _sendDataVector[to].insert(dataPair);
   if (!utils::contained(id, _allData)) {
@@ -154,14 +154,14 @@ void MultiCouplingScheme::addDataToSend(
 }
 
 void MultiCouplingScheme::addDataToReceive(
-    mesh::PtrData data,
-    mesh::PtrMesh mesh,
-    bool          initialize,
-    std::string   from)
+    const mesh::PtrData &data,
+    mesh::PtrMesh        mesh,
+    bool                 initialize,
+    const std::string &  from)
 {
   int id = data->getID();
   PRECICE_DEBUG("Configuring receive data from {}", from);
-  PtrCouplingData     ptrCplData(new CouplingData(data, mesh, initialize));
+  PtrCouplingData     ptrCplData(new CouplingData(data, std::move(mesh), initialize));
   DataMap::value_type dataPair = std::make_pair(id, ptrCplData);
   _receiveDataVector[from].insert(dataPair);
   if (!utils::contained(id, _allData)) {

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -49,17 +49,17 @@ public:
 
   /// Adds data to be sent on data exchange and possibly be modified during coupling iterations.
   void addDataToSend(
-      mesh::PtrData data,
-      mesh::PtrMesh mesh,
-      bool          initialize,
-      std::string   to);
+      const mesh::PtrData &data,
+      mesh::PtrMesh        mesh,
+      bool                 initialize,
+      const std::string &  to);
 
   /// Adds data to be received on data exchange.
   void addDataToReceive(
-      mesh::PtrData data,
-      mesh::PtrMesh mesh,
-      bool          initialize,
-      std::string   from);
+      const mesh::PtrData &data,
+      mesh::PtrMesh        mesh,
+      bool                 initialize,
+      const std::string &  from);
 
   /// returns list of all coupling partners
   std::vector<std::string> getCouplingPartners() const override final;

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -1,4 +1,7 @@
 #include "ParallelCouplingScheme.hpp"
+
+#include <utility>
+
 #include "cplscheme/BiCouplingScheme.hpp"
 #include "logging/LogMacros.hpp"
 
@@ -18,7 +21,7 @@ ParallelCouplingScheme::ParallelCouplingScheme(
     CouplingMode                  cplMode,
     int                           maxIterations)
     : BiCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, validDigits, firstParticipant,
-                       secondParticipant, localParticipant, m2n, maxIterations, cplMode, dtMethod) {}
+                       secondParticipant, localParticipant, std::move(m2n), maxIterations, cplMode, dtMethod) {}
 
 void ParallelCouplingScheme::initializeImplementation()
 {

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -2,6 +2,8 @@
 #include <cmath>
 #include <memory>
 #include <ostream>
+#include <utility>
+
 #include <vector>
 #include "acceleration/Acceleration.hpp"
 #include "acceleration/SharedPointer.hpp"
@@ -29,7 +31,7 @@ SerialCouplingScheme::SerialCouplingScheme(
     CouplingMode                  cplMode,
     int                           maxIterations)
     : BiCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, validDigits, firstParticipant,
-                       secondParticipant, localParticipant, m2n, maxIterations, cplMode, dtMethod)
+                       secondParticipant, localParticipant, std::move(m2n), maxIterations, cplMode, dtMethod)
 {
   if (dtMethod == constants::FIRST_PARTICIPANT_SETS_TIME_WINDOW_SIZE) {
     if (doesFirstStep()) {

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -355,8 +355,8 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
 }
 
 void CouplingSchemeConfiguration::addCouplingScheme(
-    PtrCouplingScheme  cplScheme,
-    const std::string &participantName)
+    const PtrCouplingScheme &cplScheme,
+    const std::string &      participantName)
 {
   PRECICE_TRACE(participantName);
   if (utils::contained(participantName, _couplingSchemes)) {
@@ -1072,9 +1072,9 @@ void CouplingSchemeConfiguration::checkSerialImplicitAccelerationData(
 }
 
 void CouplingSchemeConfiguration::addConvergenceMeasures(
-    BaseCouplingScheme *                           scheme,
-    const std::string                              participant,
-    const std::vector<ConvergenceMeasureDefintion> convergenceMeasureDefinitions) const
+    BaseCouplingScheme *                            scheme,
+    const std::string &                             participant,
+    const std::vector<ConvergenceMeasureDefintion> &convergenceMeasureDefinitions) const
 {
   for (auto &elem : convergenceMeasureDefinitions) {
     _meshConfig->addNeededMesh(participant, elem.meshName);
@@ -1085,8 +1085,8 @@ void CouplingSchemeConfiguration::addConvergenceMeasures(
 
 void CouplingSchemeConfiguration::setSerialAcceleration(
     BaseCouplingScheme *scheme,
-    const std::string   first,
-    const std::string   second) const
+    const std::string & first,
+    const std::string & second) const
 {
   if (_accelerationConfig->getAcceleration().get() != nullptr) {
     for (std::string &neededMesh : _accelerationConfig->getNeededMeshes()) {
@@ -1101,7 +1101,7 @@ void CouplingSchemeConfiguration::setSerialAcceleration(
 
 void CouplingSchemeConfiguration::setParallelAcceleration(
     BaseCouplingScheme *scheme,
-    const std::string   participant) const
+    const std::string & participant) const
 {
   if (_accelerationConfig->getAcceleration().get() != nullptr) {
     for (std::string &neededMesh : _accelerationConfig->getNeededMeshes()) {

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -75,7 +75,7 @@ public:
   virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
   /// Adds a manually configured coupling scheme for a participant.
-  void addCouplingScheme(PtrCouplingScheme cplScheme, const std::string &participantName);
+  void addCouplingScheme(const PtrCouplingScheme &cplScheme, const std::string &participantName);
 
 private:
   mutable logging::Logger _log{"cplscheme::CouplingSchemeConfiguration"};
@@ -266,18 +266,18 @@ private:
       DataID dataID, const std::string &first, const std::string &second) const;
 
   void addConvergenceMeasures(
-      BaseCouplingScheme *                           scheme,
-      const std::string                              participant,
-      const std::vector<ConvergenceMeasureDefintion> convergenceMeasureDefinitions) const;
+      BaseCouplingScheme *                            scheme,
+      const std::string &                             participant,
+      const std::vector<ConvergenceMeasureDefintion> &convergenceMeasureDefinitions) const;
 
   void setSerialAcceleration(
       BaseCouplingScheme *scheme,
-      const std::string   first,
-      const std::string   second) const;
+      const std::string & first,
+      const std::string & second) const;
 
   void setParallelAcceleration(
       BaseCouplingScheme *scheme,
-      const std::string   participant) const;
+      const std::string & participant) const;
 
   friend struct CplSchemeTests::ParallelImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation; // For whitebox tests
   friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testParseConfigurationWithRelaxation;   // For whitebox tests

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -21,10 +21,10 @@ public:
   /** Creates a Boost logger for the said module.
    * @param[in] module the name of the module.
    */
-  explicit LoggerImpl(std::string module);
+  explicit LoggerImpl(const std::string &module);
 };
 
-Logger::LoggerImpl::LoggerImpl(std::string module)
+Logger::LoggerImpl::LoggerImpl(const std::string &module)
 {
   add_attribute("Module", boost::log::attributes::constant<std::string>(module));
 

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -18,7 +18,7 @@ namespace m2n {
 GatherScatterCommunication::GatherScatterCommunication(
     com::PtrCommunication com,
     mesh::PtrMesh         mesh)
-    : DistributedCommunication(mesh),
+    : DistributedCommunication(std::move(mesh)),
       _com(std::move(com)),
       _isConnected(false)
 {

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -198,7 +198,7 @@ com::PtrCommunication M2N::getMasterCommunication()
   return _masterCom; /// @todo maybe it would be a nicer design to not offer this
 }
 
-void M2N::createDistributedCommunication(mesh::PtrMesh mesh)
+void M2N::createDistributedCommunication(const mesh::PtrMesh &mesh)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(not _useOnlyMasterCom);

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -144,7 +144,7 @@ public:
   com::PtrCommunication getMasterCommunication();
 
   /// Creates a new distributes communication for that mesh, stores the pointer in _distComs
-  void createDistributedCommunication(mesh::PtrMesh mesh);
+  void createDistributedCommunication(const mesh::PtrMesh &mesh);
 
   /// Sends an array of double values from all slaves (different for each slave).
   void send(precice::span<double const> itemsToSend,

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -31,7 +31,7 @@ namespace m2n {
 
 void send(mesh::Mesh::VertexDistribution const &m,
           int                                   rankReceiver,
-          com::PtrCommunication                 communication)
+          const com::PtrCommunication &         communication)
 {
   communication->send(static_cast<int>(m.size()), rankReceiver);
 
@@ -45,7 +45,7 @@ void send(mesh::Mesh::VertexDistribution const &m,
 
 void receive(mesh::Mesh::VertexDistribution &m,
              int                             rankSender,
-             com::PtrCommunication           communication)
+             const com::PtrCommunication &   communication)
 {
   m.clear();
   int size = 0;
@@ -59,7 +59,7 @@ void receive(mesh::Mesh::VertexDistribution &m,
 }
 
 void broadcastSend(mesh::Mesh::VertexDistribution const &m,
-                   com::PtrCommunication                 communication = utils::MasterSlave::_communication)
+                   const com::PtrCommunication &         communication = utils::MasterSlave::_communication)
 {
   communication->broadcast(static_cast<int>(m.size()));
 
@@ -73,7 +73,7 @@ void broadcastSend(mesh::Mesh::VertexDistribution const &m,
 
 void broadcastReceive(mesh::Mesh::VertexDistribution &m,
                       int                             rankBroadcaster,
-                      com::PtrCommunication           communication = utils::MasterSlave::_communication)
+                      const com::PtrCommunication &   communication = utils::MasterSlave::_communication)
 {
   m.clear();
   int size = 0;
@@ -287,7 +287,7 @@ std::map<int, std::vector<int>> buildCommunicationMap(
 PointToPointCommunication::PointToPointCommunication(
     com::PtrCommunicationFactory communicationFactory,
     mesh::PtrMesh                mesh)
-    : DistributedCommunication(mesh),
+    : DistributedCommunication(std::move(mesh)),
       _communicationFactory(std::move(communicationFactory))
 {
 }

--- a/src/mesh/Utils.cpp
+++ b/src/mesh/Utils.cpp
@@ -7,7 +7,7 @@ namespace precice {
 namespace mesh {
 
 /// Given the data and the mesh, this function returns the surface integral. Assumes no overlap exists for the mesh
-Eigen::VectorXd integrate(PtrMesh mesh, PtrData data)
+Eigen::VectorXd integrate(const PtrMesh &mesh, const PtrData &data)
 {
   const int       valueDimensions = data->getDimensions();
   const int       meshDimensions  = mesh->getDimensions();

--- a/src/mesh/Utils.hpp
+++ b/src/mesh/Utils.hpp
@@ -133,7 +133,7 @@ std::array<Eigen::VectorXd, n> coordsFor(const std::array<Vertex *, n> &vertexPt
 }
 
 /// Given the data and the mesh, this function returns the surface integral. Assumes no overlap exists for the mesh
-Eigen::VectorXd integrate(PtrMesh mesh, PtrData data);
+Eigen::VectorXd integrate(const PtrMesh &mesh, const PtrData &data);
 
 } // namespace mesh
 } // namespace precice

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -31,7 +31,7 @@ namespace partition {
 
 ProvidedPartition::ProvidedPartition(
     mesh::PtrMesh mesh)
-    : Partition(mesh)
+    : Partition(std::move(mesh))
 {
 }
 

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -32,7 +32,7 @@ extern bool syncMode;
 namespace partition {
 
 ReceivedPartition::ReceivedPartition(
-    mesh::PtrMesh mesh, GeometricFilter geometricFilter, double safetyFactor)
+    const mesh::PtrMesh &mesh, GeometricFilter geometricFilter, double safetyFactor)
     : Partition(mesh),
       _geometricFilter(geometricFilter),
       _bb(mesh->getDimensions()),

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -37,7 +37,7 @@ public:
   };
 
   /// Constructor
-  ReceivedPartition(mesh::PtrMesh mesh, GeometricFilter geometricFilter, double safetyFactor);
+  ReceivedPartition(const mesh::PtrMesh &mesh, GeometricFilter geometricFilter, double safetyFactor);
 
   virtual ~ReceivedPartition() {}
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1459,7 +1459,7 @@ void SolverInterfaceImpl::computePartitions()
   }
 }
 
-void SolverInterfaceImpl::computeMappings(utils::ptr_vector<MappingContext> contexts, const std::string &mappingType)
+void SolverInterfaceImpl::computeMappings(const utils::ptr_vector<MappingContext> &contexts, const std::string &mappingType)
 {
   PRECICE_TRACE();
   using namespace mapping;
@@ -1478,7 +1478,7 @@ void SolverInterfaceImpl::computeMappings(utils::ptr_vector<MappingContext> cont
   }
 }
 
-void SolverInterfaceImpl::mapData(utils::ptr_vector<DataContext> contexts, const std::string &mappingType)
+void SolverInterfaceImpl::mapData(const utils::ptr_vector<DataContext> &contexts, const std::string &mappingType)
 {
   PRECICE_TRACE();
   using namespace mapping;

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -628,10 +628,10 @@ private:
   void computePartitions();
 
   /// Helper for mapWrittenData and mapReadData
-  void computeMappings(utils::ptr_vector<MappingContext> contexts, const std::string &mappingType);
+  void computeMappings(const utils::ptr_vector<MappingContext> &contexts, const std::string &mappingType);
 
   /// Helper for mapWrittenData and mapReadData
-  void mapData(utils::ptr_vector<DataContext> contexts, const std::string &mappingType);
+  void mapData(const utils::ptr_vector<DataContext> &contexts, const std::string &mappingType);
 
   /// Helper for mapWrittenData and mapReadData
   void clearMappings(utils::ptr_vector<MappingContext> contexts);

--- a/src/precice/impl/WatchIntegral.cpp
+++ b/src/precice/impl/WatchIntegral.cpp
@@ -107,7 +107,7 @@ void WatchIntegral::exportIntegralData(
   }
 }
 
-Eigen::VectorXd WatchIntegral::calculateIntegral(mesh::PtrData data) const
+Eigen::VectorXd WatchIntegral::calculateIntegral(const mesh::PtrData &data) const
 {
   int                    dim    = data->getDimensions();
   const Eigen::VectorXd &values = data->values();

--- a/src/precice/impl/WatchIntegral.hpp
+++ b/src/precice/impl/WatchIntegral.hpp
@@ -55,7 +55,7 @@ private:
 
   bool _isScalingOn;
 
-  Eigen::VectorXd calculateIntegral(mesh::PtrData data) const;
+  Eigen::VectorXd calculateIntegral(const mesh::PtrData &data) const;
 
   double calculateSurfaceArea() const;
 };

--- a/src/time/Waveform.cpp
+++ b/src/time/Waveform.cpp
@@ -21,7 +21,7 @@ Waveform::Waveform(
   _timeWindows        = Eigen::MatrixXd::Zero(numberOfData, numberOfSamples);
 }
 
-void Waveform::store(Eigen::VectorXd data)
+void Waveform::store(const Eigen::VectorXd &data)
 {
   this->_timeWindows.col(0) = data;
 }

--- a/src/time/Waveform.hpp
+++ b/src/time/Waveform.hpp
@@ -20,7 +20,7 @@ public:
    * @brief Updates entry in _timeWindows corresponding to this window with given data
    * @param data new sample for this time window
    */
-  void store(Eigen::VectorXd data);
+  void store(const Eigen::VectorXd &data);
 
   /**
    * @brief Called, when moving to the next time window. All entries in _timeWindows are shifted. The new entry is initialized as the value from the last window (= constant extrapolation)

--- a/src/utils/Event.cpp
+++ b/src/utils/Event.cpp
@@ -5,14 +5,14 @@
 namespace precice {
 namespace utils {
 
-Event::Event(std::string eventName, Clock::duration initialDuration)
+Event::Event(const std::string &eventName, Clock::duration initialDuration)
     : name(EventRegistry::instance().prefix + eventName),
       duration(initialDuration)
 {
   EventRegistry::instance().put(*this);
 }
 
-Event::Event(std::string eventName, bool barrier, bool autostart)
+Event::Event(const std::string &eventName, bool barrier, bool autostart)
     : name(eventName),
       _barrier(barrier)
 {
@@ -79,7 +79,7 @@ Event::Clock::duration Event::getDuration() const
   return duration;
 }
 
-void Event::addData(std::string key, int value)
+void Event::addData(const std::string &key, int value)
 {
   data[key].push_back(value);
 }

--- a/src/utils/Event.hpp
+++ b/src/utils/Event.hpp
@@ -36,11 +36,11 @@ public:
   std::string name;
 
   /// Allows to put a non-measured (i.e. with a given duration) Event to the measurements.
-  Event(std::string eventName, Clock::duration initialDuration);
+  Event(const std::string &eventName, Clock::duration initialDuration);
 
   /// Creates a new event and starts it, unless autostart = false, synchronize processes, when barrier == true
   /** Use barrier == true with caution, as it can lead to deadlocks. */
-  Event(std::string eventName, bool barrier = false, bool autostart = true);
+  Event(const std::string &eventName, bool barrier = false, bool autostart = true);
 
   /// Stops the event if it's running and report its times to the EventRegistry
   ~Event();
@@ -58,7 +58,7 @@ public:
   Clock::duration getDuration() const;
 
   /// Adds named integer data, associated to an event.
-  void addData(std::string key, int value);
+  void addData(const std::string &key, int value);
 
   Data data;
 

--- a/src/utils/EventUtils.cpp
+++ b/src/utils/EventUtils.cpp
@@ -198,8 +198,8 @@ EventRegistry &EventRegistry::instance()
 
 void EventRegistry::initialize(std::string applicationName, std::string runName, MPI_Comm comm)
 {
-  this->applicationName = applicationName;
-  this->runName         = runName;
+  this->applicationName = std::move(applicationName);
+  this->runName         = std::move(runName);
   this->comm            = comm;
 
   localRankData.initialize();

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -166,7 +166,7 @@ MPI_Comm getCommunicator(T obj)
 }
 
 template <class T>
-void setName(T obj, std::string name)
+void setName(T obj, const std::string &name)
 {
   PetscErrorCode ierr = 0;
   ierr                = PetscObjectSetName(reinterpret_cast<PetscObject>(obj), name.c_str());
@@ -385,7 +385,7 @@ std::pair<PetscInt, PetscInt> Vector::ownerRange() const
   return std::make_pair(range_start, range_end);
 }
 
-void Vector::write(std::string filename, VIEWERFORMAT format) const
+void Vector::write(const std::string &filename, VIEWERFORMAT format) const
 {
   Viewer viewer{filename, format, getCommunicator(vector)};
   VecView(vector, viewer.viewer);
@@ -398,7 +398,7 @@ double Vector::l2norm() const
   return val;
 }
 
-void Vector::read(std::string filename, VIEWERFORMAT format)
+void Vector::read(const std::string &filename, VIEWERFORMAT format)
 {
   Viewer viewer{filename, format, getCommunicator(vector)};
   VecLoad(vector, viewer.viewer);
@@ -423,7 +423,7 @@ Matrix::Matrix(std::string name)
   PetscErrorCode ierr = 0;
   ierr                = MatCreate(utils::Parallel::current()->comm, &matrix);
   CHKERRV(ierr);
-  setName(matrix, name);
+  setName(matrix, std::move(name));
 }
 
 Matrix::~Matrix()
@@ -567,7 +567,7 @@ PetscInt Matrix::blockSize() const
   return bs;
 }
 
-void Matrix::write(std::string filename, VIEWERFORMAT format) const
+void Matrix::write(const std::string &filename, VIEWERFORMAT format) const
 {
   PetscErrorCode ierr = 0;
   Viewer         viewer{filename, format, getCommunicator(matrix)};
@@ -575,7 +575,7 @@ void Matrix::write(std::string filename, VIEWERFORMAT format) const
   CHKERRV(ierr);
 }
 
-void Matrix::read(std::string filename)
+void Matrix::read(const std::string &filename)
 {
   PetscErrorCode ierr = 0;
   Viewer         viewer{filename, BINARY, getCommunicator(matrix)};
@@ -614,7 +614,7 @@ KSPSolver::KSPSolver(std::string name)
   PetscErrorCode ierr = 0;
   ierr                = KSPCreate(utils::Parallel::current()->comm, &ksp);
   CHKERRV(ierr);
-  setName(ksp, name);
+  setName(ksp, std::move(name));
 }
 
 KSPSolver::~KSPSolver()

--- a/src/utils/Petsc.hpp
+++ b/src/utils/Petsc.hpp
@@ -144,10 +144,10 @@ public:
   std::pair<PetscInt, PetscInt> ownerRange() const;
 
   /// Writes the vector to file.
-  void write(std::string filename, VIEWERFORMAT format = ASCII) const;
+  void write(const std::string &filename, VIEWERFORMAT format = ASCII) const;
 
   /// Reads the vector from file.
-  void read(std::string filename, VIEWERFORMAT format = ASCII);
+  void read(const std::string &filename, VIEWERFORMAT format = ASCII);
 
   /// Prints the vector
   void view() const;
@@ -220,10 +220,10 @@ public:
   PetscInt blockSize() const;
 
   /// Writes the matrix to file.
-  void write(std::string filename, VIEWERFORMAT format = ASCII) const;
+  void write(const std::string &filename, VIEWERFORMAT format = ASCII) const;
 
   /// Reads the matrix from file, stored in PETSc binary format
-  void read(std::string filename);
+  void read(const std::string &filename);
 
   /// Prints the matrix
   void view() const;

--- a/src/utils/TableWriter.cpp
+++ b/src/utils/TableWriter.cpp
@@ -46,7 +46,7 @@ void Table::printHeader()
   }
 
   out << '\n';
-  int         headerLength = std::accumulate(cols.begin(), cols.end(), 0, [this](int count, Column col) {
+  int         headerLength = std::accumulate(cols.begin(), cols.end(), 0, [this](int count, const Column &col) {
     return count + col.width + sepChar.size() + 2;
   });
   std::string sepLine(headerLength, '-');


### PR DESCRIPTION
## Main changes of this PR
Related to #999. 

## Motivation and additional information
Read [here](https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html) about the rationale.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)