### PR TITLE
Hide non-API symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,14 +461,25 @@ endif()
 # Setup General Install for:
 # precice - the library
 # precice-tools - the precice binary
+
+# preciceInternal needs to be added to the export set if we are building a static library
+set(precice_install_targets precice)
+if(NOT BUILD_SHARED_LIBS)
+  set(precice_install_targets ${precice_install_targets} preciceInternal)
+endif()
+if(PRECICE_BUILD_TOOLS)
+  set(precice_install_targets ${precice_install_targets} precice-tools)
+endif()
+
 include(GNUInstallDirs)
-install(TARGETS precicelib
+install(TARGETS ${precice_install_targets}
   EXPORT preciceTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
   )
+unset(precice_install_targets)
 
 if(PRECICE_BUILD_TOOLS)
   install(TARGETS precice-tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,8 @@ print_section("TARGETS & PACKAGES")
 
 
 # Add precice as an empty target
-add_library(precice OBJECT)
-set_target_properties(precice PROPERTIES
+add_library(preciceInternal OBJECT)
+set_target_properties(preciceInternal PROPERTIES
   # precice is a C++17 project
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED Yes
@@ -267,21 +267,21 @@ set_target_properties(precice PROPERTIES
 
 # Setup release override options
 if(PRECICE_RELEASE_WITH_DEBUG_LOG)
-  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_DEBUG_LOG)
+  target_compile_definitions(preciceInternal PRIVATE PRECICE_RELEASE_WITH_DEBUG_LOG)
 endif()
 
 if(PRECICE_RELEASE_WITH_TRACE_LOG)
-  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_TRACE_LOG)
+  target_compile_definitions(preciceInternal PRIVATE PRECICE_RELEASE_WITH_TRACE_LOG)
 endif()
 
 if(PRECICE_RELEASE_WITH_ASSERTIONS)
-  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_ASSERTIONS)
+  target_compile_definitions(preciceInternal PRIVATE PRECICE_RELEASE_WITH_ASSERTIONS)
 endif()
 
 
 # Setup Boost
-target_compile_definitions(precice PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
-target_link_libraries(precice PUBLIC
+target_compile_definitions(preciceInternal PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
+target_link_libraries(preciceInternal PUBLIC
   Boost::boost
   Boost::filesystem
   Boost::log
@@ -292,40 +292,40 @@ target_link_libraries(precice PUBLIC
   Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
-  target_compile_definitions(precice PUBLIC _GNU_SOURCE)
-  target_link_libraries(precice PUBLIC ${CMAKE_DL_LIBS})
+  target_compile_definitions(preciceInternal PUBLIC _GNU_SOURCE)
+  target_link_libraries(preciceInternal PUBLIC ${CMAKE_DL_LIBS})
 endif()
 
 # Setup Eigen3
-target_link_libraries(precice PUBLIC Eigen3::Eigen)
-target_compile_definitions(precice PUBLIC "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
+target_link_libraries(preciceInternal PUBLIC Eigen3::Eigen)
+target_compile_definitions(preciceInternal PUBLIC "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
 
 # Setup LIBXML2
-target_link_libraries(precice PRIVATE LibXml2::LibXml2)
+target_link_libraries(preciceInternal PRIVATE LibXml2::LibXml2)
 
 # Setup JSON
-target_link_libraries(precice PUBLIC JSON fmt-header-only)
+target_link_libraries(preciceInternal PUBLIC JSON fmt-header-only)
 
 # Setup MPI
 if (PRECICE_MPICommunication)
-  target_link_libraries(precice PUBLIC MPI::MPI_CXX)
+  target_link_libraries(preciceInternal PUBLIC MPI::MPI_CXX)
 else()
-  target_compile_definitions(precice PUBLIC PRECICE_NO_MPI)
+  target_compile_definitions(preciceInternal PUBLIC PRECICE_NO_MPI)
 endif()
 
 # Setup PETSC
 if (PRECICE_PETScMapping AND PRECICE_MPICommunication)
-  target_link_libraries(precice PUBLIC PETSc::PETSc)
+  target_link_libraries(preciceInternal PUBLIC PETSc::PETSc)
 else()
-  target_compile_definitions(precice PUBLIC PRECICE_NO_PETSC)
+  target_compile_definitions(preciceInternal PUBLIC PRECICE_NO_PETSC)
 endif()
 
 # Option Python
 if (PRECICE_PythonActions)
-  target_link_libraries(precice PRIVATE Python3::NumPy Python3::Python)
-  target_compile_definitions(precice PRIVATE NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
+  target_link_libraries(preciceInternal PRIVATE Python3::NumPy Python3::Python)
+  target_compile_definitions(preciceInternal PRIVATE NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
 else()
-  target_compile_definitions(precice PUBLIC PRECICE_NO_PYTHON)
+  target_compile_definitions(preciceInternal PUBLIC PRECICE_NO_PYTHON)
 endif()
 
 
@@ -336,25 +336,29 @@ configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJE
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
 
 # Includes Configuration
-target_include_directories(precice PUBLIC
+target_include_directories(preciceInternal PUBLIC
   $<BUILD_INTERFACE:${preCICE_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${preCICE_BINARY_DIR}/src>
   $<INSTALL_INTERFACE:include>
   )
 
-# Sources Configuration
-include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
+#
+# Add actual precice library
+#
 
-add_library(precicelib)
-target_link_libraries(precicelib
+add_library(precice)
+target_link_libraries(precice
   PRIVATE
-  precice
+  preciceInternal
   )
-set_target_properties(precicelib PROPERTIES
+set_target_properties(precice PROPERTIES
   VERSION ${preCICE_VERSION}
   SOVERSION ${preCICE_SOVERSION}
-  OUTPUT_NAME libprecice
   )
+copy_target_property(preciceInternal precice INTERFACE_INCLUDE_DIRECTORIES)
+
+# Sources Configuration
+include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 
 #
 # Configuration of Target precice-tools
@@ -363,7 +367,7 @@ if (PRECICE_BUILD_TOOLS)
   add_executable(precice-tools "src/drivers/main.cpp")
   target_link_libraries(precice-tools
     PRIVATE
-   precice
+    preciceInternal
    )
   set_target_properties(precice-tools PROPERTIES
     # precice is a C++17 project
@@ -391,7 +395,7 @@ IF (BUILD_TESTING)
   add_executable(testprecice "src/testing/main.cpp")
   target_link_libraries(testprecice
     PRIVATE
-    precice
+    preciceInternal
     )
   set_target_properties(testprecice PROPERTIES
     # precice is a C++17 project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,15 +253,16 @@ add_compile_definitions("$<$<CONFIG:DEBUG>:_GLIBCXX_ASSERTIONS>")
 print_empty()
 print_section("TARGETS & PACKAGES")
 
+
+
 # Add precice as an empty target
-add_library(precice)
+add_library(precice OBJECT)
 set_target_properties(precice PROPERTIES
   # precice is a C++17 project
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED Yes
   CXX_EXTENSIONS No
-  VERSION ${preCICE_VERSION}
-  SOVERSION ${preCICE_SOVERSION}
+  POSITION_INDEPENDENT_CODE YES
   )
 
 # Setup release override options
@@ -280,7 +281,7 @@ endif()
 
 # Setup Boost
 target_compile_definitions(precice PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
-target_link_libraries(precice PRIVATE
+target_link_libraries(precice PUBLIC
   Boost::boost
   Boost::filesystem
   Boost::log
@@ -291,32 +292,32 @@ target_link_libraries(precice PRIVATE
   Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
-  target_compile_definitions(precice PRIVATE _GNU_SOURCE)
-  target_link_libraries(precice PRIVATE ${CMAKE_DL_LIBS})
+  target_compile_definitions(precice PUBLIC _GNU_SOURCE)
+  target_link_libraries(precice PUBLIC ${CMAKE_DL_LIBS})
 endif()
 
 # Setup Eigen3
-target_link_libraries(precice PRIVATE Eigen3::Eigen)
-target_compile_definitions(precice PRIVATE "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
+target_link_libraries(precice PUBLIC Eigen3::Eigen)
+target_compile_definitions(precice PUBLIC "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
 
 # Setup LIBXML2
 target_link_libraries(precice PRIVATE LibXml2::LibXml2)
 
 # Setup JSON
-target_link_libraries(precice PRIVATE JSON fmt-header-only)
+target_link_libraries(precice PUBLIC JSON fmt-header-only)
 
 # Setup MPI
 if (PRECICE_MPICommunication)
-  target_link_libraries(precice PRIVATE MPI::MPI_CXX)
+  target_link_libraries(precice PUBLIC MPI::MPI_CXX)
 else()
-  target_compile_definitions(precice PRIVATE PRECICE_NO_MPI)
+  target_compile_definitions(precice PUBLIC PRECICE_NO_MPI)
 endif()
 
 # Setup PETSC
 if (PRECICE_PETScMapping AND PRECICE_MPICommunication)
-  target_link_libraries(precice PRIVATE PETSc::PETSc)
+  target_link_libraries(precice PUBLIC PETSc::PETSc)
 else()
-  target_compile_definitions(precice PRIVATE PRECICE_NO_PETSC)
+  target_compile_definitions(precice PUBLIC PRECICE_NO_PETSC)
 endif()
 
 # Option Python
@@ -324,7 +325,7 @@ if (PRECICE_PythonActions)
   target_link_libraries(precice PRIVATE Python3::NumPy Python3::Python)
   target_compile_definitions(precice PRIVATE NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
 else()
-  target_compile_definitions(precice PRIVATE PRECICE_NO_PYTHON)
+  target_compile_definitions(precice PUBLIC PRECICE_NO_PYTHON)
 endif()
 
 
@@ -344,6 +345,16 @@ target_include_directories(precice PUBLIC
 # Sources Configuration
 include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 
+add_library(precicelib)
+target_link_libraries(precicelib
+  PRIVATE
+  precice
+  )
+set_target_properties(precicelib PROPERTIES
+  VERSION ${preCICE_VERSION}
+  SOVERSION ${preCICE_SOVERSION}
+  OUTPUT_NAME libprecice
+  )
 
 #
 # Configuration of Target precice-tools
@@ -380,18 +391,7 @@ IF (BUILD_TESTING)
   add_executable(testprecice "src/testing/main.cpp")
   target_link_libraries(testprecice
     PRIVATE
-    Threads::Threads
     precice
-    Eigen3::Eigen
-    fmt-header-only
-    Boost::boost
-    Boost::filesystem
-    Boost::log
-    Boost::log_setup
-    Boost::program_options
-    Boost::system
-    Boost::thread
-    Boost::unit_test_framework
     )
   set_target_properties(testprecice PROPERTIES
     # precice is a C++17 project
@@ -400,21 +400,20 @@ IF (BUILD_TESTING)
     CXX_EXTENSIONS No
     )
   target_include_directories(testprecice PRIVATE
-    ${preCICE_SOURCE_DIR}/src
     ${preCICE_SOURCE_DIR}/tests
     )
   # Copy needed properties from the lib to the executatble. This is necessary as
   # this executable uses the library source, not only the interface.
-  copy_target_property(precice testprecice COMPILE_DEFINITIONS)
-  copy_target_property(precice testprecice COMPILE_OPTIONS)
+  # copy_target_property(precice testprecice COMPILE_DEFINITIONS)
+  # copy_target_property(precice testprecice COMPILE_OPTIONS)
 
   # Testprecice fully depends on MPI and PETSc.
-  if(PRECICE_MPICommunication)
-    target_link_libraries(testprecice PRIVATE MPI::MPI_CXX)
-  endif()
-  if(PRECICE_MPICommunication AND PRECICE_PETScMapping)
-    target_link_libraries(testprecice PRIVATE PETSc::PETSc)
-  endif()
+  #if(PRECICE_MPICommunication)
+  #  target_link_libraries(testprecice PRIVATE MPI::MPI_CXX)
+  #endif()
+  #if(PRECICE_MPICommunication AND PRECICE_PETScMapping)
+  #  target_link_libraries(testprecice PRIVATE PETSc::PETSc)
+  #endif()
 
   message(STATUS "Including test sources")
   # Test Sources Configuration
@@ -443,7 +442,7 @@ endif()
 # precice - the library
 # precice-tools - the precice binary
 include(GNUInstallDirs)
-install(TARGETS precice
+install(TARGETS precicelib
   EXPORT preciceTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,6 @@ target_link_libraries(preciceInternal PUBLIC
   Boost::program_options
   Boost::system
   Boost::thread
-  Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
   target_compile_definitions(preciceInternal PUBLIC _GNU_SOURCE)
@@ -412,6 +411,7 @@ IF (BUILD_TESTING)
   target_link_libraries(testprecice
     PRIVATE
     preciceInternal
+    Boost::unit_test_framework
     )
   set_target_properties(testprecice PROPERTIES
     # precice is a C++17 project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,8 @@ set_target_properties(preciceInternal PROPERTIES
   CXX_STANDARD_REQUIRED Yes
   CXX_EXTENSIONS No
   POSITION_INDEPENDENT_CODE YES
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN YES
   )
 
 # Setup release override options
@@ -342,6 +344,16 @@ target_include_directories(preciceInternal PUBLIC
   $<INSTALL_INTERFACE:include>
   )
 
+# Setup export header
+include(GenerateExportHeader)
+GENERATE_EXPORT_HEADER(preciceInternal
+  EXPORT_FILE_NAME "src/precice/export.hpp"
+  BASE_NAME PRECICE
+  EXPORT_MACRO_NAME PRECICE_API
+  INCLUDE_GUARD_NAME PRECICE_EXPORT
+  )
+
+
 #
 # Add actual precice library
 #
@@ -354,8 +366,12 @@ target_link_libraries(precice
 set_target_properties(precice PROPERTIES
   VERSION ${preCICE_VERSION}
   SOVERSION ${preCICE_SOVERSION}
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN YES
   )
 copy_target_property(preciceInternal precice INTERFACE_INCLUDE_DIRECTORIES)
+
+set_property(TARGET precice PROPERTY PUBLIC_HEADER ${CMAKE_BINARY_DIR}/src/precice/export.hpp)
 
 # Sources Configuration
 include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,15 +478,11 @@ install(TARGETS ${precice_install_targets}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   )
 unset(precice_install_targets)
 
 if(PRECICE_BUILD_TOOLS)
-  install(TARGETS precice-tools
-    EXPORT preciceTargets
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
-
   # Install the binprecice link for backwards compatibility
   # TODO remove in 3.0.0
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/binprecice DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/cmake/DetectGitRevision.cmake
+++ b/cmake/DetectGitRevision.cmake
@@ -20,7 +20,7 @@ if(GIT_FOUND)
     DEPENDS src/precice/impl/versions.cpp.in
     VERBATIM
     )
-  add_dependencies(precice GitRevision)
+  add_dependencies(preciceInternal GitRevision)
 else(GIT_FOUND)
   set(preCICE_REVISION "no-info [Git not found]")
   configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.cpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp" @ONLY)

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "precice/Version.h"
+#include "precice/export.hpp"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,7 +25,7 @@ extern "C" {
  * @param[in] solverProcessSize The number of solver processes using preCICE.
  * @param[in] communicator A pointer to an MPI_Comm to use as communicator.
  */
-void precicec_createSolverInterface_withCommunicator(
+PRECICE_API void precicec_createSolverInterface_withCommunicator(
     const char *participantName,
     const char *configFileName,
     int         solverProcessIndex,
@@ -46,7 +47,7 @@ void precicec_createSolverInterface_withCommunicator(
  *                               from 0 and end with solverProcessSize - 1.
  * @param[in] solverProcessSize The number of solver processes using preCICE.
  */
-void precicec_createSolverInterface(
+PRECICE_API void precicec_createSolverInterface(
     const char *participantName,
     const char *configFileName,
     int         solverProcessIndex,
@@ -62,12 +63,12 @@ void precicec_createSolverInterface(
  *
  * @return Maximal length of first timestep to be computed by solver.
  */
-double precicec_initialize();
+PRECICE_API double precicec_initialize();
 
 /**
  * @brief Initializes coupling data.
  */
-void precicec_initialize_data();
+PRECICE_API void precicec_initialize_data();
 
 /**
  * @brief Exchanges data between solver and coupling supervisor.
@@ -75,12 +76,12 @@ void precicec_initialize_data();
  * @param[in] computedTimestepLength Length of timestep computed by solver.
  * @return Maximal length of next timestep to be computed by solver.
  */
-double precicec_advance(double computedTimestepLength);
+PRECICE_API double precicec_advance(double computedTimestepLength);
 
 /**
  * @brief Finalizes the coupling to the coupling supervisor.
  */
-void precicec_finalize();
+PRECICE_API void precicec_finalize();
 
 ///@}
 
@@ -90,17 +91,17 @@ void precicec_finalize();
 /**
  * @brief Returns the number of spatial configurations for the coupling.
  */
-int precicec_getDimensions();
+PRECICE_API int precicec_getDimensions();
 
 /**
  * @brief Returns true (->1), if the coupled simulation is ongoing
  */
-int precicec_isCouplingOngoing();
+PRECICE_API int precicec_isCouplingOngoing();
 
 /**
  * @brief Returns true (->1), if new data to read is available.
  */
-int precicec_isReadDataAvailable();
+PRECICE_API int precicec_isReadDataAvailable();
 
 /**
  * @brief Checks if new data has to be written before calling advance().
@@ -109,22 +110,22 @@ int precicec_isReadDataAvailable();
  *
  * @return true (->1) if new data has to be written.
  */
-int precicec_isWriteDataRequired(double computedTimestepLength);
+PRECICE_API int precicec_isWriteDataRequired(double computedTimestepLength);
 
 /**
  * @brief Returns true (->1), if the coupling time window is completed.
  */
-int precicec_isTimeWindowComplete();
+PRECICE_API int precicec_isTimeWindowComplete();
 
 /**
  * @brief Returns whether the solver has to evaluate the surrogate model representation.
  */
-int precicec_hasToEvaluateSurrogateModel();
+PRECICE_API int precicec_hasToEvaluateSurrogateModel();
 
 /**
  * @brief Returns whether the solver has to evaluate the fine model representation.
  */
-int precicec_hasToEvaluateFineModel();
+PRECICE_API int precicec_hasToEvaluateFineModel();
 
 ///@}
 
@@ -136,7 +137,7 @@ int precicec_hasToEvaluateFineModel();
  * @param[in] action the name of the action
  * @returns whether the action is required
  */
-int precicec_isActionRequired(const char *action);
+PRECICE_API int precicec_isActionRequired(const char *action);
 
 /**
  * @brief Indicates preCICE that a required action has been fulfilled by a solver.
@@ -144,7 +145,7 @@ int precicec_isActionRequired(const char *action);
  *
  * @param[in] action the name of the action
  */
-void precicec_markActionFulfilled(const char *action);
+PRECICE_API void precicec_markActionFulfilled(const char *action);
 
 ///@}
 
@@ -158,15 +159,15 @@ void precicec_markActionFulfilled(const char *action);
  * @param[in] meshName the name of the mesh
  * @returns whether the mesh is used.
  */
-int precicec_hasMesh(const char *meshName);
+PRECICE_API int precicec_hasMesh(const char *meshName);
 
 /**
  * @brief Returns id belonging to the given mesh name
  */
-int precicec_getMeshID(const char *meshName);
+PRECICE_API int precicec_getMeshID(const char *meshName);
 
 /// @copydoc precice::SolverInterface::isMeshConnectivityRequired()
-int precicec_isMeshConnectivityRequired(int meshID);
+PRECICE_API int precicec_isMeshConnectivityRequired(int meshID);
 
 /**
  * @brief Creates a mesh vertex
@@ -175,7 +176,7 @@ int precicec_isMeshConnectivityRequired(int meshID);
  * @param[in] position a pointer to the coordinates of the vertex.
  * @returns the id of the created vertex
  */
-int precicec_setMeshVertex(
+PRECICE_API int precicec_setMeshVertex(
     int           meshID,
     const double *position);
 
@@ -185,7 +186,7 @@ int precicec_setMeshVertex(
  * @param[in] meshID the id of the mesh
  * @returns the amount of the vertices of the mesh
  */
-int precicec_getMeshVertexSize(int meshID);
+PRECICE_API int precicec_getMeshVertexSize(int meshID);
 
 /**
  * @brief Creates multiple mesh vertices
@@ -198,7 +199,7 @@ int precicec_getMeshVertexSize(int meshID);
  *
  * @param[out] ids The ids of the created vertices
  */
-void precicec_setMeshVertices(
+PRECICE_API void precicec_setMeshVertices(
     int           meshID,
     int           size,
     const double *positions,
@@ -214,7 +215,7 @@ void precicec_setMeshVertices(
  *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
  *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
  */
-void precicec_getMeshVertices(
+PRECICE_API void precicec_getMeshVertices(
     int        meshID,
     int        size,
     const int *ids,
@@ -230,7 +231,7 @@ void precicec_getMeshVertices(
  *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
  * @param[out] ids IDs corresponding to positions.
  */
-void precicec_getMeshVertexIDsFromPositions(
+PRECICE_API void precicec_getMeshVertexIDsFromPositions(
     int           meshID,
     int           size,
     const double *positions,
@@ -245,7 +246,7 @@ void precicec_getMeshVertexIDsFromPositions(
  *
  * @return the ID of the edge
  */
-int precicec_setMeshEdge(
+PRECICE_API int precicec_setMeshEdge(
     int meshID,
     int firstVertexID,
     int secondVertexID);
@@ -258,7 +259,7 @@ int precicec_setMeshEdge(
  * @param[in] secondEdgeID ID of the second edge of the triangle
  * @param[in] thirdEdgeID ID of the third edge of the triangle
  */
-void precicec_setMeshTriangle(
+PRECICE_API void precicec_setMeshTriangle(
     int meshID,
     int firstEdgeID,
     int secondEdgeID,
@@ -267,7 +268,7 @@ void precicec_setMeshTriangle(
 /**
  * @brief Sets a triangle from vertex IDs. Creates missing edges.
  */
-void precicec_setMeshTriangleWithEdges(
+PRECICE_API void precicec_setMeshTriangleWithEdges(
     int meshID,
     int firstVertexID,
     int secondVertexID,
@@ -282,7 +283,7 @@ void precicec_setMeshTriangleWithEdges(
  * @param[in] thirdEdgeID ID of the third edge of the Quad
  * @param[in] fourthEdgeID ID of the forth edge of the Quad
  */
-void precicec_setMeshQuad(
+PRECICE_API void precicec_setMeshQuad(
     int meshID,
     int firstEdgeID,
     int secondEdgeID,
@@ -298,7 +299,7 @@ void precicec_setMeshQuad(
   * @param[in] thirdVertexID ID of the third vertex of the Quad
   * @param[in] fourthVertexID ID of the fourth vertex of the Quad
  */
-void precicec_setMeshQuadWithEdges(
+PRECICE_API void precicec_setMeshQuadWithEdges(
     int meshID,
     int firstVertexID,
     int secondVertexID,
@@ -329,7 +330,7 @@ void precicec_setMeshTetrahedron(
 /**
  * @brief Returns true (!=0), if data with given name is available.
  */
-int precicec_hasData(const char *dataName, int meshID);
+PRECICE_API int precicec_hasData(const char *dataName, int meshID);
 
 /**
  * @brief Returns the data id belonging to the given name.
@@ -338,17 +339,17 @@ int precicec_hasData(const char *dataName, int meshID);
  * configuration file. The data id obtained can be used to read and write
  * data to and from the coupling mesh.
  */
-int precicec_getDataID(const char *dataName, int meshID);
+PRECICE_API int precicec_getDataID(const char *dataName, int meshID);
 
 /**
  * @brief Computes and maps all read data mapped to mesh with given ID.
  */
-void precicec_mapReadDataTo(int toMeshID);
+PRECICE_API void precicec_mapReadDataTo(int toMeshID);
 
 /**
  * @brief Computes and maps all write data mapped from mesh with given ID.
  */
-void precicec_mapWriteDataFrom(int fromMeshID);
+PRECICE_API void precicec_mapWriteDataFrom(int fromMeshID);
 
 /**
  * @brief Writes vector data values given as block.
@@ -361,7 +362,7 @@ void precicec_mapWriteDataFrom(int fromMeshID);
  * @param[in] size Number of indices, and number of values * dimensions.
  * @param[in] values Values of the data to be written.
  */
-void precicec_writeBlockVectorData(
+PRECICE_API void precicec_writeBlockVectorData(
     int           dataID,
     int           size,
     const int *   valueIndices,
@@ -374,7 +375,7 @@ void precicec_writeBlockVectorData(
  * @param[in] dataPosition Spatial position of the data to be written.
  * @param[in] dataValue Vectorial data value to be written.
  */
-void precicec_writeVectorData(
+PRECICE_API void precicec_writeVectorData(
     int           dataID,
     int           valueIndex,
     const double *dataValue);
@@ -382,7 +383,7 @@ void precicec_writeVectorData(
 /**
  * @brief See precice::SolverInterface::writeBlockScalarData().
  */
-void precicec_writeBlockScalarData(
+PRECICE_API void precicec_writeBlockScalarData(
     int           dataID,
     int           size,
     const int *   valueIndices,
@@ -395,7 +396,7 @@ void precicec_writeBlockScalarData(
  * @param[in] dataPosition Spatial position of the data to be written.
  * @param[in] dataValue Scalar data value to be written.
  */
-void precicec_writeScalarData(
+PRECICE_API void precicec_writeScalarData(
     int    dataID,
     int    valueIndex,
     double dataValue);
@@ -412,7 +413,7 @@ void precicec_writeScalarData(
  * @param[in] valueIndices Indices (from setReadPosition()) of data values.
  * @param[in] values Values of the data to be read.
  */
-void precicec_readBlockVectorData(
+PRECICE_API void precicec_readBlockVectorData(
     int        dataID,
     int        size,
     const int *valueIndices,
@@ -425,7 +426,7 @@ void precicec_readBlockVectorData(
  * @param[in] dataPosition Position where the read data should be mapped to.
  * @param[out] dataValue Vectorial data value read.
  */
-void precicec_readVectorData(
+PRECICE_API void precicec_readVectorData(
     int     dataID,
     int     valueIndex,
     double *dataValue);
@@ -433,7 +434,7 @@ void precicec_readVectorData(
 /**
  * @brief See precice::SolverInterface::readBlockScalarData().
  */
-void precicec_readBlockScalarData(
+PRECICE_API void precicec_readBlockScalarData(
     int        dataID,
     int        size,
     const int *valueIndices,
@@ -446,7 +447,7 @@ void precicec_readBlockScalarData(
  * @param[in] dataPosition Position where the read data should be mapped to.
  * @param[out] dataValue Scalar data value read.
  */
-void precicec_readScalarData(
+PRECICE_API void precicec_readScalarData(
     int     dataID,
     int     valueIndex,
     double *dataValue);
@@ -460,16 +461,16 @@ void precicec_readScalarData(
  * 2) the revision information of preCICE
  * 3) the configuration of preCICE including MPI, PETSC, PYTHON
  */
-const char *precicec_getVersionInformation();
+PRECICE_API const char *precicec_getVersionInformation();
 
 // @brief Name of action for writing initial data.
-const char *precicec_actionWriteInitialData();
+PRECICE_API const char *precicec_actionWriteInitialData();
 
 // @brief Name of action for writing iteration checkpoint
-const char *precicec_actionWriteIterationCheckpoint();
+PRECICE_API const char *precicec_actionWriteIterationCheckpoint();
 
 // @brief Name of action for reading iteration checkpoint.
-const char *precicec_actionReadIterationCheckpoint();
+PRECICE_API const char *precicec_actionReadIterationCheckpoint();
 
 ///@}
 
@@ -510,14 +511,14 @@ void precicec_writeBlockVectorGradientData(
 /**
  * @brief See precice::SolverInterface::setMeshAccessRegion().
  */
-void precicec_setMeshAccessRegion(
+PRECICE_API void precicec_setMeshAccessRegion(
     const int     meshID,
     const double *boundingBox);
 
 /**
  * @brief See precice::SolverInterface::getMeshVerticesAndIDs().
  */
-void precicec_getMeshVerticesAndIDs(
+PRECICE_API void precicec_getMeshVerticesAndIDs(
     const int meshID,
     const int size,
     int *     ids,

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <precice/export.hpp>
+
 /** @file
  * This file contains a Fortran 77 compatible interface written in C/C++.
  *
@@ -27,7 +29,7 @@ extern "C" {
  * @copydoc precice::SolverInterface::SolverInterface()
  *
  */
-void precicef_create_(
+PRECICE_API void precicef_create_(
     const char *participantName,
     const char *configFileName,
     const int * solverProcessIndex,
@@ -45,7 +47,7 @@ void precicef_create_(
  * @copydoc precice::SolverInterface::initialize()
  *
  */
-void precicef_initialize_(double *timestepLengthLimit);
+PRECICE_API void precicef_initialize_(double *timestepLengthLimit);
 
 /**
  * Fortran syntax:
@@ -57,7 +59,7 @@ void precicef_initialize_(double *timestepLengthLimit);
  * @copydoc precice::SolverInterface::initializeData()
  *
  */
-void precicef_initialize_data_();
+PRECICE_API void precicef_initialize_data_();
 
 /**
  * Fortran syntax:
@@ -69,7 +71,7 @@ void precicef_initialize_data_();
  * @copydoc precice::SolverInterface::advance()
  *
  */
-void precicef_advance_(double *timestepLengthLimit);
+PRECICE_API void precicef_advance_(double *timestepLengthLimit);
 
 /**
  * Fortran syntax:
@@ -78,7 +80,7 @@ void precicef_advance_(double *timestepLengthLimit);
  * @copydoc precice::SolverInterface::finalize()
  *
  */
-void precicef_finalize_();
+PRECICE_API void precicef_finalize_();
 
 /**
  * Fortran syntax:
@@ -90,7 +92,7 @@ void precicef_finalize_();
  * @copydoc precice::SolverInterface::getDimensions()
  *
  */
-void precicef_get_dims_(int *dimensions);
+PRECICE_API void precicef_get_dims_(int *dimensions);
 
 /**
  * @deprecated Forwards to precicef_is_coupling_ongoing_
@@ -104,7 +106,7 @@ void precicef_get_dims_(int *dimensions);
  * @copydoc precice::SolverInterface::isOngoing()
  *
  */
-[[deprecated("Use precicef_is_coupling_ongoing_() instead.")]] void precicef_ongoing_(int *isOngoing);
+[[deprecated("Use precicef_is_coupling_ongoing_() instead.")]] PRECICE_API void precicef_ongoing_(int *isOngoing);
 
 /**
  * Fortran syntax:
@@ -116,7 +118,7 @@ void precicef_get_dims_(int *dimensions);
  * @copydoc precice::SolverInterface::isCouplingOngoing()
  *
  */
-void precicef_is_coupling_ongoing_(int *isOngoing);
+PRECICE_API void precicef_is_coupling_ongoing_(int *isOngoing);
 
 /**
  * @deprecated Forwards to precicef_is_write_data_required_
@@ -132,7 +134,7 @@ void precicef_is_coupling_ongoing_(int *isOngoing);
  * @copydoc precice::SolverInterface::isWriteDataRequired()
  *
  */
-[[deprecated("Use precicef_is_write_data_required_(...) with the same arguments instead.")]] void precicef_write_data_required_(
+[[deprecated("Use precicef_is_write_data_required_(...) with the same arguments instead.")]] PRECICE_API void precicef_write_data_required_(
     const double *computedTimestepLength,
     int *         isRequired);
 
@@ -148,7 +150,7 @@ void precicef_is_coupling_ongoing_(int *isOngoing);
  * @copydoc precice::SolverInterface::isWriteDataRequired()
  *
  */
-void precicef_is_write_data_required_(
+PRECICE_API void precicef_is_write_data_required_(
     const double *computedTimestepLength,
     int *         isRequired);
 
@@ -164,7 +166,7 @@ void precicef_is_write_data_required_(
  * @copydoc precice::SolverInterface::isReadDataAvailable()
  *
  */
-[[deprecated("Use precicef_is_read_data_available_() instead.")]] void precicef_read_data_available_(int *isAvailable);
+[[deprecated("Use precicef_is_read_data_available_() instead.")]] PRECICE_API void precicef_read_data_available_(int *isAvailable);
 
 /**
  * Fortran syntax:
@@ -176,7 +178,7 @@ void precicef_is_write_data_required_(
  * @copydoc precice::SolverInterface::isReadDataAvailable()
  *
  */
-void precicef_is_read_data_available_(int *isAvailable);
+PRECICE_API void precicef_is_read_data_available_(int *isAvailable);
 
 /**
  * Fortran syntax:
@@ -188,7 +190,7 @@ void precicef_is_read_data_available_(int *isAvailable);
  * @copydoc precice::SolverInterface::isTimeWindowComplete()
  *
  */
-void precicef_is_time_window_complete_(int *isComplete);
+PRECICE_API void precicef_is_time_window_complete_(int *isComplete);
 
 /**
  * Fortran syntax:
@@ -200,7 +202,7 @@ void precicef_is_time_window_complete_(int *isComplete);
  * @copydoc precice::SolverInterface::hasToEvaluateSurrogateModel()
  *
  */
-void precicef_has_to_evaluate_surrogate_model_(int *hasToEvaluate);
+PRECICE_API void precicef_has_to_evaluate_surrogate_model_(int *hasToEvaluate);
 
 /**
  * Fortran syntax:
@@ -212,7 +214,7 @@ void precicef_has_to_evaluate_surrogate_model_(int *hasToEvaluate);
  * @copydoc precice::SolverInterface::hasToEvaluateFineModel()
  *
  */
-void precicef_has_to_evaluate_fine_model_(int *hasToEvaluate);
+PRECICE_API void precicef_has_to_evaluate_fine_model_(int *hasToEvaluate);
 
 /**
  * @deprecated Forwards to precicef_is_action_required_
@@ -228,7 +230,7 @@ void precicef_has_to_evaluate_fine_model_(int *hasToEvaluate);
  * @copydoc precice::SolverInterface::isActionRequired()
  *
  */
-[[deprecated("Use precicef_is_action_required_(...) with the same arguments instead.")]] void precicef_action_required_(
+[[deprecated("Use precicef_is_action_required_(...) with the same arguments instead.")]] PRECICE_API void precicef_action_required_(
     const char *action,
     int *       isRequired,
     int         lengthAction);
@@ -245,7 +247,7 @@ void precicef_has_to_evaluate_fine_model_(int *hasToEvaluate);
  * @copydoc precice::SolverInterface::isActionRequired()
  *
  */
-void precicef_is_action_required_(
+PRECICE_API void precicef_is_action_required_(
     const char *action,
     int *       isRequired,
     int         lengthAction);
@@ -260,7 +262,7 @@ void precicef_is_action_required_(
  * @copydoc precice::SolverInterface::markActionFulfilled()
  *
  */
-void precicef_mark_action_fulfilled_(
+PRECICE_API void precicef_mark_action_fulfilled_(
     const char *action,
     int         lengthAction);
 
@@ -276,7 +278,7 @@ void precicef_mark_action_fulfilled_(
  * @copydoc precice::SolverInterface::hasMesh()
  *
  */
-void precicef_has_mesh_(
+PRECICE_API void precicef_has_mesh_(
     const char *meshName,
     int *       hasMesh,
     int         lengthMeshName);
@@ -293,7 +295,7 @@ void precicef_has_mesh_(
  * @copydoc precice::SolverInterface::getMeshID()
  *
  */
-void precicef_get_mesh_id_(
+PRECICE_API void precicef_get_mesh_id_(
     const char *meshName,
     int *       meshID,
     int         lengthMeshName);
@@ -312,7 +314,7 @@ void precicef_get_mesh_id_(
  * @copydoc precice::SolverInterface::hasData()
  *
  */
-void precicef_has_data_(
+PRECICE_API void precicef_has_data_(
     const char *dataName,
     const int * meshID,
     int *       hasData,
@@ -337,7 +339,7 @@ void precicef_has_data_(
  * @copydoc precice::SolverInterface::getDataID()
  *
  */
-void precicef_get_data_id_(
+PRECICE_API void precicef_get_data_id_(
     const char *dataName,
     const int * meshID,
     int *       dataID,
@@ -354,7 +356,7 @@ void precicef_get_data_id_(
  *
  * @copydoc precice::SolverInterface::isMeshConnectivityRequired()
  */
-void precicef_is_mesh_connectivity_required_(
+PRECICE_API void precicef_is_mesh_connectivity_required_(
     const int *meshID,
     int *      required);
 
@@ -371,7 +373,7 @@ void precicef_is_mesh_connectivity_required_(
  * @copydoc precice::SolverInterface::setMeshVertex()
  *
  */
-void precicef_set_vertex_(
+PRECICE_API void precicef_set_vertex_(
     const int *   meshID,
     const double *position,
     int *         vertexID);
@@ -388,7 +390,7 @@ void precicef_set_vertex_(
  * @copydoc precice::SolverInterface::getMeshVertexSize()
  *
  */
-void precicef_get_mesh_vertex_size_(
+PRECICE_API void precicef_get_mesh_vertex_size_(
     const int *meshID,
     int *      meshSize);
 
@@ -406,7 +408,7 @@ void precicef_get_mesh_vertex_size_(
  * @copydoc precice::SolverInterface::setMeshVertices()
  *
  */
-void precicef_set_vertices_(
+PRECICE_API void precicef_set_vertices_(
     const int *meshID,
     const int *size,
     double *   positions,
@@ -426,7 +428,7 @@ void precicef_set_vertices_(
  * @copydoc precice::SolverInterface::getMeshVertices()
  *
  */
-void precicef_get_vertices_(
+PRECICE_API void precicef_get_vertices_(
     const int *meshID,
     const int *size,
     int *      ids,
@@ -446,7 +448,7 @@ void precicef_get_vertices_(
  * @copydoc precice::SolverInterface::getMeshVertexIDsFromPositions()
  *
  */
-void precicef_get_vertex_ids_from_positions_(
+PRECICE_API void precicef_get_vertex_ids_from_positions_(
     const int *meshID,
     const int *size,
     double *   positions,
@@ -466,7 +468,7 @@ void precicef_get_vertex_ids_from_positions_(
  * @copydoc precice::SolverInterface::setMeshEdge()
  *
  */
-void precicef_set_edge_(
+PRECICE_API void precicef_set_edge_(
     const int *meshID,
     const int *firstVertexID,
     const int *secondVertexID,
@@ -486,7 +488,7 @@ void precicef_set_edge_(
  * @copydoc precice::SolverInterface::setMeshTriangle()
  *
  */
-void precicef_set_triangle_(
+PRECICE_API void precicef_set_triangle_(
     const int *meshID,
     const int *firstEdgeID,
     const int *secondEdgeID,
@@ -506,7 +508,7 @@ void precicef_set_triangle_(
  * @copydoc precice::SolverInterface::setMeshTriangleWithEdges()
  *
  */
-void precicef_set_triangle_we_(
+PRECICE_API void precicef_set_triangle_we_(
     const int *meshID,
     const int *firstVertexID,
     const int *secondVertexID,
@@ -527,7 +529,7 @@ void precicef_set_triangle_we_(
  * @copydoc precice::SolverInterface::setMeshQuad()
  *
  */
-void precicef_set_quad_(
+PRECICE_API void precicef_set_quad_(
     const int *meshID,
     const int *firstEdgeID,
     const int *secondEdgeID,
@@ -549,7 +551,7 @@ void precicef_set_quad_(
  * @copydoc precice::SolverInterface::setMeshQuadWithEdges()
  *
  */
-void precicef_set_quad_we_(
+PRECICE_API void precicef_set_quad_we_(
     const int *meshID,
     const int *firstVertexID,
     const int *secondVertexID,
@@ -592,7 +594,7 @@ void precicef_set_tetrahedron(
  * @copydoc precice::SolverInterface::writeBlockVectorData
  *
  */
-void precicef_write_bvdata_(
+PRECICE_API void precicef_write_bvdata_(
     const int *dataID,
     const int *size,
     int *      valueIndices,
@@ -611,7 +613,7 @@ void precicef_write_bvdata_(
  * @copydoc precice::SolverInterface::writeVectorData
  *
  */
-void precicef_write_vdata_(
+PRECICE_API void precicef_write_vdata_(
     const int *   dataID,
     const int *   valueIndex,
     const double *dataValue);
@@ -630,7 +632,7 @@ void precicef_write_vdata_(
  * @copydoc precice::SolverInterface::writeBlockScalarData
  *
  */
-void precicef_write_bsdata_(
+PRECICE_API void precicef_write_bsdata_(
     const int *dataID,
     const int *size,
     int *      valueIndices,
@@ -649,7 +651,7 @@ void precicef_write_bsdata_(
  * @copydoc precice::SolverInterface::writeScalarData
  *
  */
-void precicef_write_sdata_(
+PRECICE_API void precicef_write_sdata_(
     const int *   dataID,
     const int *   valueIndex,
     const double *dataValue);
@@ -668,7 +670,7 @@ void precicef_write_sdata_(
  * @copydoc precice::SolverInterface::readBlockVectorData
  *
  */
-void precicef_read_bvdata_(
+PRECICE_API void precicef_read_bvdata_(
     const int *dataID,
     const int *size,
     int *      valueIndices,
@@ -687,7 +689,7 @@ void precicef_read_bvdata_(
  * @copydoc precice::SolverInterface::readVectorData
  *
  */
-void precicef_read_vdata_(
+PRECICE_API void precicef_read_vdata_(
     const int *dataID,
     const int *valueIndex,
     double *   dataValue);
@@ -706,7 +708,7 @@ void precicef_read_vdata_(
  * @copydoc precice::SolverInterface::readBlockScalarData
  *
  */
-void precicef_read_bsdata_(
+PRECICE_API void precicef_read_bsdata_(
     const int *dataID,
     const int *size,
     int *      valueIndices,
@@ -725,7 +727,7 @@ void precicef_read_bsdata_(
  * @copydoc precice::SolverInterface::readScalarData
  *
  */
-void precicef_read_sdata_(
+PRECICE_API void precicef_read_sdata_(
     const int *dataID,
     const int *valueIndex,
     double *   dataValue);
@@ -740,7 +742,7 @@ void precicef_read_sdata_(
  * @copydoc precice::SolverInterface::mapWriteDataFrom()
  *
  */
-void precicef_map_write_data_from_(const int *meshID);
+PRECICE_API void precicef_map_write_data_from_(const int *meshID);
 
 /**
  * Fortran syntax:
@@ -752,7 +754,7 @@ void precicef_map_write_data_from_(const int *meshID);
  * @copydoc precice::SolverInterface::mapReadDataTo()
  *
  */
-void precicef_map_read_data_to_(const int *meshID);
+PRECICE_API void precicef_map_read_data_to_(const int *meshID);
 
 /**
  * @brief Name of action for writing iteration checkpoint.
@@ -760,7 +762,7 @@ void precicef_map_read_data_to_(const int *meshID);
  * Fortran syntax:
  * precicef_action_write_iter_checkpoint( CHARACTER nameAction(*) )
  */
-void precicef_action_write_iter_checkp_(
+PRECICE_API void precicef_action_write_iter_checkp_(
     char *nameAction,
     int   lengthNameAction);
 
@@ -770,7 +772,7 @@ void precicef_action_write_iter_checkp_(
  * FortranSyntax:
  * precicef_action_write_initial_data( CHARACTER nameAction(*) )
  */
-void precicef_action_write_initial_data_(
+PRECICE_API void precicef_action_write_initial_data_(
     char *nameAction,
     int   lengthNameAction);
 
@@ -780,11 +782,11 @@ void precicef_action_write_initial_data_(
  * Fortran syntax:
  * precicef_action_read_iter_checkpoint( CHARACTER nameAction(*) )
  */
-void precicef_action_read_iter_checkp_(
+PRECICE_API void precicef_action_read_iter_checkp_(
     char *nameAction,
     int   lengthNameAction);
 
-void precicef_get_version_information_(
+PRECICE_API void precicef_get_version_information_(
     char *versionInfo,
     int   lengthVersionInfo);
 
@@ -889,7 +891,7 @@ void precicef_write_bvgradient_data_(
  *
  * @copydoc precice::SolverInterface::setMeshAccessRegion()
  */
-void precicef_set_mesh_access_region_(
+PRECICE_API void precicef_set_mesh_access_region_(
     const int     meshID,
     const double *boundingBox);
 
@@ -906,7 +908,7 @@ void precicef_set_mesh_access_region_(
  *
  * @copydoc precice::SolverInterface::getMeshVerticesAndIDs()
  */
-void precicef_get_mesh_vertices_and_IDs_(
+PRECICE_API void precicef_get_mesh_vertices_and_IDs_(
     const int meshID,
     const int size,
     int *     ids,

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <precice/export.hpp>
 #include <set>
 #include <string>
 #include <vector>
@@ -36,7 +37,7 @@ namespace precice {
  *  We use solver, simulation code, and participant as synonyms.
  *  The preferred name in the documentation is participant.
  */
-class SolverInterface {
+class PRECICE_API SolverInterface {
 public:
   ///@name Construction and Configuration
   ///@{
@@ -1271,18 +1272,18 @@ private:
  * 2) the revision information of preCICE
  * 3) the configuration of preCICE including MPI, PETSC, PYTHON
  */
-std::string getVersionInformation();
+PRECICE_API std::string getVersionInformation();
 
 namespace constants {
 
 // @brief Name of action for writing initial data.
-const std::string &actionWriteInitialData();
+PRECICE_API const std::string &actionWriteInitialData();
 
 // @brief Name of action for writing iteration checkpoint
-const std::string &actionWriteIterationCheckpoint();
+PRECICE_API const std::string &actionWriteIterationCheckpoint();
 
 // @brief Name of action for reading iteration checkpoint.
-const std::string &actionReadIterationCheckpoint();
+PRECICE_API const std::string &actionReadIterationCheckpoint();
 
 } // namespace constants
 

--- a/src/precice/Tooling.hpp
+++ b/src/precice/Tooling.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <iosfwd>
-#include <string>
 #include <precice/export.hpp>
+#include <string>
 
 namespace precice {
 

--- a/src/precice/Tooling.hpp
+++ b/src/precice/Tooling.hpp
@@ -2,6 +2,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <precice/export.hpp>
 
 namespace precice {
 
@@ -19,7 +20,7 @@ namespace tooling {
 /** The type of reference to generate
  * @see \ref precice::tooling::printConfigReference
  */
-enum struct ConfigReferenceType {
+enum struct PRECICE_API ConfigReferenceType {
   /// XML with inlined help
   XML = 0,
   /// DTD to check an XML
@@ -35,10 +36,10 @@ enum struct ConfigReferenceType {
  *
  * @see \ref precice::tooling::ConfigReferenceType
  */
-void printConfigReference(std::ostream &out, ConfigReferenceType reftype);
+PRECICE_API void printConfigReference(std::ostream &out, ConfigReferenceType reftype);
 
 /// @brief Checks a given configuration
-void checkConfiguration(const std::string &filename, const std::string &participant, int size);
+PRECICE_API void checkConfiguration(const std::string &filename, const std::string &participant, int size);
 
 } // namespace tooling
 

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -2,7 +2,7 @@
 # This file lists all sources that will be compiles into the precice library
 #
 
-target_sources(precice
+target_sources(preciceInternal
     PRIVATE
     ${CMAKE_BINARY_DIR}/src/precice/impl/versions.cpp
     ${CMAKE_BINARY_DIR}/src/precice/impl/versions.hpp

--- a/tools/building/updateSourceFiles.py
+++ b/tools/building/updateSourceFiles.py
@@ -104,7 +104,7 @@ SOURCES_BASE = """#
 # This file lists all sources that will be compiles into the precice library
 #
 
-target_sources(precice
+target_sources(preciceInternal
     PRIVATE
     {}
     )


### PR DESCRIPTION
## Main changes of this PR

**This requires us to drop support for Ubuntu 18.04 LTS.**

This PR ~~upgrades the CMake version to 3.12 and~~ enables hidden symbols. _I rebased it on develop_

Hiding Non-API symbols consists out of 3 parts:

1. The CMake library
    * We use an object library `preciceInternal` to compile all preCICE sources.
    * We link these sources into a shared or static library `precice`
    * We link `precice-tools` to `precice`, so it needs to use the public API
    * We link `testprecice` to `preciceInternals`, which is not influenced by the symbol visibility
3. Hiding symbols by default
    * We set the symbol and inline visibility of `preciceInternal` to hidden.
5. Exporting only the API
    * We auto-generate an export header and add it to the public headers of preCICE.
    * We annotate all API function with `PRECICE_API` 

## Motivation and additional information

Closes #623

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
