### PR TITLE
Add integration test suite detection

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -277,16 +277,6 @@ add_precice_test(
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   )
 add_precice_test(
-  NAME serial
-  ARGUMENTS "--run_test=PreciceTests/Serial"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-  )
-add_precice_test(
-  NAME parallel
-  ARGUMENTS "--run_test=PreciceTests/Parallel"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-  )
-add_precice_test(
   NAME query
   ARGUMENTS "--run_test=QueryTests"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
@@ -306,6 +296,23 @@ add_precice_test(
   ARGUMENTS "--run_test=XML"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   )
+
+# Remove the parallel suite once the migration to the new test structure is finished
+add_precice_test(
+  NAME parallel
+  ARGUMENTS "--run_test=PreciceTests/Parallel"
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
+  )
+
+# Register integration tests from tests/
+# These are defined in tests/tests.cmake
+foreach(testsuite IN LISTS PRECICE_TEST_SUITES)
+  add_precice_test(
+    NAME "integration.${testsuite}"
+    ARGUMENTS "--run_test=PreciceTests/${testsuite}"
+    TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
+    )
+endforeach()
 
 add_precice_test_build_solverdummy(cpp)
 add_precice_test_build_solverdummy(c)

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -175,10 +175,10 @@ target_sources(precice
     src/mapping/Mapping.hpp
     src/mapping/NearestNeighborBaseMapping.cpp
     src/mapping/NearestNeighborBaseMapping.hpp
-    src/mapping/NearestNeighborMapping.cpp
-    src/mapping/NearestNeighborMapping.hpp
     src/mapping/NearestNeighborGradientMapping.cpp
     src/mapping/NearestNeighborGradientMapping.hpp
+    src/mapping/NearestNeighborMapping.cpp
+    src/mapping/NearestNeighborMapping.hpp
     src/mapping/NearestProjectionMapping.cpp
     src/mapping/NearestProjectionMapping.hpp
     src/mapping/PetRadialBasisFctMapping.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -39,8 +39,8 @@ target_sources(testprecice
     src/m2n/tests/GatherScatterCommunicationTest.cpp
     src/m2n/tests/PointToPointCommunicationTest.cpp
     src/mapping/tests/MappingConfigurationTest.cpp
-    src/mapping/tests/NearestNeighborMappingTest.cpp
     src/mapping/tests/NearestNeighborGradientMappingTest.cpp
+    src/mapping/tests/NearestNeighborMappingTest.cpp
     src/mapping/tests/NearestProjectionMappingTest.cpp
     src/mapping/tests/PetRadialBasisFctMappingTest.cpp
     src/mapping/tests/PolationTest.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1,5 +1,5 @@
 #
-# This file lists all tests sources that will be compiled into the test executable
+# This file lists all integration test sources and test suites
 #
 target_sources(testprecice
     PRIVATE
@@ -17,3 +17,6 @@ target_sources(testprecice
     tests/serial/time/explicit/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/ReadWriteScalarDataWithSubcycling.cpp
     )
+
+# Contains the list of integration test suites
+set(PRECICE_TEST_SUITES Serial)

--- a/tools/building/createTest.py
+++ b/tools/building/createTest.py
@@ -200,6 +200,7 @@ def main():
     print("Create test config {}".format(config))
     if not args.dry_run:
         generateTestConfig(args.test.name, args.test.suites, configPath)
+    print("Remember to run tools/building/updateSourceFiles.py or make sourcesIndex")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Main changes of this PR

This PR adds the detection of integration test suites.

So all directories in `tests/` will be converted to CamelCase and available as ctests called `precice.integration.CamelCase`.

The createTest script now also reminds the user to update the source index.

## Motivation and additional information

Follow-up of #1148

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
