### PR TITLE
VTP exporter

### DIFF
--- a/docs/changelog/1137.md
+++ b/docs/changelog/1137.md
@@ -1,1 +1,1 @@
-- Added export to VTP using `<export:vto />`.
+- Added export to VTP using `<export:vtp />`.

--- a/docs/changelog/1137.md
+++ b/docs/changelog/1137.md
@@ -1,0 +1,1 @@
+- Added export to VTP using `<export:vto />`.

--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -32,7 +32,7 @@ public:
   virtual void doExport(
       const std::string &name,
       const std::string &location,
-      mesh::Mesh &       mesh) = 0;
+      const mesh::Mesh & mesh) = 0;
 };
 
 } // namespace io

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -21,7 +21,7 @@ namespace io {
 void ExportVTK::doExport(
     const std::string &name,
     const std::string &location,
-    mesh::Mesh &       mesh)
+    const mesh::Mesh & mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
   PRECICE_ASSERT(name != std::string(""));
@@ -42,7 +42,9 @@ void ExportVTK::doExport(
   outstream.close();
 }
 
-void ExportVTK::exportMesh(std::ofstream &outFile, mesh::Mesh const &mesh)
+void ExportVTK::exportMesh(
+    std::ofstream &   outFile,
+    const mesh::Mesh &mesh)
 {
   PRECICE_TRACE(mesh.getName());
 
@@ -101,7 +103,9 @@ void ExportVTK::exportMesh(std::ofstream &outFile, mesh::Mesh const &mesh)
   outFile << '\n';
 }
 
-void ExportVTK::exportData(std::ofstream &outFile, mesh::Mesh const &mesh)
+void ExportVTK::exportData(
+    std::ofstream &   outFile,
+    const mesh::Mesh &mesh)
 {
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
 

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -22,7 +22,7 @@ public:
   virtual void doExport(
       const std::string &name,
       const std::string &location,
-      mesh::Mesh &       mesh);
+      const mesh::Mesh & mesh);
 
   static void initializeWriting(
       std::ofstream &filestream);
@@ -42,15 +42,19 @@ public:
       std::ostream &outFile);
 
 private:
-  logging::Logger _log{"io::ExportVTK"};
+  mutable logging::Logger _log{"io::ExportVTK"};
 
   void openFile(
       std::ofstream &    outFile,
       const std::string &filename) const;
 
-  void exportMesh(std::ofstream &outFile, mesh::Mesh const &mesh);
+  void exportMesh(
+      std::ofstream &   outFile,
+      const mesh::Mesh &mesh);
 
-  void exportData(std::ofstream &outFile, mesh::Mesh const &mesh);
+  void exportData(
+      std::ofstream &   outFile,
+      const mesh::Mesh &mesh);
 };
 
 } // namespace io

--- a/src/io/ExportVTP.cpp
+++ b/src/io/ExportVTP.cpp
@@ -23,11 +23,11 @@ std::string ExportVTP::getPieceExtension() const
   return ".vtp";
 }
 
-std::string ExportVTP::getPieceAttributes(const mesh::Mesh& mesh) const
+std::string ExportVTP::getPieceAttributes(const mesh::Mesh &mesh) const
 {
   std::ostringstream oss;
-  oss << "NumberOfPoints=\""<< mesh.vertices().size() <<"\" ";
-  oss << "NumberOfLines=\"" << mesh.edges().size() <<"\" ";
+  oss << "NumberOfPoints=\"" << mesh.vertices().size() << "\" ";
+  oss << "NumberOfLines=\"" << mesh.edges().size() << "\" ";
   oss << "NumberOfPolys=\"" << mesh.triangles().size() << "\"";
   return oss.str();
 }

--- a/src/io/ExportVTP.cpp
+++ b/src/io/ExportVTP.cpp
@@ -1,0 +1,85 @@
+#include "io/ExportVTP.hpp"
+#include <boost/filesystem.hpp>
+#include <sstream>
+#include <string>
+#include "mesh/Data.hpp"
+#include "mesh/Mesh.hpp"
+
+namespace precice {
+namespace io {
+
+std::string ExportVTP::getVTKFormat() const
+{
+  return "PolyData";
+}
+
+std::string ExportVTP::getMasterExtension() const
+{
+  return ".pvtp";
+}
+
+std::string ExportVTP::getPieceExtension() const
+{
+  return ".vtp";
+}
+
+std::string ExportVTP::getPieceAttributes(const mesh::Mesh& mesh) const
+{
+  std::ostringstream oss;
+  oss << "NumberOfPoints=\""<< mesh.vertices().size() <<"\" ";
+  oss << "NumberOfLines=\"" << mesh.edges().size() <<"\" ";
+  oss << "NumberOfPolys=\"" << mesh.triangles().size() << "\"";
+  return oss.str();
+}
+
+void ExportVTP::writeMasterCells(std::ostream &out) const
+{
+  out << "      <PLines>\n";
+  out << "         <PDataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\"/>\n";
+  out << "         <PDataArray type=\"Int32\" Name=\"offsets\"      NumberOfComponents=\"1\"/>\n";
+  out << "      </PLines>\n";
+  out << "      <PPolys>\n";
+  out << "         <PDataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\"/>\n";
+  out << "         <PDataArray type=\"Int32\" Name=\"offsets\"      NumberOfComponents=\"1\"/>\n";
+  out << "      </PPolys>\n";
+}
+
+void ExportVTP::exportConnectivity(
+    std::ostream &    outFile,
+    const mesh::Mesh &mesh) const
+{
+  outFile << "         <Lines>\n";
+  outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "               ";
+  for (const mesh::Edge &edge : mesh.edges()) {
+    writeLine(edge, outFile);
+  }
+  outFile << '\n';
+  outFile << "            </DataArray> \n";
+  outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "               ";
+  for (size_t i = 1; i <= mesh.edges().size(); i++) {
+    outFile << 2 * i << "  ";
+  }
+  outFile << '\n';
+  outFile << "            </DataArray>\n";
+  outFile << "         </Lines>\n";
+  outFile << "         <Polys>\n";
+  outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "               ";
+  for (const mesh::Triangle &triangle : mesh.triangles()) {
+    writeTriangle(triangle, outFile);
+  }
+  outFile << '\n';
+  outFile << "            </DataArray> \n";
+  outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "               ";
+  for (size_t i = 1; i <= mesh.triangles().size(); i++) {
+    outFile << 3 * i << "  ";
+  }
+  outFile << '\n';
+  outFile << "            </DataArray>\n";
+  outFile << "         </Polys>\n";
+}
+} // namespace io
+} // namespace precice

