### PR TITLE
added barycentric coordinates for tetrahedron

### DIFF
--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -100,6 +100,52 @@ Eigen::Vector3d calcBarycentricCoordsForTriangle(
   return barycentricCoords;
 }
 
+Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
+    const Eigen::VectorXd &a,
+    const Eigen::VectorXd &b,
+    const Eigen::VectorXd &c,
+    const Eigen::VectorXd &d,
+    const Eigen::VectorXd &u)
+{
+  using Eigen::Vector3d;
+  using Eigen::Vector4d;
+
+  const int dimensions = a.size();
+
+  PRECICE_ASSERT(dimensions == 3, dimensions);
+  PRECICE_ASSERT(dimensions == b.size(), "A and B need to have the same dimensions.", dimensions, b.size());
+  PRECICE_ASSERT(dimensions == c.size(), "A and C need to have the same dimensions.", dimensions, c.size());
+  PRECICE_ASSERT(dimensions == d.size(), "A and D need to have the same dimensions.", dimensions, d.size());
+  PRECICE_ASSERT(dimensions == u.size(), "A and the point need to have the same dimensions.", dimensions, u.size());
+
+  Vector4d barycentricCoords;
+
+  // Varying per poit
+  Vector3d au = u - a;
+  Vector3d du = u - d;
+  Vector3d cu = u - c;
+
+  // Necessary to compute triangles
+  Vector3d ab = b - a;
+  Vector3d ac = c - a;
+  Vector3d ad = d - a;
+  Vector3d bc = c - b;
+
+  // Triangles
+  Vector3d abc = ab.cross(bc);
+  Vector3d abd = ab.cross(-ad);
+  Vector3d acd = ac.cross(ad);
+
+  auto volume = abc.dot(ad);
+
+  barycentricCoords(3) = abc.dot(au) / volume;
+  barycentricCoords(2) = abd.dot(du) / volume;
+  barycentricCoords(1) = acd.dot(cu) / volume;
+  barycentricCoords(0) = 1 - barycentricCoords(3) - barycentricCoords(2) - barycentricCoords(1);
+
+  return barycentricCoords;
+}
+
 } // namespace barycenter
 } // namespace math
 } // namespace precice

--- a/src/math/barycenter.cpp
+++ b/src/math/barycenter.cpp
@@ -120,7 +120,7 @@ Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
 
   Vector4d barycentricCoords;
 
-  // Varying per poit
+  // Varying per point
   Vector3d au = u - a;
   Vector3d du = u - d;
   Vector3d cu = u - c;

--- a/src/math/barycenter.hpp
+++ b/src/math/barycenter.hpp
@@ -41,6 +41,26 @@ Eigen::Vector3d calcBarycentricCoordsForTriangle(
     const Eigen::VectorXd &c,
     const Eigen::VectorXd &u);
 
+/** Takes the corner vertices of a tetrahedron and a point in 3D space.
+ *  Returns the barycentric coordinates for that point's projection onto the given tetrahedron.
+ *
+ *  @param a point A of the tetrahedron ABCD
+ *  @param b point B of the tetrahedron ABCD
+ *  @param c point C of the tetrahedron ABCD
+*  @param d point D of the tetrahedron ABCD
+ *  @param u the point to compute the barycentric coordinates for
+ *
+ * @note This implements an efficient one-step algorithm (no separate projection) 
+ * described in Boris Martin's Master's thesis
+ *
+ */
+Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
+    const Eigen::VectorXd &a,
+    const Eigen::VectorXd &b,
+    const Eigen::VectorXd &c,
+    const Eigen::VectorXd &d,
+    const Eigen::VectorXd &u);
+
 } // namespace barycenter
 } // namespace math
 } // namespace precice

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -1,11 +1,11 @@
 #include <Eigen/Core>
+#include <boost/mpl/vector.hpp>
 #include <ostream>
 #include "math/barycenter.hpp"
 #include "math/constants.hpp"
 #include "math/differences.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
