### PR TITLE
Improve communication info publisher

### DIFF
--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -115,7 +115,7 @@ void ConnectionInfoWriter::write(std::string const &info) const
 
   {
     auto message = "Unable to establish connection as a {}connection file already exists at \"{}\". "
-                   "This is likely a leftover of a previous crash during communication build-up. "
+                   "This is likely a leftover of a previous crash or stop during communication build-up. "
                    "Please remove the \"precice-run\" directory and restart the simulation.";
     PRECICE_CHECK(!bfs::exists(path), message, "", path);
     PRECICE_CHECK(!bfs::exists(tmp), message, "temporary ")

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -89,17 +89,16 @@ ConnectionInfoWriter::~ConnectionInfoWriter()
   if (!bfs::exists(path)) {
     PRECICE_WARN("Cannot clean-up the connection file \"{}\" as it doesn't exist. "
                  "In case of connection problems, please report this to the preCICE developers.",
-                 path);
+                 path.generic_string());
     return;
   }
-  PRECICE_DEBUG("Deleting connection file \"{}\"", path);
+  PRECICE_DEBUG("Deleting connection file \"{}\"", path.generic_string());
   try {
     bfs::remove(path);
-    /// @TODO Check if we need to sleep to let the underlying filesystem synchronize
     if (bfs::exists(path)) {
       PRECICE_WARN("The connection file \"{}\" wasn't properly removed. "
                    "Make sure to delete the \"precice-run\" directory before restarting the simulation.",
-                   path);
+                   path.generic_string());
     }
   } catch (const bfs::filesystem_error &e) {
     PRECICE_WARN("Unable to clean-up connection file due to error: {}. "
@@ -121,11 +120,11 @@ void ConnectionInfoWriter::write(std::string const &info) const
     PRECICE_CHECK(!bfs::exists(tmp), message, "temporary ")
   }
 
-  PRECICE_DEBUG("Writing temporary connection file \"{}\"", tmp);
+  PRECICE_DEBUG("Writing temporary connection file \"{}\"", tmp.generic_string());
   bfs::create_directories(tmp.parent_path());
   {
     std::ofstream ofs(tmp.string());
-    PRECICE_CHECK(ofs, "Unable to establish connection as the temporary connection file \"{}\" couldn't be opened.", tmp);
+    PRECICE_CHECK(ofs, "Unable to establish connection as the temporary connection file \"{}\" couldn't be opened.", tmp.generic_string());
     fmt::print(ofs,
                "{}\nAcceptor: {}, Requester: {}, Tag: {}, Rank: {}",
                info, acceptorName, requesterName, tag, rank);
@@ -133,15 +132,14 @@ void ConnectionInfoWriter::write(std::string const &info) const
   PRECICE_CHECK(bfs::exists(tmp),
                 "Unable to establish connection as the temporary connection file \"{}\" was written, but doesn't exist on disk. "
                 "Please report this bug to the preCICE developers.",
-                tmp);
+                tmp.generic_string());
 
   PRECICE_DEBUG("Publishing connection file \"{}\"", path);
   bfs::rename(tmp, path);
-  /// @TODO Check if we need to sleep to let the underlying filesystem synchronize
   if (bfs::exists(tmp)) {
     PRECICE_WARN("The temporary connection file \"{}\" wasn't properly removed. "
                  "Make sure to delete the \"precice-run\" directory before restarting the simulation.",
-                 tmp);
+                 tmp.generic_string());
   }
   PRECICE_CHECK(bfs::exists(path),
                 "Unable to establish connection as the connection file \"{}\" doesn't exist on disk. "

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -80,10 +80,22 @@ std::string ConnectionInfoReader::read() const
 
 ConnectionInfoWriter::~ConnectionInfoWriter()
 {
+  bfs::path path(getFilename());
+  if (!bfs::exists(path)) {
+    PRECICE_WARN("Cannot remove the connection file {} as it doesn't exist. "
+                 "In case of connection problems, please report this to the preCICE developers.",
+                 path);
+    return;
+  }
+  PRECICE_DEBUG("Deleting connection file {}", path);
   try {
-    bfs::path p(getFilename());
-    PRECICE_DEBUG("Deleting connection file {}", p.string());
-    bfs::remove(p);
+    bfs::remove(path);
+    /// @TODO Check if we need to sleep to let the underlying filesystem synchronize
+    if (bfs::exists(path)) {
+      PRECICE_WARN("The connection file {} wasn't properly removed. "
+                   "Make sure to delete the \"precice-run\" directory before restarting the simulation.",
+                   path);
+    }
   } catch (const bfs::filesystem_error &e) {
     PRECICE_WARN("Unable to delete connection file due to error: {}", e.what());
   }


### PR DESCRIPTION
## Main changes of this PR

This PR extends read and write of connection files to be more strict and robust.

The most common issues are now actively checked and result in error messages.
Messages guide the user to either fix or report problems.

## Motivation and additional information

Problems with connection files are tricky to debug as the writers and readers don't actively check conditions.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
* [x] Do you agree with the verbosity and the wording?
* [ ] @KyleDavisSA Can you try this on SuperMUC and see if these errors and warnings get triggered by the synchronization delay of filesystem system?