### PR TITLE
Add SerialTests/Time and SerialTests/InitializeData

### DIFF
--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -291,6 +291,9 @@ BOOST_AUTO_TEST_CASE(TestExplicitSockets)
   runTestExplicit(config, context);
 }
 
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Explicit)
+
 /// Test to run a simple "do nothing" coupling with subcycling solvers.
 BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling)
 {
@@ -327,9 +330,6 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling)
     BOOST_TEST(timestep == 30);
   }
 }
-
-BOOST_AUTO_TEST_SUITE(Waveform)
-BOOST_AUTO_TEST_SUITE(Explicit)
 
 /// Test to run a simple coupling with subcycling.
 /// Ensures that each time step provides its own data, but preCICE will only exchange data at the end of the window.

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -442,6 +442,148 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
   BOOST_TEST(timestep == nWindows * nSubsteps);
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Implicit)
+
+/// Test to run a simple coupling with subcycling.
+/// Ensures that each time step provides its own data, but preCICE will only exchange data at the end of the window.
+BOOST_AUTO_TEST_CASE(testImplicitReadWriteScalarDataWithSubcycling)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  SolverInterface precice(context.name, _pathToTests + "implicit-scalar-data-init.xml", 0, 1); // serial coupling, SolverOne first
+
+  MeshID meshID;
+  DataID writeDataID;
+  DataID readDataID;
+
+  typedef double (*DataFunction)(double, int);
+
+  DataFunction dataOneFunction = [](double t, int idx) -> double {
+    return (double) (2 + t + idx);
+  };
+  DataFunction dataTwoFunction = [](double t, int idx) -> double {
+    return (double) (10 + t + idx);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  if (context.isNamed("SolverOne")) {
+    meshID        = precice.getMeshID("MeshOne");
+    writeDataID   = precice.getDataID("DataOne", meshID);
+    writeFunction = dataOneFunction;
+    readDataID    = precice.getDataID("DataTwo", meshID);
+    readFunction  = dataTwoFunction;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshID        = precice.getMeshID("MeshTwo");
+    writeDataID   = precice.getDataID("DataTwo", meshID);
+    writeFunction = dataTwoFunction;
+    readDataID    = precice.getDataID("DataOne", meshID);
+    readFunction  = dataOneFunction;
+  }
+
+  int n_vertices = 1;
+
+  std::vector<VertexID> vertexIDs(n_vertices, 0);
+  std::vector<double>   writeData(n_vertices, 0);
+  std::vector<double>   readData(n_vertices, 0);
+  double                oldWriteData, oldReadData;
+
+  vertexIDs[0] = precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+
+  int    nSubsteps       = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows        = 5; // perform 5 windows.
+  double maxDt           = precice.initialize();
+  double windowDt        = maxDt;
+  int    timestep        = 0;
+  int    timewindow      = 0;
+  double startTime       = 0;
+  double windowStartTime = 0;
+  int    windowStartStep = 0;
+  int    iterations      = 0;
+  double dt              = windowDt / (nSubsteps - 0.5); // Timestep length desired by solver. E.g. 4 steps with size 4/7. Fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+  double expectedDts[]   = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0};
+  double currentDt       = dt; // Timestep length used by solver
+  double time            = timestep * dt;
+
+  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+    for (int i = 0; i < n_vertices; i++) {
+      writeData[i] = writeFunction(time, i);
+      precice.writeScalarData(writeDataID, vertexIDs[i], writeData[i]);
+    }
+    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
+  }
+
+  precice.initializeData();
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+      windowStartTime = time;
+      windowStartStep = timestep;
+      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+    }
+
+    BOOST_TEST(readData.size() == n_vertices);
+    for (int i = 0; i < n_vertices; i++) {
+      oldReadData = readData[i];
+      precice.readScalarData(readDataID, vertexIDs[i], readData[i]);
+      std::cout << context.name << " at time " << time << " reads " << readData[i] << " for time window = " << timewindow << ", time step " << timestep << ", it = " << iterations << std::endl;
+      if (iterations == 0 && timestep == 0 && context.isNamed("SolverOne")) {                      // special situation: SolverOne in its very first time window, first iteration, first time step
+        BOOST_TEST(readData[i] != oldReadData);                                                    // update from uninitialized to initial data.
+        BOOST_TEST(readData[i] == readFunction(startTime, i));                                     // use initial data only.
+      } else if (iterations == 0 && context.isNamed("SolverOne")) {                                // special situation: SolverOne gets the old data its first iteration for all time windows.
+        BOOST_TEST(readData[i] == oldReadData);                                                    // ensure that read data stays the same from one step to the next, if not a new window is entered
+        BOOST_TEST(readData[i] == readFunction(startTime + (timewindow) *windowDt, i));            // data at end of window was written by other solver.
+      } else if (iterations == 1 && timestep == windowStartStep && context.isNamed("SolverOne")) { // special situation: SolverOne in its second iteration, first timestep of window
+        BOOST_TEST(readData[i] != oldReadData);                                                    // ensure that read data stays the same from one step to the next, if not a new window is entered
+        BOOST_TEST(readData[i] == readFunction(startTime + (timewindow + 1) * windowDt, i));       // data at end of window was written by other solver.
+      } else if (iterations == 0 && timestep == 0 && context.isNamed("SolverTwo")) {               // special situation: SolverTwo in its very first time window, first iteration, first time step
+        BOOST_TEST(readData[i] != oldReadData);                                                    // update from uninitialized to initial data.
+        BOOST_TEST(readData[i] == readFunction(startTime + (timewindow + 1) * windowDt, i));       // data at end of window was written by other solver.
+      } else if (precice.isTimeWindowComplete()) {                                                 // moving to next window
+        BOOST_TEST(readData[i] != oldReadData);                                                    // ensure that read data changes from one step to the next, if a new window is entered
+        BOOST_TEST(readData[i] == readFunction(startTime + (timewindow + 1) * windowDt, i));       // data at end of window was written by other solver.
+      } else if (not precice.isTimeWindowComplete()) {                                             // still iterating in the same window
+        BOOST_TEST(readData[i] == oldReadData);                                                    // ensure that read data stays the same from one step to the next, if not a new window is entered
+        BOOST_TEST(readData[i] == readFunction(startTime + (timewindow + 1) * windowDt, i));       // data at end of window was written by other solver.
+      } else {                                                                                     // we should not enter this branch, because this would skip all tests.
+        BOOST_TEST(false);
+      }
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    BOOST_TEST(currentDt == expectedDts[timestep % nSubsteps]);
+    time += currentDt;
+
+    BOOST_TEST(writeData.size() == n_vertices);
+    for (int i = 0; i < n_vertices; i++) {
+      oldWriteData = writeData[i];
+      writeData[i] = writeFunction(time, i);
+      //std::cout << context.name << " at time " << time << " writes " << writeData[i] << " for time window = " << timewindow << ", time step " << timestep << ", it = " << iterations << std::endl;
+      BOOST_TEST(writeData[i] != oldWriteData); // ensure that write data differs from one step to the next
+      precice.writeScalarData(writeDataID, vertexIDs[i], writeData[i]);
+    }
+    maxDt     = precice.advance(currentDt);
+    currentDt = dt > maxDt ? maxDt : dt;
+    timestep++;
+    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+      iterations++;
+      timestep = windowStartStep;
+      time     = windowStartTime;
+      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
+    }
+    if (precice.isTimeWindowComplete()) {
+      timewindow++;
+      iterations = 0;
+    }
+  }
+
+  precice.finalize();
+  BOOST_TEST(timestep == nWindows * nSubsteps);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 
 /// One solver uses incremental position set, read/write methods.

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -539,6 +539,61 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
 #endif
 
 BOOST_AUTO_TEST_SUITE(InitializeData)
