### PR TITLE
Fix used order depending on window

### DIFF
--- a/docs/changelog/1097.md
+++ b/docs/changelog/1097.md
@@ -1,0 +1,1 @@
+Fixed used extrapolation order depending on current time window.

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -465,25 +465,38 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(cplData->values()(0), 0.0));
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 0.0));
 
-  cplData->values()(0) = 1.0;
+  // start first window
+  cplData->values()(0) = 1.0; // data provided at end of first window
   scheme.setTimeWindows(scheme.getTimeWindows() + 1);
   scheme.storeDataInWaveforms();
   BOOST_TEST(testing::equals(cplData->values()(0), 1.0));
-  scheme.moveToNextWindow();
+
+  // go to second window
+  scheme.moveToNextWindow(); // uses zeroth order extrapolation at end of first window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 0.0));
-
   scheme.storeIteration();
-  BOOST_TEST(testing::equals(cplData->values()(0), 2.0));
-  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
-
-  cplData->values()(0) = 4.0;
+  BOOST_TEST(testing::equals(cplData->values()(0), 1.0));
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 1.0));
+  cplData->values()(0) = 4.0; // data provided at end of second window
   scheme.setTimeWindows(scheme.getTimeWindows() + 1);
   scheme.storeDataInWaveforms();
-  scheme.moveToNextWindow();
-  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
+
+  // go to third window
+  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowd) at end of second window
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 1.0));
   scheme.storeIteration();
   BOOST_TEST(testing::equals(cplData->values()(0), 7.0));
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 7.0));
+  cplData->values()(0) = 10.0; // data provided at end of third window
+  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
+  scheme.storeDataInWaveforms();
+
+  // go to fourth window
+  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowd) at end of third window
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 7.0));
+  scheme.storeIteration();
+  BOOST_TEST(testing::equals(cplData->values()(0), 16.0)); // = 2*10 - 4
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 16.0));
 
   // Test second order extrapolation
   cplData->values() = Eigen::VectorXd::Zero(cplData->values().size());
@@ -497,26 +510,42 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_CHECK(cplData); // no nullptr
   BOOST_TEST(cplData->values().size() == 1);
   BOOST_TEST(cplData->previousIteration().size() == 1);
+
+  // initialized as zero
   BOOST_TEST(testing::equals(cplData->values()(0), 0.0));
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 0.0));
 
-  cplData->values()(0) = 1.0;
+  // start first window
+  cplData->values()(0) = 1.0; // data provided at end of first window
   scheme2.setTimeWindows(scheme2.getTimeWindows() + 1);
   scheme2.storeDataInWaveforms();
-  scheme2.moveToNextWindow();
+
+  // go to second window
+  scheme2.moveToNextWindow(); // uses zeroth order extrapolation at end of first window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 0.0));
   scheme2.storeIteration();
-  BOOST_TEST(testing::equals(cplData->values()(0), 2.0));
-  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
-
-  cplData->values()(0) = 4.0;
+  BOOST_TEST(testing::equals(cplData->values()(0), 1.0));
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 1.0));
+  cplData->values()(0) = 4.0; // data provided at end of second window
   scheme2.setTimeWindows(scheme2.getTimeWindows() + 1);
   scheme2.storeDataInWaveforms();
-  scheme2.moveToNextWindow();
-  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
+
+  //go to third window
+  scheme2.moveToNextWindow(); // uses first order extrapolation at end of second window
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 1.0));
   scheme2.storeIteration();
-  BOOST_TEST(testing::equals(cplData->values()(0), 8.0));
-  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 8.0));
+  BOOST_TEST(testing::equals(cplData->values()(0), 7.0)); // = 2*4.0 - 1.0
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 7.0));
+  cplData->values()(0) = 10.0; // data provided at end of third window
+  scheme2.setTimeWindows(scheme2.getTimeWindows() + 1);
+  scheme2.storeDataInWaveforms();
+
+  // go to fourth window
+  scheme2.moveToNextWindow(); // uses second order extrapolation at end of third window
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 7.0));
+  scheme2.storeIteration();
+  BOOST_TEST(testing::equals(cplData->values()(0), 17.5)); // = 2.5*10 - 2*4 + 0.5*1
+  BOOST_TEST(testing::equals(cplData->previousIteration()(0), 17.5));
 }
 
 /// Test that cplScheme gives correct results when applying extrapolation.
