### PR TITLE
Change naming convention in VTKXML exporting

### DIFF
--- a/docs/changelog/1126.md
+++ b/docs/changelog/1126.md
@@ -1,0 +1,1 @@
+- Fixed the naming scheme of parallel VTU files (`.pvtu` and `.vtu` pieces). Paraview now correctly detects exports of multiple time-steps as a time series.

--- a/src/io/ExportVTKXML.cpp
+++ b/src/io/ExportVTKXML.cpp
@@ -67,7 +67,7 @@ void ExportVTKXML::writeMasterFile(
 {
   namespace fs = boost::filesystem;
   fs::path outfile(location);
-  outfile = outfile / fs::path(name + "_master.pvtu");
+  outfile = outfile / fs::path(name + ".pvtu");
   std::ofstream outMasterFile(outfile.string(), std::ios::trunc);
 
   PRECICE_CHECK(outMasterFile, "VTKXML export failed to open master file \"{}\"", outfile);
@@ -112,7 +112,7 @@ void ExportVTKXML::writeMasterFile(
 
   for (int i = 0; i < utils::MasterSlave::getSize(); i++) {
     if (mesh.getVertexDistribution()[i].size() > 0) { //only non-empty subfiles
-      outMasterFile << "      <Piece Source=\"" << name << "_r" << i << ".vtu\"/>\n";
+      outMasterFile << "      <Piece Source=\"" << name << "_" << i << ".vtu\"/>\n";
     }
   }
 
@@ -137,7 +137,7 @@ void ExportVTKXML::writeSubFile(
 
   namespace fs = boost::filesystem;
   fs::path outfile(location);
-  outfile = outfile / fs::path(name + "_r" + std::to_string(utils::MasterSlave::getRank()) + ".vtu");
+  outfile = outfile / fs::path(name + "_" + std::to_string(utils::MasterSlave::getRank()) + ".vtu");
   std::ofstream outSubFile(outfile.string(), std::ios::trunc);
 
   PRECICE_CHECK(outSubFile, "VTKXML export failed to open slave file \"{}\"", outfile);


### PR DESCRIPTION
## Main changes of this PR

The naming convention of Parallel VTU export is changed.

## Motivation and additional information

This change fixes #1125, closes #226.


## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
