### PR TITLE
Test data read and write for subcycling

### DIFF
--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -288,6 +288,142 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling)
   }
 }
 
+/// Test to run a simple coupling with subcycling.
+/// Ensures that each time step provides its own data, but preCICE will only exchange data at the end of the window.
+BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  SolverInterface precice(context.name, _pathToTests + "explicit-scalar-data-init.xml", 0, 1);
+
+  MeshID meshID;
+  DataID writeDataID;
+  DataID readDataID;
+
+  typedef double (*DataFunction)(double, int);
+
+  DataFunction dataOneFunction = [](double t, int idx) -> double {
+    return (double) (2 + t + idx);
+  };
+  DataFunction dataTwoFunction = [](double t, int idx) -> double {
+    return (double) (10 + t + idx);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  if (context.isNamed("SolverOne")) {
+    meshID = precice.getMeshID("MeshOne");
+    BOOST_TEST(meshID == 0);
+    writeDataID   = precice.getDataID("DataOne", meshID);
+    writeFunction = dataOneFunction;
+    BOOST_TEST(writeDataID == 0);
+    readDataID   = precice.getDataID("DataTwo", meshID);
+    readFunction = dataTwoFunction;
+    BOOST_TEST(readDataID == 1);
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshID = precice.getMeshID("MeshTwo");
+    BOOST_TEST(meshID == 1);
+    writeDataID   = precice.getDataID("DataTwo", meshID);
+    writeFunction = dataTwoFunction;
+    BOOST_TEST(writeDataID == 3);
+    readDataID   = precice.getDataID("DataOne", meshID);
+    readFunction = dataOneFunction;
+    BOOST_TEST(readDataID == 2);
+  }
+
+  writeFunction(1, 1);
+  readFunction(1, 1);
+
+  int n_vertices = 1;
+
+  std::vector<VertexID> vertexIDs(n_vertices, 0);
+  std::vector<double>   writeData(n_vertices, 0);
+  std::vector<double>   readData(n_vertices, 0);
+  double                oldWriteData, oldReadData;
+
+  vertexIDs[0] = precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+
+  int    nSubsteps  = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows   = 5; // perform 5 windows.
+  double maxDt      = precice.initialize();
+  double windowDt   = maxDt;
+  int    timestep   = 0;
+  int    timewindow = 0;
+  double dt         = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps;   // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt = dt;                    // Timestep length used by solver
+  double time      = timestep * dt;
+
+  if (context.isNamed("SolverOne")) {
+    meshID = precice.getMeshID("MeshOne");
+    BOOST_TEST(meshID == 0);
+    writeDataID = precice.getDataID("DataOne", meshID);
+    BOOST_TEST(writeDataID == 0);
+    readDataID = precice.getDataID("DataTwo", meshID);
+    BOOST_TEST(readDataID == 1);
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshID = precice.getMeshID("MeshTwo");
+    BOOST_TEST(meshID == 1);
+    writeDataID = precice.getDataID("DataTwo", meshID);
+    BOOST_TEST(writeDataID == 3);
+    readDataID = precice.getDataID("DataOne", meshID);
+    BOOST_TEST(readDataID == 2);
+  }
+
+  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+    for (int i = 0; i < n_vertices; i++) {
+      writeData[i] = writeFunction(time, i);
+      precice.writeScalarData(writeDataID, vertexIDs[i], writeData[i]);
+    }
+    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
+  }
+
+  precice.initializeData();
+
+  while (precice.isCouplingOngoing()) {
+    double readTime;
+    if (context.isNamed("SolverOne")) {
+      readTime = timewindow * windowDt; // solver one lags one window behind solver two.
+    } else {
+      readTime = (timewindow + 1) * windowDt;
+    }
+    BOOST_TEST(readData.size() == n_vertices);
+    for (int i = 0; i < n_vertices; i++) {
+      oldReadData = readData[i];
+      precice.readScalarData(readDataID, vertexIDs[i], readData[i]);
+      if (precice.isTimeWindowComplete() ||
+          (timestep == 0)) {                      // exception: First timestep will also have different data, even though formally no time window is completed.
+        BOOST_TEST((readData[i] != oldReadData)); // ensure that read data changes from one step to the next, if a new window is entered
+      } else {
+        BOOST_TEST((readData[i] == oldReadData)); // ensure that read data stays the same from one step to the next, if not a new window is entered
+      }
+      BOOST_TEST(readData[i] == readFunction(readTime, i));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    time += currentDt;
+
+    BOOST_TEST(writeData.size() == n_vertices);
+    for (int i = 0; i < n_vertices; i++) {
+      oldWriteData = writeData[i];
+      writeData[i] = writeFunction(time, i);
+      BOOST_TEST(writeData[i] != oldWriteData); // ensure that write data differs from one step to the next
+      precice.writeScalarData(writeDataID, vertexIDs[i], writeData[i]);
+    }
+    maxDt     = precice.advance(currentDt);
+    currentDt = dt > maxDt ? maxDt : dt;
+    timestep++;
+    if (precice.isTimeWindowComplete()) {
+      timewindow++;
+    }
+  }
+
+  precice.finalize();
+  BOOST_TEST(timestep == nWindows * nSubsteps);
+}
+
 /// One solver uses incremental position set, read/write methods.
 BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
 {

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
-  SolverInterface precice(context.name, _pathToTests + "explicit-scalar-data-init.xml", 0, 1);
+  SolverInterface precice(context.name, _pathToTests + "explicit-scalar-data-init.xml", 0, 1); // serial coupling, SolverOne first
 
   MeshID meshID;
   DataID writeDataID;
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
   while (precice.isCouplingOngoing()) {
     double readTime;
     if (context.isNamed("SolverOne")) {
-      readTime = timewindow * windowDt; // solver one lags one window behind solver two.
+      readTime = timewindow * windowDt; // SolverOne lags one window behind SolverTwo for serial-explicit coupling.
     } else {
       readTime = (timewindow + 1) * windowDt;
     }

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -335,15 +335,16 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
 
   vertexIDs[0] = precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
 
-  int    nSubsteps  = 4; // perform subcycling on solvers. 4 steps happen in each window.
-  int    nWindows   = 5; // perform 5 windows.
-  double maxDt      = precice.initialize();
-  double windowDt   = maxDt;
-  int    timestep   = 0;
-  int    timewindow = 0;
-  double dt         = windowDt / (nSubsteps - 0.5); // Timestep length desired by solver. E.g. 4 steps with size 2/7. Fourth step will be restricted to 1/7 via preCICE steering to fit into the window.
-  double currentDt  = dt;                           // Timestep length used by solver
-  double time       = timestep * dt;
+  int    nSubsteps     = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows      = 5; // perform 5 windows.
+  double maxDt         = precice.initialize();
+  double windowDt      = maxDt;
+  int    timestep      = 0;
+  int    timewindow    = 0;
+  double dt            = windowDt / (nSubsteps - 0.5); // Timestep length desired by solver. E.g. 4 steps with size 2/7. Fourth step will be restricted to 1/7 via preCICE steering to fit into the window.
+  double expectedDts[] = {2.0 / 7.0, 2.0 / 7.0, 2.0 / 7.0, 1.0 / 7.0};
+  double currentDt     = dt; // Timestep length used by solver
+  double time          = timestep * dt;
 
   if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
     for (int i = 0; i < n_vertices; i++) {
@@ -376,6 +377,7 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
     }
 
     // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    BOOST_TEST(currentDt == expectedDts[timestep % nSubsteps]);
     time += currentDt;
 
     BOOST_TEST(writeData.size() == n_vertices);

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -341,10 +341,9 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
   double windowDt   = maxDt;
   int    timestep   = 0;
   int    timewindow = 0;
-  double dt         = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps;   // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                    // Timestep length used by solver
-  double time      = timestep * dt;
+  double dt         = windowDt / (nSubsteps - 0.5); // Timestep length desired by solver. E.g. 4 steps with size 2/7. Fourth step will be restricted to 1/7 via preCICE steering to fit into the window.
+  double currentDt  = dt;                           // Timestep length used by solver
+  double time       = timestep * dt;
 
   if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
     for (int i = 0; i < n_vertices; i++) {

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -312,28 +312,19 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
   DataFunction readFunction;
 
   if (context.isNamed("SolverOne")) {
-    meshID = precice.getMeshID("MeshOne");
-    BOOST_TEST(meshID == 0);
+    meshID        = precice.getMeshID("MeshOne");
     writeDataID   = precice.getDataID("DataOne", meshID);
     writeFunction = dataOneFunction;
-    BOOST_TEST(writeDataID == 0);
-    readDataID   = precice.getDataID("DataTwo", meshID);
-    readFunction = dataTwoFunction;
-    BOOST_TEST(readDataID == 1);
+    readDataID    = precice.getDataID("DataTwo", meshID);
+    readFunction  = dataTwoFunction;
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
-    meshID = precice.getMeshID("MeshTwo");
-    BOOST_TEST(meshID == 1);
+    meshID        = precice.getMeshID("MeshTwo");
     writeDataID   = precice.getDataID("DataTwo", meshID);
     writeFunction = dataTwoFunction;
-    BOOST_TEST(writeDataID == 3);
-    readDataID   = precice.getDataID("DataOne", meshID);
-    readFunction = dataOneFunction;
-    BOOST_TEST(readDataID == 2);
+    readDataID    = precice.getDataID("DataOne", meshID);
+    readFunction  = dataOneFunction;
   }
-
-  writeFunction(1, 1);
-  readFunction(1, 1);
 
   int n_vertices = 1;
 
@@ -354,23 +345,6 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
   dt += windowDt / nSubsteps / nSubsteps;   // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
   double currentDt = dt;                    // Timestep length used by solver
   double time      = timestep * dt;
-
-  if (context.isNamed("SolverOne")) {
-    meshID = precice.getMeshID("MeshOne");
-    BOOST_TEST(meshID == 0);
-    writeDataID = precice.getDataID("DataOne", meshID);
-    BOOST_TEST(writeDataID == 0);
-    readDataID = precice.getDataID("DataTwo", meshID);
-    BOOST_TEST(readDataID == 1);
-  } else {
-    BOOST_TEST(context.isNamed("SolverTwo"));
-    meshID = precice.getMeshID("MeshTwo");
-    BOOST_TEST(meshID == 1);
-    writeDataID = precice.getDataID("DataTwo", meshID);
-    BOOST_TEST(writeDataID == 3);
-    readDataID = precice.getDataID("DataOne", meshID);
-    BOOST_TEST(readDataID == 2);
-  }
 
   if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
     for (int i = 0; i < n_vertices; i++) {

--- a/src/precice/tests/explicit-scalar-data-init.xml
+++ b/src/precice/tests/explicit-scalar-data-init.xml
@@ -27,14 +27,12 @@
         direction="write"
         from="MeshTwo"
         to="MeshOne"
-        constraint="conservative"
-        timing="initial" />
+        constraint="conservative" />
       <mapping:nearest-neighbor
         direction="read"
         from="MeshOne"
         to="MeshTwo"
-        constraint="consistent"
-        timing="initial" />
+        constraint="consistent" />
       <write-data name="DataTwo" mesh="MeshTwo" />
       <read-data name="DataOne" mesh="MeshTwo" />
     </participant>

--- a/src/precice/tests/explicit-scalar-data-init.xml
+++ b/src/precice/tests/explicit-scalar-data-init.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="DataOne" />
+    <data:scalar name="DataTwo" />
+
+    <mesh name="MeshOne">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <write-data name="DataOne" mesh="MeshOne" />
+      <read-data name="DataTwo" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshTwo" provide="on" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="conservative"
+        timing="initial" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="consistent"
+        timing="initial" />
+      <write-data name="DataTwo" mesh="MeshTwo" />
+      <read-data name="DataOne" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="5" />
+      <time-window-size value="1.0" />
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>


### PR DESCRIPTION
## Main changes of this PR

Adds a test to ensure that data is written and read as currently specified for subcycling. This means:

* write data functions can write arbitrary data for any time step within the window.
* read data functions will only receive for each time step data that was written by the other solver at the end of the window. 
* All data written inside the window is lost and cannot be accessed by the reading solver.

## Motivation and additional information

Currently the tests succeed in #1029 and associated PRs ~~, even though the subcycling functionality is changed and preCICE does not behave anymore as described above (see [this test](https://github.com/BenjaminRodenberg/precice/blob/d3cb5fe98c3d13f70a431a67ccf3f147956585c1/src/precice/tests/SerialTests.cpp#L434-L570)). I would rather expect a failing test here.~~. *edit:* The tests still succeed in #1029. This is due to the implementation of `readScalarData`. If no `dt` is given, it always samples at the end of the window, which is exactly the functionality described above. I still think it's reasonable to test this, because it ensures that the read functions are implemented correctly.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)