### PR TITLE
Simplify implementation of data mapping in SolverInterfaceImpl

### DIFF
--- a/docs/changelog/1216.md
+++ b/docs/changelog/1216.md
@@ -1,0 +1,1 @@
+- Refactor how data mapping is performed in SolverInterfaceImpl. Improves encapsulation of DataContext.

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -98,10 +98,10 @@ bool DataContext::isMappingRequired()
     return false;
   }
 
-  auto timing    = _mappingContext.timing;
+  auto       timing    = _mappingContext.timing;
   const bool hasMapped = _mappingContext.hasMappedData;
-  const bool mapNow    = (timing == MappingConfiguration::ON_ADVANCE) |= 
-                         (timing == MappingConfiguration::INITIAL);
+  const bool mapNow    = (timing == MappingConfiguration::ON_ADVANCE) |=
+      (timing == MappingConfiguration::INITIAL);
 
   if ((not mapNow) || hasMapped) {
     return false;

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -117,6 +117,14 @@ bool DataContext::isMappingRequired()
   return true;
 }
 
+void DataContext::mapData()
+{
+  int fromDataID = getFromDataID();
+  int toDataID   = getToDataID();
+  resetToData();
+  mappingContext().mapping->map(fromDataID, toDataID);
+}
+
 bool DataContext::hasReadMapping() const
 {
   return _toData == _providedData;

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -20,12 +20,6 @@ mesh::PtrData DataContext::providedData()
   return _providedData;
 }
 
-mesh::PtrData DataContext::toData()
-{
-  PRECICE_ASSERT(_toData);
-  return _toData;
-}
-
 std::string DataContext::getDataName() const
 {
   PRECICE_ASSERT(_providedData);

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -1,5 +1,6 @@
 #include "precice/impl/DataContext.hpp"
 #include <memory>
+#include "utils/EigenHelperFunctions.hpp"
 
 namespace precice {
 namespace impl {
@@ -18,12 +19,6 @@ mesh::PtrData DataContext::providedData()
 {
   PRECICE_ASSERT(_providedData);
   return _providedData;
-}
-
-mesh::PtrData DataContext::toData()
-{
-  PRECICE_ASSERT(_toData);
-  return _toData;
 }
 
 std::string DataContext::getDataName() const
@@ -122,6 +117,7 @@ void DataContext::mapData()
   int toDataID   = getToDataID();
   _toData->toZero();
   _mappingContext.mapping->map(fromDataID, toDataID);
+  PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, _toData->values()));
 }
 
 bool DataContext::hasReadMapping() const

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -99,9 +99,9 @@ bool DataContext::isMappingRequired()
   }
 
   auto timing    = _mappingContext.timing;
-  bool hasMapped = _mappingContext.hasMappedData;
-  bool mapNow    = timing == MappingConfiguration::ON_ADVANCE;
-  mapNow |= timing == MappingConfiguration::INITIAL;
+  const bool hasMapped = _mappingContext.hasMappedData;
+  const bool mapNow    = (timing == MappingConfiguration::ON_ADVANCE) |= 
+                         (timing == MappingConfiguration::INITIAL);
 
   if ((not mapNow) || hasMapped) {
     return false;

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -40,6 +40,15 @@ int DataContext::getFromDataID() const
   return _fromData->getID();
 }
 
+void DataContext::resetData()
+{
+  resetProvidedData();
+  if (hasMapping()) {
+    PRECICE_ASSERT(hasWriteMapping());
+    resetToData();
+  }
+}
+
 void DataContext::resetProvidedData()
 {
   PRECICE_TRACE();

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -20,6 +20,12 @@ mesh::PtrData DataContext::providedData()
   return _providedData;
 }
 
