### PR TITLE
Simplify boost test setup

### DIFF
--- a/src/testing/GlobalFixtures.cpp
+++ b/src/testing/GlobalFixtures.cpp
@@ -1,0 +1,113 @@
+#include <boost/test/detail/log_level.hpp>
+#include <boost/test/tools/fpc_tolerance.hpp>
+#include <boost/test/tree/test_unit.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_parameters.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <iostream>
+
+#include "logging/LogConfiguration.hpp"
+#include "utils/ArgumentFormatter.hpp"
+
+namespace precice {
+namespace testing {
+
+/// Boost test Initialization function
+/**
+Boost Test Log Levels and corresponding command line arguments to --log_level
+as of Boost 1.68:
+
+\code
+type = enum boost::unit_test::log_level : int {
+  boost::unit_test::invalid_log_level = -1,
+  boost::unit_test::log_successful_tests = 0, all
+  boost::unit_test::log_test_units = 1, unit_scope, test_suite
+  boost::unit_test::log_messages = 2, message
+  boost::unit_test::log_warnings = 3, warning
+  boost::unit_test::log_all_errors = 4, error (default log level)
+  boost::unit_test::log_cpp_exception_errors = 5, cpp_exception
+  boost::unit_test::log_system_errors = 6, system_error
+  boost::unit_test::log_fatal_errors, fatal_error
+  boost::unit_test::log_nothing, nothing
+}
+\endcode
+**/
+boost::unit_test::log_level getBoostTestLogLevel()
+{
+  namespace bu = boost::unit_test;
+#if BOOST_VERSION == 106900 || __APPLE__ && __MACH__
+  std::cerr << "Boost 1.69 and macOS get log_level is broken, preCICE log level set to debug.\n";
+  return = bu::log_successful_tests;
+#else
+  return bu::runtime_config::get<bu::log_level>(bu::runtime_config::btrt_log_level);
+#endif
+}
+
+std::string filterFromLogLevel(boost::unit_test::log_level logLevel)
+{
+  namespace bu = boost::unit_test;
+
+  if (logLevel == bu::log_successful_tests || logLevel == bu::log_test_units) {
+    return "%Severity% >= debug";
+  }
+  if (logLevel == bu::log_messages) {
+    return "%Severity% >= info";
+  }
+  if (logLevel == bu::log_warnings) {
+    return "%Severity% >= warning";
+  }
+  // log warnings in any case
+  return "%Severity% >= warning";
+}
+
+void setupTestLogging()
+{
+  // See if there is a manual override using a log.conf file.
+  auto logConfigs = logging::readLogConfFile("log.conf");
+
+  if (logConfigs.empty()) {
+    // Nothing has been read from log.conf
+    // We configure the log level based on the test framework log level
+
+    logging::BackendConfiguration config;
+    config.filter = filterFromLogLevel(getBoostTestLogLevel());
+
+    const std::string prefix{"%TimeStamp(format=\"%H:%M:%S.%f\")%|%Participant%|%Rank%|%Module%|l%Line%|%Function%|"};
+
+    // Console output
+    config.format = prefix + "%ColorizedSeverity%%Message%";
+    config.type   = "stream";
+    config.output = "stdout";
+    logConfigs.push_back(config);
+
+    // File Outputs
+    config.format = prefix + "%Severity%%Message%";
+    config.type   = "file";
+    config.output = "test.log";
+    logConfigs.push_back(config);
+
+    // The full debug log
+    config.output = "test.debug.log";
+    config.filter = "%Severity% >= debug";
+    logConfigs.push_back(config);
+  }
+
+  logging::setupLogging(logConfigs);
+  // Lock the logging configuration to prevent systemtests from changing them
+  logging::lockConf();
+}
+
+} // namespace testing
+} // namespace precice
+
+// Fixtures need to be defined in the global scope
+
+struct PreciceTestLoggingFixture {
+  static void setup()
+  {
+    std::cerr << "Settup up logging\n";
+    precice::testing::setupTestLogging();
+  }
+};
+
+BOOST_TEST_GLOBAL_FIXTURE(PreciceTestLoggingFixture);

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -1,18 +1,16 @@
 // Setup boost test
-// Disable the generation of a main
+// Disable the auto generation of main()
 #define BOOST_TEST_NO_MAIN
-// Disable the legacy API of the init function
-#define BOOST_TEST_ALTERNATIVE_INIT_API
-// BOOST_TEST_MODULE omitted as we define our own init function
+// Specify the overall name of test framework
+#define BOOST_TEST_MODULE "preCICE Tests"
 
+#include <boost/test/tools/fpc_tolerance.hpp>
 #include <boost/test/tree/test_case_counter.hpp>
 #include <boost/test/tree/traverse.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/test/unit_test_parameters.hpp>
 #include <iostream>
-#include <memory>
 #include <string>
-#include <vector>
+
 #include "com/SharedPointer.hpp"
 #include "logging/LogConfiguration.hpp"
 #include "utils/MasterSlave.hpp"
@@ -22,94 +20,6 @@ namespace precice {
 extern bool syncMode;
 } // namespace precice
 
