### PR TITLE
Configuration Checker

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -384,6 +384,21 @@ add_bin_test(
   MATCH "<!ELEMENT precice-configuration"
   )
 
+add_bin_test(
+  NAME check.file
+  COMMAND binprecice check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml
+  )
+
+add_bin_test(
+  NAME check.file+name
+  COMMAND binprecice check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo
+  )
+
+add_bin_test(
+  NAME check.file+name+size
+  COMMAND binprecice check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
+  )
+
 # Add a separate target to test only the base
 add_custom_target(
   test_base

--- a/docs/changelog/1132.md
+++ b/docs/changelog/1132.md
@@ -1,0 +1,1 @@
+- Add the command `check` to `binprecice`, which checks a given configuration file for correctness.

--- a/docs/man/man1/binprecice.1
+++ b/docs/man/man1/binprecice.1
@@ -1,29 +1,45 @@
-.TH binprecice 1  "January 18, 2019" "USER COMMANDS"
+.TH binprecice 1
 
 .SH NAME
-binprecice \- dumps the xml reference used for the configuration of libprecice
+binprecice \- command line utility for preCICE
 
 .SH SYNOPSIS
 .B binprecice xml
 |
 .B dtd
+|
+.B md
+|
+[\fB version \fR|\fB --version \fR]
+|
+.B check \fIfile\fR [\fIparticipant\fR [\fIsize\fR]]
 
 .SH OPTIONS
+
 .TP
 .B xml
-Prints the XML reference
+Prints the configuration reference as XML with inlined help to the standard output.
+
 .TP
 .B dtd
-Prints the DTD for the XML config
+Prints the DTD file to the standard output, which may be used to check XML configuration files.
 
-.SH RETURN VALUES
-binprecice returns a zero exist status if it succeeds.
+.TP
+.B md
+Prints the configuration reference as markdown to the standard output.
+
+.TP
+.B version \fR|\fB --version \fR
+Prints the preCICE version string ( \fIprecice::getVersionInformation()\fR ) to the standard output.
+
+.TP
+.B check \fIfile\fR [\fIparticipant\fR [\fIsize\fR]]
+Checks given preCICE configuration \fIfile\fR and prints any errors. Pass the name of a \fIparticipant\fR to fully check its configuration. The optional \fIsize\fR indicates how many ranks run in parallel, which checks custom \fI<master: ... />\fR tags.
+
+.SH EXIT STATUS
+binprecice returns a zero exist status if it succeeds to run the provided command.
 Non zero is returned in case of failure.
 
-.SH AUTHOR
-Frédéric Simonis (simonis (at) in.tum.de)
-
 .SH SEE ALSO
-testprecice(1)
 .PP
-www.precice.org \- the website of the project
+precice.org \- the website of the project

--- a/docs/man/man1/binprecice.1
+++ b/docs/man/man1/binprecice.1
@@ -37,7 +37,7 @@ Prints the preCICE version string ( \fIprecice::getVersionInformation()\fR ) to 
 Checks given preCICE configuration \fIfile\fR and prints any errors. Pass the name of a \fIparticipant\fR to fully check its configuration. The optional \fIsize\fR indicates how many ranks run in parallel, which checks custom \fI<master: ... />\fR tags.
 
 .SH EXIT STATUS
-binprecice returns a zero exist status if it succeeds to run the provided command.
+binprecice returns a zero exit status if it succeeds to run the provided command.
 Non zero is returned in case of failure.
 
 .SH SEE ALSO

--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -13,6 +13,7 @@ void printUsage()
   std::cerr << "Print Markdown reference :  binprecice md\n";
   std::cerr << "Print preCICE version    :  binprecice version\n";
   std::cerr << "                            binprecice --version\n";
+  std::cerr << "Check configuration file :  binprecice check FILE [ PARTICIPANT [ COMMSIZE ] ]\n";
 }
 
 int main(int argc, char **argv)
