### PR TITLE
Add VTK PolyData Export

### DIFF
--- a/src/io/Constants.cpp
+++ b/src/io/Constants.cpp
@@ -19,6 +19,11 @@ int exportVTKXML()
   return 3;
 }
 
+int exportVTP()
+{
+  return 4;
+}
+
 } // namespace constants
 } // namespace io
 } // namespace precice

--- a/src/io/Constants.hpp
+++ b/src/io/Constants.hpp
@@ -7,6 +7,7 @@ namespace constants {
 int exportVTK();
 int exportAll();
 int exportVTKXML();
+int exportVTP();
 
 } // namespace constants
 } // namespace io

--- a/src/io/ExportVTP.cpp
+++ b/src/io/ExportVTP.cpp
@@ -1,0 +1,175 @@
+#include "ExportVTP.hpp"
+#include <Eigen/Core>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include "Constants.hpp"
+#include "io/Export.hpp"
+#include "logging/LogMacros.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice {
+namespace io {
+
+int ExportVTP::getType() const
+{
+  return constants::exportVTP();
+}
+
+void ExportVTP::doExport(
+    const std::string &name,
+    const std::string &location,
+    mesh::Mesh &       mesh)
+{
+  PRECICE_TRACE(name, location, mesh.getName());
+  PRECICE_ASSERT(name != std::string(""));
+
+  namespace fs = boost::filesystem;
+  fs::path outfile(location);
+  if (not location.empty())
+    fs::create_directories(outfile);
+  outfile = outfile / fs::path(name + ".vtp");
+  std::ofstream outstream(outfile.string(), std::ios::trunc);
+  PRECICE_CHECK(outstream, "VTP export failed to open destination file \"{}\"", outfile);
+
+  initializeWriting(outstream);
+  writeHeader(outstream);
+  exportMesh(outstream, mesh);
+  exportData(outstream, mesh);
+  outstream.close();
+}
+
+void ExportVTP::exportMesh(std::ofstream &outFile, mesh::Mesh const &mesh)
+{
+  PRECICE_TRACE(mesh.getName());
+
+  // Plot vertices
+  outFile << "POINTS " << mesh.vertices().size() << " double \n\n";
+  for (const mesh::Vertex &vertex : mesh.vertices()) {
+    writeVertex(vertex.getCoords(), outFile);
+  }
+  outFile << '\n';
+
+  // Plot edges
+
+  outFile << "LINES " << mesh.edges().size() << ' ' << mesh.edges().size() * 3 << "\n\n";
+  for (auto const &edge : mesh.edges()) {
+    int internalIndices[2];
+    internalIndices[0] = edge.vertex(0).getID();
+    internalIndices[1] = edge.vertex(1).getID();
+    writeLine(internalIndices, outFile);
+  }
+  if (mesh.getDimensions() == 3) {
+    size_t sizeTriangles = mesh.triangles().size();
+    outFile << "POLYGONS " << sizeTriangles << ' '
+            << sizeTriangles * 4 << "\n\n";
+    for (auto const &triangle : mesh.triangles()) {
+      int internalIndices[3];
+      internalIndices[0] = triangle.vertex(0).getID();
+      internalIndices[1] = triangle.vertex(1).getID();
+      internalIndices[2] = triangle.vertex(2).getID();
+      writeTriangle(internalIndices, outFile);
+    }
+  }
+  outFile << '\n';
+}
+
+void ExportVTP::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
+{
+  outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
+
+  outFile << "SCALARS Rank unsigned_int\n";
+  outFile << "LOOKUP_TABLE default\n";
+  std::fill_n(std::ostream_iterator<char const *>(outFile), mesh.vertices().size(), "0 ");
+  outFile << "\n\n";
+
+  for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
+    Eigen::VectorXd &values = data->values();
+    if (data->getDimensions() > 1) {
+      Eigen::VectorXd viewTemp(data->getDimensions());
+      outFile << "VECTORS " << data->getName() << " double\n";
+      for (const mesh::Vertex &vertex : mesh.vertices()) {
+        int offset = vertex.getID() * data->getDimensions();
+        for (int i = 0; i < data->getDimensions(); i++) {
+          viewTemp[i] = values(offset + i);
+        }
+        int i = 0;
+        for (; i < data->getDimensions(); i++) {
+          outFile << viewTemp[i] << ' ';
+        }
+        if (i < 3) {
+          outFile << '0';
+        }
+        outFile << '\n';
+      }
+      outFile << '\n';
+    } else if (data->getDimensions() == 1) {
+      outFile << "SCALARS " << data->getName() << " double\n";
+      outFile << "LOOKUP_TABLE default\n";
+      for (const mesh::Vertex &vertex : mesh.vertices()) {
+        outFile << values(vertex.getID()) << '\n';
+      }
+      outFile << '\n';
+    }
+  }
+}
+
+void ExportVTP::initializeWriting(
+    std::ofstream &filestream)
+{
+  filestream.setf(std::ios::showpoint);
+  filestream.setf(std::ios::scientific);
+  filestream << std::setprecision(std::numeric_limits<double>::max_digits10);
+}
+
+void ExportVTP::writeHeader(
+    std::ostream &outFile)
+{
+  outFile << "# vtk DataFile Version 2.0\n\n"
+          << "ASCII\n\n"
+          << "DATASET POLYDATA\n\n";
+}
+
+void ExportVTP::writeVertex(
+    const Eigen::VectorXd &position,
+    std::ostream &         outFile)
+{
+  if (position.size() == 2) {
+    outFile << position(0) << "  " << position(1) << "  " << 0.0 << '\n';
+  } else {
+    PRECICE_ASSERT(position.size() == 3);
+    outFile << position(0) << "  " << position(1) << "  " << position(2) << '\n';
+  }
+}
+
+void ExportVTP::writeTriangle(
+    int           vertexIndices[3],
+    std::ostream &outFile)
+{
+  outFile << 3 << ' ';
+  for (int i = 0; i < 3; i++) {
+    outFile << vertexIndices[i] << ' ';
+  }
+  outFile << '\n';
+}
+
+void ExportVTP::writeLine(
+    int           vertexIndices[2],
+    std::ostream &outFile)
+{
+  outFile << 2 << ' ';
+  for (int i = 0; i < 2; i++) {
+    outFile << vertexIndices[i] << ' ';
+  }
+  outFile << '\n';
+}
+
+} // namespace io
+} // namespace precice

