### PR TITLE
Fix data ID management

### DIFF
--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -26,8 +26,8 @@ BOOST_AUTO_TEST_CASE(AllMethods)
   mesh->createVertex(Eigen::Vector3d::Constant(1.0));
   mesh->createVertex(Eigen::Vector3d::Constant(2.0));
   mesh->createVertex(Eigen::Vector3d::Constant(3.0));
-  int targetID = mesh->createData("TargetData", 1)->getID();
-  int sourceID = mesh->createData("SourceData", 1)->getID();
+  int targetID = mesh->createData("TargetData", 1, 0_dataID)->getID();
+  int sourceID = mesh->createData("SourceData", 1, 1_dataID)->getID();
   mesh->allocateDataValues();
   std::string  path = testing::getPathToSources() + "/action/tests/";
   PythonAction action(PythonAction::WRITE_MAPPING_PRIOR, path, "TestAllAction", mesh, targetID, sourceID);
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
   {
     mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
-    mesh::PtrData data = mesh->createData("TargetData", 1);
+    mesh::PtrData data = mesh->createData("TargetData", 1, 0_dataID);
     mesh->allocateDataValues();
     PythonAction action(PythonAction::WRITE_MAPPING_PRIOR, path, "TestOmitAction2", mesh, data->getID(), -1);
     action.performAction(0.0, 0.0, 0.0, 0.0);
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(OmitMethods)
   {
     mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
-    mesh::PtrData data = mesh->createData("SourceData", 1);
+    mesh::PtrData data = mesh->createData("SourceData", 1, 0_dataID);
     mesh->allocateDataValues();
     PythonAction action(PythonAction::WRITE_MAPPING_PRIOR, path, "TestOmitAction3", mesh, -1, data->getID());
     action.performAction(0.0, 0.0, 0.0, 0.0);
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(DeprecatedNormal)
   {
     mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
     mesh->createVertex(Eigen::Vector3d::Zero());
-    mesh::PtrData data = mesh->createData("TargetData", 1);
+    mesh::PtrData data = mesh->createData("TargetData", 1, 0_dataID);
     mesh->allocateDataValues();
     PythonAction action(PythonAction::WRITE_MAPPING_PRIOR, path, "TestDeprecatedAction", mesh, data->getID(), -1);
     action.performAction(0.0, 0.0, 0.0, 0.0);

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(DivideByArea2D)
   PRECICE_TEST(1_rank);
   using namespace mesh;
   PtrMesh mesh(new Mesh("Mesh", 2, testing::nextMeshID()));
-  PtrData data   = mesh->createData("test-data", 1);
+  PtrData data   = mesh->createData("test-data", 1, 0_dataID);
   int     dataID = data->getID();
   Vertex &v0     = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v1     = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(DivideByArea3D)
   PRECICE_TEST(1_rank);
   using namespace mesh;
   PtrMesh mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
-  PtrData data   = mesh->createData("test-data", 1);
+  PtrData data   = mesh->createData("test-data", 1, 0_dataID);
   int     dataID = data->getID();
   Vertex &v0     = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   Vertex &v1     = mesh->createVertex(Eigen::Vector3d(6.0, 2.0, 0.0));
@@ -112,8 +112,8 @@ BOOST_AUTO_TEST_CASE(ScaleByTimeStepSizeToTimeWindowSize)
   PRECICE_TEST(1_rank);
   using namespace mesh;
   PtrMesh mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
-  PtrData sourceData   = mesh->createData("SourceData", 1);
-  PtrData targetData   = mesh->createData("TargetData", 1);
+  PtrData sourceData   = mesh->createData("SourceData", 1, 0_dataID);
+  PtrData targetData   = mesh->createData("TargetData", 1, 1_dataID);
   int     sourceDataID = sourceData->getID();
   int     targetDataID = targetData->getID();
   mesh->createVertex(Eigen::Vector3d::Constant(0.0));
@@ -168,8 +168,8 @@ BOOST_AUTO_TEST_CASE(ScaleByComputedTimeWindowPart)
   PRECICE_TEST(1_rank);
   using namespace mesh;
   PtrMesh mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
-  PtrData sourceData   = mesh->createData("SourceData", 1);
-  PtrData targetData   = mesh->createData("TargetData", 1);
+  PtrData sourceData   = mesh->createData("SourceData", 1, 0_dataID);
+  PtrData targetData   = mesh->createData("TargetData", 1, 1_dataID);
   int     sourceDataID = sourceData->getID();
   int     targetDataID = targetData->getID();
   mesh->createVertex(Eigen::Vector3d::Constant(0.0));

--- a/src/action/tests/SummationActionTest.cpp
+++ b/src/action/tests/SummationActionTest.cpp
@@ -29,10 +29,10 @@ BOOST_AUTO_TEST_CASE(SummationOneDimensional)
   using namespace mesh;
   PtrMesh          mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
   int              dimension   = 1;
-  PtrData          sourceData1 = mesh->createData("SourceData1", dimension);
-  PtrData          sourceData2 = mesh->createData("SourceData2", dimension);
-  PtrData          sourceData3 = mesh->createData("SourceData3", dimension);
-  PtrData          targetData  = mesh->createData("TargetData", dimension);
+  PtrData          sourceData1 = mesh->createData("SourceData1", dimension, 0_dataID);
+  PtrData          sourceData2 = mesh->createData("SourceData2", dimension, 1_dataID);
+  PtrData          sourceData3 = mesh->createData("SourceData3", dimension, 2_dataID);
+  PtrData          targetData  = mesh->createData("TargetData", dimension, 3_dataID);
   std::vector<int> sourceDataIDs{sourceData1->getID(), sourceData2->getID(), sourceData3->getID()};
   int              targetDataID = targetData->getID();
   mesh->createVertex(Eigen::Vector3d::Constant(0.0));
@@ -87,9 +87,9 @@ BOOST_AUTO_TEST_CASE(SummationThreeDimensional)
   using namespace mesh;
   int              dimension = 3;
   PtrMesh          mesh(new Mesh("Mesh", dimension, testing::nextMeshID()));
-  PtrData          sourceData1 = mesh->createData("SourceData1", dimension);
-  PtrData          sourceData2 = mesh->createData("SourceData2", dimension);
-  PtrData          targetData  = mesh->createData("TargetData", dimension);
+  PtrData          sourceData1 = mesh->createData("SourceData1", dimension, 0_dataID);
+  PtrData          sourceData2 = mesh->createData("SourceData2", dimension, 1_dataID);
+  PtrData          targetData  = mesh->createData("TargetData", dimension, 2_dataID);
   std::vector<int> sourceDataIDs{sourceData1->getID(), sourceData2->getID()};
   int              targetDataID = targetData->getID();
   mesh->createVertex(Eigen::Vector3d::Constant(0.0));

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -288,8 +288,8 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
   dataConfig->addData("Data1", 3);
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   mesh::PtrMesh           mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
-  mesh->createData("Data0", 1);
-  mesh->createData("Data1", 3);
+  mesh->createData("Data0", 1, 0_dataID);
+  mesh->createData("Data1", 3, 1_dataID);
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
@@ -592,8 +592,8 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
-  mesh->createData("Data0", 1);
-  mesh->createData("Data1", 3);
+  mesh->createData("Data0", 1, 0_dataID);
+  mesh->createData("Data1", 3, 1_dataID);
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -83,8 +83,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
-  const auto    dataID0 = mesh->createData("Data0", 1)->getID();
-  const auto    dataID1 = mesh->createData("Data1", 3)->getID();
+  const auto    dataID0 = mesh->createData("Data0", 1, 0_dataID)->getID();
+  const auto    dataID1 = mesh->createData("Data1", 3, 1_dataID)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   using namespace mesh;
 
   PtrMesh mesh(new Mesh("MyMesh", 3, testing::nextMeshID()));
-  PtrData data   = mesh->createData("MyData", 1);
+  PtrData data   = mesh->createData("MyData", 1, 0_dataID);
   int     dataID = data->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(SecondOrder)
   using namespace mesh;
 
   PtrMesh mesh(new Mesh("MyMesh", 3, testing::nextMeshID()));
-  PtrData data   = mesh->createData("MyData", 1);
+  PtrData data   = mesh->createData("MyData", 1, 0_dataID);
   int     dataID = data->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
@@ -619,8 +619,8 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", geometrical_dimensions, testing::nextMeshID()));
-  const auto    dataID0 = mesh->createData("Data0", data_dimensions)->getID();
-  const auto    dataID1 = mesh->createData("Data1", data_dimensions)->getID();
+  const auto    dataID0 = mesh->createData("Data0", data_dimensions, 0_dataID)->getID();
+  const auto    dataID1 = mesh->createData("Data1", data_dimensions, 1_dataID)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
@@ -818,8 +818,8 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", geometrical_dimensions, testing::nextMeshID()));
-  const auto    dataID0 = mesh->createData("Data0", data_dimensions)->getID();
-  const auto    dataID1 = mesh->createData("Data1", data_dimensions)->getID();
+  const auto    dataID0 = mesh->createData("Data0", data_dimensions, 0_dataID)->getID();
+  const auto    dataID1 = mesh->createData("Data1", data_dimensions, 1_dataID)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
@@ -1060,8 +1060,8 @@ BOOST_AUTO_TEST_CASE(SecondOrderWithAcceleration)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", geometrical_dimensions, testing::nextMeshID()));
-  const auto    dataID0 = mesh->createData("Data0", data_dimensions)->getID();
-  const auto    dataID1 = mesh->createData("Data1", data_dimensions)->getID();
+  const auto    dataID0 = mesh->createData("Data0", data_dimensions, 0_dataID)->getID();
+  const auto    dataID1 = mesh->createData("Data1", data_dimensions, 1_dataID)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
@@ -1293,8 +1293,8 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
   MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new Mesh("Mesh", 3, testing::nextMeshID()));
-  mesh->createData("data0", 1);
-  mesh->createData("data1", 3);
+  mesh->createData("data0", 1, 0_dataID);
+  mesh->createData("data1", 3, 1_dataID);
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
@@ -1394,8 +1394,8 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
-  mesh->createData("data0", 1);
-  mesh->createData("data1", 3);
+  mesh->createData("data0", 1, 0_dataID);
+  mesh->createData("data1", 3, 1_dataID);
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
@@ -1456,8 +1456,8 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
-  mesh->createData("data0", 1);
-  mesh->createData("data1", 3);
+  mesh->createData("data0", 1, 0_dataID);
+  mesh->createData("data1", 3, 1_dataID);
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
@@ -1521,8 +1521,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   mesh::MeshConfiguration meshConfig(root, dataConfig);
   meshConfig.setDimensions(3);
   mesh::PtrMesh mesh(new mesh::Mesh("Mesh", 3, testing::nextMeshID()));
-  const auto    dataID0 = mesh->createData("Data0", 1)->getID();
-  const auto    dataID1 = mesh->createData("Data1", 3)->getID();
+  const auto    dataID0 = mesh->createData("Data0", 1, 0_dataID)->getID();
+  const auto    dataID1 = mesh->createData("Data1", 3, 1_dataID)->getID();
   mesh->createVertex(Eigen::Vector3d::Zero());
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);

--- a/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
@@ -24,8 +24,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inDataScalar   = inMesh->createDataWithGradient("InDataScalar", 1, dimensions);
-  PtrData inDataVector   = inMesh->createDataWithGradient("InDataVector", 2, dimensions);
+  PtrData inDataScalar   = inMesh->createDataWithGradient("InDataScalar", 1, dimensions, 0_dataID);
+  PtrData inDataVector   = inMesh->createDataWithGradient("InDataVector", 2, dimensions, 1_dataID);
   int     inDataScalarID = inDataScalar->getID();
   int     inDataVectorID = inDataVector->getID();
   Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1);
