### PR TITLE
Add Quicktest for simpler integration tests

### DIFF
--- a/src/testing/QuickTest.hpp
+++ b/src/testing/QuickTest.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <boost/test/unit_test.hpp>
+#include <cmath>
+#include <precice/SolverInterface.hpp>
+#include <string>
+#include <vector>
+
+namespace precice {
+namespace testing {
+
+struct QuickTest {
+
+  /// Represents named data and its type
+  struct Data {
+    std::string name;
+    bool        vectorial;
+  };
+
+  /// Creates quicktest based on one mesh
+  QuickTest(SolverInterface &si, const std::string &mesh)
+      : interface(&si), dims(si.getDimensions()), meshID(si.getMeshID(mesh))
+  {
+  }
+
+  /** Sets mesh vertices based on the given coordinates while saving ids for later access.
+   *
+   * Will automatically deduce the amount of vertices to set.
+   *
+   * @see precice::SolverInterface::setMeshVertices()
+   */
+  QuickTest &setVertices(const std::vector<double> &pos)
+  {
+    int n = static_cast<int>(pos.size()) / dims;
+    BOOST_REQUIRE(n > 0);
+    vertexIDs.resize(n, -1);
+    interface->setMeshVertices(meshID, n, pos.data(), vertexIDs.data());
+    BOOST_REQUIRE(std::count(vertexIDs.begin(), vertexIDs.end(), -1) == 0);
+    return *this;
+  }
+
+  /** Wrapper around initialize() ignoring the return dt.
+   *
+   * @see precice::SolverInterface::initialize()
+   */
+  QuickTest &initialize()
+  {
+    interface->initialize();
+    return *this;
+  }
+
+  /** Wrapper around finalize.
+   *
+   * @see precice::SolverInterface::finalize()
+   */
+  void finalize()
+  {
+    interface->finalize();
+  }
+
+  /** Wrapper around advance(dt) ignoring the return dt.
+   *
+   * @see precice::SolverInterface::advance()
+   */
+  QuickTest &advance(double dt = 1.0)
+  {
+    interface->advance(dt);
+    return *this;
+  }
+
+  /// Initializes data
+  QuickTest &initializeData()
+  {
+    auto action = precice::constants::actionWriteInitialData();
+    if (interface->isActionRequired(action)) {
+      interface->markActionFulfilled(action);
+    }
+    interface->initializeData();
+    return *this;
+  }
+
+  /// Writes the data to vertices defined in \ref setVertices()
+  QuickTest &write(Data d, const std::vector<double> &data)
+  {
+    auto dataID = interface->getDataID(d.name, meshID);
+    if (d.vectorial) {
+      auto n = data.size() / dims;
+      interface->writeBlockVectorData(dataID, n, vertexIDs.data(), data.data());
+    } else {
+      interface->writeBlockScalarData(dataID, data.size(), vertexIDs.data(), data.data());
+    }
+    return *this;
+  }
+
+  /// Reads the data from vertices defined in \ref setVertices() and returns a vector
+  QuickTest &read(Data d)
+  {
+    auto dataID = interface->getDataID(d.name, meshID);
+    auto n      = vertexIDs.size();
+
+    std::vector<double> result;
+    if (d.vectorial) {
+      result.resize(n * dims, -0.0);
+      interface->readBlockVectorData(dataID, n, vertexIDs.data(), result.data());
+    } else {
+      result.resize(n, -0.0);
+      interface->readBlockScalarData(dataID, n, vertexIDs.data(), result.data());
+    }
+    reads.push_back(std::move(result));
+    return *this;
+  }
+
+  std::vector<double> &last()
+  {
+    return reads.back();
+  }
+
+  SolverInterface *                interface;
+  int                              dims;
+  int                              meshID;
+  std::vector<int>                 vertexIDs;
+  std::vector<std::vector<double>> reads;
+};
+
+inline QuickTest::Data operator""_scalar(const char *name, std::size_t)
+{
+  return {name, false};
+}
+
+inline QuickTest::Data operator""_vector(const char *name, std::size_t)
+{
+  return {name, true};
+}
+
+} // namespace testing
+} // namespace precice

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <boost/test/tools/collection_comparison_op.hpp>
 #include <boost/test/unit_test.hpp>
 #include <limits>
 #include <string>
 #include <type_traits>
