### PR TITLE
Add Access to Mesh Requirements via API

### DIFF
--- a/docs/changelog/1080.md
+++ b/docs/changelog/1080.md
@@ -1,0 +1,1 @@
+- Added `isMeshConnectivityRequired(meshID)` to the SolverInterface API. This is useful to generate connectivity information only if required by preCICE.

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -163,6 +163,9 @@ int precicec_hasMesh(const char *meshName);
  */
 int precicec_getMeshID(const char *meshName);
 
+/// @copydoc precice::SolverInterface::isMeshConnectivityRequired()
+int precicec_isMeshConnectivityRequired(int meshID);
+
 /**
  * @brief Creates a mesh vertex
  *

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -189,6 +189,12 @@ int precicec_getDataID(const char *dataName, int meshID)
   return impl->getDataID(stringDataName, meshID);
 }
 
+int precicec_isMeshConnectivityRequired(int meshID)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  return impl->isMeshConnectivityRequired(meshID);
+}
+
 int precicec_setMeshVertex(
     int           meshID,
     const double *position)

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -192,7 +192,10 @@ int precicec_getDataID(const char *dataName, int meshID)
 int precicec_isMeshConnectivityRequired(int meshID)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  return impl->isMeshConnectivityRequired(meshID);
+  if (impl->isMeshConnectivityRequired(meshID)) {
+    return 1;
+  }
+  return 0;  
 }
 
 int precicec_setMeshVertex(

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -195,7 +195,7 @@ int precicec_isMeshConnectivityRequired(int meshID)
   if (impl->isMeshConnectivityRequired(meshID)) {
     return 1;
   }
-  return 0;  
+  return 0;
 }
 
 int precicec_setMeshVertex(

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -345,6 +345,21 @@ void precicef_get_data_id_(
 
 /**
  * Fortran syntax:
+ * precicef_has_data(
+ *   INTEGER   meshID
+ *   INTEGER   required)
+ *
+ * IN:  meshID
+ * OUT: required(1:true, 0:false)
+ *
+ * @copydoc precice::SolverInterface::isMeshConnectivityRequired()
+ */
+void precicef_isMeshConnectivityRequired(
+    const int *meshID,
+    int *      required);
+
+/**
+ * Fortran syntax:
  * precicef_set_vertex(
  *   INTEGER          meshID,
  *   DOUBLE PRECISION position(dim),

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -354,7 +354,7 @@ void precicef_get_data_id_(
  *
  * @copydoc precice::SolverInterface::isMeshConnectivityRequired()
  */