-  PtrData outDataVector   = outMesh->createData("OutDataVector", 2);
+  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1, 2_dataID);
+  PtrData outDataVector   = outMesh->createData("OutDataVector", 2, 3_dataID);
   int     outDataScalarID = outDataScalar->getID();
   int     outDataVectorID = outDataVector->getID();
   Vertex &outVertex0      = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -113,8 +113,8 @@ BOOST_AUTO_TEST_CASE(ConsistentGradientNotConstant)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inDataScalar   = inMesh->createDataWithGradient("InDataScalar", 1, dimensions);
-  PtrData inDataVector   = inMesh->createDataWithGradient("InDataVector", 2, dimensions);
+  PtrData inDataScalar   = inMesh->createDataWithGradient("InDataScalar", 1, dimensions, 0_dataID);
+  PtrData inDataVector   = inMesh->createDataWithGradient("InDataVector", 2, dimensions, 1_dataID);
   int     inDataScalarID = inDataScalar->getID();
   int     inDataVectorID = inDataVector->getID();
   Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -141,8 +141,8 @@ BOOST_AUTO_TEST_CASE(ConsistentGradientNotConstant)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1);
-  PtrData outDataVector   = outMesh->createData("OutDataVector", 2);
+  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1, 2_dataID);
+  PtrData outDataVector   = outMesh->createData("OutDataVector", 2, 3_dataID);
   int     outDataScalarID = outDataScalar->getID();
   int     outDataVectorID = outDataVector->getID();
   Vertex &outVertex0      = outMesh->createVertex(Eigen::Vector2d::Constant(0.1));
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData    = inMesh->createDataWithGradient("InData", 1, dimensions);
+  PtrData inData    = inMesh->createDataWithGradient("InData", 1, dimensions, 0_dataID);
   int     inDataID  = inData->getID();
   Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
   Vertex &inVertex1 = inMesh->createVertex(Eigen::Vector2d::Constant(1.0));
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData    = outMesh->createData("OutData", 1);
+  PtrData outData    = outMesh->createData("OutData", 1, 1_dataID);
   int     outDataID  = outData->getID();
   Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
   Vertex &outVertex1 = outMesh->createVertex(Eigen::Vector2d::Constant(1.0));

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -27,8 +27,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inDataScalar   = inMesh->createData("InDataScalar", 1);
-  PtrData inDataVector   = inMesh->createData("InDataVector", 2);
+  PtrData inDataScalar   = inMesh->createData("InDataScalar", 1, 0_dataID);
+  PtrData inDataVector   = inMesh->createData("InDataVector", 2, 1_dataID);
   int     inDataScalarID = inDataScalar->getID();
   int     inDataVectorID = inDataVector->getID();
   Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -41,8 +41,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1);
