### PR TITLE
Improved edge barycentric coordinates computation

### DIFF
--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -25,17 +25,15 @@ Eigen::Vector2d calcBarycentricCoordsForEdge(
 
   Vector2d barycentricCoords;
   VectorXd ab, au;
-  double   lenAb, lenProjected;
 
-  // constant per edge
-  ab    = b - a;
-  lenAb = sqrt(ab.dot(ab));
+  // Let AB be the edge and U the input point. We compute the projection P of U on the edge.
+  // To find P, start from A and move from dot(AU, AB) / |AB| along the AB direction.
+  // Divide again by |AB| to find the barycentric coordinate of P relative to U
+  // This means we just need to compute dot(AU, AB) / dot(AB, AB)
+  ab = b - a;
+  au = u - a;
 
-  // varying per point
-  au           = u - a;
-  lenProjected = au.dot(ab / lenAb);
-
-  barycentricCoords(1) = lenProjected / lenAb;
+  barycentricCoords(1) = au.dot(ab) / ab.dot(ab);
   barycentricCoords(0) = 1 - barycentricCoords(1);
 
   return barycentricCoords;


### PR DESCRIPTION
## Main changes of this PR

To compute the projection P of a point U on the edge AB, we move around the AB direction (i.e. normalized AB vector) by a factor `dot(AB, AU) / |AB|`. Then the ratio between AP and AB is used to compute barycentric coordinates. That's a lot of division, and it can be simplified as "barycentricCoordinate(1) = dot(AB, AU)/dot(AB, AB)`. Previously, there were two divisions by `sqrt(dot(AB, AB))` which was not very efficient.

New code is shorter, simpler, and almost certainly  faster (one less division and one less square root).


## Motivation and additional information

I didn't do any profiling, but removing square roots when possible seems like a no-brainer if it doesn't harm readability of maintainability.
I don't think the old way was better in terms of numerical stability either.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
