### PR TITLE
Fix missing vtu data pieces in master pvtu file

### DIFF
--- a/docs/changelog/1233.md
+++ b/docs/changelog/1233.md
@@ -1,0 +1,1 @@
+- Fix missing data pieces in the master pvtu file for empty vertex distributions (e.g. a mesh is not exchanged) [#1233](https://github.com/precice/precice/pull/1233).

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -84,11 +84,11 @@ void ExportXML::writeMasterFile(
   if (offsets[0] > 0) {
     outMasterFile << "      <Piece Source=\"" << name << "_" << 0 << getPieceExtension() << "\"/>\n";
   }
-  for (int i = 1; i < utils::MasterSlave::getSize(); i++) {
-    PRECICE_ASSERT(i < offsets.size());
-    if (offsets[i] - offsets[i - 1] > 0) {
+  for (auto rank : utils::MasterSlave::allSlaves()) {
+    PRECICE_ASSERT(rank < offsets.size());
+    if (offsets[rank] - offsets[rank - 1] > 0) {
       //only non-empty subfiles
-      outMasterFile << "      <Piece Source=\"" << name << "_" << i << getPieceExtension() << "\"/>\n";
+      outMasterFile << "      <Piece Source=\"" << name << "_" << rank << getPieceExtension() << "\"/>\n";
     }
   }
 

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -80,6 +80,7 @@ void ExportXML::writeMasterFile(
   writeMasterData(outMasterFile);
 
   const auto &offsets = mesh.getVertexOffsets();
+  PRECICE_ASSERT(offsets.size() > 0);
   if (offsets[0] > 0) {
     outMasterFile << "      <Piece Source=\"" << name << "_" << 0 << getPieceExtension() << "\"/>\n";
   }

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -79,10 +79,13 @@ void ExportXML::writeMasterFile(
 
   writeMasterData(outMasterFile);
 
-  const auto &vertexDistribution = mesh.getVertexDistribution();
-  for (int i = 0; i < utils::MasterSlave::getSize(); i++) {
-    auto iter = vertexDistribution.find(i);
-    if (iter != vertexDistribution.end() && iter->second.size() > 0) {
+  const auto &offsets = mesh.getVertexOffsets();
+  if (offsets[0] > 0) {
+    outMasterFile << "      <Piece Source=\"" << name << "_" << 0 << getPieceExtension() << "\"/>\n";
+  }
+  for (int i = 1; i < utils::MasterSlave::getSize(); i++) {
+    PRECICE_ASSERT(i < offsets.size());
+    if (offsets[i] - offsets[i - 1] > 0) {
       //only non-empty subfiles
       outMasterFile << "      <Piece Source=\"" << name << "_" << i << getPieceExtension() << "\"/>\n";
     }

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -58,10 +58,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createEdge(v1, v2);
     mesh.createEdge(v2, v3);
     mesh.createEdge(v3, v1);
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {};
-    mesh.getVertexDistribution()[2] = {3, 4, 5};
-    mesh.getVertexDistribution()[3] = {6};
+    mesh.getVertexOffsets() = {3, 3, 6, 7};
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -98,10 +95,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Edge &e3 = mesh.createEdge(v3, v1);
     mesh.createTriangle(e1, e2, e3);
 
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {};
-    mesh.getVertexDistribution()[2] = {3, 4, 5};
-    mesh.getVertexDistribution()[3] = {6};
+    mesh.getVertexOffsets() = {3, 3, 6, 7};
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -142,10 +136,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
 
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {3, 4, 5};
-    mesh.getVertexDistribution()[2] = {6, 7, 8};
-    mesh.getVertexDistribution()[3] = {9, 10, 11};
+    mesh.getVertexOffsets() = {3, 6, 9, 12};
   } else if (context.isRank(1)) {
     mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
     mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -58,10 +58,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createEdge(v1, v2);
     mesh.createEdge(v2, v3);
     mesh.createEdge(v3, v1);
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {};
-    mesh.getVertexDistribution()[2] = {3, 4, 5};
-    mesh.getVertexDistribution()[3] = {6};
+    mesh.getVertexOffsets() = {3, 3, 6, 7};
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -97,11 +94,8 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Edge &e2 = mesh.createEdge(v2, v3);
     mesh::Edge &e3 = mesh.createEdge(v3, v1);
     mesh.createTriangle(e1, e2, e3);
+    mesh.getVertexOffsets() = {3, 3, 6, 7};
 
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {};
-    mesh.getVertexDistribution()[2] = {3, 4, 5};
-    mesh.getVertexDistribution()[3] = {6};
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -142,10 +136,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
 
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {3, 4, 5};
-    mesh.getVertexDistribution()[2] = {6, 7, 8};
-    mesh.getVertexDistribution()[3] = {9, 10, 11};
+    mesh.getVertexOffsets() = {3, 6, 9, 12};
   } else if (context.isRank(1)) {
     mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
     mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -58,10 +58,8 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createEdge(v1, v2);
     mesh.createEdge(v2, v3);
     mesh.createEdge(v3, v1);
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {};
-    mesh.getVertexDistribution()[2] = {3, 4, 5};
-    mesh.getVertexDistribution()[3] = {6};
+    mesh.getVertexOffsets() = {3, 3, 6, 7};
+
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -98,10 +96,8 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Edge &e3 = mesh.createEdge(v3, v1);
     mesh.createTriangle(e1, e2, e3);
 
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {};
-    mesh.getVertexDistribution()[2] = {3, 4, 5};
-    mesh.getVertexDistribution()[3] = {6};
+    mesh.getVertexOffsets() = {3, 3, 6, 7};
+
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -141,11 +137,8 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
+    mesh.getVertexOffsets() = {3, 6, 9, 12};
 
-    mesh.getVertexDistribution()[0] = {0, 1, 2};
-    mesh.getVertexDistribution()[1] = {3, 4, 5};
-    mesh.getVertexDistribution()[2] = {6, 7, 8};
-    mesh.getVertexDistribution()[3] = {9, 10, 11};
   } else if (context.isRank(1)) {
     mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
     mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});


### PR DESCRIPTION
## Main changes of this PR
Fixes a bug where an empty vertex distribution leads to missing exported data pieces. Resolves #1102 

## Motivation and additional information
Instead of the vertex distribution, I selected now the vertex offsets, which work reliably.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
