### PR TITLE
Add VTU exporter

### DIFF
--- a/docs/changelog/1136.md
+++ b/docs/changelog/1136.md
@@ -1,0 +1,2 @@
+- Added a warning when using `<export:vtk />` in a parallel participant.
+- Added export to VTU using `<export:vtu />`.

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -14,7 +14,7 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
   XMLTag::Occurrence occ = XMLTag::OCCUR_ARBITRARY;
   {
     XMLTag tag(*this, VALUE_VTK, occ, TAG);
-    tag.setDocumentation("Exports meshes to VTK text files.");
+    tag.setDocumentation("Exports meshes to VTK legacy format files. Parallel participants will use the VTU exporter instead.");
     tags.push_back(tag);
   }
   {

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -17,6 +17,11 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
     tag.setDocumentation("Exports meshes to VTK text files.");
     tags.push_back(tag);
   }
+  {
+    XMLTag tag(*this, VALUE_VTU, occ, TAG);
+    tag.setDocumentation("Exports meshes to VTU files in serial or PVTU files with VTU piece files in parallel.");
+    tags.push_back(tag);
+  }
 
   auto attrLocation = XMLAttribute<std::string>(ATTR_LOCATION, "")
                           .setDocumentation("Directory to export the files to.");

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -43,6 +43,7 @@ private:
   const std::string ATTR_TYPE     = "type";
   const std::string ATTR_AUTO     = "auto";
   const std::string VALUE_VTK     = "vtk";
+  const std::string VALUE_VTU     = "vtu";
 
   const std::string ATTR_EVERY_N_TIME_WINDOWS = "every-n-time-windows";
   const std::string ATTR_NEIGHBORS            = "neighbors";

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -549,7 +549,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     io::PtrExport exporter;
     if (exportContext.type == VALUE_VTK) {
       if (context.size > 1) {
-        PRECICE_WARN("You use the VTK exporter in a parallel participant. Note that this will export as PVTU instead. For consistency, prefer to use \"<export:vtu ... />\" instead.");
+        PRECICE_WARN("You are using the VTK exporter in a parallel participant. Note that this will export as PVTU instead. For consistency, prefer \"<export:vtu ... />\" instead.");
         exporter = io::PtrExport(new io::ExportVTU());
       } else {
         exporter = io::PtrExport(new io::ExportVTK());

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -553,6 +553,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
       } else {
         exporter = io::PtrExport(new io::ExportVTK());
       }
+    } else if (exportContext.type == VALUE_VTU) {
+      exporter = io::PtrExport(new io::ExportVTU());
     } else {
       PRECICE_ERROR("Participant {} defines an <export/> tag of unknown type \"{}\".",
                     _participants.back()->getName(), exportContext.type);

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -549,6 +549,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     io::PtrExport exporter;
     if (exportContext.type == VALUE_VTK) {
       if (context.size > 1) {
+        PRECICE_WARN("You use the VTK exporter in a parallel participant. Note that this will export as PVTU instead. For consistency, prefer to use \"<export:vtu ... />\" instead.");
         exporter = io::PtrExport(new io::ExportVTU());
       } else {
         exporter = io::PtrExport(new io::ExportVTK());

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -98,6 +98,7 @@ private:
   const std::string VALUE_NO_FILTER        = "no-filter";
 
   const std::string VALUE_VTK = "vtk";
+  const std::string VALUE_VTU = "vtu";
 
   int _dimensions = 0;
 


### PR DESCRIPTION
## Main changes of this PR

* Adds a configurable exporter to export to vtu/pvtu files. `<export:vtu ... />`
* Adds a warning when using `<export:vtk />` with parallel participants: 
  ```
  You use the VTK exporter in a parallel participant. Note that this will export as PVTU instead. For consistency, prefer to use "<export:vtu ... />" instead.
  ```

## Motivation and additional information

* The legacy vtk exporter is incapable of exporting meshes of parallel participants as the format lacks support for this. This is why the VTU format exists, which allows to export piece `.vtu` files which are then accessible as a whole using a single `.pvtu` file.
* The name `vtk` exporter is misleading as it will silently fallback to exporting VTU files for parallel participants.
* This PR adds the `vtu` exporter, which allows to explicitly request VTU exports for both serial and parallel participants.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
