### PR TITLE
Fixes double definition of SolverInterfaceImpl

### DIFF
--- a/tests/serial/mapping-scaled-consistent/helpers.cpp
+++ b/tests/serial/mapping-scaled-consistent/helpers.cpp
@@ -1,11 +1,10 @@
 #ifndef PRECICE_NO_MPI
 
 #include "helpers.hpp"
-#include "testing/Testing.hpp"
-
-#include "math.h"
+#include "math/geometry.hpp"
 #include "precice/SolverInterface.hpp"
-#include "precice/impl/SolverInterfaceImpl.cpp"
+#include "precice/impl/SolverInterfaceImpl.hpp"
+#include "testing/Testing.hpp"
 
 void testQuadMappingScaledConsistent(const std::string configFile, const TestContext &context)
 {


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a double definition of the SolverInterfaceImpl symbols due to inclusion of the `.cpp` file.
I stumbled across this while working on #1193.

## Motivation and additional information

Technically, this violates the one definition rule and is not permitted.
Luckily, this only affects the test binary.
It doesn't show up when preCICE is built as a shared library, so the default works.
It also somehow doesn't trigger when building preCICE as a static library.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
