### PR TITLE
Enable boost unit test help messages

### DIFF
--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -123,9 +123,9 @@ int main(int argc, char *argv[])
   const auto size = utils::Parallel::current()->size();
   logging::setMPIRank(rank);
 
-  if (size < 4) {
+  if (size < 4 && argc < 2) {
     if (rank == 0) {
-      std::cerr << "ERROR: The tests require at least 4 MPI processes.\n";
+      std::cerr << "ERROR: The tests require at least 4 MPI processes. Please use \"mpirun -np 4 ./tesprecice\" or \"ctest\" to run the full testsuite. \n";
     }
     return 2;
   }

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
 
   if (size < 4 && argc < 2) {
     if (rank == 0) {
-      std::cerr << "ERROR: The tests require at least 4 MPI processes. Please use \"mpirun -np 4 ./tesprecice\" or \"ctest\" to run the full testsuite. \n";
+      std::cerr << "ERROR: The tests require at least 4 MPI processes. Please use \"mpirun -np 4 ./testprecice\" or \"ctest\" to run the full testsuite. \n";
     }
     return 2;
   }


### PR DESCRIPTION
## Main changes of this PR

Enables user and developer interaction with the `testprecice` executable by making the exception conditional on the number of provided command line arguments. 

## Motivation and additional information

As just learned from @ajaust, the boost unit test framework has awesome stand-alone features. One of my favorite ones is probably `tesprecice --list_content` in order to get an overview of all available tests, because I always need to search for (nested) test names when I want to execute them selectively. You can also use `testprecice --help` in order to get a full picture of all available options of our test executable. The help list is additionally much more comprehensive than our developer documentation with respect to configurable options.
However, in our current test suite, we can't use these features, since we immediately exit if our testsuite is not executed on four ranks. The main purpose of this exception is to prevent (unknowing) users from running the tests in serial and running into failures. This behavior would still be caught by counting the input arguments, so that `./testprecice` (which doesn't make sense) results in an error, but `testprecice --help` works.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