-#include <boost/mpl/vector.hpp>
 
 using namespace precice;
 using namespace precice::math::barycenter;

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -398,7 +398,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExtrapolation, T, Tetrahed
     BOOST_TEST(ret.sum() == 1.0);
     BOOST_TEST(equals(ret, coords));
   }
-  // Mirror of D
+  // Mirror of D with respect to A
   {
     Vector4d coords(2.0, 0.0, 0.0, -1.0);
     auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 2 * a - d);

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -237,6 +237,74 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle2D)
   }
 }
 
+BOOST_AUTO_TEST_CASE(BarycenterTetrahedron)
+{
+  PRECICE_TEST(1_rank);
+  using Eigen::Vector3d;
+  using Eigen::Vector4d;
+  using precice::testing::equals;
+  Vector3d a(0.0, 0.0, 0.0);
+  Vector3d b(0.0, 1.0, 0.0);
+  Vector3d c(1.0, 0.0, 0.0);
+  Vector3d d(0.0, 0.0, 1.0);
+  // is center?
+  {
+    Vector4d coords(0.25, 0.25, 0.25, 0.25);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, (a + b + c + d) / 4);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // random combination?
+  {
+    Vector4d coords(0.2, 0.3, 0.4, 0.1);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.2 * a + +0.3 * b + +0.4 * c + +0.1 * d);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is A?
+  {
+    Vector4d coords(1.0, 0.0, 0.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, a);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is B?
+  {
+    Vector4d coords(0.0, 1.0, 0.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, b);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is C?
+  {
+    Vector4d coords(0.0, 0.0, 1.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, c);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is D?
+  {
+    Vector4d coords(0.0, 0.0, 0.0, 1.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, d);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is middle of AB?
+  {
+    Vector4d coords(0.5, 0.5, 0.0, 0.0);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.5 * a + 0.5 * b);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+  // Is middle of ABD?
+  {
+    Vector4d coords(1. / 3, 1. / 3, 0.0, 1. / 3);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, (a + b + d) / 3);
+    BOOST_TEST(ret.sum() == 1.0);
+    BOOST_TEST(equals(ret, coords));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Barycenter
 
 BOOST_AUTO_TEST_SUITE_END() // Math

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -5,6 +5,7 @@
 #include "math/differences.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
+#include <boost/mpl/vector.hpp>
 
 using namespace precice;
 using namespace precice::math::barycenter;

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(BarycenterEdge3D)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END() // BarycenterEdges
 
 BOOST_AUTO_TEST_SUITE(BarycenterTriangle)
 
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle2D)
   }
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END() // BarycenterTriangles
 
 BOOST_AUTO_TEST_SUITE(BarycenterTetrahedra)
 
@@ -253,7 +253,6 @@ struct TetrahedronFixture {
   Eigen::Vector3d d{0.0, 0.0, 1.0};
 
   Eigen::Vector3d center{0.25, 0.25, 0.25};
-  Eigen::Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
 };
 
 struct FlippedTetrahedronFixture {
@@ -263,7 +262,6 @@ struct FlippedTetrahedronFixture {
   Eigen::Vector3d d{0.0, 0.0, -1.0};
 
   Eigen::Vector3d center{0.25, 0.25, -0.25};
-  Eigen::Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
 };
 
 struct AlmostDegenerateTetrahedronFixture {
@@ -273,7 +271,6 @@ struct AlmostDegenerateTetrahedronFixture {
   Eigen::Vector3d d{0.0, 0.0, 0.001};
 
   Eigen::Vector3d center{0.25, 0.25, 0.00025};
-  Eigen::Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
 };
 
 struct FunnyTetrahedronFixture {
@@ -287,142 +284,113 @@ struct FunnyTetrahedronFixture {
 
 typedef boost::mpl::vector<TetrahedronFixture, FlippedTetrahedronFixture, AlmostDegenerateTetrahedronFixture, FunnyTetrahedronFixture> TetrahedraFixtures;
 
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronVertices, T, TetrahedraFixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExactOnA, T, TetrahedraFixtures, T)
 {
   PRECICE_TEST(1_rank);
-  using Eigen::Vector3d;
-  using Eigen::Vector4d;
-  using precice::testing::equals;
 
-  // Alias for fixture data
-  const auto &a = T::a;
-  const auto &b = T::b;
-  const auto &c = T::c;
-  const auto &d = T::d;
-
-  // Is A?
-  {
-    Vector4d coords(1.0, 0.0, 0.0, 0.0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, a);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
-  // Is B?
-  {
-    Vector4d coords(0.0, 1.0, 0.0, 0.0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, b);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
-  // Is C?
-  {
-    Vector4d coords(0.0, 0.0, 1.0, 0.0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, c);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
-  // Is D?
-  {
-    Vector4d coords(0.0, 0.0, 0.0, 1.0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, d);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
+  Eigen::Vector4d coords(1.0, 0.0, 0.0, 0.0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, T::a);
+  BOOST_TEST(precice::testing::equals(ret, coords));
 }
 
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronCenter, T, TetrahedraFixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExactOnB, T, TetrahedraFixtures, T)
 {
   PRECICE_TEST(1_rank);
-  using Eigen::Vector3d;
-  using Eigen::Vector4d;
-  using precice::testing::equals;
 
-  // Alias for fixture data
-  const auto &a      = T::a;
-  const auto &b      = T::b;
-  const auto &c      = T::c;
-  const auto &d      = T::d;
-  const auto &center = T::center;
+  Eigen::Vector4d coords(0.0, 1.0, 0.0, 0.0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, T::b);
+  BOOST_TEST(precice::testing::equals(ret, coords));
+}
 
-  Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
-  auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, center);
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExactOnC, T, TetrahedraFixtures, T)
+{
+  PRECICE_TEST(1_rank);
+
+  Eigen::Vector4d coords(0.0, 0.0, 1.0, 0.0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, T::c);
+  BOOST_TEST(precice::testing::equals(ret, coords));
+}
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExactOnD, T, TetrahedraFixtures, T)
+{
+  PRECICE_TEST(1_rank);
+
+  Eigen::Vector4d coords(0.0, 0.0, 0.0, 1.0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, T::d);
+  BOOST_TEST(precice::testing::equals(ret, coords));
+}
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExactOnCenter, T, TetrahedraFixtures, T)
+{
+  PRECICE_TEST(1_rank);
+
+  Eigen::Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, T::center);
+  BOOST_TEST(precice::testing::equals(ret, center_coords));
+}
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronInsidePoint, T, TetrahedraFixtures, T)
+{
+  PRECICE_TEST(1_rank);
+
+  Eigen::Vector4d coords(0.2, 0.3, 0.4, 0.1);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, 0.2 * T::a + 0.3 * T::b + 0.4 * T::c + 0.1 * T::d);
   BOOST_TEST(ret.sum() == 1.0);
-  BOOST_TEST(equals(ret, center_coords));
+  BOOST_TEST(precice::testing::equals(ret, coords));
 }
 
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronInterpolation, T, TetrahedraFixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronEdgeCenter, T, TetrahedraFixtures, T)
 {
   PRECICE_TEST(1_rank);
-  using Eigen::Vector3d;
   using Eigen::Vector4d;
-  using precice::testing::equals;
 
-  // Alias for fixture data
-  const auto &a = T::a;
-  const auto &b = T::b;
-  const auto &c = T::c;
-  const auto &d = T::d;
-
-  // Arbitrary combination
-  {
-    Vector4d coords(0.2, 0.3, 0.4, 0.1);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.2 * a + 0.3 * b + 0.4 * c + 0.1 * d);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
-
-  // Middle of edge AB
-  {
-    Vector4d coords(0.5, 0.5, 0.0, 0.0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.5 * a + 0.5 * b);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
-  // Middle of triangle ABD
-  {
-    Vector4d coords(1. / 3, 1. / 3, 0.0, 1. / 3);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, (a + b + d) / 3);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
+  Eigen::Vector4d coords(0.5, 0.5, 0.0, 0.0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, 0.5 * T::a + 0.5 * T::b);
+  BOOST_TEST(ret.sum() == 1.0);
+  BOOST_TEST(precice::testing::equals(ret, coords));
 }
 
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExtrapolation, T, TetrahedraFixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronTriangleCenter, T, TetrahedraFixtures, T)
 {
   PRECICE_TEST(1_rank);
-  using Eigen::Vector3d;
   using Eigen::Vector4d;
-  using precice::testing::equals;
 
-  // Alias for fixture data
-  const auto &a = T::a;
-  const auto &b = T::b;
-  const auto &c = T::c;
-  const auto &d = T::d;
-
-  // A + 3*(B-A)
-  {
-    Vector4d coords(-2.0, 3.0, 0, 0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, a + 3 * (b - a));
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
-  // Mirror of D with respect to A
-  {
-    Vector4d coords(2.0, 0.0, 0.0, -1.0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 2 * a - d);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
-  // Mirrored D with ABC as symmetry plane
-  {
-    Vector4d coords(1.0, 1.0, 1.0, -2.0);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, (a + b + c) - 2 * d);
-    BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
-  }
+  Eigen::Vector4d coords(1. / 3, 1. / 3, 0.0, 1. / 3);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, (T::a + T::b + T::d) / 3);
+  BOOST_TEST(ret.sum() == 1.0);
+  BOOST_TEST(precice::testing::equals(ret, coords));
 }
 
-BOOST_AUTO_TEST_SUITE_END() // Barycenter
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExtrapolationOnEdge, T, TetrahedraFixtures, T)
+{
+  PRECICE_TEST(1_rank);
+
+  Eigen::Vector4d coords(-2.0, 3.0, 0, 0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, T::a + 3 * (T::b - T::a));
+  BOOST_TEST(ret.sum() == 1.0);
+  BOOST_TEST(precice::testing::equals(ret, coords));
+}
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExtrapolationOnMirrored, T, TetrahedraFixtures, T)
+{
+  PRECICE_TEST(1_rank);
+
+  Eigen::Vector4d coords(2.0, 0.0, 0.0, -1.0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, 2 * T::a - T::d);
+  BOOST_TEST(ret.sum() == 1.0);
+  BOOST_TEST(precice::testing::equals(ret, coords));
+}
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedronExtrapolationOnMirroredFromTriangle, T, TetrahedraFixtures, T)
+{
+  PRECICE_TEST(1_rank);
+
+  Eigen::Vector4d coords(1.0, 1.0, 1.0, -2.0);
+  auto            ret = calcBarycentricCoordsForTetrahedron(T::a, T::b, T::c, T::d, (T::a + T::b + T::c) - 2 * T::d);
+  BOOST_TEST(ret.sum() == 1.0);
+  BOOST_TEST(precice::testing::equals(ret, coords));
+}
+
+BOOST_AUTO_TEST_SUITE_END() // BarycenterTetrahedra
 
 BOOST_AUTO_TEST_SUITE_END() // Math

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -11,7 +11,7 @@ using namespace precice;
 using namespace precice::math::barycenter;
 
 BOOST_AUTO_TEST_SUITE(MathTests)