--- a/src/io/ExportVTP.hpp
+++ b/src/io/ExportVTP.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <iosfwd>
+#include <string>
+#include "Export.hpp"
+#include "logging/Logger.hpp"
+
+namespace precice {
+namespace mesh {
+class Mesh;
+}
+} // namespace precice
+
+namespace precice {
+namespace io {
+
+/// Writes polygonal, or triangle meshes to vtk files.
+class ExportVTP : public Export {
+public:
+  /// Returns the VTK type ID.
+  virtual int getType() const;
+
+  /// Perform writing to VTK file
+  virtual void doExport(
+      const std::string &name,
+      const std::string &location,
+      mesh::Mesh &       mesh);
+
+  static void initializeWriting(
+      std::ofstream &filestream);
+
+  static void writeHeader(std::ostream &outFile);
+
+  static void writeVertex(
+      const Eigen::VectorXd &position,
+      std::ostream &         outFile);
+
+  static void writeLine(
+      int           vertexIndices[2],
+      std::ostream &outFile);
+
+  static void writeTriangle(
+      int           vertexIndices[3],
+      std::ostream &outFile);
+
+private:
+  logging::Logger _log{"io::ExportVTP"};
+
+  void openFile(
+      std::ofstream &    outFile,
+      const std::string &filename) const;
+
+  void exportMesh(std::ofstream &outFile, mesh::Mesh const &mesh);
+
+  void exportData(std::ofstream &outFile, mesh::Mesh const &mesh);
+};
+
+} // namespace io
+} // namespace precice

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -1,0 +1,67 @@
+#include <Eigen/Core>
+#include <algorithm>
+#include <string>
+#include "io/Export.hpp"
+#include "io/ExportVTP.hpp"
+#include "mesh/Mesh.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+namespace precice {
+namespace mesh {
+class Edge;
+class Vertex;
+} // namespace mesh
+} // namespace precice
+
+BOOST_AUTO_TEST_SUITE(IOTests)
+
+BOOST_AUTO_TEST_SUITE(VTPExport)
+
+using namespace precice;
+
+BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
+{
+  PRECICE_TEST(1_rank);
+  int             dim = 2;
+  mesh::Mesh      mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
+  mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
+  Eigen::VectorXd coords3 = Eigen::VectorXd::Constant(dim, 0.0);
+  coords3(0)              = 1.0;
+  mesh::Vertex &v3        = mesh.createVertex(coords3);
+
+  mesh.createEdge(v1, v2);
+  mesh.createEdge(v2, v3);
+  mesh.createEdge(v3, v1);
+
+  io::ExportVTP exportVTP;
+  std::string   filename = "io-VTPExport-ExportPolygonalMesh";
+  std::string   location = "";
+  exportVTP.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
+{
+  PRECICE_TEST(1_rank);
+  int             dim = 3;
+  mesh::Mesh      mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Vertex &  v1      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 0.0));
+  mesh::Vertex &  v2      = mesh.createVertex(Eigen::VectorXd::Constant(dim, 1.0));
+  Eigen::VectorXd coords3 = Eigen::VectorXd::Zero(dim);
+  coords3(0)              = 1.0;
+  mesh::Vertex &v3        = mesh.createVertex(coords3);
+
+  mesh::Edge &e1 = mesh.createEdge(v1, v2);
+  mesh::Edge &e2 = mesh.createEdge(v2, v3);
+  mesh::Edge &e3 = mesh.createEdge(v3, v1);
+  mesh.createTriangle(e1, e2, e3);
+
+  io::ExportVTP exportVTP;
+  std::string   filename = "io-VTPExport-ExportTriangulatedMesh";
+  std::string   location = "";
+  exportVTP.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ExportVTP
+BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -13,6 +13,7 @@
 #include "io/ExportContext.hpp"
 #include "io/ExportVTK.hpp"
 #include "io/ExportVTKXML.hpp"
