### PR TITLE
Cleanup integration tests

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -273,7 +273,7 @@ add_precice_test(
   )
 add_precice_test(
   NAME interface
-  ARGUMENTS "--run_test=PreciceTests:\!PreciceTests/Serial:\!PreciceTests/Parallel"
+  ARGUMENTS "--run_test=PreciceTests"
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   )
 add_precice_test(
@@ -297,19 +297,12 @@ add_precice_test(
   TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
   )
 
-# Remove the parallel suite once the migration to the new test structure is finished
-add_precice_test(
-  NAME parallel
-  ARGUMENTS "--run_test=PreciceTests/Parallel"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-  )
-
 # Register integration tests from tests/
 # These are defined in tests/tests.cmake
 foreach(testsuite IN LISTS PRECICE_TEST_SUITES)
   add_precice_test(
     NAME "integration.${testsuite}"
-    ARGUMENTS "--run_test=PreciceTests/${testsuite}"
+    ARGUMENTS "--run_test=Integration/${testsuite}"
     TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
     )
 endforeach()

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -32,14 +32,14 @@ struct MappingContext;
 } // namespace precice
 
 // Forward declaration to friend the boost test struct
-namespace PreciceTests {
+namespace Integration {
 namespace Serial {
 namespace Whitebox {
 struct TestConfigurationPeano;
 struct TestConfigurationComsol;
 } // namespace Whitebox
 } // namespace Serial
-} // namespace PreciceTests
+} // namespace Integration
 
 namespace precice {
 namespace utils {
@@ -332,8 +332,8 @@ private:
   void checkDuplicatedData(const mesh::PtrData &data, const std::string &meshName);
 
   /// To allow white box tests.
-  friend struct PreciceTests::Serial::Whitebox::TestConfigurationPeano;
-  friend struct PreciceTests::Serial::Whitebox::TestConfigurationComsol;
+  friend struct Integration::Serial::Whitebox::TestConfigurationPeano;
+  friend struct Integration::Serial::Whitebox::TestConfigurationComsol;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -26,14 +26,14 @@ class SolverInterfaceConfiguration;
 } // namespace precice
 
 // Forward declaration to friend the boost test struct
-namespace PreciceTests {
+namespace Integration {
 namespace Serial {
 namespace Whitebox {
 struct TestConfigurationPeano;
 struct TestConfigurationComsol;
 } // namespace Whitebox
 } // namespace Serial
-} // namespace PreciceTests
+} // namespace Integration
 
 namespace precice {
 namespace cplscheme {
@@ -637,8 +637,8 @@ private:
   void closeCommunicationChannels(CloseChannels cc);
 
   /// To allow white box tests.
-  friend struct PreciceTests::Serial::Whitebox::TestConfigurationPeano;
-  friend struct PreciceTests::Serial::Whitebox::TestConfigurationComsol;
+  friend struct Integration::Serial::Whitebox::TestConfigurationPeano;
+  friend struct Integration::Serial::Whitebox::TestConfigurationComsol;
 };
 
 } // namespace impl

--- a/tests/parallel/CouplingOnLine.cpp
+++ b/tests/parallel/CouplingOnLine.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 /// This testcase is based on a bug reported by Thorsten for acoustic FASTEST-Ateles coupling
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(CouplingOnLine)
 {
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/ExportTimeseries.cpp
+++ b/tests/parallel/ExportTimeseries.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(ExportTimeseries)
 {
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(ExportTimeseries)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/GlobalRBFPartitioning.cpp
+++ b/tests/parallel/GlobalRBFPartitioning.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning)
 {
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/LocalRBFPartitioning.cpp
+++ b/tests/parallel/LocalRBFPartitioning.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(LocalRBFPartitioning)
 {
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/MasterSockets.cpp
+++ b/tests/parallel/MasterSockets.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(MasterSockets)
 {
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(MasterSockets)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/NearestProjectionRePartitioning.cpp
+++ b/tests/parallel/NearestProjectionRePartitioning.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 /// This testcase is based on a bug documented in issue #371
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning)
 {
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(NearestProjectionRePartitioning)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/TestBoundingBoxInitialization.cpp
+++ b/tests/parallel/TestBoundingBoxInitialization.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(TestBoundingBoxInitialization)
 {
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitialization)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/TestBoundingBoxInitializationTwoWay.cpp
+++ b/tests/parallel/TestBoundingBoxInitializationTwoWay.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationTwoWay)
 {
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationTwoWay)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/TestFinalize.cpp
+++ b/tests/parallel/TestFinalize.cpp
@@ -6,7 +6,7 @@
 #include <precice/impl/SolverInterfaceImpl.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(TestFinalize)
 {
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(TestFinalize)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/UserDefinedMPICommunicator.cpp
+++ b/tests/parallel/UserDefinedMPICommunicator.cpp
@@ -12,9 +12,10 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator)
 {
   PRECICE_TEST("SolverOne"_on(3_ranks), "SolverTwo"_on(1_rank));
 
+  /// @todo simplify once #1191 is merged
   if (context.isNamed("SolverOne")) {
     MPI_Comm                 myComm = precice::utils::Parallel::current()->comm;
-    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size, &myComm);
     int                      meshID = interface.getMeshID("MeshOne");
 
     int    vertexIDs[2];
@@ -24,7 +25,8 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator)
     interface.initialize();
     interface.finalize();
   } else {
-    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    MPI_Comm                 myComm = precice::utils::Parallel::current()->comm;
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size, &myComm);
     int                      meshID = interface.getMeshID("MeshTwo");
     int                      vertexIDs[6];
     double                   positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};

--- a/tests/parallel/UserDefinedMPICommunicator.cpp
+++ b/tests/parallel/UserDefinedMPICommunicator.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 // Tests SolverInterface() with a user-defined MPI communicator.
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator)
 {
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_MPI

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.cpp
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.cpp
@@ -8,7 +8,7 @@
 
 // Tests SolverInterface() with a user-defined MPI communicator.
 // Since PETSc also uses MPI, we use petrbf mapping here.
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF)
 {
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 
 #endif // PRECICE_NO_PETSC

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
@@ -9,7 +9,7 @@
 // by another participant (see above). In addition to the direct mesh access
 // and data writing in one direction, an additional mapping (NN) is defined
 // in the other direction.
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshEmptyPartition)
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshEmptyPartition)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 0);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshEmptyPartitionTwoLevelInit)
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshEmptyPartitionTwoLevelInit)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 0);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshNoOverlap)
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshNoOverlap)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 0);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshNoOverlapTwoLevelInit)
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshNoOverlapTwoLevelInit)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 0);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlap)
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlap)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 0);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlapNoWrite)
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlapNoWrite)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 1);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlapNoWriteTwoLevelInit)
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlapNoWriteTwoLevelInit)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 1);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlapTwoLevelInit)
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlapTwoLevelInit)
   runTestAccessReceivedMesh(context, boundingBoxSlave, writeDataSlave, expectedPositionSlave, expectedReadDataSlave, 0);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
 

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.cpp
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DistributedCommunication)
 BOOST_AUTO_TEST_CASE(TestDistributedCommunicationGatherScatterMPI)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(TestDistributedCommunicationGatherScatterMPI)
   runTestDistributedCommunication(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DistributedCommunication
 

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.cpp
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DistributedCommunication)
 BOOST_AUTO_TEST_CASE(TestDistributedCommunicationP2PMPI)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(TestDistributedCommunicationP2PMPI)
   runTestDistributedCommunication(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DistributedCommunication
 

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.cpp
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DistributedCommunication)
 BOOST_AUTO_TEST_CASE(TestDistributedCommunicationP2PSockets)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(TestDistributedCommunicationP2PSockets)
   runTestDistributedCommunication(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // DistributedCommunication
 

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyMaster.cpp
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyMaster.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(GatherScatter)
 BOOST_AUTO_TEST_CASE(EnforceGatherScatterEmptyMaster)
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(EnforceGatherScatterEmptyMaster)
   runTestEnforceGatherScatter(std::vector<double>{}, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // GatherScatter
 

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedMaster.cpp
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedMaster.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(GatherScatter)
 BOOST_AUTO_TEST_CASE(EnforceGatherScatterEmptyReceivedMaster)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(EnforceGatherScatterEmptyReceivedMaster)
   runTestEnforceGatherScatter(std::vector<double>{0.0, 2.0, 0.0, 2.5}, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // GatherScatter
 

--- a/tests/parallel/lifecycle/ConstructAndExplicitFinalize.cpp
+++ b/tests/parallel/lifecycle/ConstructAndExplicitFinalize.cpp
@@ -7,7 +7,7 @@
 
 // Test representing the minimal lifecylce with explicit finalization.
 // This shows how to manually finalize MPI etc without using the SolverInterface.
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 BOOST_AUTO_TEST_CASE(ConstructAndExplicitFinalize)
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(ConstructAndExplicitFinalize)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 

--- a/tests/parallel/lifecycle/ConstructOnly.cpp
+++ b/tests/parallel/lifecycle/ConstructOnly.cpp
@@ -7,7 +7,7 @@
 
 // Test representing the minimal lifecylce, which consists out of construction only.
 // The destructor has to cleanup correctly.
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 BOOST_AUTO_TEST_CASE(ConstructOnly)
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(ConstructOnly)
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 

--- a/tests/parallel/lifecycle/Full.cpp
+++ b/tests/parallel/lifecycle/Full.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 // Test representing the full explicit lifecycle of a SolverInterface
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 BOOST_AUTO_TEST_CASE(Full)
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(Full)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 

--- a/tests/parallel/lifecycle/ImplicitFinalize.cpp
+++ b/tests/parallel/lifecycle/ImplicitFinalize.cpp
@@ -8,7 +8,7 @@
 // Test representing the full lifecycle of a SolverInterface
 // Finalize is not called explicitly here.
 // The destructor has to cleanup.
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 BOOST_AUTO_TEST_CASE(ImplicitFinalize)
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ImplicitFinalize)
   BOOST_TEST(interface.isCouplingOngoing());
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 

--- a/tests/parallel/quasi-newton/TestQN1.cpp
+++ b/tests/parallel/quasi-newton/TestQN1.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_CASE(TestQN1)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(TestQN1)
   runTestQN(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
 

--- a/tests/parallel/quasi-newton/TestQN1EmptyPartition.cpp
+++ b/tests/parallel/quasi-newton/TestQN1EmptyPartition.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_CASE(TestQN1EmptyPartition)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(TestQN1EmptyPartition)
   runTestQNEmptyPartition(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
 

--- a/tests/parallel/quasi-newton/TestQN2.cpp
+++ b/tests/parallel/quasi-newton/TestQN2.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_CASE(TestQN2)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(TestQN2)
   runTestQN(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
 

--- a/tests/parallel/quasi-newton/TestQN2EmptyPartition.cpp
+++ b/tests/parallel/quasi-newton/TestQN2EmptyPartition.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_CASE(TestQN2EmptyPartition)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(TestQN2EmptyPartition)
   runTestQNEmptyPartition(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
 

--- a/tests/parallel/quasi-newton/TestQN3.cpp
+++ b/tests/parallel/quasi-newton/TestQN3.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_CASE(TestQN3)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(TestQN3)
   runTestQN(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
 

--- a/tests/parallel/quasi-newton/TestQN3EmptyPartition.cpp
+++ b/tests/parallel/quasi-newton/TestQN3EmptyPartition.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_CASE(TestQN3EmptyPartition)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(TestQN3EmptyPartition)
   runTestQNEmptyPartition(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Parallel
 BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
 

--- a/tests/serial/AitkenAcceleration.cpp
+++ b/tests/serial/AitkenAcceleration.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_CASE(AitkenAcceleration)
 {
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/PreconditionerBug.cpp
+++ b/tests/serial/PreconditionerBug.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Test to reproduce the problem of issue 383, https://github.com/precice/precice/issues/383
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_CASE(PreconditionerBug)
 {
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(PreconditionerBug)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/SendMeshToMultipleParticipants.cpp
+++ b/tests/serial/SendMeshToMultipleParticipants.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Tests sending one mesh to multiple participants
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_CASE(SendMeshToMultipleParticipants)
 {
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(SendMeshToMultipleParticipants)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/SummationActionTwoSources.cpp
+++ b/tests/serial/SummationActionTwoSources.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
 {
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/TestBug.cpp
+++ b/tests/serial/TestBug.cpp
@@ -17,7 +17,7 @@
  *
  * @todo rename this test and config
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_CASE(TestBug)
 {
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(TestBug)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/TestExplicitWithDataMultipleReadWrite.cpp
+++ b/tests/serial/TestExplicitWithDataMultipleReadWrite.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 /**
  * @brief Tests the reading and writing of data multiple times within one timestep.
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataMultipleReadWrite)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/TestExplicitWithSolverGeometry.cpp
+++ b/tests/serial/TestExplicitWithSolverGeometry.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 /**
   * @brief Runs a coupled simulation where one solver supplies a geometry.
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithSolverGeometry)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/TestImplicit.cpp
+++ b/tests/serial/TestImplicit.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_CASE(TestImplicit)
 {
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(TestImplicit)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/access-received-mesh/Explicit.cpp
+++ b/tests/serial/access-received-mesh/Explicit.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(AccessReceivedMesh)
 // Test case for a direct mesh access on one participant to a mesh defined
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // AccessReceivedMesh
 

--- a/tests/serial/access-received-mesh/ExplicitAndMapping.cpp
+++ b/tests/serial/access-received-mesh/ExplicitAndMapping.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(AccessReceivedMesh)
 // Test case for a direct mesh access on one participant to a mesh defined
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // AccessReceivedMesh
 

--- a/tests/serial/access-received-mesh/ExplicitRead.cpp
+++ b/tests/serial/access-received-mesh/ExplicitRead.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(AccessReceivedMesh)
 // Test case for a direct mesh access on one participant to a mesh defined
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // AccessReceivedMesh
 

--- a/tests/serial/access-received-mesh/Implicit.cpp
+++ b/tests/serial/access-received-mesh/Implicit.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(AccessReceivedMesh)
 // Test case for a direct mesh access on one participant to a mesh defined
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // AccessReceivedMesh
 

--- a/tests/serial/action-timings/ActionTimingsExplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsExplicit.cpp
@@ -9,7 +9,7 @@
 /**
  * @brief Test to make sure that actions are called in the right order for explicit coupling via RecorderAction
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ActionTimings)
 BOOST_AUTO_TEST_CASE(ActionTimingsExplicit)
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ActionTimingsExplicit)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ActionTimings
 

--- a/tests/serial/action-timings/ActionTimingsImplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsImplicit.cpp
@@ -10,7 +10,7 @@
 /**
  * @brief Test to make sure that actions are called in the right order for implicit coupling via RecorderAction
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ActionTimings)
 BOOST_AUTO_TEST_CASE(ActionTimingsImplicit)
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(ActionTimingsImplicit)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ActionTimings
 

--- a/tests/serial/convergence-measures/testConvergenceMeasures1.cpp
+++ b/tests/serial/convergence-measures/testConvergenceMeasures1.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ConvergenceMeasures)
 BOOST_AUTO_TEST_CASE(testConvergenceMeasures1)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(testConvergenceMeasures1)
   testConvergenceMeasures(context.config(), context, expectedIterations);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ConvergenceMeasures
 

--- a/tests/serial/convergence-measures/testConvergenceMeasures2.cpp
+++ b/tests/serial/convergence-measures/testConvergenceMeasures2.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ConvergenceMeasures)
 BOOST_AUTO_TEST_CASE(testConvergenceMeasures2)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(testConvergenceMeasures2)
   testConvergenceMeasures(context.config(), context, expectedIterations);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ConvergenceMeasures
 

--- a/tests/serial/convergence-measures/testConvergenceMeasures3.cpp
+++ b/tests/serial/convergence-measures/testConvergenceMeasures3.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ConvergenceMeasures)
 BOOST_AUTO_TEST_CASE(testConvergenceMeasures3)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(testConvergenceMeasures3)
   testConvergenceMeasures(context.config(), context, expectedIterations);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ConvergenceMeasures
 

--- a/tests/serial/explicit/TestExplicitMPI.cpp
+++ b/tests/serial/explicit/TestExplicitMPI.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Explicit)
 BOOST_AUTO_TEST_CASE(TestExplicitMPI)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitMPI)
   runTestExplicit(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Explicit
 

--- a/tests/serial/explicit/TestExplicitMPISingle.cpp
+++ b/tests/serial/explicit/TestExplicitMPISingle.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Explicit)
 BOOST_AUTO_TEST_CASE(TestExplicitMPISingle)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitMPISingle)
   runTestExplicit(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Explicit
 

--- a/tests/serial/explicit/TestExplicitSockets.cpp
+++ b/tests/serial/explicit/TestExplicitSockets.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Explicit)
 BOOST_AUTO_TEST_CASE(TestExplicitSockets)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitSockets)
   runTestExplicit(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Explicit
 

--- a/tests/serial/initialize-data/Explicit.cpp
+++ b/tests/serial/initialize-data/Explicit.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(InitializeData)
 
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // InitializeData
 

--- a/tests/serial/initialize-data/Implicit.cpp
+++ b/tests/serial/initialize-data/Implicit.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(InitializeData)
 /**
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
   couplingInterface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // InitializeData
 

--- a/tests/serial/initialize-data/ReadMapping.cpp
+++ b/tests/serial/initialize-data/ReadMapping.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(InitializeData)
 
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(ReadMapping)
   testDataInitialization(context, context.config());
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // InitializeData
 

--- a/tests/serial/initialize-data/WriteMapping.cpp
+++ b/tests/serial/initialize-data/WriteMapping.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(InitializeData)
 
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(WriteMapping)
   testDataInitialization(context, context.config());
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // InitializeData
 

--- a/tests/serial/lifecycle/ConstructAndExplicitFinalize.cpp
+++ b/tests/serial/lifecycle/ConstructAndExplicitFinalize.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 // Test representing the minimal lifecylce with explicit finalization.
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(ConstructAndExplicitFinalize)
   interface.finalize();
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 

--- a/tests/serial/lifecycle/ConstructOnly.cpp
+++ b/tests/serial/lifecycle/ConstructOnly.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 // Test representing the minimal lifecylce, which consists out of construction only.
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(ConstructOnly)
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 

--- a/tests/serial/lifecycle/Full.cpp
+++ b/tests/serial/lifecycle/Full.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 // Test representing the full explicit lifecycle of a SolverInterface
@@ -37,6 +37,6 @@ BOOST_AUTO_TEST_CASE(Full)
 
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 BOOST_AUTO_TEST_SUITE_END() // Serial
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/ImplicitFinalize.cpp
+++ b/tests/serial/lifecycle/ImplicitFinalize.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Lifecycle)
 // Test representing the full lifecycle of a SolverInterface
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(ImplicitFinalize)
   BOOST_TEST(interface.isCouplingOngoing());
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Lifecycle
 

--- a/tests/serial/mapping-nearest-projection/MappingNearestProjectionExplicitEdges.cpp
+++ b/tests/serial/mapping-nearest-projection/MappingNearestProjectionExplicitEdges.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(MappingNearestProjectionExplicitEdges)
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(MappingNearestProjectionExplicitEdges)
   testMappingNearestProjection(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-nearest-projection/MappingNearestProjectionImplicitEdges.cpp
+++ b/tests/serial/mapping-nearest-projection/MappingNearestProjectionImplicitEdges.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(MappingNearestProjectionImplicitEdges)
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(MappingNearestProjectionImplicitEdges)
   testMappingNearestProjection(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionExplicitEdgesTallKite.cpp
+++ b/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionExplicitEdgesTallKite.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Tests the Nearest Projection Mapping on a single participant on a quad mesh of a tall kite with setMeshQuadWithEdges
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionExplicitEdgesTallKite)
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionExplicitEdgesTallKi
   testQuadMappingNearestProjectionTallKite(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionExplicitEdgesWideKite.cpp
+++ b/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionExplicitEdgesWideKite.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Tests the Nearest Projection Mapping on a single participant on a quad mesh of a tall kite with setMeshQuad
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionExplicitEdgesWideKite)
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionExplicitEdgesWideKi
   testQuadMappingNearestProjectionWideKite(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionImplicitEdgesTallKite.cpp
+++ b/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionImplicitEdgesTallKite.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Tests the Nearest Projection Mapping on a single participant on a quad mesh of a tall kite with setMeshQuad
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionImplicitEdgesTallKite)
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionImplicitEdgesTallKi
   testQuadMappingNearestProjectionTallKite(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionImplicitEdgesWideKite.cpp
+++ b/tests/serial/mapping-nearest-projection/testQuadMappingDiagonalNearestProjectionImplicitEdgesWideKite.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Tests the Nearest Projection Mapping on a single participant on a quad mesh of a tall kite with setMeshQuadWithEdges
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionImplicitEdgesWideKite)
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingDiagonalNearestProjectionImplicitEdgesWideKi
   testQuadMappingNearestProjectionWideKite(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-nearest-projection/testQuadMappingNearestProjectionExplicitEdges.cpp
+++ b/tests/serial/mapping-nearest-projection/testQuadMappingNearestProjectionExplicitEdges.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Tests the Nearest Projection Mapping between two participants with explicit definition of edges from a quad to a triangle
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(testQuadMappingNearestProjectionExplicitEdges)
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingNearestProjectionExplicitEdges)
   testQuadMappingNearestProjection(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-nearest-projection/testQuadMappingNearestProjectionImplicitEdges.cpp
+++ b/tests/serial/mapping-nearest-projection/testQuadMappingNearestProjectionImplicitEdges.cpp
@@ -8,7 +8,7 @@
 /**
  * @brief Tests the Nearest Projection Mapping between two participants with explicit definition of edges from a quad to a triangle
  */
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingNearestProjection)
 BOOST_AUTO_TEST_CASE(testQuadMappingNearestProjectionImplicitEdges)
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingNearestProjectionImplicitEdges)
   testQuadMappingNearestProjection(defineEdgesExplicitly, context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingNearestProjection
 

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.cpp
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingScaledConsistent)
 BOOST_AUTO_TEST_CASE(testQuadMappingScaledConsistentOnA)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingScaledConsistentOnA)
   testQuadMappingScaledConsistent(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingScaledConsistent
 

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.cpp
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MappingScaledConsistent)
 BOOST_AUTO_TEST_CASE(testQuadMappingScaledConsistentOnB)
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(testQuadMappingScaledConsistentOnB)
   testQuadMappingScaledConsistent(context.config(), context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MappingScaledConsistent
 

--- a/tests/serial/mesh-requirements/NearestNeighborA.cpp
+++ b/tests/serial/mesh-requirements/NearestNeighborA.cpp
@@ -4,7 +4,7 @@
 
 #include <precice/SolverInterface.hpp>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MeshRequirements)
 BOOST_AUTO_TEST_CASE(NearestNeighborA)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(NearestNeighborA)
   BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MeshRequirements
 

--- a/tests/serial/mesh-requirements/NearestNeighborB.cpp
+++ b/tests/serial/mesh-requirements/NearestNeighborB.cpp
@@ -4,7 +4,7 @@
 
 #include <precice/SolverInterface.hpp>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MeshRequirements)
 BOOST_AUTO_TEST_CASE(NearestNeighborB)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(NearestNeighborB)
   BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MeshRequirements
 

--- a/tests/serial/mesh-requirements/NearestProjection2DA.cpp
+++ b/tests/serial/mesh-requirements/NearestProjection2DA.cpp
@@ -4,7 +4,7 @@
 
 #include <precice/SolverInterface.hpp>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MeshRequirements)
 BOOST_AUTO_TEST_CASE(NearestProjection2DA)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(NearestProjection2DA)
   BOOST_TEST(interface.isMeshConnectivityRequired(meshID));
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MeshRequirements
 

--- a/tests/serial/mesh-requirements/NearestProjection2DB.cpp
+++ b/tests/serial/mesh-requirements/NearestProjection2DB.cpp
@@ -4,7 +4,7 @@
 
 #include <precice/SolverInterface.hpp>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MeshRequirements)
 BOOST_AUTO_TEST_CASE(NearestProjection2DB)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(NearestProjection2DB)
   BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MeshRequirements
 

--- a/tests/serial/multi-coupling/MultiCoupling.cpp
+++ b/tests/serial/multi-coupling/MultiCoupling.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultiCoupling)
 /// Four solvers are multi-coupled.
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
 

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers1.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers1.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultiCoupling)
 BOOST_AUTO_TEST_CASE(MultiCouplingFourSolvers1)
@@ -17,6 +17,6 @@ BOOST_AUTO_TEST_CASE(MultiCouplingFourSolvers1)
 
 BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
 BOOST_AUTO_TEST_SUITE_END() // Serial
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers2.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers2.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultiCoupling)
 BOOST_AUTO_TEST_CASE(MultiCouplingFourSolvers2)
@@ -17,6 +17,6 @@ BOOST_AUTO_TEST_CASE(MultiCouplingFourSolvers2)
 
 BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
 BOOST_AUTO_TEST_SUITE_END() // Serial
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultiCoupling)
 BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers1)
@@ -17,6 +17,6 @@ BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers1)
 
 BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
 BOOST_AUTO_TEST_SUITE_END() // Serial
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultiCoupling)
 BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers2)
@@ -17,6 +17,6 @@ BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers2)
 
 BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
 BOOST_AUTO_TEST_SUITE_END() // Serial
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.cpp
@@ -5,7 +5,7 @@
 #include "helpers.hpp"
 #include "testing/Testing.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultiCoupling)
 BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers3)
@@ -17,6 +17,6 @@ BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers3)
 
 BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
 BOOST_AUTO_TEST_SUITE_END() // Serial
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/multiple-mappings/MultipleFromMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleFromMappings.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultipleMappings)
 BOOST_AUTO_TEST_CASE(MultipleFromMappings)
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(MultipleFromMappings)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MultipleMappings
 