@@ -673,8 +702,8 @@ BOOST_AUTO_TEST_CASE(testAccelerationWithLinearExtrapolation)
     BOOST_TEST(cplScheme.isCouplingOngoing());
     if (context.isNamed(first)) {
       if (i == 0) {
-        // extrapolated data
-        BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 4);
+        // extrapolated data, constant extrapolation from first window
+        BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 2);
       } else if (i == 1) {
         // accelerated data from second participant: 0.5 * 2 + 0.5 * 3 = 2.5
         BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 2.5);
@@ -710,8 +739,9 @@ BOOST_AUTO_TEST_CASE(testAccelerationWithLinearExtrapolation)
     }
   }
 
+  // third window
   if (context.isNamed(first)) {
-    // extrapolated data
+    // extrapolated data, linear extrapolation from first and second window
     BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 4); // extrapolated data: 2, 3, 4
   } else if (context.isNamed(second)) {
     BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 5); // this is now actually an extrapolated value, since it's not overwritten by the first participant: 1, 3, 5
@@ -876,8 +906,8 @@ BOOST_AUTO_TEST_CASE(testAccelerationWithQuadraticExtrapolation)
     BOOST_TEST(cplScheme.isCouplingOngoing());
     if (context.isNamed(first)) {
       if (i == 0) {
-        // extrapolated data
-        BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 4);
+        // extrapolated data, constant extrapolation from first window
+        BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 2);
       } else if (i == 1) {
         // accelerated data from second participant: 0.5 * 2 + 0.5 * 3 = 2.5
         BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 2.5);
@@ -919,8 +949,8 @@ BOOST_AUTO_TEST_CASE(testAccelerationWithQuadraticExtrapolation)
     BOOST_TEST(cplScheme.isCouplingOngoing());
     if (context.isNamed(first)) {
       if (i == 0) {
-        // extrapolated data: 0, 2, 3 -> 2.5*x^t - 2*x^(t-1) + 0.5*x^(t-2) = 3.5
-        BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 3.5);
+        // extrapolated data, linear extrapolation from first window and second
+        BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 4);
       } else if (i == 1) {
         // accelerated data from second participant: 0.5 * 3 + 0.5 * 5 = 4
         BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 4);
@@ -956,9 +986,10 @@ BOOST_AUTO_TEST_CASE(testAccelerationWithQuadraticExtrapolation)
     }
   }
 
+  // fourth window
   if (context.isNamed(first)) {
-    // extrapolated data
-    BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 7.5); // extrapolated data: 2, 3, 5 -> 2.5*x^t - 2*x^(t-1) + 0.5*x^(t-2) = 7.5
+    // extrapolated data: 2, 3, 5 -> 2.5*x^t - 2*x^(t-1) + 0.5*x^(t-2) = 7.5
+    BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 7.5);
   } else if (context.isNamed(second)) {
     BOOST_TEST(mesh->data(receiveDataIndex)->values()(0) == 7); // this is now actually an extrapolated value, since it's not overwritten by the first participant: 1, 3, 5 -> 2.5*x^t - 2*x^(t-1) + 0.5*x^(t-2) = 7
   }

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   scheme.storeDataInWaveforms();
 
   // go to third window
-  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowd) at end of second window
+  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowed) at end of second window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 1.0));
   scheme.storeIteration();
   BOOST_TEST(testing::equals(cplData->values()(0), 7.0));
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   scheme.storeDataInWaveforms();
 
   // go to fourth window
-  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowd) at end of third window
+  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowed) at end of third window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 7.0));
   scheme.storeIteration();
   BOOST_TEST(testing::equals(cplData->values()(0), 16.0)); // = 2*10 - 4

