### PR TITLE
Fix locking in SocketSendQueue

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -2,7 +2,7 @@
 # CTest
 #
 
-set(PRECICE_TEST_TIMEOUT_LONG 60 CACHE STRING "The timeout in seconds for longer tests.")
+set(PRECICE_TEST_TIMEOUT_LONG 120 CACHE STRING "The timeout in seconds for longer tests.")
 set(PRECICE_TEST_TIMEOUT_SHORT 20 CACHE STRING "The timeout in seconds for shorter tests.")
 
 set(PRECICE_TEST_DIR "${preCICE_BINARY_DIR}/TestOutput")

--- a/docs/changelog/1262.md
+++ b/docs/changelog/1262.md
@@ -1,0 +1,1 @@
+- Fixed a bug in the socket communication back-end, which occasionally lead to crashes.

--- a/src/com/SocketSendQueue.cpp
+++ b/src/com/SocketSendQueue.cpp
@@ -23,18 +23,24 @@ void SocketSendQueue::dispatch(std::shared_ptr<Socket>      sock,
                                boost::asio::const_buffers_1 data,
                                std::function<void()>        callback)
 {
-  {
-    std::lock_guard<std::mutex> lock(_queueMutex);
-    _itemQueue.push_back({std::move(sock), std::move(data), std::move(callback)});
-  }
+  std::lock_guard<std::mutex> lock(_queueMutex);
+  _itemQueue.push_back({std::move(sock), std::move(data), std::move(callback)});
+  process(); // if queue was previously empty, start it now.
+}
+
+void SocketSendQueue::sendCompleted()
+{
+  std::lock_guard<std::mutex> lock(_queueMutex);
+  _ready = true;
   process(); // if queue was previously empty, start it now.
 }
 
 void SocketSendQueue::process()
 {
-  std::lock_guard<std::mutex> lock(_queueMutex);
-  if (!_ready || _itemQueue.empty())
+  if (!_ready || _itemQueue.empty()) {
     return;
+  }
+
   auto item = _itemQueue.front();
   _itemQueue.pop_front();
   _ready = false;
@@ -42,8 +48,7 @@ void SocketSendQueue::process()
                     item.data,
                     [item, this](boost::system::error_code const &, std::size_t) {
                       item.callback();
-                      this->_ready = true;
-                      this->process();
+                      this->sendCompleted();
                     });
 }
 

--- a/src/com/SocketSendQueue.hpp
+++ b/src/com/SocketSendQueue.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <boost/asio.hpp>
 #include <deque>
 #include <functional>
@@ -27,6 +26,9 @@ public:
   /// Put data in the queue, start processing the queue.
   void dispatch(std::shared_ptr<Socket> sock, boost::asio::const_buffers_1 data, std::function<void()> callback);
 
+  /// Notifies the queue that the last asynchronous send operation has completed.
+  void sendCompleted();
+
 private:
   /// This method can be called arbitrarily many times, but enough times to ensure the queue makes progress.
   void process();
@@ -42,7 +44,7 @@ private:
   /// The mutex protecting access to the queue
   std::mutex _queueMutex;
   /// Is the queue allowed to start another asynchronous send?
-  std::atomic_bool _ready{true};
+  bool _ready = true;
 };
 
 } // namespace com

--- a/src/com/SocketSendQueue.hpp
+++ b/src/com/SocketSendQueue.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <boost/asio.hpp>
 #include <deque>
 #include <functional>
@@ -36,9 +37,12 @@ private:
     std::function<void()>        callback;
   };
 
+  /// The queue, containing items to asynchronously send using boost.asio.
   std::deque<SendItem> _itemQueue;
-  std::mutex           _sendMutex;
-  bool                 _ready = true;
+  /// The mutex protecting access to the queue
+  std::mutex _queueMutex;
+  /// Is the queue allowed to start another asynchronous send?
+  std::atomic_bool _ready{true};
 };
 
 } // namespace com


### PR DESCRIPTION
## Main changes of this PR

This PR fixes incorrect locking in the SocketSendQueue, which may occasinally lead to crashes when using a socket communication.


## Motivation and additional information

Closes #1243

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
