### PR TITLE
Lift baseline from Ubuntu 18.04 LTS to 20.04 LTS 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Short rational why preCICE needs this change. If this is already described in an
 * [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
 * [ ] I ran `make format` to ensure everything is formatted correctly.
 * [ ] I sticked to C++14 features.
-* [ ] I sticked to CMake version 3.10.
+* [ ] I sticked to CMake version 3.16.3.
 * [ ] I squashed / am about to squash all commits that should be seen as one.
 
 ## Reviewers' checklist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        TARGET: ["ubuntu:18.04", "ubuntu:20.04", "ubuntu:21.04", "ubuntu:21.10", "debian:11"]
+        TARGET: ["ubuntu:20.04", "ubuntu:21.04", "ubuntu:21.10", "ubuntu:22.04", "debian:11"]
     steps:
       - uses: actions/checkout@v2
       - name: Generate build directory
@@ -40,20 +40,12 @@ jobs:
         run: |
           apt update
           apt -y upgrade
-          apt -y install git build-essential lsb-release cmake libeigen3-dev libxml2-dev libboost-all-dev python3-dev python3-numpy
-      - name: Install PETSc
-        if: ${{ matrix.TARGET != 'ubuntu:18.04' }}
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          apt install -y petsc-dev
+          apt -y install git build-essential lsb-release cmake libeigen3-dev libxml2-dev libboost-all-dev python3-dev python3-numpy petsc-dev
       - name: Configure
         working-directory: build
-        env:
-          PETSc: ${{ matrix.TARGET != 'ubuntu:18.04' }}
         run: |
           cmake --version
-          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCPACK_GENERATOR="DEB" -DPRECICE_PETScMapping=${{ env.PETSc }} -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON ..
+          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCPACK_GENERATOR="DEB" -DPRECICE_PETScMapping=ON -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON ..
       - name: Compile
         working-directory: build
         run: make -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10.2)
+cmake_minimum_required (VERSION 3.16.3)
 project(preCICE VERSION 2.3.0 LANGUAGES CXX)
 set(preCICE_SOVERSION ${preCICE_VERSION_MAJOR})
 
@@ -153,7 +153,7 @@ if(TPL_ENABLE_BOOST)
   set(Boost_NO_SYSTEM_PATHS ON CACHE BOOL "" FORCE)
   unset(ENV{BOOST_ROOT})
 endif()
-find_package(Boost 1.65.1 REQUIRED
+find_package(Boost 1.71.0 REQUIRED
   COMPONENTS filesystem log log_setup program_options system thread unit_test_framework
   )
 

--- a/docs/changelog/1259.md
+++ b/docs/changelog/1259.md
@@ -1,0 +1,1 @@
+- Changed baseline from Ubuntu 18.04 LTS to Ubuntu 20.04 LTS. preCICE now requires Boost version `1.71.0` and CMake version `3.16.3`.


### PR DESCRIPTION
## Main changes of this PR

This PR lifts the Baseline of preCICE from Ubuntu 18.04 LTS to 20.04 LTS.
This primarily changes the requirements for Boost (1.65.1 -> 1.71.0) and CMake (3.10.2 -> 3.16.3).

This requires quite a few documentation updates.

## Motivation and additional information

Following the release strategy of preCICE.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.


## Reviewer's checklist

* Do you approve the upgrade?