### PR TITLE
Add test suites InitializeData and Time

### DIFF
--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -291,6 +291,9 @@ BOOST_AUTO_TEST_CASE(TestExplicitSockets)
   runTestExplicit(config, context);
 }
 
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Explicit)
+
 /// Test to run a simple "do nothing" coupling with subcycling solvers.
 BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling)
 {
@@ -327,9 +330,6 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling)
     BOOST_TEST(timestep == 30);
   }
 }
-
-BOOST_AUTO_TEST_SUITE(Waveform)
-BOOST_AUTO_TEST_SUITE(Explicit)
 
 /// Test to run a simple coupling with subcycling.
 /// Ensures that each time step provides its own data, but preCICE will only exchange data at the end of the window.


### PR DESCRIPTION
## Main changes of this PR

Related to https://github.com/precice/precice/issues/1021. Adds new test suites in `SerialTests.cpp`:

```
PreciceTests*
    Serial*
        Time*
            Explicit*
                testExplicitWithSubcycling
                testExplicitReadWriteScalarDataWithSubcycling*
        InitializeData*
            testExplicitWithDataInitialization*
            testImplicitWithDataInitialization*
```

## Motivation and additional information

`SerialTests.cpp` contains too many tests and has little structure. I'm adding more test suites in this PR. This is preparatory work for adding more tests in the respective test suite and moving tests suites into independent files `InitializeDataTests.cpp` and `WaveformTests.cpp`. See also #1112.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes. **no relevant changes**
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