+
+/**
+ * @brief helper function for a simple test with data initialization
+ */
+void testDataInitialization(precice::testing::TestContext context, std::string config)
+{
+  using Eigen::Vector3d;
+
+  SolverInterface cplInterface(context.name, config, 0, 1);
+  if (context.isNamed("SolverOne")) {
+    int      meshOneID = cplInterface.getMeshID("MeshOne");
+    Vector3d pos       = Vector3d::Zero();
+    cplInterface.setMeshVertex(meshOneID, pos.data());
+    double maxDt      = cplInterface.initialize();
+    int    dataID     = cplInterface.getDataID("Data", meshOneID);
+    double valueDataB = 0.0;
+    cplInterface.initializeData();
+    cplInterface.readScalarData(dataID, 0, valueDataB);
+    BOOST_TEST(2.0 == valueDataB);
+    cplInterface.finalize();
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    int      meshTwoID = cplInterface.getMeshID("MeshTwo");
+    Vector3d pos       = Vector3d::Zero();
+    cplInterface.setMeshVertex(meshTwoID, pos.data());
+    double maxDt  = cplInterface.initialize();
+    int    dataID = cplInterface.getDataID("Data", meshTwoID);
+    cplInterface.writeScalarData(dataID, 0, 2.0);
+    //tell preCICE that data has been written and call initializeData
+    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
+    cplInterface.initializeData();
+    cplInterface.finalize();
+  }
+}
+
+/**
+ * @brief The second solver initializes the data of the first. Use write mapping for data.
+ */
+BOOST_AUTO_TEST_CASE(testDataInitializationWriteMapping)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  testDataInitialization(context, _pathToTests + "oneway-data-init-write-mapping.xml");
+}
+
+/**
+ * @brief The second solver initializes the data of the first. Use read mapping for data.
+ */
+BOOST_AUTO_TEST_CASE(testDataInitializationReadMapping)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  testDataInitialization(context, _pathToTests + "oneway-data-init-read-mapping.xml");
+}
+
 /**
  * @brief The second solver initializes the data of the first.
  *

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -328,6 +328,9 @@ BOOST_AUTO_TEST_CASE(testExplicitWithSubcycling)
   }
 }
 
+BOOST_AUTO_TEST_SUITE(Waveform)
+BOOST_AUTO_TEST_SUITE(Explicit)
+
 /// Test to run a simple coupling with subcycling.
 /// Ensures that each time step provides its own data, but preCICE will only exchange data at the end of the window.
 BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
@@ -438,6 +441,8 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
   precice.finalize();
   BOOST_TEST(timestep == nWindows * nSubsteps);
 }
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
 
 /// One solver uses incremental position set, read/write methods.
 /// @todo This test uses resetmesh. How did this ever work?
@@ -533,6 +538,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataExchange)
 }
 #endif
 
+BOOST_AUTO_TEST_SUITE(InitializeData)
 /**
  * @brief The second solver initializes the data of the first.
  *
@@ -589,6 +595,7 @@ BOOST_AUTO_TEST_CASE(testExplicitWithDataInitialization)
     cplInterface.finalize();
   }
 }
+BOOST_AUTO_TEST_SUITE_END()
 
 /**
  * @brief Tests the reading and writing of data multiple times within one timestep.
@@ -1550,6 +1557,7 @@ BOOST_AUTO_TEST_CASE(testImplicit)
   }
 }
 
+BOOST_AUTO_TEST_SUITE(InitializeData)
 /// Test simple coupled simulation with iterations, data initialization and without acceleration
 BOOST_AUTO_TEST_CASE(testImplicitWithDataInitialization)
 {
@@ -1614,6 +1622,8 @@ BOOST_AUTO_TEST_CASE(testImplicitWithDataInitialization)
   }
   couplingInterface.finalize();
 }
+
+BOOST_AUTO_TEST_SUITE_END()
 
 /// Tests stationary mapping with solver provided meshes.
 void runTestStationaryMappingWithSolverMesh(std::string const &config, int dim, TestContext const &context)

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithSubcycling)
   int    timestep      = 0;
   int    timewindow    = 0;
   double dt            = windowDt / (nSubsteps - 0.5); // Timestep length desired by solver. E.g. 4 steps with size 2/7. Fourth step will be restricted to 1/7 via preCICE steering to fit into the window.
-  double expectedDts[] = {2.0 / 7.0, 2.0 / 7.0, 2.0 / 7.0, 1.0 / 7.0};
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0};
   double currentDt     = dt; // Timestep length used by solver
   double time          = timestep * dt;
 

--- a/src/precice/tests/explicit-scalar-data-init.xml
+++ b/src/precice/tests/explicit-scalar-data-init.xml
@@ -42,7 +42,7 @@
     <coupling-scheme:serial-explicit>
       <participants first="SolverOne" second="SolverTwo" />
       <max-time-windows value="5" />
-      <time-window-size value="1.0" />
+      <time-window-size value="2" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>

--- a/src/precice/tests/implicit-scalar-data-init.xml
+++ b/src/precice/tests/implicit-scalar-data-init.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="DataOne" />
+    <data:scalar name="DataTwo" />
+
+    <mesh name="MeshOne">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <write-data name="DataOne" mesh="MeshOne" />
+      <read-data name="DataTwo" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshTwo" provide="on" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="conservative" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="consistent" />
+      <write-data name="DataTwo" mesh="MeshTwo" />
+      <read-data name="DataOne" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="5" />
+      <time-window-size value="2" />
+      <max-iterations value="3" />
+      <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/precice/tests/oneway-data-init-read-mapping.xml
+++ b/src/precice/tests/oneway-data-init-read-mapping.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="Data" />
+
+    <mesh name="MeshOne">
+      <use-data name="Data" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="Data" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <use-mesh name="MeshTwo" from="SolverTwo" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="conservative"
+        timing="initial" />
+      <read-data name="Data" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshTwo" provide="on" />
+      <write-data name="Data" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="5" />
+      <time-window-size value="1.0" />
+      <exchange data="Data" mesh="MeshTwo" from="SolverTwo" to="SolverOne" initialize="on" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/precice/tests/oneway-data-init-write-mapping.xml
+++ b/src/precice/tests/oneway-data-init-write-mapping.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="Data" />
+
+    <mesh name="MeshOne">
+      <use-data name="Data" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="Data" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <read-data name="Data" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshTwo" provide="on" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="conservative"
+        timing="initial" />
+      <write-data name="Data" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="5" />
+      <time-window-size value="1.0" />
+      <exchange data="Data" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>


### PR DESCRIPTION
## Main changes of this PR

Adds more tests for subcycling and data initialization. Preparation for features implemented in #1029.

```
PreciceTests*
    Serial*
        Time*
            Explicit*
                testExplicitWithSubcycling*
                testExplicitReadWriteScalarDataWithSubcycling*
            Implicit*
                testImplicitReadWriteScalarDataWithSubcycling*
        InitializeData*
            testDataInitializationWriteMapping*
            testDataInitializationReadMapping*
            testExplicitWithDataInitialization*
            testImplicitWithDataInitialization*
```

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes. **not relevant**
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [x] Merge #1119 first.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
