### PR TITLE
New API  method isScalar(dataID)

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -19,7 +19,7 @@ SolverInterface::SolverInterface(
     const std::string &configurationFileName,
     int                solverProcessIndex,
     int                solverProcessSize,
-    void              *communicator)
+    void *             communicator)
     : _impl(new impl::SolverInterfaceImpl(participantName, configurationFileName, solverProcessIndex, solverProcessSize, communicator))
 {
 }
@@ -153,7 +153,7 @@ void SolverInterface::setMeshVertices(
     int           meshID,
     int           size,
     const double *positions,
-    int          *ids)
+    int *         ids)
 {
   _impl->setMeshVertices(meshID, size, positions, ids);
 }
@@ -162,7 +162,7 @@ void SolverInterface::getMeshVertices(
     int        meshID,
     int        size,
     const int *ids,
-    double    *positions) const
+    double *   positions) const
 {
   _impl->getMeshVertices(meshID, size, ids, positions);
 }
@@ -171,7 +171,7 @@ void SolverInterface::getMeshVertexIDsFromPositions(
     int           meshID,
     int           size,
     const double *positions,
-    int          *ids) const
+    int *         ids) const
 {
   _impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
 }
@@ -238,7 +238,7 @@ void SolverInterface::mapWriteDataFrom(
 void SolverInterface::writeBlockVectorData(
     int           dataID,
     int           size,
-    const int    *valueIndices,
+    const int *   valueIndices,
     const double *values)
 {
   _impl->writeBlockVectorData(dataID, size, valueIndices, values);
@@ -255,7 +255,7 @@ void SolverInterface::writeVectorData(
 void SolverInterface::writeBlockScalarData(
     int           dataID,
     int           size,
-    const int    *valueIndices,
+    const int *   valueIndices,
     const double *values)
 {
   _impl->writeBlockScalarData(dataID, size, valueIndices, values);
@@ -273,7 +273,7 @@ void SolverInterface::readBlockVectorData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double    *values) const
+    double *   values) const
 {
   _impl->readBlockVectorData(dataID, size, valueIndices, values);
 }
@@ -290,7 +290,7 @@ void SolverInterface::readBlockScalarData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double    *values) const
+    double *   values) const
 {
   _impl->readBlockScalarData(dataID, size, valueIndices, values);
 }
@@ -311,8 +311,8 @@ void SolverInterface::setMeshAccessRegion(const int     meshID,
 
 void SolverInterface::getMeshVerticesAndIDs(const int meshID,
                                             const int size,
-                                            int      *ids,
-                                            double   *coordinates) const
+                                            int *     ids,
+                                            double *  coordinates) const
 {
   _impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
 }

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -19,7 +19,7 @@ SolverInterface::SolverInterface(
     const std::string &configurationFileName,
     int                solverProcessIndex,
     int                solverProcessSize,
-    void *             communicator)
+    void              *communicator)
     : _impl(new impl::SolverInterfaceImpl(participantName, configurationFileName, solverProcessIndex, solverProcessSize, communicator))
 {
 }
@@ -129,12 +129,12 @@ bool SolverInterface::hasToEvaluateFineModel() const
   return _impl->hasToEvaluateFineModel();
 }
 
-//void SolverInterface:: resetMesh
+// void SolverInterface:: resetMesh
 //(
-//  int meshID )
+//   int meshID )
 //{
-//  _impl->resetMesh(meshID);
-//}
+//   _impl->resetMesh(meshID);
+// }
 
 int SolverInterface::setMeshVertex(
     int           meshID,
@@ -153,7 +153,7 @@ void SolverInterface::setMeshVertices(
     int           meshID,
     int           size,
     const double *positions,
-    int *         ids)
+    int          *ids)
 {
   _impl->setMeshVertices(meshID, size, positions, ids);
 }
@@ -162,7 +162,7 @@ void SolverInterface::getMeshVertices(
     int        meshID,
     int        size,
     const int *ids,
-    double *   positions) const
+    double    *positions) const
 {
   _impl->getMeshVertices(meshID, size, ids, positions);
 }
@@ -171,7 +171,7 @@ void SolverInterface::getMeshVertexIDsFromPositions(
     int           meshID,
     int           size,
     const double *positions,
-    int *         ids) const
+    int          *ids) const
 {
   _impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
 }
