### PR TITLE
Simplification of constructors and some extra add documentation

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -9,15 +9,6 @@ SolverInterface::SolverInterface(
     const std::string &participantName,
     const std::string &configurationFileName,
     int                solverProcessIndex,
-    int                solverProcessSize)
-    : _impl(new impl::SolverInterfaceImpl(participantName, configurationFileName, solverProcessIndex, solverProcessSize))
-{
-}
-
-SolverInterface::SolverInterface(
-    const std::string &participantName,
-    const std::string &configurationFileName,
-    int                solverProcessIndex,
     int                solverProcessSize,
     void *             communicator)
     : _impl(new impl::SolverInterfaceImpl(participantName, configurationFileName, solverProcessIndex, solverProcessSize, communicator))

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -40,7 +40,6 @@ public:
   ///@name Construction and Configuration
   ///@{
 
-
   /**
    * @param[in] participantName Name of the participant using the interface. Has to
    *        match the name given for a participant in the xml configuration file.

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -40,20 +40,6 @@ public:
   ///@name Construction and Configuration
   ///@{
 
-  /**
-   * @param[in] participantName Name of the participant using the interface. Has to
-   *        match the name given for a participant in the xml configuration file.
-   * @param[in] configurationFileName Name (with path) of the xml configuration file.
-   * @param[in] solverProcessIndex If the solver code runs with several processes,
-   *        each process using preCICE has to specify its index, which has to start
-   *        from 0 and end with solverProcessSize - 1.
-   * @param[in] solverProcessSize The number of solver processes using preCICE.
-   */
-  SolverInterface(
-      const std::string &participantName,
-      const std::string &configurationFileName,
-      int                solverProcessIndex,
-      int                solverProcessSize);
 
   /**
    * @param[in] participantName Name of the participant using the interface. Has to
@@ -63,14 +49,15 @@ public:
    *        each process using preCICE has to specify its index, which has to start
    *        from 0 and end with solverProcessSize - 1.
    * @param[in] solverProcessSize The number of solver processes using preCICE.
-   * @param[in] communicator A pointer to an MPI_Comm to use as communicator.
+   * @param[in] communicator A pointer to an MPI_Comm to use as communicator. Is
+   *        nullptr if standard communicator should be used.
    */
   SolverInterface(
       const std::string &participantName,
       const std::string &configurationFileName,
       int                solverProcessIndex,
       int                solverProcessSize,
-      void *             communicator);
+      void *             communicator = nullptr);
 
   ~SolverInterface();
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -136,15 +136,6 @@ SolverInterfaceImpl::SolverInterfaceImpl(
 #endif
 }
 
-SolverInterfaceImpl::SolverInterfaceImpl(
-    std::string        participantName,
-    const std::string &configurationFileName,
-    int                accessorProcessRank,
-    int                accessorCommunicatorSize)
-    : SolverInterfaceImpl::SolverInterfaceImpl(std::move(participantName), configurationFileName, accessorProcessRank, accessorCommunicatorSize, nullptr)
-{
-}
-
 SolverInterfaceImpl::~SolverInterfaceImpl()
 {
   if (_state != State::Finalized) {

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -46,23 +46,6 @@ namespace impl {
 /// Implementation of solver interface.
 class SolverInterfaceImpl {
 public:
-  /**
-   * @brief Constructor.
-   *
-   * A solver that wants to use the SolverInterfaceImpl must instatiate an object
-   * of this class. The object has to be configured by one of the configure
-   * methods before it has a reasonable state and can be used.
-   *
-   * @param[in] configurationFileName Name (with path) of the xml config file.
-   * @param[in] participantName Name of the participant using the interface. Has to
-   *                            match the name given for a participant in the
-   *                            xml configuration file.
-   */
-  SolverInterfaceImpl(
-      std::string        participantName,
-      const std::string &configurationFileName,
-      int                accessorProcessRank,
-      int                accessorCommunicatorSize);
 
   /// Deleted copy constructor
   SolverInterfaceImpl(SolverInterfaceImpl const &) = delete;
@@ -90,14 +73,19 @@ public:
    *                            match the name given for a participant in the
    *                            xml configuration file.
    * @param[in] configurationFileName Name (with path) of the xml config file.
-   * @param[in] communicator    A pointer to the MPI_Comm to use.
+   * @param[in] accessorProcessRank If the solver code runs with several processes,
+   *        each process using preCICE has to specify its index, which has to start
+   *        from 0 and end with accessorCommunicatorSize - 1.
+   * @param[in] accessorCommunicatorSize The number of solver processes using preCICE.
+   * @param[in] communicator A pointer to the MPI_Comm to use. Is nullptr if
+   *                         standard communicator should be used.
    */
   SolverInterfaceImpl(
       std::string        participantName,
       const std::string &configurationFileName,
       int                accessorProcessRank,
       int                accessorCommunicatorSize,
-      void *             communicator);
+      void *             communicator = nullptr);
 
   /** Ensures that finalize() has been called.
    *

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -46,7 +46,6 @@ namespace impl {
 /// Implementation of solver interface.
 class SolverInterfaceImpl {
 public:
-
   /// Deleted copy constructor
   SolverInterfaceImpl(SolverInterfaceImpl const &) = delete;
 


### PR DESCRIPTION
## Main changes of this PR

This PR does the following:
- Make constructors of `SolverInterfaceImpl` and `SolverInterface` simpler by setting default parameter for communicator to avoid code duplication.
- Add documentation for `accessorProcessRank` and `accessorCommunicatorSize` in class `SolverInterfaceImpl`. However, this contains some information duplication of documenation of `SolverInterface`.

## Motivation and additional information

I stumbled upon some code duplication in the constructors of `SolverInterface` and `SolverInterfaceImpl`. Both classes provide an interface that accepts an explicitly set communicator and without the communicator specified. Instead of actually defining the constructors twice one can set a default parameter for the `communicator` variable/pointer.

The main advantages are:
- Less code and thus less code that can be wrong
- Easier to read classes as they get shorts
- Less code that has to be documented
- Less code and documentation duplication. For the constructor of `SolverInterfaceImpl` there was actually documentation missing that I tried to fix.

If you work on reducing code duplication anyway, please ignore this PR. I found it easy to change. I ran the tests locally and they all passed (Ubuntu 20.04).

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
