### PR TITLE
Make reformatting options more verbose

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Short rational why preCICE needs this change. If this is already described in an
 ## Author's checklist
 
 * [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
-* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
+* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly. Run `tools/formatting/format-all` to reformat files automatically.
 * [ ] I sticked to C++14 features.
 * [ ] I sticked to CMake version 3.10.
 * [ ] I squashed / am about to squash all commits that should be seen as one.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Short rational why preCICE needs this change. If this is already described in an
 ## Author's checklist
 
 * [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
-* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly. Run `tools/formatting/format-all` to reformat files automatically.
+* [ ] I ran `tools/formatting/format-all` to ensure everything is formatted correctly.
 * [ ] I sticked to C++14 features.
 * [ ] I sticked to CMake version 3.10.
 * [ ] I squashed / am about to squash all commits that should be seen as one.

--- a/tools/formatting/check-format
+++ b/tools/formatting/check-format
@@ -5,7 +5,7 @@
 # Returns
 # 0 on success
 # 1 on an incorrect format
-# 2 is clang-format 8 could not be found 
+# 2 is clang-format 8 could not be found
 
 # Detect version
 if command -v clang-format-8 > /dev/null; then
@@ -92,6 +92,7 @@ if [[ -n "$DIFFS" ]]; then
     for file in $DIFFS; do
         echo "$file"
     done
+    echo "You can automatically reformat all files using the script tools/formatting/format-all"
     exit 1
 else
     echo "All files are formatted correctly"


### PR DESCRIPTION
## Main changes of this PR

- Mention `reformat-all` script in PR template
- `check-format` mentions `reformat-all` script if some files are formatted wrongly.
 
  ```bash
  $ tools/formatting/check-format
  Using binary: clang-format-8
  GNU parallel detected.
  Checking 388 C/C++ files
  100% 388:0=0s tools/testing/communication_dummies/mainB.cpp                                                                                 
  Checking 100 XML files
  100% 100:0=0s src/xml/tests/xmltest-unique-attribute-config.xml                                                                             
  The following files are not formatted correctly:
  src/precice/impl/SolverInterfaceImpl.cpp
  You can automatically reformat all files using the script tools/formatting/format-all
  ```

  Note, that the last line in the output is new.

## Motivation and additional information

I found author's checklist of limited help when it comes to format checking. I ran the `check-format` tool and my files were formatted wrongly, see

```bash
$ tools/formatting/check-format
Using binary: clang-format-8
GNU parallel detected.
Checking 388 C/C++ files
100% 388:0=0s tools/testing/communication_dummies/mainB.cpp                                                                                 
Checking 100 XML files
100% 100:0=0s src/xml/tests/xmltest-unique-attribute-config.xml                                                                             
The following files are not formatted correctly:
src/precice/SolverInterface.hpp
src/precice/impl/SolverInterfaceImpl.hpp
```

However, it did not give me insight regarding what is wrong, nor a patch to apply, nor any hint to the `format-all` script. Sadly, the `README.md` in `tools/formatting` does not help much either.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
