### PR TITLE
Removes RS-LS truncation of stored columns

### DIFF
--- a/docs/changelog/1257.md
+++ b/docs/changelog/1257.md
@@ -1,1 +1,1 @@
-- Removed least squares truncation of stored columns per time window for IQN-IMVJ acceleration restart.
+- Removed restriction to only use 5 iterations in the `RS_LS` restart mode of the IQN-IMVJ acceleration method.

--- a/docs/changelog/1257.md
+++ b/docs/changelog/1257.md
@@ -1,0 +1,1 @@
+- Removed least squares truncation of stored columns per time window for IQN-IMVJ acceleration restart.

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -181,11 +181,9 @@ void MVQNAcceleration::updateDifferenceMatrices(
 
           // store columns if restart mode = RS-LS
           if (_imvjRestartType == RS_LS) {
-            if (_matrixCols_RSLS.front() < _usedColumnsPerTimeWindow) {
-              utils::appendFront(_matrixV_RSLS, v);
-              utils::appendFront(_matrixW_RSLS, w);
-              _matrixCols_RSLS.front()++;
-            }
+            utils::appendFront(_matrixV_RSLS, v);
+            utils::appendFront(_matrixW_RSLS, w);
+            _matrixCols_RSLS.front()++;
           }
 
           // imvj without restart is used, but efficient update, i.e. no Jacobian assembly in each iteration

--- a/src/acceleration/MVQNAcceleration.cpp
+++ b/src/acceleration/MVQNAcceleration.cpp
@@ -61,7 +61,6 @@ MVQNAcceleration::MVQNAcceleration(
       _imvjRestart(false),
       _chunkSize(chunkSize),
       _RSLSreusedTimeWindows(RSLSreusedTimeWindows),
-      _usedColumnsPerTimeWindow(5),
       _nbRestarts(0),
       _avgRank(0)
 {

--- a/src/acceleration/MVQNAcceleration.hpp
+++ b/src/acceleration/MVQNAcceleration.hpp
@@ -131,9 +131,6 @@ private:
   /// @brief: Number of reused time windows at restart if restart-mode = RS-LS
   int _RSLSreusedTimeWindows;
 
-  /// @brief: Number of used columns per time window. Always the first _usedColumnsPerTwindow are used.
-  int _usedColumnsPerTimeWindow;
-
   /// @brief tracks the number of restarts of IMVJ
   int _nbRestarts;
 


### PR DESCRIPTION
## Main changes of this PR
This PR removes the arbitrary truncation of all but the first `5` columns per time window for the least squares restart for IQ-IMVJ method. This negatively impacts the performance of the RS-LS method. The accumulation of columns is handled by the filtering the of the RS-LS columns during the restart step.

## Motivation and additional information
Tests have shown that this truncation ignores information helpful for convergence. The problem of too many columns used is covered by the filtering step in https://github.com/precice/precice/blob/cf1c06e2298baf0f1efe0f078aef9b298d286ef4/src/acceleration/MVQNAcceleration.cpp#L584-L603

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
