### PR TITLE
Finer classification of mesh connectivity requirements

### DIFF
--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -130,14 +130,7 @@ bool Mapping::hasConstraint(const Constraint &constraint) const
 
 bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs)
 {
-  switch (lhs) {
-  case (Mapping::MeshRequirement::UNDEFINED):
-    return rhs != Mapping::MeshRequirement::UNDEFINED;
-  case (Mapping::MeshRequirement::VERTEX):
-    return rhs == Mapping::MeshRequirement::FULL;
-  case (Mapping::MeshRequirement::FULL):
-    return false;
-  };
+  return int(lhs) < int(rhs);
   BOOST_UNREACHABLE_RETURN(false);
 }
 
@@ -149,6 +142,15 @@ std::ostream &operator<<(std::ostream &out, Mapping::MeshRequirement val)
     break;
   case (Mapping::MeshRequirement::VERTEX):
     out << "VERTEX";
+    break;
+  case (Mapping::MeshRequirement::EDGE):
+    out << "EDGE";
+    break;
+  case (Mapping::MeshRequirement::SURFACE):
+    out << "SURFACE";
+    break;
+  case (Mapping::MeshRequirement::VOLUME):
+    out << "VOLUME";
     break;
   case (Mapping::MeshRequirement::FULL):
     out << "FULL";

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -42,8 +42,14 @@ public:
     UNDEFINED = 0,
     /// Vertices only.
     VERTEX = 1,
+    // Edges also required (e.g. surface coupling in 2D nearest projection)
+    EDGE = 2,
+    // Surfaces required (e.g. surface coupling in 3D nearest projection, or volumetric NP in 2D)
+    SURFACE = 3,
+    // Volume data required (e.g. volumetric 3D coupling)
+    VOLUME = 4,
     /// Full mesh.
