### PR TITLE
adds a pre-commit config for clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v8.0.1'
+    hooks:
+    -   id: clang-format
+        exclude: "^thirdparty"


### PR DESCRIPTION
## Main changes of this PR

Adds a config for [pre-commit](https://pre-commit.com/)

## Motivation and additional information

I saw the release announcement mention a target to run clang-format
and thought preCICE could use some pre-commit hooks to automate that.
Basically `pre-commit` is a framework to configure, install and run
git hooks. For clang-format there's a [hook implementation](https://github.com/pre-commit/mirrors-clang-format) available
that installs clang-format from [binary wheels](https://pypi.org/project/clang-format/#history). That might be valuable
even if you do not want to use pre-commit itself.
I usually run a [CI step](https://github.com/pymor/pymor-deal.II/blob/main/.github/workflows/checks.yml#L24) that executes all hooks and fails if not all hooks pass in my projects.
I can add that to this PR if there's interest for it.

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
