### PR TITLE
Add equals function for comparing std::vector<double>

### DIFF
--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -108,12 +108,12 @@ void runP2PComTest1(const TestContext &context, com::PtrCommunicationFactory cf)
     c.send(data);
     c.receive(data);
 
-    BOOST_TEST(data == expectedData);
+    BOOST_TEST(testing::equals(data, expectedData));
   } else {
     c.acceptConnection("B", "A");
 
     c.receive(data);
-    BOOST_TEST(data == expectedData);
+    BOOST_TEST(testing::equals(data, expectedData));
     process(data);
     c.send(data);
   }
@@ -183,12 +183,12 @@ void runP2PComTest2(const TestContext &context, com::PtrCommunicationFactory cf)
 
     c.send(data);
     c.receive(data);
-    BOOST_TEST(data == expectedData);
+    BOOST_TEST(testing::equals(data, expectedData));
   } else {
     c.acceptConnection("B", "A");
 
     c.receive(data);
-    BOOST_TEST(data == expectedData);
+    BOOST_TEST(testing::equals(data, expectedData));
     process(data);
     c.send(data);
   }

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -865,7 +865,7 @@ void runTestAccessReceivedMesh(const std::string         configName,
 
     // Check the received vertex coordinates
     std::vector<double> expectedPositions = context.isMaster() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.0}) : expectedPositionSlave;
-    BOOST_TEST(expectedPositions == coordinates);
+    BOOST_TEST(testing::equals(expectedPositions, coordinates));
 
     // Check the received vertex IDs (IDs are local?!)
     std::vector<int> expectedIDs;
@@ -915,7 +915,7 @@ void runTestAccessReceivedMesh(const std::string         configName,
       std::vector<double> ownCoordinates(ownMeshSize * dim);
       interface.getMeshVerticesAndIDs(meshID, ownMeshSize, ownIDs.data(), ownCoordinates.data());
       BOOST_TEST(ownIDs == ids);
-      BOOST_TEST(ownCoordinates == ownCoordinates);
+      BOOST_TEST(testing::equals(ownCoordinates, ownCoordinates));  // @todo looks wrong
     }
 
     // Initialize the solverinterface
@@ -1095,7 +1095,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
       // Expected data according to the writeData
       // Values are summed up
       std::vector<double> expectedData = context.isMaster() ? std::vector<double>({0, 1, 0}) : std::vector<double>({1, 2, 2});
-      BOOST_TEST(expectedData == readData);
+      BOOST_TEST(testing::equals(expectedData, readData));
     }
 
   } else {
@@ -1130,7 +1130,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
       // Expected data according to the writeData
       // Values are summed up
       std::vector<double> expectedData = context.isMaster() ? std::vector<double>({15, 16}) : std::vector<double>({22, 6, 7});
-      BOOST_TEST(expectedData == readData);
+      BOOST_TEST(testing::equals(expectedData, readData));
     }
   }
 }

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -915,7 +915,7 @@ void runTestAccessReceivedMesh(const std::string         configName,
       std::vector<double> ownCoordinates(ownMeshSize * dim);
       interface.getMeshVerticesAndIDs(meshID, ownMeshSize, ownIDs.data(), ownCoordinates.data());
       BOOST_TEST(ownIDs == ids);
-      BOOST_TEST(testing::equals(ownCoordinates, ownCoordinates));  // @todo looks wrong
+      BOOST_TEST(testing::equals(ownCoordinates, ownCoordinates)); // @todo looks wrong
     }
 
     // Initialize the solverinterface

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization)
     int    dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int    dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
     cplInterface.writeScalarData(dataBID, 0, 2.0);
-    //sagen dass daten jetzt geschrieben
+    //tell preCICE that data has been written and call initializeData
     cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     cplInterface.initializeData();
     Vector3d valueDataA;
@@ -725,7 +725,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshExplicit)
 
     // Expected data = positions of the other participant's mesh
     const std::vector<double> expectedData = positions;
