### PR TITLE
Adds initial QN updates for improvements

### DIFF
--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -24,6 +24,7 @@ public:
   static const int QR1FILTER_ABS = 2;
   static const int QR2FILTER     = 3;
   static const int PODFILTER     = 4;
+  static const int QR3FILTER     = 5;
 
   /// Map from data ID to data values.
   using DataMap   = std::map<int, cplscheme::PtrCouplingData>;

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -480,12 +480,6 @@ void BaseQNAcceleration::concatenateCouplingData(
       _values(i + offset)    = values(i);
       _oldValues(i + offset) = oldValues(i);
     }
-    // Delete column if the input values of solver is zero
-    double _normValues = utils::MasterSlave::l2norm(values);
-    if (_firstIteration && (_normValues == 0)) {
-      _deleteFirstColumn = true;
-      PRECICE_DEBUG("Data with ID: {} in has a zero input vector.", id);
-    }
     offset += size;
   }
 }

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -311,7 +311,6 @@ void BaseQNAcceleration::performAcceleration(
    */
   updateDifferenceMatrices(cplData);
 
-
   if (_firstIteration && (_firstTimeWindow || _forceInitialRelaxation)) {
     PRECICE_DEBUG("   Performing underrelaxation");
     _oldXTilde    = _values;    // Store x tilde
@@ -322,8 +321,6 @@ void BaseQNAcceleration::performAcceleration(
     _residuals *= _initialRelaxation;
     _residuals += _oldValues;
     _values = _residuals;
-
-    
 
     computeUnderrelaxationSecondaryData(cplData);
   } else {
@@ -378,15 +375,15 @@ void BaseQNAcceleration::performAcceleration(
     // apply the configured filter to the LS system. Automatically delete the first column if a zero vector occurs.
     // Automatic deletion can only occur in the first time window.
     //if (its == 2 && tWindows == 0) {
-      //if (_deleteFirstColumn) {
-        // Only remove a column if it exists, i.e. at least 2 columns are present
-        //if ((_matrixV.cols() - 1) == 1) {
-          //PRECICE_INFO("  Automatically removing the first column in Matrices V and W due to an initial zero sub-vector.");
-          //removeMatrixColumn(_matrixV.cols() - 1);
-          //_qrV.deleteColumn(_matrixV.cols() - 1);
-        //}
-      //}
-      //_deleteFirstColumn = false;
+    //if (_deleteFirstColumn) {
+    // Only remove a column if it exists, i.e. at least 2 columns are present
+    //if ((_matrixV.cols() - 1) == 1) {
+    //PRECICE_INFO("  Automatically removing the first column in Matrices V and W due to an initial zero sub-vector.");
+    //removeMatrixColumn(_matrixV.cols() - 1);
+    //_qrV.deleteColumn(_matrixV.cols() - 1);
+    //}
+    //}
+    //_deleteFirstColumn = false;
     //}
 
     utils::Event applyingFilter("ApplyFilter");

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -198,6 +198,9 @@ void BaseQNAcceleration::updateDifferenceMatrices(
   _residuals = _values;
   _residuals -= _oldValues;
 
+  //PRECICE_INFO("_values: {}", _values);
+  //PRECICE_INFO("_residuals: {}", _residuals);
+
   if (math::equals(utils::MasterSlave::l2norm(_residuals), 0.0)) {
     PRECICE_WARN("The coupling residual equals almost zero. There is maybe something wrong in your adapter. "
                  "Maybe you always write the same data or you call advance without "
@@ -308,6 +311,7 @@ void BaseQNAcceleration::performAcceleration(
    */
   updateDifferenceMatrices(cplData);
 
+
   if (_firstIteration && (_firstTimeWindow || _forceInitialRelaxation)) {
     PRECICE_DEBUG("   Performing underrelaxation");
     _oldXTilde    = _values;    // Store x tilde
@@ -318,6 +322,8 @@ void BaseQNAcceleration::performAcceleration(
     _residuals *= _initialRelaxation;
     _residuals += _oldValues;
     _values = _residuals;
+
+    
 
     computeUnderrelaxationSecondaryData(cplData);
   } else {
@@ -371,17 +377,17 @@ void BaseQNAcceleration::performAcceleration(
 
     // apply the configured filter to the LS system. Automatically delete the first column if a zero vector occurs.
     // Automatic deletion can only occur in the first time window.
-    if (its == 2 && tWindows == 0) {
-      if (_deleteFirstColumn) {
+    //if (its == 2 && tWindows == 0) {
+      //if (_deleteFirstColumn) {
         // Only remove a column if it exists, i.e. at least 2 columns are present
-        if ((_matrixV.cols() - 1) == 1) {
-          PRECICE_DEBUG("  Automatically removing the first column in Matrices V and W due to an initial zero sub-vector.");
-          removeMatrixColumn(_matrixV.cols() - 1);
-          _qrV.deleteColumn(_matrixV.cols() - 1);
-        }
-      }
-      _deleteFirstColumn = false;
-    }
+        //if ((_matrixV.cols() - 1) == 1) {
+          //PRECICE_INFO("  Automatically removing the first column in Matrices V and W due to an initial zero sub-vector.");
+          //removeMatrixColumn(_matrixV.cols() - 1);
+          //_qrV.deleteColumn(_matrixV.cols() - 1);
+        //}
+      //}
+      //_deleteFirstColumn = false;
+    //}
 
     utils::Event applyingFilter("ApplyFilter");
     applyFilter();

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -372,20 +372,6 @@ void BaseQNAcceleration::performAcceleration(
       _nbDropCols = 0;
     }
 
-    // apply the configured filter to the LS system. Automatically delete the first column if a zero vector occurs.
-    // Automatic deletion can only occur in the first time window.
-    //if (its == 2 && tWindows == 0) {
-    //if (_deleteFirstColumn) {
-    // Only remove a column if it exists, i.e. at least 2 columns are present
-    //if ((_matrixV.cols() - 1) == 1) {
-    //PRECICE_INFO("  Automatically removing the first column in Matrices V and W due to an initial zero sub-vector.");
-    //removeMatrixColumn(_matrixV.cols() - 1);
-    //_qrV.deleteColumn(_matrixV.cols() - 1);
-    //}
-    //}
-    //_deleteFirstColumn = false;
-    //}
-
     utils::Event applyingFilter("ApplyFilter");
     applyFilter();
     applyingFilter.stop();

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -198,9 +198,6 @@ void BaseQNAcceleration::updateDifferenceMatrices(
   _residuals = _values;
   _residuals -= _oldValues;
 
-  //PRECICE_INFO("_values: {}", _values);
-  //PRECICE_INFO("_residuals: {}", _residuals);
-
   if (math::equals(utils::MasterSlave::l2norm(_residuals), 0.0)) {
     PRECICE_WARN("The coupling residual equals almost zero. There is maybe something wrong in your adapter. "
                  "Maybe you always write the same data or you call advance without "
@@ -361,7 +358,7 @@ void BaseQNAcceleration::performAcceleration(
 
     if (_preconditioner->requireNewQR()) {
       if ((not(_filter == Acceleration::QR2FILTER) && not(_filter == Acceleration::QR3FILTER))) { //for QR2 and QR3 (Fast filter) filter, there is no need to do this twice
-        PRECICE_DEBUG("  QR Reset");
+        PRECICE_DEBUG("  QR Decomposition will be reset ");
         _qrV.reset(_matrixV, getLSSystemRows());
       }
       _preconditioner->newQRfulfilled();
@@ -376,7 +373,8 @@ void BaseQNAcceleration::performAcceleration(
     applyFilter();
     applyingFilter.stop();
 
-    _preconditioner->updatedWeightsReset(); // Reset the check for the pre-scaling weights.
+    // Reset the check for the pre-scaling weights so that they are not updated each iteration.
+    _preconditioner->updatedWeightsReset(); 
     // revert scaling of V, in computeQNUpdate all data objects are unscaled.
     _preconditioner->revert(_matrixV);
 

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -204,7 +204,7 @@ protected:
   impl::QRFactorization _qrV;
 
   /** @brief filter method that is used to maintain good conditioning of the least-squares system
-    *        Either of two types: QR1FILTER or QR2Filter
+    *        Either of two types: QR1FILTER, QR2Filter or QR3Filter
     */
   int _filter;
 

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -204,7 +204,7 @@ protected:
   impl::QRFactorization _qrV;
 
   /** @brief filter method that is used to maintain good conditioning of the least-squares system
-    *        Either of two types: QR1FILTER, QR2Filter or QR3Filter
+    *        Either of three types: QR1FILTER, QR2Filter, or QR3Filter
     */
   int _filter;
 
@@ -294,8 +294,8 @@ private:
   /// Number of dropped columns in this time window (old time window out of scope)
   int _nbDropCols = 0;
 
-  /// Delete first column if input values are zero
-  bool _deleteFirstColumn = false; 
+  /// @brief Sets the first column to be deleted due to an initial zero sub-vector from a solver.
+  bool _deleteFirstColumn = false;
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -293,6 +293,9 @@ private:
 
   /// Number of dropped columns in this time window (old time window out of scope)
   int _nbDropCols = 0;
+
+  /// Delete first column if input values are zero
+  bool _deleteFirstColumn = false; 
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -518,14 +518,6 @@ void MVQNAcceleration::restartIMVJ()
     // truncated SVD, i.e., Wtil^0 = \phi, Z^0 = S\psi^T, this should not be added to the SVD.
     int q = _svdJ.isSVDinitialized() ? 1 : 0;
 
-    // If the preconditioner weights have been reset, then the old SVD must be discarded as the
-    // new chunk cannot be added to the old chunk
-    if (_preconditioner->svdWeightsSet()){
-      PRECICE_INFO("  Resetting SVD due to pre-scaling weights.");
-      _svdJ.reset();
-      _preconditioner->svdReset();
-    }
-
     // perform M-1 rank-1 updates of the truncated SVD-dec of the Jacobian
     for (; q < static_cast<int>(_WtilChunk.size()); q++) {
       // update SVD, i.e., PSI * SIGMA * PHI^T <-- PSI * SIGMA * PHI^T + Wtil^q * Z^q

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -518,6 +518,14 @@ void MVQNAcceleration::restartIMVJ()
     // truncated SVD, i.e., Wtil^0 = \phi, Z^0 = S\psi^T, this should not be added to the SVD.
     int q = _svdJ.isSVDinitialized() ? 1 : 0;
 
+    // If the preconditioner weights have been reset, then the old SVD must be discarded as the
+    // new chunk cannot be added to the old chunk
+    if (_preconditioner->svdWeightsSet()){
+      PRECICE_INFO("  Resetting SVD due to pre-scaling weights.");
+      _svdJ.reset();
+      _preconditioner->svdReset();
+    }
+
     // perform M-1 rank-1 updates of the truncated SVD-dec of the Jacobian
     for (; q < static_cast<int>(_WtilChunk.size()); q++) {
       // update SVD, i.e., PSI * SIGMA * PHI^T <-- PSI * SIGMA * PHI^T + Wtil^q * Z^q

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -54,6 +54,8 @@ AccelerationConfiguration::AccelerationConfiguration(
       ATTR_RSLS_REUSED_TIME_WINDOWS("reused-time-windows-at-restart"),
       ATTR_RSSVD_TRUNCATIONEPS("truncation-threshold"),
       ATTR_PRECOND_NONCONST_TIME_WINDOWS("freeze-after"),
+      ATTR_PRECOND_MONITOR("monitor"),
+      ATTR_PRECOND_FREEZE_RESET("freeze-reset"),
       VALUE_CONSTANT("constant"),
       VALUE_AITKEN("aitken"),
       VALUE_IQNILS("IQN-ILS"),
@@ -204,6 +206,8 @@ void AccelerationConfiguration::xmlTagCallback(
   } else if (callingTag.getName() == TAG_PRECONDITIONER) {
     _config.preconditionerType         = callingTag.getStringAttributeValue(ATTR_TYPE);
     _config.precond_nbNonConstTWindows = callingTag.getIntAttributeValue(ATTR_PRECOND_NONCONST_TIME_WINDOWS);
+    _config.precond_monitor            = callingTag.getBooleanAttributeValue(ATTR_PRECOND_MONITOR);
+    _config.precond_freezeReset        = callingTag.getIntAttributeValue(ATTR_PRECOND_FREEZE_RESET);
   } else if (callingTag.getName() == TAG_IMVJRESTART) {
 
     if (_config.alwaysBuildJacobian)
@@ -258,10 +262,16 @@ void AccelerationConfiguration::xmlEndTagCallback(
         _preconditioner = PtrPreconditioner(new ConstantPreconditioner(factors));
       } else if (_config.preconditionerType == VALUE_VALUE_PRECONDITIONER) {
         _preconditioner = PtrPreconditioner(new ValuePreconditioner(_config.precond_nbNonConstTWindows));
+        _preconditioner = PtrPreconditioner(new ValuePreconditioner(_config.precond_monitor ));
+        _preconditioner = PtrPreconditioner(new ValuePreconditioner(_config.precond_freezeReset ));
       } else if (_config.preconditionerType == VALUE_RESIDUAL_PRECONDITIONER) {
         _preconditioner = PtrPreconditioner(new ResidualPreconditioner(_config.precond_nbNonConstTWindows));
+        _preconditioner = PtrPreconditioner(new ResidualPreconditioner(_config.precond_monitor ));
+        _preconditioner = PtrPreconditioner(new ResidualPreconditioner(_config.precond_freezeReset ));
       } else if (_config.preconditionerType == VALUE_RESIDUAL_SUM_PRECONDITIONER) {
         _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_config.precond_nbNonConstTWindows));
+        _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_config.precond_monitor ));
+        _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_config.precond_freezeReset ));
       } else {
         // no preconditioner defined
         std::vector<double> factors;

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -54,8 +54,6 @@ AccelerationConfiguration::AccelerationConfiguration(
       ATTR_RSLS_REUSED_TIME_WINDOWS("reused-time-windows-at-restart"),
       ATTR_RSSVD_TRUNCATIONEPS("truncation-threshold"),
       ATTR_PRECOND_NONCONST_TIME_WINDOWS("freeze-after"),
-      ATTR_PRECOND_MONITOR("monitor"),
-      ATTR_PRECOND_FREEZE_RESET("freeze-reset"),
       VALUE_CONSTANT("constant"),
       VALUE_AITKEN("aitken"),
       VALUE_IQNILS("IQN-ILS"),
@@ -64,6 +62,7 @@ AccelerationConfiguration::AccelerationConfiguration(
       VALUE_QR1FILTER("QR1"),
       VALUE_QR1_ABSFILTER("QR1-absolute"),
       VALUE_QR2FILTER("QR2"),
+      VALUE_QR3FILTER("QR3"),
       VALUE_CONSTANT_PRECONDITIONER("constant"),
       VALUE_VALUE_PRECONDITIONER("value"),
       VALUE_RESIDUAL_PRECONDITIONER("residual"),
@@ -199,6 +198,8 @@ void AccelerationConfiguration::xmlTagCallback(
       _config.filter = Acceleration::QR1FILTER_ABS;
     } else if (f == VALUE_QR2FILTER) {
       _config.filter = Acceleration::QR2FILTER;
+    } else if (f == VALUE_QR3FILTER) {
+      _config.filter = Acceleration::QR3FILTER;
     } else {
       PRECICE_ASSERT(false);
     }
@@ -206,8 +207,6 @@ void AccelerationConfiguration::xmlTagCallback(
   } else if (callingTag.getName() == TAG_PRECONDITIONER) {
     _config.preconditionerType         = callingTag.getStringAttributeValue(ATTR_TYPE);
     _config.precond_nbNonConstTWindows = callingTag.getIntAttributeValue(ATTR_PRECOND_NONCONST_TIME_WINDOWS);
-    _config.precond_monitor            = callingTag.getBooleanAttributeValue(ATTR_PRECOND_MONITOR);
-    _config.precond_freezeReset        = callingTag.getIntAttributeValue(ATTR_PRECOND_FREEZE_RESET);
   } else if (callingTag.getName() == TAG_IMVJRESTART) {
 
     if (_config.alwaysBuildJacobian)
@@ -262,16 +261,10 @@ void AccelerationConfiguration::xmlEndTagCallback(
         _preconditioner = PtrPreconditioner(new ConstantPreconditioner(factors));
       } else if (_config.preconditionerType == VALUE_VALUE_PRECONDITIONER) {
         _preconditioner = PtrPreconditioner(new ValuePreconditioner(_config.precond_nbNonConstTWindows));
-        _preconditioner = PtrPreconditioner(new ValuePreconditioner(_config.precond_monitor ));
-        _preconditioner = PtrPreconditioner(new ValuePreconditioner(_config.precond_freezeReset ));
       } else if (_config.preconditionerType == VALUE_RESIDUAL_PRECONDITIONER) {
         _preconditioner = PtrPreconditioner(new ResidualPreconditioner(_config.precond_nbNonConstTWindows));
-        _preconditioner = PtrPreconditioner(new ResidualPreconditioner(_config.precond_monitor ));
-        _preconditioner = PtrPreconditioner(new ResidualPreconditioner(_config.precond_freezeReset ));
       } else if (_config.preconditionerType == VALUE_RESIDUAL_SUM_PRECONDITIONER) {
         _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_config.precond_nbNonConstTWindows));
-        _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_config.precond_monitor ));
-        _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_config.precond_freezeReset ));
       } else {
         // no preconditioner defined
         std::vector<double> factors;
@@ -376,7 +369,8 @@ void AccelerationConfiguration::addCommonIQNSubtags(xml::XMLTag &tag)
   auto attrFilterName = XMLAttribute<std::string>(ATTR_TYPE)
                             .setOptions({VALUE_QR1FILTER,
                                          VALUE_QR1_ABSFILTER,
-                                         VALUE_QR2FILTER})
+                                         VALUE_QR2FILTER,
+                                         VALUE_QR3FILTER})
                             .setDocumentation("Type of the filter.");
   tagFilter.addAttribute(attrFilterName);
   tag.addSubtag(tagFilter);

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -76,6 +76,7 @@ private:
   const std::string VALUE_QR1FILTER;
   const std::string VALUE_QR1_ABSFILTER;
   const std::string VALUE_QR2FILTER;
+  const std::string VALUE_QR3FILTER;
   const std::string VALUE_CONSTANT_PRECONDITIONER;
   const std::string VALUE_VALUE_PRECONDITIONER;
   const std::string VALUE_RESIDUAL_PRECONDITIONER;

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -65,6 +65,8 @@ private:
   const std::string ATTR_RSLS_REUSED_TIME_WINDOWS;
   const std::string ATTR_RSSVD_TRUNCATIONEPS;
   const std::string ATTR_PRECOND_NONCONST_TIME_WINDOWS;
+  const std::string ATTR_PRECOND_MONITOR;
+  const std::string ATTR_PRECOND_FREEZE_RESET;
 
   const std::string VALUE_CONSTANT;
   const std::string VALUE_AITKEN;
@@ -110,6 +112,8 @@ private:
     int                   imvjChunkSize              = 0;
     int                   imvjRSLS_reusedTimeWindows = 0;
     int                   precond_nbNonConstTWindows = -1;
+    bool                  precond_monitor            = false;
+    int                   precond_freezeReset        = 10;
     double                singularityLimit           = 0;
     double                imvjRSSVD_truncationEps    = 0;
     bool                  estimateJacobian           = false;

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -113,8 +113,8 @@ private:
     int                   imvjChunkSize              = 0;
     int                   imvjRSLS_reusedTimeWindows = 0;
     int                   precond_nbNonConstTWindows = -1;
-    bool                  precond_monitor            = false;
-    int                   precond_freezeReset        = 10;
+    bool                  precondMonitor             = false;
+    int                   precondFreezeReset         = 10;
     double                singularityLimit           = 0;
     double                imvjRSSVD_truncationEps    = 0;
     bool                  estimateJacobian           = false;

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -24,7 +24,7 @@ namespace impl {
 class Preconditioner {
 public:
   Preconditioner(int maxNonConstTimeWindows)
-      : _maxNonConstTimeWindows(maxNonConstTimeWindows)
+      : _maxNonConstTimeWindows(maxNonConstTimeWindows) 
   {
   }
 
@@ -192,6 +192,18 @@ public:
     _requireNewQR = false;
   }
 
+  /// to tell the filtering that the pre-scaling weights were updated 
+  bool updatedWeights()
+  {
+    return _updatedWeights;
+  }
+
+  /// to tell that the QR decomposition has been reset due to updated pre-scaling weights
+  void updatedWeightsReset()
+  {
+    _updatedWeights = false;
+  }
+
   std::vector<double> &getWeights()
   {
     return _weights;
@@ -222,6 +234,9 @@ protected:
 
   /// True if a QR decomposition from scratch is necessary
   bool _requireNewQR = false;
+
+  /// True if pre-scaling weights were updated
+  bool _updatedWeights = false;
 
   /// True if _nbNonConstTimeWindows >= _maxNonConstTimeWindows, i.e., preconditioner is not updated any more.
   bool _frozen = false;

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -24,7 +24,7 @@ namespace impl {
 class Preconditioner {
 public:
   Preconditioner(int maxNonConstTimeWindows)
-      : _maxNonConstTimeWindows(maxNonConstTimeWindows) 
+      : _maxNonConstTimeWindows(maxNonConstTimeWindows)
   {
   }
 
@@ -192,16 +192,16 @@ public:
     _requireNewQR = false;
   }
 
-  /// to tell the filtering that the pre-scaling weights were updated 
-  bool updatedWeights()
+  /// to tell the filtering that the pre-scaling weights were updated
+  bool areWeightsUpdated()
   {
-    return _updatedWeights;
+    return _areWeightsUpdated;
   }
 
   /// to tell that the QR decomposition has been reset due to updated pre-scaling weights
   void updatedWeightsReset()
   {
-    _updatedWeights = false;
+    _areWeightsUpdated = false;
   }
 
   std::vector<double> &getWeights()
@@ -235,8 +235,8 @@ protected:
   /// True if a QR decomposition from scratch is necessary
   bool _requireNewQR = false;
 
-  /// True if pre-scaling weights were updated
-  bool _updatedWeights = false;
+  /// @brief True if pre-scaling weights were updated in the iteration, and a QR decomposition is required
+  bool _areWeightsUpdated = false;
 
   /// True if _nbNonConstTimeWindows >= _maxNonConstTimeWindows, i.e., preconditioner is not updated any more.
   bool _frozen = false;

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -142,22 +142,53 @@ void QRFactorization::applyFilter(double singularityLimit, std::vector<int> &del
       }
     }
   } else if (_filter == Acceleration::QR2FILTER) {
-    _Q.resize(0, 0);
-    _R.resize(0, 0);
-    _cols = 0;
-    _rows = V.rows();
-    // starting with the most recent input/output information, i.e., the latest column
-    // which is at position 0 in _matrixV (latest information is never filtered out!)
-    for (int k = 0; k < V.cols(); k++) {
-      Eigen::VectorXd v = V.col(k);
-      // this is the same as pushBack(v) as _cols grows within the insertion process
-      bool inserted = insertColumn(_cols, v, singularityLimit);
-      if (!inserted) {
-        delIndices.push_back(k);
+
+    resetFilter(singularityLimit, delIndices, V);
+
+  } else if (_filter == Acceleration::QR3FILTER) {
+    int index        = cols() - 1;
+    // Iterate from the last column to the 2nd column from the left
+    if ( computeQR2 == true) {
+      PRECICE_DEBUG("  Weights were reset. Reverting to QR2.");
+      resetFilter(singularityLimit, delIndices, V);
+    } else {
+      for (size_t i = index; i > 1 ; i--) {
+        Eigen::VectorXd v = V.col(i);
+        double rho0 = utils::MasterSlave::l2norm(v);
+        if (std::fabs(_R(i, i)) < rho0*singularityLimit) {
+          resetFilter(singularityLimit, delIndices, V);
+          break;
+          //deleteColumn(i);
+          //delIndices.push_back(i);
+        }
+        /*if ( delIndices.size() > 2 ) 
+          PRECICE_DEBUG("Too many columns deleted. Defaulting to QR2 Filter");
+          resetFilter(singularityLimit, delIndices, V);
+          break; */
       }
     }
+    computeQR2 = false;
+    PRECICE_DEBUG("Deleting {} columns in QR3 Filter", delIndices.size());
   }
   std::sort(delIndices.begin(), delIndices.end());
+}
+
+void QRFactorization::resetFilter(double singularityLimit, std::vector<int> &delIndices, Eigen::MatrixXd &V)
+{
+  _Q.resize(0, 0);
+  _R.resize(0, 0);
+  _cols = 0;
+  _rows = V.rows();
+  // starting with the most recent input/output information, i.e., the latest column
+  // which is at position 0 in _matrixV (latest information is never filtered out!)
+  for (int k = 0; k < V.cols(); k++) {
+    Eigen::VectorXd v = V.col(k);
+    // this is the same as pushBack(v) as _cols grows within the insertion process
+    bool inserted = insertColumn(_cols, v, singularityLimit);
+    if (!inserted) {
+      delIndices.push_back(k);
+    }
+  }
 }
 
 /**

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -146,25 +146,19 @@ void QRFactorization::applyFilter(double singularityLimit, std::vector<int> &del
     resetFilter(singularityLimit, delIndices, V);
 
   } else if (_filter == Acceleration::QR3FILTER) {
-    int index        = cols() - 1;
+    int index = cols() - 1;
     // Iterate from the last column to the 2nd column from the left
-    if ( computeQR2 == true) {
-      PRECICE_DEBUG("  Weights were reset. Reverting to QR2.");
+    if (computeQR2 == true) {
+      PRECICE_DEBUG("  Pre-scaling weights were reset. Reverting to QR2 and rebuilding QR.");
       resetFilter(singularityLimit, delIndices, V);
     } else {
-      for (size_t i = index; i > 1 ; i--) {
-        Eigen::VectorXd v = V.col(i);
-        double rho0 = utils::MasterSlave::l2norm(v);
-        if (std::fabs(_R(i, i)) < rho0*singularityLimit) {
+      for (size_t i = index; i > 1; i--) {
+        Eigen::VectorXd v    = V.col(i);
+        double          rho0 = utils::MasterSlave::l2norm(v);
+        if (std::fabs(_R(i, i)) < rho0 * singularityLimit) {
           resetFilter(singularityLimit, delIndices, V);
           break;
-          //deleteColumn(i);
-          //delIndices.push_back(i);
         }
-        /*if ( delIndices.size() > 2 ) 
-          PRECICE_DEBUG("Too many columns deleted. Defaulting to QR2 Filter");
-          resetFilter(singularityLimit, delIndices, V);
-          break; */
       }
     }
     computeQR2 = false;

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -63,6 +63,13 @@ public:
   virtual ~QRFactorization() {}
 
   /**
+   * @brief performs a reset of A = QR using the QR2 Filter. This eliminates
+   * columns during the reconsrtuction of QR.
+   * 
+   */
+  void resetFilter(double singularityLimit, std::vector<int> &delIndices, Eigen::MatrixXd &V);
+
+  /**
     * @brief resets the QR factorization zo zero Q(0:0, 0:0)R(0:0, 0:0)
     */
   void reset();
@@ -157,6 +164,8 @@ public:
 
   // @brief sets the filtering technique to maintain good conditioning of the least squares system
   void setFilter(int filter);
+
+  bool computeQR2 = false;
 
 private:
   struct givensRot {

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -63,8 +63,8 @@ public:
   virtual ~QRFactorization() {}
 
   /**
-   * @brief performs a reset of A = QR using the QR2 Filter. This eliminates
-   * columns during the reconsrtuction of QR.
+   * @brief Performs a reset of A = QR using the QR2 Filter. This eliminates
+   * columns during the reconstruction of the QR decomposition.
    * 
    */
   void resetFilter(double singularityLimit, std::vector<int> &delIndices, Eigen::MatrixXd &V);
@@ -165,7 +165,11 @@ public:
   // @brief sets the filtering technique to maintain good conditioning of the least squares system
   void setFilter(int filter);
 
+  // @brief forces a complete QR decomposition
   bool computeQR2 = false;
+
+  // @brief forces the truncated SVD to be reset
+  bool resetSVD = false;
 
 private:
   struct givensRot {

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -22,8 +22,7 @@ void ResidualSumPreconditioner::initialize(std::vector<size_t> &svs)
   Preconditioner::initialize(svs);
 
   _residualSum.resize(_subVectorSizes.size(), 0.0);
-  _setWeights.resize(_subVectorSizes.size(), 1.0);
-
+  _previousScalingWeights.resize(_subVectorSizes.size(), 1.0);
 }
 
 void ResidualSumPreconditioner::_update_(bool                   timeWindowComplete,
@@ -35,8 +34,8 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
 
     double sum = 0.0;
 
-    int offset = 0;
-    int resetWeight = 0;
+    int  offset       = 0;
+    bool resetWeights = false; // True if pre-scaling weights must be reset
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       Eigen::VectorXd part = Eigen::VectorXd::Zero(_subVectorSizes[k]);
       for (size_t i = 0; i < _subVectorSizes[k]; i++) {
@@ -70,37 +69,38 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
     }
 
     offset = 0;
-    //normWeights.resize(_subVectorSizes.size());
-    // Chech if the new scaling weights are more than 1 order of magnitude from the previous weights
+    // normWeights.resize(_subVectorSizes.size());
+    // Chech if the new scaling weights are more or less than 1 order of magnitude from the previous weights
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      if(((1 / _residualSum[k])/_setWeights[k] > 10) || ((1 / _residualSum[k])/_setWeights[k] < 0.1)){
-        resetWeight = 1;
-        PRECICE_DEBUG( "Resetting pre-scaling weights as the value has changed by more than 1 order of magnitude" );
+      double newScalingWeight = (1 / _residualSum[k]);
+      if ((newScalingWeight / _previousScalingWeights[k] > 10) || (newScalingWeight / _previousScalingWeights[k] < 0.1)) {
+        resetWeights = true;
+        PRECICE_DEBUG("Resetting pre-scaling weights as the value has increased/decreased by more than 1 order of magnitude");
       }
     }
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       if (not math::equals(_residualSum[k], 0.0)) {
         // Always adjust pre-scaling weights in the first time window
-        if (tWindowPrecon < 2 || resetWeight == 1){
+        if (timeWindowPreconditioner < 1 || resetWeights) {
           for (size_t i = 0; i < _subVectorSizes[k]; i++) {
             _weights[i + offset]    = 1 / _residualSum[k];
             _invWeights[i + offset] = _residualSum[k];
           }
           PRECICE_DEBUG("preconditioner scaling factor[{}] = {}", k, 1 / _residualSum[k]);
-          _setWeights[k] = 1 / _residualSum[k]; 
-          _requireNewQR = true;
-          _updatedWeights = true;
+          _previousScalingWeights[k] = 1 / _residualSum[k];
+          _requireNewQR              = true;
+          _areWeightsUpdated         = true;
         }
       }
       //normWeights[k] = 1 / _residualSum[k];
-      PRECICE_DEBUG("Actual Norm of weights: {}", _setWeights[k]);
+      PRECICE_DEBUG("Actual Norm of pre-scaling weights in current iteration: {}", _previousScalingWeights[k]);
       offset += _subVectorSizes[k];
     }
-    resetWeight = 0;
+    resetWeights = false;
 
   } else {
-    tWindowPrecon++;
+    timeWindowPreconditioner++;
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       _residualSum[k] = 0.0;
     }

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -75,7 +75,7 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       if(((1 / _residualSum[k])/_setWeights[k] > 10) || ((1 / _residualSum[k])/_setWeights[k] < 0.1)){
         resetWeight = 1;
-        PRECICE_DEBUG( "Resetting weights due to difference to previous weights in subvector." );
+        PRECICE_DEBUG( "Resetting pre-scaling weights as the value has changed by more than 1 order of magnitude" );
       }
     }
 

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -78,14 +78,14 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
         PRECICE_INFO("Resetting pre-scaling weights as the value has increased/decreased by more than 1 order of magnitude");
       }
     }
-    
+
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       if (not math::equals(_residualSum[k], 0.0)) {
         // Always adjust pre-scaling weights in the first time window
         if (timeWindowPreconditioner < 1 || resetWeights) {
           for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-              _weights[i + offset]    = 1 / _residualSum[k];
-              _invWeights[i + offset] = _residualSum[k];
+            _weights[i + offset]    = 1 / _residualSum[k];
+            _invWeights[i + offset] = _residualSum[k];
           }
           PRECICE_INFO("preconditioner scaling factor[{}] = {}", k, 1 / _residualSum[k]);
           _previousScalingWeights[k] = 1 / _residualSum[k];

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -75,6 +75,7 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
       double newScalingWeight = (1 / _residualSum[k]);
       if ((newScalingWeight / _previousScalingWeights[k] > 10) || (newScalingWeight / _previousScalingWeights[k] < 0.1)) {
         resetWeights = true;
+        _resetSVD    = true;
         PRECICE_INFO("Resetting pre-scaling weights as the value has increased/decreased by more than 1 order of magnitude");
       }
     }

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -75,26 +75,26 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
       double newScalingWeight = (1 / _residualSum[k]);
       if ((newScalingWeight / _previousScalingWeights[k] > 10) || (newScalingWeight / _previousScalingWeights[k] < 0.1)) {
         resetWeights = true;
-        PRECICE_DEBUG("Resetting pre-scaling weights as the value has increased/decreased by more than 1 order of magnitude");
+        PRECICE_INFO("Resetting pre-scaling weights as the value has increased/decreased by more than 1 order of magnitude");
       }
     }
-
+    
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       if (not math::equals(_residualSum[k], 0.0)) {
         // Always adjust pre-scaling weights in the first time window
         if (timeWindowPreconditioner < 1 || resetWeights) {
           for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-            _weights[i + offset]    = 1 / _residualSum[k];
-            _invWeights[i + offset] = _residualSum[k];
+              _weights[i + offset]    = 1 / _residualSum[k];
+              _invWeights[i + offset] = _residualSum[k];
           }
-          PRECICE_DEBUG("preconditioner scaling factor[{}] = {}", k, 1 / _residualSum[k]);
+          PRECICE_INFO("preconditioner scaling factor[{}] = {}", k, 1 / _residualSum[k]);
           _previousScalingWeights[k] = 1 / _residualSum[k];
           _requireNewQR              = true;
           _areWeightsUpdated         = true;
         }
       }
       //normWeights[k] = 1 / _residualSum[k];
-      PRECICE_DEBUG("Actual Norm of pre-scaling weights in current iteration: {}", _previousScalingWeights[k]);
+      PRECICE_INFO("Actual Norm of pre-scaling weights in current iteration: {}", _previousScalingWeights[k]);
       offset += _subVectorSizes[k];
     }
     resetWeights = false;

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -36,6 +36,9 @@ private:
   logging::Logger _log{"acceleration::ResidualSumPreconditioner"};
 
   std::vector<double> _residualSum;
+  std::vector<double> _setWeights;
+  int tWindowPrecon = 1;
+
 };
 
 } // namespace impl

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -36,9 +36,8 @@ private:
   logging::Logger _log{"acceleration::ResidualSumPreconditioner"};
 
   std::vector<double> _residualSum;
-  std::vector<double> _setWeights;
-  int tWindowPrecon = 1;
-
+  std::vector<double> _previousScalingWeights;
+  int                 timeWindowPreconditioner = 0;
 };
 
 } // namespace impl


### PR DESCRIPTION
## Main changes of this PR

1. Automatically deletes the first column in time step 4 if an initial sub-vector from at least 1 solver is zero, measured by the L2 norm.
2. Monitors the residual sum preconditioner weights and only updates them if they change by a specified factor. This is required for faster QR filtering.

## Motivation and additional information
Firstly, deleting the first column if there is a zero sub-vector has been shown to be beneficial. 

Secondly, currently the preconditioner weights are updated in every iteration. This is unnecessary if the weights change by a small value, but the entire QR decomposition is performed again. Vast improvements in runtime can be found by not always updating the preconditioner weights. 

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [x] I ran `tools/formatting/format-all` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

A few more tasks include 
* [ ] Allow preconditioner weight monitoring to be turned on/off via the config file.
* [ ] Allow column deletion to be turned on/off via the config file.
* [x] Include the fast QR filter when preconditioner weight monitoring is applied.