+#include "io/ExportVTP.hpp"
 #include "io/SharedPointer.hpp"
 #include "io/config/ExportConfiguration.hpp"
 #include "logging/LogMacros.hpp"
@@ -552,6 +553,12 @@ void ParticipantConfiguration::finishParticipantConfiguration(
         exporter = io::PtrExport(new io::ExportVTKXML());
       } else {
         exporter = io::PtrExport(new io::ExportVTK());
+      }
+    } else if (exportContext.type == VALUE_VTP) {
+      if (context.size > 1) {
+        PRECICE_ERROR("VTP Export only available for non-parallel cases");
+      } else {
+        exporter = io::PtrExport(new io::ExportVTP());
       }
     } else {
       PRECICE_ERROR("Participant {} defines an <export/> tag of unknown type \"{}\".",

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -98,6 +98,7 @@ private:
   const std::string VALUE_NO_FILTER        = "no-filter";
 
   const std::string VALUE_VTK = "vtk";
+  const std::string VALUE_VTP = "vtp";
 
   int _dimensions = 0;
 

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -130,6 +130,8 @@ target_sources(precice
     src/io/ExportVTK.hpp
     src/io/ExportVTKXML.cpp
     src/io/ExportVTKXML.hpp
+    src/io/ExportVTP.cpp
+    src/io/ExportVTP.hpp
     src/io/SharedPointer.hpp
     src/io/TXTReader.cpp
     src/io/TXTReader.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -31,6 +31,7 @@ target_sources(testprecice
     src/io/tests/ExportConfigurationTest.cpp
     src/io/tests/ExportVTKTest.cpp
     src/io/tests/ExportVTKXMLTest.cpp
+    src/io/tests/ExportVTPTest.cpp
     src/io/tests/TXTTableWriterTest.cpp
     src/io/tests/TXTWriterReaderTest.cpp
     src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -52,6 +53,7 @@ target_sources(testprecice
     src/mesh/tests/VertexTest.cpp
     src/partition/tests/ProvidedPartitionTest.cpp
     src/partition/tests/ReceivedPartitionTest.cpp
+    src/partition/tests/fixtures.hpp
     src/precice/tests/DataContextTest.cpp
     src/precice/tests/ParallelTests.cpp
     src/precice/tests/SerialTests.cpp
@@ -68,9 +70,9 @@ target_sources(testprecice
     src/testing/TestContext.hpp
     src/testing/Testing.cpp
     src/testing/Testing.hpp
-    src/testing/main.cpp
     src/testing/WaveformFixture.cpp
     src/testing/WaveformFixture.hpp
+    src/testing/main.cpp
     src/testing/tests/ExampleTests.cpp
     src/time/tests/WaveformTest.cpp
     src/utils/tests/AlgorithmTest.cpp


### PR DESCRIPTION
## Main changes of this PR

Add VTK PolyData `vtp` support for serial cases.

## Motivation and additional information

(closes #694)
Parallel cases are not supported. Could it be possible or `xmlPolyData` is required? 

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [X] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [X] I sticked to C++14 features.
* [X] I sticked to CMake version 3.10.
* [X] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] Does change in configuration correct?
<!-- add more questions/tasks if necessary -->
