### PR TITLE
Adds a warning for small relative convergence thresholds

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -212,10 +212,9 @@ void BaseQNAcceleration::updateDifferenceMatrices(
       }
 
       PRECICE_CHECK(not math::equals(residualMagnitude, 0.0),
-                    "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residual "
-                    "in two consecutive iterations is identical. There is probably something wrong in your adapter. "
-                    "Maybe you always write the same (or only incremented) data or you call advance without "
-                    "providing  new data first.");
+                    "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residuals "
+                    "in two consecutive iterations are identical. If a relative convergence limit was selected, "
+                    "consider increasing the convergence threshold.");
 
       bool columnLimitReached = getLSSystemCols() == _maxIterationsUsed;
       bool overdetermined     = getLSSystemCols() <= getLSSystemRows();

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -697,6 +697,10 @@ void CouplingSchemeConfiguration::addRelativeConvergenceMeasure(
                 "Please check the <relative-convergence-measure limit=\"{}\" data=\"{}\" mesh=\"{}\" /> subtag "
                 "in your <coupling-scheme ... /> in the preCICE configuration file.",
                 limit, dataName, meshName);
+  if (math::smallerEquals(limit/10, 0.0)){
+    PRECICE_WARN("Relative convergence limit is too small. This may cause a conflict with "
+                 "the quasi-Newton acceleration scheme if selected. ");
+  }
 
   impl::PtrConvergenceMeasure measure(new impl::RelativeConvergenceMeasure(limit));
   ConvergenceMeasureDefintion convMeasureDef;
@@ -722,6 +726,11 @@ void CouplingSchemeConfiguration::addResidualRelativeConvergenceMeasure(
                 "Please check the <residul-relative-convergence-measure limit=\"{}\" data=\"{}\" mesh=\"{}\" /> subtag "
                 "in your <coupling-scheme ... /> in the preCICE configuration file.",
                 limit, dataName, meshName);
+  if (math::smallerEquals(limit/10, 0.0)){
+    PRECICE_WARN("Residual Relative convergence limit is too small. This may cause a conflict with "
+                 "the quasi-Newton acceleration scheme if selected. ");
+  }
+  
   impl::PtrConvergenceMeasure measure(new impl::ResidualRelativeConvergenceMeasure(limit));
   ConvergenceMeasureDefintion convMeasureDef;
   convMeasureDef.data        = getData(dataName, meshName);


### PR DESCRIPTION
## Main changes of this PR
Adds a warning if the relative convergence threshold is close to the machine tolerance.

## Motivation and additional information
closes https://github.com/precice/precice/issues/1107

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