-/// Boost test Initialization function
-/**
-Boost Test Log Levels and corresponding command line arguments to --log_level
-as of Boost 1.68:
-
-\code
-type = enum boost::unit_test::log_level : int {
-  boost::unit_test::invalid_log_level = -1,
-  boost::unit_test::log_successful_tests = 0, all
-  boost::unit_test::log_test_units = 1, unit_scope, test_suite
-  boost::unit_test::log_messages = 2, message
-  boost::unit_test::log_warnings = 3, warning
-  boost::unit_test::log_all_errors = 4, error (default log level)
-  boost::unit_test::log_cpp_exception_errors = 5, cpp_exception
-  boost::unit_test::log_system_errors = 6, system_error
-  boost::unit_test::log_fatal_errors, fatal_error
-  boost::unit_test::log_nothing, nothing
-}
-\endcode
-**/
-bool precice_init_unit_test()
-{
-  using namespace boost::unit_test;
-  using namespace precice;
-
-  auto &master_suite        = framework::master_test_suite();
-  master_suite.p_name.value = "preCICE Tests";
-
-  auto logConfigs = logging::readLogConfFile("log.conf");
-
-  if (logConfigs.empty()) { // nothing has been read from log.conf
-#if BOOST_VERSION == 106900 || __APPLE__ && __MACH__
-    std::cerr << "Boost 1.69 and macOS get log_level is broken, preCICE log level set to debug.\n";
-    auto logLevel = log_successful_tests;
-#else
-    auto logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);
-#endif
-
-    logging::BackendConfiguration config;
-    if (logLevel == log_successful_tests or logLevel == log_test_units)
-      config.filter = "%Severity% >= debug";
-    if (logLevel == log_messages)
-      config.filter = "%Severity% >= info";
-    if (logLevel == log_warnings)
-      config.filter = "%Severity% >= warning";
-    if (logLevel >= log_all_errors)
-      config.filter = "%Severity% >= warning"; // log warnings in any case
-
-    const std::string prefix{"%TimeStamp(format=\"%H:%M:%S.%f\")%|%Participant%|%Rank%|%Module%|l%Line%|%Function%|"};
-
-    // Console output
-    config.format = prefix + "%ColorizedSeverity%%Message%";
-    config.type   = "stream";
-    config.output = "stdout";
-    logConfigs.push_back(config);
-
-    // File Outputs
-    config.format = prefix + "%Severity%%Message%";
-    config.type   = "file";
-
-    // Same as console output
-    config.output = "test.log";
-    logConfigs.push_back(config);
-
-    // The full debug log
-    config.output = "test.debug.log";
-    config.filter = "%Severity% >= debug";
-    logConfigs.push_back(config);
-  }
-
-  // Initialize either with empty logConfig -> default, configs that are read from file
-  // or from the Boost Test log level.
-  logging::setupLogging(logConfigs);
-  logging::lockConf();
-
-  // Sets the default tolerance for floating point comparisions
-  // Can be overwritten on a per-test or per-suite basis using decators
-  // boost::unit_test::decorator::collector::instance() * boost::unit_test::tolerance(0.001);
-  *tolerance(1e-9); // Stores the decorator in the collector singleton
-#if BOOST_VERSION < 106900
-  decorator::collector::instance().store_in(master_suite);
-#else
-  decorator::collector_t::instance().store_in(master_suite);
-#endif
-
-  return true;
-}
-
 int countEnabledTests()
 {
   using namespace boost::unit_test;
@@ -118,13 +28,20 @@ int countEnabledTests()
   return tcc.p_count;
 }
 
+void setupTolerance()
+{
+  static constexpr double tolerance = 1e-9;
+
+  boost::test_tools::fpc_tolerance<double>() = tolerance;
+  boost::test_tools::fpc_tolerance<float>()  = tolerance;
+}
+
 /// Entry point for the boost test executable
 int main(int argc, char *argv[])
 {
   using namespace precice;
 
   precice::syncMode = false;
-  logging::setupLogging(); // first logging initalization, as early as possible
   utils::Parallel::initializeMPI(&argc, &argv);
   const auto rank = utils::Parallel::current()->rank();
   const auto size = utils::Parallel::current()->size();
@@ -139,7 +56,8 @@ int main(int argc, char *argv[])
 
   std::cout << "This test suite runs on rank " << rank << " of " << size << '\n';
 
-  int       retCode  = boost::unit_test::unit_test_main(&precice_init_unit_test, argc, argv);
+  setupTolerance();
+  int       retCode  = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
   const int testsRan = countEnabledTests();
 
   // Override the return code if the slaves have nothing to test

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -68,6 +68,7 @@ target_sources(testprecice
     src/query/tests/RTreeTests.cpp
     src/testing/ExtrapolationFixture.cpp
     src/testing/ExtrapolationFixture.hpp
+    src/testing/GlobalFixtures.cpp
     src/testing/ParallelCouplingSchemeFixture.cpp
     src/testing/ParallelCouplingSchemeFixture.hpp
     src/testing/SerialCouplingSchemeFixture.cpp


### PR DESCRIPTION
## Main changes of this PR

The initialization of the Boost.test setup is unnecessarily complicated.

This PR:
* sets the global tolerance using the public interface of Boost.test
* moves the logging initialization to a global fixture (which is the recommended way for such use-cases)
* uses the default testsuite initialization provided by Boost.test

## Motivation and additional information

* Reduces hacky code
* Less code to maintain and understand
* Less usage of the Boost.test internals

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
