### PR TITLE
Add tools to CMake

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,8 @@ Short rational why preCICE needs this change. If this is already described in an
 
 ## Author's checklist
 
-* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
-* [ ] I ran `tools/formatting/format-all` to ensure everything is formatted correctly.
+* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
+* [ ] I ran `make format` to ensure everything is formatted correctly.
 * [ ] I sticked to C++14 features.
 * [ ] I sticked to CMake version 3.10.
 * [ ] I squashed / am about to squash all commits that should be seen as one.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,7 +576,7 @@ endif()
 #
 
 add_custom_target(
-  docs
+  doxygen
   COMMAND doxygen
   WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
   USES_TERMINAL
@@ -590,7 +590,7 @@ add_custom_target(
   )
 
 add_custom_target(
-  update
+  sourcesIndex
   COMMAND tools/building/updateSourceFiles.py
   WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
   USES_TERMINAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,3 +569,36 @@ if (BUILD_TESTING)
 
   include(${CMAKE_CURRENT_LIST_DIR}/cmake/TestInstall.cmake)
 endif()
+
+
+#
+# Tooling
+#
+
+add_custom_target(
+  docs
+  COMMAND doxygen
+  WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
+  USES_TERMINAL
+  )
+
+add_custom_target(
+  format
+  COMMAND tools/formatting/format-all
+  WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
+  USES_TERMINAL
+  )
+
+add_custom_target(
+  update
+  COMMAND tools/building/updateSourceFiles.py
+  WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
+  USES_TERMINAL
+  )
+
+add_custom_target(
+  changelog
+  COMMAND tools/building/createChangelog
+  WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
+  USES_TERMINAL
+  )

--- a/docs/changelog/1143.md
+++ b/docs/changelog/1143.md
@@ -1,0 +1,1 @@
+- Added tooling to CMake, which simplifies contributing.


### PR DESCRIPTION
## Main changes of this PR

This PR adds targets for our tools to CMake, which allows to quickly run the most common tools from the build directory.
This is related to @ajaust 's proposed #1142.

Job | Manual | Addition
--- | --- | ---
Generate documentation | `doxygen` | `make doxygen`
Format the codebase | `tools/formatting/format-all` | `make format`
Updating sources | `tools/building/updateSourceFiles.py` | `make sourcesIndex`
Add changelog entry | `tools/building/createChangelog` | `make changelog`

## Motivation and additional information

Makes the tooling more straight forward to use and simplifies the author checklist in the PR template.

## Author's checklist

* [ ] I added a changelog entry using `make changelog` if there are noteworthy changes.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?