### PR TITLE
Fix typo in return of unittest for MacOS 

### DIFF
--- a/src/testing/GlobalFixtures.cpp
+++ b/src/testing/GlobalFixtures.cpp
@@ -37,7 +37,7 @@ boost::unit_test::log_level getBoostTestLogLevel()
   namespace bu = boost::unit_test;
 #if BOOST_VERSION == 106900 || __APPLE__ && __MACH__
   std::cerr << "Boost 1.69 and macOS get log_level is broken, preCICE log level set to debug.\n";
-  return = bu::log_successful_tests;
+  return bu::log_successful_tests;
 #else
   return bu::runtime_config::get<bu::log_level>(bu::runtime_config::btrt_log_level);
 #endif


### PR DESCRIPTION
This PR fixes error mentioned in #1227.

There was an assignment in the return statement due to a typo. It is removed.
