### PR TITLE
Improve NumPy usage

### DIFF
--- a/cmake/Validation.cmake
+++ b/cmake/Validation.cmake
@@ -71,7 +71,7 @@ endmacro()
 # Validation for NumPy
 macro(precice_validate_numpy)
   precice_validate_lib(
-    "#include <Python.h>\n#include <numpy/arrayobject.h>\nint main() { return 0; } "
+    "#include <Python.h>\n#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\n#include <numpy/arrayobject.h>\nint main() { return 0; } "
     NAME NumPy
     COMPILE_DEFINITIONS "-I ${PYTHON_INCLUDE_DIRS}"
     LINK_LIBRARIES NumPy::NumPy ${PYTHON_LIBRARIES}

--- a/cmake/Validation.cmake
+++ b/cmake/Validation.cmake
@@ -71,7 +71,7 @@ endmacro()
 # Validation for NumPy
 macro(precice_validate_numpy)
   precice_validate_lib(
-    "#include <Python.h>\n#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\n#include <numpy/arrayobject.h>\nint main() { return 0; } "
+    "#include <Python.h>\n#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\n#include <numpy/arrayobject.h>\n int main() { import_array1(0); return 0; } "
     NAME NumPy
     COMPILE_DEFINITIONS "-I ${PYTHON_INCLUDE_DIRS}"
     LINK_LIBRARIES NumPy::NumPy ${PYTHON_LIBRARIES}

--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -6,11 +6,13 @@
 #include <boost/filesystem/operations.hpp>
 #include <cstdlib>
 #include <memory>
-#include <numpy/arrayobject.h>
 #include <ostream>
 #include <pthread.h>
 #include <string>
 #include <utility>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
 
 #include "logging/LogMacros.hpp"
 #include "mesh/Data.hpp"


### PR DESCRIPTION
## Main changes of this PR

- Disable deprecated numpy API
- Fix numpy validation

Part of #1018

## Motivation and additional information

Disables the deprecated NumPy API, which we don't use.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
