### PR TITLE
Add CSV exporter

### DIFF
--- a/docs/changelog/1144.md
+++ b/docs/changelog/1144.md
@@ -1,0 +1,1 @@
+- Added export to CSV using `<export:csv />`.

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -34,8 +34,10 @@ void ExportCSV::doExport(
 
   // Construct full filename
   std::string filename{name};
+  int         rank{0};
   if (utils::MasterSlave::isParallel()) {
-    filename.append("_").append(std::to_string(utils::MasterSlave::getRank()));
+    rank = utils::MasterSlave::getRank();
+    filename.append("_").append(std::to_string(rank));
   }
   filename.append(".csv");
 
@@ -48,10 +50,11 @@ void ExportCSV::doExport(
   const bool    is3d = (mesh.getDimensions() == 3);
 
   // write header
-  outFile << "PosX;PosY;";
+  outFile << "PosX;PosY";
   if (is3d) {
-    outFile << "PosZ";
+    outFile << ";PosZ";
   }
+  outFile << ";Rank";
   for (const auto &data : mesh.data()) {
     auto name = data->getName();
     auto dim  = data->getDimensions();
@@ -65,7 +68,8 @@ void ExportCSV::doExport(
   outFile << '\n';
 
   // write vertex data
-  const auto size = mesh.vertices().size();
+  const std::string rankCol = ";" + std::to_string(rank);
+  const auto        size    = mesh.vertices().size();
   for (std::size_t vid = 0; vid < size; ++vid) {
     const auto &vertex = mesh.vertices()[vid];
     outFile << vertex.getCoords()[0] << ';';
@@ -73,7 +77,7 @@ void ExportCSV::doExport(
     if (is3d) {
       outFile << ";" << vertex.getCoords()[2];
     }
-
+    outFile << rankCol;
     for (const auto &data : mesh.data()) {
       auto dim    = data->getDimensions();
       auto offset = vid * dim;

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -60,6 +60,9 @@ void ExportCSV::doExport(
 
   namespace fs = boost::filesystem;
   fs::path outfile(location);
+  if (not location.empty()) {
+    fs::create_directories(outfile);
+  }
   outfile /= filename;
 
   // Prepare filestream

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -1,0 +1,96 @@
+#include "io/ExportCSV.hpp"
+
+#include <Eigen/Core>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include "io/Export.hpp"
+#include "logging/LogMacros.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/Vertex.hpp"
+#include "utils/MasterSlave.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice {
+namespace io {
+
+void ExportCSV::doExport(
+    const std::string &name,
+    const std::string &location,
+    const mesh::Mesh & mesh)
+{
+  PRECICE_TRACE(name, location, mesh.getName());
+  PRECICE_ASSERT(!name.empty());
+
+  // Ignore empty meshes
+  if (mesh.vertices().empty()) {
+    return;
+  }
+
+  // Construct full filename
+  std::string filename{name};
+  if (utils::MasterSlave::isParallel()) {
+    filename.append("_").append(std::to_string(utils::MasterSlave::getRank()));
+  }
+  filename.append(".csv");
+
+  namespace fs = boost::filesystem;
+  fs::path outfile(location);
+  outfile /= filename;
+
+  // Prepare filestream
+  std::ofstream outFile(outfile.string(), std::ios::trunc);
+  const bool    is3d = (mesh.getDimensions() == 3);
+
+  // write header
+  outFile << "PosX;PosY;";
+  if (is3d) {
+    outFile << "PosZ";
+  }
+  for (const auto &data : mesh.data()) {
+    auto name = data->getName();
+    auto dim  = data->getDimensions();
+    outFile << ';' << name;
+    if (dim == 2) {
+      outFile << "X;" << name << 'Y';
+    } else if (dim == 3) {
+      outFile << "X;" << name << "Y;" << name << 'Z';
+    }
+  }
+  outFile << '\n';
+
+  // write vertex data
+  const auto size = mesh.vertices().size();
+  for (std::size_t vid = 0; vid < size; ++vid) {
+    const auto &vertex = mesh.vertices()[vid];
+    outFile << vertex.getCoords()[0] << ';';
+    outFile << vertex.getCoords()[1];
+    if (is3d) {
+      outFile << ";" << vertex.getCoords()[2];
+    }
+
+    for (const auto &data : mesh.data()) {
+      auto dim    = data->getDimensions();
+      auto offset = vid * dim;
+
+      outFile << ';' << data->values()[offset];
+      if (dim == 1) {
+        continue;
+      }
+      outFile << ';' << data->values()[offset + 1];
+      if (dim == 2) {
+        continue;
+      }
+      outFile << ';' << data->values()[offset + 2];
+    }
+    outFile << '\n';
+  }
+}
+
+} // namespace io
+} // namespace precice

--- a/src/io/ExportCSV.hpp
+++ b/src/io/ExportCSV.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include "io/Export.hpp"
+#include "logging/Logger.hpp"
+
+namespace precice {
+namespace io {
+
+class ExportCSV : public Export {
+public:
+  virtual void doExport(
+      const std::string &name,
+      const std::string &location,
+      const mesh::Mesh & mesh);
+
+private:
+  mutable logging::Logger _log{"io::ExportCSV"};
+};
+
+} // namespace io
+} // namespace precice

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -27,6 +27,11 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
     tag.setDocumentation("Exports meshes to VTP files in serial or PVTP files with VTP piece files in parallel.");
     tags.push_back(tag);
   }
+  {
+    XMLTag tag(*this, VALUE_CSV, occ, TAG);
+    tag.setDocumentation("Exports vertex coordinates and data to CSV files.");
+    tags.push_back(tag);
+  }
 
   auto attrLocation = XMLAttribute<std::string>(ATTR_LOCATION, "")
                           .setDocumentation("Directory to export the files to.");

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -45,6 +45,7 @@ private:
   const std::string VALUE_VTK     = "vtk";
   const std::string VALUE_VTU     = "vtu";
   const std::string VALUE_VTP     = "vtp";
+  const std::string VALUE_CSV     = "csv";
 
   const std::string ATTR_EVERY_N_TIME_WINDOWS = "every-n-time-windows";
   const std::string ATTR_NEIGHBORS            = "neighbors";

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -1,0 +1,193 @@
+#ifndef PRECICE_NO_MPI
+
+#include <Eigen/Core>
+#include <algorithm>
+#include <map>
+#include <string>
+#include "com/SharedPointer.hpp"
+#include "io/Export.hpp"
+#include "io/ExportCSV.hpp"
+#include "mesh/Mesh.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+#include "utils/Parallel.hpp"
+
+namespace precice {
+namespace mesh {
+class Edge;
+class Vertex;
+} // namespace mesh
+} // namespace precice
+
+BOOST_AUTO_TEST_SUITE(IOTests)
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(CSVExport)
+
+BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
+{
+  PRECICE_TEST(""_on(1_rank).setupMasterSlaves());
+  int           dim = 2;
+  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
+
+  mesh.createEdge(v1, v2);
+  mesh.createEdge(v2, v3);
+  mesh.createEdge(v3, v1);
+
+  io::ExportCSV exportCSV;
+  std::string   filename = "io-CSVExport-ExportPolygonalMesh";
+  std::string   location = "";
+  exportCSV.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  int        dim = 2;
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+
+  if (context.isRank(0)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0});
+
+    mesh.createEdge(v1, v2);
+    mesh.createEdge(v2, v3);
+    mesh.createEdge(v3, v1);
+    mesh.getVertexDistribution()[0] = {0, 1, 2};
+    mesh.getVertexDistribution()[1] = {};
+    mesh.getVertexDistribution()[2] = {3, 4, 5};
+    mesh.getVertexDistribution()[3] = {6};
+  } else if (context.isRank(1)) {
+    // nothing
+  } else if (context.isRank(2)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Constant(1));
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(2));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
+
+    mesh.createEdge(v1, v2);
+    mesh.createEdge(v2, v3);
+    mesh.createEdge(v3, v1);
+  } else if (context.isRank(3)) {
+    mesh.createVertex(Eigen::Vector2d::Constant(3.0));
+  }
+
+  io::ExportCSV exportCSV;
+  std::string   filename = "io-ExportCSVTest-testExportPolygonalMesh";
+  std::string   location = "";
+  exportCSV.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  int        dim = 3;
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+
+  if (context.isRank(0)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d::Constant(1));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
+
+    mesh::Edge &e1 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2 = mesh.createEdge(v2, v3);
+    mesh::Edge &e3 = mesh.createEdge(v3, v1);
+    mesh.createTriangle(e1, e2, e3);
+
+    mesh.getVertexDistribution()[0] = {0, 1, 2};
+    mesh.getVertexDistribution()[1] = {};
+    mesh.getVertexDistribution()[2] = {3, 4, 5};
+    mesh.getVertexDistribution()[3] = {6};
+  } else if (context.isRank(1)) {
+    // nothing
+  } else if (context.isRank(2)) {
+    mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Constant(1));
+    mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d::Constant(2));
+    mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{0.0, 1.0, 0.0});
+
+    mesh::Edge &e1 = mesh.createEdge(v1, v2);
+    mesh::Edge &e2 = mesh.createEdge(v2, v3);
+    mesh::Edge &e3 = mesh.createEdge(v3, v1);
+    mesh.createTriangle(e1, e2, e3);
+  } else if (context.isRank(3)) {
+    mesh.createVertex(Eigen::Vector3d::Constant(3.0));
+  }
+
+  io::ExportCSV exportCSV;
+  std::string   filename = "io-ExportCSVTest-testExportTriangulatedMesh";
+  std::string   location = "";
+  exportCSV.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_CASE(ExportSplitSquare)
+{
+  PRECICE_TEST(""_on(4_ranks).setupMasterSlaves());
+  int        dim = 3;
+  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+
+  mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
+  if (context.isRank(0)) {
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{0.0, 2.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+
+    mesh.getVertexDistribution()[0] = {0, 1, 2};
+    mesh.getVertexDistribution()[1] = {3, 4, 5};
+    mesh.getVertexDistribution()[2] = {6, 7, 8};
+    mesh.getVertexDistribution()[3] = {9, 10, 11};
+  } else if (context.isRank(1)) {
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{0.0, -2.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  } else if (context.isRank(2)) {
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{-1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{-2.0, 0.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  } else if (context.isRank(3)) {
+    mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, 1.0, 0.0});
+    mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
+    mesh::Vertex &vo  = mesh.createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
+    mesh::Edge &  em1 = mesh.createEdge(vm, v1);
+    mesh::Edge &  e12 = mesh.createEdge(v1, v2);
+    mesh::Edge &  e2m = mesh.createEdge(v2, vm);
+    mesh.createTriangle(em1, e12, e2m);
+    mesh::Edge &eo1 = mesh.createEdge(vo, v1);
+    mesh::Edge &e2o = mesh.createEdge(v2, vo);
+    mesh.createTriangle(eo1, e12, e2o);
+  }
+
+  io::ExportCSV exportCSV;
+  std::string   filename = "io-ExportCSVTest-Square";
+  std::string   location = "";
+  exportCSV.doExport(filename, location, mesh);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // IOTests
+BOOST_AUTO_TEST_SUITE_END() // CSVExport
+
+#endif // PRECICE_NO_MPI

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -10,6 +10,7 @@
 #include "com/MPIDirectCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "com/config/CommunicationConfiguration.hpp"
+#include "io/ExportCSV.hpp"
 #include "io/ExportContext.hpp"
 #include "io/ExportVTK.hpp"
 #include "io/ExportVTP.hpp"
@@ -566,6 +567,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
       exporter = io::PtrExport(new io::ExportVTU());
     } else if (exportContext.type == VALUE_VTP) {
       exporter = io::PtrExport(new io::ExportVTP());
+    } else if (exportContext.type == VALUE_CSV) {
+      exporter = io::PtrExport(new io::ExportCSV());
     } else {
       PRECICE_ERROR("Participant {} defines an <export/> tag of unknown type \"{}\".",
                     _participants.back()->getName(), exportContext.type);

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -100,6 +100,7 @@ private:
   const std::string VALUE_VTK = "vtk";
   const std::string VALUE_VTU = "vtu";
   const std::string VALUE_VTP = "vtp";
+  const std::string VALUE_CSV = "csv";
 
   int _dimensions = 0;
 

--- a/src/precice/tests/export-timeseries.xml
+++ b/src/precice/tests/export-timeseries.xml
@@ -21,6 +21,7 @@
       <export:vtk directory="timeseries" />
       <export:vtu directory="timeseries" />
       <export:vtp directory="timeseries" />
+      <export:csv directory="timeseries" />
     </participant>
 
     <participant name="ExporterTwo">
@@ -31,6 +32,7 @@
       <mapping:nearest-neighbor direction="read" from="A" to="B" constraint="consistent" />
       <export:vtu directory="timeseries" />
       <export:vtp directory="timeseries" />
+      <export:csv directory="timeseries" />
     </participant>
 
     <m2n:sockets from="ExporterOne" to="ExporterTwo" />

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -123,6 +123,8 @@ target_sources(precice
     src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
     src/cplscheme/impl/SharedPointer.hpp
     src/io/Export.hpp
+    src/io/ExportCSV.cpp
+    src/io/ExportCSV.hpp
     src/io/ExportContext.hpp
     src/io/ExportVTK.cpp
     src/io/ExportVTK.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -28,6 +28,7 @@ target_sources(testprecice
     src/cplscheme/tests/RelativeConvergenceMeasureTest.cpp
     src/cplscheme/tests/ResidualRelativeConvergenceMeasureTest.cpp
     src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+    src/io/tests/ExportCSVTest.cpp
     src/io/tests/ExportConfigurationTest.cpp
     src/io/tests/ExportVTKTest.cpp
     src/io/tests/ExportVTPTest.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds a CSV exporter, which allows to export the vertex information to a semicolon-separated values format.

## Motivation and additional information

Intended purpose is:
* provide an accessible export format
* usable without Paraview
* easy to import into speadsheet applications (quick visualisation of data)
* easy to check (may be useful for integration tests)
* more natural fit for applications with pseudo-meshes

The exporter
* does not export connectivity information
* saves 1 file per rank
* uses the same naming scheme as the other exporters

To merge and process csv of a parallel participant, one can use pandas:
```py
import pandas
import glob

name = "A-ExporterTwo.dt1"
df = pandas.concat([pandas.read_csv(name, sep=";") for name in glob.glob(f"{name}_*.csv")], ignore_index=True)
```

To import timesteps as well
```py
import pandas
import glob
import re

l = [  (re.search("dt(\d+)_", s).group(1), s) for s in  glob.glob(f"{n}.dt*_*.csv")]
p = pandas.concat([pandas.read_csv(file, sep=";").assign(dt=dt) for dt, file in l], ignore_index=True)
```

## Author's checklist

* [x] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/format-all` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