--- a/tests/serial/multiple-mappings/MultipleToMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleToMappings.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(MultipleMappings)
 BOOST_AUTO_TEST_CASE(MultipleToMappings)
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(MultipleToMappings)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // MultipleMappings
 

--- a/tests/serial/stationary-mapping-with-solver-mesh/StationaryMappingWithSolverMesh2D.cpp
+++ b/tests/serial/stationary-mapping-with-solver-mesh/StationaryMappingWithSolverMesh2D.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(StationaryMappingWithSolverMesh)
 BOOST_AUTO_TEST_CASE(StationaryMappingWithSolverMesh2D)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(StationaryMappingWithSolverMesh2D)
   runTestStationaryMappingWithSolverMesh(context.config(), 2, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // StationaryMappingWithSolvermesh
 

--- a/tests/serial/stationary-mapping-with-solver-mesh/StationaryMappingWithSolverMesh3D.cpp
+++ b/tests/serial/stationary-mapping-with-solver-mesh/StationaryMappingWithSolverMesh3D.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(StationaryMappingWithSolverMesh)
 BOOST_AUTO_TEST_CASE(StationaryMappingWithSolverMesh3D)
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(StationaryMappingWithSolverMesh3D)
   runTestStationaryMappingWithSolverMesh(context.config(), 3, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // StationaryMappingWithSolvermesh
 

--- a/tests/serial/three-solvers/ThreeSolversExplicitExplicit.cpp
+++ b/tests/serial/three-solvers/ThreeSolversExplicitExplicit.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ThreeSolvers)
 BOOST_AUTO_TEST_CASE(ThreeSolversExplicitExplicit)
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(ThreeSolversExplicitExplicit)
   runTestThreeSolvers(config, expectedCallsOfAdvance, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ThreeSolvers
 

--- a/tests/serial/three-solvers/ThreeSolversExplicitImplicit.cpp
+++ b/tests/serial/three-solvers/ThreeSolversExplicitImplicit.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ThreeSolvers)
 BOOST_AUTO_TEST_CASE(ThreeSolversExplicitImplicit)
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(ThreeSolversExplicitImplicit)
   runTestThreeSolvers(config, expectedCallsOfAdvance, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ThreeSolvers
 

--- a/tests/serial/three-solvers/ThreeSolversImplicitExplicit.cpp
+++ b/tests/serial/three-solvers/ThreeSolversImplicitExplicit.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ThreeSolvers)
 BOOST_AUTO_TEST_CASE(ThreeSolversImplicitExplicit)
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(ThreeSolversImplicitExplicit)
   runTestThreeSolvers(config, expectedCallsOfAdvance, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ThreeSolvers
 

--- a/tests/serial/three-solvers/ThreeSolversImplicitImplicit.cpp
+++ b/tests/serial/three-solvers/ThreeSolversImplicitImplicit.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ThreeSolvers)
 BOOST_AUTO_TEST_CASE(ThreeSolversImplicitImplicit)
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(ThreeSolversImplicitImplicit)
   runTestThreeSolvers(config, expectedCallsOfAdvance, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ThreeSolvers
 

--- a/tests/serial/three-solvers/ThreeSolversParallel.cpp
+++ b/tests/serial/three-solvers/ThreeSolversParallel.cpp
@@ -5,7 +5,7 @@
 #include <precice/SolverInterface.hpp>
 #include "helpers.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(ThreeSolvers)
 BOOST_AUTO_TEST_CASE(ThreeSolversParallel)
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(ThreeSolversParallel)
   runTestThreeSolvers(config, expectedCallsOfAdvance, context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // ThreeSolvers
 

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Time)
 BOOST_AUTO_TEST_SUITE(Explicit)
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(timestep == nWindows * nSubsteps);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Time
 BOOST_AUTO_TEST_SUITE_END() // Explicit

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Time)
 BOOST_AUTO_TEST_SUITE(Explicit)
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(timestep == nWindows * nSubsteps);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Time
 BOOST_AUTO_TEST_SUITE_END() // Explicit

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Time)
 BOOST_AUTO_TEST_SUITE(Explicit)
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(timestep == nWindows * nSubsteps);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Time
 BOOST_AUTO_TEST_SUITE_END() // Explicit

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Time)
 BOOST_AUTO_TEST_SUITE(Implicit)
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(timestep == nWindows * nSubsteps);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Time
 BOOST_AUTO_TEST_SUITE_END() // Implicit

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -7,7 +7,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Time)
 BOOST_AUTO_TEST_SUITE(Implicit)
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(timestep == nWindows * nSubsteps);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Time
 BOOST_AUTO_TEST_SUITE_END() // Implicit