--- a/src/time/Waveform.cpp
+++ b/src/time/Waveform.cpp
@@ -54,25 +54,47 @@ int Waveform::numberOfData()
 
 Eigen::VectorXd Waveform::extrapolateData(int order, int timeWindows)
 {
-  Eigen::VectorXd extrapolatedValue;
-  if ((order == 0) || (timeWindows < 2 && order > 0)) {
+  int usedOrder = 0;
+
+  if (order == 0) {
+    usedOrder = 0;
+  } else if (order == 1) {
+    if (timeWindows < 3) {
+      usedOrder = 0;
+    } else {
+      usedOrder = 1;
+    }
+  } else if (order == 2) {
+    if (timeWindows < 3) {
+      usedOrder = 0;
+    } else if (timeWindows < 4) {
+      usedOrder = 1;
+    } else {
+      usedOrder = 2;
+    }
+  } else {
+    PRECICE_ASSERT(false);
+  }
+
+  if (usedOrder == 0) {
     PRECICE_ASSERT(this->numberOfSamples() > 0);
-    extrapolatedValue = this->_timeWindows.col(0);
-  } else if ((order == 1) || (timeWindows < 3 && order > 1)) { //timesteps is increased before extrapolate is called
+    return this->_timeWindows.col(0);
+  }
+  Eigen::VectorXd extrapolatedValue;
+  if (usedOrder == 1) { //timesteps is increased before extrapolate is called
     PRECICE_DEBUG("Performing first order extrapolation");
     PRECICE_ASSERT(this->numberOfSamples() > 1);
     extrapolatedValue = this->_timeWindows.col(0) * 2.0; // = 2*x^t
     extrapolatedValue -= this->_timeWindows.col(1);      // = 2*x^t - x^(t-1)
-  } else if (order == 2) {
-    // uses formula given in https://doi.org/10.1016/j.compstruc.2008.11.013, p.796, Algorithm line 1
-    PRECICE_DEBUG("Performing second order extrapolation");
-    PRECICE_ASSERT(this->numberOfSamples() > 2);
-    extrapolatedValue = this->_timeWindows.col(0) * 2.5;  // = 2.5*x^t
-    extrapolatedValue -= this->_timeWindows.col(1) * 2.0; // = 2.5*x^t - 2*x^(t-1)
-    extrapolatedValue += this->_timeWindows.col(2) * 0.5; // = 2.5*x^t - 2*x^(t-1) + 0.5*x^(t-2)
-  } else {
-    PRECICE_ASSERT(false, "Extrapolation order is invalid.");
+    return extrapolatedValue;
   }
+  PRECICE_ASSERT(usedOrder == 2);
+  // uses formula given in https://doi.org/10.1016/j.compstruc.2008.11.013, p.796, Algorithm line 1
+  PRECICE_DEBUG("Performing second order extrapolation");
+  PRECICE_ASSERT(this->numberOfSamples() > 2);
+  extrapolatedValue = this->_timeWindows.col(0) * 2.5;  // = 2.5*x^t
+  extrapolatedValue -= this->_timeWindows.col(1) * 2.0; // = 2.5*x^t - 2*x^(t-1)
+  extrapolatedValue += this->_timeWindows.col(2) * 0.5; // = 2.5*x^t - 2*x^(t-1) + 0.5*x^(t-2)
   return extrapolatedValue;
 }
 

--- a/src/time/tests/WaveformTest.cpp
+++ b/src/time/tests/WaveformTest.cpp
@@ -29,8 +29,8 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 1.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 0.0));
   timeWindowCounter++;
-  waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 2.0));
+  waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder); // only applies constant extrapolation in second window
+  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 1.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
 
   value(0) = 4.0;
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 4.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
   timeWindowCounter++;
-  waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);
+  waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder); // applies first order extrapolation in third window
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 7.0));
   BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 4.0));
 
@@ -58,8 +58,8 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 0.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 0.0));
   timeWindowCounter++;
-  waveform2.moveToNextWindow(timeWindowCounter, extrapolationOrder); // only applies first order extrapolation
-  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 2.0));
+  waveform2.moveToNextWindow(timeWindowCounter, extrapolationOrder); // only applies constant extrapolation in second window
+  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 1.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 1.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 0.0));
 
@@ -69,10 +69,21 @@ BOOST_AUTO_TEST_CASE(testExtrapolateData)
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 1.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 0.0));
   timeWindowCounter++;
-  waveform2.moveToNextWindow(timeWindowCounter, extrapolationOrder); // applies second order extrapolation
+  waveform2.moveToNextWindow(timeWindowCounter, extrapolationOrder); // only applies first order extrapolation in third window
+  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 7.0));
+  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 4.0));
+  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 1.0));
+
+  value(0) = 8.0;
+  waveform2.store(value);
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 8.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 4.0));
   BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 1.0));
+  timeWindowCounter++;
+  waveform2.moveToNextWindow(timeWindowCounter, extrapolationOrder);    // applies second order extrapolation in fourth window
+  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 0), 12.5)); // 12.5 = 2.5 * 8 - 2 * 4 + 0.5 * 1
+  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 1), 8.0));
+  BOOST_TEST(testing::equals(waveform2.lastTimeWindows()(0, 2), 4.0));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Main changes of this PR

Fixes condition for extrapolation:

* At the end of the first window we always have to use no extrapolation (constant extrapolation), because there is only a single sample available.
* At the end of the second window we are at maximum allowed to use first order extrapolation, because there are only two samples available.
* At the end of the third window we are allowed to do second order extrapolation, because there are three samples available

## Motivation and additional information

This is a regression compared to https://github.com/precice/precice/releases/tag/v2.2.1, which can be seen by using extrapolation of different order and comparing the results.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