-  PtrData outDataVector   = outMesh->createData("OutDataVector", 2);
+  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1, 2_dataID);
+  PtrData outDataVector   = outMesh->createData("OutDataVector", 2, 3_dataID);
   int     outDataScalarID = outDataScalar->getID();
   int     outDataVectorID = outDataVector->getID();
   Vertex &outVertex0      = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData    = inMesh->createData("InData", 1);
+  PtrData inData    = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID  = inData->getID();
   Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
   Vertex &inVertex1 = inMesh->createVertex(Eigen::Vector2d::Constant(1.0));
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(ConservativeNonIncremental)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData    = outMesh->createData("OutData", 1);
+  PtrData outData    = outMesh->createData("OutData", 1, 1_dataID);
   int     outDataID  = outData->getID();
   Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d::Constant(0.0));
   Vertex &outVertex1 = outMesh->createVertex(Eigen::Vector2d::Constant(1.0));
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData    = inMesh->createData("InData", 1);
+  PtrData inData    = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID  = inData->getID();
   Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &inVertex1 = inMesh->createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentNonIncremental)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData    = outMesh->createData("OutData", 1);
+  PtrData outData    = outMesh->createData("OutData", 1, 1_dataID);
   int     outDataID  = outData->getID();
   Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &outVertex1 = outMesh->createVertex(Eigen::Vector2d(0.8, 0.0));

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
 
   // Setup geometry to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData   = outMesh->createData("Data", 1);
+  PtrData outData   = outMesh->createData("Data", 1, 0_dataID);
   int     outDataID = outData->getID();
   Vertex &v1        = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2        = outMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
     // Setup mapping with mapping coordinates and geometry used
     mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
     PtrMesh                           inMesh(new Mesh("InMesh0", dimensions, testing::nextMeshID()));
-    PtrData                           inData   = inMesh->createData("Data0", 1);
+    PtrData                           inData   = inMesh->createData("Data0", 1, 1_dataID);
     int                               inDataID = inData->getID();
 
     // Map value 1.0 from middle of edge to geometry. Expect half of the
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(testConservativeNonIncremental)
     // Setup mapping with mapping coordinates and geometry used
     mapping::NearestProjectionMapping mapping(mapping::Mapping::CONSERVATIVE, dimensions);
     PtrMesh                           inMesh(new Mesh("InMesh1", dimensions, testing::nextMeshID()));
-    PtrData                           inData   = inMesh->createData("Data1", 1);
+    PtrData                           inData   = inMesh->createData("Data1", 1, 1_dataID);
     int                               inDataID = inData->getID();
 
     inMesh->createVertex(Eigen::Vector2d(-1.0, -1.0));
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData   = inMesh->createData("InData", 1);
+  PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   {
     // Create mesh to map to
     PtrMesh outMesh(new Mesh("OutMesh0", dimensions, testing::nextMeshID()));
-    PtrData outData   = outMesh->createData("OutData", 1);
+    PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
     int     outDataID = outData->getID();
 
     // Setup mapping with mapping coordinates and geometry used
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental2D)
   {
     // Create mesh to map to
     PtrMesh outMesh(new Mesh("OutMesh1", dimensions, testing::nextMeshID()));
-    PtrData outData   = outMesh->createData("OutData", 1);
+    PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
     int     outDataID = outData->getID();
 
     // Setup mapping with mapping coordinates and geometry used
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase1)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData   = inMesh->createData("InData", 1);
+  PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase1)
   auto inputIntegral = mesh::integrate(inMesh, inData);
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh0", dimensions, testing::nextMeshID()));
-  PtrData outData   = outMesh->createData("OutData", 1);
+  PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int     outDataID = outData->getID();
   auto &  outValues = outData->values();
   // Setup mapping with mapping coordinates and geometry used
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase2)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData   = inMesh->createData("InData", 1);
+  PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(ScaleConsistentNonIncremental2DCase2)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh1", dimensions, testing::nextMeshID()));
-  PtrData outData   = outMesh->createData("OutData", 1);
+  PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int     outDataID = outData->getID();
   auto &  outValues = outData->values();
 
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData   = inMesh->createData("InData", 1);
+  PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   {
     // Create mesh to map to
     PtrMesh outMesh(new Mesh("OutMesh1", dimensions, testing::nextMeshID()));
-    PtrData outData   = outMesh->createData("OutData1", 1);
+    PtrData outData   = outMesh->createData("OutData1", 1, 1_dataID);
     int     outDataID = outData->getID();
 
     // Setup mapping with mapping coordinates and geometry used
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncrementalPseudo3D)
   {
     // Create mesh to map to
     PtrMesh outMesh(new Mesh("OutMesh2", dimensions, testing::nextMeshID()));
-    PtrData outData   = outMesh->createData("OutData2", 1);
+    PtrData outData   = outMesh->createData("OutData2", 1, 0_dataID);
     int     outDataID = outData->getID();
 
     // Setup mapping with mapping coordinates and geometry used
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData   = inMesh->createData("InData", 1);
+  PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID = inData->getID();
   Vertex &v1       = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   Vertex &v2       = inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnEdges)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData   = outMesh->createData("OutData", 1);
+  PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int     outDataID = outData->getID();
 
   // Setup mapping with mapping coordinates and geometry used
@@ -504,7 +504,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData   = inMesh->createData("InData", 1);
+  PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int     inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE(Consistent3DFalbackOnVertices)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData   = outMesh->createData("OutData", 1);
+  PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int     outDataID = outData->getID();
 
   // Setup mapping with mapping coordinates and geometry used
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
 
   // Create mesh to map from with Triangles ABD and BDC
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData = inMesh->createData("InData", 1);
+  PtrData inData = inMesh->createData("InData", 1, 0_dataID);
   Vertex &inVA   = inMesh->createVertex(Eigen::Vector3d{0, 0, 0});
   Vertex &inVB   = inMesh->createVertex(Eigen::Vector3d{0, 1, 0});
   Vertex &inVC   = inMesh->createVertex(Eigen::Vector3d{1, 1, 0});
@@ -575,7 +575,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedTriangles)
 
   // Create mesh to map to with one vertex per defined traingle
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
+  PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
   outMesh->createVertex(Eigen::Vector3d{0.33, 0.33, 0});
   outMesh->createVertex(Eigen::Vector3d{0.66, 0.66, 0});
   outMesh->allocateDataValues();
