### PR TITLE
Split testExtrapolateData and use SerialCouplingSchemeFixture

### DIFF
--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -11,15 +11,6 @@
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
-// @todo: Use fixture!
-// Forward declaration to friend the boost test struct
-namespace CplSchemeTests {
-namespace SerialImplicitCouplingSchemeTests {
-struct testFirstOrderExtrapolateData;
-struct testSecondOrderExtrapolateData;
-} // namespace SerialImplicitCouplingSchemeTests
-} // namespace CplSchemeTests
-
 namespace precice {
 namespace cplscheme {
 class CouplingData;
@@ -47,9 +38,6 @@ public:
       int                           maxIterations,
       CouplingMode                  cplMode,
       constants::TimesteppingMethod dtMethod);
-
-  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testFirstOrderExtrapolateData;  // For whitebox tests
-  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testSecondOrderExtrapolateData; // For whitebox tests
 
   /// Adds data to be sent on data exchange and possibly be modified during coupling iterations.
   void addDataToSend(

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -11,11 +11,13 @@
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
+// @todo: Use fixture!
 // Forward declaration to friend the boost test struct
 namespace CplSchemeTests {
 namespace SerialImplicitCouplingSchemeTests {
-struct testExtrapolateData;
-}
+struct testFirstOrderExtrapolateData;
+struct testSecondOrderExtrapolateData;
+} // namespace SerialImplicitCouplingSchemeTests
 } // namespace CplSchemeTests
 
 namespace precice {
@@ -46,7 +48,8 @@ public:
       CouplingMode                  cplMode,
       constants::TimesteppingMethod dtMethod);
 
-  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testExtrapolateData; // For whitebox tests
+  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testFirstOrderExtrapolateData;  // For whitebox tests
+  friend struct CplSchemeTests::SerialImplicitCouplingSchemeTests::testSecondOrderExtrapolateData; // For whitebox tests
 
   /// Adds data to be sent on data exchange and possibly be modified during coupling iterations.
   void addDataToSend(

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -451,19 +451,20 @@ BOOST_AUTO_TEST_CASE(testFirstOrderExtrapolateData)
   int                   maxIterations = 1;
 
   // Test first order extrapolation
-  SerialCouplingScheme scheme(maxTime, maxTimesteps, dt, 16, first, second,
+  SerialCouplingScheme                 scheme(maxTime, maxTimesteps, dt, 16, first, second,
                               accessor, globalCom, constants::FIXED_TIME_WINDOW_SIZE,
                               BaseCouplingScheme::Implicit, maxIterations);
+  testing::SerialCouplingSchemeFixture fixture;
 
   scheme.addDataToSend(data, mesh, true);
   scheme.setExtrapolationOrder(1);
-  scheme.setupDataMatrices();
-  CouplingData *cplData = scheme.getSendData(dataID);
+  fixture.setupDataMatrices(scheme);
+  CouplingData *cplData = fixture.getSendData(scheme, dataID);
   BOOST_CHECK(cplData); // no nullptr
   BOOST_TEST(cplData->values().size() == 1);
   BOOST_TEST(cplData->previousIteration().size() == 1);
 
-  scheme.moveToNextWindow();
+  fixture.moveToNextWindow(scheme);
 
   // data is uninitialized
   BOOST_TEST(testing::equals(cplData->values()(0), 0.0));
@@ -471,34 +472,34 @@ BOOST_AUTO_TEST_CASE(testFirstOrderExtrapolateData)
 
   // start first window
   cplData->values()(0) = 1.0; // data provided at end of first window
-  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
-  scheme.storeDataInWaveforms();
+  fixture.setTimeWindows(scheme, scheme.getTimeWindows() + 1);
+  fixture.storeDataInWaveforms(scheme);
   BOOST_TEST(testing::equals(cplData->values()(0), 1.0));
 
   // go to second window
-  scheme.moveToNextWindow(); // uses first order extrapolation at end of first window
+  fixture.moveToNextWindow(scheme); // uses first order extrapolation at end of first window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 0.0));
-  scheme.storeIteration();
+  fixture.storeIteration(scheme);
   BOOST_TEST(testing::equals(cplData->values()(0), 2.0)); // = 2*1 - 0
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
   cplData->values()(0) = 4.0; // data provided at end of second window
-  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
-  scheme.storeDataInWaveforms();
+  fixture.setTimeWindows(scheme, scheme.getTimeWindows() + 1);
+  fixture.storeDataInWaveforms(scheme);
 
   // go to third window
-  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowed) at end of second window
+  fixture.moveToNextWindow(scheme); // uses first order extrapolation (maximum allowed) at end of second window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
-  scheme.storeIteration();
+  fixture.storeIteration(scheme);
   BOOST_TEST(testing::equals(cplData->values()(0), 7.0)); // = 2*4 - 1
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 7.0));
   cplData->values()(0) = 10.0; // data provided at end of third window
