### PR TITLE
Add sticky boost test context

### DIFF
--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -38,7 +38,8 @@ using precice::testing::operator""_dataID;
   if (context.invalid) {                              \
     return;                                           \
   }                                                   \
-  BOOST_TEST_MESSAGE(context.describe());
+  BOOST_TEST_MESSAGE(context.describe());             \
+  boost::unit_test::framework::add_context(BOOST_TEST_LAZY_MSG(context.describe()), true);
 
 /// Boost.Test decorator that unconditionally deletes the test.
 class Deleted : public bt::decorator::base {


### PR DESCRIPTION
## Main changes of this PR

Adds a sticky context to boost test cases.
This adds a description of the test context to every check in the test making it easier to identify which rank of which test executed the check.

Example:
```
/.../main/src/testing/tests/ExampleTests.cpp(159): info: check context.hasSize(2) has passed
Assertion occurred in a following context:
    Test context represents "Solid" and runs on rank 1 out of 2.
```

## Motivation and additional information

This simplifies debugging a lot!

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
