### PR TITLE
Prevent name resolution in sockets

### DIFF
--- a/docs/changelog/1068.md
+++ b/docs/changelog/1068.md
@@ -1,0 +1,1 @@
+- Fixed socket communication to fail without a internet connection.

--- a/docs/changelog/1068.md
+++ b/docs/changelog/1068.md
@@ -1,1 +1,1 @@
-- Fixed socket communication to fail without a internet connection.
+- Fixed socket communication to fail without a network connection.

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -220,7 +220,7 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
 
     using asio::ip::tcp;
 
-    tcp::resolver::query query(tcp::v4(), ipAddress, portNumber, tcp::resolver::query::canonical_name);
+    tcp::resolver::query query(tcp::v4(), ipAddress, portNumber, tcp::resolver::query::numeric_host);
 
     while (not isConnected()) {
       tcp::resolver                resolver(*_ioService);
@@ -283,7 +283,7 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
 
       PRECICE_DEBUG("Requesting connection to {}, port {}", ipAddress, portNumber);
 
-      tcp::resolver::query query(tcp::v4(), ipAddress, portNumber);
+      tcp::resolver::query query(tcp::v4(), ipAddress, portNumber, tcp::resolver::query::numeric_host);
 
       while (not isConnected()) {
         tcp::resolver             resolver(*_ioService);


### PR DESCRIPTION
## Main changes of this PR

Forces boost.asio to interpret IP addresses in the queries.
This avoids name resolution and prevents the error in #45

## Motivation and additional information

Closes #45

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)
