### PR TITLE
Improve MPI Communication backends

### DIFF
--- a/docs/changelog/1292.md
+++ b/docs/changelog/1292.md
@@ -1,0 +1,2 @@
+- Added checks of MPI ports functions and descriptive error messages.
+- Fixed a bug leading to large whitespace sections in logs when using MPI ports.

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -9,6 +9,7 @@
 #include "logging/LogMacros.hpp"
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
+#include "utils/String.hpp"
 
 namespace precice {
 namespace com {
@@ -45,8 +46,10 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
   setRankOffset(rankOffset);
 
   _isAcceptor = true;
-  _portName.reserve(MPI_MAX_PORT_NAME);
-  MPI_Open_port(MPI_INFO_NULL, &_portName[0]);
+
+  utils::StringMaker<MPI_MAX_PORT_NAME> sm;
+  MPI_Open_port(MPI_INFO_NULL, sm.data());
+  _portName = sm.str();
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
   conInfo.write(_portName);
@@ -104,8 +107,9 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
 
   _isAcceptor = true;
 
-  _portName.reserve(MPI_MAX_PORT_NAME);
-  MPI_Open_port(MPI_INFO_NULL, &_portName[0]);
+  utils::StringMaker<MPI_MAX_PORT_NAME> sm;
+  MPI_Open_port(MPI_INFO_NULL, sm.data());
+  _portName = sm.str();
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
   conInfo.write(_portName);

--- a/src/utils/MPIResult.hpp
+++ b/src/utils/MPIResult.hpp
@@ -1,0 +1,52 @@
+#include <ostream>
+#ifndef PRECICE_NO_MPI
+
+#pragma once
+
+#include <mpi.h>
+#include <ostream>
+
+#include "utils/String.hpp"
+
+namespace precice {
+namespace utils {
+
+/** Utility class to simplify use of MPI return codes
+ *
+ * Provides implicit conversion to bool and message printing.
+ */
+struct MPIResult {
+  int code;
+
+  MPIResult() = default;
+
+  MPIResult(const MPIResult &other) = default;
+
+  MPIResult(int res)
+      : code(res) {}
+
+  MPIResult &operator=(MPIResult other)
+  {
+    code = other.code;
+    return *this;
+  }
+
+  operator bool() const
+  {
+    return code == MPI_SUCCESS;
+  }
+
+  std::string message() const
+  {
+    utils::StringMaker<MPI_MAX_ERROR_STRING> sm;
+
+    int i;
+    MPI_Error_string(code, sm.data(), &i);
+    return sm.str();
+  }
+};
+
+} // namespace utils
+} // namespace precice
+
+#endif

--- a/src/utils/String.hpp
+++ b/src/utils/String.hpp
@@ -1,10 +1,43 @@
 #pragma once
 
+#include <array>
 #include <sstream>
 #include <string>
 
 namespace precice {
 namespace utils {
+
+/// Utility class to build a string from C functions with output pointers and static maximum length
+template <int MAX>
+class StringMaker {
+public:
+  StringMaker()
+  {
+    clear();
+  }
+
+  void clear()
+  {
+    _data.fill('\0');
+  }
+
+  char *data()
+  {
+    return _data.data();
+  }
+
+  /** constructs a string from the buffer
+   *
+   *  The returned string ends at the fill NULL char.
+   */
+  std::string str() const
+  {
+    return std::string(_data.data());
+  }
+
+private:
+  std::array<char, MAX + 1> _data;
+};
 
 std::string wrapText(
     const std::string &text,

--- a/src/utils/tests/StringTest.cpp
+++ b/src/utils/tests/StringTest.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(StringMaker)
   BOOST_TEST(sm.str().empty());
 
   auto cstr = "1234";
-  std::copy(cstr, cstr+4, sm.data());
+  std::copy(cstr, cstr + 4, sm.data());
   BOOST_TEST(*sm.data() == '1');
 
   auto str = sm.str();
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(StringMaker)
   BOOST_TEST(str == cstr);
 
   sm.data()[2] = '\0';
-  auto str2 = sm.str();
+  auto str2    = sm.str();
   BOOST_TEST(str2.size() == 2);
   BOOST_TEST(str2 == "12");
 }

--- a/src/utils/tests/StringTest.cpp
+++ b/src/utils/tests/StringTest.cpp
@@ -1,3 +1,4 @@
+#include <boost/test/tools/old/interface.hpp>
 #include <string>
 #include "math/constants.hpp"
 #include "testing/TestContext.hpp"
@@ -68,6 +69,28 @@ BOOST_AUTO_TEST_CASE(ConvertStringToBool)
   BOOST_TEST(convertStringToBool("0") == false);
   BOOST_TEST(convertStringToBool("yes") == true);
   BOOST_TEST(convertStringToBool("no") == false);
+}
+
+BOOST_AUTO_TEST_CASE(StringMaker)
+{
+  PRECICE_TEST(1_rank);
+  utils::StringMaker<10> sm;
+  BOOST_REQUIRE(sm.data() != nullptr);
+  BOOST_TEST(*sm.data() == '\0');
+  BOOST_TEST(sm.str().empty());
+
+  auto cstr = "1234";
+  std::copy(cstr, cstr+4, sm.data());
+  BOOST_TEST(*sm.data() == '1');
+
+  auto str = sm.str();
+  BOOST_TEST(str.size() == 4);
+  BOOST_TEST(str == cstr);
+
+  sm.data()[2] = '\0';
+  auto str2 = sm.str();
+  BOOST_TEST(str2.size() == 2);
+  BOOST_TEST(str2 == "12");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Main changes of this PR

This PR
- Uses a StringMaker to reduce clutter when dealing with CStrings
- Add error code checks to main MPI ports functionality

## Motivation and additional information

Using strings to deal with cstrings of a maximum length is messy, as std::string itself does easily shrink to the cstring representation.
Printing a std::string that containts 0 will print everything, leading to very strange output containting lots of whitespaces including newlines.
We now use a array of 0 chars of fixed size for MPI to write to. Then, we construct a std::string based on its content interpreted as a cstring.

Furthermore, we never checked the return code of MPI functions. We now check the main return codes for the MPI client-server functionality.

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
