### PR TITLE
Lift CI baseline to Ubuntu 20.04 LTS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,34 +32,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - IMAGE: 'ubuntu-1804'
+          - IMAGE: 'ubuntu-2004'
             CONFIG: Bare
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-1804'
+          - IMAGE: 'ubuntu-2004'
             CONFIG: MPI
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-1804'
+          - IMAGE: 'ubuntu-2004'
             CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-1804'
+          - IMAGE: 'ubuntu-2004'
             CONFIG: Bare
-            CXX: 'g++'
-            TYPE: Release
-          - IMAGE: 'ubuntu-1804'
-            CONFIG: MPI
-            CXX: 'g++'
-            TYPE: Release
-          - IMAGE: 'ubuntu-1804'
-            CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Release
           - IMAGE: 'ubuntu-2004'
+            CONFIG: MPI
+            CXX: 'g++'
+            TYPE: Release
+          - IMAGE: 'ubuntu-2004'
+            CONFIG: MPIPETSc
+            CXX: 'g++'
+            TYPE: Release
+          - IMAGE: 'ubuntu-2204'
             CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Debug


### PR DESCRIPTION
## Main changes of this PR

This PR lifts the baseline of preCICE in the CI by

* dropping Ubuntu 18.04 LTS
* changing baseline (and coverage) to Ubuntu 20.04 LTS
* changing newest LTS to Beta Ubuntu 22.04 LTS