-  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
-  scheme.storeDataInWaveforms();
+  fixture.setTimeWindows(scheme, scheme.getTimeWindows() + 1);
+  fixture.storeDataInWaveforms(scheme);
 
   // go to fourth window
-  scheme.moveToNextWindow(); // uses first order extrapolation (maximum allowed) at end of third window
+  fixture.moveToNextWindow(scheme); // uses first order extrapolation (maximum allowed) at end of third window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 7.0));
-  scheme.storeIteration();
+  fixture.storeIteration(scheme);
   BOOST_TEST(testing::equals(cplData->values()(0), 16.0)); // = 2*10 - 4
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 16.0));
 }
@@ -526,17 +527,18 @@ BOOST_AUTO_TEST_CASE(testSecondOrderExtrapolateData)
   int                   maxIterations = 1;
 
   // Test second order extrapolation
-  SerialCouplingScheme scheme(maxTime, maxTimesteps, dt, 16, first, second, accessor, globalCom, constants::FIXED_TIME_WINDOW_SIZE, BaseCouplingScheme::Implicit, maxIterations);
+  SerialCouplingScheme                 scheme(maxTime, maxTimesteps, dt, 16, first, second, accessor, globalCom, constants::FIXED_TIME_WINDOW_SIZE, BaseCouplingScheme::Implicit, maxIterations);
+  testing::SerialCouplingSchemeFixture fixture;
 
   scheme.addDataToSend(data, mesh, true);
   scheme.setExtrapolationOrder(2);
-  scheme.setupDataMatrices();
-  CouplingData *cplData = scheme.getSendData(dataID);
+  fixture.setupDataMatrices(scheme);
+  CouplingData *cplData = fixture.getSendData(scheme, dataID);
   BOOST_CHECK(cplData); // no nullptr
   BOOST_TEST(cplData->values().size() == 1);
   BOOST_TEST(cplData->previousIteration().size() == 1);
 
-  scheme.moveToNextWindow();
+  fixture.moveToNextWindow(scheme);
 
   // data is uninitialized
   BOOST_TEST(testing::equals(cplData->values()(0), 0.0));
@@ -544,33 +546,33 @@ BOOST_AUTO_TEST_CASE(testSecondOrderExtrapolateData)
 
   // start first window
   cplData->values()(0) = 1.0; // data provided at end of first window
-  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
-  scheme.storeDataInWaveforms();
+  fixture.setTimeWindows(scheme, scheme.getTimeWindows() + 1);
+  fixture.storeDataInWaveforms(scheme);
 
   // go to second window
-  scheme.moveToNextWindow(); // uses first order extrapolation at end of first window
+  fixture.moveToNextWindow(scheme); // uses first order extrapolation at end of first window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 0.0));
-  scheme.storeIteration();
+  fixture.storeIteration(scheme);
   BOOST_TEST(testing::equals(cplData->values()(0), 2.0)); // = 2*1 - 0
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
   cplData->values()(0) = 4.0; // data provided at end of second window
-  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
-  scheme.storeDataInWaveforms();
+  fixture.setTimeWindows(scheme, scheme.getTimeWindows() + 1);
+  fixture.storeDataInWaveforms(scheme);
 
   //go to third window
-  scheme.moveToNextWindow(); // uses second order extrapolation at end of second window
+  fixture.moveToNextWindow(scheme); // uses second order extrapolation at end of second window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.0));
-  scheme.storeIteration();
+  fixture.storeIteration(scheme);
   BOOST_TEST(testing::equals(cplData->values()(0), 8.0)); // = 2.5*4 - 2*1 + 0.5*0
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 8.0));
   cplData->values()(0) = 4.0; // data provided at end of third window
-  scheme.setTimeWindows(scheme.getTimeWindows() + 1);
-  scheme.storeDataInWaveforms();
+  fixture.setTimeWindows(scheme, scheme.getTimeWindows() + 1);
+  fixture.storeDataInWaveforms(scheme);
 
   // go to fourth window