-BOOST_AUTO_TEST_SUITE(Barycenter)
+BOOST_AUTO_TEST_SUITE(BarycenterEdge)
 
 BOOST_AUTO_TEST_CASE(BarycenterEdge2D)
 {
@@ -96,6 +96,10 @@ BOOST_AUTO_TEST_CASE(BarycenterEdge3D)
     BOOST_TEST(equals(ret, coords), fmt::format("Coords are {} but should be {}", ret, coords));
   }
 }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(BarycenterTriangle)
 
 BOOST_AUTO_TEST_CASE(BarycenterTriangle3D)
 {
@@ -237,6 +241,10 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle2D)
     BOOST_TEST((ret.array() < -precice::math::NUMERICAL_ZERO_DIFFERENCE).any(), fmt::format("Min 1 coord should be negative {}", ret));
   }
 }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(BarycenterTetrahedra)
 
 struct TetrahedronFixture {
   Eigen::Vector3d a{0.0, 0.0, 0.0};

--- a/src/math/tests/BarycenterTest.cpp
+++ b/src/math/tests/BarycenterTest.cpp
@@ -237,27 +237,72 @@ BOOST_AUTO_TEST_CASE(BarycenterTriangle2D)
   }
 }
 
-BOOST_AUTO_TEST_CASE(BarycenterTetrahedron)
+struct TetrahedronFixture {
+  Eigen::Vector3d a{0.0, 0.0, 0.0};
+  Eigen::Vector3d b{0.0, 1.0, 0.0};
+  Eigen::Vector3d c{1.0, 0.0, 0.0};
+  Eigen::Vector3d d{0.0, 0.0, 1.0};
+
+  Eigen::Vector3d center{0.25, 0.25, 0.25};
+  Eigen::Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
+};
+
+struct FlippedTetrahedronFixture {
+  Eigen::Vector3d a{0.0, 0.0, 0.0};
+  Eigen::Vector3d b{0.0, 1.0, 0.0};
+  Eigen::Vector3d c{1.0, 0.0, 0.0};
+  Eigen::Vector3d d{0.0, 0.0, -1.0};
+
+  Eigen::Vector3d center{0.25, 0.25, -0.25};
+  Eigen::Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
+};
+
+struct AlmostDegenerateTetrahedronFixture {
+  Eigen::Vector3d a{0.0, 0.0, 0.0};
+  Eigen::Vector3d b{0.0, 1.0, 0.0};
+  Eigen::Vector3d c{1.0, 0.0, 0.0};
+  Eigen::Vector3d d{0.0, 0.0, 0.001};
+
+  Eigen::Vector3d center{0.25, 0.25, 0.00025};
+  Eigen::Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
+};
+
+struct FunnyTetrahedronFixture {
+  Eigen::Vector3d a{0.0, 0.0, 0.0};
+  Eigen::Vector3d b{0.0, 1.0, 0.0};
+  Eigen::Vector3d c{1.0, 0.0, 0.0};
+  Eigen::Vector3d d{11.0, 11.0, 1.0};
+
+  Eigen::Vector3d center{3.0, 3.0, 0.25};
+};
+
+typedef boost::mpl::vector<TetrahedronFixture, FlippedTetrahedronFixture, AlmostDegenerateTetrahedronFixture, FunnyTetrahedronFixture> TetrahedraFixtures;
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(BarycenterTetrahedron, T, TetrahedraFixtures, T)
 {
   PRECICE_TEST(1_rank);
   using Eigen::Vector3d;
   using Eigen::Vector4d;
   using precice::testing::equals;
-  Vector3d a(0.0, 0.0, 0.0);
-  Vector3d b(0.0, 1.0, 0.0);
-  Vector3d c(1.0, 0.0, 0.0);
-  Vector3d d(0.0, 0.0, 1.0);
+
+  // Alias for fixture data
+  const auto& a = T::a;
+  const auto& b = T::b;
+  const auto& c = T::c;
+  const auto& d = T::d;
+  const auto& center = T::center;
+
   // is center?
   {
-    Vector4d coords(0.25, 0.25, 0.25, 0.25);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, (a + b + c + d) / 4);
+    Vector4d center_coords{0.25, 0.25, 0.25, 0.25};
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, center);
     BOOST_TEST(ret.sum() == 1.0);
-    BOOST_TEST(equals(ret, coords));
+    BOOST_TEST(equals(ret, center_coords));
   }
   // random combination?
   {
     Vector4d coords(0.2, 0.3, 0.4, 0.1);
-    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.2 * a + +0.3 * b + +0.4 * c + +0.1 * d);
+    auto     ret = calcBarycentricCoordsForTetrahedron(a, b, c, d, 0.2 * a + 0.3 * b + 0.4 * c + 0.1 * d);
     BOOST_TEST(ret.sum() == 1.0);
     BOOST_TEST(equals(ret, coords));
   }


### PR DESCRIPTION
## Main changes of this PR

Added a function for computing the barycentric coordinates of a point with respect to a tetrahedron (with 4 vertices as input), as well as unit tests to check its correctness. Split of #1240 

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
