### PR TITLE
Move constant UNDEFINED_EXTRAPOLATION_ORDER into time::Time

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -18,6 +18,7 @@
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
 #include "precice/types.hpp"
+#include "time/Time.hpp"
 #include "time/Waveform.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/MasterSlave.hpp"
@@ -71,7 +72,7 @@ BaseCouplingScheme::BaseCouplingScheme(
   }
 
   if (isExplicitCouplingScheme()) {
-    PRECICE_ASSERT(_extrapolationOrder == UNDEFINED_EXTRAPOLATION_ORDER, "Extrapolation is not allowed for explicit coupling");
+    PRECICE_ASSERT(_extrapolationOrder == time::Time::UNDEFINED_EXTRAPOLATION_ORDER, "Extrapolation is not allowed for explicit coupling");
   } else {
     PRECICE_ASSERT(isImplicitCouplingScheme());
     PRECICE_CHECK((_extrapolationOrder == 0) || (_extrapolationOrder == 1) || (_extrapolationOrder == 2),

--- a/src/cplscheme/CouplingScheme.cpp
+++ b/src/cplscheme/CouplingScheme.cpp
@@ -9,8 +9,6 @@ const int CouplingScheme::UNDEFINED_TIME_WINDOWS = -1;
 
 const double CouplingScheme::UNDEFINED_TIME_WINDOW_SIZE = -1.0;
 
-const int CouplingScheme::UNDEFINED_EXTRAPOLATION_ORDER = -1;
-
 const int CouplingScheme::UNDEFINED_MAX_ITERATIONS = -1;
 
 } // namespace cplscheme

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -47,9 +47,6 @@ public:
   /// To be used, when the time window size is determined dynamically during the coupling.
   static const double UNDEFINED_TIME_WINDOW_SIZE;
 
-  /// To be used, when the extrapolation order is not defined (for explicit coupling).
-  static const int UNDEFINED_EXTRAPOLATION_ORDER;
-
   /// To be used, when the number of max iterations is not defined (for explicit coupling).
   static const int UNDEFINED_MAX_ITERATIONS;
 

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -6,6 +6,7 @@
 #include "cplscheme/Constants.hpp"
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
+#include "time/Time.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -54,7 +55,7 @@ public:
       constants::TimesteppingMethod dtMethod,
       CouplingMode                  cplMode,
       int                           maxIterations      = UNDEFINED_MAX_ITERATIONS,
-      int                           extrapolationOrder = UNDEFINED_EXTRAPOLATION_ORDER);
+      int                           extrapolationOrder = time::Time::UNDEFINED_EXTRAPOLATION_ORDER);
 
 private:
   logging::Logger _log{"cplscheme::ParallelCouplingScheme"};

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -6,6 +6,7 @@
 #include "cplscheme/Constants.hpp"
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
+#include "time/Time.hpp"
 
 namespace precice {
 
@@ -52,7 +53,7 @@ public:
       constants::TimesteppingMethod dtMethod,
       CouplingMode                  cplMode,
       int                           maxIterations      = UNDEFINED_MAX_ITERATIONS,
-      int                           extrapolationOrder = UNDEFINED_EXTRAPOLATION_ORDER);
+      int                           extrapolationOrder = time::Time::UNDEFINED_EXTRAPOLATION_ORDER);
 
 private:
   logging::Logger _log{"cplschemes::SerialCouplingSchemes"};

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -246,6 +246,8 @@ target_sources(precice
     src/query/impl/Indexer.hpp
     src/query/impl/RTreeAdapter.hpp
     src/time/SharedPointer.hpp
+    src/time/Time.cpp
+    src/time/Time.hpp
     src/time/Waveform.cpp
     src/time/Waveform.hpp
     src/utils/ArgumentFormatter.hpp

--- a/src/time/Time.cpp
+++ b/src/time/Time.cpp
@@ -1,0 +1,9 @@
+#include "Time.hpp"
+
+namespace precice {
+namespace time {
+
+const int Time::UNDEFINED_EXTRAPOLATION_ORDER = -1;
+
+} // namespace time
+} // namespace precice

--- a/src/time/Time.hpp
+++ b/src/time/Time.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace precice {
+namespace time {
+
+class Time {
+public:
+  /// To be used, when the extrapolation order is not defined.
+  static const int UNDEFINED_EXTRAPOLATION_ORDER;
+};
+
+} // namespace time
+} // namespace precice


### PR DESCRIPTION
## Main changes of this PR

Creates a class `time::Time` for storing constants on extrapolation.

## Motivation and additional information

This class can be used for storing other constants (e.g. `UNDEFINED_INTERPOLATION_ORDER`) at a later point in time. It also helps to further split the packages `cplscheme` and `time`.

Alternatively, we could also create a class `time::Constants`, but I followed the rationale in `cplscheme::CouplingScheme`.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
