### PR TITLE
Add CMake variable to control when assertions are enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,18 @@ if(PRECICE_PETScMapping AND NOT PRECICE_MPICommunication)
 endif()
 
 set(PRECICE_CTEST_MPI_FLAGS "" CACHE STRING "Add additional flags to mpiexec for running tests via CTest.")
+set(PRECICE_ASSERTION_POLICY DEBUG CACHE STRING "For which builds to enable assertions (always, debug only, never). Debug only is default.")
+set_property(CACHE PRECICE_ASSERTION_POLICY PROPERTY STRINGS ON DEBUG OFF)
+
+# from CMake 3.12 add_compile_definitions can/should be used here
+# unfortunately the preprocessor is too stupid to use proper strings
+if(PRECICE_ASSERTION_POLICY STREQUAL "ON")
+  add_definitions(-DASSERT_ALWAYS)
+elseif(PRECICE_ASSERTION_POLICY STREQUAL "DEBUG")
+  add_definitions(-DASSERT_DEBUG)
+elseif(PRECICE_ASSERTION_POLICY STREQUAL "OFF")
+  add_definitions(-DASSERT_NEVER)
+endif()
 
 include(XSDKOptions)
 

--- a/docs/changelog/1181.md
+++ b/docs/changelog/1181.md
@@ -1,0 +1,1 @@
+- Add CMake variable ``PRECICE_ASSERTION_POLICY`` that can be set to ``ON`` (always), ``DEBUG`` (debug builds only, default), or ``OFF`` (never) to govern in which builds assertions are enabled.

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-#ifdef NDEBUG
+#if defined(ASSERT_NEVER) || (defined(NDEBUG) && defined(ASSERT_DEBUG))
 
 #define PRECICE_ASSERT(...) \
   {                         \


### PR DESCRIPTION
## Main changes of this PR
Adds CMake variable `PRECICE_ASSERTION_POLICY` that can be set to `ON`/always, `DEBUG`/debug builds only, or `OFF`/never to govern in which builds assertions are enabled, which is translated to preprocessor flags `ASSERT_ALWAYS`, `ASSERT_DEBUG`, and `ASSERT_NEVER`, respectively. The default is `DEBUG`.

## Motivation and additional information

Closes #663 

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