@@ -602,7 +602,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   constexpr int dimensions = 3;
 
   PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
-  PtrData      inData = inMesh->createData("InData", 1);
+  PtrData      inData = inMesh->createData("InData", 1, 0_dataID);
   const double z1     = 0.1;
   const double z2     = -0.1;
   auto &       v00    = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(Query_3D_FullMesh)
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
+  PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
   outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
   outMesh->allocateDataValues();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
@@ -657,7 +657,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
   constexpr int dimensions = 3;
 
   PtrMesh      inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
-  PtrData      inData = inMesh->createData("InData", 1);
+  PtrData      inData = inMesh->createData("InData", 1, 0_dataID);
   const double z1     = 0.1;
   const double z2     = -0.1;
   auto &       v00    = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -685,7 +685,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
   inData->values() = Eigen::VectorXd::Constant(6, 1.0);
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
+  PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
   auto &  outV1   = outMesh->createVertex(Eigen::Vector3d{0.7, 0.5, 0.0});
   auto &  outV2   = outMesh->createVertex(Eigen::Vector3d{0.5, 0.0, 0.05});
   auto &  outV3   = outMesh->createVertex(Eigen::Vector3d{0.5, 0.0, 0.0});
@@ -744,7 +744,7 @@ BOOST_AUTO_TEST_CASE(AvoidClosestTriangle)
   constexpr int dimensions = 3;
 
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
-  PtrData inData = inMesh->createData("InData", 1);
+  PtrData inData = inMesh->createData("InData", 1, 0_dataID);
   // Close triangle - extrapolating
   auto &vc0 = inMesh->createVertex(Eigen::Vector3d(3, 0, 0));
   auto &vc1 = inMesh->createVertex(Eigen::Vector3d(3, 2, 0));
@@ -761,7 +761,7 @@ BOOST_AUTO_TEST_CASE(AvoidClosestTriangle)
   inData->values() << 0, 0, 0, 1, 1, 1;
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
+  PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
   outMesh->createVertex(Eigen::Vector3d{2, 1, 0});
   outMesh->allocateDataValues();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
@@ -777,7 +777,7 @@ BOOST_AUTO_TEST_CASE(PickClosestTriangle)
   using namespace precice::mesh;
 
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
-  PtrData inData = inMesh->createData("InData", 1);
+  PtrData inData = inMesh->createData("InData", 1, 0_dataID);
   // Far triangle - interpolating
   auto &vf0 = inMesh->createVertex(Eigen::Vector3d(0, 0, -1));
   auto &vf1 = inMesh->createVertex(Eigen::Vector3d(0, 1, 1));
@@ -794,7 +794,7 @@ BOOST_AUTO_TEST_CASE(PickClosestTriangle)
   inData->values() << 1, 1, 1, 0, 0, 0;
 
   PtrMesh outMesh(new Mesh("OutMesh", 3, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
+  PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 0});
   outMesh->allocateDataValues();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
@@ -811,7 +811,7 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
   constexpr int dimensions = 3;
 
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
-  PtrData inData = inMesh->createData("InData", 1);
+  PtrData inData = inMesh->createData("InData", 1, 0_dataID);
   // Close edge
   auto &vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
   auto &vc1 = inMesh->createVertex(Eigen::Vector3d(0, 2, 0));
@@ -827,7 +827,7 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
   inData->values() << 0, 0, 1, 1, 1;
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
+  PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 1});
   outMesh->allocateDataValues();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);
@@ -844,7 +844,7 @@ BOOST_AUTO_TEST_CASE(TriangleDistances)
   constexpr int dimensions = 3;
 
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
-  PtrData inData = inMesh->createData("InData", 1);
+  PtrData inData = inMesh->createData("InData", 1, 0_dataID);
 
   // Close triangle
   auto &vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
@@ -862,7 +862,7 @@ BOOST_AUTO_TEST_CASE(TriangleDistances)
   inData->values() << 1, 1, 1, 0, 0, 0;
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData = outMesh->createData("OutData", 1);
+  PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
   outMesh->createVertex(Eigen::Vector3d{1, 1, 1});
   outMesh->allocateDataValues();
   outData->values() = Eigen::VectorXd::Constant(1, 0.0);

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -134,13 +134,13 @@ void testDistributed(const TestContext &    context,
   int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", valueDimension);
+  mesh::PtrData inData   = inMesh->createData("InData", valueDimension, 0_dataID);
   int           inDataID = inData->getID();
 
   getDistributedMesh(context, inMeshSpec, inMesh, inData, inGlobalIndexOffset);
 
   mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", valueDimension);
+  mesh::PtrData outData   = outMesh->createData("OutData", valueDimension, 1_dataID);
   int           outDataID = outData->getID();
 
   getDistributedMesh(context, outMeshSpec, outMesh, outData);
@@ -1020,11 +1020,11 @@ void testTagging(const TestContext &context,
   int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData inData = inMesh->createData("InData", valueDimension);
+  mesh::PtrData inData = inMesh->createData("InData", valueDimension, 0_dataID);
   getDistributedMesh(context, inMeshSpec, inMesh, inData);
 
   mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData outData = outMesh->createData("OutData", valueDimension);
+  mesh::PtrData outData = outMesh->createData("OutData", valueDimension, 1_dataID);
   getDistributedMesh(context, outMeshSpec, outMesh, outData);
   BOOST_TEST_MESSAGE("Mesh sizes in: " << inMesh->vertices().size() << " out: " << outMesh->vertices().size());
 
@@ -1143,7 +1143,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
   inMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1157,7 +1157,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
@@ -1238,7 +1238,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 2);
+  mesh::PtrData inData   = inMesh->createData("InData", 2, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
   inMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1252,7 +1252,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 2);
+  mesh::PtrData outData   = outMesh->createData("OutData", 2, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
@@ -1350,7 +1350,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -1368,7 +1368,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector3d::Zero());
   outMesh->allocateDataValues();
@@ -1484,7 +1484,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Vector2d(0.0, 0.0));
   auto &        inV2     = inMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1504,7 +1504,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Vector2d(0.0, 0.0));
   auto &        outV2     = outMesh->createVertex(Vector2d(0.0, 1.0));
@@ -1533,7 +1533,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   auto &        inV2     = inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -1558,7 +1558,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   auto &        outV2     = outMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -1589,7 +1589,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
   mesh::Vertex &vertex1  = inMesh->createVertex(Vector2d(0, 0));
@@ -1599,7 +1599,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
   outMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1657,7 +1657,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 2);
+  mesh::PtrData inData   = inMesh->createData("InData", 2, 0_dataID);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
   mesh::Vertex &vertex1  = inMesh->createVertex(Vector2d(0, 0));
@@ -1667,7 +1667,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 2);
+  mesh::PtrData outData   = outMesh->createData("OutData", 2, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
   outMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1729,7 +1729,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector3d(0, 0, 0));
   mesh::Vertex &vertex1  = inMesh->createVertex(Vector3d(0, 0, 0));