+mesh::PtrData DataContext::toData()
+{
+  PRECICE_ASSERT(_toData);
+  return _toData;
+}
+
 std::string DataContext::getDataName() const
 {
   PRECICE_ASSERT(_providedData);

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -100,8 +100,7 @@ bool DataContext::isMappingRequired()
 
   auto       timing    = _mappingContext.timing;
   const bool hasMapped = _mappingContext.hasMappedData;
-  const bool mapNow    = (timing == MappingConfiguration::ON_ADVANCE) |=
-      (timing == MappingConfiguration::INITIAL);
+  const bool mapNow    = (timing == MappingConfiguration::ON_ADVANCE) || (timing == MappingConfiguration::INITIAL);
 
   if ((not mapNow) || hasMapped) {
     return false;

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -104,6 +104,27 @@ bool DataContext::hasMapping() const
   return hasReadMapping() || hasWriteMapping();
 }
 
+bool DataContext::isMappingRequired()
+{
+  using namespace mapping;
+  MappingConfiguration::Timing timing;
+
+  if (not hasMapping()) {
+    return false;
+  }
+
+  timing         = mappingContext().timing;
+  bool hasMapped = mappingContext().hasMappedData;
+  bool mapNow    = timing == MappingConfiguration::ON_ADVANCE;
+  mapNow |= timing == MappingConfiguration::INITIAL;
+
+  if ((not mapNow) || hasMapped) {
+    return false;
+  }
+
+  return true;
+}
+
 bool DataContext::hasReadMapping() const
 {
   return _toData == _providedData;

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -26,35 +26,35 @@ class DataContext {
 public:
   /**
    * @brief Get _providedData member.
-   * 
+   *
    * @return mesh::PtrData _providedData.
    */
   mesh::PtrData providedData();
 
   /**
    * @brief Get _toData member.
-   * 
+   *
    * @return mesh::PtrData _toData.
    */
   mesh::PtrData toData();
 
   /**
    * @brief Get the Name of _providedData.
-   * 
+   *
    * @return std::string Name of _providedData.
    */
   std::string getDataName() const;
 
   /**
    * @brief Get the ID of _providedData.
-   * 
+   *
    * @return int ID of _providedData.
    */
   int getProvidedDataID() const;
 
   /**
    * @brief Get the ID of _fromData. Used for performing the mapping outside of this class.
-   * 
+   *
    * @return int ID of _fromData.
    */
   int getFromDataID() const;
@@ -71,63 +71,72 @@ public:
 
   /**
    * @brief Get the ID of _toData. Used for performing the mapping outside of this class.
-   * 
+   *
    * @return int ID of _toData.
    */
   int getToDataID() const;
 
   /**
    * @brief Get the dimensions of _providedData.
-   * 
+   *
    * @return int Dimensions of _providedData.
    */
   int getDataDimensions() const;
 
   /**
    * @brief Get the name of _mesh.
-   * 
+   *
    * @return std::string Name of _mesh.
    */
   std::string getMeshName() const;
 
   /**
    * @brief Get the ID of _mesh.
-   * 
+   *
    * @return int ID of _mesh.
    */
   int getMeshID() const;
 
   /**
    * @brief Informs the user whether this DataContext has a _mappingContext.
-   * 
-   * @return True, if this DataContext is associated with a mapping. False, if not. 
+   *
+   * @return True, if this DataContext is associated with a mapping. False, if not.
    */
   bool hasMapping() const;
 
   /**
+   * @brief Check whether mapping has to be performed.
+   *
+   * Checks whether a mapping exists for this context and the timing configuration.
+   *
+   * @return True, if a mapping has to be performed.
+   */
+  bool isMappingRequired();
+
+  /**
    * @brief Get the _mappingContext associated with this DataContext.
-   * 
+   *
    * @return const MappingContext The _mappingContext of this DataContext.
    */
   const MappingContext mappingContext() const;
 
   /**
    * @brief Informs the user whether this DataContext has a read mapping.
-   * 
+   *
    * @return True, if DataContext has a read mapping.
    */
   bool hasReadMapping() const;
 
   /**
    * @brief Informs the user whether this DataContext has a write mapping.
-   * 
+   *
    * @return True, if DataContext has a write mapping.
    */
   bool hasWriteMapping() const;
 
   /**
    * @brief Links a MappingContext and the MeshContext required by the mapping to this DataContext.
-   * 
+   *
    * A mapping maps the given data from or to _providedData (depending on whether it is a read or write mapping).
    *
    * @param[in] mappingContext Context of the mapping
@@ -138,7 +147,7 @@ public:
 protected:
   /**
    * @brief Construct a new DataContext without a mapping. Protected, because only ReadDataContext and WriteDataContext should use this constructor.
-   * 
+   *
    * @param data Data associated with this DataContext.
    * @param mesh Mesh associated with this DataContext.
    */
@@ -158,7 +167,7 @@ protected:
 
   /**
    * @brief Helper to set _mappingContext, _fromData and _toData.
-   * 
+   *
    * @param mappingContext MappingContext this DataContext will be associated to.
    * @param fromData Data the mapping maps from.
    * @param toData Data the mapping maps to.

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -32,6 +32,13 @@ public:
   mesh::PtrData providedData();
 
   /**
+   * @brief Get _toData member.
+   *
+   * @return mesh::PtrData _toData.
+   */
+  mesh::PtrData toData();
+
+  /**
    * @brief Get the Name of _providedData.
    *
    * @return std::string Name of _providedData.

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -139,13 +139,6 @@ private:
   static logging::Logger _log;
 
   /**
-   * @brief Get the ID of _providedData.
-   *
-   * @return int ID of _providedData.
-   */
-  int getProvidedDataID() const;
-
-  /**
    * @brief Get the ID of _fromData. Used for performing the mapping outside of this class.
    *
    * @return int ID of _fromData.
@@ -158,23 +151,6 @@ private:
    * @return int ID of _toData.
    */
   int getToDataID() const;
-
-  /**
-   * @brief Purpose unclear. See also https://github.com/precice/precice/issues/1156.
-   */
-  void resetProvidedData();
-
-  /**
-   * @brief Resets _toData to zero. Used before mapping is performed.
-   */
-  void resetToData();
-
-  /**
-   * @brief Get the _mappingContext associated with this DataContext.
-   *
-   * @return const MappingContext The _mappingContext of this DataContext.
-   */
-  const MappingContext mappingContext() const;
 
   /**
    * @brief Informs the user whether this DataContext has a _mappingContext.

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -39,35 +39,9 @@ public:
   std::string getDataName() const;
 
   /**
-   * @brief Get the ID of _providedData.
-   *
-   * @return int ID of _providedData.
+   * @brief Resets provided data and (if mapping exists) fromData or toData.
    */
-  int getProvidedDataID() const;
-
-  /**
-   * @brief Get the ID of _fromData. Used for performing the mapping outside of this class.
-   *
-   * @return int ID of _fromData.
-   */
-  int getFromDataID() const;
-
-  /**
-   * @brief Purpose unclear. See also https://github.com/precice/precice/issues/1156.
-   */
-  void resetProvidedData();
-
-  /**
-   * @brief Resets _toData to zero. Used before mapping is performed.
-   */
-  void resetToData();
-
-  /**
-   * @brief Get the ID of _toData. Used for performing the mapping outside of this class.
-   *
-   * @return int ID of _toData.
-   */
-  int getToDataID() const;
+  void resetData();
 
   /**
    * @brief Get the dimensions of _providedData.
@@ -91,13 +65,6 @@ public:
   int getMeshID() const;
 
   /**
-   * @brief Informs the user whether this DataContext has a _mappingContext.
-   *
-   * @return True, if this DataContext is associated with a mapping. False, if not.
-   */
-  bool hasMapping() const;
-
-  /**
    * @brief Check whether mapping has to be performed.
    *
    * Checks whether a mapping exists for this context and the timing configuration.
@@ -110,27 +77,6 @@ public:
    * @brief Perform mapping using mapping context of this data context and from and to data
    */
   void mapData();
-
-  /**
-   * @brief Get the _mappingContext associated with this DataContext.
-   *
-   * @return const MappingContext The _mappingContext of this DataContext.
-   */
-  const MappingContext mappingContext() const;
-
-  /**
-   * @brief Informs the user whether this DataContext has a read mapping.
-   *
-   * @return True, if DataContext has a read mapping.
-   */
-  bool hasReadMapping() const;
-
-  /**
-   * @brief Informs the user whether this DataContext has a write mapping.
-   *
-   * @return True, if DataContext has a write mapping.
-   */
-  bool hasWriteMapping() const;
 
   /**
    * @brief Links a MappingContext and the MeshContext required by the mapping to this DataContext.
@@ -172,11 +118,70 @@ protected:
    */
   void setMapping(MappingContext mappingContext, mesh::PtrData fromData, mesh::PtrData toData);
 
+  /**
+   * @brief Informs the user whether this DataContext has a read mapping.
+   *
+   * @return True, if DataContext has a read mapping.
+   */
+  bool hasReadMapping() const;
+
+  /**
+   * @brief Informs the user whether this DataContext has a write mapping.
+   *
+   * @return True, if DataContext has a write mapping.
+   */
+  bool hasWriteMapping() const;
+
 private:
   /// Mesh associated with _providedData.
   mesh::PtrMesh _mesh;
 
   static logging::Logger _log;
+
+  /**
+   * @brief Get the ID of _providedData.
+   *
+   * @return int ID of _providedData.
+   */
+  int getProvidedDataID() const;
+
+  /**
+   * @brief Get the ID of _fromData. Used for performing the mapping outside of this class.
+   *
+   * @return int ID of _fromData.
+   */
+  int getFromDataID() const;
+
+  /**
+   * @brief Get the ID of _toData. Used for performing the mapping outside of this class.
+   *
+   * @return int ID of _toData.
+   */
+  int getToDataID() const;
+
+  /**
+   * @brief Purpose unclear. See also https://github.com/precice/precice/issues/1156.
+   */
+  void resetProvidedData();
+
+  /**
+   * @brief Resets _toData to zero. Used before mapping is performed.
+   */
+  void resetToData();
+
+  /**
+   * @brief Get the _mappingContext associated with this DataContext.
+   *
+   * @return const MappingContext The _mappingContext of this DataContext.
+   */
+  const MappingContext mappingContext() const;
+
+  /**
+   * @brief Informs the user whether this DataContext has a _mappingContext.
+   *
+   * @return True, if this DataContext is associated with a mapping. False, if not.
+   */
+  bool hasMapping() const;
 };
 
 } // namespace impl

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -32,13 +32,6 @@ public:
   mesh::PtrData providedData();
 
   /**
-   * @brief Get _toData member.
-   *
-   * @return mesh::PtrData _toData.
-   */
-  mesh::PtrData toData();
-
-  /**
    * @brief Get the Name of _providedData.
    *
    * @return std::string Name of _providedData.

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -107,6 +107,11 @@ public:
   bool isMappingRequired();
 
   /**
+   * @brief Perform mapping using mapping context of this data context and from and to data
+   */
+  void mapData();
+
+  /**
    * @brief Get the _mappingContext associated with this DataContext.
    *
    * @return const MappingContext The _mappingContext of this DataContext.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1009,7 +1009,7 @@ void SolverInterfaceImpl::mapWriteDataFrom(
       }
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
       PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
-      mapData(context);
+      context.mapData();
     }
     mappingContext.hasMappedData = true;
   }
@@ -1041,7 +1041,7 @@ void SolverInterfaceImpl::mapReadDataTo(
       }
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
       PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
-      mapData(context);
+      context.mapData();
     }
     mappingContext.hasMappedData = true;
   }
@@ -1560,18 +1560,9 @@ void SolverInterfaceImpl::computeMappings(const utils::ptr_vector<MappingContext
     if (mapNow && not hasComputed) {
       PRECICE_INFO("Compute \"{}\" mapping from mesh \"{}\" to mesh \"{}\".",
                    mappingType, _accessor->meshContext(context.fromMeshID).mesh->getName(), _accessor->meshContext(context.toMeshID).mesh->getName());
-
       context.mapping->computeMapping();
     }
   }
-}
-
-void SolverInterfaceImpl::mapData(DataContext &context)
-{
-  int fromDataID = context.getFromDataID();
-  int toDataID   = context.getToDataID();
-  context.resetToData();
-  context.mappingContext().mapping->map(fromDataID, toDataID);
 }
 
 void SolverInterfaceImpl::clearMappings(utils::ptr_vector<MappingContext> contexts)
@@ -1595,7 +1586,7 @@ void SolverInterfaceImpl::mapWrittenData()
   for (auto &context : _accessor->writeDataContexts()) {
     if (context.isMappingRequired()) {
       PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
-      mapData(context);
+      context.mapData();
     }
   }
   clearMappings(_accessor->writeMappingContexts());
@@ -1608,7 +1599,7 @@ void SolverInterfaceImpl::mapReadData()
   for (auto &context : _accessor->readDataContexts()) {
     if (context.isMappingRequired()) {
       PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
-      mapData(context);
+      context.mapData();
     }
   }
   clearMappings(_accessor->readMappingContexts());

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1587,33 +1587,12 @@ void SolverInterfaceImpl::clearMappings(utils::ptr_vector<MappingContext> contex
   }
 }
 
-bool SolverInterfaceImpl::isMappingRequired(DataContext &context)
-{
-  using namespace mapping;
-  MappingConfiguration::Timing timing;
-
-  if (not context.hasMapping()) {
-    return false;
-  }
-
-  timing         = context.mappingContext().timing;
-  bool hasMapped = context.mappingContext().hasMappedData;
-  bool mapNow    = timing == MappingConfiguration::ON_ADVANCE;
-  mapNow |= timing == MappingConfiguration::INITIAL;
-
-  if ((not mapNow) || hasMapped) {
-    return false;
-  }
-
-  return true;
-}
-
 void SolverInterfaceImpl::mapWrittenData()
 {
   PRECICE_TRACE();
   computeMappings(_accessor->writeMappingContexts(), "write");
   for (auto &context : _accessor->writeDataContexts()) {
-    if (isMappingRequired(context)) {
+    if (context.isMappingRequired()) {
       mapData(context, "write");
     }
   }
@@ -1625,7 +1604,7 @@ void SolverInterfaceImpl::mapReadData()
   PRECICE_TRACE();
   computeMappings(_accessor->readMappingContexts(), "read");
   for (auto &context : _accessor->readDataContexts()) {
-    if (isMappingRequired(context)) {
+    if (context.isMappingRequired()) {
       mapData(context, "read");
     }
   }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1007,6 +1007,7 @@ void SolverInterfaceImpl::mapWriteDataFrom(
       if (context.getMeshID() != fromMeshID) {
         continue;
       }
+      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
       mapData(context, "write");
     }
     mappingContext.hasMappedData = true;
@@ -1037,6 +1038,7 @@ void SolverInterfaceImpl::mapReadDataTo(
       if (context.getMeshID() != toMeshID) {
         continue;
       }
+      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
       mapData(context, "read");
     }
     mappingContext.hasMappedData = true;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1585,7 +1585,6 @@ void SolverInterfaceImpl::mapWrittenData()
     if (context.isMappingRequired()) {
       PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
       context.mapData();
-      PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, context.toData()->values())); // @todo might be better to move this debug message into Mapping::map and remove getter DataContext::toData()
     }
   }
   clearMappings(_accessor->writeMappingContexts());
@@ -1599,7 +1598,6 @@ void SolverInterfaceImpl::mapReadData()
     if (context.isMappingRequired()) {
       PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
       context.mapData();
-      PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, context.toData()->values())); // @todo might be better to move this debug message into Mapping::map and remove getter DataContext::toData()
     }
   }
   clearMappings(_accessor->readMappingContexts());

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1008,7 +1008,8 @@ void SolverInterfaceImpl::mapWriteDataFrom(
         continue;
       }
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
-      mapData(context, "write");
+      PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
+      mapData(context);
     }
     mappingContext.hasMappedData = true;
   }
@@ -1039,7 +1040,8 @@ void SolverInterfaceImpl::mapReadDataTo(
         continue;
       }
       PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
-      mapData(context, "read");
+      PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
+      mapData(context);
     }
     mappingContext.hasMappedData = true;
   }
@@ -1564,14 +1566,11 @@ void SolverInterfaceImpl::computeMappings(const utils::ptr_vector<MappingContext
   }
 }
 
-void SolverInterfaceImpl::mapData(DataContext &context, const std::string &mappingType)
+void SolverInterfaceImpl::mapData(DataContext &context)
 {
   int fromDataID = context.getFromDataID();
   int toDataID   = context.getToDataID();
-  PRECICE_DEBUG("Map \"{}\" data \"{}\" from mesh \"{}\"",
-                mappingType, context.getDataName(), context.getMeshName());
   context.resetToData();
-  PRECICE_DEBUG("Map from dataID {} to dataID: {}", fromDataID, toDataID);
   context.mappingContext().mapping->map(fromDataID, toDataID);
 }
 
@@ -1595,7 +1594,8 @@ void SolverInterfaceImpl::mapWrittenData()
   computeMappings(_accessor->writeMappingContexts(), "write");
   for (auto &context : _accessor->writeDataContexts()) {
     if (context.isMappingRequired()) {
-      mapData(context, "write");
+      PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
+      mapData(context);
     }
   }
   clearMappings(_accessor->writeMappingContexts());
@@ -1607,7 +1607,8 @@ void SolverInterfaceImpl::mapReadData()
   computeMappings(_accessor->readMappingContexts(), "read");
   for (auto &context : _accessor->readDataContexts()) {
     if (context.isMappingRequired()) {
-      mapData(context, "read");
+      PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
+      mapData(context);
     }
   }
   clearMappings(_accessor->readMappingContexts());

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1585,6 +1585,7 @@ void SolverInterfaceImpl::mapWrittenData()
     if (context.isMappingRequired()) {
       PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
       context.mapData();
+      PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, context.toData()->values())); // @todo might be better to move this debug message into Mapping::map and remove getter DataContext::toData()
     }
   }
   clearMappings(_accessor->writeMappingContexts());
@@ -1598,6 +1599,7 @@ void SolverInterfaceImpl::mapReadData()
     if (context.isMappingRequired()) {
       PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
       context.mapData();
+      PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, context.toData()->values())); // @todo might be better to move this debug message into Mapping::map and remove getter DataContext::toData()
     }
   }
   clearMappings(_accessor->readMappingContexts());

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1007,7 +1007,6 @@ void SolverInterfaceImpl::mapWriteDataFrom(
       if (context.getMeshID() != fromMeshID) {
         continue;
       }
-      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
       PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
       context.mapData();
     }
@@ -1039,7 +1038,6 @@ void SolverInterfaceImpl::mapReadDataTo(
       if (context.getMeshID() != toMeshID) {
         continue;
       }
-      PRECICE_ASSERT(mappingContext.mapping == context.mappingContext().mapping);
       PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
       context.mapData();
     }
@@ -1658,11 +1656,7 @@ void SolverInterfaceImpl::resetWrittenData()
 {
   PRECICE_TRACE();
   for (auto &context : _accessor->writeDataContexts()) {
-    context.resetProvidedData();
-    if (context.hasMapping()) {
-      PRECICE_ASSERT(context.hasWriteMapping());
-      context.resetToData();
-    }
+    context.resetData();
   }
 }
 

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -588,9 +588,6 @@ private:
   void computeMappings(const utils::ptr_vector<MappingContext> &contexts, const std::string &mappingType);
 
   /// Helper for mapWrittenData and mapReadData
-  void mapData(DataContext &context);
-
-  /// Helper for mapWrittenData and mapReadData
   void clearMappings(utils::ptr_vector<MappingContext> contexts);
 
   /// Computes, performs, and resets all suitable write mappings.

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -593,6 +593,16 @@ private:
   /// Helper for mapWrittenData and mapReadData
   void clearMappings(utils::ptr_vector<MappingContext> contexts);
 
+  // @todo move into DataContext?
+  /**
+   * @brief Check whether mapping has to be performed.
+   *
+   * Checks whether a mapping exists for this context and the timing configuration.
+   *
+   * @return True, if a mapping has to be performed.
+   */
+  bool isMappingRequired(DataContext &context);
+
   /// Computes, performs, and resets all suitable write mappings.
   void mapWrittenData();
 

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -593,16 +593,6 @@ private:
   /// Helper for mapWrittenData and mapReadData
   void clearMappings(utils::ptr_vector<MappingContext> contexts);
 
-  // @todo move into DataContext?
-  /**
-   * @brief Check whether mapping has to be performed.
-   *
-   * Checks whether a mapping exists for this context and the timing configuration.
-   *
-   * @return True, if a mapping has to be performed.
-   */
-  bool isMappingRequired(DataContext &context);
-
   /// Computes, performs, and resets all suitable write mappings.
   void mapWrittenData();
 

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -588,7 +588,7 @@ private:
   void computeMappings(const utils::ptr_vector<MappingContext> &contexts, const std::string &mappingType);
 
   /// Helper for mapWrittenData and mapReadData
-  void mapData(DataContext &context, const std::string &mappingType);
+  void mapData(DataContext &context);
 
   /// Helper for mapWrittenData and mapReadData
   void clearMappings(utils::ptr_vector<MappingContext> contexts);

--- a/src/precice/tests/DataContextTest.cpp
+++ b/src/precice/tests/DataContextTest.cpp
@@ -5,6 +5,7 @@
 #include "mesh/Vertex.hpp"
 #include "precice/impl/ReadDataContext.hpp"
 #include "precice/impl/WriteDataContext.hpp"
+#include "testing/DataContextFixture.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 
@@ -18,6 +19,8 @@ BOOST_AUTO_TEST_SUITE(DataContextTests)
 BOOST_AUTO_TEST_CASE(testDataContextWriteMapping)
 {
   PRECICE_TEST(1_rank);
+
+  testing::DataContextFixture fixture;
 
   // Create mesh object for from mesh
   int           dimensions  = 3;
@@ -48,32 +51,34 @@ BOOST_AUTO_TEST_CASE(testDataContextWriteMapping)
   BOOST_TEST(ptrToData->getID() != ptrFromData->getID());
   BOOST_TEST(ptrToMesh->getID() != ptrFromMesh->getID());
 
-  BOOST_TEST(!dataContext.hasMapping());
-  BOOST_TEST(dataContext.getProvidedDataID() == ptrFromData->getID());
+  BOOST_TEST(!fixture.hasMapping(dataContext));
+  BOOST_TEST(fixture.getProvidedDataID(dataContext) == ptrFromData->getID());
   BOOST_TEST(dataContext.getMeshID() == ptrFromMesh->getID());
 
   dataContext.configureMapping(mappingContext, toMeshContext);
 
   // mapping is configured. Write mapping, therefore _providedData == _fromData
-  BOOST_TEST(dataContext.hasMapping());
-  BOOST_TEST(dataContext.getFromDataID() == ptrFromData->getID());
-  BOOST_TEST(dataContext.getToDataID() == ptrToData->getID());
-  BOOST_TEST(dataContext.getProvidedDataID() != ptrToData->getID());
-  BOOST_TEST(dataContext.getProvidedDataID() == ptrFromData->getID());
+  BOOST_TEST(fixture.hasMapping(dataContext));
+  BOOST_TEST(fixture.getFromDataID(dataContext) == ptrFromData->getID());
+  BOOST_TEST(fixture.getToDataID(dataContext) == ptrToData->getID());
+  BOOST_TEST(fixture.getProvidedDataID(dataContext) != ptrToData->getID());
+  BOOST_TEST(fixture.getProvidedDataID(dataContext) == ptrFromData->getID());
   BOOST_TEST(dataContext.getMeshID() != ptrToMesh->getID());
   BOOST_TEST(dataContext.getMeshID() == ptrFromMesh->getID());
-  BOOST_TEST(dataContext.hasWriteMapping());
-  BOOST_TEST(!dataContext.hasReadMapping());
-  BOOST_TEST(dataContext.mappingContext().fromMeshID == mappingContext.fromMeshID);
-  BOOST_TEST(dataContext.mappingContext().toMeshID == mappingContext.toMeshID);
-  BOOST_TEST(dataContext.mappingContext().hasMappedData == mappingContext.hasMappedData);
-  BOOST_TEST(dataContext.mappingContext().mapping == mappingContext.mapping);
-  BOOST_TEST(dataContext.mappingContext().timing == mappingContext.timing);
+  BOOST_TEST(fixture.hasWriteMapping(dataContext));
+  BOOST_TEST(!fixture.hasReadMapping(dataContext));
+  BOOST_TEST(fixture.mappingContext(dataContext).fromMeshID == mappingContext.fromMeshID);
+  BOOST_TEST(fixture.mappingContext(dataContext).toMeshID == mappingContext.toMeshID);
+  BOOST_TEST(fixture.mappingContext(dataContext).hasMappedData == mappingContext.hasMappedData);
+  BOOST_TEST(fixture.mappingContext(dataContext).mapping == mappingContext.mapping);
+  BOOST_TEST(fixture.mappingContext(dataContext).timing == mappingContext.timing);
 }
 
 BOOST_AUTO_TEST_CASE(testDataContextReadMapping)
 {
   PRECICE_TEST(1_rank);
+
+  testing::DataContextFixture fixture;
 
   // Create mesh object
   int           dimensions = 3;
@@ -104,27 +109,27 @@ BOOST_AUTO_TEST_CASE(testDataContextReadMapping)
   BOOST_TEST(ptrToData->getID() != ptrFromData->getID());
   BOOST_TEST(ptrToMesh->getID() != ptrFromMesh->getID());
 
-  BOOST_TEST(!dataContext.hasMapping());
-  BOOST_TEST(dataContext.getProvidedDataID() == ptrToData->getID());
+  BOOST_TEST(!fixture.hasMapping(dataContext));
+  BOOST_TEST(fixture.getProvidedDataID(dataContext) == ptrToData->getID());
   BOOST_TEST(dataContext.getMeshID() == ptrToMesh->getID());
 
   dataContext.configureMapping(mappingContext, fromMeshContext);
 
   // mapping is configured. Write mapping, therefore _providedData == _toData
-  BOOST_TEST(dataContext.hasMapping());
-  BOOST_TEST(dataContext.getFromDataID() == ptrFromData->getID());
-  BOOST_TEST(dataContext.getToDataID() == ptrToData->getID());
-  BOOST_TEST(dataContext.getProvidedDataID() == ptrToData->getID());
-  BOOST_TEST(dataContext.getProvidedDataID() != ptrFromData->getID());
+  BOOST_TEST(fixture.hasMapping(dataContext));
+  BOOST_TEST(fixture.getFromDataID(dataContext) == ptrFromData->getID());
+  BOOST_TEST(fixture.getToDataID(dataContext) == ptrToData->getID());
+  BOOST_TEST(fixture.getProvidedDataID(dataContext) == ptrToData->getID());
+  BOOST_TEST(fixture.getProvidedDataID(dataContext) != ptrFromData->getID());
   BOOST_TEST(dataContext.getMeshID() == ptrToMesh->getID());
   BOOST_TEST(dataContext.getMeshID() != ptrFromMesh->getID());
-  BOOST_TEST(!dataContext.hasWriteMapping());
-  BOOST_TEST(dataContext.hasReadMapping());
-  BOOST_TEST(dataContext.mappingContext().fromMeshID == mappingContext.fromMeshID);
-  BOOST_TEST(dataContext.mappingContext().toMeshID == mappingContext.toMeshID);
-  BOOST_TEST(dataContext.mappingContext().hasMappedData == mappingContext.hasMappedData);
-  BOOST_TEST(dataContext.mappingContext().mapping == mappingContext.mapping);
-  BOOST_TEST(dataContext.mappingContext().timing == mappingContext.timing);
+  BOOST_TEST(!fixture.hasWriteMapping(dataContext));
+  BOOST_TEST(fixture.hasReadMapping(dataContext));
+  BOOST_TEST(fixture.mappingContext(dataContext).fromMeshID == mappingContext.fromMeshID);
+  BOOST_TEST(fixture.mappingContext(dataContext).toMeshID == mappingContext.toMeshID);
+  BOOST_TEST(fixture.mappingContext(dataContext).hasMappedData == mappingContext.hasMappedData);
+  BOOST_TEST(fixture.mappingContext(dataContext).mapping == mappingContext.mapping);
+  BOOST_TEST(fixture.mappingContext(dataContext).timing == mappingContext.timing);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/testing/DataContextFixture.cpp
+++ b/src/testing/DataContextFixture.cpp
@@ -5,12 +5,12 @@ namespace testing {
 
 impl::MappingContext DataContextFixture::mappingContext(precice::impl::DataContext &dataContext)
 {
-  return dataContext.mappingContext();
+  return dataContext._mappingContext;
 }
 
 int DataContextFixture::getProvidedDataID(precice::impl::DataContext &dataContext)
 {
-  return dataContext.getProvidedDataID();
+  return dataContext._providedData->getID();
 }
 
 int DataContextFixture::getFromDataID(precice::impl::DataContext &dataContext)
@@ -20,7 +20,7 @@ int DataContextFixture::getFromDataID(precice::impl::DataContext &dataContext)
 
 int DataContextFixture::getToDataID(precice::impl::DataContext &dataContext)
 {
-    return dataContext.getToDataID();
+  return dataContext.getToDataID();
 }
 
 bool DataContextFixture::hasMapping(precice::impl::DataContext &dataContext)

--- a/src/testing/DataContextFixture.cpp
+++ b/src/testing/DataContextFixture.cpp
@@ -1,0 +1,42 @@
+#include "testing/DataContextFixture.hpp"
+
+namespace precice {
+namespace testing {
+
+impl::MappingContext DataContextFixture::mappingContext(precice::impl::DataContext &dataContext)
+{
+  return dataContext.mappingContext();
+}
+
+int DataContextFixture::getProvidedDataID(precice::impl::DataContext &dataContext)
+{
+  return dataContext.getProvidedDataID();
+}
+
+int DataContextFixture::getFromDataID(precice::impl::DataContext &dataContext)
+{
+  return dataContext.getFromDataID();
+}
+
+int DataContextFixture::getToDataID(precice::impl::DataContext &dataContext)
+{
+    return dataContext.getToDataID();
+}
+
+bool DataContextFixture::hasMapping(precice::impl::DataContext &dataContext)
+{
+  return dataContext.hasMapping();
+}
+
+bool DataContextFixture::hasReadMapping(precice::impl::DataContext &dataContext)
+{
+  return dataContext.hasReadMapping();
+}
+
+bool DataContextFixture::hasWriteMapping(precice::impl::DataContext &dataContext)
+{
+  return dataContext.hasWriteMapping();
+}
+
+} // namespace testing
+} // namespace precice

--- a/src/testing/DataContextFixture.hpp
+++ b/src/testing/DataContextFixture.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "precice/impl/DataContext.hpp"
+#include "precice/impl/MappingContext.hpp"
+
+namespace precice {
+namespace testing {
+/*
+ * @brief A fixture that is used to access private functions of the DataContext class.
+ *
+ * The fixture can be used to call private functions for individual testing.
+ */
+class DataContextFixture {
+public:
+  impl::MappingContext mappingContext(precice::impl::DataContext &dataContext);
+
+  int getProvidedDataID(precice::impl::DataContext &dataContext);
+
+  int getFromDataID(precice::impl::DataContext &dataContext);
+
+  int getToDataID(precice::impl::DataContext &dataContext);
+
+  bool hasMapping(precice::impl::DataContext &dataContext);
+
+  bool hasReadMapping(precice::impl::DataContext &dataContext);
+
+  bool hasWriteMapping(precice::impl::DataContext &dataContext);
+};
+
+} // namespace testing
+} // namespace precice

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -66,6 +66,8 @@ target_sources(testprecice
     src/precice/tests/WatchPointTest.cpp
     src/query/tests/RTreeAdapterTests.cpp
     src/query/tests/RTreeTests.cpp
+    src/testing/DataContextFixture.cpp
+    src/testing/DataContextFixture.hpp
     src/testing/ExtrapolationFixture.cpp
     src/testing/ExtrapolationFixture.hpp
     src/testing/GlobalFixtures.cpp


### PR DESCRIPTION
## Main changes of this PR

Creates function `isMappingRequired` and uses `mapData` everywhere, where mapping is performed.

## Motivation and additional information

Branched off from #1187 

## Author's checklist

* [x] Move `isMappingRequired` into `DataContext`?
* [x] Move `mapData` into `DataContext`?
* [x] Move most of the implementation of `SolverInterfaceImpl::resetWrittenData` into `DataContext`?
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
