### PR TITLE
Fix GatherScatter bug

### DIFF
--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -93,7 +93,7 @@ void GatherScatterCommunication::send(precice::span<double const> itemsToSend, i
       PRECICE_DEBUG("Slave Size = {}", slaveSize);
       if (slaveSize > 0) {
         std::vector<double> valuesSlave(slaveSize);
-        utils::MasterSlave::getCommunication()->receive(valuesSlave, rankSlave);
+        utils::MasterSlave::getCommunication()->receive(span<double>{valuesSlave}, rankSlave);
         for (size_t i = 0; i < vertexDistribution[rankSlave].size(); i++) {
           for (int j = 0; j < valueDimension; j++) {
             globalItemsToSend[vertexDistribution[rankSlave][i] * valueDimension + j] += valuesSlave[i * valueDimension + j];


### PR DESCRIPTION
## Main changes of this PR

This PR fixes the mismatch between a send and receive in GatherScatter which lead to a quiet out of bounds access in the Parallel tests.

## Motivation and additional information

Closes #926

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
