### PR TITLE
Add options to extend release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ option(PRECICE_ALWAYS_VALIDATE_LIBS "Validate libraries even after the validatat
 option(PRECICE_ENABLE_C "Enable the native C bindings" ON)
 option(PRECICE_ENABLE_FORTRAN "Enable the native Fortran bindings" ON)
 
+option(PRECICE_RELEASE_WITH_DEBUG_LOG "Enable debug logging in release builds" OFF)
+option(PRECICE_RELEASE_WITH_TRACE_LOG "Enable trace logging in release builds" OFF)
+option(PRECICE_RELEASE_WITH_ASSERTIONS "Enable assertions in release builds" OFF)
+
 xsdk_tpl_option_override(PRECICE_MPICommunication TPL_ENABLE_MPI)
 xsdk_tpl_option_override(PRECICE_PETScMapping TPL_ENABLE_PETSC)
 xsdk_tpl_option_override(PRECICE_PythonActions TPL_ENABLE_PYTHON)
@@ -270,6 +274,20 @@ set_target_properties(precice PROPERTIES
   VERSION ${preCICE_VERSION}
   SOVERSION ${preCICE_SOVERSION}
   )
+
+# Setup release override options
+if(PRECICE_RELEASE_WITH_DEBUG_LOG)
+  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_DEBUG_LOG)
+endif()
+
+if(PRECICE_RELEASE_WITH_TRACE_LOG)
+  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_TRACE_LOG)
+endif()
+
+if(PRECICE_RELEASE_WITH_ASSERTIONS)
+  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_ASSERTIONS)
+endif()
+
 
 # Setup Boost
 target_compile_definitions(precice PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -23,7 +23,14 @@
     PRECICE_ERROR(__VA_ARGS__);   \
   }
 
-#ifdef NDEBUG
+// Debug logging is disabled in release (NDEBUG) builds by default.
+// To enable it anyhow, enable the CMake option PRECICE_RELEASE_WITH_DEBUG_LOG.
+
+#if defined(NDEBUG) && !defined(PRECICE_RELEASE_WITH_DEBUG_LOG)
+#define PRECICE_NO_DEBUG_LOG
+#endif
+
+#ifdef PRECICE_NO_DEBUG_LOG
 
 #define PRECICE_DEBUG(...) \
   {                        \
@@ -32,16 +39,34 @@
   {                        \
   }
 
-#else // NDEBUG
+#else // PRECICE_NO_DEBUG_LOG
 
-#include "logging/Tracer.hpp"
 #include "utils/ArgumentFormatter.hpp"
 
 #define PRECICE_DEBUG(...) _log.debug(PRECICE_LOG_LOCATION, fmt::format(__VA_ARGS__))
+
+#endif // ! PRECICE_NO_DEBUG_LOG
+
+// Trace logging is disabled in release (NDEBUG) builds by default.
+// To enable it anyhow, enable the CMake option PRECICE_RELEASE_WITH_TRACE_LOG.
+
+#if defined(NDEBUG) && !defined(PRECICE_RELEASE_WITH_TRACE_LOG)
+#define PRECICE_NO_TRACE_LOG
+#endif
+
+#ifdef PRECICE_NO_TRACE_LOG
+
+#define PRECICE_TRACE(...) \
+  {                        \
+  }
+
+#else // PRECICE_NO_TRACE_LOG
+
+#include "logging/Tracer.hpp"
 
 // Do not put do {...} while (false) here, it will destroy the _tracer_ right after creation
 #define PRECICE_TRACE(...)                                       \
   precice::logging::Tracer _tracer_(_log, PRECICE_LOG_LOCATION); \
   _log.trace(PRECICE_LOG_LOCATION, std::string{"Entering "} + __func__ + PRECICE_LOG_ARGUMENTS(__VA_ARGS__))
 
-#endif // ! NDEBUG
+#endif // ! PRECICE_NO_TRACE_LOG

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -171,7 +171,18 @@ void SolverInterfaceImpl::configure(
 #ifndef NDEBUG
     PRECICE_INFO("Configuration: Debug");
 #else
-    PRECICE_INFO("Configuration: Release (Debug and Trace log unavailable)");
+    // Assemble and print release message
+    std::string releaseMessage = "Release";
+#ifndef PRECICE_NO_DEBUG_LOG
+    releaseMessage.append(" + debug log");
+#endif
+#ifndef PRECICE_NO_TRACE_LOG
+    releaseMessage.append(" + trace log");
+#endif
+#ifndef PRECICE_NO_ASSERTIONS
+    releaseMessage.append(" + assertions");
+#endif
+    PRECICE_INFO("Configuration: {}", releaseMessage);
 #endif
     PRECICE_INFO("Configuring preCICE with configuration \"{}\"", configurationFileName);
     PRECICE_INFO("I am participant \"{}\"", _accessorName);


### PR DESCRIPTION
## Main changes of this PR

This PR adds CMake options to enable the following features in release builds:
* debug logging 
* trace logging
* assertions

The preCICE greeting now shows these options in the following format:
```
This is preCICE version 2.3.0
Revision info: v2.3.0-97-g1c20fcc9-dirty
Configuration: Release + debug log + assertions
Configuring preCICE with configuration "..."
```

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
