### PR TITLE
Remove mostly redundant initialization of _allData.

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -256,7 +256,7 @@ void BaseCouplingScheme::advance()
 void BaseCouplingScheme::storeExtrapolationData()
 {
   PRECICE_TRACE(_timeWindows);
-  for (DataMap::value_type &pair : _allData) {
+  for (DataMap::value_type &pair : getAllData()) {
     PRECICE_DEBUG("Store data: {}", pair.first);
     pair.second->storeExtrapolationData();
   }
@@ -449,7 +449,7 @@ void BaseCouplingScheme::initializeStorages()
 {
   PRECICE_TRACE();
   // Reserve storage for all data
-  for (DataMap::value_type &pair : _allData) {
+  for (DataMap::value_type &pair : getAllData()) {
     pair.second->initializeExtrapolation();
   }
   // Reserve storage for acceleration
@@ -482,8 +482,8 @@ void BaseCouplingScheme::addConvergenceMeasure(
     bool                        doesLogging)
 {
   ConvergenceMeasureContext convMeasure;
-  PRECICE_ASSERT(_allData.count(dataID) == 1, "Data with given data ID must exist!");
-  convMeasure.couplingData = &(*_allData[dataID]);
+  PRECICE_ASSERT(getAllData().count(dataID) == 1, "Data with given data ID must exist!");
+  convMeasure.couplingData = &(*getAllData()[dataID]);
   convMeasure.suffices     = suffices;
   convMeasure.strict       = strict;
   convMeasure.measure      = std::move(measure);
@@ -662,8 +662,8 @@ bool BaseCouplingScheme::doImplicitStep()
 void BaseCouplingScheme::assignDataToConvergenceMeasure(ConvergenceMeasureContext *convergenceMeasure, DataID dataID)
 {
   PRECICE_TRACE(dataID);
-  DataMap::iterator iter = _allData.find(dataID);
-  PRECICE_ASSERT(iter != _allData.end(), "Given data ID does not exist in _allData!");
+  DataMap::iterator iter = getAllData().find(dataID);
+  PRECICE_ASSERT(iter != getAllData().end(), "Given data ID does not exist in getAllData()!");
   convergenceMeasure->couplingData = &(*(iter->second));
 }
 

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -251,6 +251,12 @@ protected:
   void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData);
 
   /**
+   * @brief interface to provide all CouplingData, depending on coupling scheme being used
+   * @return DataMap containing all CouplingData
+   */
+  virtual DataMap &getAllData() = 0;
+
+  /**
    * @brief Function to determine whether coupling scheme is an explicit coupling scheme
    * @returns true, if coupling scheme is explicit
    */
@@ -354,7 +360,7 @@ protected:
   void storeIteration()
   {
     PRECICE_ASSERT(isImplicitCouplingScheme());
-    for (DataMap::value_type &pair : _allData) {
+    for (DataMap::value_type &pair : getAllData()) {
       pair.second->storeIteration();
     }
   }

--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -65,8 +65,6 @@ void BiCouplingScheme::addDataToSend(
     }
     PRECICE_ASSERT(_sendData.count(pair.first) == 0, "Key already exists!");
     _sendData.insert(pair);
-    PRECICE_ASSERT(_allData.count(pair.first) == 0, "Key already exists!");
-    _allData.insert(pair);
   } else {
     PRECICE_ERROR("Data \"{0}\" cannot be added twice for sending. Please remove any duplicate <exchange data=\"{0}\" .../> tags", data->getName());
   }
@@ -88,8 +86,6 @@ void BiCouplingScheme::addDataToReceive(
     }
     PRECICE_ASSERT(_receiveData.count(pair.first) == 0, "Key already exists!");
     _receiveData.insert(pair);
-    PRECICE_ASSERT(_allData.count(pair.first) == 0, "Key already exists!");
-    _allData.insert(pair);
   } else {
     PRECICE_ERROR("Data \"{0}\" cannot be added twice for receiving. Please remove any duplicate <exchange data=\"{0}\" ... /> tags", data->getName());
   }

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -8,6 +8,7 @@
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "precice/impl/SharedPointer.hpp"
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
@@ -82,6 +83,22 @@ protected:
   DataMap &getReceiveData()
   {
     return _receiveData;
+  }
+
+  /**
+   * @brief BiCouplingScheme has _sendData and _receiveData
+   * @returns DataMap with all data
+   */
+  DataMap &getAllData() override
+  {
+    // @todo user C++17 std::map::merge
+    for (auto &pair : _sendData) {
+      _allData.emplace(pair);
+    }
+    for (auto &pair : _receiveData) {
+      _allData.emplace(pair);
+    }
+    return _allData;
   }
 
   /// Sets the values

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -15,9 +15,6 @@
 #include "m2n/SharedPointer.hpp"
 #include "mesh/Data.hpp"
 #include "mesh/Mesh.hpp"
-#include "utils/Helpers.hpp"
-#include "utils/MasterSlave.hpp"
-#include "utils/assertion.hpp"
 
 namespace precice {
 namespace cplscheme {
@@ -149,9 +146,6 @@ void MultiCouplingScheme::addDataToSend(
   PtrCouplingData     ptrCplData(new CouplingData(data, std::move(mesh), initialize, getExtrapolationOrder()));
   DataMap::value_type dataPair = std::make_pair(id, ptrCplData);
   _sendDataVector[to].insert(dataPair);
-  if (!utils::contained(id, _allData)) {
-    _allData.insert(dataPair);
-  }
 }
 
 void MultiCouplingScheme::addDataToReceive(
@@ -165,9 +159,6 @@ void MultiCouplingScheme::addDataToReceive(
   PtrCouplingData     ptrCplData(new CouplingData(data, std::move(mesh), initialize, getExtrapolationOrder()));
   DataMap::value_type dataPair = std::make_pair(id, ptrCplData);
   _receiveDataVector[from].insert(dataPair);
-  if (!utils::contained(id, _allData)) {
-    _allData.insert(dataPair);
-  }
 }
 
 } // namespace cplscheme

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -8,6 +8,7 @@
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "utils/Helpers.hpp"
 
 namespace precice {
 namespace cplscheme {
@@ -93,6 +94,30 @@ private:
   logging::Logger _log{"cplscheme::MultiCouplingScheme"};
 
   /**
+   * @brief BiCouplingScheme has _sendData and _receiveData
+   * @returns DataMap with all data
+   */
+  DataMap &getAllData() override
+  {
+    // @todo user C++17 std::map::merge
+    for (auto &sendData : _sendDataVector) {
+      for (auto &dataPair : sendData.second) {
+        if (!utils::contained(dataPair.first, _allData)) {
+          _allData.emplace(dataPair);
+        }
+      }
+    }
+    for (auto &receiveData : _receiveDataVector) {
+      for (auto &dataPair : receiveData.second) {
+        if (!utils::contained(dataPair.first, _allData)) {
+          _allData.emplace(dataPair);
+        }
+      }
+    }
+    return _allData;
+  }
+
+  /**
    * @brief Exchanges all data between the participants of the MultiCouplingScheme and applies acceleration.
    * @returns true, if iteration converged
    */
@@ -104,7 +129,7 @@ private:
    */
   DataMap &getAccelerationData() override
   {
-    return _allData;
+    return getAllData();
   }
 
   /**

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -66,13 +66,13 @@ private:
   bool exchangeDataAndAccelerate() override;
 
   /**
-   * @brief ParallelCouplingScheme applies acceleration to _allData
+   * @brief ParallelCouplingScheme applies acceleration to all CouplingData
    * @returns DataMap being accelerated
    */
   DataMap &getAccelerationData() override
   {
     PRECICE_ASSERT(!doesFirstStep(), "Only the second participant should do the acceleration.");
-    return _allData;
+    return getAllData();
   }
 
   /**


### PR DESCRIPTION
## Main changes of this PR

`_allData` is storing mostly redundant information. Initializing it correctly is prone to error. Therefore, I would like not actually store `_allData`, but compute it on-the-fly depending on the context it is used.

Question: Is there a nicer way to return a reference to `_allData`? I guess we have to store `_allData` somewhere, if we want to return a reference. Or is there a possibility to create a wrapper that looks like a reference from the perspective of client code asking for `_allData`?

## Motivation and additional information

Belongs to the bigger work package #1029, because I will have to change some of the underlying datastructures in the coupling scheme. If I don't have to worry about `_allData` anymore, this will make things easier.

I'm not sure how performance critical this is, but since we are only collecting and rearranging pointers, I don't expect a large impact.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
