### PR TITLE
Fix fstream inclusion in com/ConnectionInfoPublisher.cpp

### DIFF
--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -4,7 +4,7 @@
 #include <boost/uuid/string_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <chrono>
-#include <istream>
+#include <fstream>
 #include <thread>
 
 #include "ConnectionInfoPublisher.hpp"


### PR DESCRIPTION
The 'istream' header does not provide the fstream family of types. They were being incidentally included through Boost headers. Starting with Boost-1.79.0, these transitive includes are broken.

I haven't figured out exactly what changed in Boost to make this happen, but I have verified that it is only since 1.79.0.