### PR TITLE
Fix scalar header for RANK variable in vtk exports

### DIFF
--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -98,6 +98,7 @@ void ExportVTK::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
 
   outFile << "SCALARS Rank unsigned_int\n";
+  outFile << "LOOKUP_TABLE default\n";
   std::fill_n(std::ostream_iterator<char const *>(outFile), mesh.vertices().size(), "0 ");
   outFile << "\n\n";
 


### PR DESCRIPTION
## Main changes of this PR
Adds the lookup default keyword to the RANK variable of our vtk exports. 

## Motivation and additional information
With our current vtk exports I get the following error message using paraview v5.8.1

```bash
(   4.390s) [paraview        ]      vtkDataReader.cxx:2293   ERR| vtkUnstructuredGridReader (0x693b1f0): Cannot read scalar header! for file: ~/exports/Neumann-Mesh-Neumann.init.vtk
```
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)