### PR TITLE
Added base components for tetrahedra

### DIFF
--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -112,17 +112,19 @@ Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
 
   const int dimensions = a.size();
   PRECICE_ASSERT(dimensions == 3, dimensions);
-  //TODO add chekcs for D
   PRECICE_ASSERT(dimensions == b.size(), "A and B need to have the same dimensions.", dimensions, b.size());
   PRECICE_ASSERT(dimensions == c.size(), "A and C need to have the same dimensions.", dimensions, c.size());
+  PRECICE_ASSERT(dimensions == d.size(), "A and D need to have the same dimensions.", dimensions, d.size());
   PRECICE_ASSERT(dimensions == u.size(), "A and the point need to have the same dimensions.", dimensions, u.size());
 
   Vector4d barycentricCoords;
 
+  // Varying per poit
   Vector3d au = u - a;
   Vector3d du = u - d;
   Vector3d cu = u - c;
 
+  // Necessary to compute triangles
   Vector3d ab = b - a;
   Vector3d ac = c - a;
   Vector3d ad = d - a;

--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -144,8 +144,6 @@ Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
 
   return barycentricCoords;
 }
-<<<<<<< HEAD
-=======
 
 Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
     const Eigen::VectorXd &a,
@@ -191,7 +189,6 @@ Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
 
   return barycentricCoords;
 }
->>>>>>> a9273df95654aa43ab6ae519d2e044c72f047bfa
 } // namespace barycenter
 } // namespace math
 } // namespace precice

--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -100,6 +100,48 @@ Eigen::Vector3d calcBarycentricCoordsForTriangle(
   return barycentricCoords;
 }
 
+Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
+    const Eigen::VectorXd &a,
+    const Eigen::VectorXd &b,
+    const Eigen::VectorXd &c,
+    const Eigen::VectorXd &d,
+    const Eigen::VectorXd &u)
+{
+  using Eigen::Vector3d;
+  using Eigen::Vector4d;
+
+  const int dimensions = a.size();
+  PRECICE_ASSERT(dimensions == 3, dimensions);
+  //TODO add chekcs for D
+  PRECICE_ASSERT(dimensions == b.size(), "A and B need to have the same dimensions.", dimensions, b.size());
+  PRECICE_ASSERT(dimensions == c.size(), "A and C need to have the same dimensions.", dimensions, c.size());
+  PRECICE_ASSERT(dimensions == u.size(), "A and the point need to have the same dimensions.", dimensions, u.size());
+
+  Vector4d barycentricCoords;
+
+  Vector3d au = u - a;
+  Vector3d du = u - d;
+  Vector3d cu = u - c;
+
+  Vector3d ab = b - a;
+  Vector3d ac = c - a;
+  Vector3d ad = d - a;
+  Vector3d bc = c - b;
+
+  // Triangles
+  Vector3d abc = ab.cross(bc);
+  Vector3d abd = ab.cross(-ad);
+  Vector3d acd = ac.cross(ad);
+
+  auto volume = abc.dot(ad);
+
+  barycentricCoords(3) = abc.dot(au) / volume;
+  barycentricCoords(2) = abd.dot(du) / volume;
+  barycentricCoords(1) = acd.dot(cu) / volume;
+  barycentricCoords(0) = 1 - barycentricCoords(3) - barycentricCoords(2) - barycentricCoords(1);
+
+  return barycentricCoords;
+}
 } // namespace barycenter
 } // namespace math
 } // namespace precice

--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -145,50 +145,6 @@ Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
   return barycentricCoords;
 }
 
-Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
-    const Eigen::VectorXd &a,
-    const Eigen::VectorXd &b,
-    const Eigen::VectorXd &c,
-    const Eigen::VectorXd &d,
-    const Eigen::VectorXd &u)
-{
-  using Eigen::Vector3d;
-  using Eigen::Vector4d;
-
-  const int dimensions = a.size();
-  PRECICE_ASSERT(dimensions == 3, dimensions);
-  PRECICE_ASSERT(dimensions == b.size(), "A and B need to have the same dimensions.", dimensions, b.size());
-  PRECICE_ASSERT(dimensions == c.size(), "A and C need to have the same dimensions.", dimensions, c.size());
-  PRECICE_ASSERT(dimensions == d.size(), "A and D need to have the same dimensions.", dimensions, d.size());
-  PRECICE_ASSERT(dimensions == u.size(), "A and the point need to have the same dimensions.", dimensions, u.size());
-
-  Vector4d barycentricCoords;
-
-  // Varying per poit
-  Vector3d au = u - a;
-  Vector3d du = u - d;
-  Vector3d cu = u - c;
-
-  // Necessary to compute triangles
-  Vector3d ab = b - a;
-  Vector3d ac = c - a;
-  Vector3d ad = d - a;
-  Vector3d bc = c - b;
-
-  // Triangles
-  Vector3d abc = ab.cross(bc);
-  Vector3d abd = ab.cross(-ad);
-  Vector3d acd = ac.cross(ad);
-
-  auto volume = abc.dot(ad);
-
-  barycentricCoords(3) = abc.dot(au) / volume;
-  barycentricCoords(2) = abd.dot(du) / volume;
-  barycentricCoords(1) = acd.dot(cu) / volume;
-  barycentricCoords(0) = 1 - barycentricCoords(3) - barycentricCoords(2) - barycentricCoords(1);
-
-  return barycentricCoords;
-}
 } // namespace barycenter
 } // namespace math
 } // namespace precice

--- a/src/math/barycenter.hpp
+++ b/src/math/barycenter.hpp
@@ -41,6 +41,27 @@ Eigen::Vector3d calcBarycentricCoordsForTriangle(
     const Eigen::VectorXd &c,
     const Eigen::VectorXd &u);
 
+/** Takes the corner vertices of a tetrahedron and a point in 3D space.
+ *  Returns the barycentric coordinates for that point's projection onto the given tetrahedron.
+ *
+ *  @param a point A of the tetrahedron ABCD
+ *  @param b point B of the tetrahedron ABCD
+ *  @param c point C of the tetrahedron ABCD
+  *  @param d point D of the tetrahedron ABCD
+
+ *  @param u the point to compute the barycentric coordinates for
+ *
+ * @note This implements an efficient one-step algorithm (no separate projection) 
+ * described in Boris Martin's Master's thesis
+ *
+ */
+Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
+    const Eigen::VectorXd &a,
+    const Eigen::VectorXd &b,
+    const Eigen::VectorXd &c,
+    const Eigen::VectorXd &d,
+    const Eigen::VectorXd &u);
+
 } // namespace barycenter
 } // namespace math
 } // namespace precice

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -166,7 +166,6 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle3D)
   }
 }
 
-<<<<<<< HEAD
 BOOST_AUTO_TEST_CASE(BarycenterTriangle2D)
 {
   PRECICE_TEST(1_rank);
@@ -238,8 +237,6 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle2D)
   }
 }
 
-=======
->>>>>>> a9273df95654aa43ab6ae519d2e044c72f047bfa
 BOOST_AUTO_TEST_CASE(BarycenterTetrahedron)
 {
   PRECICE_TEST(1_rank);

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -261,6 +261,34 @@ BOOST_AUTO_TEST_CASE(BarycenterTetrahedron)
     BOOST_TEST(ret.sum() == 1.0);
     BOOST_TEST(equals(ret, coords));
   }
