### PR TITLE
Enable compiler annotations in workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -119,6 +119,9 @@ jobs:
         with:
           name: ${{ format('{0} {1} {2} {3}', matrix.IMAGE, matrix.CXX, matrix.CONFIG, matrix.TYPE) }} CompileCommands 
           path: build/compile_commands.json
+      - name: Enable compiler annotations
+        uses: electronjoe/gcc-problem-matcher@v1
+        if: ${{ matrix.IMAGE == 'archlinux' }}
       - name: Compile
         working-directory: build
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: build
         env:
           CXX: ${{ matrix.CXX }}
-          CXXFLAGS: "-Wall ${{ matrix.COVFLAGS }}"
+          CXXFLAGS: "-Wall -Wextra -Wno-unused-parameter ${{ matrix.COVFLAGS }}"
           MPI: ${{ contains(matrix.CONFIG, 'MPI') }}
           PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
         run: |


### PR DESCRIPTION
## Main changes of this PR

Attempts to integrate compiler warnings as annotations in GitHub.
Currently, this only shows warnings of the newest compilers aka on Arch.

This PR is experimental.

Closes #1135
Replaces #1138 