--- a/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.cpp
+++ b/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.cpp
@@ -7,7 +7,7 @@
 #include "helpers.hpp"
 #include "io/TXTTableWriter.hpp"
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_CASE(WatchIntegralScaleAndNoScale)
 {
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(WatchIntegralScaleAndNoScale)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/whitebox/TestConfigurationComsol.cpp
+++ b/tests/serial/whitebox/TestConfigurationComsol.cpp
@@ -9,7 +9,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Whitebox)
 /// Test reading of a full features coupling configuration file.
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
   BOOST_TEST(comsol->_usedMeshContexts.size() == 1);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Whitebox
 

--- a/tests/serial/whitebox/TestConfigurationPeano.cpp
+++ b/tests/serial/whitebox/TestConfigurationPeano.cpp
@@ -9,7 +9,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Whitebox)
 /// Test reading of a full features coupling configuration file.
@@ -36,6 +36,6 @@ BOOST_AUTO_TEST_CASE(TestConfigurationPeano)
 
 BOOST_AUTO_TEST_SUITE_END() // Whitebox
 BOOST_AUTO_TEST_SUITE_END() // Serial
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
@@ -8,7 +8,7 @@
 
 using namespace precice;
 
-BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(Whitebox)
 /**
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // PreciceTests
+BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Whitebox
 

--- a/tools/building/createTest.py
+++ b/tools/building/createTest.py
@@ -141,7 +141,7 @@ def generateTestSource(name, suite, filepath):
     includes = [
         "<precice/SolverInterface.hpp>", "<vector>", '"testing/Testing.hpp"'
     ]
-    suites = ["PreciceTests"] + suite
+    suites = ["Integration"] + suite
     space = [""]
     lines = ["#ifndef PRECICE_NO_MPI"]
     lines += space


### PR DESCRIPTION
## Main changes of this PR

As a follow-up of #1205, this PR renames the main test suite used for integration tests from `PreciceTests` to `Integration`.
This allows to separately test the tooling and versioning functionality, which are contained in the `PreciceTests`.
This PR now also removes the `precice.parallel` CTest suite, as the integration test suites are automatically picked up.
I also fixed a test in the process.


## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.
