### PR TITLE
Restrict access to Waveform::_timeWindows.

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -261,7 +261,7 @@ void BaseCouplingScheme::moveToNextWindow()
   for (DataMap::value_type &pair : getAccelerationData()) {
     PRECICE_DEBUG("Store data: {}", pair.first);
     _waveforms[pair.first]->moveToNextWindow(getTimeWindows(), _extrapolationOrder);
-    pair.second->values() = _waveforms[pair.first]->lastTimeWindows().col(0);
+    pair.second->values() = _waveforms[pair.first]->getInitialGuess();
   }
 }
 

--- a/src/testing/WaveformFixture.cpp
+++ b/src/testing/WaveformFixture.cpp
@@ -12,5 +12,11 @@ int WaveformFixture::numberOfData(time::Waveform &waveform)
 {
   return waveform.numberOfData();
 }
+
+double WaveformFixture::getValue(time::Waveform &waveform, int dataID, int sampleID)
+{
+  return waveform._timeWindows(dataID, sampleID);
+}
+
 } // namespace testing
 } // namespace precice

--- a/src/testing/WaveformFixture.hpp
+++ b/src/testing/WaveformFixture.hpp
@@ -14,6 +14,8 @@ public:
   int numberOfSamples(time::Waveform &waveform);
 
   int numberOfData(time::Waveform &waveform);
+
+  double getValue(time::Waveform &waveform, int dataID, int sampleID);
 };
 
 } // namespace testing

--- a/src/time/Waveform.cpp
+++ b/src/time/Waveform.cpp
@@ -37,9 +37,9 @@ void Waveform::moveToNextWindow(int timeWindows, int order)
   utils::shiftSetFirst(this->_timeWindows, initialGuess);
 }
 
-const Eigen::MatrixXd &Waveform::lastTimeWindows()
+const Eigen::VectorXd Waveform::getInitialGuess()
 {
-  return _timeWindows;
+  return _timeWindows.col(0);
 }
 
 int Waveform::numberOfSamples()

--- a/src/time/Waveform.hpp
+++ b/src/time/Waveform.hpp
@@ -36,10 +36,9 @@ public:
   void moveToNextWindow(int timeWindows, int order = 0);
 
   /**
-   * @brief getter for Eigen::MatrixXd containing data of current and past time windows. Each column represents a sample in time, with col(0)
-   * being the current time window.
+   * @brief getter for data at the current time window.
    */
-  const Eigen::MatrixXd &lastTimeWindows();
+  const Eigen::VectorXd getInitialGuess();
 
 private:
   /// Data values of time windows.

--- a/src/time/tests/WaveformTest.cpp
+++ b/src/time/tests/WaveformTest.cpp
@@ -23,27 +23,27 @@ BOOST_AUTO_TEST_CASE(testExtrapolateDataFirstOrder)
   Waveform  waveform(1, extrapolationOrder);
   BOOST_TEST(fixture.numberOfSamples(waveform) == 2);
   BOOST_TEST(fixture.numberOfData(waveform) == 1);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 0.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 0.0));
 
   Eigen::VectorXd value(1);
   value(0) = 1.0;
   waveform.store(value);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 1.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 0.0));
   timeWindowCounter++;
   waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);   // applies first order extrapolation in second window
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 2.0)); // = 2*1 - 0
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 2.0)); // = 2*1 - 0
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 1.0));
 
   value(0) = 4.0;
   waveform.store(value);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 4.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 4.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 1.0));
   timeWindowCounter++;
   waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);   // applies first order extrapolation in third window
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 7.0)); // = 2*4 - 1
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 4.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 7.0)); // = 2*4 - 1
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 4.0));
 }
 
 BOOST_AUTO_TEST_CASE(testExtrapolateDataSecondOrder)
@@ -58,43 +58,43 @@ BOOST_AUTO_TEST_CASE(testExtrapolateDataSecondOrder)
   Waveform  waveform(1, extrapolationOrder);
   BOOST_TEST(fixture.numberOfSamples(waveform) == 3);
   BOOST_TEST(fixture.numberOfData(waveform) == 1);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 0.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 0.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 2), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 2), 0.0));
 
   Eigen::VectorXd value(1);
   value(0) = 1.0;
   waveform.store(value);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 1.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 0.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 2), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 2), 0.0));
   timeWindowCounter++;
   waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);   // applies first order extrapolation in second window
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 2.0)); // = 2*1 - 0
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 2), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 2.0)); // = 2*1 - 0
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 2), 0.0));
 
   value(0) = 4.0;
   waveform.store(value);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 4.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 1.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 2), 0.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 4.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 2), 0.0));
   timeWindowCounter++;
   waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);   // applies second order extrapolation in third window
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 8.0)); // = 2.5*4 - 2 * 1 + 0.5 * 0
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 4.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 2), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 8.0)); // = 2.5*4 - 2 * 1 + 0.5 * 0
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 4.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 2), 1.0));
 
   value(0) = 8.0;
   waveform.store(value);
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 8.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 4.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 2), 1.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 8.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 4.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 2), 1.0));
   timeWindowCounter++;
   waveform.moveToNextWindow(timeWindowCounter, extrapolationOrder);    // applies second order extrapolation in fourth window
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 0), 12.5)); // = 2.5 * 8 - 2 * 4 + 0.5 * 1
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 1), 8.0));
-  BOOST_TEST(testing::equals(waveform.lastTimeWindows()(0, 2), 4.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 0), 12.5)); // = 2.5 * 8 - 2 * 4 + 0.5 * 1
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 1), 8.0));
+  BOOST_TEST(testing::equals(fixture.getValue(waveform, 0, 2), 4.0));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Main changes of this PR

Restrict access to the `_timeWindows` data structure. `BaseCouplingScheme` only has to access a single column. Other columns are be accessed from the tests only. This can be done via the fixture.

## Author's checklist

* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.