+  // Is A?
+  {
+    Vector4d coords(1.0, 0.0, 0.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, a);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is B?
+  {
+    Vector4d coords(0.0, 1.0, 0.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, b);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is C?
+  {
+    Vector4d coords(0.0, 0.0, 1.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, c);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is D?
+  {
+    Vector4d coords(0.0, 0.0, 0.0, 1.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, d);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Barycenter

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -237,6 +237,32 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle2D)
   }
 }
 
+BOOST_AUTO_TEST_CASE(BarycenterTetrahedron)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector3d;
+  using Eigen::Vector4d;
+  using precice::testing::equals;
+  Vector3d a(0.0, 0.0, 0.0);
+  Vector3d b(0.0, 1.0, 0.0);
+  Vector3d c(1.0, 0.0, 0.0);
+  Vector3d d(0.0, 0.0, 1.0);
+  // is center?
+  {
+    Vector4d coords(0.25, 0.25, 0.25, 0.25);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, (a + b + c + d) / 4);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // random combination?
+  {
+    Vector4d coords(0.2, 0.3, 0.4, 0.1);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.2 * a + +0.3 * b + +0.4 * c + +0.1 * d);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Barycenter
 
 BOOST_AUTO_TEST_SUITE_END() // Math

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -289,6 +289,20 @@ BOOST_AUTO_TEST_CASE(BarycenterTetrahedron)
     BOOST_TEST(ret.sum() == 1.0);
     BOOST_TEST(equals(ret, coords));
   }
