### PR TITLE
Fixed outdated documentation

### DIFF
--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -114,8 +114,8 @@ public:
   /**
    * @brief Compares two Triangles for equality
    *
-   * Two Triangles are equal if their normal vector is equal AND
-   * if the three edges are equal, whereas the order of edges is NOT important.
+   * Two Triangles are equal if the three edges are equal, 
+   * whereas the order of edges is NOT important.
    */
   bool operator==(const Triangle &other) const;
 


### PR DESCRIPTION
Quick fix of a comment that no longer reflects implementation.

Implementation of `Triangle::operator==`:
https://github.com/precice/precice/blob/502d1aa6a278131908871ef9f54cbac2ba24cc86/src/mesh/Triangle.cpp#L109-L113

There is no comparison of the normal vector anymore.