@@ -1739,7 +1739,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 0.0, 0.0));
   outMesh->createVertex(Vector3d(1.0, 0.0, 0.0));
@@ -1960,7 +1960,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 1.0));
   inMesh->createVertex(Vector2d(1.0, 1.0));
@@ -1974,7 +1974,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
@@ -2008,7 +2008,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector3d(0.0, 3.0, 0.0));
   inMesh->createVertex(Vector3d(1.0, 3.0, 0.0));
@@ -2022,7 +2022,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 2.9, 0.0));
   outMesh->createVertex(Vector3d(0.8, 2.9, 0.1));
@@ -2059,7 +2059,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 1.0));
   inMesh->createVertex(Vector2d(1.0, 1.0));
@@ -2072,7 +2072,7 @@ BOOST_AUTO_TEST_CASE(SolutionCaching)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0, 3));
   outMesh->allocateDataValues();
@@ -2110,7 +2110,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(1, 1));
   inMesh->createVertex(Vector2d(1, 0));
@@ -2122,7 +2122,7 @@ BOOST_AUTO_TEST_CASE(ConsistentPolynomialSwitch,
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(3, 3)); // Point is outside the inMesh
 
@@ -2175,7 +2175,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0, 0));
   inMesh->createVertex(Vector2d(1, 0));
@@ -2187,7 +2187,7 @@ BOOST_AUTO_TEST_CASE(ConservativePolynomialSwitch,
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.4, 0));
   outMesh->createVertex(Vector2d(6, 6));
@@ -2255,13 +2255,13 @@ BOOST_AUTO_TEST_CASE(NoMapping)
   {
     // Call only computeMapping
     mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", 2, testing::nextMeshID()));
-    mesh::PtrData inData = inMesh->createData("InData", 1);
+    mesh::PtrData inData = inMesh->createData("InData", 1, 0_dataID);
     inMesh->createVertex(Eigen::Vector2d(0, 0));
     inMesh->allocateDataValues();
     addGlobalIndex(inMesh);
 
     mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", 2, testing::nextMeshID()));
-    mesh::PtrData outData = outMesh->createData("OutData", 1);
+    mesh::PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
     outMesh->createVertex(Eigen::Vector2d(0, 0));
     outMesh->allocateDataValues();
     addGlobalIndex(outMesh);
@@ -2286,7 +2286,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(1, 1)).setGlobalIndex(2);
   inMesh->createVertex(Vector2d(1, 0)).setGlobalIndex(3);
@@ -2298,7 +2298,7 @@ BOOST_AUTO_TEST_CASE(TestNonHomongenousGlobalIndex)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.5, 0.5));
 

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -121,13 +121,13 @@ void testDistributed(const TestContext &    context,
   int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", valueDimension);
+  mesh::PtrData inData   = inMesh->createData("InData", valueDimension, 0_dataID);
   int           inDataID = inData->getID();
 
   getDistributedMesh(context, inMeshSpec, inMesh, inData, inGlobalIndexOffset);
 
   mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", valueDimension);
+  mesh::PtrData outData   = outMesh->createData("OutData", valueDimension, 1_dataID);
   int           outDataID = outData->getID();
 
   getDistributedMesh(context, outMeshSpec, outMesh, outData);
@@ -1007,11 +1007,11 @@ void testTagging(const TestContext &context,
   int valueDimension = inMeshSpec.at(0).value.size();
 
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData inData = inMesh->createData("InData", valueDimension);
+  mesh::PtrData inData = inMesh->createData("InData", valueDimension, 0_dataID);
   getDistributedMesh(context, inMeshSpec, inMesh, inData);
 
   mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
-  mesh::PtrData outData = outMesh->createData("OutData", valueDimension);
+  mesh::PtrData outData = outMesh->createData("OutData", valueDimension, 1_dataID);
   getDistributedMesh(context, outMeshSpec, outMesh, outData);
 
   Gaussian                        fct(4.5); //Support radius approx. 1
@@ -1100,7 +1100,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
   inMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1114,7 +1114,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
@@ -1195,7 +1195,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 2);
+  mesh::PtrData inData   = inMesh->createData("InData", 2, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 0.0));
   inMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1209,7 +1209,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 2);
+  mesh::PtrData outData   = outMesh->createData("OutData", 2, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
@@ -1307,7 +1307,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -1325,7 +1325,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector3d::Zero());
   outMesh->allocateDataValues();
@@ -1441,7 +1441,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Vector2d(0.0, 0.0));
   auto &        inV2     = inMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1461,7 +1461,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Vector2d(0.0, 0.0));
   auto &        outV2     = outMesh->createVertex(Vector2d(0.0, 1.0));
@@ -1490,7 +1490,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   auto &        inV1     = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   auto &        inV2     = inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -1515,7 +1515,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   auto &        outV1     = outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   auto &        outV2     = outMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -1546,7 +1546,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
   mesh::Vertex &vertex1  = inMesh->createVertex(Vector2d(0, 0));
@@ -1556,7 +1556,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
   outMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1614,7 +1614,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 2);
+  mesh::PtrData inData   = inMesh->createData("InData", 2, 0_dataID);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector2d(0, 0));
   mesh::Vertex &vertex1  = inMesh->createVertex(Vector2d(0, 0));
@@ -1624,7 +1624,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 2);
+  mesh::PtrData outData   = outMesh->createData("OutData", 2, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector2d(0.0, 0.0));
   outMesh->createVertex(Vector2d(1.0, 0.0));
@@ -1686,7 +1686,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   mesh::Vertex &vertex0  = inMesh->createVertex(Vector3d(0, 0, 0));
   mesh::Vertex &vertex1  = inMesh->createVertex(Vector3d(0, 0, 0));
@@ -1696,7 +1696,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 0.0, 0.0));
   outMesh->createVertex(Vector3d(1.0, 0.0, 0.0));
@@ -1917,7 +1917,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector2d(0.0, 1.0));
   inMesh->createVertex(Vector2d(1.0, 1.0));
@@ -1931,7 +1931,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis2)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
@@ -1965,7 +1965,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", 1);
+  mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   int           inDataID = inData->getID();
   inMesh->createVertex(Vector3d(0.0, 3.0, 0.0));
   inMesh->createVertex(Vector3d(1.0, 3.0, 0.0));