--- a/src/io/ExportVTP.hpp
+++ b/src/io/ExportVTP.hpp
@@ -19,9 +19,9 @@ namespace precice {
 namespace io {
 
 /// Writes meshes to xml-vtk files. Only for parallel usage. Serial usage (coupling mode) should still use ExportVTK
-class ExportVTU : public ExportXML {
+class ExportVTP : public ExportXML {
 private:
-  mutable logging::Logger _log{"io::ExportVTU"};
+  mutable logging::Logger _log{"io::ExportVTP"};
 
   std::string getVTKFormat() const override;
   std::string getMasterExtension() const override;

--- a/src/io/ExportVTP.hpp
+++ b/src/io/ExportVTP.hpp
@@ -26,7 +26,7 @@ private:
   std::string getVTKFormat() const override;
   std::string getMasterExtension() const override;
   std::string getPieceExtension() const override;
-  std::string getPieceAttributes(const mesh::Mesh& mesh) const override;
+  std::string getPieceAttributes(const mesh::Mesh &mesh) const override;
 
   void writeMasterCells(std::ostream &out) const override;
 

--- a/src/io/ExportVTP.hpp
+++ b/src/io/ExportVTP.hpp
@@ -18,7 +18,12 @@ class Triangle;
 namespace precice {
 namespace io {
 
-/// Writes meshes to xml-vtk files. Only for parallel usage. Serial usage (coupling mode) should still use ExportVTK
+/** Exporter for VTP and PVTP.
+ *
+ * Writes meshes to VTP piece files.
+ * Parallel participants additionally write a PVTP file.
+ * The naming scheme allows to import these files into Paraview as time series.
+ */
 class ExportVTP : public ExportXML {
 private:
   mutable logging::Logger _log{"io::ExportVTP"};

--- a/src/io/ExportVTU.cpp
+++ b/src/io/ExportVTU.cpp
@@ -25,6 +25,24 @@ std::string ExportVTU::getVTKFormat() const
   return "UnstructuredGrid";
 }
 
+std::string ExportVTU::getMasterExtension() const
+{
+  return ".pvtu";
+}
+
+std::string ExportVTU::getPieceExtension() const
+{
+  return ".vtu";
+}
+
+std::string ExportVTU::getPieceAttributes(const mesh::Mesh &mesh) const
+{
+  std::ostringstream oss;
+  oss << "NumberOfPoints=\"" << mesh.vertices().size() << "\" ";
+  oss << "NumberOfCells=\"" << mesh.edges().size() + mesh.triangles().size() << "\" ";
+  return oss.str();
+}
+
 void ExportVTU::writeMasterCells(std::ostream &out) const
 {
   out << "      <PCells>\n";
@@ -35,7 +53,7 @@ void ExportVTU::writeMasterCells(std::ostream &out) const
 }
 
 void ExportVTU::exportConnectivity(
-    std::ostream &   outFile,
+    std::ostream &    outFile,
     const mesh::Mesh &mesh) const
 {
   outFile << "         <Cells>\n";

--- a/src/io/ExportVTU.cpp
+++ b/src/io/ExportVTU.cpp
@@ -20,299 +20,57 @@
 namespace precice {
 namespace io {
 
-void ExportVTU::doExport(
-    const std::string &name,
-    const std::string &location,
-    mesh::Mesh &       mesh)
+std::string ExportVTU::getVTKFormat() const
 {
-  PRECICE_TRACE(name, location, mesh.getName());
-  processDataNamesAndDimensions(mesh);
-  if (not location.empty())
-    boost::filesystem::create_directories(location);
-  if (utils::MasterSlave::isMaster()) {
-    writeMasterFile(name, location, mesh);
-  }
-  if (mesh.vertices().size() > 0) { //only procs at the coupling interface should write output (for performance reasons)
-    writeSubFile(name, location, mesh);
-  }
+  return "UnstructuredGrid";
 }
 
-void ExportVTU::processDataNamesAndDimensions(mesh::Mesh const &mesh)
+void ExportVTU::writeMasterCells(std::ostream &out) const
 {
-  _vectorDataNames.clear();
-  _scalarDataNames.clear();
-  for (const mesh::PtrData &data : mesh.data()) {
-    int dataDimensions = data->getDimensions();
-    PRECICE_ASSERT(dataDimensions >= 1);
-    std::string dataName = data->getName();
-    if (dataDimensions == 1) {
-      _scalarDataNames.push_back(dataName);
-    } else {
-      _vectorDataNames.push_back(dataName);
-    }
-  }
+  out << "      <PCells>\n";
+  out << "         <PDataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\"/>\n";
+  out << "         <PDataArray type=\"Int32\" Name=\"offsets\"      NumberOfComponents=\"1\"/>\n";
+  out << "         <PDataArray type=\"UInt8\" Name=\"types\"        NumberOfComponents=\"1\"/>\n";
+  out << "      </PCells>\n";
 }
 
-void ExportVTU::writeMasterFile(
-    const std::string &name,
-    const std::string &location,
-    mesh::Mesh &       mesh)
+void ExportVTU::exportConnectivity(
+    std::ostream &   outFile,
+    const mesh::Mesh &mesh) const
 {
-  namespace fs = boost::filesystem;
-  fs::path outfile(location);
-  outfile = outfile / fs::path(name + ".pvtu");
-  std::ofstream outMasterFile(outfile.string(), std::ios::trunc);
-
-  PRECICE_CHECK(outMasterFile, "VTU export failed to open master file \"{}\"", outfile);
-
-  outMasterFile << "<?xml version=\"1.0\"?>\n";
-  outMasterFile << "<VTKFile type=\"PUnstructuredGrid\" version=\"0.1\" byte_order=\"";
-  outMasterFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">") << '\n';
-  outMasterFile << "   <PUnstructuredGrid GhostLevel=\"0\">\n";
-
-  outMasterFile << "      <PPoints>\n";
-  outMasterFile << "         <PDataArray type=\"Float64\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>\n";
-  outMasterFile << "      </PPoints>\n";
-
-  outMasterFile << "      <PCells>\n";
-  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\"/>\n";
-  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"offsets\"      NumberOfComponents=\"1\"/>\n";
-  outMasterFile << "         <PDataArray type=\"UInt8\" Name=\"types\"        NumberOfComponents=\"1\"/>\n";
-  outMasterFile << "      </PCells>\n";
-
-  // write scalar data names
-  outMasterFile << "      <PPointData Scalars=\"Rank ";
-  for (const auto &scalarDataName : _scalarDataNames) {
-    outMasterFile << scalarDataName << ' ';
-  }
-  // write vector data names
-  outMasterFile << "\" Vectors=\"";
-  for (const auto &vectorDataName : _vectorDataNames) {
-    outMasterFile << vectorDataName << ' ';
-  }
-  outMasterFile << "\">\n";
-
-  outMasterFile << "         <PDataArray type=\"Int32\" Name=\"Rank\" NumberOfComponents=\"1\"/>\n";
-
-  for (const auto &scalarDataName : _scalarDataNames) {
-    outMasterFile << "         <PDataArray type=\"Float64\" Name=\"" << scalarDataName << "\" NumberOfComponents=\"" << 1 << "\"/>\n";
-  }
-
-  for (const auto &vectorDataName : _vectorDataNames) {
-    outMasterFile << "         <PDataArray type=\"Float64\" Name=\"" << vectorDataName << "\" NumberOfComponents=\"" << 3 << "\"/>\n";
-  }
-  outMasterFile << "      </PPointData>\n";
-
-  for (int i = 0; i < utils::MasterSlave::getSize(); i++) {
-    if (mesh.getVertexDistribution()[i].size() > 0) { //only non-empty subfiles
-      outMasterFile << "      <Piece Source=\"" << name << "_" << i << ".vtu\"/>\n";
-    }
-  }
-
-  outMasterFile << "   </PUnstructuredGrid>\n";
-  outMasterFile << "</VTKFile>\n";
-
-  outMasterFile.close();
-}
-
-void ExportVTU::writeSubFile(
-    const std::string &name,
-    const std::string &location,
-    mesh::Mesh &       mesh)
-{
-  int numPoints = mesh.vertices().size(); // number of vertices
-  int numCells;                           // number of cells
-  if (mesh.getDimensions() == 2) {
-    numCells = mesh.edges().size();
-  } else {
-    numCells = mesh.triangles().size() + mesh.edges().size();
-  }
-
-  namespace fs = boost::filesystem;
-  fs::path outfile(location);
-  outfile = outfile / fs::path(name + "_" + std::to_string(utils::MasterSlave::getRank()) + ".vtu");
-  std::ofstream outSubFile(outfile.string(), std::ios::trunc);
-
-  PRECICE_CHECK(outSubFile, "VTU export failed to open slave file \"{}\"", outfile);
-
-  outSubFile << "<?xml version=\"1.0\"?>\n";
-  outSubFile << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\" byte_order=\"";
-  outSubFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">") << '\n';
-
-  outSubFile << "   <UnstructuredGrid>\n";
-  outSubFile << "      <Piece NumberOfPoints=\"" << numPoints << "\" NumberOfCells=\"" << numCells << "\"> \n";
-  outSubFile << "         <Points> \n";
-  outSubFile << "            <DataArray type=\"Float64\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\" format=\"ascii\"> \n";
-  for (const mesh::Vertex &vertex : mesh.vertices()) {
-    writeVertex(vertex.getCoords(), outSubFile);
-  }
-  outSubFile << "            </DataArray>\n";
-  outSubFile << "         </Points> \n\n";
-
-  // Write Mesh
-  exportMesh(outSubFile, mesh);
-
-  // Write data
-  exportData(outSubFile, mesh);
-
-  outSubFile << "      </Piece>\n";
-  outSubFile << "   </UnstructuredGrid> \n";
-  outSubFile << "</VTKFile>\n";
-
-  outSubFile.close();
-}
-
-void ExportVTU::exportMesh(
-    std::ofstream &   outFile,
-    mesh::Mesh const &mesh)
-{
-  if (mesh.getDimensions() == 2) { // write edges as cells
-    outFile << "         <Cells>\n";
-    outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
-    outFile << "               ";
-    for (const mesh::Edge &edge : mesh.edges()) {
-      writeLine(edge, outFile);
-    }
-    outFile << '\n';
-    outFile << "            </DataArray> \n";
-    outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">\n";
-    outFile << "               ";
-    for (size_t i = 1; i <= mesh.edges().size(); i++) {
-      outFile << 2 * i << "  ";
-    }
-    outFile << '\n';
-    outFile << "            </DataArray>\n";
-    outFile << "            <DataArray type=\"UInt8\"  Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">\n";
-    outFile << "               ";
-    for (size_t i = 1; i <= mesh.edges().size(); i++) {
-      outFile << 3 << "  ";
-    }
-    outFile << '\n';
-    outFile << "            </DataArray>\n";
-    outFile << "         </Cells>\n";
-  } else { // write triangles as cells
-
-    outFile << "         <Cells>\n";
-    outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
-    outFile << "               ";
-    for (const mesh::Triangle &triangle : mesh.triangles()) {
-      writeTriangle(triangle, outFile);
-    }
-    for (const mesh::Edge &edge : mesh.edges()) {
-      writeLine(edge, outFile);
-    }
-    outFile << '\n';
-    outFile << "            </DataArray> \n";
-    outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">\n";
-    outFile << "               ";
-    for (size_t i = 1; i <= mesh.triangles().size(); i++) {
-      outFile << 3 * i << "  ";
-    }
-    for (size_t i = 1; i <= mesh.edges().size(); i++) {
-      outFile << 2 * i << "  ";
-    }
-    outFile << '\n';
-    outFile << "            </DataArray>\n";
-    outFile << "            <DataArray type=\"UInt8\"  Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">\n";
-    outFile << "               ";
-    for (size_t i = 1; i <= mesh.triangles().size(); i++) {
-      outFile << 5 << "  ";
-    }
-    for (size_t i = 1; i <= mesh.edges().size(); i++) {
-      outFile << 3 << "  ";
-    }
-    outFile << '\n';
-    outFile << "            </DataArray>\n";
-    outFile << "         </Cells>\n";
-  }
-}
-
-void ExportVTU::exportData(
-    std::ofstream &outFile,
-    mesh::Mesh &   mesh)
-{
-  outFile << "         <PointData Scalars=\"Rank ";
-  for (const auto &scalarDataName : _scalarDataNames) {
-    outFile << scalarDataName << ' ';
-  }
-  outFile << "\" Vectors=\"";
-  for (const auto &vectorDataName : _vectorDataNames) {
-    outFile << vectorDataName << ' ';
-  }
-  outFile << "\">\n";
-
-  // Export the current rank
-  outFile << "            <DataArray type=\"UInt32\" Name=\"Rank\" NumberOfComponents=\"1\" format=\"ascii\">\n";
-  const auto rank = utils::MasterSlave::getRank();
-  for (size_t count = 0; count < mesh.vertices().size(); ++count) {
-    outFile << rank << ' ';
-  }
-  outFile << "\n            </DataArray>\n";
-
-  for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
-    Eigen::VectorXd &values         = data->values();
-    int              dataDimensions = data->getDimensions();
-    std::string      dataName(data->getName());
-    int              numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
-    outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
-    outFile << "\" format=\"ascii\">\n";
-    outFile << "               ";
-    if (dataDimensions > 1) {
-      Eigen::VectorXd viewTemp(dataDimensions);
-      for (size_t count = 0; count < mesh.vertices().size(); count++) {
-        size_t offset = count * dataDimensions;
-        for (int i = 0; i < dataDimensions; i++) {
-          viewTemp[i] = values(offset + i);
-        }
-        for (int i = 0; i < dataDimensions; i++) {
-          outFile << viewTemp[i] << ' ';
-        }
-        if (dataDimensions == 2) {
-          outFile << "0.0" << ' '; //2D data needs to be 3D for vtk
-        }
-        outFile << ' ';
-      }
-    } else if (dataDimensions == 1) {
-      for (size_t count = 0; count < mesh.vertices().size(); count++) {
-        outFile << values(count) << ' ';
-      }
-    }
-    outFile << '\n'
-            << "            </DataArray>\n";
-  }
-  outFile << "         </PointData> \n";
-}
-
-void ExportVTU::writeVertex(
-    const Eigen::VectorXd &position,
-    std::ofstream &        outFile)
-{
+  outFile << "         <Cells>\n";
+  outFile << "            <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">\n";
   outFile << "               ";
-  for (int i = 0; i < position.size(); i++) {
-    outFile << position(i) << "  ";
+  for (const mesh::Triangle &triangle : mesh.triangles()) {
+    writeTriangle(triangle, outFile);
   }
-  if (position.size() == 2) {
-    outFile << 0.0 << "  "; //also for 2D scenario, vtk needs 3D data
+  for (const mesh::Edge &edge : mesh.edges()) {
+    writeLine(edge, outFile);
   }
   outFile << '\n';
+  outFile << "            </DataArray> \n";
+  outFile << "            <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "               ";
+  for (size_t i = 1; i <= mesh.triangles().size(); i++) {
+    outFile << 3 * i << "  ";
+  }
+  const auto triangleOffset = 3 * mesh.triangles().size();
+  for (size_t i = 1; i <= mesh.edges().size(); i++) {
+    outFile << 2 * i + triangleOffset << "  ";
+  }
+  outFile << '\n';
+  outFile << "            </DataArray>\n";
+  outFile << "            <DataArray type=\"UInt8\"  Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "               ";
+  for (size_t i = 1; i <= mesh.triangles().size(); i++) {
+    outFile << 5 << "  ";
+  }
+  for (size_t i = 1; i <= mesh.edges().size(); i++) {
+    outFile << 3 << "  ";
+  }
+  outFile << '\n';
+  outFile << "            </DataArray>\n";
+  outFile << "         </Cells>\n";
 }
-
-void ExportVTU::writeTriangle(
-    const mesh::Triangle &triangle,
-    std::ofstream &       outFile)
-{
-  outFile << triangle.vertex(0).getID() << "  ";
-  outFile << triangle.vertex(1).getID() << "  ";
-  outFile << triangle.vertex(2).getID() << "  ";
-}
-
-void ExportVTU::writeLine(
-    const mesh::Edge &edge,
-    std::ofstream &   outFile)
-{
-  outFile << edge.vertex(0).getID() << "  ";
-  outFile << edge.vertex(1).getID() << "  ";
-}
-
 } // namespace io
 } // namespace precice

--- a/src/io/ExportVTU.hpp
+++ b/src/io/ExportVTU.hpp
@@ -4,7 +4,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
-#include "io/Export.hpp"
+#include "io/ExportXML.hpp"
 #include "logging/Logger.hpp"
 
 namespace precice {
@@ -19,69 +19,15 @@ namespace precice {
 namespace io {
 
 /// Writes meshes to xml-vtk files. Only for parallel usage. Serial usage (coupling mode) should still use ExportVTK
-class ExportVTU : public Export {
-public:
-  /// Perform writing to vtk file
-  /**
-   * @param[in] name filename to export to
-   * @param[in] locastion Export path
-   * @param[mesh] mesh Mesh to export
-   */
-  virtual void doExport(
-      const std::string &name,
-      const std::string &location,
-      mesh::Mesh &       mesh);
-
-  static void writeVertex(
-      const Eigen::VectorXd &position,
-      std::ofstream &        outFile);
-
-  static void writeLine(
-      const mesh::Edge &edge,
-      std::ofstream &   outFile);
-
-  static void writeTriangle(
-      const mesh::Triangle &triangle,
-      std::ofstream &       outFile);
-
+class ExportVTU : public ExportXML {
 private:
-  logging::Logger _log{"io::ExportVTU"};
+  mutable logging::Logger _log{"io::ExportVTU"};
 
-  /// List of names of all scalar data on mesh
-  std::vector<std::string> _scalarDataNames;
+  std::string getVTKFormat() const override;
 
-  /// List of names of all vector data on mesh
-  std::vector<std::string> _vectorDataNames;
+  void writeMasterCells(std::ostream &out) const override;
 
-  /**
-    * @brief Stores scalar and vector data names in string vectors
-    * Needed for writing master file and sub files
-    */
-  void processDataNamesAndDimensions(mesh::Mesh const &mesh);
-
-  /**
-    * @brief Writes the master file (called only by the master rank)
-    */
-  void writeMasterFile(
-      const std::string &name,
-      const std::string &location,
-      mesh::Mesh &       mesh);
-
-  /**
-    * @brief Writes the sub file for each rank
-    */
-  void writeSubFile(
-      const std::string &name,
-      const std::string &location,
-      mesh::Mesh &       mesh);
-
-  void exportMesh(
-      std::ofstream &   outFile,
-      mesh::Mesh const &mesh);
-
-  void exportData(
-      std::ofstream &outFile,
-      mesh::Mesh &   mesh);
+  void exportConnectivity(std::ostream &outFile, const mesh::Mesh &mesh) const override;
 };
 
 } // namespace io

--- a/src/io/ExportVTU.hpp
+++ b/src/io/ExportVTU.hpp
@@ -26,7 +26,7 @@ private:
   std::string getVTKFormat() const override;
   std::string getMasterExtension() const override;
   std::string getPieceExtension() const override;
-  std::string getPieceAttributes(const mesh::Mesh& mesh) const override;
+  std::string getPieceAttributes(const mesh::Mesh &mesh) const override;
 
   void writeMasterCells(std::ostream &out) const override;
 

--- a/src/io/ExportVTU.hpp
+++ b/src/io/ExportVTU.hpp
@@ -18,7 +18,12 @@ class Triangle;
 namespace precice {
 namespace io {
 
-/// Writes meshes to xml-vtk files. Only for parallel usage. Serial usage (coupling mode) should still use ExportVTK
+/** Exporter for VTU and PVTU.
+ *
+ * Writes meshes to VTU piece files.
+ * Parallel participants additionally write a PVTU file.
+ * The naming scheme allows to import these files into Paraview as time series.
+ */
 class ExportVTU : public ExportXML {
 private:
   mutable logging::Logger _log{"io::ExportVTU"};

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -94,6 +94,16 @@ void ExportXML::writeMasterFile(
   outMasterFile.close();
 }
 
+namespace {
+std::string getPieceSuffix()
+{
+  if (!utils::MasterSlave::isParallel()) {
+    return "";
+  }
+  return "_" + std::to_string(utils::MasterSlave::getRank());
+}
+} // namespace
+
 void ExportXML::writeSubFile(
     const std::string &name,
     const std::string &location,
@@ -101,7 +111,7 @@ void ExportXML::writeSubFile(
 {
   namespace fs = boost::filesystem;
   fs::path outfile(location);
-  outfile = outfile / fs::path(name + "_" + std::to_string(utils::MasterSlave::getRank()) + getPieceExtension());
+  outfile /= fs::path(name + getPieceSuffix() + getPieceExtension());
   std::ofstream outSubFile(outfile.string(), std::ios::trunc);
 
   PRECICE_CHECK(outSubFile, "{} export failed to open slave file \"{}\"", getVTKFormat(), outfile);

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -1,0 +1,267 @@
+#include "io/ExportXML.hpp"
+#include <Eigen/Core>
+#include <algorithm>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <memory>
+#include <string>
+#include "io/Export.hpp"
+#include "logging/LogMacros.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
+#include "utils/Helpers.hpp"
+#include "utils/MasterSlave.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice {
+namespace io {
+
+void ExportXML::doExport(
+    const std::string &name,
+    const std::string &location,
+    const mesh::Mesh & mesh)
+{
+  PRECICE_TRACE(name, location, mesh.getName());
+  processDataNamesAndDimensions(mesh);
+  if (not location.empty())
+    boost::filesystem::create_directories(location);
+  if (utils::MasterSlave::isMaster()) {
+    writeMasterFile(name, location, mesh);
+  }
+  if (mesh.vertices().size() > 0) { //only procs at the coupling interface should write output (for performance reasons)
+    writeSubFile(name, location, mesh);
+  }
+}
+
+void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
+{
+  _vectorDataNames.clear();
+  _scalarDataNames.clear();
+  for (const mesh::PtrData &data : mesh.data()) {
+    int dataDimensions = data->getDimensions();
+    PRECICE_ASSERT(dataDimensions >= 1);
+    std::string dataName = data->getName();
+    if (dataDimensions == 1) {
+      _scalarDataNames.push_back(dataName);
+    } else {
+      _vectorDataNames.push_back(dataName);
+    }
+  }
+}
+
+void ExportXML::writeMasterFile(
+    const std::string &name,
+    const std::string &location,
+    const mesh::Mesh & mesh) const
+{
+  namespace fs = boost::filesystem;
+  fs::path outfile(location);
+  outfile = outfile / fs::path(name + ".pvtu");
+  std::ofstream outMasterFile(outfile.string(), std::ios::trunc);
+
+  PRECICE_CHECK(outMasterFile, "VTU export failed to open master file \"{}\"", outfile);
+
+  const auto formatType = getVTKFormat();
+  outMasterFile << "<?xml version=\"1.0\"?>\n";
+  outMasterFile << "<VTKFile type=\"P" << formatType << "\" version=\"0.1\" byte_order=\"";
+  outMasterFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">") << '\n';
+  outMasterFile << "   <P" << formatType << " GhostLevel=\"0\">\n";
+
+  outMasterFile << "      <PPoints>\n";
+  outMasterFile << "         <PDataArray type=\"Float64\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\"/>\n";
+  outMasterFile << "      </PPoints>\n";
+
+  writeMasterCells(outMasterFile);
+
+  writeMasterData(outMasterFile);
+
+  const auto &vertexDistribution = mesh.getVertexDistribution();
+  for (int i = 0; i < utils::MasterSlave::getSize(); i++) {
+    auto iter = vertexDistribution.find(i);
+    if (iter != vertexDistribution.end() && iter->second.size() > 0) {
+      //only non-empty subfiles
+      outMasterFile << "      <Piece Source=\"" << name << "_" << i << ".vtu\"/>\n";
+    }
+  }
+
+  outMasterFile << "   </P" << formatType << ">\n";
+  outMasterFile << "</VTKFile>\n";
+
+  outMasterFile.close();
+}
+
+void ExportXML::writeSubFile(
+    const std::string &name,
+    const std::string &location,
+    const mesh::Mesh & mesh) const
+{
+  int numPoints = mesh.vertices().size(); // number of vertices
+  int numCells;                           // number of cells
+  if (mesh.getDimensions() == 2) {
+    numCells = mesh.edges().size();
+  } else {
+    numCells = mesh.triangles().size() + mesh.edges().size();
+  }
+
+  namespace fs = boost::filesystem;
+  fs::path outfile(location);
+  outfile = outfile / fs::path(name + "_" + std::to_string(utils::MasterSlave::getRank()) + ".vtu");
+  std::ofstream outSubFile(outfile.string(), std::ios::trunc);
+
+  PRECICE_CHECK(outSubFile, "VTU export failed to open slave file \"{}\"", outfile);
+
+  const auto formatType = getVTKFormat();
+  outSubFile << "<?xml version=\"1.0\"?>\n";
+  outSubFile << "<VTKFile type=\"" << formatType << "\" version=\"0.1\" byte_order=\"";
+  outSubFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">") << '\n';
+
+  outSubFile << "   <" << formatType << ">\n";
+  outSubFile << "      <Piece NumberOfPoints=\"" << numPoints << "\" NumberOfCells=\"" << numCells << "\"> \n";
+  exportPoints(outSubFile, mesh);
+
+  // Write Mesh
+  exportConnectivity(outSubFile, mesh);
+
+  // Write data
+  exportData(outSubFile, mesh);
+
+  outSubFile << "      </Piece>\n";
+  outSubFile << "   </" << formatType << "> \n";
+  outSubFile << "</VTKFile>\n";
+
+  outSubFile.close();
+}
+
+void ExportXML::exportData(
+    std::ostream &    outFile,
+    const mesh::Mesh &mesh) const
+{
+  outFile << "         <PointData Scalars=\"Rank ";
+  for (const auto &scalarDataName : _scalarDataNames) {
+    outFile << scalarDataName << ' ';
+  }
+  outFile << "\" Vectors=\"";
+  for (const auto &vectorDataName : _vectorDataNames) {
+    outFile << vectorDataName << ' ';
+  }
+  outFile << "\">\n";
+
+  // Export the current rank
+  outFile << "            <DataArray type=\"UInt32\" Name=\"Rank\" NumberOfComponents=\"1\" format=\"ascii\">\n";
+  outFile << "               ";
+  const auto rank = utils::MasterSlave::getRank();
+  for (size_t count = 0; count < mesh.vertices().size(); ++count) {
+    outFile << rank << ' ';
+  }
+  outFile << "\n            </DataArray>\n";
+
+  for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
+    Eigen::VectorXd &values         = data->values();
+    int              dataDimensions = data->getDimensions();
+    std::string      dataName(data->getName());
+    int              numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
+    outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
+    outFile << "\" format=\"ascii\">\n";
+    outFile << "               ";
+    if (dataDimensions > 1) {
+      Eigen::VectorXd viewTemp(dataDimensions);
+      for (size_t count = 0; count < mesh.vertices().size(); count++) {
+        size_t offset = count * dataDimensions;
+        for (int i = 0; i < dataDimensions; i++) {
+          viewTemp[i] = values(offset + i);
+        }
+        for (int i = 0; i < dataDimensions; i++) {
+          outFile << viewTemp[i] << ' ';
+        }
+        if (dataDimensions == 2) {
+          outFile << "0.0" << ' '; //2D data needs to be 3D for vtk
+        }
+        outFile << ' ';
+      }
+    } else if (dataDimensions == 1) {
+      for (size_t count = 0; count < mesh.vertices().size(); count++) {
+        outFile << values(count) << ' ';
+      }
+    }
+    outFile << '\n'
+            << "            </DataArray>\n";
+  }
+  outFile << "         </PointData> \n";
+}
+
+void ExportXML::writeVertex(
+    const Eigen::VectorXd &position,
+    std::ostream &         outFile)
+{
+  outFile << "               ";
+  for (int i = 0; i < position.size(); i++) {
+    outFile << position(i) << "  ";
+  }
+  if (position.size() == 2) {
+    outFile << 0.0 << "  "; //also for 2D scenario, vtk needs 3D data
+  }
+  outFile << '\n';
+}
+
+void ExportXML::writeTriangle(
+    const mesh::Triangle &triangle,
+    std::ostream &        outFile)
+{
+  outFile << triangle.vertex(0).getID() << "  ";
+  outFile << triangle.vertex(1).getID() << "  ";
+  outFile << triangle.vertex(2).getID() << "  ";
+}
+
+void ExportXML::writeLine(
+    const mesh::Edge &edge,
+    std::ostream &    outFile)
+{
+  outFile << edge.vertex(0).getID() << "  ";
+  outFile << edge.vertex(1).getID() << "  ";
+}
+
+void ExportXML::exportPoints(
+    std::ostream &    outFile,
+    const mesh::Mesh &mesh) const
+{
+  outFile << "         <Points> \n";
+  outFile << "            <DataArray type=\"Float64\" Name=\"Position\" NumberOfComponents=\"" << 3 << "\" format=\"ascii\"> \n";
+  for (const mesh::Vertex &vertex : mesh.vertices()) {
+    writeVertex(vertex.getCoords(), outFile);
+  }
+  outFile << "            </DataArray>\n";
+  outFile << "         </Points> \n\n";
+}
+
+void ExportXML::writeMasterData(std::ostream &out) const
+{
+  // write scalar data names
+  out << "      <PPointData Scalars=\"Rank ";
+  for (const auto &scalarDataName : _scalarDataNames) {
+    out << scalarDataName << ' ';
+  }
+  // write vector data names
+  out << "\" Vectors=\"";
+  for (const auto &vectorDataName : _vectorDataNames) {
+    out << vectorDataName << ' ';
+  }
+  out << "\">\n";
+
+  out << "         <PDataArray type=\"Int32\" Name=\"Rank\" NumberOfComponents=\"1\"/>\n";
+
+  for (const auto &scalarDataName : _scalarDataNames) {
+    out << "         <PDataArray type=\"Float64\" Name=\"" << scalarDataName << "\" NumberOfComponents=\"" << 1 << "\"/>\n";
+  }
+
+  for (const auto &vectorDataName : _vectorDataNames) {
+    out << "         <PDataArray type=\"Float64\" Name=\"" << vectorDataName << "\" NumberOfComponents=\"" << 3 << "\"/>\n";
+  }
+  out << "      </PPointData>\n";
+}
+
+} // namespace io
+} // namespace precice

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -112,7 +112,7 @@ void ExportXML::writeSubFile(
   outSubFile << (utils::isMachineBigEndian() ? "BigEndian\">" : "LittleEndian\">") << '\n';
 
   outSubFile << "   <" << formatType << ">\n";
-  outSubFile << "      <Piece "<<getPieceAttributes(mesh)<<"> \n";
+  outSubFile << "      <Piece " << getPieceAttributes(mesh) << "> \n";
   exportPoints(outSubFile, mesh);
 
   // Write Mesh

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include "io/Export.hpp"
+#include "logging/Logger.hpp"
+
+namespace precice {
+namespace mesh {
+class Mesh;
+class Edge;
+class Triangle;
+} // namespace mesh
+} // namespace precice
+
+namespace precice {
+namespace io {
+
+/// Writes meshes to xml-vtk files. Only for parallel usage. Serial usage (coupling mode) should still use ExportVTK
+class ExportXML : public Export {
+public:
+  /// Perform writing to vtk file
+  /**
+   * @param[in] name filename to export to
+   * @param[in] locastion Export path
+   * @param[mesh] mesh Mesh to export
+   */
+  void doExport(
+      const std::string &name,
+      const std::string &location,
+      const mesh::Mesh & mesh) override;
+
+  static void writeVertex(
+      const Eigen::VectorXd &position,
+      std::ostream &         outFile);
+
+  static void writeLine(
+      const mesh::Edge &edge,
+      std::ostream &    outFile);
+
+  static void writeTriangle(
+      const mesh::Triangle &triangle,
+      std::ostream &        outFile);
+
+private:
+  mutable logging::Logger _log{"io::ExportXML"};
+
+  /// List of names of all scalar data on mesh
+  std::vector<std::string> _scalarDataNames;
+
+  /// List of names of all vector data on mesh
+  std::vector<std::string> _vectorDataNames;
+
+  virtual std::string getVTKFormat() const = 0;
+
+  /**
+    * @brief Stores scalar and vector data names in string vectors
+    * Needed for writing master file and sub files
+    */
+  void processDataNamesAndDimensions(const mesh::Mesh &mesh);
+
+  /**
+    * @brief Writes the master file (called only by the master rank)
+    */
+  void writeMasterFile(
+      const std::string &name,
+      const std::string &location,
+      const mesh::Mesh & mesh) const;
+
+  virtual void writeMasterCells(std::ostream &out) const = 0;
+
+  void writeMasterData(std::ostream &out) const;
+
+  /**
+    * @brief Writes the sub file for each rank
+    */
+  void writeSubFile(
+      const std::string &name,
+      const std::string &location,
+      const mesh::Mesh & mesh) const;
+
+  void exportPoints(
+      std::ostream &    outFile,
+      const mesh::Mesh &mesh) const;
+
+  virtual void exportConnectivity(
+      std::ostream &    outFile,
+      const mesh::Mesh &mesh) const = 0;
+
+  void exportData(
+      std::ostream &    outFile,
+      const mesh::Mesh &mesh) const;
+};
+
+} // namespace io
+} // namespace precice

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -53,10 +53,10 @@ private:
   /// List of names of all vector data on mesh
   std::vector<std::string> _vectorDataNames;
 
-  virtual std::string getVTKFormat() const = 0;
-  virtual std::string getMasterExtension() const = 0;
-  virtual std::string getPieceExtension() const = 0;
-  virtual std::string getPieceAttributes(const mesh::Mesh & mesh) const = 0;
+  virtual std::string getVTKFormat() const                             = 0;
+  virtual std::string getMasterExtension() const                       = 0;
+  virtual std::string getPieceExtension() const                        = 0;
+  virtual std::string getPieceAttributes(const mesh::Mesh &mesh) const = 0;
 
   /**
     * @brief Stores scalar and vector data names in string vectors
@@ -95,7 +95,6 @@ private:
   void exportData(
       std::ostream &    outFile,
       const mesh::Mesh &mesh) const;
-
 };
 
 } // namespace io

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -18,15 +18,9 @@ class Triangle;
 namespace precice {
 namespace io {
 
-/// Writes meshes to xml-vtk files. Only for parallel usage. Serial usage (coupling mode) should still use ExportVTK
+/// Common class to generate the VTK XML-based formats.
 class ExportXML : public Export {
 public:
-  /// Perform writing to vtk file
-  /**
-   * @param[in] name filename to export to
-   * @param[in] locastion Export path
-   * @param[mesh] mesh Mesh to export
-   */
   void doExport(
       const std::string &name,
       const std::string &location,

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -54,6 +54,9 @@ private:
   std::vector<std::string> _vectorDataNames;
 
   virtual std::string getVTKFormat() const = 0;
+  virtual std::string getMasterExtension() const = 0;
+  virtual std::string getPieceExtension() const = 0;
+  virtual std::string getPieceAttributes(const mesh::Mesh & mesh) const = 0;
 
   /**
     * @brief Stores scalar and vector data names in string vectors
@@ -92,6 +95,7 @@ private:
   void exportData(
       std::ostream &    outFile,
       const mesh::Mesh &mesh) const;
+
 };
 
 } // namespace io

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -22,6 +22,11 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
     tag.setDocumentation("Exports meshes to VTU files in serial or PVTU files with VTU piece files in parallel.");
     tags.push_back(tag);
   }
+  {
+    XMLTag tag(*this, VALUE_VTP, occ, TAG);
+    tag.setDocumentation("Exports meshes to VTP files in serial or PVTP files with VTP piece files in parallel.");
+    tags.push_back(tag);
+  }
 
   auto attrLocation = XMLAttribute<std::string>(ATTR_LOCATION, "")
                           .setDocumentation("Directory to export the files to.");

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -44,6 +44,7 @@ private:
   const std::string ATTR_AUTO     = "auto";
   const std::string VALUE_VTK     = "vtk";
   const std::string VALUE_VTU     = "vtu";
+  const std::string VALUE_VTP     = "vtp";
 
   const std::string ATTR_EVERY_N_TIME_WINDOWS = "every-n-time-windows";
   const std::string ATTR_NEIGHBORS            = "neighbors";

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -1,0 +1,129 @@
+#ifndef PRECICE_NO_MPI
+
+#include <Eigen/Core>
+#include <algorithm>
+#include <map>
+#include <string>
+#include "com/SharedPointer.hpp"
+#include "io/Export.hpp"
+#include "io/ExportVTP.hpp"
+#include "mesh/Mesh.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+#include "utils/Parallel.hpp"
+
+namespace precice {
+namespace mesh {
+class Edge;
+class Vertex;
+} // namespace mesh
+} // namespace precice
+
+BOOST_AUTO_TEST_SUITE(IOTests)
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(VTPExport)
+
+BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+  int           dim = 2;
+  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
+
+  mesh.createEdge(v1, v2);
+  mesh.createEdge(v2, v3);
+  mesh.createEdge(v3, v1);
+
+  io::ExportVTP exportVTP;
+  std::string   filename = "io-VTPExport-ExportPolygonalMesh";
+  std::string   location = "";
+  exportVTP.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  int        dim = 2;
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+
+  if (context.isRank(0)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0});
+
+    mesh.createEdge(v1, v2);
+    mesh.createEdge(v2, v3);
+    mesh.createEdge(v3, v1);
+    mesh.getVertexDistribution()[0] = {0, 1, 2};
+    mesh.getVertexDistribution()[1] = {};
+    mesh.getVertexDistribution()[2] = {3, 4, 5};
+    mesh.getVertexDistribution()[3] = {6};
+  } else if (context.isRank(1)) {
+    // nothing
+  } else if (context.isRank(2)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Constant(1));
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(2));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
+
+    mesh.createEdge(v1, v2);
+    mesh.createEdge(v2, v3);
+    mesh.createEdge(v3, v1);
+  } else if (context.isRank(3)) {
+    mesh.createVertex(Eigen::Vector2d::Constant(3.0));
+  }
+
+  io::ExportVTP exportVTP;
+  std::string   filename = "io-ExportVTPTest-testExportPolygonalMesh";
+  std::string   location = "";
+  exportVTP.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  int        dim = 3;
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+
+  if (context.isRank(0)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d::Constant(1));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
+
+    mesh::Edge &e1 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2 = mesh.createEdge(v2, v3);
+    mesh::Edge &e3 = mesh.createEdge(v3, v1);
+    mesh.createTriangle(e1, e2, e3);
+
+    mesh.getVertexDistribution()[0] = {0, 1, 2};
+    mesh.getVertexDistribution()[1] = {};
+    mesh.getVertexDistribution()[2] = {3, 4, 5};
+    mesh.getVertexDistribution()[3] = {6};
+  } else if (context.isRank(1)) {
+    // nothing
+  } else if (context.isRank(2)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Constant(1));
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d::Constant(2));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{0.0, 1.0, 0.0});
+
+    mesh::Edge &e1 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2 = mesh.createEdge(v2, v3);
+    mesh::Edge &e3 = mesh.createEdge(v3, v1);
+    mesh.createTriangle(e1, e2, e3);
+  } else if (context.isRank(3)) {
+    mesh.createVertex(Eigen::Vector3d::Constant(3.0));
+  }
+
+  io::ExportVTP exportVTP;
+  std::string   filename = "io-ExportVTPTest-testExportTriangulatedMesh";
+  std::string   location = "";
+  exportVTP.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // IOTests
+BOOST_AUTO_TEST_SUITE_END() // VTPExport
+
+#endif // PRECICE_NO_MPI

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -131,12 +131,12 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, 2.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{0.0, 2.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
@@ -147,34 +147,34 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.getVertexDistribution()[2] = {6, 7, 8};
     mesh.getVertexDistribution()[3] = {9, 10, 11};
   } else if (context.isRank(1)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, -2.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{0.0, -2.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
   } else if (context.isRank(2)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{-2.0, 0.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{-2.0, 0.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
   } else if (context.isRank(3)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -123,6 +123,70 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   exportVTP.doExport(filename, location, mesh);
 }
 
+BOOST_AUTO_TEST_CASE(ExportSplitSquare)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  int        dim = 3;
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+
+  mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
+  if (context.isRank(0)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, 2.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+
+    mesh.getVertexDistribution()[0] = {0, 1, 2};
+    mesh.getVertexDistribution()[1] = {3, 4, 5};
+    mesh.getVertexDistribution()[2] = {6, 7, 8};
+    mesh.getVertexDistribution()[3] = {9, 10, 11};
+  } else if (context.isRank(1)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, -2.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  } else if (context.isRank(2)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{-2.0, 0.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  } else if (context.isRank(3)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  }
+
+  io::ExportVTP exportVTP;
+  std::string   filename = "io-ExportVTPTest-Square";
+  std::string   location = "";
+  exportVTP.doExport(filename, location, mesh);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // IOTests
 BOOST_AUTO_TEST_SUITE_END() // VTPExport
 

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -123,6 +123,70 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   exportVTU.doExport(filename, location, mesh);
 }
 
+BOOST_AUTO_TEST_CASE(ExportSplitSquare)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  int        dim = 3;
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+
+  mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
+  if (context.isRank(0)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, 2.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+
+    mesh.getVertexDistribution()[0] = {0, 1, 2};
+    mesh.getVertexDistribution()[1] = {3, 4, 5};
+    mesh.getVertexDistribution()[2] = {6, 7, 8};
+    mesh.getVertexDistribution()[3] = {9, 10, 11};
+  } else if (context.isRank(1)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, -2.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  } else if (context.isRank(2)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{-2.0, 0.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  } else if (context.isRank(3)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
+    mesh::Edge &em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  }
+
+  io::ExportVTU exportVTU;
+  std::string   filename = "io-ExportVTUTest-Square";
+  std::string   location = "";
+  exportVTU.doExport(filename, location, mesh);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // IOTests
 BOOST_AUTO_TEST_SUITE_END() // VTUExport
 

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -131,12 +131,12 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, 2.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{0.0, 2.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
@@ -147,34 +147,34 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.getVertexDistribution()[2] = {6, 7, 8};
     mesh.getVertexDistribution()[3] = {9, 10, 11};
   } else if (context.isRank(1)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{0.0, -2.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{0.0, -2.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
   } else if (context.isRank(2)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{-2.0, 0.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{-2.0, 0.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
   } else if (context.isRank(3)) {
-    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
-    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
-    mesh::Vertex &vo = mesh.createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
-    mesh::Edge &em1 = mesh.createEdge(vm, v1);
-    mesh::Edge &e12 = mesh.createEdge(v1, v2);
-    mesh::Edge &e2m = mesh.createEdge(v2, vm);
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
     mesh.createTriangle(em1, e12, e2m);
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -13,6 +13,7 @@
 #include "io/ExportContext.hpp"
 #include "io/ExportVTK.hpp"
 #include "io/ExportVTU.hpp"
+#include "io/ExportVTP.hpp"
 #include "io/SharedPointer.hpp"
 #include "io/config/ExportConfiguration.hpp"
 #include "logging/LogMacros.hpp"
@@ -556,6 +557,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
       }
     } else if (exportContext.type == VALUE_VTU) {
       exporter = io::PtrExport(new io::ExportVTU());
+    } else if (exportContext.type == VALUE_VTP) {
+      exporter = io::PtrExport(new io::ExportVTP());
     } else {
       PRECICE_ERROR("Participant {} defines an <export/> tag of unknown type \"{}\".",
                     _participants.back()->getName(), exportContext.type);

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -549,7 +549,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
   for (io::ExportContext &exportContext : _exportConfig->exportContexts()) {
     io::PtrExport exporter;
     if (exportContext.type == VALUE_VTK) {
-      // This is handles with respect to the current configuration context.
+      // This is handled with respect to the current configuration context.
       // Hence, this is potentially wrong for every participant other than context.name.
       if (context.size > 1) {
         // Only display the warning message if this participant configuration is the current one.

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -12,8 +12,8 @@
 #include "com/config/CommunicationConfiguration.hpp"
 #include "io/ExportContext.hpp"
 #include "io/ExportVTK.hpp"
-#include "io/ExportVTU.hpp"
 #include "io/ExportVTP.hpp"
+#include "io/ExportVTU.hpp"
 #include "io/SharedPointer.hpp"
 #include "io/config/ExportConfiguration.hpp"
 #include "logging/LogMacros.hpp"
@@ -549,8 +549,15 @@ void ParticipantConfiguration::finishParticipantConfiguration(
   for (io::ExportContext &exportContext : _exportConfig->exportContexts()) {
     io::PtrExport exporter;
     if (exportContext.type == VALUE_VTK) {
+      // This is handles with respect to the current configuration context.
+      // Hence, this is potentially wrong for every participant other than context.name.
       if (context.size > 1) {
-        PRECICE_WARN("You are using the VTK exporter in a parallel participant. Note that this will export as PVTU instead. For consistency, prefer \"<export:vtu ... />\" instead.");
+        // Only display the warning message if this participant configuration is the current one.
+        if (context.name == participant->getName()) {
+          PRECICE_WARN("You are using the VTK exporter in the parallel participant {}. "
+                       "Note that this will export as PVTU instead. For consistency, prefer \"<export:vtu ... />\" instead.",
+                       participant->getName());
+        }
         exporter = io::PtrExport(new io::ExportVTU());
       } else {
         exporter = io::PtrExport(new io::ExportVTK());

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -99,6 +99,7 @@ private:
 
   const std::string VALUE_VTK = "vtk";
   const std::string VALUE_VTU = "vtu";
+  const std::string VALUE_VTP = "vtp";
 
   int _dimensions = 0;
 

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -1673,6 +1673,59 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
 //   multiCouplingThreeSolversParallelControl(configFile, context);
 // }
 
+BOOST_AUTO_TEST_CASE(ExportTimeseries)
+{
+  PRECICE_TEST("ExporterOne"_on(1_rank), "ExporterTwo"_on(2_ranks));
+  std::string config = _pathToTests + "export-timeseries.xml";
+
+  SolverInterface couplingInterface(context.name, config, context.rank, context.size);
+  BOOST_REQUIRE(couplingInterface.getDimensions() == 3);
+
+  std::vector<VertexID> vertexIds(6 / context.size, -1);
+  double                y = context.size;
+  std::vector<double>   coords{0, y, 0, 1, y, 0, 2, y, 0, 3, y, 0, 4, y, 0, 5, y, 0};
+  const MeshID          meshID = couplingInterface.getMeshID(context.isNamed("ExporterOne") ? "A" : "B");
+
+  if (context.isNamed("ExporterOne")) {
+    couplingInterface.setMeshVertices(meshID, 6, coords.data(), vertexIds.data());
+  } else {
+    couplingInterface.setMeshVertices(meshID, 3, &coords[context.rank * 9], vertexIds.data());
+  }
+
+  double time = 0.0;
+  double dt   = couplingInterface.initialize();
+
+  if (context.isNamed("ExporterOne")) {
+    const DataID sdataID = couplingInterface.getDataID("S", meshID);
+    const DataID vdataID = couplingInterface.getDataID("V", meshID);
+
+    std::vector<double> sdata(6);
+    std::vector<double> vdata(6 * 3, 0);
+    while (couplingInterface.isCouplingOngoing()) {
+      for (int x = 0; x < 6; ++x) {
+        const double pi  = 3.1415;
+        sdata[x]         = std::sin(x * pi / 3 + pi * time * 0.5);
+        vdata[3 * x]     = std::cos(x * pi / 3 + pi * time * 0.5);
+        vdata[3 * x + 1] = std::sin(x * pi / 3 + pi * time * 0.5);
+        vdata[3 * x + 2] = 0;
+      }
+      couplingInterface.writeBlockScalarData(sdataID, 6, vertexIds.data(), sdata.data());
+      couplingInterface.writeBlockVectorData(vdataID, 6, vertexIds.data(), vdata.data());
+
+      time += dt;
+      dt = couplingInterface.advance(dt);
+    }
+  } else {
+    while (couplingInterface.isCouplingOngoing()) {
+      time += dt;
+      dt = couplingInterface.advance(dt);
+    };
+  }
+  BOOST_TEST(time == 5);
+  BOOST_TEST(dt == 1);
+  couplingInterface.finalize();
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 #endif // PRECICE_NO_MPI

--- a/src/precice/tests/export-timeseries.xml
+++ b/src/precice/tests/export-timeseries.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="S" />
+    <data:vector name="V" />
+
+    <mesh name="A">
+      <use-data name="S" />
+      <use-data name="V" />
+    </mesh>
+
+    <mesh name="B">
+      <use-data name="S" />
+      <use-data name="V" />
+    </mesh>
+
+    <participant name="ExporterOne">
+      <use-mesh name="A" provide="on" />
+      <write-data name="S" mesh="A" />
+      <write-data name="V" mesh="A" />
+      <export:vtk />
+    </participant>
+
+    <participant name="ExporterTwo">
+      <use-mesh name="A" from="ExporterOne" />
+      <use-mesh name="B" provide="on" />
+      <read-data name="S" mesh="B" />
+      <read-data name="V" mesh="B" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="A"
+        to="B"
+        constraint="consistent"/>
+      <export:vtu />
+      <export:vtp />
+    </participant>
+
+    <m2n:sockets from="ExporterOne" to="ExporterTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="ExporterOne" second="ExporterTwo" />
+      <max-time-windows value="5" />
+      <time-window-size value="1.0" />
+      <exchange data="S" mesh="A" from="ExporterOne" to="ExporterTwo" />
+      <exchange data="V" mesh="A" from="ExporterOne" to="ExporterTwo" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/precice/tests/export-timeseries.xml
+++ b/src/precice/tests/export-timeseries.xml
@@ -26,11 +26,7 @@
       <use-mesh name="B" provide="on" />
       <read-data name="S" mesh="B" />
       <read-data name="V" mesh="B" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="A"
-        to="B"
-        constraint="consistent"/>
+      <mapping:nearest-neighbor direction="read" from="A" to="B" constraint="consistent" />
       <export:vtu />
       <export:vtp />
     </participant>

--- a/src/precice/tests/export-timeseries.xml
+++ b/src/precice/tests/export-timeseries.xml
@@ -18,7 +18,9 @@
       <use-mesh name="A" provide="on" />
       <write-data name="S" mesh="A" />
       <write-data name="V" mesh="A" />
-      <export:vtk />
+      <export:vtk directory="timeseries" />
+      <export:vtu directory="timeseries" />
+      <export:vtp directory="timeseries" />
     </participant>
 
     <participant name="ExporterTwo">
@@ -27,8 +29,8 @@
       <read-data name="S" mesh="B" />
       <read-data name="V" mesh="B" />
       <mapping:nearest-neighbor direction="read" from="A" to="B" constraint="consistent" />
-      <export:vtu />
-      <export:vtp />
+      <export:vtu directory="timeseries" />
+      <export:vtp directory="timeseries" />
     </participant>
 
     <m2n:sockets from="ExporterOne" to="ExporterTwo" />

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -126,6 +126,8 @@ target_sources(precice
     src/io/ExportContext.hpp
     src/io/ExportVTK.cpp
     src/io/ExportVTK.hpp
+    src/io/ExportVTP.cpp
+    src/io/ExportVTP.hpp
     src/io/ExportVTU.cpp
     src/io/ExportVTU.hpp
     src/io/ExportXML.cpp

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -128,6 +128,8 @@ target_sources(precice
     src/io/ExportVTK.hpp
     src/io/ExportVTU.cpp
     src/io/ExportVTU.hpp
+    src/io/ExportXML.cpp
+    src/io/ExportXML.hpp
     src/io/SharedPointer.hpp
     src/io/TXTReader.cpp
     src/io/TXTReader.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -30,6 +30,7 @@ target_sources(testprecice
     src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
     src/io/tests/ExportConfigurationTest.cpp
     src/io/tests/ExportVTKTest.cpp
+    src/io/tests/ExportVTPTest.cpp
     src/io/tests/ExportVTUTest.cpp
     src/io/tests/TXTTableWriterTest.cpp
     src/io/tests/TXTWriterReaderTest.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds a VTP/PVTP exporter, which is based on the refactored version of the VTU exporter.
The XML exporter contains the common functionality of both the VTU and the VTP exporter.

Closes #694 
Superseeds #1128 

## Motivation and additional information

VTP files can be displayed in Paraview glance. This allows us to embed example visualizations directly in the tutorials documentation.

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?