@@ -238,7 +238,7 @@ void SolverInterface::mapWriteDataFrom(
 void SolverInterface::writeBlockVectorData(
     int           dataID,
     int           size,
-    const int *   valueIndices,
+    const int    *valueIndices,
     const double *values)
 {
   _impl->writeBlockVectorData(dataID, size, valueIndices, values);
@@ -255,7 +255,7 @@ void SolverInterface::writeVectorData(
 void SolverInterface::writeBlockScalarData(
     int           dataID,
     int           size,
-    const int *   valueIndices,
+    const int    *valueIndices,
     const double *values)
 {
   _impl->writeBlockScalarData(dataID, size, valueIndices, values);
@@ -273,7 +273,7 @@ void SolverInterface::readBlockVectorData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double *   values) const
+    double    *values) const
 {
   _impl->readBlockVectorData(dataID, size, valueIndices, values);
 }
@@ -290,7 +290,7 @@ void SolverInterface::readBlockScalarData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double *   values) const
+    double    *values) const
 {
   _impl->readBlockScalarData(dataID, size, valueIndices, values);
 }
@@ -311,10 +311,15 @@ void SolverInterface::setMeshAccessRegion(const int     meshID,
 
 void SolverInterface::getMeshVerticesAndIDs(const int meshID,
                                             const int size,
-                                            int *     ids,
-                                            double *  coordinates) const
+                                            int      *ids,
+                                            double   *coordinates) const
 {
   _impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
+}
+
+bool SolverInterface::isScalar(const int dataID) const
+{
+  return _impl->isScalar(dataID);
 }
 
 std::string getVersionInformation()

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -70,7 +70,7 @@ public:
       const std::string &configurationFileName,
       int                solverProcessIndex,
       int                solverProcessSize,
-      void *             communicator);
+      void              *communicator);
 
   ~SolverInterface();
 
@@ -411,7 +411,7 @@ public:
       int           meshID,
       int           size,
       const double *positions,
-      int *         ids);
+      int          *ids);
 
   /**
    * @brief Get vertex positions for multiple vertex ids from a given mesh
@@ -432,7 +432,7 @@ public:
       int        meshID,
       int        size,
       const int *ids,
-      double *   positions) const;
+      double    *positions) const;
 
   /**
    * @brief Gets mesh vertex IDs from positions.
@@ -453,7 +453,7 @@ public:
       int           meshID,
       int           size,
       const double *positions,
-      int *         ids) const;
+      int          *ids) const;
 
   /**
    * @brief Sets mesh edge from vertex IDs, returns edge ID.
@@ -621,7 +621,7 @@ public:
   void writeBlockVectorData(
       int           dataID,
       int           size,
-      const int *   valueIndices,
+      const int    *valueIndices,
       const double *values);
 
   /**
@@ -668,7 +668,7 @@ public:
   void writeBlockScalarData(
       int           dataID,
       int           size,
-      const int *   valueIndices,
+      const int    *valueIndices,
       const double *values);
 
   /**
@@ -716,7 +716,7 @@ public:
       int        dataID,
       int        size,
       const int *valueIndices,
-      double *   values) const;
+      double    *values) const;
 
   /**
    * @brief Reads vector data form a vertex
@@ -767,7 +767,7 @@ public:
       int        dataID,
       int        size,
       const int *valueIndices,
-      double *   values) const;
+      double    *values) const;
 
   /**
    * @brief Reads scalar data of a vertex.
@@ -877,9 +877,17 @@ public:
   void getMeshVerticesAndIDs(
       const int meshID,
       const int size,
-      int *     ids,
-      double *  coordinates) const;
+      int      *ids,
+      double   *coordinates) const;
 
+  /**
+   * @brief Returns whether data with given ID is scalar.
+   *
+   * @param[in] meshID the id of the associated data.
+   *
+   * @returns whether data with given ID is scalar.
+   */
+  bool isScalar(const int dataID) const;
   ///@}
 
   /// Disable copy construction

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -70,7 +70,7 @@ public:
       const std::string &configurationFileName,
       int                solverProcessIndex,
       int                solverProcessSize,
-      void              *communicator);
+      void *             communicator);
 
   ~SolverInterface();
 