@@ -1979,7 +1979,7 @@ BOOST_AUTO_TEST_CASE(DeadAxis3D)
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData outData   = outMesh->createData("OutData", 1);
+  mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   outMesh->createVertex(Vector3d(0.0, 2.9, 0.0));
   outMesh->createVertex(Vector3d(0.8, 2.9, 0.1));

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -9,8 +9,6 @@
 namespace precice {
 namespace mesh {
 
-size_t Data::_dataCount = 0;
-
 Data::Data()
     : _name(""),
       _id(-1),
@@ -35,12 +33,6 @@ Data::Data(
       _hasGradient(hasGradient)
 {
   PRECICE_ASSERT(dimensions > 0, dimensions);
-  _dataCount++;
-}
-
-Data::~Data()
-{
-  _dataCount--;
 }
 
 Eigen::VectorXd &Data::values()
@@ -99,16 +91,6 @@ int Data::getDimensions() const
 int Data::getSpacialDimensions() const
 {
   return _spacialDimensions;
-}
-
-size_t Data::getDataCount()
-{
-  return _dataCount;
-}
-
-void Data::resetDataCount()
-{
-  _dataCount = 0;
 }
 
 } // namespace mesh

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -38,20 +38,6 @@ public:
   //static const std::string TYPE_NAME_VECTOR;
 
   /**
-   * @brief Returns the number of created (and still existing) Data objects.
-   *
-   * Used to give Data objects unique IDs.
-   */
-  static size_t getDataCount();
-
-  /**
-   * @brief Sets the data counter to zero.
-   *
-   * Used in test cases where multiple scenarios with data are run.
-   */
-  static void resetDataCount();
-
-  /**
    * @brief Do not use this constructor! Only there for compatibility with std::map.
    */
   Data();
@@ -65,9 +51,6 @@ public:
       int         dimension,
       int         spacialDimensions = -1,
       bool        hasGradient       = false);
-
-  /// Destructor, decrements data count.
-  ~Data();
 
   /// Returns a reference to the data values.
   Eigen::VectorXd &values();
@@ -101,9 +84,6 @@ public:
 
 private:
   logging::Logger _log{"mesh::Data"};
-
-  /// Counter for existing Data objects.
-  static size_t _dataCount;
 
   Eigen::VectorXd _values;
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -129,7 +129,8 @@ Triangle &Mesh::createTriangle(
 
 PtrData &Mesh::createData(
     const std::string &name,
-    int                dimension)
+    int                dimension,
+    DataID             id)
 {
   PRECICE_TRACE(name, dimension);
   for (const PtrData &data : _data) {
@@ -138,7 +139,6 @@ PtrData &Mesh::createData(
                   "Please rename or remove one of the use-data tags with name \"{}\".",
                   name, _name, name);
   }
-  int     id = Data::getDataCount();
   PtrData data(new Data(name, id, dimension));
   _data.push_back(data);
   return _data.back();
@@ -186,7 +186,8 @@ const PtrData &Mesh::data(const std::string &dataName) const
 PtrData &Mesh::createDataWithGradient(
     const std::string &name,
     int                dimension,
-    int                meshDimensions)
+    int                meshDimensions,
+    DataID             id)
 {
   PRECICE_TRACE(name, dimension);
   for (const PtrData &data : _data) {
@@ -195,7 +196,6 @@ PtrData &Mesh::createDataWithGradient(
                   "Please rename or remove one of the use-data tags with name \"{}\".",
                   name, _name, name);
   }
-  int id = Data::getDataCount();
 
   //#rows = dimensions of current mesh #columns = dimensions of corresponding data set
   PtrData data(new Data(name, id, dimension, meshDimensions, true));

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -130,13 +130,15 @@ public:
 
   /// Create only data for vertex
   PtrData &createData(const std::string &name,
-                      int                dimension);
+                      int                dimension,
+                      DataID             id);
 
   /// Creates data for vertex with additional gradient data
   PtrData &createDataWithGradient(
       const std::string &name,
       int                dimension,
-      int                meshDimensions);
+      int                meshDimensions,
+      DataID             id);
 
   /// Allows access to all data
   const DataContainer &data() const;

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -75,15 +75,14 @@ void DataConfiguration::addData(
     const std::string &name,
     int                dataDimensions)
 {
-  ConfiguredData data(name, dataDimensions);
-
   // Check if data with same name has been added already
   for (auto &elem : _data) {
-    PRECICE_CHECK(elem.name != data.name,
+    PRECICE_CHECK(elem.name != name,
                   "Data \"{0}\" has already been defined. Please rename or remove one of the data tags with name=\"{0}\".",
-                  data.name);
+                  name);
   }
-  _data.push_back(data);
+
+  _data.push_back({name, dataDimensions});
 }
 
 int DataConfiguration::getDataDimensions(

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "logging/Logger.hpp"
 #include "mesh/Data.hpp"
+#include "utils/ManageUniqueIDs.hpp"
 #include "xml/XMLTag.hpp"
 
 namespace precice {
@@ -15,11 +16,6 @@ public:
   struct ConfiguredData {
     std::string name;
     int         dimensions;
-
-    ConfiguredData(
-        const std::string &name,
-        int                dimensions)
-        : name(name), dimensions(dimensions) {}
   };
 
   DataConfiguration(xml::XMLTag &parent);

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -86,7 +86,7 @@ void MeshConfiguration::xmlTagCallback(
     bool        found = false;
     for (const DataConfiguration::ConfiguredData &data : _dataConfig->data()) {
       if (data.name == name) {
-        _meshes.back()->createData(data.name, data.dimensions);
+        _meshes.back()->createData(data.name, data.dimensions, _dataIDManager.getFreeID());
         found = true;
         break;
       }

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -88,6 +88,8 @@ private:
   std::map<std::string, std::vector<std::string>> _neededMeshes;
 
   std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
+
+  utils::ManageUniqueIDs _dataIDManager;
 };
 
 } // namespace mesh

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     int         dataDimensions = dim;
     // Add a data set to the mesh. Every data value is associated to a vertex in
     // the mesh via the vertex ID.
-    PtrData data = mesh.createData(dataName, dataDimensions);
+    PtrData data = mesh.createData(dataName, dataDimensions, 0_dataID);
 
     // Validate data state
     BOOST_TEST(data->getName() == dataName);
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(ResizeDataGrow)
 {
   PRECICE_TEST(1_rank);
   precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
-  const auto &        values = mesh.createData("Data", 1)->values();
+  const auto &        values = mesh.createData("Data", 1, 0_dataID)->values();
 
   // Create mesh
   mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(ResizeDataShrink)
 {
   PRECICE_TEST(1_rank);
   precice::mesh::Mesh mesh("MyMesh", 3, testing::nextMeshID());
-  const auto &        values = mesh.createData("Data", 1)->values();
+  const auto &        values = mesh.createData("Data", 1, 0_dataID)->values();
 
   // Create mesh
   mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE(AsChain)
 {
   PRECICE_TEST(1_rank);
   Mesh mesh("Mesh1", 3, testing::nextMeshID());
-  mesh.createData("Data", 1);
+  mesh.createData("Data", 1, 0_dataID);
 
   Eigen::Vector3d coords0;
   Eigen::Vector3d coords1;
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(ShareVertex)
 {
   PRECICE_TEST(1_rank);
   Mesh mesh("Mesh1", 3, testing::nextMeshID());
-  mesh.createData("Data", 1);
+  mesh.createData("Data", 1, 0_dataID);
 
   Eigen::Vector3d coords0;
   Eigen::Vector3d coords1;
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(VertexPtrsFor)
 {
   PRECICE_TEST(1_rank);
   Mesh mesh("Mesh1", 3, testing::nextMeshID());
-  mesh.createData("Data", 1);
+  mesh.createData("Data", 1, 0_dataID);
 
   Eigen::Vector3d coords0;
   Eigen::Vector3d coords1;
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(CoordsForIDs)
 {
   PRECICE_TEST(1_rank);
   Mesh mesh("Mesh1", 3, testing::nextMeshID());
-  mesh.createData("Data", 1);
+  mesh.createData("Data", 1, 0_dataID);
 
   Eigen::Vector3d coords0;
   Eigen::Vector3d coords1;
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(CoordsForPtrs)
 {
   PRECICE_TEST(1_rank);
   Mesh mesh("Mesh1", 3, testing::nextMeshID());
-  mesh.createData("Data", 1);
+  mesh.createData("Data", 1, 0_dataID);
 
   Eigen::Vector3d coords0;
   Eigen::Vector3d coords1;
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(Integrate2DScalarData)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
-  mesh->createData("Data", 1);
+  mesh->createData("Data", 1, 0_dataID);
 
   auto &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   auto &v2 = mesh->createVertex(Eigen::Vector2d(0.0, 0.5));
@@ -547,7 +547,7 @@ BOOST_AUTO_TEST_CASE(Integrate2DVectorData)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
-  mesh->createData("Data", 2);
+  mesh->createData("Data", 2, 0_dataID);
 
   auto &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   auto &v2 = mesh->createVertex(Eigen::Vector2d(0.0, 0.5));
@@ -579,7 +579,7 @@ BOOST_AUTO_TEST_CASE(Integrate3DScalarData)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
-  mesh->createData("Data", 1);
+  mesh->createData("Data", 1, 0_dataID);
 
   auto &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   auto &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(Integrate3DVectorData)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
-  mesh->createData("Data", 2);
+  mesh->createData("Data", 2, 0_dataID);
 
   auto &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   auto &v2 = mesh->createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -39,11 +39,6 @@ using precice::testing::TestContext;
 BOOST_AUTO_TEST_SUITE(PartitionTests)
 BOOST_AUTO_TEST_SUITE(ProvidedPartitionTests)
 
-void tearDownParallelEnvironment()
-{
-  mesh::Data::resetDataCount();
-}
-
 BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
 {
   PRECICE_TEST("NASTIN"_on(1_rank), "SOLIDZ"_on(3_ranks).setupMasterSlaves(), Require::Events);
@@ -113,8 +108,6 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
       BOOST_TEST(pSolidzMesh->getVertexOffsets().at(2) == 6);
     }
   }
-
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
@@ -226,8 +219,6 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
       BOOST_TEST(vertices.at(3).isOwner() == true);
     }
   }
-
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
@@ -410,8 +401,6 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
 
     com::CommunicateBoundingBox(m2n->getMasterCommunication()).sendConnectionMap(connectionMap, 0);
   }
-
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestSendBoundingBoxes3D)
@@ -495,8 +484,6 @@ BOOST_AUTO_TEST_CASE(TestSendBoundingBoxes3D)
     std::vector<int> connectedRanksList;
     m2n->getMasterCommunication()->send(connectedRanksList, 0);
   }
-
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
@@ -594,8 +581,6 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
       BOOST_TEST(mesh->vertices().at(3).getCoords()(1) == 1.0);
     }
   }
-
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning2D)
@@ -734,7 +719,6 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning2D)
     part.communicate();
     part.compute();
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning3D)
@@ -863,7 +847,6 @@ BOOST_AUTO_TEST_CASE(TestTwoLevelRepartitioning3D)
     part.communicate();
     part.compute();
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -49,11 +49,6 @@ using precice::testing::TestContext;
 BOOST_AUTO_TEST_SUITE(PartitionTests)
 BOOST_AUTO_TEST_SUITE(ReceivedPartitionTests)
 