+  // Is middle of AB?
+  {
+    Vector4d coords(0.5, 0.5, 0.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.5 * a + 0.5 * b);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is middle of ABD?
+  {
+    Vector4d coords(1. / 3, 1. / 3, 0.0, 1. / 3);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, (a + b + d) / 3);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Barycenter

--- a/src/mesh/Tetrahedron.cpp
+++ b/src/mesh/Tetrahedron.cpp
@@ -25,7 +25,7 @@ Tetrahedron::Tetrahedron(
     Vertex &      vertexThree,
     Vertex &      vertexFour,
     TetrahedronID id)
-    : _vertices({&vertexOne, &vertexTwo, &vertexThree, vertexFour}),
+    : _vertices({&vertexOne, &vertexTwo, &vertexThree, &vertexFour}),
       _id(id)
 {
   PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),

--- a/src/mesh/Tetrahedron.cpp
+++ b/src/mesh/Tetrahedron.cpp
@@ -20,11 +20,11 @@ BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Tetrahedron>) );
 BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Tetrahedron>) );
 
 Tetrahedron::Tetrahedron(
-      Vertex &     vertexOne,
-      Vertex &     vertexTwo,
-      Vertex &     vertexThree,
-      Vertex &     vertexFour,
-      TetrahedronID id)
+    Vertex &      vertexOne,
+    Vertex &      vertexTwo,
+    Vertex &      vertexThree,
+    Vertex &      vertexFour,
+    TetrahedronID id)
     : _vertices({&vertexOne, &vertexTwo, &vertexThree, vertexFour}),
       _id(id)
 {
@@ -32,10 +32,9 @@ Tetrahedron::Tetrahedron(
                  vertexOne.getDimensions(), vertexTwo.getDimensions());
   PRECICE_ASSERT(vertexOne.getDimensions() == vertexThree.getDimensions(),
                  vertexOne.getDimensions(), vertexThree.getDimensions());
-    PRECICE_ASSERT(vertexOne.getDimensions() == vertexFour.getDimensions(),
+  PRECICE_ASSERT(vertexOne.getDimensions() == vertexFour.getDimensions(),
                  vertexOne.getDimensions(), vertexFour.getDimensions());
   PRECICE_ASSERT(getDimensions() == 3, getDimensions());
-
 
   PRECICE_ASSERT(
       (&vertexOne != &vertexTwo) &&
@@ -47,7 +46,7 @@ Tetrahedron::Tetrahedron(
       "Tetrahedron vertices are not unique!");
 }
 
-double Tetrahedron::getArea() const
+double Tetrahedron::getVolume() const
 {
   return math::geometry::tetraVolume(vertex(0).getCoords(), vertex(1).getCoords(), vertex(2).getCoords(), vertex(3).getCoords());
 }

--- a/src/mesh/Tetrahedron.cpp
+++ b/src/mesh/Tetrahedron.cpp
@@ -1,0 +1,97 @@
+#include "Tetrahedron.hpp"
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <boost/concept/assert.hpp>
+#include <boost/range/concepts.hpp>
+#include "math/differences.hpp"
+#include "math/geometry.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Vertex.hpp"
+#include "utils/EigenIO.hpp"
+
+namespace precice {
+namespace mesh {
+
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Tetrahedron::iterator>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Tetrahedron::const_iterator>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<Tetrahedron>) );
+BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Tetrahedron>) );
+
+Tetrahedron::Tetrahedron(
+      Vertex &     vertexOne,
+      Vertex &     vertexTwo,
+      Vertex &     vertexThree,
+      Vertex &     vertexFour,
+      TetrahedronID id)
+    : _vertices({&vertexOne, &vertexTwo, &vertexThree, vertexFour}),
+      _id(id)
+{
+  PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),
+                 vertexOne.getDimensions(), vertexTwo.getDimensions());
+  PRECICE_ASSERT(vertexOne.getDimensions() == vertexThree.getDimensions(),
+                 vertexOne.getDimensions(), vertexThree.getDimensions());
+    PRECICE_ASSERT(vertexOne.getDimensions() == vertexFour.getDimensions(),
+                 vertexOne.getDimensions(), vertexFour.getDimensions());
+  PRECICE_ASSERT(getDimensions() == 3, getDimensions());
+
+
+  PRECICE_ASSERT(
+      (&vertexOne != &vertexTwo) &&
+          (&vertexOne != &vertexThree) &&
+          (&vertexOne != &vertexFour) &&
+          (&vertexTwo != &vertexThree) &&
+          (&vertexTwo != &vertexFour) &&
+          (&vertexThree != &vertexFour),
+      "Tetrahedron vertices are not unique!");
+}
+
+double Tetrahedron::getArea() const
+{
+  return math::geometry::tetraVolume(vertex(0).getCoords(), vertex(1).getCoords(), vertex(2).getCoords(), vertex(3).getCoords());
+}
+
+int Tetrahedron::getDimensions() const
+{
+  return _vertices[0]->getDimensions();
+}
+
+const Eigen::VectorXd Tetrahedron::getCenter() const
+{
+  return (vertex(0).getCoords() + vertex(1).getCoords() + vertex(2).getCoords() + vertex(3).getCoords()) / 4.0;
+}
+
+double Tetrahedron::getEnclosingRadius() const
+{
+  auto center = getCenter();
+  return std::max({(center - vertex(0).getCoords()).norm(),
+                   (center - vertex(1).getCoords()).norm(),
+                   (center - vertex(2).getCoords()).norm(),
+                   (center - vertex(3).getCoords()).norm()});
+}
+
+bool Tetrahedron::operator==(const Tetrahedron &other) const
+{
+  return std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin(),
+                             [](const Vertex *v1, const Vertex *v2) { return *v1 == *v2; });
+}
+
+bool Tetrahedron::operator!=(const Tetrahedron &other) const
+{
+  return !(*this == other);
+}
+
+std::ostream &operator<<(std::ostream &os, const Tetrahedron &t)
+{
+  using utils::eigenio::wkt;
+  return os << "POLYGON (("
+            << t.vertex(0).getCoords().transpose().format(wkt()) << ", "
+            << t.vertex(1).getCoords().transpose().format(wkt()) << ", "
+            << t.vertex(2).getCoords().transpose().format(wkt()) << ", "
+            << t.vertex(3).getCoords().transpose().format(wkt()) << ", "
+            << t.vertex(0).getCoords().transpose().format(wkt()) << "))";
+}
+
+} // namespace mesh
+} // namespace precice

--- a/src/mesh/Tetrahedron.hpp
+++ b/src/mesh/Tetrahedron.hpp
@@ -7,8 +7,8 @@
 
 #include "math/differences.hpp"
 #include "mesh/Edge.hpp"
-#include "mesh/Triangle.hpp"
 #include "mesh/RangeAccessor.hpp"
+#include "mesh/Triangle.hpp"
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
 
