### PR TITLE
Explicitly require python3 for config formatting

### DIFF
--- a/tools/formatting/config-formatter
+++ b/tools/formatting/config-formatter
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from lxml import etree
 import itertools


### PR DESCRIPTION
## Main changes of this PR
Sets the environment for our config formatter to `python3`

## Motivation and additional information

My system uses python2 by default, which leads to the following error message: 
```
  File "~/precice/tools/formatting/config-formatter", line 48
    def print(self, text=''):
            ^
SyntaxError: invalid syntax
```

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)