-void tearDownParallelEnvironment()
-{
-  mesh::Data::resetDataCount();
-}
-
 void createSolidzMesh2D(mesh::PtrMesh pSolidzMesh)
 {
   int dimensions = 2;
@@ -289,8 +284,6 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D)
       }
     }
   }
-
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D)
@@ -342,7 +335,6 @@ BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D)
       BOOST_TEST(pSolidzMesh->edges().size() == 1);
     }
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D)
@@ -395,7 +387,6 @@ BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D)
       }
     }
   }
-  tearDownParallelEnvironment();
 }
 
 #ifndef PRECICE_NO_PETSC
@@ -480,7 +471,6 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
       }
     }
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
@@ -554,7 +544,6 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
       }
     }
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
@@ -634,7 +623,6 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
       }
     }
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
@@ -721,7 +709,6 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
       }
     }
   }
-  tearDownParallelEnvironment();
 }
 
 #endif // PRECICE_NO_PETSC
@@ -776,7 +763,6 @@ BOOST_AUTO_TEST_CASE(RePartitionNPBroadcastFilter3D)
       BOOST_TEST(pSolidzMesh->triangles().size() == 1);
     }
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
@@ -999,7 +985,6 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
     part.addToMapping(boundingToMapping);
     part.compareBoundingBoxes();
   }
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
@@ -1069,7 +1054,6 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
     part.addToMapping(boundingToMapping);
     part.compareBoundingBoxes();
   }
-  tearDownParallelEnvironment();
 }
 
 void testParallelSetOwnerInformation(mesh::PtrMesh mesh, int dimensions)
@@ -1561,8 +1545,6 @@ BOOST_AUTO_TEST_CASE(RePartitionMultipleMappings)
       }
     }
   }
-
-  tearDownParallelEnvironment();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -102,7 +102,7 @@ void Participant::addWriteData(
     const mesh::PtrData &data,
     const mesh::PtrMesh &mesh)
 {
-  checkDuplicatedData(data);
+  checkDuplicatedData(data, mesh->getName());
   _writeDataContexts.emplace(data->getID(), WriteDataContext(data, mesh));
 }
 
@@ -110,7 +110,7 @@ void Participant::addReadData(
     const mesh::PtrData &data,
     const mesh::PtrMesh &mesh)
 {
-  checkDuplicatedData(data);
+  checkDuplicatedData(data, mesh->getName());
   _readDataContexts.emplace(data->getID(), ReadDataContext(data, mesh));
 }
 
@@ -409,12 +409,12 @@ void Participant::checkDuplicatedUse(const mesh::PtrMesh &mesh)
                 mesh->getName(), _name, mesh->getName());
 }
 
-void Participant::checkDuplicatedData(const mesh::PtrData &data)
+void Participant::checkDuplicatedData(const mesh::PtrData &data, const std::string &meshName)
 {
   PRECICE_CHECK(!isDataWrite(data->getID()) && !isDataRead(data->getID()),
-                "Participant \"{}\" can read/write data \"{}\" only once. "
+                "Participant \"{}\" can read/write data \"{}\" from/to mesh \"{}\" only once. "
                 "Please remove any duplicate instances of write-data/read-data nodes.",
-                _name, data->getName());
+                _name, meshName, data->getName());
 }
 
 } // namespace impl

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -327,7 +327,7 @@ private:
 
   void checkDuplicatedUse(const mesh::PtrMesh &mesh);
 