@@ -42,10 +42,10 @@ public:
 
   /// Constructor, the order of vertices doesn't matter.
   Tetrahedron(
-      Vertex &     vertexOne,
-      Vertex &     vertexTwo,
-      Vertex &     vertexThree,
-      Vertex &     vertexFour,
+      Vertex &      vertexOne,
+      Vertex &      vertexTwo,
+      Vertex &      vertexThree,
+      Vertex &      vertexFour,
       TetrahedronID id);
 
   /// Returns dimensionalty of space the Tetrahedron is embedded in.
@@ -60,7 +60,6 @@ public:
    * @brief Returns const tetrahedron vertex with index 0, 1, 2 or 3.
    */
   const Vertex &vertex(int i) const;
-
 
   ///@name Iterators
   ///@{
@@ -111,7 +110,6 @@ private:
   /// Vertices defining the Tetrahedron.
   std::array<Vertex *, 4> _vertices;
 
-
   /// ID of the Tetrahedron.
   TetrahedronID _id;
 };
@@ -121,15 +119,14 @@ private:
 inline Vertex &Tetrahedron::vertex(int i)
 {
   PRECICE_ASSERT((i >= 0) && (i < 4), i);
-  return _vertices[i];
+  return *_vertices[i];
 }
 
 inline const Vertex &Tetrahedron::vertex(int i) const
 {
   PRECICE_ASSERT((i >= 0) && (i < 4), i);
-  return _vertices[i];
+  return *_vertices[i];
 }
