### PR TITLE
Track number of valid samples inside Waveform and simplify interface.

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -251,7 +251,7 @@ void BaseCouplingScheme::moveToNextWindow()
   PRECICE_TRACE(_timeWindows);
   for (DataMap::value_type &pair : _allData) {
     PRECICE_DEBUG("Store data: {}", pair.first);
-    _waveforms[pair.first]->moveToNextWindow(getTimeWindows(), _extrapolationOrder);
+    _waveforms[pair.first]->moveToNextWindow(_extrapolationOrder);
     pair.second->values() = _waveforms[pair.first]->lastTimeWindows().col(0);
   }
 }

--- a/src/time/Waveform.hpp
+++ b/src/time/Waveform.hpp
@@ -24,9 +24,8 @@ public:
 
   /**
    * @brief Called, when moving to the next time window. All entries in _timeWindows are shifted. The new entry is initialized as the value from the last window (= constant extrapolation)
-   * @param timeWindows number of samples that are valid and may be used for extrapolation. Usually number of past time windows.
    */
-  void moveToNextWindow(int timeWindows, int order = 0);
+  void moveToNextWindow(int order = 0);
 
   /**
    * @brief getter for Eigen::MatrixXd containing data of current and past time windows. Each column represents a sample in time, with col(0)
@@ -40,6 +39,11 @@ public:
   int numberOfSamples();
 
   /**
+   * @brief returns number of valid samples in time stored by this waveform
+   */
+  int numberOfValidSamples();
+
+  /**
    * @brief returns number of data per sample in time stored by this waveform
    */
   int numberOfData();
@@ -47,6 +51,9 @@ public:
 private:
   /// Data values of time windows.
   Eigen::MatrixXd _timeWindows;
+
+  /// number of valid samples in _timeWindows
+  int _numberOfValidSamples;
 
   mutable logging::Logger _log{"time::Waveform"};
 
@@ -57,9 +64,8 @@ private:
    * If order two is required, but only two samples are available, the extrapolation order is automatically reduced to one.
    * 
    * @param order Order of the extrapolation scheme to be used.
-   * @param timeWindows number of valid samples.
    */
-  Eigen::VectorXd extrapolateData(int order, int timeWindows);
+  Eigen::VectorXd extrapolateData(int order);
 };
 
 } // namespace time

--- a/src/time/tests/WaveformTest.cpp
+++ b/src/time/tests/WaveformTest.cpp
@@ -16,9 +16,9 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
 
   // Test first order extrapolation
   int      extrapolationOrder = 1;
-  int      timeWindowCounter  = 1;
   Waveform waveform(1, extrapolationOrder);
   BOOST_TEST(waveform.numberOfSamples() == 2);
+  BOOST_TEST(waveform.numberOfValidSamples() == 1);
   BOOST_TEST(waveform.numberOfData() == 1);
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 0.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 0.0));
@@ -28,8 +28,8 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   waveform.store(value);
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 1.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 0.0));
-  timeWindowCounter++;
-  waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);
+  waveform.moveToNextWindow(extrapolationOrder);
+  BOOST_TEST(waveform.numberOfValidSamples() == 2);
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 2.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
 
@@ -37,16 +37,16 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   waveform.store(value);
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 4.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
-  timeWindowCounter++;
-  waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);
+  waveform.moveToNextWindow(extrapolationOrder);
+  BOOST_TEST(waveform.numberOfValidSamples() == 2);
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 7.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 4.0));
 
   // Test second order extrapolation
   extrapolationOrder = 2;
-  timeWindowCounter  = 1;
   Waveform waveform2(1, extrapolationOrder);
   BOOST_TEST(waveform2.numberOfSamples() == 3);
+  BOOST_TEST(waveform2.numberOfValidSamples() == 1);
   BOOST_TEST(waveform2.numberOfData() == 1);
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 0.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 0.0));
@@ -57,8 +57,8 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 1.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 0.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 0.0));
-  timeWindowCounter++;
-  waveform2.moveToNextWindow(timeWindowCounter, extrapolationOrder); // only applies first order extrapolation
+  waveform2.moveToNextWindow(extrapolationOrder); // only applies first order extrapolation
+  BOOST_TEST(waveform2.numberOfValidSamples() == 2);
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 2.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 1.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 0.0));
@@ -68,8 +68,8 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 4.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 1.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 0.0));
-  timeWindowCounter++;
-  waveform2.moveToNextWindow(timeWindowCounter, extrapolationOrder); // applies second order extrapolation
+  waveform2.moveToNextWindow(extrapolationOrder); // applies second order extrapolation
+  BOOST_TEST(waveform2.numberOfValidSamples() == 3);
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 8.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 4.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 1.0));


### PR DESCRIPTION
## Main changes of this PR

Tracks number of valid samples inside Waveform and allows to simplify corresponding interface.

## Motivation and additional information

This is only a small simplification which I factored out from #1029 to merge directly. This avoids ambiguity with respect to what "timeWindows" means and makes `Waveform` easier to use.

A newly constructed waveform now has only a single valid sample by default. New valid samples can be added to the waveform by moving to the next window. This will archive the current sample in `_timeWindows` and allows the user to add a new sample via `store()`.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)