-  scheme.moveToNextWindow(); // uses second order extrapolation at end of third window
+  fixture.moveToNextWindow(scheme); // uses second order extrapolation at end of third window
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 8.0));
-  scheme.storeIteration();
+  fixture.storeIteration(scheme);
   BOOST_TEST(testing::equals(cplData->values()(0), 2.5)); // = 2.5*4 - 2*4 + 0.5*1
   BOOST_TEST(testing::equals(cplData->previousIteration()(0), 2.5));
 }

--- a/src/testing/SerialCouplingSchemeFixture.cpp
+++ b/src/testing/SerialCouplingSchemeFixture.cpp
@@ -8,14 +8,39 @@ bool SerialCouplingSchemeFixture::isImplicitCouplingScheme(cplscheme::SerialCoup
   return cplscheme.isImplicitCouplingScheme();
 }
 
-cplscheme::CouplingData *SerialCouplingSchemeFixture::getReceiveData(cplscheme::SerialCouplingScheme &cplscheme, int dataID)
+cplscheme::CouplingData *SerialCouplingSchemeFixture::getReceiveData(cplscheme::SerialCouplingScheme &cplscheme, DataID dataID)
 {
   return cplscheme.getReceiveData(dataID);
 }
 
-cplscheme::CouplingData *SerialCouplingSchemeFixture::getSendData(cplscheme::SerialCouplingScheme &cplscheme, int dataID)
+cplscheme::CouplingData *SerialCouplingSchemeFixture::getSendData(cplscheme::SerialCouplingScheme &cplscheme, DataID dataID)
 {
   return cplscheme.getSendData(dataID);
+}
+
+void SerialCouplingSchemeFixture::setTimeWindows(cplscheme::SerialCouplingScheme &cplscheme, int timeWindows)
+{
+  cplscheme.setTimeWindows(timeWindows);
+}
+
+void SerialCouplingSchemeFixture::storeIteration(cplscheme::SerialCouplingScheme &cplscheme)
+{
+  cplscheme.storeIteration();
+}
+
+void SerialCouplingSchemeFixture::setupDataMatrices(cplscheme::SerialCouplingScheme &cplscheme)
+{
+  cplscheme.setupDataMatrices();
+}
+
+void SerialCouplingSchemeFixture::storeDataInWaveforms(cplscheme::SerialCouplingScheme &cplscheme)
+{
+  cplscheme.storeDataInWaveforms();
+}
+
+void SerialCouplingSchemeFixture::moveToNextWindow(cplscheme::SerialCouplingScheme &cplscheme)
+{
+  cplscheme.moveToNextWindow();
 }
 } // namespace testing
 } // namespace precice

--- a/src/testing/SerialCouplingSchemeFixture.hpp
+++ b/src/testing/SerialCouplingSchemeFixture.hpp
@@ -12,9 +12,19 @@ namespace testing {
 struct SerialCouplingSchemeFixture {
   bool isImplicitCouplingScheme(cplscheme::SerialCouplingScheme &cplscheme);
 
-  cplscheme::CouplingData *getReceiveData(cplscheme::SerialCouplingScheme &cplscheme, int dataID);
+  cplscheme::CouplingData *getReceiveData(cplscheme::SerialCouplingScheme &cplscheme, DataID dataID);
 
-  cplscheme::CouplingData *getSendData(cplscheme::SerialCouplingScheme &cplscheme, int dataID);
+  cplscheme::CouplingData *getSendData(cplscheme::SerialCouplingScheme &cplscheme, DataID dataID);
+
+  void setTimeWindows(cplscheme::SerialCouplingScheme &cplscheme, int timeWindows);
+
+  void storeIteration(cplscheme::SerialCouplingScheme &cplscheme);
+
+  void setupDataMatrices(cplscheme::SerialCouplingScheme &cplscheme);
+
+  void storeDataInWaveforms(cplscheme::SerialCouplingScheme &cplscheme);
+
+  void moveToNextWindow(cplscheme::SerialCouplingScheme &cplscheme);
 };
 
 } // namespace testing


### PR DESCRIPTION
## Main changes of this PR

Splits `testExtrapolateData` into `testFirstOrderExtrapolateData` and `testSecondOrderExtrapolateData`. Use `SerialCouplingSchemeFixture` and don't make test a friend of `SerialCouplingScheme`.

## Motivation and additional information

Splitting the test, because the state when testing second order extrapolation is inconsistent. This caused problems in https://github.com/precice/precice/pull/1083 and therefore I'm pulling this change here into this PR.

Using fixtures is a style we agreed on for doing tests, where we have to access private member functions.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
