### PR TITLE
Updates difference matrices if residuals are not zero only

### DIFF
--- a/docs/changelog/1092.md
+++ b/docs/changelog/1092.md
@@ -1,0 +1,1 @@
+- Fixed wrong error in tightly converging QN coupling. (Issue #976)

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -228,43 +228,45 @@ void BaseQNAcceleration::updateDifferenceMatrices(
       Eigen::VectorXd deltaXTilde = _values;
       deltaXTilde -= _oldXTilde;
 
-      PRECICE_CHECK(not math::equals(utils::MasterSlave::l2norm(deltaR), 0.0),
-                    "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residual "
-                    "in two consecutive iterations is identical. There is probably something wrong in your adapter. "
-                    "Maybe you always write the same (or only incremented) data or you call advance without "
-                    "providing  new data first.");
+      if (not math::equals(utils::MasterSlave::l2norm(deltaR), 0.0)) {
+        
+        bool columnLimitReached = getLSSystemCols() == _maxIterationsUsed;
+        bool overdetermined     = getLSSystemCols() <= getLSSystemRows();
+        if (not columnLimitReached && overdetermined) {
 
-      bool columnLimitReached = getLSSystemCols() == _maxIterationsUsed;
-      bool overdetermined     = getLSSystemCols() <= getLSSystemRows();
-      if (not columnLimitReached && overdetermined) {
+          utils::appendFront(_matrixV, deltaR);
+          utils::appendFront(_matrixW, deltaXTilde);
 
-        utils::appendFront(_matrixV, deltaR);
-        utils::appendFront(_matrixW, deltaXTilde);
+          // insert column deltaR = _residuals - _oldResiduals at pos. 0 (front) into the
+          // QR decomposition and update decomposition
 
-        // insert column deltaR = _residuals - _oldResiduals at pos. 0 (front) into the
-        // QR decomposition and update decomposition
+          //apply scaling here
+          _preconditioner->apply(deltaR);
+          _qrV.pushFront(deltaR);
 
-        //apply scaling here
-        _preconditioner->apply(deltaR);
-        _qrV.pushFront(deltaR);
+          _matrixCols.front()++;
+        } else {
+          utils::shiftSetFirst(_matrixV, deltaR);
+          utils::shiftSetFirst(_matrixW, deltaXTilde);
 
-        _matrixCols.front()++;
-      } else {
-        utils::shiftSetFirst(_matrixV, deltaR);
-        utils::shiftSetFirst(_matrixW, deltaXTilde);
+          // inserts column deltaR at pos. 0 to the QR decomposition and deletes the last column
+          // the QR decomposition of V is updated
+          _preconditioner->apply(deltaR);
+          _qrV.pushFront(deltaR);
+          _qrV.popBack();
 
-        // inserts column deltaR at pos. 0 to the QR decomposition and deletes the last column
-        // the QR decomposition of V is updated
-        _preconditioner->apply(deltaR);
-        _qrV.pushFront(deltaR);
-        _qrV.popBack();
-
-        _matrixCols.front()++;
-        _matrixCols.back()--;
-        if (_matrixCols.back() == 0) {
-          _matrixCols.pop_back();
+          _matrixCols.front()++;
+          _matrixCols.back()--;
+          if (_matrixCols.back() == 0) {
+            _matrixCols.pop_back();
+          }
+          _nbDropCols++;
         }
-        _nbDropCols++;
+      } else {
+        PRECICE_WARN("Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residual "
+                      "in two consecutive iterations is identical. There is probably something wrong in your adapter. "
+                      "Maybe you always write the same (or only incremented) data or you call advance without "
+                      "providing  new data first.");
       }
     }
     _oldResiduals = _residuals; // Store residuals

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -235,10 +235,10 @@ void BaseQNAcceleration::updateDifferenceMatrices(
       }
 
       PRECICE_CHECK(not math::equals(residualMagnitude, 0.0),
-                      "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residual "
-                      "in two consecutive iterations is identical. There is probably something wrong in your adapter. "
-                      "Maybe you always write the same (or only incremented) data or you call advance without "
-                      "providing  new data first.");
+                    "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residual "
+                    "in two consecutive iterations is identical. There is probably something wrong in your adapter. "
+                    "Maybe you always write the same (or only incremented) data or you call advance without "
+                    "providing  new data first.");
 
       bool columnLimitReached = getLSSystemCols() == _maxIterationsUsed;
       bool overdetermined     = getLSSystemCols() <= getLSSystemRows();

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -234,7 +234,7 @@ void BaseQNAcceleration::updateDifferenceMatrices(
         residualMagnitude /= utils::MasterSlave::l2norm(_values);
       }
 
-      PRECICE_CHECK((residualMagnitude, 0.0),
+      PRECICE_CHECK(not math::equals(residualMagnitude, 0.0),
                       "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residual "
                       "in two consecutive iterations is identical. There is probably something wrong in your adapter. "
                       "Maybe you always write the same (or only incremented) data or you call advance without "

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -230,7 +230,7 @@ void BaseQNAcceleration::updateDifferenceMatrices(
 
       double residualMagnitude = utils::MasterSlave::l2norm(deltaR);
 
-      if (utils::MasterSlave::l2norm(_values) < 1e-14) {
+      if (not math::equals(utils::MasterSlave::l2norm(_values), 0.0)) {
         residualMagnitude /= utils::MasterSlave::l2norm(_values);
       }
 


### PR DESCRIPTION
## Main changes of this PR

When updating the difference matrices, if the residuals are zero an error is thrown. This PR only updates the difference matrices if the residual is non-zero, otherwise only a warning is thrown.

## Motivation and additional information

Closes https://github.com/precice/precice/issues/976

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?