### PR TITLE
Fix multiple warnings (in the context of v2.4.0)

### DIFF
--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -87,11 +87,11 @@ private:
   /// Data associated with this CouplingData
   mesh::PtrData _data;
 
-  /// Extrapolation associated with this CouplingData
-  cplscheme::impl::Extrapolation _extrapolation;
-
   /// Mesh associated with this CouplingData
   mesh::PtrMesh _mesh;
+
+  /// Extrapolation associated with this CouplingData
+  cplscheme::impl::Extrapolation _extrapolation;
 };
 
 } // namespace cplscheme

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -84,7 +84,7 @@ void ExportXML::writeParallelFile(
   if (offsets[0] > 0) {
     outParallelFile << "      <Piece Source=\"" << name << "_" << 0 << getPieceExtension() << "\"/>\n";
   }
-  for (auto rank : utils::IntraComm::allSecondaryRanks()) {
+  for (size_t rank : utils::IntraComm::allSecondaryRanks()) {
     PRECICE_ASSERT(rank < offsets.size());
     if (offsets[rank] - offsets[rank - 1] > 0) {
       //only non-empty subfiles

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -12,13 +12,13 @@ Mapping::Mapping(
     Constraint constraint,
     int        dimensions,
     bool       requireGradient)
-    : _constraint(constraint),
+    : _requireGradient(requireGradient),
+      _constraint(constraint),
       _inputRequirement(MeshRequirement::UNDEFINED),
       _outputRequirement(MeshRequirement::UNDEFINED),
       _input(),
       _output(),
-      _dimensions(dimensions),
-      _requireGradient(requireGradient)
+      _dimensions(dimensions)
 {
 }
 

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -95,11 +95,11 @@ private:
   /// ID of the data set (supposed to be unique).
   DataID _id;
 
-  /// Spacial Dimension of one element -> number of rows (only 2, 3 allowed for 2D, 3D).
-  int _spatialDimensions;
-
   /// Dimensionality of one data value.
   int _dimensions;
+
+  /// Spacial Dimension of one element -> number of rows (only 2, 3 allowed for 2D, 3D).
+  int _spatialDimensions;
 
   /// Flag if the gradient data is available
   bool _hasGradient;

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -696,7 +696,7 @@ void ReceivedPartition::createOwnerInformation()
        If both ranks have same vertex count, the lower rank will own the vertex.
     */
 
-    for (int i = 0; i < sharedVerticesGlobalIDs.size(); i++) {
+    for (size_t i = 0; i < sharedVerticesGlobalIDs.size(); i++) {
       bool owned = true;
 
       for (auto &sharingRank : sharedVerticesReceiveMap) {

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -623,7 +623,7 @@ void ReceivedPartition::createOwnerInformation()
         }
 
         if (not vertexIsShared) {
-          tags[i]     = 1;
+          tags[i] = 1;
           ownedVerticesCount++;
         }
       }

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -608,7 +608,6 @@ void ReceivedPartition::createOwnerInformation()
     PRECICE_DEBUG("Tag vertices, number of vertices {}", numberOfVertices);
     std::vector<int> tags(numberOfVertices, -1);
     std::vector<int> globalIDs(numberOfVertices, -1);
-    bool             atInterface        = false;
     int              ownedVerticesCount = 0; // number of vertices owned by this rank
     for (int i = 0; i < numberOfVertices; i++) {
       globalIDs[i] = _mesh->vertices()[i].getGlobalIndex();
@@ -625,7 +624,6 @@ void ReceivedPartition::createOwnerInformation()
 
         if (not vertexIsShared) {
           tags[i]     = 1;
-          atInterface = true;
           ownedVerticesCount++;
         }
       }

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -1058,7 +1058,6 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
 
 void testParallelSetOwnerInformation(mesh::PtrMesh mesh, int dimensions)
 {
-  bool   flipNormals  = true;
   double safetyFactor = 0;
 
   testing::ConnectionOptions options;

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -21,7 +21,7 @@ std::string DataContext::getDataName() const
   return _providedData->getName();
 }
 
-DataID DataContext::getFromDataID(int dataVectorIndex) const
+DataID DataContext::getFromDataID(size_t dataVectorIndex) const
 {
   PRECICE_ASSERT(hasMapping());
   PRECICE_ASSERT(dataVectorIndex < _fromData.size())
@@ -39,7 +39,7 @@ void DataContext::resetData()
   }
 }
 
-DataID DataContext::getToDataID(int dataVectorIndex) const
+DataID DataContext::getToDataID(size_t dataVectorIndex) const
 {
   PRECICE_ASSERT(hasMapping());
   PRECICE_ASSERT(dataVectorIndex < _toData.size())

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -141,7 +141,7 @@ private:
    *
    * @return DataID ID of _fromDatas.
    */
-  DataID getFromDataID(int dataVectorIndex) const;
+  DataID getFromDataID(size_t dataVectorIndex) const;
 
   /**
    * @brief Get the ID of the data in the _toDatas container. Used for performing the mapping outside of this class.
@@ -150,7 +150,7 @@ private:
    *
    * @return DataID ID of _toDatas.
    */
-  DataID getToDataID(int dataVectorIndex) const;
+  DataID getToDataID(size_t dataVectorIndex) const;
 
   /**
    * @brief Informs the user whether this DataContext has any _mappingContext.

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.cpp
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF)
   if (context.isNamed("SolverOne")) {
 
     MPI_Comm                 myComm = precice::utils::Parallel::current()->comm;
-    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size, &myComm);
 
     int    meshID = interface.getMeshID("MeshOne");
     int    vertexIDs[2];

--- a/tests/parallel/direct-mesh-access/helpers.cpp
+++ b/tests/parallel/direct-mesh-access/helpers.cpp
@@ -11,7 +11,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
                                const std::vector<double> writeDataSecondaryRank,
                                const std::vector<double> expectedPositionSecondaryRank,
                                const std::vector<double> expectedReadDataSecondaryRank,
-                               const int                 startIndex)
+                               const size_t              startIndex)
 {
   if (context.isNamed("SolverOne")) {
     // Defines the bounding box and writes data to the received mesh

--- a/tests/parallel/direct-mesh-access/helpers.hpp
+++ b/tests/parallel/direct-mesh-access/helpers.hpp
@@ -12,6 +12,6 @@ void runTestAccessReceivedMesh(const TestContext &       context,
                                const std::vector<double> writeDataSecondaryRank,
                                const std::vector<double> expectedPositionSecondaryRank,
                                const std::vector<double> expectedReadDataSecondaryRank,
-                               const int                 startIndex);
+                               const size_t              startIndex);
 
 #endif

--- a/tests/serial/initialize-data/helpers.cpp
+++ b/tests/serial/initialize-data/helpers.cpp
@@ -30,7 +30,7 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
     Vector3d pos       = Vector3d::Zero();
     cplInterface.setMeshVertex(meshTwoID, pos.data());
     cplInterface.initialize();
-    int    dataID = cplInterface.getDataID("Data", meshTwoID);
+    int dataID = cplInterface.getDataID("Data", meshTwoID);
     cplInterface.writeScalarData(dataID, 0, 2.0);
     //tell preCICE that data has been written and call initializeData
     cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());

--- a/tests/serial/initialize-data/helpers.cpp
+++ b/tests/serial/initialize-data/helpers.cpp
@@ -17,7 +17,7 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
     int      meshOneID = cplInterface.getMeshID("MeshOne");
     Vector3d pos       = Vector3d::Zero();
     cplInterface.setMeshVertex(meshOneID, pos.data());
-    double maxDt      = cplInterface.initialize();
+    cplInterface.initialize();
     int    dataID     = cplInterface.getDataID("Data", meshOneID);
     double valueDataB = 0.0;
     cplInterface.initializeData();
@@ -29,7 +29,7 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
     int      meshTwoID = cplInterface.getMeshID("MeshTwo");
     Vector3d pos       = Vector3d::Zero();
     cplInterface.setMeshVertex(meshTwoID, pos.data());
-    double maxDt  = cplInterface.initialize();
+    cplInterface.initialize();
     int    dataID = cplInterface.getDataID("Data", meshTwoID);
     cplInterface.writeScalarData(dataID, 0, 2.0);
     //tell preCICE that data has been written and call initializeData

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
@@ -60,7 +60,6 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
 
   int    nWindows   = 5; // perform 5 windows.
   double maxDt      = precice.initialize();
-  double windowDt   = maxDt;
   int    timewindow = 0;
   int    timewindowCheckpoint;
   double dt        = maxDt; // Timestep length desired by solver

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -94,7 +94,6 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
       BOOST_TEST(!precice.isReadDataAvailable());
     }
 
-    double oldReadData = readData;
     if (precice.isReadDataAvailable()) {
       precice.readScalarData(readDataID, vertexID, readData);
     }


### PR DESCRIPTION
## Main changes of this PR

This fixes the following kind of warnings observed in https://github.com/precice/precice/commit/56a50feb38c4383865c73cbd8741c78185b4b852 (based on https://github.com/precice/precice/commit/805fbdda268d090018ef4e55ce9296afcdba83e5), i.e., in the context of https://github.com/precice/precice/pull/1284.

## Motivation and additional information

These are warnings that have been introduced in different PRs since v2.3.0.

I looked at the scope surrounding each code line, but there are good chances that I may misunderstand something. In particular, try to reflect on why these variables were still there in the first place: is a test wrong? Is a feature not complete?

More specifically, this fixes:
- [x] All trivial `-Wunused-variable` and `-Wunused-but-set-variable`
- [ ] The remaining `-Wunused-variable` in `src/mapping/tests/NearestNeighborGradientMappingTest.cpp` (this would need a `[[maybe_unused]]`, i.e., upgrading to C++17).
- [x] The test case `UserDefinedMPICommunicatorPetRBF`, which seemed to not actually use the user-defined communicator. 
- [x] All `-Wreorder`
- [x] All `-Wsign-compare`

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> N/A
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
