### PR TITLE
Fix typos in `docs/`

### DIFF
--- a/docs/documents/020_conventions.dox
+++ b/docs/documents/020_conventions.dox
@@ -21,17 +21,17 @@ General Guidelines
 - Use ```std::make_shared``` for creating smart pointers. Why: <a href="https://stackoverflow.com/questions/20895648/difference-in-make-shared-and-normal-shared-ptr-in-c">Difference in make_shared and normal shared_ptr in C++</a>
 
 
-Indention & Formatting
-----------------------
+Indentation & Formatting
+------------------------
 As a rule of thumb again: Orient yourself on the already written code!
 
 There is a settings file for ```clang-format```. See the page on \ref tooling for more information on clang-format.
 
-Regarding indention, we follow the BSD-style.
+Regarding indentation, we follow the BSD-style.
 
 We do not indent namespaces since three or so levels of nested namespaces fill the offset without adding any viable information.
 
-Using Emacs you get the indention style using this snippet.
+Using Emacs you get the indentation style using this snippet.
 
 ~~~~~{.el}
 (setq c-basic-offset 2)

--- a/docs/documents/030_optimization.dox
+++ b/docs/documents/030_optimization.dox
@@ -11,7 +11,7 @@ general, the code development process looks as follows:
 -# Optimize the implementation based on profiling and start from point 2 again.
 
 The important message is that code implementation and code optimization are 
-seperated from each other. This seperation derives from an 80-20 rule, i.e. the 
+separated from each other. This separation derives from an 80-20 rule, i.e. the 
 observation that approximately 80% of the runtime of a program are spent in only 
 about 20% of its implemented code. This implies that optimizations applied at 
 the right place can save a lot of efforts and leave large parts of a program in 

--- a/docs/documents/040_eventtimings.dox
+++ b/docs/documents/040_eventtimings.dox
@@ -50,7 +50,7 @@ If you just want to measure precice internal functions that's about it.
 Internals
 ---------
 
- The EventTimings classes use a singleton instance to save Events and the global start / stop time. To start the measurement call \c precice::utils::EventRegistry::instance().initialize(_accessorName)  and \c precice::utils::EventRegistry::instance().finalize() to stop. This is done by precice and normally should not be needed to call explicitely. Keep in mind that multiple calls to initalize or finalize may mess up global timings.
+ The EventTimings classes use a singleton instance to save Events and the global start / stop time. To start the measurement call \c precice::utils::EventRegistry::instance().initialize(_accessorName)  and \c precice::utils::EventRegistry::instance().finalize() to stop. This is done by precice and normally should not be needed to call explicitly. Keep in mind that multiple calls to initialize or finalize may mess up global timings.
 
 Usually an event is auto started when instantiated. You can use \c Event e("name", false, false) to override that and use \c e.start() to start it later. An Event can also act as a barrier, see the Event constructuor. Multiple calls to \c start() or \c stop() have no effect.
 

--- a/docs/documents/060_release.dox
+++ b/docs/documents/060_release.dox
@@ -13,7 +13,7 @@ We use versioning inspired by semantic versioning: https://semver.org/
 Guidelines
 ------------------
 
-- Use ```git cherrypick``` to backport small bug fixes from develop to master. That consitutes an revision release, i.e. increment last digit.
+- Use ```git cherrypick``` to backport small bug fixes from develop to master. That constitutes a revision release, i.e. increment last digit.
 - For bigger bug fixes, branch from master, fix the bug and merge back into master. Then merge master to develop.
 - Use coding days to release.
 - Update ```CHANGELOG.md``` with all user notable changes. Whenever such a change is pushed to develop, update the changelog for the upcoming release.

--- a/docs/documents/namespaces.dox
+++ b/docs/documents/namespaces.dox
@@ -59,7 +59,7 @@
  */
 
 /** @namespace precice::utils
- *  @brief contains precice-related utilites.
+ *  @brief contains precice-related utilities.
  */
 
 /** @namespace precice::xml

--- a/docs/man/man1/testprecice.1
+++ b/docs/man/man1/testprecice.1
@@ -26,7 +26,7 @@ The base MPI test suite containing a fraction of MPI tests based on 2 Ranks.
 .B 4 Rank
 The extended MPI test suite containing mainly integration tests based on 4 Ranks.
 
-Be aware that the intergration tests will produce a large amount of .log .vtk .vtu and .pvtu files.
+Be aware that the integration tests will produce a large amount of .log .vtk .vtu and .pvtu files.
 
 .SH OPTIONS
 .TP


### PR DESCRIPTION
## Main changes of this PR
Various typos fixes

## Motivation and additional information
Text uniformity and clear of grammar/spelling issues

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