+
 #include "math/differences.hpp"
 #include "math/math.hpp"
 #include "testing/TestContext.hpp"

--- a/src/testing/tests/ExampleQuickTests.cpp
+++ b/src/testing/tests/ExampleQuickTests.cpp
@@ -1,0 +1,119 @@
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+
+BOOST_AUTO_TEST_SUITE(TestingTests) // Use name of the module, e.g. subdirectory below src/, suffixed with Tests
+
+BOOST_AUTO_TEST_SUITE(Examples) // If your file contains multiple tests, put them in a test suite
+
+BOOST_AUTO_TEST_SUITE(QuickTests)
+
+BOOST_AUTO_TEST_CASE(CheckAtTheEnd)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  using namespace precice::testing;
+  std::string config = getPathToRepository() + "/src/testing/tests/quicktest.xml";
+
+  // First initialize the SolverInterface as usual
+  precice::SolverInterface interface(context.name, config, context.rank, context.size);
+
+  if (context.isNamed("SolverOne")) {
+    // Create a quicktest instance for MeshOne
+    QuickTest qt{interface, "MeshOne"};
+    qt.setVertices({0.0, 0.0, 0.0,
+                    1.0, 0.0, 0.0})
+        .initialize()
+        .initializeData()
+        .read("DataTwo"_vector)
+        .write("DataOne"_scalar, {1, 2})
+        .advance()
+        .read("DataTwo"_vector)
+        .finalize();
+
+    auto expected0 = {1, 1, 1, 4, 4, 4};
+    auto expected1 = {0, 0, 0, 3, 3, 3};
+    BOOST_TEST(qt.reads.at(0) == expected0, boost::test_tools::per_element());
+    BOOST_TEST(qt.reads.at(1) == expected1, boost::test_tools::per_element());
+  } else {
+    //  Create a quicktest instance for MeshTwo
+    QuickTest qt{interface, "MeshTwo"};
+    qt.setVertices({0.0, 0.0, 0.0,
+                    0.33, 0.0, 0.0,
+                    0.66, 0.0, 0.0,
+                    1.0, 0.0, 0.0})
+        .initialize()
+        .write("DataTwo"_vector, {1, 1, 1,
+                                  2, 2, 2,
+                                  3, 3, 3,
+                                  4, 4, 4})
+        .initializeData()
+        .read("DataOne"_scalar)
+        .write("DataTwo"_vector, {0, 0, 0,
+                                  1, 1, 1,
+                                  2, 2, 2,
+                                  3, 3, 3})
+        .advance()
+        .finalize();
+
+    auto expected0 = {1, 1, 2, 2};
+    BOOST_TEST(qt.reads.at(0) == expected0, boost::test_tools::per_element());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(CheckAfterRead)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  using namespace precice::testing;
+  std::string config = getPathToRepository() + "/src/testing/tests/quicktest.xml";
+
+  // First initialize the SolverInterface as usual
+  precice::SolverInterface interface(context.name, config, context.rank, context.size);
+
+  if (context.isNamed("SolverOne")) {
+    // Create a quicktest instance for MeshOne
+    QuickTest qt{interface, "MeshOne"};
+    qt.setVertices({0.0, 0.0, 0.0,
+                    1.0, 0.0, 0.0})
+        .initialize()
+        .initializeData()
+        .read("DataTwo"_vector);
+
+    auto expected0 = {1, 1, 1, 4, 4, 4};
+    BOOST_TEST(qt.last() == expected0, boost::test_tools::per_element());
+
+    qt.write("DataOne"_scalar, {1, 2})
+        .advance()
+        .read("DataTwo"_vector);
+
+    auto expected1 = {0, 0, 0, 3, 3, 3};
+    BOOST_TEST(qt.last() == expected1, boost::test_tools::per_element());
+    qt.finalize();
+  } else {
+    //  Create a quicktest instance for MeshTwo
+    QuickTest qt{interface, "MeshTwo"};
+    qt.setVertices({0.0, 0.0, 0.0,
+                    0.33, 0.0, 0.0,
+                    0.66, 0.0, 0.0,
+                    1.0, 0.0, 0.0})
+        .initialize()
+        .write("DataTwo"_vector, {1, 1, 1,
+                                  2, 2, 2,
+                                  3, 3, 3,
+                                  4, 4, 4})
+        .initializeData()
+        .read("DataOne"_scalar);
+    auto expected0 = {1, 1, 2, 2};
+    BOOST_TEST(qt.last() == expected0, boost::test_tools::per_element());
+    qt.write("DataTwo"_vector, {0, 0, 0,
+                                1, 1, 1,
+                                2, 2, 2,
+                                3, 3, 3})
+        .advance()
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // QuickTests
+BOOST_AUTO_TEST_SUITE_END() // Examples
+BOOST_AUTO_TEST_SUITE_END() // TestingTests

--- a/src/testing/tests/quicktest.xml
+++ b/src/testing/tests/quicktest.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="DataOne" />
+    <data:vector name="DataTwo" />
+
+    <mesh name="MeshOne">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <write-data name="DataOne" mesh="MeshOne" />
+      <read-data name="DataTwo" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshTwo" provide="on" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="consistent" />
+      <write-data name="DataTwo" mesh="MeshTwo" />
+      <read-data name="DataOne" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="1" />
+      <time-window-size value="1.0" />
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -71,6 +71,7 @@ target_sources(testprecice
     src/testing/GlobalFixtures.cpp
     src/testing/ParallelCouplingSchemeFixture.cpp
     src/testing/ParallelCouplingSchemeFixture.hpp
+    src/testing/QuickTest.hpp
     src/testing/SerialCouplingSchemeFixture.cpp
     src/testing/SerialCouplingSchemeFixture.hpp
     src/testing/TestContext.cpp
@@ -78,6 +79,7 @@ target_sources(testprecice
     src/testing/Testing.cpp
     src/testing/Testing.hpp
     src/testing/main.cpp
+    src/testing/tests/ExampleQuickTests.cpp
     src/testing/tests/ExampleTests.cpp
     src/utils/tests/AlgorithmTest.cpp
     src/utils/tests/DimensionsTest.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds a helper class called QuickTest. It allows to quickly write simple integration tests using a single mesh per participant without having to handle vertex ids, storage etc.
`read()`s and `write()`s infer the sizes from the argument.
Reads will be saved in the `reads` vector for later inspection. You can also call `.last()` to inspect the latest read data, which is useful for checking data directly after `read()`s

Basic use-case:

1. Create a solverinterface as usual
   ```cpp
   SolverInterface interface{...};
   ```
2. Create a quicktest for a mesh
   ```cpp
   QuickTest qt{interface, "MeshOne"};
   ```
3. set your mesh and initialize
   ```cpp
   qt.setVertices({0.0, 0.0, 0.0,
                   1.0, 0.0, 0.0})
     .initialize();
   ```
4. read, write, advance as usual
   ```cpp
   qt.initializeData()
     .read("DataTwo"_vector)
     .write("DataOne"_scalar, {1, 2})
     .advance()
     .read("DataTwo"_vector)
     .finalize();
   ```
5. test read data
   ```cpp
   auto expected0 = {1, 1, 1, 4, 4, 4};
   auto expected1 = {0, 0, 0, 3, 3, 3};
   BOOST_TEST(qt.reads.at(0) == expected0, boost::test_tools::per_element());
   BOOST_TEST(qt.reads.at(1) == expected1, boost::test_tools::per_element());
   ```

You can chain most calls of `QuickTest` (except `finalize()` for obvious reasons.)
```cpp
QuickTest qt{interface, "MeshTwo"};
qt.setVertices({0.0, 0.0, 0.0,
                0.33, 0.0, 0.0,
                0.66, 0.0, 0.0,
                1.0, 0.0, 0.0})
    .initialize()
    .write("DataTwo"_vector, {1, 1, 1,
                              2, 2, 2,
                              3, 3, 3,
                              4, 4, 4})
    .initializeData()
    .read("DataOne"_scalar)
    .write("DataTwo"_vector, {0, 0, 0,
                              1, 1, 1,
                              2, 2, 2,
                              3, 3, 3})
    .advance()
    .finalize();

auto expected0 = {1, 1, 2, 2};
BOOST_TEST(qt.reads.at(0) == expected0, boost::test_tools::per_element());
```


## Motivation and additional information

Reduce boilerplate to quickly write integration tests.

I implemented this to quickly test various scenarios with reinitialization. 

The data arguments could be names only if we had #1183 

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