-
 
 inline Tetrahedron::iterator Tetrahedron::begin()
 {

--- a/src/mesh/Tetrahedron.hpp
+++ b/src/mesh/Tetrahedron.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <algorithm>
+#include <array>
+#include <iostream>
+
+#include "math/differences.hpp"
+#include "mesh/Edge.hpp"
+#include "mesh/Triangle.hpp"
+#include "mesh/RangeAccessor.hpp"
+#include "precice/types.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice {
+namespace mesh {
+class Vertex;
+}
+} // namespace precice
+
+// ----------------------------------------------------------- CLASS DEFINITION
+
+namespace precice {
+namespace mesh {
+
+/// Tetrahedron of a mesh, defined by 4 vertices
+class Tetrahedron {
+public:
+  /// Type of the read-only const random-access iterator over Vertex coords
+  /**
+   * This index-based iterator iterates over the vertices of this Tetrahedron.
+   * The returned value is the forwarded result of Vertex::getCoords.
+   * It is thus a read-only random-access iterator.
+   */
+  using const_iterator = IndexRangeIterator<const Tetrahedron, const Vertex::RawCoords>;
+
+  /// Type of the read-only random access vertex iterator
+  using iterator = const_iterator;
+
+  /// Fix for the Boost.Test versions 1.65.1 - 1.67
+  using value_type = Vertex::RawCoords;
+
+  /// Constructor, the order of vertices doesn't matter.
+  Tetrahedron(
+      Vertex &     vertexOne,
+      Vertex &     vertexTwo,
+      Vertex &     vertexThree,
+      Vertex &     vertexFour,
+      TetrahedronID id);
+
+  /// Returns dimensionalty of space the Tetrahedron is embedded in.
+  int getDimensions() const;
+
+  /**
+   * @brief Returns tetrahedron vertex with index 0, 1, 2 or 3.
+   */
+  Vertex &vertex(int i);
+
+  /**
+   * @brief Returns const tetrahedron vertex with index 0, 1, 2 or 3.
+   */
+  const Vertex &vertex(int i) const;
+
+
+  ///@name Iterators
+  ///@{
+
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2]
+  iterator begin();
+
+  /// Returns a read-only random-access iterator to the end (3) of the vertex range [0,1,2]
+  iterator end();
+
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2]
+  const_iterator begin() const;
+
+  /// Returns a read-only random access iterator to the end (3) of the vertex range [0,1,2]
+  const_iterator end() const;
+
+  /// Returns a read-only random-access iterator to the begin (0) of the vertex range [0,1,2]
+  const_iterator cbegin() const;
+
+  /// Returns a read-only random access iterator to the end (3) of the vertex range [0,1,2]
+  const_iterator cend() const;
+
+  ///@}
+
+  /// Returns a among Tetrahedrons globally unique ID.
+  TetrahedronID getID() const;
+
+  /// Returns the unsigned volume of the tetrahedron
+  double getVolume() const;
+
+  /// Returns the barycenter of the tetrahedron.
+  const Eigen::VectorXd getCenter() const;
+
+  /// Returns the radius of the sphere enclosing the tetrahedron.
+  double getEnclosingRadius() const;
+
+  /**
+   * @brief Compares two Tetrahedrons for equality
+   *
+   * Two Tetrahedrons are equal if their vertices are the same, up to permutations
+   */
+  bool operator==(const Tetrahedron &other) const;
+
+  /// Not equal, implemented in terms of equal.
+  bool operator!=(const Tetrahedron &other) const;
+
+private:
+  /// Vertices defining the Tetrahedron.
+  std::array<Vertex *, 4> _vertices;
+
+
+  /// ID of the Tetrahedron.
+  TetrahedronID _id;
+};
+
+// --------------------------------------------------------- HEADER DEFINITIONS
+
+inline Vertex &Tetrahedron::vertex(int i)
+{
+  PRECICE_ASSERT((i >= 0) && (i < 4), i);
+  return _vertices[i];
+}
+
+inline const Vertex &Tetrahedron::vertex(int i) const
+{
+  PRECICE_ASSERT((i >= 0) && (i < 4), i);
+  return _vertices[i];
+}
+
+
+inline Tetrahedron::iterator Tetrahedron::begin()
+{
+  return {this, 0};
+}
+
+inline Tetrahedron::iterator Tetrahedron::end()
+{
+  return {this, 4};
+}
+
+inline Tetrahedron::const_iterator Tetrahedron::begin() const
+{
+  return {this, 0};
+}
+
+inline Tetrahedron::const_iterator Tetrahedron::end() const
+{
+  return {this, 4};
+}
+
+inline Tetrahedron::const_iterator Tetrahedron::cbegin() const
+{
+  return begin();
+}
+
+inline Tetrahedron::const_iterator Tetrahedron::cend() const
+{
+  return end();
+}
+
+inline TetrahedronID Tetrahedron::getID() const
+{
+  return _id;
+}
+
+std::ostream &operator<<(std::ostream &os, const Tetrahedron &t);
+
+} // namespace mesh
+} // namespace precice

--- a/src/precice/types.hpp
+++ b/src/precice/types.hpp
@@ -18,6 +18,11 @@ using EdgeID = int;
 using TriangleID = int;
 
 /**
+ * Type used for the IDs of tetrahedra
+ */
+using TetrahedronID = int;
+
+/**
  * Type used for the IDs of data (incl. gradient data)
  */
 using DataID = int;

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -210,6 +210,8 @@ target_sources(precice
     src/mesh/SharedPointer.hpp
     src/mesh/Triangle.cpp
     src/mesh/Triangle.hpp
+    src/mesh/Tetrahedron.cpp
+    src/mesh/Tetrahedron.hpp
     src/mesh/Utils.cpp
     src/mesh/Utils.hpp
     src/mesh/Vertex.cpp


### PR DESCRIPTION
## Main changes of this PR

- Added a Tetrahedron geometric primitive with elementary interface similar to the one of triangles. (get volume, center, enclosing radius, iterate over vertices, ...). Internally, it only works with vertices. (No underlying edge or triangle)
- Added a function for computing the barycentric coordinates of a point with respect to a tetrahedron (with 4 vertices as input), as well as unit tests to check its correctness.

## Motivation and additional information

Prerequisite for https://github.com/precice/precice/issues/468. Not actually used yet, as some additional parts are required (like the R-Tree implementation). 

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] Add tests for some functions like center computation etc

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
