### PR TITLE
Change macos runner to the one provided by GitHub

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }}
-    runs-on: [self-hosted, macOS]
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -32,7 +32,8 @@ jobs:
     steps:
     - name: Check out preCICE
       uses: actions/checkout@v3
-      ref: master
+      with:
+        ref: master
     - name: Install preCICE dependencies
       run: brew install cmake eigen libxml2 boost petsc openmpi python3 numpy
     - name: Generate build directory

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
     - name: Check out preCICE
       uses: actions/checkout@v3
-      with:
-        ref: master
     - name: Install preCICE dependencies
       run: brew install cmake eigen libxml2 boost petsc openmpi python3 numpy
     - name: Generate build directory

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
     - name: Check out preCICE
       uses: actions/checkout@v3
+      ref: master
     - name: Install preCICE dependencies
       run: brew install cmake eigen libxml2 boost petsc openmpi python3 numpy
     - name: Generate build directory

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -1,8 +1,18 @@
 name: Build and Test macOS
 on:
   push:
-    branches-ignore:
-      - '**'
+    branches:
+      - master
+      - develop
+  pull_request:
+    paths:
+      - 'cmake/**'
+      - 'examples/**'
+      - 'src/**'
+      - 'thirdparty/**'
+      - 'CMakeLists.txt'
+      - 'extras/bindings/**'
+      - '.github/workflows/build-and-test-mac.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -30,6 +30,10 @@ jobs:
             CXX: 'clang++'
             TYPE: Release
     steps:
+    - name: Check out preCICE
+      uses: actions/checkout@v3
+    - name: Install preCICE dependencies
+      run: brew install cmake eigen libxml2 boost petsc openmpi python3 numpy
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     name: ${{ format('{0} {1} {2}', matrix.CXX, matrix.CONFIG, matrix.TYPE) }}
-    runs-on: macos-11
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I am changing the macOS build and test action from our own runner (which was offline for a long time, so tests did not run), to the ones provided by GitHub. 
`macos-latest` points to the latest available runner. We could also hard-code `macos-11` or similar.

I am currently checking out the master branch, since develop gives a build problem.

```
[ 59%] Building CXX object CMakeFiles/testprecice.dir/src/testing/ParallelCouplingSchemeFixture.cpp.o
/Users/runner/work/precice/precice/src/testing/GlobalFixtures.cpp:40:10: error: expected expression
  return = bu::log_successful_tests;
```

@fsimonis Any idea what could be the problem here?

We should switch back to develop. I only checkout master here to show that it used to build.

Joint work with @ajaust 

