### PR TITLE
Add Fedora 34 to the CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ on:
       - 'thirdparty/**'
       - 'CMakeLists.txt'
       - 'extras/bindings/**'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Tests
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
+          BOOST_TEST_LOG_LEVEL: all
         working-directory: build
         run: su -c "ctest" $PRECICE_USER
       - name: Coverage Report

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ on:
       - 'thirdparty/**'
       - 'CMakeLists.txt'
       - 'extras/bindings/**'
+      - '.github/workflows/build-and-test.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,6 +72,14 @@ jobs:
             CONFIG: MPIPETSc
             CXX: 'clang++'
             TYPE: Release
+          - IMAGE: 'fedora-34'
+            CONFIG: MPIPETSc
+            CXX: 'g++'
+            TYPE: Debug
+          - IMAGE: 'fedora-34'
+            CONFIG: MPIPETSc
+            CXX: 'g++'
+            TYPE: Release
     env:
       CCACHE_DIR: "$GITHUB_WORKSPACE/ccache"
       OMPI_MCA_rmaps_base_oversubscribe: 1

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -252,7 +252,7 @@ add_precice_test(
 add_precice_test(
   NAME mapping.petrbf
   ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
   LABELS petsc
   PETSC
   )


### PR DESCRIPTION
## Main changes of this PR

This PR adds Fedora 34 to the CI using the MPICH system packages.

## Motivation and additional information

This fills the uncovered workstation segment as well as MPICH
Related to #713 