-    BOOST_TEST(solverTwoMesh == expectedData);
+    BOOST_TEST(testing::equals(solverTwoMesh, expectedData));
 
     while (couplingInterface.isCouplingOngoing()) {
       // Write data
@@ -754,7 +754,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshExplicit)
                                             ids.data(), readData.data());
       // Expected data according to the writeData
       std::vector<double> expectedData({1, 2, 3, 4});
-      BOOST_TEST(expectedData == readData);
+      BOOST_TEST(testing::equals(expectedData, readData));
     }
   }
 }
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
                                     ids.data(), readData.data());
       // Expected data according to the writeData
       std::vector<double> expectedData({1, 2, 3, 4, 5});
-      BOOST_TEST(expectedData == readData);
+      BOOST_TEST(testing::equals(expectedData, readData));
     }
   }
 }
@@ -925,9 +925,8 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshImplicit)
 
       // Expected data according to the writeData
       std::vector<double> expectedData({10, 11, 12, 13});
-      BOOST_TEST(expectedData == readData);
+      BOOST_TEST(testing::equals(expectedData, readData));
     }
-
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
     std::vector<double>         positions = {0.0, 0.0, 0.2, 0.3, 0.1, 0.1};
@@ -978,7 +977,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshImplicit)
 
       // Expected data according to the writeData
       std::vector<double> expectedData({1, 2, 3});
-      BOOST_TEST(expectedData == readData);
+      BOOST_TEST(testing::equals(expectedData, readData));
     }
   }
 }

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -83,13 +83,19 @@ boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,
 }
 
 /// equals to be used in tests. Prints both operatorans on failure
-template <class DerivedA, class DerivedB>
-boost::test_tools::predicate_result equals(std::vector<DerivedA> &A,
-                                           std::vector<DerivedB> &B,
+template <typename TA, typename TB>
+boost::test_tools::predicate_result equals(const std::vector<TA> &A,
+                                           const std::vector<TB> &B,
                                            double                 tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
-  Eigen::Map<Eigen::MatrixXd> MatrixA(A.data(), A.size(), 1);
-  Eigen::Map<Eigen::MatrixXd> MatrixB(B.data(), B.size(), 1);
+  Eigen::MatrixXd MatrixA(A.size(), 1);
+  for (int i = 0; i < A.size(); ++i) {
+    MatrixA(i, 0) = A[i];
+  }
+  Eigen::MatrixXd MatrixB(B.size(), 1);
+  for (int i = 0; i < B.size(); ++i) {
+    MatrixB(i, 0) = B[i];
+  }
   return equals(MatrixA, MatrixB, tolerance);
 }
 

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -61,7 +61,7 @@ struct WhiteboxAccessor {
   }
 };
 
-/// equals to be used in tests. Prints both operatorans on failure
+/// equals to be used in tests. Compares two matrices using a given tolerance. Prints both operands on failure.
 template <class DerivedA, class DerivedB>
 boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,
                                            const Eigen::MatrixBase<DerivedB> &B,
@@ -82,24 +82,21 @@ boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,
   return true;
 }
 
