### PR TITLE
Print logs and infos consistently with fixed width

### DIFF
--- a/docs/changelog/1093.md
+++ b/docs/changelog/1093.md
@@ -1,0 +1,2 @@
+- Changed the convergence measures INFO print to a fixed width scientific format (issue #975)
+- Changed the precice convergence log file to a fixed width scientific notation (issue #975)

--- a/docs/changelog/1093.md
+++ b/docs/changelog/1093.md
@@ -1,2 +1,2 @@
 - Changed the convergence measures INFO print to a fixed width scientific format (issue #975)
-- Changed the precice log files (convergence and watchpoint) to print a fixed width scientific notation using 8 digits after the comma (issue #975)
+- Changed the precice log files to print a fixed width scientific notation using 8 digits after the comma for floating point numbers and a fixed width for integer values(issue #975)

--- a/docs/changelog/1093.md
+++ b/docs/changelog/1093.md
@@ -1,2 +1,2 @@
 - Changed the convergence measures INFO print to a fixed width scientific format (issue #975)
-- Changed the precice convergence log file to a fixed width scientific notation (issue #975)
+- Changed the precice log files (convergence and watchpoint) to print a fixed width scientific notation using 8 digits after the comma (issue #975)

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <iomanip>
 #include <ostream>
 #include <string>
 #include "ConvergenceMeasure.hpp"
@@ -58,8 +59,8 @@ public:
   {
     std::ostringstream os;
     os << "absolute convergence measure: ";
-    os << "two-norm diff of data \"";
-    os << dataName << "\" = " << _normDiff;
+    os << "two-norm diff of data \"" << dataName << "\" = ";
+    os << std::scientific << std::setprecision(2) << _normDiff;
     os << ", limit = " << _convergenceLimit;
     os << ", conv = ";
     if (_isConvergence)

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -83,8 +83,9 @@ public:
   {
     std::ostringstream os;
     os << "relative convergence measure: ";
-    os << "relative two-norm diff of data \"";
-    os << dataName << "\" = " << getNormResidual();
+    os << "relative two-norm diff of data ";
+    os << std::setw(14) << std::string("\"" + dataName + "\"") << " = ";
+    os << std::scientific << std::setprecision(2) << getNormResidual();
     os << ", limit = " << _convergenceLimitPercent;
     os << ", normalization = " << _norm;
     os << ", conv = ";

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <iomanip>
 #include <limits>
 #include <math.h>
 #include <ostream>

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -84,8 +84,7 @@ public:
   {
     std::ostringstream os;
     os << "relative convergence measure: ";
-    os << "relative two-norm diff of data ";
-    os << std::setw(14) << std::string("\"" + dataName + "\"") << " = ";
+    os << "relative two-norm diff of data \"" << dataName << "\" = ";
     os << std::scientific << std::setprecision(2) << getNormResidual();
     os << ", limit = " << _convergenceLimitPercent;
     os << ", normalization = " << _norm;

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <iomanip>
 #include <limits>
 #include <ostream>
 #include <string>
@@ -67,8 +68,8 @@ public:
   {
     std::ostringstream os;
     os << "residual relative convergence measure: ";
-    os << "relative two-norm diff of data \"";
-    os << dataName << "\" = " << getNormResidual();
+    os << "relative two-norm diff of data \"" << dataName << "\" = ";
+    os << std::scientific << std::setprecision(2) << getNormResidual();
     os << ", limit = " << _convergenceLimitPercent;
     os << ", normalization = " << _normFirstResidual;
     os << ", conv = ";

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -45,8 +45,9 @@ void TXTTableWriter::addData(
   }
   // Print out everyting apart from INT consistently in scientific
   // notation using a fixed precision
-  if (type == DOUBLE || type == VECTOR2D || VECTOR3D)
+  if (type == DOUBLE || type == VECTOR2D || VECTOR3D) {
     _outputStream << std::scientific << std::setprecision(8);
+  }
   _writeIterator = _data.end();
 }
 

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -63,7 +63,7 @@ void TXTTableWriter::writeData(
   }
   PRECICE_ASSERT(_writeIterator->name == name, _writeIterator->name, name);
   PRECICE_ASSERT(_writeIterator->type == INT, _writeIterator->type);
-  _outputStream << value << "  ";
+  _outputStream << std::setw(6) << value << "  ";
   _writeIterator++;
   if (_writeIterator == _data.end()) {
     _outputStream.flush();

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -43,6 +43,10 @@ void TXTTableWriter::addData(
       _outputStream << name << i << "  ";
     }
   }
+  // Print out everyting apart from INT consistently in scientific
+  // notation using a fixed precision
+  if (type == DOUBLE || type == VECTOR2D || VECTOR3D)
+    _outputStream << std::scientific << std::setprecision(8);
   _writeIterator = _data.end();
 }
 


### PR DESCRIPTION
## Main changes of this PR
Closes #975 

## Motivation and additional information
Main question: how many digits do we want for the fixed notation? Do we want everywhere the same number of digits (limits, norm..)? <del> And do we want to 'format' align the data names as good as possible? </del>Example using two digits:
```bash
---[precice]  relative convergence measure: relative two-norm diff of data "Displacement" = 2.93e-01, limit = 5.00e-03, normalization = 4.29e-02, conv = false
---[precice]  relative convergence measure: relative two-norm diff of data "Force" = 6.62e-02, limit = 5.00e-03, normalization = 6.01e+01, conv = false
```


<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
