### PR TITLE
Cancel CI workflows on PR updates

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,10 @@ on:
       - '.github/workflows/build-and-test.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
 jobs:
   build:
     name: ${{ format('{0} {1} {2} {3}', matrix.IMAGE, matrix.CXX, matrix.CONFIG, matrix.TYPE) }}


### PR DESCRIPTION
## Main changes of this PR
This PR uses [GitHub concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) in order to cancel CIs which do not run on the HEAD of a current PR. 

## Motivation and additional information
Running the whole pipeline on outdated states of PR is a waste of resources and usually undesired. I need to experiment here in order to figure out if it works as expected.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
