### PR TITLE
Add support for 3D meshes in ScaleByAreaAction

### DIFF
--- a/docs/changelog/1072.md
+++ b/docs/changelog/1072.md
@@ -1,0 +1,1 @@
+- Added support for 3D meshes in `ScaleByAreaAction`

--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -31,26 +31,35 @@ void ScaleByAreaAction::performAction(
     double timeWindowSize)
 {
   PRECICE_TRACE();
-  PRECICE_ASSERT(getMesh()->getDimensions() == 2, "The ScaleByAreaAction requires a mesh of dimensionality 2.");
-  auto &          targetValues = _targetData->values();
-  Eigen::VectorXd areas        = Eigen::VectorXd::Zero(getMesh()->vertices().size());
-  for (mesh::Edge &edge : getMesh()->edges()) {
-    areas[edge.vertex(0).getID()] += edge.getEnclosingRadius();
-    areas[edge.vertex(1).getID()] += edge.getEnclosingRadius();
+  const int       meshDimensions  = getMesh()->getDimensions();
+  auto &          targetValues    = _targetData->values();
+  const int       valueDimensions = _targetData->getDimensions();
+  Eigen::VectorXd areas           = Eigen::VectorXd::Zero(getMesh()->vertices().size());
+  PRECICE_ASSERT(targetValues.size() / valueDimensions == areas.size());
+
+  if (meshDimensions == 2) {
+    for (mesh::Edge &edge : getMesh()->edges()) {
+      areas[edge.vertex(0).getID()] += edge.getEnclosingRadius();
+      areas[edge.vertex(1).getID()] += edge.getEnclosingRadius();
+    }
+  } else {
+    for (mesh::Triangle &face : getMesh()->triangles()) {
+      areas[face.vertex(0).getID()] += face.getArea() / 3.0;
+      areas[face.vertex(1).getID()] += face.getArea() / 3.0;
+      areas[face.vertex(2).getID()] += face.getArea() / 3.0;
+    }
   }
-  int dimensions = _targetData->getDimensions();
-  PRECICE_ASSERT(targetValues.size() / dimensions == areas.size());
   if (_scaling == SCALING_DIVIDE_BY_AREA) {
     for (int i = 0; i < areas.size(); i++) {
-      for (int dim = 0; dim < dimensions; dim++) {
-        int valueIndex = i * dimensions + dim;
+      for (int dim = 0; dim < valueDimensions; dim++) {
+        int valueIndex = i * valueDimensions + dim;
         targetValues[valueIndex] /= areas[i];
       }
     }
   } else if (_scaling == SCALING_MULTIPLY_BY_AREA) {
     for (int i = 0; i < areas.size(); i++) {
-      for (int dim = 0; dim < dimensions; dim++) {
-        int valueIndex = i * dimensions + dim;
+      for (int dim = 0; dim < valueDimensions; dim++) {
+        int valueIndex = i * valueDimensions + dim;
         targetValues[valueIndex] *= areas[i];
       }
     }

--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -38,11 +38,15 @@ void ScaleByAreaAction::performAction(
   PRECICE_ASSERT(targetValues.size() / valueDimensions == areas.size());
 
   if (meshDimensions == 2) {
+    PRECICE_CHECK(getMesh()->edges().size() != 0,
+                  "The multiply/divide-by-area actions require meshes with connectivity information. In 2D, please ensure that the mesh {} contains edges.", getMesh()->getName());
     for (mesh::Edge &edge : getMesh()->edges()) {
       areas[edge.vertex(0).getID()] += edge.getEnclosingRadius();
       areas[edge.vertex(1).getID()] += edge.getEnclosingRadius();
     }
   } else {
+    PRECICE_CHECK(getMesh()->triangles().size() != 0,
+                  "The multiply/divide-by-area actions require meshes with connectivity information. In 3D, please ensure that the mesh {} contains triangles.", getMesh()->getName());
     for (mesh::Triangle &face : getMesh()->triangles()) {
       areas[face.vertex(0).getID()] += face.getArea() / 3.0;
       areas[face.vertex(1).getID()] += face.getArea() / 3.0;

--- a/src/action/ScaleByAreaAction.hpp
+++ b/src/action/ScaleByAreaAction.hpp
@@ -40,9 +40,6 @@ public:
 
   /**
    * @brief Scales data on mesh nodes according to selected scaling type.
-   *
-   * At the moment, only a division of a property value by the associated area
-   * of the neighboring edges (2D) is possible.
    */
   virtual void performAction(
       double time,

--- a/src/action/config/ActionConfiguration.cpp
+++ b/src/action/config/ActionConfiguration.cpp
@@ -242,18 +242,10 @@ void ActionConfiguration::createAction()
 
   action::PtrAction action;
   if (_configuredAction.type == NAME_MULTIPLY_BY_AREA) {
-    PRECICE_CHECK(mesh->getDimensions() == 2,
-                  "The action \"{}\" is only available for a solverinterface dimensionality of 2. "
-                  "Please check the \"dimensions\" attribute of the <solverinterface> or use a custom action.",
-                  NAME_MULTIPLY_BY_AREA);
     action = action::PtrAction(
         new action::ScaleByAreaAction(timing, targetDataID,
                                       mesh, action::ScaleByAreaAction::SCALING_MULTIPLY_BY_AREA));
   } else if (_configuredAction.type == NAME_DIVIDE_BY_AREA) {
-    PRECICE_CHECK(mesh->getDimensions() == 2,
-                  "The action \"{}\" is only available for a solverinterface dimensionality of 2. "
-                  "Please check the \"dimensions\" attribute of the <solverinterface> or use a custom action.",
-                  NAME_DIVIDE_BY_AREA);
     action = action::PtrAction(
         new action::ScaleByAreaAction(timing, targetDataID,
                                       mesh, action::ScaleByAreaAction::SCALING_DIVIDE_BY_AREA));


### PR DESCRIPTION
## Main changes of this PR

Extend the ScaleByAreaAction to apply to 3D meshes as well instead of 2D meshes only.

## Motivation and additional information

closes #752 

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes -> **Not so worthy to add to Changelog**
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
* [ ] (more questions/tasks)