-/// equals to be used in tests. Prints both operatorans on failure
-template <typename TA, typename TB>
-boost::test_tools::predicate_result equals(const std::vector<TA> &A,
-                                           const std::vector<TB> &B,
-                                           double                 tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
+/// equals to be used in tests. Compares two std::vectors using a given tolerance. Prints both operands on failure
+template <typename NumberType>
+boost::test_tools::predicate_result equals(const std::vector<NumberType> &VectorA,
+                                           const std::vector<NumberType> &VectorB,
+                                           double                         tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
-  Eigen::MatrixXd MatrixA(A.size(), 1);
-  for (int i = 0; i < A.size(); ++i) {
-    MatrixA(i, 0) = A[i];
-  }
-  Eigen::MatrixXd MatrixB(B.size(), 1);
-  for (int i = 0; i < B.size(); ++i) {
-    MatrixB(i, 0) = B[i];
-  }
+  PRECICE_ASSERT(VectorA.size() == VectorB.size());
+  Eigen::MatrixXd MatrixA(VectorA.size(), 1);
+  std::copy(VectorA.begin(), VectorA.end(), MatrixA.data());
+  Eigen::MatrixXd MatrixB(VectorB.size(), 1);
+  std::copy(VectorB.begin(), VectorB.end(), MatrixB.data());
   return equals(MatrixA, MatrixB, tolerance);
 }
 
-/// equals to be used in tests. Prints both operatorans on failure
+/// equals to be used in tests. Compares two scalar numbers using a given tolerance. Prints both operands on failure
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, boost::test_tools::predicate_result>::type equals(const Scalar a, const Scalar b, const Scalar tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -83,6 +83,17 @@ boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,
 }
 
 /// equals to be used in tests. Prints both operatorans on failure
+template <class DerivedA, class DerivedB>
+boost::test_tools::predicate_result equals(std::vector<DerivedA> &A,
+                                           std::vector<DerivedB> &B,
+                                           double                 tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
+{
+  Eigen::Map<Eigen::MatrixXd> MatrixA(A.data(), A.size(), 1);
+  Eigen::Map<Eigen::MatrixXd> MatrixB(B.data(), B.size(), 1);
+  return equals(MatrixA, MatrixB, tolerance);
+}
+
+/// equals to be used in tests. Prints both operatorans on failure
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, boost::test_tools::predicate_result>::type equals(const Scalar a, const Scalar b, const Scalar tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {

--- a/src/utils/tests/MasterSlaveTest.cpp
+++ b/src/utils/tests/MasterSlaveTest.cpp
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(ParallelReduceSum)
       std::vector<double> in{4, 5, 6}, out{-1, -1, -1};
       auto                expected = out;
       utils::MasterSlave::reduceSum(in, out);
-      BOOST_TEST(out == expected, boost::test_tools::per_element());
+      BOOST_TEST(testing::equals(out, expected), boost::test_tools::per_element());
     }
     {
       int in = 3, out = -1;
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(ParallelReduceSum)
       std::vector<double> in{7, 8, 9}, out{-1, -1, -1};
       auto                expected = out;
       utils::MasterSlave::reduceSum(in, out);
-      BOOST_TEST(out == expected, boost::test_tools::per_element());
+      BOOST_TEST(testing::equals(out, expected), boost::test_tools::per_element());
     }
     {
       int in = 5, out = -1;
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(SerialReduceSum)
   {
     std::vector<double> in{1, 2, 3}, out{-1, -1, -1};
     utils::MasterSlave::reduceSum(in, out);
-    BOOST_TEST(out == in, boost::test_tools::per_element());
+    BOOST_TEST(testing::equals(out, in), boost::test_tools::per_element());
   }
   {
     int in = 1, out = -1;
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(SerialAllReduceSum)
   {
     std::vector<double> in{1, 2, 3}, out{-1, -1, -1};
     utils::MasterSlave::allreduceSum(in, out);
-    BOOST_TEST(out == in, boost::test_tools::per_element());
+    BOOST_TEST(testing::equals(out, in), boost::test_tools::per_element());
   }
   {
     int in = 1, out = -1;


### PR DESCRIPTION
## Main changes of this PR

* Add `boost::test_tools::predicate_result equals<DerivedA, DerivedB>(std::vector<DerivedA> &A, std::vector<DerivedB> &B, double tolerance = precice::math::NUMERICAL_ZERO_DIFFERENCE)`
* Don't use `BOOST_TEST(vecA == vecB)`, but `BOOST_TEST(testing::equals(vecA, vecB))` with some floating point tolerance.

## Motivation and additional information

A `BOOST_TEST(vecA == vecB)` caused a lot of confusion in https://github.com/BenjaminRodenberg/precice/pull/1. We were lucky until now that floating point accuracy did not matter here, but it will as soon as interpolation (or something else) happens when data is exchanged.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)