### PR TITLE
Rename `uint` to `unsigned int` in RBF test

### DIFF
--- a/docs/changelog/1298.md
+++ b/docs/changelog/1298.md
@@ -1,0 +1,1 @@
+- Fix data type of 'uint' to compatible 'unsigned int' type in RBF test

--- a/tests/serial/mapping-rbf-gaussian/helpers.cpp
+++ b/tests/serial/mapping-rbf-gaussian/helpers.cpp
@@ -29,7 +29,7 @@ void testRBFMapping(const std::string configFile, const TestContext &context)
 
   std::vector<double> values;
   const unsigned int  nCoords = 12;
-  for (uint i = 0; i < nCoords; ++i)
+  for (unsigned int i = 0; i < nCoords; ++i)
     values.emplace_back(std::pow(i + 1, 2));
   // MeshTwo
   Vector3d coordTwoA{0.0, 0.0, z}; // Maps to vertex A


### PR DESCRIPTION
## Main changes of this PR

The data type `uint` is not universal and we need to substitute it with `unsigned int` 

## Motivation and additional information

Related to #1288 
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
