### PR TITLE
Fix format-all-docker modifying file owner

### DIFF
--- a/docs/changelog/1210.md
+++ b/docs/changelog/1210.md
@@ -1,0 +1,1 @@
+- Fixed the `format-all-docker` script to change of reformatted files to root.

--- a/tools/formatting/format-all-docker
+++ b/tools/formatting/format-all-docker
@@ -6,7 +6,7 @@
 PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." >/dev/null 2>&1 && pwd )"
 if [[ -f "$PROJECT_ROOT/CMakeLists.txt" && -f "$PROJECT_ROOT/.clang-format" ]]; then
   echo "Assuming project root: $PROJECT_ROOT"
-  docker run --rm -i -v $PROJECT_ROOT:/repo -w /repo precice/ci-formatting:latest tools/formatting/format-all
+  docker run --rm -i --user "$(id -u):$(id -g)" -v $PROJECT_ROOT:/repo -w /repo precice/ci-formatting:latest tools/formatting/format-all
   exit $?
 else
   echo "ERROR: Could not find the root of the project."


### PR DESCRIPTION
## Main changes of this PR

This PR changes the `tools/formatting/format-all-docker` tool to not modify file owners.
This prevents reformatted files to be owned by root.

## Motivation and additional information

Being able to delete your files is good.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.
