### PR TITLE
Fix `isGradientDataRequired` to behave properly

### DIFF
--- a/docs/changelog/1295.md
+++ b/docs/changelog/1295.md
@@ -1,0 +1,1 @@
+- Fixed the API function `isGradientDataRequired` to behave as documented

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -134,7 +134,7 @@ PtrData &Mesh::createData(
                   name, _name, name);
   }
   //#rows = dimensions of current mesh #columns = dimensions of corresponding data set
-  PtrData data(new Data(name, id, dimension, _dimensions, true));
+  PtrData data(new Data(name, id, dimension, _dimensions, withGradient));
   _data.push_back(data);
   return _data.back();
 }

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -145,14 +145,14 @@ ReadDataContext &Participant::readDataContext(DataID dataID)
 const WriteDataContext &Participant::writeDataContext(DataID dataID) const
 {
   auto it = _writeDataContexts.find(dataID);
-  PRECICE_CHECK(it != _writeDataContexts.end(), "DataID does not exist.")
+  PRECICE_CHECK(it != _writeDataContexts.end(), "DataID \"{}\" does not exist in write direction.", dataID)
   return it->second;
 }
 
 WriteDataContext &Participant::writeDataContext(DataID dataID)
 {
   auto it = _writeDataContexts.find(dataID);
-  PRECICE_CHECK(it != _writeDataContexts.end(), "DataID does not exist.")
+  PRECICE_CHECK(it != _writeDataContexts.end(), "DataID \"{}\" does not exist in write direction.", dataID)
   return it->second;
 }
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -664,6 +664,10 @@ bool SolverInterfaceImpl::isMeshConnectivityRequired(int meshID) const
 bool SolverInterfaceImpl::isGradientDataRequired(int dataID) const
 {
   PRECICE_VALIDATE_DATA_ID(dataID);
+  // Read data never requires gradients
+  if (!_accessor->isDataWrite(dataID))
+    return false;
+
   WriteDataContext &context = _accessor->writeDataContext(dataID);
   return context.providedData()->hasGradient();
 }

--- a/tests/serial/mapping-nearest-projection/helpers.cpp
+++ b/tests/serial/mapping-nearest-projection/helpers.cpp
@@ -93,7 +93,9 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
     BOOST_TEST(interface.isCouplingOngoing(), "Receiving participant should have to advance once!");
 
     // Read the mapped data from the mesh.
-    int    dataAID = interface.getDataID("DataOne", meshTwoID);
+    int dataAID = interface.getDataID("DataOne", meshTwoID);
+    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+
     double valueA, valueB, valueC;
     interface.readScalarData(dataAID, idA, valueA);
     interface.readScalarData(dataAID, idB, valueB);

--- a/tests/serial/mapping-nearest-projection/helpers.cpp
+++ b/tests/serial/mapping-nearest-projection/helpers.cpp
@@ -66,6 +66,8 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, const std::string 
 
     // Write the data to be send.
     int dataAID = interface.getDataID("DataOne", meshOneID);
+    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+
     interface.writeScalarData(dataAID, idA, valOneA);
     interface.writeScalarData(dataAID, idB, valOneB);
     interface.writeScalarData(dataAID, idC, valOneC);

--- a/tests/serial/mapping-rbf-gaussian/helpers.cpp
+++ b/tests/serial/mapping-rbf-gaussian/helpers.cpp
@@ -89,7 +89,9 @@ void testRBFMapping(const std::string configFile, const TestContext &context)
     BOOST_TEST(interface.isCouplingOngoing(), "Receiving participant should have to advance once!");
 
     // Read the mapped data from the mesh.
-    int    dataAID = interface.getDataID("DataOne", meshTwoID);
+    int dataAID = interface.getDataID("DataOne", meshTwoID);
+    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+
     double valueA, valueB, valueC;
     interface.readScalarData(dataAID, idA, valueA);
     interface.readScalarData(dataAID, idB, valueB);

--- a/tests/serial/mapping-rbf-gaussian/helpers.cpp
+++ b/tests/serial/mapping-rbf-gaussian/helpers.cpp
@@ -63,9 +63,10 @@ void testRBFMapping(const std::string configFile, const TestContext &context)
     // Initialize, thus sending the mesh.
     double maxDt = interface.initialize();
     BOOST_TEST(interface.isCouplingOngoing(), "Sending participant should have to advance once!");
-
     // Write the data to be send.
     int dataAID = interface.getDataID("DataOne", meshOneID);
+    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+
     interface.writeBlockScalarData(dataAID, nCoords, ids.data(), values.data());
 
     // Advance, thus send the data to the receiving partner.


### PR DESCRIPTION
## Main changes of this PR
We have unfortunately no compiler warnings for unused data. <del>I still need to fix the behavior for readData IDs </del>. Related to #1169.

## Motivation and additional information

Before, this API function returned always true independent of the mapping configuration, leading to an unconditional memory allocation for gradients as well as gradient communication.
FYI: @kursatyurt 

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