-    FULL = 2
+    FULL = 5
   };
 
   /// Constructor, takes mapping constraint.

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -21,8 +21,14 @@ NearestNeighborGradientMapping::NearestNeighborGradientMapping(
     : NearestNeighborBaseMapping(constraint, dimensions, true, "NearestNeighborGradientMapping", "nng")
 {
   if (hasConstraint(SCALEDCONSISTENT)) {
-    setInputRequirement(Mapping::MeshRequirement::FULL);
-    setOutputRequirement(Mapping::MeshRequirement::FULL);
+    // Full requirements for surface integrals: edges in 2D, surfaces in 3D
+    if (getDimensions() == 2) {
+      setInputRequirement(Mapping::MeshRequirement::EDGE);
+      setOutputRequirement(Mapping::MeshRequirement::EDGE);
+    } else {
+      setInputRequirement(Mapping::MeshRequirement::SURFACE);
+      setOutputRequirement(Mapping::MeshRequirement::SURFACE);
+    }
   } else {
     setInputRequirement(Mapping::MeshRequirement::VERTEX);
     setOutputRequirement(Mapping::MeshRequirement::VERTEX);

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -20,11 +20,14 @@ NearestNeighborMapping::NearestNeighborMapping(
     : NearestNeighborBaseMapping(constraint, dimensions, false, "NearestNeighborMapping", "nn")
 {
   if (hasConstraint(SCALEDCONSISTENT)) {
-    setInputRequirement(Mapping::MeshRequirement::FULL);
-    setOutputRequirement(Mapping::MeshRequirement::FULL);
-  } else {
-    setInputRequirement(Mapping::MeshRequirement::VERTEX);
-    setOutputRequirement(Mapping::MeshRequirement::VERTEX);
+    // Full requirements for surface integrals: edges in 2D, surfaces in 3D
+    if (getDimensions() == 2) {
+      setInputRequirement(Mapping::MeshRequirement::EDGE);
+      setOutputRequirement(Mapping::MeshRequirement::EDGE);
+    } else {
+      setInputRequirement(Mapping::MeshRequirement::SURFACE);
+      setOutputRequirement(Mapping::MeshRequirement::SURFACE);
+    }
   }
 }
 

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -33,7 +33,7 @@ NearestProjectionMapping::NearestProjectionMapping(
 {
 
   Mapping::MeshRequirement required;
-  if (dimensions() == 2) {
+  if (getDimensions() == 2) {
     required = Mapping::MeshRequirement::EDGE;
   } else {
     required = Mapping::MeshRequirement::SURFACE;

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -31,16 +31,25 @@ NearestProjectionMapping::NearestProjectionMapping(
     int        dimensions)
     : Mapping(constraint, dimensions)
 {
+
+  Mapping::MeshRequirement required;
+  if (dimensions() == 2) {
+    required = Mapping::MeshRequirement::EDGE;
+  }
+  else {
+    required = Mapping::MeshRequirement::SURFACE;
+  }
+
   if (constraint == CONSISTENT) {
-    setInputRequirement(Mapping::MeshRequirement::FULL);
+    setInputRequirement(required);
     setOutputRequirement(Mapping::MeshRequirement::VERTEX);
   } else if (constraint == CONSERVATIVE) {
     setInputRequirement(Mapping::MeshRequirement::VERTEX);
-    setOutputRequirement(Mapping::MeshRequirement::FULL);
+    setOutputRequirement(required);
   } else {
     PRECICE_ASSERT(constraint == SCALEDCONSISTENT, constraint);
-    setInputRequirement(Mapping::MeshRequirement::FULL);
-    setOutputRequirement(Mapping::MeshRequirement::FULL);
+    setInputRequirement(required);
+    setOutputRequirement(required);
   }
 }
 

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -35,8 +35,7 @@ NearestProjectionMapping::NearestProjectionMapping(
   Mapping::MeshRequirement required;
   if (dimensions() == 2) {
     required = Mapping::MeshRequirement::EDGE;
-  }
-  else {
+  } else {
     required = Mapping::MeshRequirement::SURFACE;
   }
 

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -210,9 +210,16 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping(
       _preallocation(preallocation),
       _commState(utils::Parallel::current())
 {
-  if (constraint == SCALEDCONSISTENT) {
-    setInputRequirement(Mapping::MeshRequirement::FULL);
-    setOutputRequirement(Mapping::MeshRequirement::FULL);
+
+  if (hasConstraint(SCALEDCONSISTENT)) {
+    // Full requirements for surface integrals: edges in 2D, surfaces in 3D
+    if (getDimensions() == 2) {
+      setInputRequirement(Mapping::MeshRequirement::EDGE);
+      setOutputRequirement(Mapping::MeshRequirement::EDGE);
+    } else {
+      setInputRequirement(Mapping::MeshRequirement::SURFACE);
+      setOutputRequirement(Mapping::MeshRequirement::SURFACE);
+    }
   } else {
     setInputRequirement(Mapping::MeshRequirement::VERTEX);
     setOutputRequirement(Mapping::MeshRequirement::VERTEX);

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -116,13 +116,20 @@ RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctMapping(
     : Mapping(constraint, dimensions),
       _basisFunction(function)
 {
-  if (constraint == SCALEDCONSISTENT) {
-    setInputRequirement(Mapping::MeshRequirement::FULL);
-    setOutputRequirement(Mapping::MeshRequirement::FULL);
+  if (hasConstraint(SCALEDCONSISTENT)) {
+    // Full requirements for surface integrals: edges in 2D, surfaces in 3D
+    if (getDimensions() == 2) {
+      setInputRequirement(Mapping::MeshRequirement::EDGE);
+      setOutputRequirement(Mapping::MeshRequirement::EDGE);
+    } else {
+      setInputRequirement(Mapping::MeshRequirement::SURFACE);
+      setOutputRequirement(Mapping::MeshRequirement::SURFACE);
+    }
   } else {
     setInputRequirement(Mapping::MeshRequirement::VERTEX);
     setOutputRequirement(Mapping::MeshRequirement::VERTEX);
   }
+
   setDeadAxis(xDead, yDead, zDead);
 }
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -638,7 +638,7 @@ bool SolverInterfaceImpl::isMeshConnectivityRequired(int meshID) const
 {
   PRECICE_VALIDATE_MESH_ID(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
-  return context.meshRequirement == mapping::Mapping::MeshRequirement::FULL;
+  return context.meshRequirement > mapping::Mapping::MeshRequirement::VERTEX;
 }
 
 int SolverInterfaceImpl::getMeshVertexSize(
@@ -781,7 +781,7 @@ int SolverInterfaceImpl::setMeshEdge(
   PRECICE_TRACE(meshID, firstVertexID, secondVertexID);
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+  if (context.meshRequirement >= mapping::Mapping::MeshRequirement::EDGE) {
     mesh::PtrMesh &mesh = context.mesh;
     using impl::errorInvalidVertexID;
     PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), errorInvalidVertexID(firstVertexID));
@@ -805,7 +805,7 @@ void SolverInterfaceImpl::setMeshTriangle(
                                   " Please set the dimension to 3 in the preCICE configuration file.");
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+  if (context.meshRequirement >= mapping::Mapping::MeshRequirement::SURFACE) {
     mesh::PtrMesh &mesh = context.mesh;
     using impl::errorInvalidEdgeID;
     PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID), errorInvalidEdgeID(firstEdgeID));
@@ -836,7 +836,7 @@ void SolverInterfaceImpl::setMeshTriangleWithEdges(
                                   " Please set the dimension to 3 in the preCICE configuration file.");
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+  if (context.meshRequirement >= mapping::Mapping::MeshRequirement::SURFACE) {
     mesh::PtrMesh &mesh = context.mesh;
     using impl::errorInvalidVertexID;
     PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), errorInvalidVertexID(firstVertexID));
@@ -875,7 +875,7 @@ void SolverInterfaceImpl::setMeshQuad(
                                   "Please set the dimension to 3 in the preCICE configuration file.");
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+  if (context.meshRequirement >= mapping::Mapping::MeshRequirement::SURFACE) {
     mesh::PtrMesh &mesh = context.mesh;
     using impl::errorInvalidEdgeID;
     PRECICE_CHECK(mesh->isValidEdgeID(firstEdgeID), errorInvalidEdgeID(firstEdgeID));
@@ -935,7 +935,7 @@ void SolverInterfaceImpl::setMeshQuadWithEdges(
                                   " Please set the dimension to 3 in the preCICE configuration file.");
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
-  if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
+  if (context.meshRequirement >= mapping::Mapping::MeshRequirement::FULL) {
     PRECICE_ASSERT(context.mesh);
     mesh::Mesh &mesh = *(context.mesh);
     using impl::errorInvalidVertexID;


### PR DESCRIPTION
## Main changes of this PR

Instead of storing whether vertices are sufficient or if "full connectivity" is required, we define connectivity requirements through the "most complex primitive required": vertices, edges, surfaces, or (in the future with volume coupling), volume elements. There is a total ordering:  `VOLUME > SURFACE > EDGE > VERTEX > UNDEFINED`.


## Motivation and additional information

For instance, in the current state, if only "VERTEX" are required, using `setMeshEdges` and `setMeshTriangles` will do nothing. To have them do something, the requirement "FULL" is needed. Now, we can ask for only edges but no triangles (e.g. in surface coupling in 2D), which will disable `setMeshTriangles` but not `setMeshEdges`.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

