### PR TITLE
Clean-up cmake output messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT CMAKE_BUILD_TYPE)
   message(WARNING "You did not specify a CMAKE_BUILD_TYPE.
 
   We will assume you asked for a Debug build.")
-  set(CMAKE_BUILD_TYPE Debug CACHE STRINGS "The type of this build" FORCE)
+  set(CMAKE_BUILD_TYPE Debug CACHE STRING "The type of this build" FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
 endif()
 

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -48,7 +48,7 @@ set(CPACK_GENERATOR "TGZ")
 if("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
   list(APPEND CPACK_GENERATOR "DEB")
 else()
-  message("Debian package generator disabled: Install prefix is not \"/usr\"")
+  message(STATUS "Debian package generator disabled: Install prefix is not \"/usr\"")
 endif()
 
 #set(CPACK_SOURCE_PACKAGE_FILE_NAME "")


### PR DESCRIPTION
## Main changes of this PR
Turns the `CPack` statement into a status messages and fixes a typo of `STRING` leading to a cmake dev warning

## Motivation and additional information
Cleaning up the cmake messages
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
