### PR TITLE
Keep triangles in mesh communication/filtering in 2D

### DIFF
--- a/docs/changelog/1286.md
+++ b/docs/changelog/1286.md
@@ -1,1 +1,1 @@
-- Triangles can now be added on a 3D mesh.
+- Triangles can now be added on a 2D mesh.

--- a/docs/changelog/1286.md
+++ b/docs/changelog/1286.md
@@ -1,0 +1,1 @@
+- Triangles can now be added on a 3D mesh.

--- a/docs/changelog/1286.md
+++ b/docs/changelog/1286.md
@@ -1,1 +1,1 @@
-- Triangles can now be added on a 2D mesh.
+- Added support for triangles in 2D meshes

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -49,16 +49,14 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
   }
 
   // Add all triangles formed by the contributing edges
-  if (source.getDimensions() == 3) {
-    for (const Triangle &triangle : source.triangles()) {
-      EdgeID edgeIndex1 = triangle.edge(0).getID();
-      EdgeID edgeIndex2 = triangle.edge(1).getID();
-      EdgeID edgeIndex3 = triangle.edge(2).getID();
-      if (edgeMap.count(edgeIndex1) == 1 &&
-          edgeMap.count(edgeIndex2) == 1 &&
-          edgeMap.count(edgeIndex3) == 1) {
-        destination.createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
-      }
+  for (const Triangle &triangle : source.triangles()) {
+    EdgeID edgeIndex1 = triangle.edge(0).getID();
+    EdgeID edgeIndex2 = triangle.edge(1).getID();
+    EdgeID edgeIndex3 = triangle.edge(2).getID();
+    if (edgeMap.count(edgeIndex1) == 1 &&
+        edgeMap.count(edgeIndex2) == 1 &&
+        edgeMap.count(edgeIndex3) == 1) {
+      destination.createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
     }
   }
 }

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -373,16 +373,14 @@ void Mesh::addMesh(
     edgeMap[edge.getID()] = &e;
   }
 
-  if (_dimensions == 3) {
-    for (const Triangle &triangle : deltaMesh.triangles()) {
-      EdgeID edgeIndex1 = triangle.edge(0).getID();
-      EdgeID edgeIndex2 = triangle.edge(1).getID();
-      EdgeID edgeIndex3 = triangle.edge(2).getID();
-      PRECICE_ASSERT((edgeMap.count(edgeIndex1) == 1) &&
-                     (edgeMap.count(edgeIndex2) == 1) &&
-                     (edgeMap.count(edgeIndex3) == 1));
-      createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
-    }
+  for (const Triangle &triangle : deltaMesh.triangles()) {
+    EdgeID edgeIndex1 = triangle.edge(0).getID();
+    EdgeID edgeIndex2 = triangle.edge(1).getID();
+    EdgeID edgeIndex3 = triangle.edge(2).getID();
+    PRECICE_ASSERT((edgeMap.count(edgeIndex1) == 1) &&
+                   (edgeMap.count(edgeIndex2) == 1) &&
+                   (edgeMap.count(edgeIndex3) == 1));
+    createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
   }
   _index.clear();
 }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -828,8 +828,7 @@ void SolverInterfaceImpl::setMeshTriangle(
 {
   PRECICE_TRACE(meshID, firstEdgeID,
                 secondEdgeID, thirdEdgeID);
-  PRECICE_CHECK(_dimensions == 3, "setMeshTriangle is only possible for 3D cases."
-                                  " Please set the dimension to 3 in the preCICE configuration file.");
+
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
@@ -859,8 +858,7 @@ void SolverInterfaceImpl::setMeshTriangleWithEdges(
 {
   PRECICE_TRACE(meshID, firstVertexID,
                 secondVertexID, thirdVertexID);
-  PRECICE_CHECK(_dimensions == 3, "setMeshTriangleWithEdges is only possible for 3D cases."
-                                  " Please set the dimension to 3 in the preCICE configuration file.");
+
   PRECICE_REQUIRE_MESH_MODIFY(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {


### PR DESCRIPTION
## Main changes of this PR

Split of https://github.com/precice/precice/pull/1258. Remove restrictions where triangles woudn't be sent during mesh comunication/filtering in 2D. This is now allowed, and in cases where it shouldn't happen, triangle creation is already prevented elsewhere anyway.

## Motivation and additional information

Volumetric coupling: https://github.com/precice/precice/issues/468

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