-  void checkDuplicatedData(const mesh::PtrData &data);
+  void checkDuplicatedData(const mesh::PtrData &data, const std::string& meshName);
 
   /// To allow white box tests.
   friend struct PreciceTests::Serial::TestConfigurationPeano;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -187,7 +187,6 @@ void SolverInterfaceImpl::configure(
   Event                    e("configure"); // no precice::syncMode as this is not yet configured here
   utils::ScopedEventPrefix sep("configure/");
 
-  mesh::Data::resetDataCount();
   _meshLock.clear();
 
   _dimensions         = config.getDimensions();

--- a/src/precice/tests/DataContextTest.cpp
+++ b/src/precice/tests/DataContextTest.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(testDataContextWriteMapping)
   // Create mesh object for from mesh
   int           dimensions  = 3;
   mesh::PtrMesh ptrFromMesh = std::make_shared<mesh::Mesh>("ParticipantMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData ptrFromData = ptrFromMesh->createData("MappedData", dimensions);
+  mesh::PtrData ptrFromData = ptrFromMesh->createData("MappedData", dimensions, 0_dataID);
 
   ptrFromMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   ptrFromMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(testDataContextWriteMapping)
 
   // Create mesh object for from mesh
   mesh::PtrMesh ptrToMesh = std::make_shared<mesh::Mesh>("OtherMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData ptrToData = ptrToMesh->createData("MappedData", dimensions);
+  mesh::PtrData ptrToData = ptrToMesh->createData("MappedData", dimensions, 1_dataID);
 
   ptrToMesh->createVertex(Eigen::Vector3d(0.0, 0.1, 0.0));
   ptrToMesh->createVertex(Eigen::Vector3d(1.0, 0.1, 0.0));
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(testDataContextReadMapping)
   // Create mesh object
   int           dimensions = 3;
   mesh::PtrMesh ptrToMesh  = std::make_shared<mesh::Mesh>("ParticipantMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData ptrToData  = ptrToMesh->createData("MappedData", dimensions);
+  mesh::PtrData ptrToData  = ptrToMesh->createData("MappedData", dimensions, 0_dataID);
 
   ptrToMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   ptrToMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(testDataContextReadMapping)
 
   // Create mesh object for from mesh
   mesh::PtrMesh ptrFromMesh = std::make_shared<mesh::Mesh>("OtherMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData ptrFromData = ptrFromMesh->createData("MappedData", dimensions);
+  mesh::PtrData ptrFromData = ptrFromMesh->createData("MappedData", dimensions, 1_dataID);
 
   ptrFromMesh->createVertex(Eigen::Vector3d(0.0, 0.1, 0.0));
   ptrFromMesh->createVertex(Eigen::Vector3d(1.0, 0.1, 0.0));

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -36,15 +36,9 @@ struct SerialTestFixture : testing::WhiteboxAccessor {
 
   std::string _pathToTests;
 
-  void reset()
-  {
-    mesh::Data::resetDataCount();
-  }
-
   SerialTestFixture()
   {
     _pathToTests = testing::getPathToSources() + "/precice/tests/";
-    reset();
   }
 };
 

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -465,7 +465,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -609,7 +609,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -689,7 +689,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -823,7 +823,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
   std::string name("rectangle");
   int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
-  PtrData     doubleData   = mesh->createData("DoubleData", 1);
+  PtrData     doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &      doubleValues = doubleData->values();
 
   if (utils::MasterSlave::isMaster()) {
@@ -914,7 +914,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   std::string name("rectangle");
   int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
-  PtrData     doubleData   = mesh->createData("DoubleData", 2);
+  PtrData     doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &      doubleValues = doubleData->values();
 
   if (utils::MasterSlave::isMaster()) {
@@ -1043,7 +1043,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
     mesh->createEdge(v7, v8);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -1148,7 +1148,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
     mesh->createEdge(v7, v8);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -1271,7 +1271,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
     mesh->createTriangle(e3, e4, e5);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();
@@ -1374,7 +1374,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
     mesh->createTriangle(e3, e4, e5);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
   auto &  doubleValues = doubleData->values();
 
   mesh->allocateDataValues();

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -53,8 +53,8 @@ BOOST_AUTO_TEST_CASE(TimeSeries)
   mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
   mesh->createEdge(v1, v2);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
-  PtrData vectorData   = mesh->createData("VectorData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
+  PtrData vectorData   = mesh->createData("VectorData", 2, 1_dataID);
   auto &  doubleValues = doubleData->values();
   auto &  vectorValues = vectorData->values();
   mesh->allocateDataValues();
@@ -170,8 +170,8 @@ BOOST_AUTO_TEST_CASE(Reinitalize)
   mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector2d(1.0, 2.0));
   mesh->createEdge(v1, v2);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1);
-  PtrData vectorData   = mesh->createData("VectorData", 2);
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
+  PtrData vectorData   = mesh->createData("VectorData", 2, 1_dataID);
   auto &  doubleValues = doubleData->values();
   auto &  vectorValues = vectorData->values();
   mesh->allocateDataValues();

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -47,9 +47,6 @@ TestContext::~TestContext() noexcept
   // Clear caches
   query::clearCache();
 
-  // Reset static ids and counters
-  mesh::Data::resetDataCount();
-
   // Reset communicators
   Par::resetCommState();
   Par::resetManagedMPI();

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -3,23 +3,33 @@
 #include <Eigen/Core>
 #include <boost/test/unit_test.hpp>
 #include <string>
+#include <limits>
 #include <type_traits>
 #include "math/differences.hpp"
 #include "math/math.hpp"
 #include "testing/TestContext.hpp"
 #include "utils/ManageUniqueIDs.hpp"
 #include "utils/MasterSlave.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace testing {
 
 namespace bt = boost::unit_test;
 
+constexpr DataID operator"" _dataID ( unsigned long long n )
+{
+  PRECICE_ASSERT(n >= 0, "DataID must be positive");
+  PRECICE_ASSERT(n < std::numeric_limits<DataID>::max(), "DataID is too big");
+  return static_cast<DataID>(n);
+}
+
 namespace inject {
 using precice::testing::Require;
 using precice::testing::operator""_rank;
 using precice::testing::operator""_ranks;
 using precice::testing::operator""_on;
+using precice::testing::operator""_dataID;
 } // namespace inject
 
 #define PRECICE_TEST(...)                             \


### PR DESCRIPTION
## Main changes of this PR

This PR improves the data id manager, by replacing the `static int dataCount`-based assignment with a non-static id manager.
The new system uses the order of `<use-data />` tags to assign unique dataIDs to data during the configuration.

Tests are now required to specific dataIDs when using `Mesh::createData()`.
The `_dataID` literal simplifies this task.

## Motivation and additional information

Solves #1161 

This could impact the implementation of #1169 

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
