### PR TITLE
Split communication tests

### DIFF
--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -401,17 +401,6 @@ void TestReduceVectors(TestContext const &context)
   }
 }
 
-template <typename T>
-void TestSendAndReceive(TestContext const &context)
-{
-  TestSendAndReceivePrimitiveTypes<T>(context);
-  TestSendAndReceiveVectors<T>(context);
-  TestBroadcastPrimitiveTypes<T>(context);
-  TestBroadcastVectors<T>(context);
-  TestReducePrimitiveTypes<T>(context);
-  TestReduceVectors<T>(context);
-}
-
 } // namespace primaryprimary
 
 namespace intracomm {
@@ -756,17 +745,6 @@ void TestReduceVectors(TestContext const &context)
     }
     com.closeConnection();
   }
-}
-
-template <typename T>
-void TestSendAndReceive(TestContext const &context)
-{
-  TestSendAndReceivePrimitiveTypes<T>(context);
-  TestSendAndReceiveVectors<T>(context);
-  TestBroadcastPrimitiveTypes<T>(context);
-  TestBroadcastVectors<T>(context);
-  TestReducePrimitiveTypes<T>(context);
-  TestReduceVectors<T>(context);
 }
 
 } // namespace intracomm

--- a/src/com/tests/MPIDirectCommunicationTest.cpp
+++ b/src/com/tests/MPIDirectCommunicationTest.cpp
@@ -14,14 +14,53 @@ BOOST_AUTO_TEST_SUITE(CommunicationTests)
 
 BOOST_AUTO_TEST_SUITE(MPIDirect)
 
