### PR TITLE
Add author assign action

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,22 @@
+name: auto-author-assign
+# In most cases, pull request author should be assigned an assignee of the pull request.
+#
+# This action automatically assigns PR author as an assignee.
+# https://github.com/marketplace/actions/auto-author-assign
+
+name: 'Auto Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.4.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
In 99% of cases (at least this is how it feels to me :grin:), the author of a PR is also the one who should be assigned to the PR.
Normally, we just forget assigning somebody. Having a name there, however, makes the milestone overview page much easier to skim. 
For example: https://github.com/precice/precice/milestone/18

This action should do this automatically.

Is
```yml
          repo-token: "${{ secrets.GITHUB_TOKEN }}"
```
correct?

More information: https://github.com/marketplace/actions/auto-author-assign