### PR TITLE
Refactoring NP mapping with a base class

### DIFF
--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -54,7 +54,7 @@ void BarycentricBaseMapping::map(
   mesh::PtrData          outData   = output()->data(outputDataID);
   const Eigen::VectorXd &inValues  = inData->values();
   Eigen::VectorXd &      outValues = outData->values();
-  int dimensions = inData->getDimensions();
+const  int dimensions = inData->getDimensions();
   PRECICE_ASSERT(dimensions == outData->getDimensions());
 
   if (hasConstraint(CONSERVATIVE)) {

--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -48,7 +48,7 @@ void BarycentricBaseMapping::map(
 {
   PRECICE_TRACE(inputDataID, outputDataID);
 
-  precice::utils::Event e("map.np.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
+  precice::utils::Event e("map.bm.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
   mesh::PtrData          inData    = input()->data(inputDataID);
   mesh::PtrData          outData   = output()->data(outputDataID);

--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -54,7 +54,6 @@ void BarycentricBaseMapping::map(
   mesh::PtrData          outData   = output()->data(outputDataID);
   const Eigen::VectorXd &inValues  = inData->values();
   Eigen::VectorXd &      outValues = outData->values();
-  //assign(outValues) = 0.0;
   int dimensions = inData->getDimensions();
   PRECICE_ASSERT(dimensions == outData->getDimensions());
 

--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -1,7 +1,6 @@
 
 #include <Eigen/Core>
 #include <algorithm>
-#include <deque>
 #include <memory>
 #include <ostream>
 #include <unordered_set>

--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -97,7 +97,6 @@ void BarycentricBaseMapping::map(
   }
 }
 
-
 void BarycentricBaseMapping::tagMeshFirstRound()
 {
   PRECICE_TRACE();

--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -1,0 +1,101 @@
+
+#include <Eigen/Core>
+#include <algorithm>
+#include <deque>
+#include <memory>
+#include <ostream>
+#include <unordered_set>
+#include <utility>
+
+#include "logging/LogMacros.hpp"
+#include "mapping/BarycentricBaseMapping.hpp"
+#include "mapping/Polation.hpp"
+#include "math/differences.hpp"
+#include "mesh/Data.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
+#include "mesh/Vertex.hpp"
+#include "query/Index.hpp"
+#include "utils/Event.hpp"
+#include "utils/Statistics.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice {
+extern bool syncMode;
+
+namespace mapping {
+
+BarycentricBaseMapping::BarycentricBaseMapping(Constraint constraint, int dimensions)
+    : Mapping(constraint, dimensions)
+{
+}
+
+bool BarycentricBaseMapping::hasComputedMapping() const
+{
+  return _hasComputedMapping;
+}
+
+void BarycentricBaseMapping::clear()
+{
+  PRECICE_TRACE();
+  _interpolations.clear();
+  _hasComputedMapping = false;
+}
+
+void BarycentricBaseMapping::map(
+    int inputDataID,
+    int outputDataID)
+{
+  PRECICE_TRACE(inputDataID, outputDataID);
+
+  precice::utils::Event e("map.np.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
+
+  mesh::PtrData          inData    = input()->data(inputDataID);
+  mesh::PtrData          outData   = output()->data(outputDataID);
+  const Eigen::VectorXd &inValues  = inData->values();
+  Eigen::VectorXd &      outValues = outData->values();
+  //assign(outValues) = 0.0;
+  int dimensions = inData->getDimensions();
+  PRECICE_ASSERT(dimensions == outData->getDimensions());
+
+  if (hasConstraint(CONSERVATIVE)) {
+    PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
+    PRECICE_DEBUG("Map conservative");
+    PRECICE_ASSERT(_interpolations.size() == input()->vertices().size(),
+                   _interpolations.size(), input()->vertices().size());
+    for (size_t i = 0; i < input()->vertices().size(); i++) {
+      size_t      inOffset = i * dimensions;
+      const auto &elems    = _interpolations[i].getWeightedElements();
+      for (const auto &elem : elems) {
+        size_t outOffset = static_cast<size_t>(elem.vertexID) * dimensions;
+        for (int dim = 0; dim < dimensions; dim++) {
+          PRECICE_ASSERT(outOffset + dim < (size_t) outValues.size());
+          PRECICE_ASSERT(inOffset + dim < (size_t) inValues.size());
+          outValues(outOffset + dim) += elem.weight * inValues(inOffset + dim);
+        }
+      }
+    }
+  } else {
+    PRECICE_DEBUG("Map consistent");
+    PRECICE_ASSERT(_interpolations.size() == output()->vertices().size(),
+                   _interpolations.size(), output()->vertices().size());
+    for (size_t i = 0; i < output()->vertices().size(); i++) {
+      const auto &elems     = _interpolations[i].getWeightedElements();
+      size_t      outOffset = i * dimensions;
+      for (const auto &elem : elems) {
+        size_t inOffset = static_cast<size_t>(elem.vertexID) * dimensions;
+        for (int dim = 0; dim < dimensions; dim++) {
+          PRECICE_ASSERT(outOffset + dim < (size_t) outValues.size());
+          PRECICE_ASSERT(inOffset + dim < (size_t) inValues.size());
+          outValues(outOffset + dim) += elem.weight * inValues(inOffset + dim);
+        }
+      }
+    }
+    if (hasConstraint(SCALEDCONSISTENT)) {
+      scaleConsistentMapping(inputDataID, outputDataID);
+    }
+  }
+}
+
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -63,7 +63,7 @@ const  int dimensions = inData->getDimensions();
     PRECICE_ASSERT(_interpolations.size() == input()->vertices().size(),
                    _interpolations.size(), input()->vertices().size());
     for (size_t i = 0; i < input()->vertices().size(); i++) {
-      size_t      inOffset = i * dimensions;
+    const  size_t      inOffset = i * dimensions;
       const auto &elems    = _interpolations[i].getWeightedElements();
       for (const auto &elem : elems) {
         size_t outOffset = static_cast<size_t>(elem.vertexID) * dimensions;

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -24,10 +24,10 @@ public:
   /// Computes the projections and interpolation relations. Must be done by inherited subclass
   virtual void computeMapping() = 0;
 
-  virtual bool hasComputedMapping() const override;
+  virtual bool hasComputedMapping() const final;
 
   /// Removes a computed mapping.
-  virtual void clear() override;
+  virtual void clear() final;
 
   /**
    * @brief Uses projection and interpolation relations to map data values.
@@ -40,14 +40,15 @@ public:
    */
   virtual void map(
       int inputDataID,
-      int outputDataID) override;
+      int outputDataID) final;
 
   virtual void tagMeshFirstRound()  = 0;
   virtual void tagMeshSecondRound() = 0;
 
-protected:
+private:
   logging::Logger _log{"mapping::BarycentricBaseMapping"};
 
+protected:
   std::vector<Polation> _interpolations;
 
   bool _hasComputedMapping = false;

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -19,7 +19,7 @@ public:
   BarycentricBaseMapping(Constraint constraint, int dimensions);
 
   /// Destructor, empty.
-  virtual ~BarycentricBaseMapping() {}
+  virtual ~BarycentricBaseMapping() = default;
 
   /// Computes the projections and interpolation relations. Must be done by inherited subclass
   virtual void computeMapping() = 0;

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <list>
+#include <string>
+#include <vector>
+#include "logging/Logger.hpp"
+#include "mapping/Mapping.hpp"
+#include "mapping/Polation.hpp"
+
+namespace precice {
+namespace mapping {
+
+/**
+ * @brief Base class for interpolation based mappings, where mapping is done using a geometry-based linear combination of input values.
+ *  Subclasses differ by the way computeMapping() fills the _interpolations and by mesh tagging. Mapping itself is shared.
+ */
+class BarycentricBaseMapping : public Mapping {
+public:
+  BarycentricBaseMapping(Constraint constraint, int dimensions);
+
+  /// Destructor, empty.
+  virtual ~BarycentricBaseMapping() {}
+
+  /// Computes the projections and interpolation relations. Must be done by inherited subclass
+  virtual void computeMapping() = 0;
+
+  virtual bool hasComputedMapping() const override;
+
+  /// Removes a computed mapping.
+  virtual void clear() override;
+
+  /**
+   * @brief Uses projection and interpolation relations to map data values.
+   *
+   * Preconditions:
+   * - computeMapping() has been called
+   *
+   * @param[in] inputDataID Data ID of input data values to be mapped from.
+   * @param[in] outputDataID Data ID of output data values to be mapped to.
+   */
+  virtual void map(
+      int inputDataID,
+      int outputDataID) override;
+
+  virtual void tagMeshFirstRound()  = 0;
+  virtual void tagMeshSecondRound() = 0;
+
+protected:
+  logging::Logger _log{"mapping::BarycentricBaseMapping"};
+
+  std::vector<Polation> _interpolations;
+
+  bool _hasComputedMapping = false;
+};
+
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -30,8 +30,7 @@ public:
   /**
    * @brief Uses projection and interpolation relations to map data values.
    *
-   * Preconditions:
-   * - computeMapping() has been called
+   * @pre computeMapping() has been called
    *
    * @param[in] inputDataID Data ID of input data values to be mapped from.
    * @param[in] outputDataID Data ID of output data values to be mapped to.

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -42,8 +42,8 @@ public:
       int inputDataID,
       int outputDataID) final;
 
-  virtual void tagMeshFirstRound()  = 0;
-  virtual void tagMeshSecondRound() = 0;
+  virtual void tagMeshFirstRound() final;
+  virtual void tagMeshSecondRound() final;
 
 private:
   logging::Logger _log{"mapping::BarycentricBaseMapping"};

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <list>
-#include <string>
 #include <vector>
 #include "logging/Logger.hpp"
 #include "mapping/Mapping.hpp"

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -29,7 +29,7 @@ namespace mapping {
 NearestProjectionMapping::NearestProjectionMapping(
     Constraint constraint,
     int        dimensions)
-    : Mapping(constraint, dimensions)
+    : BarycentricBaseMapping(constraint, dimensions)
 {
   if (constraint == CONSISTENT) {
     setInputRequirement(Mapping::MeshRequirement::FULL);
@@ -120,73 +120,6 @@ void NearestProjectionMapping::computeMapping()
   }
 
   _hasComputedMapping = true;
-}
-
-bool NearestProjectionMapping::hasComputedMapping() const
-{
-  return _hasComputedMapping;
-}
-
-void NearestProjectionMapping::clear()
-{
-  PRECICE_TRACE();
-  _interpolations.clear();
-  _hasComputedMapping = false;
-}
-
-void NearestProjectionMapping::map(
-    int inputDataID,
-    int outputDataID)
-{
-  PRECICE_TRACE(inputDataID, outputDataID);
-
-  precice::utils::Event e("map.np.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
-
-  mesh::PtrData          inData    = input()->data(inputDataID);
-  mesh::PtrData          outData   = output()->data(outputDataID);
-  const Eigen::VectorXd &inValues  = inData->values();
-  Eigen::VectorXd &      outValues = outData->values();
-  //assign(outValues) = 0.0;
-  int dimensions = inData->getDimensions();
-  PRECICE_ASSERT(dimensions == outData->getDimensions());
-
-  if (hasConstraint(CONSERVATIVE)) {
-    PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
-    PRECICE_DEBUG("Map conservative");
-    PRECICE_ASSERT(_interpolations.size() == input()->vertices().size(),
-                   _interpolations.size(), input()->vertices().size());
-    for (size_t i = 0; i < input()->vertices().size(); i++) {
-      size_t      inOffset = i * dimensions;
-      const auto &elems    = _interpolations[i].getWeightedElements();
-      for (const auto &elem : elems) {
-        size_t outOffset = static_cast<size_t>(elem.vertexID) * dimensions;
-        for (int dim = 0; dim < dimensions; dim++) {
-          PRECICE_ASSERT(outOffset + dim < (size_t) outValues.size());
-          PRECICE_ASSERT(inOffset + dim < (size_t) inValues.size());
-          outValues(outOffset + dim) += elem.weight * inValues(inOffset + dim);
-        }
-      }
-    }
-  } else {
-    PRECICE_DEBUG("Map consistent");
-    PRECICE_ASSERT(_interpolations.size() == output()->vertices().size(),
-                   _interpolations.size(), output()->vertices().size());
-    for (size_t i = 0; i < output()->vertices().size(); i++) {
-      const auto &elems     = _interpolations[i].getWeightedElements();
-      size_t      outOffset = i * dimensions;
-      for (const auto &elem : elems) {
-        size_t inOffset = static_cast<size_t>(elem.vertexID) * dimensions;
-        for (int dim = 0; dim < dimensions; dim++) {
-          PRECICE_ASSERT(outOffset + dim < (size_t) outValues.size());
-          PRECICE_ASSERT(inOffset + dim < (size_t) inValues.size());
-          outValues(outOffset + dim) += elem.weight * inValues(inOffset + dim);
-        }
-      }
-    }
-    if (hasConstraint(SCALEDCONSISTENT)) {
-      scaleConsistentMapping(inputDataID, outputDataID);
-    }
-  }
 }
 
 void NearestProjectionMapping::tagMeshFirstRound()

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -2,10 +2,8 @@
 
 #include <Eigen/Core>
 #include <algorithm>
-#include <deque>
 #include <memory>
 #include <ostream>
-#include <unordered_set>
 #include <utility>
 
 #include "logging/LogMacros.hpp"

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -122,6 +122,5 @@ void NearestProjectionMapping::computeMapping()
   _hasComputedMapping = true;
 }
 
-
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -122,56 +122,6 @@ void NearestProjectionMapping::computeMapping()
   _hasComputedMapping = true;
 }
 
-void NearestProjectionMapping::tagMeshFirstRound()
-{
-  PRECICE_TRACE();
-  precice::utils::Event e("map.np.tagMeshFirstRound.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
-  PRECICE_DEBUG("Compute Mapping for Tagging");
-
-  computeMapping();
-  PRECICE_DEBUG("Tagging First Round");
-
-  // Determine the Mesh to Tag
-  mesh::PtrMesh origins;
-  if (hasConstraint(CONSERVATIVE)) {
-    origins = output();
-  } else {
-    origins = input();
-  }
-
-  // Gather all vertices to be tagged in a first phase.
-  // max_count is used to shortcut if all vertices have been tagged.
-  std::unordered_set<int> tagged;
-  const std::size_t       max_count = origins->vertices().size();
-
-  for (const Polation &interpolation : _interpolations) {
-    for (const auto &elem : interpolation.getWeightedElements()) {
-      if (!math::equals(elem.weight, 0.0)) {
-        tagged.insert(elem.vertexID);
-      }
-    }
-    // Shortcut if all vertices are tagged
-    if (tagged.size() == max_count) {
-      break;
-    }
-  }
-
-  // Now tag all vertices to be tagged in the second phase.
-  for (auto &v : origins->vertices()) {
-    if (tagged.count(v.getID()) == 1) {
-      v.tag();
-    }
-  }
-  PRECICE_DEBUG("First Round Tagged {}/{} Vertices", tagged.size(), max_count);
-
-  clear();
-}
-
-void NearestProjectionMapping::tagMeshSecondRound()
-{
-  PRECICE_TRACE();
-  // for NP mapping no operation needed here
-}
 
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 #include "logging/Logger.hpp"
-#include "mapping/Mapping.hpp"
+#include "mapping/BarycentricBaseMapping.hpp"
 #include "mapping/Polation.hpp"
 
 namespace precice {
@@ -14,7 +14,7 @@ namespace mapping {
  * @brief Mapping using orthogonal projection to nearest triangle/edge/vertex and
  *        linear interpolation from projected point.
  */
-class NearestProjectionMapping : public Mapping {
+class NearestProjectionMapping : public BarycentricBaseMapping {
 public:
   /// Constructor, taking mapping constraint.
   NearestProjectionMapping(Constraint constraint, int dimensions);
@@ -25,33 +25,8 @@ public:
   /// Computes the projections and interpolation relations.
   virtual void computeMapping() override;
 
-  virtual bool hasComputedMapping() const override;
-
-  /// Removes a computed mapping.
-  virtual void clear() override;
-
-  /**
-   * @brief Uses projection and interpolation relations to map data values.
-   *
-   * Preconditions:
-   * - computeMapping() has been called
-   *
-   * @param[in] inputDataID Data ID of input data values to be mapped from.
-   * @param[in] outputDataID Data ID of output data values to be mapped to.
-   */
-  virtual void map(
-      int inputDataID,
-      int outputDataID) override;
-
   virtual void tagMeshFirstRound() override;
   virtual void tagMeshSecondRound() override;
-
-private:
-  logging::Logger _log{"mapping::NearestProjectionMapping"};
-
-  std::vector<Polation> _interpolations;
-
-  bool _hasComputedMapping = false;
 };
 
 } // namespace mapping

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -25,8 +25,6 @@ public:
   /// Computes the projections and interpolation relations.
   virtual void computeMapping() override;
 
-  virtual void tagMeshFirstRound() override;
-  virtual void tagMeshSecondRound() override;
 
 private:
   logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <list>
-#include <string>
-#include <vector>
 #include "logging/Logger.hpp"
 #include "mapping/BarycentricBaseMapping.hpp"
 #include "mapping/Polation.hpp"

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -27,6 +27,10 @@ public:
 
   virtual void tagMeshFirstRound() override;
   virtual void tagMeshSecondRound() override;
+
+  private:
+    logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};
+
 };
 
 } // namespace mapping

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -25,7 +25,6 @@ public:
   /// Computes the projections and interpolation relations.
   virtual void computeMapping() override;
 
-
 private:
   logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};
 };

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -28,9 +28,8 @@ public:
   virtual void tagMeshFirstRound() override;
   virtual void tagMeshSecondRound() override;
 
-  private:
-    logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};
-
+private:
+  logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};
 };
 
 } // namespace mapping

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -171,6 +171,8 @@ target_sources(precice
     src/m2n/SharedPointer.hpp
     src/m2n/config/M2NConfiguration.cpp
     src/m2n/config/M2NConfiguration.hpp
+    src/mapping/BarycentricBaseMapping.cpp
+    src/mapping/BarycentricBaseMapping.hpp
     src/mapping/Mapping.cpp
     src/mapping/Mapping.hpp
     src/mapping/NearestNeighborBaseMapping.cpp


### PR DESCRIPTION
## Main changes of this PR

NP mapping has common features with the coming volumetric coupling mapping: each output vertex takes the value of a linear combination of input vertices (in the consistent case), and the map() function simply computes these combinations. The part that is not shared is how this linear combination is built. (NP uses surface primitives and volumetric use volume primitives) 

## Motivation and additional information

Part of https://github.com/precice/precice/issues/468, split of https://github.com/precice/precice/pull/1258

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
