### PR TITLE
Remove meshName from solverdummies input arguments

### DIFF
--- a/cmake/runsolverdummies.sh
+++ b/cmake/runsolverdummies.sh
@@ -3,10 +3,10 @@
 # Invoke with
 # runsolverdummies.sh path/to/solverdummy1 path/to/solverdummy2 path/to/config
 
-$1 $3 SolverOne MeshOne  &
+$1 $3 SolverOne  &
 PID=$!
 
-$2 $3 SolverTwo MeshTwo
+$2 $3 SolverTwo
 RET=$?
 
 set -e

--- a/examples/solverdummies/c/solverdummy.c
+++ b/examples/solverdummies/c/solverdummy.c
@@ -6,50 +6,71 @@
 
 int main(int argc, char **argv)
 {
-  double  dt                 = 0.0;
-  int     solverProcessIndex = 0;
-  int     solverProcessSize  = 1;
-  int     dimensions         = -1;
-  double *vertices;
-  double *readData;
-  double *writeData;
-  int     meshID = -1;
-  int     dataID = -1;
-  int *   vertexIDs;
-  int     numberOfVertices = 3;
-  int     writeDataID      = -1;
-  int     readDataID       = -1;
+  double      dt                 = 0.0;
+  int         solverProcessIndex = 0;
+  int         solverProcessSize  = 1;
+  int         dimensions         = -1;
+  double     *vertices;
+  double     *readData;
+  double     *writeData;
+  int         meshID = -1;
+  int         dataID = -1;
+  int        *vertexIDs;
+  int         numberOfVertices = 3;
+  int         writeDataID      = -1;
+  int         readDataID       = -1;
+  const char *meshName;
 
-  if (argc != 4) {
+  const char *configFileName = argv[1];
+  const char *participantName = argv[2];
+
+  if (argc == 3) {
+    ;
+  }
+  else if (argc == 4) {
+    meshName = argv[3];
+    printf("Warning: Providing the mesh name as an argument is deprecated and will be removed in v3.0.0\n");
+  }
+  else {
     printf("Usage: ./solverdummy configFile solverName meshName\n\n");
     printf("Parameter description\n");
     printf("  configurationFile: Path and filename of preCICE configuration\n");
     printf("  solverName:        SolverDummy participant name in preCICE configuration\n");
-    printf("  meshName:          Mesh in preCICE configuration that carries read and write data\n");
     return 1;
   }
 
-  const char *configFileName  = argv[1];
-  const char *participantName = argv[2];
-  const char *meshName        = argv[3];
-
-  printf("DUMMY: Running solver dummy with preCICE config file \"%s\", participant name \"%s\", and mesh name \"%s\".\n",
-         configFileName, participantName, meshName);
+  printf("DUMMY: Running solver dummy with preCICE config file \"%s\" and participant name \"%s\".\n",
+         configFileName, participantName);
 
   const char *writeItCheckp = precicec_actionWriteIterationCheckpoint();
   const char *readItCheckp  = precicec_actionReadIterationCheckpoint();
 
   precicec_createSolverInterface(participantName, configFileName, solverProcessIndex, solverProcessSize);
 
+  if (argc == 3) {
+    if (strcmp(participantName, "SolverOne") == 0) {
+    meshName = "MeshOne";
+    }
+    if (strcmp(participantName, "SolverTwo") == 0) {
+    meshName = "MeshTwo";
+    }
+  }
+
   meshID = precicec_getMeshID(meshName);
 
   if (strcmp(participantName, "SolverOne") == 0) {
     writeDataID = precicec_getDataID("dataOne", meshID);
     readDataID  = precicec_getDataID("dataTwo", meshID);
+    if (argc == 3) {
+      meshName = "MeshOne";
+    }
   }
   if (strcmp(participantName, "SolverTwo") == 0) {
     writeDataID = precicec_getDataID("dataTwo", meshID);
     readDataID  = precicec_getDataID("dataOne", meshID);
+    if (argc == 3) {
+      meshName = "MeshTwo";
+    }
   }
 
   dimensions = precicec_getDimensions();

--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -10,22 +10,36 @@ int main(int argc, char **argv)
   using namespace precice;
   using namespace precice::constants;
 
-  if (argc != 4) {
+  std::string configFileName(argv[1]);
+  std::string solverName(argv[2]);
+  std::string meshName;
+
+  if (argc == 3) {
+  }
+  else if (argc == 4) {
+    meshName = argv[3];
+    std::cout << "Warning: Providing the mesh name as an argument is deprecated and will be removed in v3.0.0\n";
+  }
+  else {
     std::cout << "Usage: ./solverdummy configFile solverName meshName\n\n";
     std::cout << "Parameter description\n";
     std::cout << "  configurationFile: Path and filename of preCICE configuration\n";
     std::cout << "  solverName:        SolverDummy participant name in preCICE configuration\n";
-    std::cout << "  meshName:          Mesh in preCICE configuration that carries read and write data\n";
     return 1;
   }
 
-  std::string configFileName(argv[1]);
-  std::string solverName(argv[2]);
-  std::string meshName(argv[3]);
-
-  std::cout << "DUMMY: Running solver dummy with preCICE config file \"" << configFileName << "\", participant name \"" << solverName << "\", and mesh name \"" << meshName << "\".\n";
+  std::cout << "DUMMY: Running solver dummy with preCICE config file \"" << configFileName << "\" and participant name \"" << solverName << "\".\n";
 
   SolverInterface interface(solverName, configFileName, commRank, commSize);
+
+  if (argc == 3) {
+    if (solverName == "SolverOne") {
+      meshName = "MeshOne";
+    }
+    if (solverName == "SolverTwo") {
+      meshName = "MeshTwo";
+    }
+  }
 
   int         meshID     = interface.getMeshID(meshName);
   int         dimensions = interface.getDimensions();

--- a/examples/solverdummies/fortran/solverdummy.f90
+++ b/examples/solverdummies/fortran/solverdummy.f90
@@ -4,7 +4,7 @@ PROGRAM main
   CHARACTER*50                    :: participantName, meshName, writeInitialData, readItCheckp, writeItCheckp
   CHARACTER*50                    :: readDataName, writeDataName
   INTEGER                         :: rank, commsize, ongoing, dimensions, meshID, bool, numberOfVertices, i,j
-  INTEGER                         :: readDataID, writeDataID
+  INTEGER                         :: nargs, readDataID, writeDataID
   DOUBLE PRECISION                :: dt
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: vertices, writeData, readData
   INTEGER, DIMENSION(:), ALLOCATABLE :: vertexIDs
@@ -19,17 +19,33 @@ PROGRAM main
   CALL precicef_action_write_iter_checkp(writeItCheckp)
 
   WRITE (*,*) 'DUMMY: Starting Fortran solver dummy...'
-  CALL getarg(1, config)
-  CALL getarg(2, participantName)
-  CALL getarg(3, meshName)
+  
+  nargs = iargc()
+
+  IF(nargs.eq.2) THEN
+    CALL getarg(1, config)
+    CALL getarg(2, participantName)
+  ENDIF
+  IF(nargs.eq.3) THEN
+    CALL getarg(1, config)
+    CALL getarg(2, participantName)
+    CALL getarg(3, meshName)
+    WRITE (*,*) 'Warning: Providing the mesh name as an argument is deprecated and will be removed in v3.0.0'
+  ENDIF
 
   IF(participantName .eq. 'SolverOne') THEN
     writeDataName = 'dataOne'
     readDataName = 'dataTwo'
+    IF(nargs.eq.2) THEN
+      meshName = 'MeshOne'
+    ENDIF
   ENDIF
   IF(participantName .eq. 'SolverTwo') THEN
     writeDataName = 'dataTwo'
     readDataName = 'dataOne'
+    IF(nargs.eq.2) THEN
+      meshName = 'MeshTwo'
+    ENDIF
   ENDIF
 
   rank = 0


### PR DESCRIPTION
## Main changes of this PR

This PR makes the meshName command line input parameter to solverdummies optional.

## Motivation and additional information

As the dataName variables are hard coded  depending on the solver name, the meshName can also be handled in a similar way.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