-void precicef_isMeshConnectivityRequired(
+void precicef_is_mesh_connectivity_required_(
     const int *meshID,
     int *      required);
 

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -274,7 +274,7 @@ void precicef_get_data_id_(
   *dataID = impl->getDataID(stringDataName, *meshID);
 }
 
-void precicef_isMeshConnectivityRequired(
+void precicef_is_mesh_connectivity_required_(
     const int *meshID,
     int *      required)
 {

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -274,6 +274,14 @@ void precicef_get_data_id_(
   *dataID = impl->getDataID(stringDataName, *meshID);
 }
 
+void precicef_isMeshConnectivityRequired(
+    const int *meshID,
+    int *      required)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  *required = impl->isMeshConnectivityRequired(*meshID);
+}
+
 void precicef_set_vertex_(
     const int *   meshID,
     const double *position,

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -279,7 +279,11 @@ void precicef_is_mesh_connectivity_required_(
     int *      required)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  *required = impl->isMeshConnectivityRequired(*meshID);
+  if (impl->isMeshConnectivityRequired(*meshID)) {
+    *required = 1;
+  } else {
+    *required = 0;
+  }
 }
 
 void precicef_set_vertex_(

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -102,6 +102,11 @@ std::set<int> SolverInterface::getMeshIDs() const
   return _impl->getMeshIDs();
 }
 
+bool SolverInterface::isMeshConnectivityRequired(int meshID) const
+{
+  return _impl->isMeshConnectivityRequired(meshID);
+}
+
 bool SolverInterface::hasData(
     const std::string &dataName, int meshID) const
 {

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -352,8 +352,8 @@ public:
   /**
    * @brief Checks if the given mesh requires connectivity.
    *
-   * preCICE may require connectivity information from the solver and will
-   * ignore any API calls regarding connectivity if it is not required.
+   * preCICE may require connectivity information from the solver and
+   * ignores any API calls regarding connectivity if it is not required.
    * Use this function to conditionally generate this connectivity.
    *
    * @param[in] meshID the id of the mesh

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -350,6 +350,18 @@ public:
   [[deprecated("Use getMeshID() for specific mesh names instead.")]] std::set<int> getMeshIDs() const;
 
   /**
+   * @brief Checks if the given mesh requires connectivity.
+   *
+   * preCICE may require connectivity information from the solver and will
+   * ignore any API calls regarding connectivity if it is not required.
+   * Use this function to conditionally generate this connectivity.
+   *
+   * @param[in] meshID the id of the mesh
+   * @returns whether connectivity is required
+   */
+  bool isMeshConnectivityRequired(int meshID) const;
+
+  /**
    * @brief Creates a mesh vertex
    *
    * @param[in] meshID the id of the mesh to add the vertex to.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -622,6 +622,13 @@ int SolverInterfaceImpl::getDataID(
   return _accessor->getUsedDataID(dataName, meshID);
 }
 
+bool SolverInterfaceImpl::isMeshConnectivityRequired(int meshID) const
+{
+  PRECICE_VALIDATE_MESH_ID(meshID);
+  MeshContext &context = _accessor->usedMeshContext(meshID);
+  return context.meshRequirement == mapping::Mapping::MeshRequirement::FULL;
+}
+
 int SolverInterfaceImpl::getMeshVertexSize(
     MeshID meshID) const
 {

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -243,6 +243,9 @@ public:
   /// Returns all mesh IDs (besides sub-ids).
   std::set<int> getMeshIDs() const;
 
+  /// @copydoc SolverInterface::isMeshConnectivityRequired()
+  bool isMeshConnectivityRequired(int meshID) const;
+
   /// Returns true, if the data with given name is used in the given mesh.
   bool hasData(const std::string &dataName, MeshID meshID) const;
 

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -110,6 +110,46 @@ BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
   BOOST_TEST(comsol->_usedMeshContexts.size() == 1);
 }
 
+BOOST_AUTO_TEST_SUITE(MeshRequirements)
+
+BOOST_AUTO_TEST_CASE(NN_A)
+{
+  PRECICE_TEST(1_rank);
+  std::string     filename = _pathToTests + "meshrequirements-nn.xml";
+  SolverInterface interface("A", filename, 0, 1);
+  auto            meshID = interface.getMeshID("MeshA");
+  BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
+}
+
+BOOST_AUTO_TEST_CASE(NN_B)
+{
+  PRECICE_TEST(1_rank);
+  std::string     filename = _pathToTests + "meshrequirements-nn.xml";
+  SolverInterface interface("B", filename, 0, 1);
+  auto            meshID = interface.getMeshID("MeshB");
+  BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
+}
+
+BOOST_AUTO_TEST_CASE(NP2D_A)
+{
+  PRECICE_TEST(1_rank);
+  std::string     filename = _pathToTests + "meshrequirements-np.xml";
+  SolverInterface interface("A", filename, 0, 1);
+  auto            meshID = interface.getMeshID("MeshA");
+  BOOST_TEST(interface.isMeshConnectivityRequired(meshID));
+}
+
+BOOST_AUTO_TEST_CASE(NP2D_B)
+{
+  PRECICE_TEST(1_rank);
+  std::string     filename = _pathToTests + "meshrequirements-np.xml";
+  SolverInterface interface("B", filename, 0, 1);
+  auto            meshID = interface.getMeshID("MeshB");
+  BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 
 // Test representing the full explicit lifecycle of a SolverInterface

--- a/src/precice/tests/meshrequirements-nn.xml
+++ b/src/precice/tests/meshrequirements-nn.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="Data" />
+
+    <mesh name="MeshA">
+      <use-data name="Data" />
+    </mesh>
+
+    <mesh name="MeshB">
+      <use-data name="Data" />
+    </mesh>
+
+    <m2n:sockets from="A" to="B" />
+
+    <participant name="A">
+      <use-mesh name="MeshA" provide="yes" />
+      <write-data name="Data" mesh="MeshA" />
+    </participant>
+
+    <participant name="B">
+      <use-mesh name="MeshA" provide="no" from="A" />
+      <use-mesh name="MeshB" provide="yes" />
+      <read-data name="Data" mesh="MeshB" />
+      <mapping:nearest-neighbor constraint="consistent" direction="read" from="MeshA" to="MeshB" />
+    </participant>
+
+    <coupling-scheme:parallel-explicit>
+      <participants first="A" second="B" />
+      <max-time value="1.0" />
+      <time-window-size value="1" />
+      <exchange data="Data" mesh="MeshA" from="A" to="B" />
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/precice/tests/meshrequirements-np.xml
+++ b/src/precice/tests/meshrequirements-np.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="Data" />
+
+    <mesh name="MeshA">
+      <use-data name="Data" />
+    </mesh>
+
+    <mesh name="MeshB">
+      <use-data name="Data" />
+    </mesh>
+
+    <m2n:sockets from="A" to="B" />
+
+    <participant name="A">
+      <use-mesh name="MeshA" provide="yes" />
+      <write-data name="Data" mesh="MeshA" />
+    </participant>
+
+    <participant name="B">
+      <use-mesh name="MeshA" provide="no" from="A" />
+      <use-mesh name="MeshB" provide="yes" />
+      <read-data name="Data" mesh="MeshB" />
+      <mapping:nearest-projection
+        constraint="consistent"
+        direction="read"
+        from="MeshA"
+        to="MeshB" />
+    </participant>
+
+    <coupling-scheme:parallel-explicit>
+      <participants first="A" second="B" />
+      <max-time value="1.0" />
+      <time-window-size value="1" />
+      <exchange data="Data" mesh="MeshA" from="A" to="B" />
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
+</precice-configuration>


### PR DESCRIPTION
## Main changes of this PR

Adds access to the mesh requirements to the SolverInterface.

```cpp
bool SolverInterface::isMeshConnectivityRequired(int meshID) const;
```

Closes #467

## Motivation and additional information

Generating connectivity information and passing it to preCICE can be expensive, but preCICE does not always need full mesh connectivity for every mesh.
preCICE ignores API calls to define connectivity if this is not required, but there is no way for the solver to know this.
Thus, solvers/adapters have to be manually configured to skip the connectivity generation.

This PR proposes an API which allows a solver to get information for each mesh directly from preCICE.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