-BOOST_AUTO_TEST_CASE(SendAndReceive)
+BOOST_AUTO_TEST_SUITE(Intra)
+
+BOOST_AUTO_TEST_CASE(SendReceivePrimitives)
 {
   PRECICE_TEST(2_ranks, Require::Events);
-  testing::com::intracomm::TestSendAndReceive<MPIDirectCommunication>(context);
+  using namespace precice::testing::com::intracomm;
+  TestSendAndReceivePrimitiveTypes<MPIDirectCommunication>(context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // MPIDirectCommunication
+BOOST_AUTO_TEST_CASE(SendReceiveVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestSendAndReceiveVectors<MPIDirectCommunication>(context);
+}
 
+BOOST_AUTO_TEST_CASE(BroadcastPrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastPrimitiveTypes<MPIDirectCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastVectors<MPIDirectCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReducePrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReducePrimitiveTypes<MPIDirectCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReduceVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReduceVectors<MPIDirectCommunication>(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Intra
+
+BOOST_AUTO_TEST_SUITE_END() // MPIDirect
 BOOST_AUTO_TEST_SUITE_END() // Communication
 
-#endif // not PRECICE_NO_MPI
+#endif

--- a/src/com/tests/MPIPortsCommunicationTest.cpp
+++ b/src/com/tests/MPIPortsCommunicationTest.cpp
@@ -12,53 +12,133 @@ using namespace precice::com;
 
 BOOST_AUTO_TEST_SUITE(CommunicationTests)
 
-BOOST_AUTO_TEST_SUITE(MPIPorts,
-                      *boost::unit_test::label("MPI_Ports"))
+BOOST_AUTO_TEST_SUITE(MPIPorts)
 
-BOOST_AUTO_TEST_CASE(SendAndReceiveMM)
-{
-  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
-  using namespace precice::testing::com::primaryprimary;
-  TestSendAndReceive<MPIPortsCommunication>(context);
-}
+BOOST_AUTO_TEST_SUITE(Intra)
 
-BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
+BOOST_AUTO_TEST_CASE(SendReceivePrimitives)
 {
   PRECICE_TEST(2_ranks, Require::Events);
   using namespace precice::testing::com::intracomm;
-  TestSendAndReceive<MPIPortsCommunication>(context);
+  TestSendAndReceivePrimitiveTypes<MPIPortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesMM)
+BOOST_AUTO_TEST_CASE(SendReceiveVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestSendAndReceiveVectors<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastPrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastPrimitiveTypes<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastVectors<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReducePrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReducePrimitiveTypes<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReduceVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReduceVectors<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Intra
+
+BOOST_AUTO_TEST_SUITE(Inter)
+
+BOOST_AUTO_TEST_CASE(SendReceivePrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestSendAndReceivePrimitiveTypes<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestSendAndReceiveVectors<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastPrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestBroadcastPrimitiveTypes<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestBroadcastVectors<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReducePrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestReducePrimitiveTypes<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReduceVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestReduceVectors<MPIPortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveFourProcesses)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::primaryprimary;
   TestSendReceiveFourProcesses<MPIPortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
+BOOST_AUTO_TEST_SUITE_END() // Inter
+
+BOOST_AUTO_TEST_SUITE(Server)
+
+BOOST_AUTO_TEST_CASE(SendReceiveTwo)
 {
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveTwoProcessesServerClient<MPIPortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient)
+BOOST_AUTO_TEST_CASE(SendReceiveFour)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveFourProcessesServerClient<MPIPortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2)
+BOOST_AUTO_TEST_CASE(SendReceiveFourV2)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveFourProcessesServerClientV2<MPIPortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // MPIPortsCommunication
+BOOST_AUTO_TEST_SUITE_END() // Server
 
+BOOST_AUTO_TEST_SUITE_END() // MPIPorts
 BOOST_AUTO_TEST_SUITE_END() // Communication
 
-#endif // not PRECICE_NO_MPI
+#endif

--- a/src/com/tests/MPISinglePortsCommunicationTest.cpp
+++ b/src/com/tests/MPISinglePortsCommunicationTest.cpp
@@ -2,61 +2,143 @@
 
 #include "GenericTestFunctions.hpp"
 #include "com/MPISinglePortsCommunication.hpp"
+#include "com/SharedPointer.hpp"
+#include "math/constants.hpp"
+#include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
-#include "utils/Parallel.hpp"
 
 using namespace precice;
 using namespace precice::com;
 
 BOOST_AUTO_TEST_SUITE(CommunicationTests)
 
-BOOST_AUTO_TEST_SUITE(MPISinglePorts,
-                      *boost::unit_test::label("MPI_Ports"))
+BOOST_AUTO_TEST_SUITE(MPISinglePorts)
 
-BOOST_AUTO_TEST_CASE(SendAndReceiveMM)
-{
-  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
-  using namespace precice::testing::com::primaryprimary;
-  TestSendAndReceive<MPISinglePortsCommunication>(context);
-}
+BOOST_AUTO_TEST_SUITE(Intra)
 
-BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
+BOOST_AUTO_TEST_CASE(SendReceivePrimitives)
 {
   PRECICE_TEST(2_ranks, Require::Events);
   using namespace precice::testing::com::intracomm;
-  TestSendAndReceive<MPISinglePortsCommunication>(context);
+  TestSendAndReceivePrimitiveTypes<MPISinglePortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesMM)
+BOOST_AUTO_TEST_CASE(SendReceiveVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestSendAndReceiveVectors<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastPrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastPrimitiveTypes<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastVectors<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReducePrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReducePrimitiveTypes<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReduceVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReduceVectors<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Intra
+
+BOOST_AUTO_TEST_SUITE(Inter)
+
+BOOST_AUTO_TEST_CASE(SendReceivePrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestSendAndReceivePrimitiveTypes<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestSendAndReceiveVectors<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastPrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestBroadcastPrimitiveTypes<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestBroadcastVectors<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReducePrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestReducePrimitiveTypes<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReduceVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestReduceVectors<MPISinglePortsCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveFourProcesses)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::primaryprimary;
   TestSendReceiveFourProcesses<MPISinglePortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
+BOOST_AUTO_TEST_SUITE_END() // Inter
+
+BOOST_AUTO_TEST_SUITE(Server)
+
+BOOST_AUTO_TEST_CASE(SendReceiveTwo)
 {
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveTwoProcessesServerClient<MPISinglePortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient)
+BOOST_AUTO_TEST_CASE(SendReceiveFour)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveFourProcessesServerClient<MPISinglePortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2)
+BOOST_AUTO_TEST_CASE(SendReceiveFourV2)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveFourProcessesServerClientV2<MPISinglePortsCommunication>(context);
 }
 
-BOOST_AUTO_TEST_SUITE_END() // MPISinglePortsCommunication
+BOOST_AUTO_TEST_SUITE_END() // Server
 
+BOOST_AUTO_TEST_SUITE_END() // MPISinglePorts
 BOOST_AUTO_TEST_SUITE_END() // Communication
 
-#endif // not PRECICE_NO_MPI
+#endif

--- a/src/com/tests/SocketCommunicationTest.cpp
+++ b/src/com/tests/SocketCommunicationTest.cpp
@@ -15,18 +15,94 @@ BOOST_AUTO_TEST_SUITE(CommunicationTests)
 
 BOOST_AUTO_TEST_SUITE(Socket)
 
-BOOST_AUTO_TEST_CASE(SendAndReceiveMM)
-{
-  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
-  using namespace precice::testing::com::primaryprimary;
-  TestSendAndReceive<SocketCommunication>(context);
-}
+BOOST_AUTO_TEST_SUITE(Intra)
 
-BOOST_AUTO_TEST_CASE(SendAndReceiveMS)
+BOOST_AUTO_TEST_CASE(SendReceivePrimitives)
 {
   PRECICE_TEST(2_ranks, Require::Events);
   using namespace precice::testing::com::intracomm;
-  TestSendAndReceive<SocketCommunication>(context);
+  TestSendAndReceivePrimitiveTypes<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestSendAndReceiveVectors<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastPrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastPrimitiveTypes<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestBroadcastVectors<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReducePrimitives)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReducePrimitiveTypes<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReduceVectors)
+{
+  PRECICE_TEST(2_ranks, Require::Events);
+  using namespace precice::testing::com::intracomm;
+  TestReduceVectors<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Intra
+
+BOOST_AUTO_TEST_SUITE(Inter)
+
+BOOST_AUTO_TEST_CASE(SendReceivePrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestSendAndReceivePrimitiveTypes<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(SendReceiveVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestSendAndReceiveVectors<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastPrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestBroadcastPrimitiveTypes<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(BroadcastVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestBroadcastVectors<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReducePrimitives)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestReducePrimitiveTypes<SocketCommunication>(context);
+}
+
+BOOST_AUTO_TEST_CASE(ReduceVectors)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
+  using namespace precice::testing::com::primaryprimary;
+  TestReduceVectors<SocketCommunication>(context);
 }
 
 BOOST_AUTO_TEST_CASE(SendReceiveFourProcesses)
@@ -36,26 +112,32 @@ BOOST_AUTO_TEST_CASE(SendReceiveFourProcesses)
   TestSendReceiveFourProcesses<SocketCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveTwoProcessesServerClient)
+BOOST_AUTO_TEST_SUITE_END() // Inter
+
+BOOST_AUTO_TEST_SUITE(Server)
+
+BOOST_AUTO_TEST_CASE(SendReceiveTwo)
 {
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveTwoProcessesServerClient<SocketCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClient)
+BOOST_AUTO_TEST_CASE(SendReceiveFour)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveFourProcessesServerClient<SocketCommunication>(context);
 }
 
-BOOST_AUTO_TEST_CASE(SendReceiveFourProcessesServerClientV2)
+BOOST_AUTO_TEST_CASE(SendReceiveFourV2)
 {
   PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks), Require::Events);
   using namespace precice::testing::com::serverclient;
   TestSendReceiveFourProcessesServerClientV2<SocketCommunication>(context);
 }
+
+BOOST_AUTO_TEST_SUITE_END() // Server
 
 BOOST_AUTO_TEST_SUITE_END() // Socket
 BOOST_AUTO_TEST_SUITE_END() // Communication


### PR DESCRIPTION
## Main changes of this PR

Splits communication into smaller units.

## Motivation and additional information

Each communication test now creates only one communication.
This prevents name collisions between connection files as all ranks are tests are synchronized between tests.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
