### PR TITLE
WIP: Deprecate isReadDataAvailable and isWriteDataRequired

### DIFF
--- a/docs/changelog/1224.md
+++ b/docs/changelog/1224.md
@@ -1,0 +1,1 @@
+- Deprecated API functions `isReadDataAvailable()` and `isWriteDataRequired()` to simplify implementation of waveform iteration.

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -192,7 +192,7 @@ public:
   /**
    * @brief Checks if new data to be read is available.
    *
-   * @deprecated Unclear use case and conflicting with waveform relaxation feature.
+   * @deprecated Removed to simplify extension to waveform relaxation.
    *
    * @returns whether new data is available to be read.
    *

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -192,6 +192,8 @@ public:
   /**
    * @brief Checks if new data to be read is available.
    *
+   * @deprecated Unclear use case and conflicting with waveform relaxation feature.
+   *
    * @returns whether new data is available to be read.
    *
    * Data is classified to be new, if it has been received while calling
@@ -207,10 +209,12 @@ public:
    * This is not recommended due to performance reasons.
    * Use this function to prevent unnecessary reads.
    */
-  bool isReadDataAvailable() const;
+  [[deprecated("Will be removed in 3.0.0. See https://github.com/precice/precice/issues/1223 and comment, if you need this function.")]] bool isReadDataAvailable() const;
 
   /**
    * @brief Checks if new data has to be written before calling advance().
+   *
+   * @deprecated Unclear use case and conflicting with waveform relaxation feature.
    *
    * @param[in] computedTimestepLength Length of timestep used by the solver.
    *
@@ -227,7 +231,7 @@ public:
    * This is not recommended due to performance reasons.
    * Use this function to prevent unnecessary writes.
    */
-  bool isWriteDataRequired(double computedTimestepLength) const;
+  [[deprecated("Will be removed in 3.0.0. See https://github.com/precice/precice/issues/1223 and comment, if you need this function.")]] bool isWriteDataRequired(double computedTimestepLength) const;
 
   /**
    * @brief Checks if the current coupling window is completed.

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -214,7 +214,7 @@ public:
   /**
    * @brief Checks if new data has to be written before calling advance().
    *
-   * @deprecated Unclear use case and conflicting with waveform relaxation feature.
+   * @deprecated Removed to simplify extension to waveform relaxation.
    *
    * @param[in] computedTimestepLength Length of timestep used by the solver.
    *


### PR DESCRIPTION
## Main changes of this PR

See #1223. Marking functions as deprecated.

## Motivation and additional information

#1223 is still an open discussion. This PR is mainly a reminder that we don't forget to deprecate the functions, if we decide to remove them. This should happen latest one release before the breaking release. Otherwise deprecation is pointless.

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
