### PR TITLE
Change VTK/VTU Output Array Format

### DIFF
--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -21,7 +21,7 @@ namespace io {
 void ExportVTK::doExport(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh  &mesh)
+    const mesh::Mesh & mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
   PRECICE_ASSERT(name != std::string(""));
@@ -43,7 +43,7 @@ void ExportVTK::doExport(
 }
 
 void ExportVTK::exportMesh(
-    std::ofstream    &outFile,
+    std::ofstream &   outFile,
     const mesh::Mesh &mesh)
 {
   PRECICE_TRACE(mesh.getName());
@@ -104,7 +104,7 @@ void ExportVTK::exportMesh(
 }
 
 void ExportVTK::exportData(
-    std::ofstream    &outFile,
+    std::ofstream &   outFile,
     const mesh::Mesh &mesh)
 {
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
@@ -165,7 +165,7 @@ void ExportVTK::writeHeader(
 
 void ExportVTK::writeVertex(
     const Eigen::VectorXd &position,
-    std::ostream          &outFile)
+    std::ostream &         outFile)
 {
   if (position.size() == 2) {
     outFile << position(0) << "  " << position(1) << "  " << 0.0 << '\n';

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -21,7 +21,7 @@ namespace io {
 void ExportVTK::doExport(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh & mesh)
+    const mesh::Mesh  &mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
   PRECICE_ASSERT(name != std::string(""));
@@ -43,7 +43,7 @@ void ExportVTK::doExport(
 }
 
 void ExportVTK::exportMesh(
-    std::ofstream &   outFile,
+    std::ofstream    &outFile,
     const mesh::Mesh &mesh)
 {
   PRECICE_TRACE(mesh.getName());
@@ -104,7 +104,7 @@ void ExportVTK::exportMesh(
 }
 
 void ExportVTK::exportData(
-    std::ofstream &   outFile,
+    std::ofstream    &outFile,
     const mesh::Mesh &mesh)
 {
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
@@ -114,11 +114,13 @@ void ExportVTK::exportData(
   std::fill_n(std::ostream_iterator<char const *>(outFile), mesh.vertices().size(), "0 ");
   outFile << "\n\n";
 
+  outFile << "FIELD FieldData " << mesh.data().size() << "\n";
+
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
     Eigen::VectorXd &values = data->values();
     if (data->getDimensions() > 1) {
       Eigen::VectorXd viewTemp(data->getDimensions());
-      outFile << "VECTORS " << data->getName() << " double\n";
+      outFile << data->getName() << " " << data->getDimensions() << " " << mesh.vertices().size() << " double\n";
       for (const mesh::Vertex &vertex : mesh.vertices()) {
         int offset = vertex.getID() * data->getDimensions();
         for (int i = 0; i < data->getDimensions(); i++) {
@@ -128,15 +130,11 @@ void ExportVTK::exportData(
         for (; i < data->getDimensions(); i++) {
           outFile << viewTemp[i] << ' ';
         }
-        if (i < 3) {
-          outFile << '0';
-        }
         outFile << '\n';
       }
       outFile << '\n';
     } else if (data->getDimensions() == 1) {
-      outFile << "SCALARS " << data->getName() << " double\n";
-      outFile << "LOOKUP_TABLE default\n";
+      outFile << data->getName() << " 1 " << mesh.vertices().size() << " double\n";
       for (const mesh::Vertex &vertex : mesh.vertices()) {
         outFile << values(vertex.getID()) << '\n';
       }
@@ -148,10 +146,10 @@ void ExportVTK::exportData(
 void ExportVTK::initializeWriting(
     std::ofstream &filestream)
 {
-  //size_t pos = fullFilename.rfind(".vtk");
-  //if ((pos == std::string::npos) || (pos != fullFilename.size()-4)){
-  //  fullFilename += ".vtk";
-  //}
+  // size_t pos = fullFilename.rfind(".vtk");
+  // if ((pos == std::string::npos) || (pos != fullFilename.size()-4)){
+  //   fullFilename += ".vtk";
+  // }
   filestream.setf(std::ios::showpoint);
   filestream.setf(std::ios::scientific);
   filestream << std::setprecision(std::numeric_limits<double>::max_digits10);
@@ -167,7 +165,7 @@ void ExportVTK::writeHeader(
 
 void ExportVTK::writeVertex(
     const Eigen::VectorXd &position,
-    std::ostream &         outFile)
+    std::ostream          &outFile)
 {
   if (position.size() == 2) {
     outFile << position(0) << "  " << position(1) << "  " << 0.0 << '\n';

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -23,7 +23,7 @@ namespace io {
 void ExportXML::doExport(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh  &mesh)
+    const mesh::Mesh & mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
   processDataNamesAndDimensions(mesh);
@@ -56,7 +56,7 @@ void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
 void ExportXML::writeMasterFile(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh  &mesh) const
+    const mesh::Mesh & mesh) const
 {
   namespace fs = boost::filesystem;
   fs::path outfile(location);
@@ -107,7 +107,7 @@ std::string getPieceSuffix()
 void ExportXML::writeSubFile(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh  &mesh) const
+    const mesh::Mesh & mesh) const
 {
   namespace fs = boost::filesystem;
   fs::path outfile(location);
@@ -139,7 +139,7 @@ void ExportXML::writeSubFile(
 }
 
 void ExportXML::exportData(
-    std::ostream     &outFile,
+    std::ostream &    outFile,
     const mesh::Mesh &mesh) const
 {
   outFile << "         <PointData Scalars=\"Rank ";
@@ -193,7 +193,7 @@ void ExportXML::exportData(
 
 void ExportXML::writeVertex(
     const Eigen::VectorXd &position,
-    std::ostream          &outFile)
+    std::ostream &         outFile)
 {
   outFile << "               ";
   for (int i = 0; i < position.size(); i++) {
@@ -207,7 +207,7 @@ void ExportXML::writeVertex(
 
 void ExportXML::writeTriangle(
     const mesh::Triangle &triangle,
-    std::ostream         &outFile)
+    std::ostream &        outFile)
 {
   outFile << triangle.vertex(0).getID() << "  ";
   outFile << triangle.vertex(1).getID() << "  ";
@@ -216,14 +216,14 @@ void ExportXML::writeTriangle(
 
 void ExportXML::writeLine(
     const mesh::Edge &edge,
-    std::ostream     &outFile)
+    std::ostream &    outFile)
 {
   outFile << edge.vertex(0).getID() << "  ";
   outFile << edge.vertex(1).getID() << "  ";
 }
 
 void ExportXML::exportPoints(
-    std::ostream     &outFile,
+    std::ostream &    outFile,
     const mesh::Mesh &mesh) const
 {
   outFile << "         <Points> \n";

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -23,7 +23,7 @@ namespace io {
 void ExportXML::doExport(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh & mesh)
+    const mesh::Mesh  &mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
   processDataNamesAndDimensions(mesh);
@@ -32,7 +32,7 @@ void ExportXML::doExport(
   if (utils::MasterSlave::isMaster()) {
     writeMasterFile(name, location, mesh);
   }
-  if (mesh.vertices().size() > 0) { //only procs at the coupling interface should write output (for performance reasons)
+  if (mesh.vertices().size() > 0) { // only procs at the coupling interface should write output (for performance reasons)
     writeSubFile(name, location, mesh);
   }
 }
@@ -56,7 +56,7 @@ void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
 void ExportXML::writeMasterFile(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh & mesh) const
+    const mesh::Mesh  &mesh) const
 {
   namespace fs = boost::filesystem;
   fs::path outfile(location);
@@ -83,7 +83,7 @@ void ExportXML::writeMasterFile(
   for (int i = 0; i < utils::MasterSlave::getSize(); i++) {
     auto iter = vertexDistribution.find(i);
     if (iter != vertexDistribution.end() && iter->second.size() > 0) {
-      //only non-empty subfiles
+      // only non-empty subfiles
       outMasterFile << "      <Piece Source=\"" << name << "_" << i << getPieceExtension() << "\"/>\n";
     }
   }
@@ -107,7 +107,7 @@ std::string getPieceSuffix()
 void ExportXML::writeSubFile(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh & mesh) const
+    const mesh::Mesh  &mesh) const
 {
   namespace fs = boost::filesystem;
   fs::path outfile(location);
@@ -139,7 +139,7 @@ void ExportXML::writeSubFile(
 }
 
 void ExportXML::exportData(
-    std::ostream &    outFile,
+    std::ostream     &outFile,
     const mesh::Mesh &mesh) const
 {
   outFile << "         <PointData Scalars=\"Rank ";
@@ -165,8 +165,7 @@ void ExportXML::exportData(
     Eigen::VectorXd &values         = data->values();
     int              dataDimensions = data->getDimensions();
     std::string      dataName(data->getName());
-    int              numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
-    outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
+    outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << "\" NumberOfComponents=\"" << dataDimensions;
     outFile << "\" format=\"ascii\">\n";
     outFile << "               ";
     if (dataDimensions > 1) {
@@ -178,9 +177,6 @@ void ExportXML::exportData(
         }
         for (int i = 0; i < dataDimensions; i++) {
           outFile << viewTemp[i] << ' ';
-        }
-        if (dataDimensions == 2) {
-          outFile << "0.0" << ' '; //2D data needs to be 3D for vtk
         }
         outFile << ' ';
       }
@@ -197,21 +193,21 @@ void ExportXML::exportData(
 
 void ExportXML::writeVertex(
     const Eigen::VectorXd &position,
-    std::ostream &         outFile)
+    std::ostream          &outFile)
 {
   outFile << "               ";
   for (int i = 0; i < position.size(); i++) {
     outFile << position(i) << "  ";
   }
   if (position.size() == 2) {
-    outFile << 0.0 << "  "; //also for 2D scenario, vtk needs 3D data
+    outFile << 0.0 << "  "; // also for 2D scenario, vtk needs 3D data
   }
   outFile << '\n';
 }
 
 void ExportXML::writeTriangle(
     const mesh::Triangle &triangle,
-    std::ostream &        outFile)
+    std::ostream         &outFile)
 {
   outFile << triangle.vertex(0).getID() << "  ";
   outFile << triangle.vertex(1).getID() << "  ";
@@ -220,14 +216,14 @@ void ExportXML::writeTriangle(
 
 void ExportXML::writeLine(
     const mesh::Edge &edge,
-    std::ostream &    outFile)
+    std::ostream     &outFile)
 {
   outFile << edge.vertex(0).getID() << "  ";
   outFile << edge.vertex(1).getID() << "  ";
 }
 
 void ExportXML::exportPoints(
-    std::ostream &    outFile,
+    std::ostream     &outFile,
     const mesh::Mesh &mesh) const
 {
   outFile << "         <Points> \n";


### PR DESCRIPTION
## Main changes of this PR

Change `vtk` export array type from `SCALAR` (1(defafult)-4 Component) and `VECTOR` (3 Component) to `FIELD` which allows arbitrary number of components.

Removes unnecessary pseudo-3D vector type from `vtu` export by removing additional component `0.0` and writing the correct number of components for 2D vectors. 

## Motivation and additional information

For ASTE replay mode we need to parse preCICE outputs. For 2D cases, the additional component causes errors while parsing data. This change writes the exact amount of components for n-D vectors.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