@@ -411,7 +411,7 @@ public:
       int           meshID,
       int           size,
       const double *positions,
-      int          *ids);
+      int *         ids);
 
   /**
    * @brief Get vertex positions for multiple vertex ids from a given mesh
@@ -432,7 +432,7 @@ public:
       int        meshID,
       int        size,
       const int *ids,
-      double    *positions) const;
+      double *   positions) const;
 
   /**
    * @brief Gets mesh vertex IDs from positions.
@@ -453,7 +453,7 @@ public:
       int           meshID,
       int           size,
       const double *positions,
-      int          *ids) const;
+      int *         ids) const;
 
   /**
    * @brief Sets mesh edge from vertex IDs, returns edge ID.
@@ -621,7 +621,7 @@ public:
   void writeBlockVectorData(
       int           dataID,
       int           size,
-      const int    *valueIndices,
+      const int *   valueIndices,
       const double *values);
 
   /**
@@ -668,7 +668,7 @@ public:
   void writeBlockScalarData(
       int           dataID,
       int           size,
-      const int    *valueIndices,
+      const int *   valueIndices,
       const double *values);
 
   /**
@@ -716,7 +716,7 @@ public:
       int        dataID,
       int        size,
       const int *valueIndices,
-      double    *values) const;
+      double *   values) const;
 
   /**
    * @brief Reads vector data form a vertex
@@ -767,7 +767,7 @@ public:
       int        dataID,
       int        size,
       const int *valueIndices,
-      double    *values) const;
+      double *   values) const;
 
   /**
    * @brief Reads scalar data of a vertex.
@@ -877,8 +877,8 @@ public:
   void getMeshVerticesAndIDs(
       const int meshID,
       const int size,
-      int      *ids,
-      double   *coordinates) const;
+      int *     ids,
+      double *  coordinates) const;
 
   /**
    * @brief Returns whether data with given ID is scalar.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -85,7 +85,7 @@ SolverInterfaceImpl::SolverInterfaceImpl(
     const std::string &configurationFileName,
     int                accessorProcessRank,
     int                accessorCommunicatorSize,
-    void *             communicator)
+    void              *communicator)
     : _accessorName(std::move(participantName)),
       _accessorProcessRank(accessorProcessRank),
       _accessorCommunicatorSize(accessorCommunicatorSize)
@@ -675,7 +675,7 @@ int SolverInterfaceImpl::setMeshVertex(
       Eigen::Map<const Eigen::VectorXd>{position, _dimensions}};
   PRECICE_DEBUG("Position = {}", internalPosition.format(utils::eigenio::debug()));
   int           index   = -1;
-  MeshContext & context = _accessor->usedMeshContext(meshID);
+  MeshContext  &context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("MeshRequirement: {}", context.meshRequirement);
   index = mesh->createVertex(internalPosition).getID();
@@ -687,11 +687,11 @@ void SolverInterfaceImpl::setMeshVertices(
     int           meshID,
     int           size,
     const double *positions,
-    int *         ids)
+    int          *ids)
 {
   PRECICE_TRACE(meshID, size);
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
-  MeshContext & context = _accessor->usedMeshContext(meshID);
+  MeshContext  &context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Set positions");
   const Eigen::Map<const Eigen::MatrixXd> posMatrix{
@@ -707,11 +707,11 @@ void SolverInterfaceImpl::getMeshVertices(
     int        meshID,
     size_t     size,
     const int *ids,
-    double *   positions) const
+    double    *positions) const
 {
   PRECICE_TRACE(meshID, size);
   PRECICE_REQUIRE_MESH_USE(meshID);
-  MeshContext & context = _accessor->usedMeshContext(meshID);
+  MeshContext  &context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Get positions");
   auto &vertices = mesh->vertices();
@@ -729,14 +729,14 @@ void SolverInterfaceImpl::getMeshVertexIDsFromPositions(
     int           meshID,
     size_t        size,
     const double *positions,
-    int *         ids) const
+    int          *ids) const
 {
   PRECICE_TRACE(meshID, size);
   PRECICE_REQUIRE_MESH_USE(meshID);
-  MeshContext & context = _accessor->usedMeshContext(meshID);
+  MeshContext  &context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Get IDs");
-  const auto &                      vertices = mesh->vertices();
+  const auto                       &vertices = mesh->vertices();
   Eigen::Map<const Eigen::MatrixXd> posMatrix{
       positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
   const auto vsize = vertices.size();
@@ -1042,7 +1042,7 @@ void SolverInterfaceImpl::mapReadDataTo(
 void SolverInterfaceImpl::writeBlockVectorData(
     int           dataID,
     int           size,
-    const int *   valueIndices,
+    const int    *valueIndices,
     const double *values)
 {
   PRECICE_TRACE(dataID, size);
@@ -1060,7 +1060,7 @@ void SolverInterfaceImpl::writeBlockVectorData(
   PRECICE_VALIDATE_DATA(values, size * _dimensions);
 
   mesh::Data &data           = *context.providedData();
-  auto &      valuesInternal = data.values();
+  auto       &valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size() / context.getDataDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
@@ -1094,7 +1094,7 @@ void SolverInterfaceImpl::writeVectorData(
   PRECICE_VALIDATE_DATA(value, _dimensions);
 
   mesh::Data &data        = *context.providedData();
-  auto &      values      = data.values();
+  auto       &values      = data.values();
   const auto  vertexCount = values.size() / context.getDataDimensions();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot write data \"{}\" to invalid Vertex ID ({}). Please make sure you only use the results from calls to setMeshVertex/Vertices().",
@@ -1108,7 +1108,7 @@ void SolverInterfaceImpl::writeVectorData(
 void SolverInterfaceImpl::writeBlockScalarData(
     int           dataID,
     int           size,
-    const int *   valueIndices,
+    const int    *valueIndices,
     const double *values)
 {
   PRECICE_TRACE(dataID, size);
@@ -1126,7 +1126,7 @@ void SolverInterfaceImpl::writeBlockScalarData(
   PRECICE_VALIDATE_DATA(values, size);
 
   mesh::Data &data           = *context.providedData();
-  auto &      valuesInternal = data.values();
+  auto       &valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size() / context.getDataDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
@@ -1158,7 +1158,7 @@ void SolverInterfaceImpl::writeScalarData(
   PRECICE_VALIDATE_DATA(static_cast<double *>(&value), 1);
 
   mesh::Data &data        = *context.providedData();
-  auto &      values      = data.values();
+  auto       &values      = data.values();
   const auto  vertexCount = values.size() / context.getDataDimensions();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot write data \"{}\" to invalid Vertex ID ({}). "
@@ -1171,7 +1171,7 @@ void SolverInterfaceImpl::readBlockVectorData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double *   values) const
+    double    *values) const
 {
   PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockVectorData(...) cannot be called after finalize().");
@@ -1187,7 +1187,7 @@ void SolverInterfaceImpl::readBlockVectorData(
                 "Use readBlockScalarData or change the data type for \"{0}\" to vector.",
                 context.getDataName());
   mesh::Data &data           = *context.providedData();
-  auto &      valuesInternal = data.values();
+  auto       &valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size() / context.getDataDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
@@ -1221,7 +1221,7 @@ void SolverInterfaceImpl::readVectorData(
                 "You cannot call readVectorData on the scalar data type \"{0}\". Use readScalarData or change the data type for \"{0}\" to vector.",
                 context.getDataName());
   mesh::Data &data        = *context.providedData();
-  auto &      values      = data.values();
+  auto       &values      = data.values();
   const auto  vertexCount = values.size() / context.getDataDimensions();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot read data \"{}\" to invalid Vertex ID ({}). "
@@ -1238,7 +1238,7 @@ void SolverInterfaceImpl::readBlockScalarData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double *   values) const
+    double    *values) const
 {
   PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockScalarData(...) cannot be called after finalize().");
@@ -1254,7 +1254,7 @@ void SolverInterfaceImpl::readBlockScalarData(
                 "Use readBlockVectorData or change the data type for \"{0}\" to scalar.",
                 context.getDataName());
   mesh::Data &data           = *context.providedData();
-  auto &      valuesInternal = data.values();
+  auto       &valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size();
 
   for (int i = 0; i < size; i++) {
@@ -1286,7 +1286,7 @@ void SolverInterfaceImpl::readScalarData(
                 "Use readVectorData or change the data type for \"{}\" to scalar.",
                 context.getDataName());
   mesh::Data &data        = *context.providedData();
-  auto &      values      = data.values();
+  auto       &values      = data.values();
   const auto  vertexCount = values.size();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot read data \"{}\" from invalid Vertex ID ({}). "
@@ -1309,7 +1309,7 @@ void SolverInterfaceImpl::setMeshAccessRegion(
   PRECICE_CHECK(boundingBox != nullptr, "setMeshAccessRegion was called with boundingBox == nullptr.");
 
   // Get the related mesh
-  MeshContext & context = _accessor->meshContext(meshID);
+  MeshContext  &context = _accessor->meshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Define bounding box");
   // Transform bounds into a suitable format
@@ -1333,8 +1333,8 @@ void SolverInterfaceImpl::setMeshAccessRegion(
 void SolverInterfaceImpl::getMeshVerticesAndIDs(
     const int meshID,
     const int size,
-    int *     ids,
-    double *  coordinates) const
+    int      *ids,
+    double   *coordinates) const
 {
   PRECICE_EXPERIMENTAL_API();
   PRECICE_TRACE(meshID, size);
@@ -1349,7 +1349,7 @@ void SolverInterfaceImpl::getMeshVerticesAndIDs(
   if (size == 0)
     return;
 
-  const MeshContext & context = _accessor->meshContext(meshID);
+  const MeshContext  &context = _accessor->meshContext(meshID);
   const mesh::PtrMesh mesh(context.mesh);
 
   PRECICE_CHECK(ids != nullptr, "getMeshVerticesAndIDs() was called with ids == nullptr");
@@ -1366,6 +1366,23 @@ void SolverInterfaceImpl::getMeshVerticesAndIDs(
     ids[i]           = vertices[i].getID();
     posMatrix.col(i) = vertices[i].getCoords();
   }
+}
+
+bool SolverInterfaceImpl::isScalar(const int dataID) const
+{
+  PRECICE_VALIDATE_DATA_ID(dataID);
+  if (_accessor->isDataRead(dataID)) {
+    ReadDataContext &context = _accessor->readDataContext(dataID);
+    if (context.getDataDimensions() == _dimensions) {
+      return false;
+    }
+  } else if (_accessor->isDataWrite(dataID)) {
+    WriteDataContext &context = _accessor->writeDataContext(dataID);
+    if (context.getDataDimensions() == _dimensions) {
+      return false;
+    }
+  }
+  return true;
 }
 
 void SolverInterfaceImpl::exportMesh(const std::string &filenameSuffix) const
@@ -1495,9 +1512,9 @@ void SolverInterfaceImpl::compareBoundingBoxes()
 
 void SolverInterfaceImpl::computePartitions()
 {
-  //We need to do this in two loops: First, communicate the mesh and later compute the partition.
-  //Originally, this was done in one loop. This however gave deadlock if two meshes needed to be communicated cross-wise.
-  //Both loops need a different sorting
+  // We need to do this in two loops: First, communicate the mesh and later compute the partition.
+  // Originally, this was done in one loop. This however gave deadlock if two meshes needed to be communicated cross-wise.
+  // Both loops need a different sorting
 
   auto &contexts = _accessor->usedMeshContexts();
 
@@ -1638,7 +1655,7 @@ void SolverInterfaceImpl::performDataActions(
 void SolverInterfaceImpl::handleExports()
 {
   PRECICE_TRACE();
-  //timesteps was already incremented before
+  // timesteps was already incremented before
   int timesteps = _couplingScheme->getTimeWindows() - 1;
 
   for (const io::ExportContext &context : _accessor->exportContexts()) {

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -85,7 +85,7 @@ SolverInterfaceImpl::SolverInterfaceImpl(
     const std::string &configurationFileName,
     int                accessorProcessRank,
     int                accessorCommunicatorSize,
-    void              *communicator)
+    void *             communicator)
     : _accessorName(std::move(participantName)),
       _accessorProcessRank(accessorProcessRank),
       _accessorCommunicatorSize(accessorCommunicatorSize)
@@ -675,7 +675,7 @@ int SolverInterfaceImpl::setMeshVertex(
       Eigen::Map<const Eigen::VectorXd>{position, _dimensions}};
   PRECICE_DEBUG("Position = {}", internalPosition.format(utils::eigenio::debug()));
   int           index   = -1;
-  MeshContext  &context = _accessor->usedMeshContext(meshID);
+  MeshContext & context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("MeshRequirement: {}", context.meshRequirement);
   index = mesh->createVertex(internalPosition).getID();
@@ -687,11 +687,11 @@ void SolverInterfaceImpl::setMeshVertices(
     int           meshID,
     int           size,
     const double *positions,
-    int          *ids)
+    int *         ids)
 {
   PRECICE_TRACE(meshID, size);
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
-  MeshContext  &context = _accessor->usedMeshContext(meshID);
+  MeshContext & context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Set positions");
   const Eigen::Map<const Eigen::MatrixXd> posMatrix{
@@ -707,11 +707,11 @@ void SolverInterfaceImpl::getMeshVertices(
     int        meshID,
     size_t     size,
     const int *ids,
-    double    *positions) const
+    double *   positions) const
 {
   PRECICE_TRACE(meshID, size);
   PRECICE_REQUIRE_MESH_USE(meshID);
-  MeshContext  &context = _accessor->usedMeshContext(meshID);
+  MeshContext & context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Get positions");
   auto &vertices = mesh->vertices();
@@ -729,14 +729,14 @@ void SolverInterfaceImpl::getMeshVertexIDsFromPositions(
     int           meshID,
     size_t        size,
     const double *positions,
-    int          *ids) const
+    int *         ids) const
 {
   PRECICE_TRACE(meshID, size);
   PRECICE_REQUIRE_MESH_USE(meshID);
-  MeshContext  &context = _accessor->usedMeshContext(meshID);
+  MeshContext & context = _accessor->usedMeshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Get IDs");
-  const auto                       &vertices = mesh->vertices();
+  const auto &                      vertices = mesh->vertices();
   Eigen::Map<const Eigen::MatrixXd> posMatrix{
       positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
   const auto vsize = vertices.size();
@@ -1042,7 +1042,7 @@ void SolverInterfaceImpl::mapReadDataTo(
 void SolverInterfaceImpl::writeBlockVectorData(
     int           dataID,
     int           size,
-    const int    *valueIndices,
+    const int *   valueIndices,
     const double *values)
 {
   PRECICE_TRACE(dataID, size);
@@ -1060,7 +1060,7 @@ void SolverInterfaceImpl::writeBlockVectorData(
   PRECICE_VALIDATE_DATA(values, size * _dimensions);
 
   mesh::Data &data           = *context.providedData();
-  auto       &valuesInternal = data.values();
+  auto &      valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size() / context.getDataDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
@@ -1094,7 +1094,7 @@ void SolverInterfaceImpl::writeVectorData(
   PRECICE_VALIDATE_DATA(value, _dimensions);
 
   mesh::Data &data        = *context.providedData();
-  auto       &values      = data.values();
+  auto &      values      = data.values();
   const auto  vertexCount = values.size() / context.getDataDimensions();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot write data \"{}\" to invalid Vertex ID ({}). Please make sure you only use the results from calls to setMeshVertex/Vertices().",
@@ -1108,7 +1108,7 @@ void SolverInterfaceImpl::writeVectorData(
 void SolverInterfaceImpl::writeBlockScalarData(
     int           dataID,
     int           size,
-    const int    *valueIndices,
+    const int *   valueIndices,
     const double *values)
 {
   PRECICE_TRACE(dataID, size);
@@ -1126,7 +1126,7 @@ void SolverInterfaceImpl::writeBlockScalarData(
   PRECICE_VALIDATE_DATA(values, size);
 
   mesh::Data &data           = *context.providedData();
-  auto       &valuesInternal = data.values();
+  auto &      valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size() / context.getDataDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
@@ -1158,7 +1158,7 @@ void SolverInterfaceImpl::writeScalarData(
   PRECICE_VALIDATE_DATA(static_cast<double *>(&value), 1);
 
   mesh::Data &data        = *context.providedData();
-  auto       &values      = data.values();
+  auto &      values      = data.values();
   const auto  vertexCount = values.size() / context.getDataDimensions();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot write data \"{}\" to invalid Vertex ID ({}). "
@@ -1171,7 +1171,7 @@ void SolverInterfaceImpl::readBlockVectorData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double    *values) const
+    double *   values) const
 {
   PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockVectorData(...) cannot be called after finalize().");
@@ -1187,7 +1187,7 @@ void SolverInterfaceImpl::readBlockVectorData(
                 "Use readBlockScalarData or change the data type for \"{0}\" to vector.",
                 context.getDataName());
   mesh::Data &data           = *context.providedData();
-  auto       &valuesInternal = data.values();
+  auto &      valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size() / context.getDataDimensions();
   for (int i = 0; i < size; i++) {
     const auto valueIndex = valueIndices[i];
@@ -1221,7 +1221,7 @@ void SolverInterfaceImpl::readVectorData(
                 "You cannot call readVectorData on the scalar data type \"{0}\". Use readScalarData or change the data type for \"{0}\" to vector.",
                 context.getDataName());
   mesh::Data &data        = *context.providedData();
-  auto       &values      = data.values();
+  auto &      values      = data.values();
   const auto  vertexCount = values.size() / context.getDataDimensions();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot read data \"{}\" to invalid Vertex ID ({}). "
@@ -1238,7 +1238,7 @@ void SolverInterfaceImpl::readBlockScalarData(
     int        dataID,
     int        size,
     const int *valueIndices,
-    double    *values) const
+    double *   values) const
 {
   PRECICE_TRACE(dataID, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockScalarData(...) cannot be called after finalize().");
@@ -1254,7 +1254,7 @@ void SolverInterfaceImpl::readBlockScalarData(
                 "Use readBlockVectorData or change the data type for \"{0}\" to scalar.",
                 context.getDataName());
   mesh::Data &data           = *context.providedData();
-  auto       &valuesInternal = data.values();
+  auto &      valuesInternal = data.values();
   const auto  vertexCount    = valuesInternal.size();
 
   for (int i = 0; i < size; i++) {
@@ -1286,7 +1286,7 @@ void SolverInterfaceImpl::readScalarData(
                 "Use readVectorData or change the data type for \"{}\" to scalar.",
                 context.getDataName());
   mesh::Data &data        = *context.providedData();
-  auto       &values      = data.values();
+  auto &      values      = data.values();
   const auto  vertexCount = values.size();
   PRECICE_CHECK(0 <= valueIndex && valueIndex < vertexCount,
                 "Cannot read data \"{}\" from invalid Vertex ID ({}). "
@@ -1309,7 +1309,7 @@ void SolverInterfaceImpl::setMeshAccessRegion(
   PRECICE_CHECK(boundingBox != nullptr, "setMeshAccessRegion was called with boundingBox == nullptr.");
 
   // Get the related mesh
-  MeshContext  &context = _accessor->meshContext(meshID);
+  MeshContext & context = _accessor->meshContext(meshID);
   mesh::PtrMesh mesh(context.mesh);
   PRECICE_DEBUG("Define bounding box");
   // Transform bounds into a suitable format
@@ -1333,8 +1333,8 @@ void SolverInterfaceImpl::setMeshAccessRegion(
 void SolverInterfaceImpl::getMeshVerticesAndIDs(
     const int meshID,
     const int size,
-    int      *ids,
-    double   *coordinates) const
+    int *     ids,
+    double *  coordinates) const
 {
   PRECICE_EXPERIMENTAL_API();
   PRECICE_TRACE(meshID, size);
@@ -1349,7 +1349,7 @@ void SolverInterfaceImpl::getMeshVerticesAndIDs(
   if (size == 0)
     return;
 
-  const MeshContext  &context = _accessor->meshContext(meshID);
+  const MeshContext & context = _accessor->meshContext(meshID);
   const mesh::PtrMesh mesh(context.mesh);
 
   PRECICE_CHECK(ids != nullptr, "getMeshVerticesAndIDs() was called with ids == nullptr");

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -97,7 +97,7 @@ public:
       const std::string &configurationFileName,
       int                accessorProcessRank,
       int                accessorCommunicatorSize,
-      void              *communicator);
+      void *             communicator);
 
   /** Ensures that finalize() has been called.
    *
@@ -281,7 +281,7 @@ public:
       int           meshID,
       int           size,
       const double *positions,
-      int          *ids);
+      int *         ids);
 
   /**
    * @brief Gets spatial positions of vertices for given IDs.
@@ -293,7 +293,7 @@ public:
       int        meshID,
       size_t     size,
       const int *ids,
-      double    *positions) const;
+      double *   positions) const;
 
   /**
    * @brief Gets vertex data ids from positions.
@@ -306,7 +306,7 @@ public:
       int           meshID,
       size_t        size,
       const double *positions,
-      int          *ids) const;
+      int *         ids) const;
 
   /**
    * @brief Set an edge of a solver mesh.
@@ -372,7 +372,7 @@ public:
   void writeBlockVectorData(
       int           fromDataID,
       int           size,
-      const int    *valueIndices,
+      const int *   valueIndices,
       const double *values);
 
   /**
@@ -399,7 +399,7 @@ public:
   void writeBlockScalarData(
       int           fromDataID,
       int           size,
-      const int    *valueIndices,
+      const int *   valueIndices,
       const double *values);
 
   /**
@@ -432,7 +432,7 @@ public:
       int        toDataID,
       int        size,
       const int *valueIndices,
-      double    *values) const;
+      double *   values) const;
 
   /**
    * @brief Reads vector data from the coupling mesh.
@@ -457,7 +457,7 @@ public:
       int        toDataID,
       int        size,
       const int *valueIndices,
-      double    *values) const;
+      double *   values) const;
 
   /**
    * @brief Read scalar data from the interface mesh.
@@ -485,8 +485,8 @@ public:
   void getMeshVerticesAndIDs(
       const int meshID,
       const int size,
-      int      *ids,
-      double   *coordinates) const;
+      int *     ids,
+      double *  coordinates) const;
 
   /**
    * @copydoc precice::SolverInterface::isScalar()

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -97,7 +97,7 @@ public:
       const std::string &configurationFileName,
       int                accessorProcessRank,
       int                accessorCommunicatorSize,
-      void *             communicator);
+      void              *communicator);
 
   /** Ensures that finalize() has been called.
    *
@@ -281,7 +281,7 @@ public:
       int           meshID,
       int           size,
       const double *positions,
-      int *         ids);
+      int          *ids);
 
   /**
    * @brief Gets spatial positions of vertices for given IDs.
@@ -293,7 +293,7 @@ public:
       int        meshID,
       size_t     size,
       const int *ids,
-      double *   positions) const;
+      double    *positions) const;
 
   /**
    * @brief Gets vertex data ids from positions.
@@ -306,7 +306,7 @@ public:
       int           meshID,
       size_t        size,
       const double *positions,
-      int *         ids) const;
+      int          *ids) const;
 
   /**
    * @brief Set an edge of a solver mesh.
@@ -372,7 +372,7 @@ public:
   void writeBlockVectorData(
       int           fromDataID,
       int           size,
-      const int *   valueIndices,
+      const int    *valueIndices,
       const double *values);
 
   /**
@@ -399,7 +399,7 @@ public:
   void writeBlockScalarData(
       int           fromDataID,
       int           size,
-      const int *   valueIndices,
+      const int    *valueIndices,
       const double *values);
 
   /**
@@ -432,7 +432,7 @@ public:
       int        toDataID,
       int        size,
       const int *valueIndices,
-      double *   values) const;
+      double    *values) const;
 
   /**
    * @brief Reads vector data from the coupling mesh.
@@ -457,7 +457,7 @@ public:
       int        toDataID,
       int        size,
       const int *valueIndices,
-      double *   values) const;
+      double    *values) const;
 
   /**
    * @brief Read scalar data from the interface mesh.
@@ -485,8 +485,13 @@ public:
   void getMeshVerticesAndIDs(
       const int meshID,
       const int size,
-      int *     ids,
-      double *  coordinates) const;
+      int      *ids,
+      double   *coordinates) const;
+
+  /**
+   * @copydoc precice::SolverInterface::isScalar()
+   */
+  bool isScalar(const int dataID) const;
 
   /**
    * @brief Sets the location for all output of preCICE.


### PR DESCRIPTION
## Main changes of this PR

Implement a new method to solver interface to get whether a data is a scalar or not.

## Motivation and additional information

As discussed in https://github.com/precice/aste/issues/84 and #474  in order to avoid duplication in configuration files we need a method to get information about data is whether scalar or not. 

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