@@ -41,6 +42,23 @@ int main(int argc, char **argv)
   }
   if ((action == "version" || action == "--version") && args == 0) {
     std::cout << precice::getVersionInformation() << '\n';
+    return 0;
+  }
+  if (action == "check" && args >= 1 && args <= 3) {
+    std::string file(argv[2]);
+    std::string participant = (args > 1) ? std::string(argv[3]) : "";
+
+    int size = 1;
+    if (args == 3) {
+      try {
+        size = std::stoi(argv[4]);
+      } catch (std::invalid_argument &e) {
+        std::cerr << "ERROR: passed COMMSIZE is not a valid number\n";
+        printUsage();
+        return 1;
+      }
+    }
+    precice::tooling::checkConfiguration(file, participant, size);
     return 0;
   }
 

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -25,6 +25,17 @@ void printConfigReference(std::ostream &out, ConfigReferenceType reftype)
   }
 }
 
+void checkConfiguration(const std::string &filename, const std::string &participant, int size)
+{
+  config::Configuration config;
+  logging::setMPIRank(0);
+  xml::ConfigurationContext context{
+      participant,
+      0,
+      size};
+  xml::configure(config.getXMLTag(), context, filename);
+}
+
 } // namespace tooling
 
 } // namespace precice

--- a/src/precice/Tooling.hpp
+++ b/src/precice/Tooling.hpp
@@ -37,6 +37,9 @@ enum struct ConfigReferenceType {
  */
 void printConfigReference(std::ostream &out, ConfigReferenceType reftype);
 
+/// @brief Checks a given configuration
+void checkConfiguration(const std::string &filename, const std::string &participant, int size);
+
 } // namespace tooling
 
 } // namespace precice

--- a/src/precice/tests/ToolingTests.cpp
+++ b/src/precice/tests/ToolingTests.cpp
@@ -48,5 +48,27 @@ BOOST_AUTO_TEST_CASE(DTDReference)
   }
 }
 
+BOOST_AUTO_TEST_SUITE(ConfigCheck)
+
+BOOST_AUTO_TEST_CASE(Serial)
+{
+  BOOST_REQUIRE_NO_THROW(
+      precice::tooling::checkConfiguration(
+          precice::testing::getPathToSources() + "/precice/tests/config-checker.xml",
+          "SolverTwo",
+          1));
+}
+
+BOOST_AUTO_TEST_CASE(Parallel)
+{
+  BOOST_REQUIRE_NO_THROW(
+      precice::tooling::checkConfiguration(
+          precice::testing::getPathToSources() + "/precice/tests/config-checker.xml",
+          "SolverTwo",
+          4));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/config-checker.xml
+++ b/src/precice/tests/config-checker.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1" />
+    <data:scalar name="Data2" />
+
+    <mesh name="MeshOne">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes" />
+      <write-data name="Data1" mesh="MeshOne" />
+      <read-data name="Data2" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <master:sockets />
+      <use-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
+      <use-mesh name="MeshTwo" provide="yes" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="conservative" />
+      <write-data name="Data2" mesh="MeshTwo" />
+      <read-data name="Data1" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="1" />
+      <time-window-size value="1.0" />
+      <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+      <max-iterations value="100" />
+      <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+      <acceleration:IQN-ILS>
+        <data name="Data2" mesh="MeshOne" />
+        <filter type="QR2" limit="1e-1" />
+        <initial-relaxation value="1.0" />
+        <max-used-iterations value="10" />
+        <time-windows-reused value="0" />
+      </acceleration:IQN-ILS>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
+</precice-configuration>


### PR DESCRIPTION
## Main changes of this PR

This PR extends `binprecice` with the ability to check configuration files for correctness.
The syntax is as follows:
```
$ binprecice check FILE [ PARTICIPANT [ COMMSIZE ] ]
```

* `FILE` is the path to the configuration file
* `PARTICIPANT` is the _optional_ participant to check. This is necessary to detect in-depth configuration issues.
* `COMMSIZE` is the _optional_ size of the communicator. This is necessary to check custom `<master />` tags.

## Motivation and additional information

Running the entire solver to test a configuration is not practical.
This extension offers a quick and simple method to check a configuration file which ships directly with preCICE.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
