### PR TITLE
Vertex-only primitives

### DIFF
--- a/docs/changelog/1311.md
+++ b/docs/changelog/1311.md
@@ -1,0 +1,2 @@
+- Improved the memory footprint of triangles in meshes.
+- Improved efficienty of mesh filtering and communication.

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -37,7 +37,12 @@ void CommunicateMesh::sendMesh(
   const auto &meshVertices     = mesh.vertices();
   const int   numberOfVertices = meshVertices.size();
   _communication->send(numberOfVertices, rankReceiver);
-  if (not mesh.vertices().empty()) {
+
+  if (mesh.vertices().empty()) {
+    return;
+  }
+
+  {
     std::vector<double> coords(static_cast<size_t>(numberOfVertices) * dim);
     std::vector<int>    globalIDs(numberOfVertices);
     for (size_t i = 0; i < static_cast<size_t>(numberOfVertices); ++i) {
@@ -48,17 +53,25 @@ void CommunicateMesh::sendMesh(
     _communication->sendRange(globalIDs, rankReceiver);
   }
 
-  const int numberOfEdges = mesh.edges().size();
-  _communication->send(numberOfEdges, rankReceiver);
-  if (not mesh.edges().empty()) {
-    // we need to send the vertexIDs first such that the right edges can be created later
-    // contrary to the normal sendMesh, this variant must also work for adding delta meshes
-    std::vector<int> vertexIDs(numberOfVertices);
-    for (int i = 0; i < numberOfVertices; i++) {
-      vertexIDs[i] = meshVertices[i].getID();
-    }
-    _communication->sendRange(vertexIDs, rankReceiver);
+  _communication->send(mesh.hasConnectivity(), rankReceiver);
+  if (!mesh.hasConnectivity()) {
+    PRECICE_DEBUG("No connectivity to send");
+    return;
+  }
 
+  // we need to send the vertexIDs first such that the right connectivity can be created later
+  // contrary to the normal sendMesh, this variant must also work for adding delta meshes
+  std::vector<int> vertexIDs(numberOfVertices);
+  for (int i = 0; i < numberOfVertices; ++i) {
+    vertexIDs[i] = meshVertices[i].getID();
+  }
+  _communication->sendRange(vertexIDs, rankReceiver);
+
+  // Send Edges
+  const int numberOfEdges = mesh.edges().size();
+  PRECICE_DEBUG("Number of edges to send: {}", numberOfEdges);
+  _communication->send(numberOfEdges, rankReceiver);
+  if (mesh.hasEdges()) {
     std::vector<int> edgeIDs(numberOfEdges * 2);
     for (int i = 0; i < numberOfEdges; i++) {
       edgeIDs[i * 2]     = mesh.edges()[i].vertex(0).getID();
@@ -67,22 +80,16 @@ void CommunicateMesh::sendMesh(
     _communication->sendRange(edgeIDs, rankReceiver);
   }
 
+  // Send Triangles
   int numberOfTriangles = mesh.triangles().size();
+  PRECICE_DEBUG("Number of triangles to send: {}", numberOfTriangles);
   _communication->send(numberOfTriangles, rankReceiver);
-  if (not mesh.triangles().empty()) {
-    // we need to send the edgeIDs first such that the right edges can be created later
-    // contrary to the normal sendMesh, this variant must also work for adding delta meshes
-    std::vector<int> edgeIDs(numberOfEdges);
-    for (int i = 0; i < numberOfEdges; i++) {
-      edgeIDs[i] = mesh.edges()[i].getID();
-    }
-    _communication->sendRange(edgeIDs, rankReceiver);
-
+  if (mesh.hasTriangles()) {
     std::vector<int> triangleIDs(numberOfTriangles * 3);
-    for (int i = 0; i < numberOfTriangles; i++) {
-      triangleIDs[i * 3]     = mesh.triangles()[i].edge(0).getID();
-      triangleIDs[i * 3 + 1] = mesh.triangles()[i].edge(1).getID();
-      triangleIDs[i * 3 + 2] = mesh.triangles()[i].edge(2).getID();
+    for (int i = 0; i < numberOfTriangles; ++i) {
+      triangleIDs[i * 3]     = mesh.triangles()[i].vertex(0).getID();
+      triangleIDs[i * 3 + 1] = mesh.triangles()[i].vertex(1).getID();
+      triangleIDs[i * 3 + 2] = mesh.triangles()[i].vertex(2).getID();
     }
     _communication->sendRange(triangleIDs, rankReceiver);
   }
@@ -99,9 +106,13 @@ void CommunicateMesh::receiveMesh(
   _communication->receive(numberOfVertices, rankSender);
   PRECICE_DEBUG("Number of vertices to receive: {}", numberOfVertices);
 
+  if (numberOfVertices == 0) {
+    return;
+  }
+
   std::vector<mesh::Vertex *> vertices;
   vertices.reserve(numberOfVertices);
-  if (numberOfVertices > 0) {
+  {
     std::vector<double> vertexCoords = _communication->receiveRange(rankSender, AsVectorTag<double>{});
     std::vector<int>    globalIDs    = _communication->receiveRange(rankSender, AsVectorTag<int>{});
     Eigen::VectorXd     coords(dim);
@@ -116,52 +127,50 @@ void CommunicateMesh::receiveMesh(
     }
   }
 
+  bool hasConnectivity{false};
+  _communication->receive(hasConnectivity, rankSender);
+  if (!hasConnectivity) {
+    PRECICE_DEBUG("No connectivity to receive");
+    return;
+  }
+
+  // we need to receive the vertexIDs first such that the right connectivity can be created later
+  // contrary to the normal receiveMesh, this variant must also work for adding delta meshes
+  boost::container::flat_map<int, mesh::Vertex *> vertexMap;
+  vertexMap.reserve(numberOfVertices);
+  const std::vector<int> vertexIDs = _communication->receiveRange(rankSender, AsVectorTag<int>{});
+  for (int i = 0; i < numberOfVertices; ++i) {
+    vertexMap[vertexIDs[i]] = vertices[i];
+  }
+
+  // Receive Edges
   int numberOfEdges = 0;
   _communication->receive(numberOfEdges, rankSender);
   PRECICE_DEBUG("Number of edges to receive: {}", numberOfEdges);
-
-  boost::container::flat_map<int, mesh::Vertex *> vertexMap;
-  vertexMap.reserve(numberOfVertices);
-  std::vector<mesh::Edge *> edges;
   if (numberOfEdges > 0) {
-    std::vector<int> vertexIDs = _communication->receiveRange(rankSender, AsVectorTag<int>{});
-    for (int i = 0; i < numberOfVertices; i++) {
-      vertexMap[vertexIDs[i]] = vertices[i];
-    }
-
     std::vector<int> edgeIDs = _communication->receiveRange(rankSender, AsVectorTag<int>{});
     for (int i = 0; i < numberOfEdges; i++) {
       PRECICE_ASSERT(vertexMap.count((edgeIDs[i * 2])) == 1);
       PRECICE_ASSERT(vertexMap.count(edgeIDs[i * 2 + 1]) == 1);
       PRECICE_ASSERT(edgeIDs[i * 2] != edgeIDs[i * 2 + 1]);
-      mesh::Edge &e = mesh.createEdge(*vertexMap[edgeIDs[i * 2]], *vertexMap[edgeIDs[i * 2 + 1]]);
-      edges.push_back(&e);
+      mesh.createEdge(*vertexMap[edgeIDs[i * 2]], *vertexMap[edgeIDs[i * 2 + 1]]);
     }
   }
 
+  // Receveive Triangles
   int numberOfTriangles = 0;
   _communication->receive(numberOfTriangles, rankSender);
-  PRECICE_DEBUG("Number of Triangles to receive: {}", numberOfTriangles);
-  PRECICE_DEBUG("Number of Edges: {}", edges.size());
+  PRECICE_DEBUG("Number of triangles to receive: {}", numberOfTriangles);
   if (numberOfTriangles > 0) {
-    PRECICE_ASSERT((edges.size() > 0) || (numberOfTriangles == 0));
-    std::vector<int>                              edgeIDs = _communication->receiveRange(rankSender, AsVectorTag<int>{});
-    boost::container::flat_map<int, mesh::Edge *> edgeMap;
-    edgeMap.reserve(numberOfEdges);
-    for (int i = 0; i < numberOfEdges; i++) {
-      edgeMap[edgeIDs[i]] = edges[i];
-    }
-
     std::vector<int> triangleIDs = _communication->receiveRange(rankSender, AsVectorTag<int>{});
+    PRECICE_ASSERT(triangleIDs.size() == numberOfTriangles*3);
 
     for (int i = 0; i < numberOfTriangles; i++) {
-      PRECICE_ASSERT(edgeMap.count(triangleIDs[i * 3]) == 1);
-      PRECICE_ASSERT(edgeMap.count(triangleIDs[i * 3 + 1]) == 1);
-      PRECICE_ASSERT(edgeMap.count(triangleIDs[i * 3 + 2]) == 1);
-      PRECICE_ASSERT(triangleIDs[i * 3] != triangleIDs[i * 3 + 1]);
-      PRECICE_ASSERT(triangleIDs[i * 3 + 1] != triangleIDs[i * 3 + 2]);
-      PRECICE_ASSERT(triangleIDs[i * 3 + 2] != triangleIDs[i * 3]);
-      mesh.createTriangle(*edgeMap[triangleIDs[i * 3]], *edgeMap[triangleIDs[i * 3 + 1]], *edgeMap[triangleIDs[i * 3 + 2]]);
+      PRECICE_ASSERT(vertexMap.count(triangleIDs[i * 3]) == 1);
+      PRECICE_ASSERT(vertexMap.count(triangleIDs[i * 3 + 1]) == 1);
+      PRECICE_ASSERT(vertexMap.count(triangleIDs[i * 3 + 2]) == 1);
+
+      mesh.createTriangle(*vertexMap[triangleIDs[i * 3]], *vertexMap[triangleIDs[i * 3 + 1]], *vertexMap[triangleIDs[i * 3 + 2]]);
     }
   }
 }
@@ -185,17 +194,23 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
     _communication->broadcast(globalIDs);
   }
 
+  _communication->broadcast(mesh.hasConnectivity());
+  if (!mesh.hasConnectivity()) {
+    return;
+  }
+
+  // we need to send the vertexIDs first such that the right connectivity can be created later
+  // contrary to the normal sendMesh, this variant must also work for adding delta meshes
+  std::vector<int> vertexIDs(numberOfVertices);
+  for (int i = 0; i < numberOfVertices; i++) {
+    vertexIDs[i] = meshVertices[i].getID();
+  }
+  _communication->broadcast(vertexIDs);
+
+  // Send Edges
   int numberOfEdges = mesh.edges().size();
   _communication->broadcast(numberOfEdges);
   if (numberOfEdges > 0) {
-    // we need to send the vertexIDs first such that the right edges can be created later
-    // contrary to the normal sendMesh, this variant must also work for adding delta meshes
-    std::vector<int> vertexIDs(numberOfVertices);
-    for (int i = 0; i < numberOfVertices; i++) {
-      vertexIDs[i] = meshVertices[i].getID();
-    }
-    _communication->broadcast(vertexIDs);
-
     std::vector<int> edgeIDs(numberOfEdges * 2);
     const auto &     meshEdges = mesh.edges();
     for (int i = 0; i < numberOfEdges; i++) {
@@ -205,23 +220,16 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
     _communication->broadcast(edgeIDs);
   }
 
+  // Send Triangles
   int numberOfTriangles = mesh.triangles().size();
   _communication->broadcast(numberOfTriangles);
   if (numberOfTriangles > 0) {
-    // we need to send the edgeIDs first such that the right edges can be created later
-    // contrary to the normal sendMesh, this variant must also work for adding delta meshes
-    std::vector<int> edgeIDs(numberOfEdges);
-    for (int i = 0; i < numberOfEdges; i++) {
-      edgeIDs[i] = mesh.edges()[i].getID();
-    }
-    _communication->broadcast(edgeIDs);
-
     std::vector<int> triangleIDs(numberOfTriangles * 3);
     const auto &     meshTriangles = mesh.triangles();
     for (int i = 0; i < numberOfTriangles; i++) {
-      triangleIDs[i * 3]     = meshTriangles[i].edge(0).getID();
-      triangleIDs[i * 3 + 1] = meshTriangles[i].edge(1).getID();
-      triangleIDs[i * 3 + 2] = meshTriangles[i].edge(2).getID();
+      triangleIDs[i * 3]     = meshTriangles[i].vertex(0).getID();
+      triangleIDs[i * 3 + 1] = meshTriangles[i].vertex(1).getID();
+      triangleIDs[i * 3 + 2] = meshTriangles[i].vertex(2).getID();
     }
     _communication->broadcast(triangleIDs);
   }
@@ -234,9 +242,8 @@ void CommunicateMesh::broadcastReceiveMesh(
   int  dim             = mesh.getDimensions();
   Rank rankBroadcaster = 0;
 
-  std::vector<mesh::Vertex *>        vertices;
-  std::map<VertexID, mesh::Vertex *> vertexMap;
-  int                                numberOfVertices = 0;
+  std::vector<mesh::Vertex *> vertices;
+  int                         numberOfVertices = 0;
   _communication->broadcast(numberOfVertices, rankBroadcaster);
 
   if (numberOfVertices > 0) {
@@ -256,48 +263,50 @@ void CommunicateMesh::broadcastReceiveMesh(
     }
   }
 
-  int                       numberOfEdges = 0;
-  std::vector<mesh::Edge *> edges;
+  bool hasConnectivity{false};
+  _communication->broadcast(hasConnectivity, rankBroadcaster);
+  if (!hasConnectivity) {
+    return;
+  }
+
+  // we need to receive the vertexIDs first such that the right connectivity can be created later
+  // contrary to the normal receiveMesh, this variant must also work for adding delta meshes
+  std::vector<int> vertexIDs;
+  _communication->broadcast(vertexIDs, rankBroadcaster);
+  boost::container::flat_map<VertexID, mesh::Vertex *> vertexMap;
+  vertexMap.reserve(vertexIDs.size());
+  for (int i = 0; i < numberOfVertices; i++) {
+    vertexMap[vertexIDs[i]] = vertices[i];
+  }
+
+  // Receive Edges
+  int numberOfEdges = 0;
   _communication->broadcast(numberOfEdges, rankBroadcaster);
   if (numberOfEdges > 0) {
-    std::vector<int> vertexIDs;
-    _communication->broadcast(vertexIDs, rankBroadcaster);
-    for (int i = 0; i < numberOfVertices; i++) {
-      vertexMap[vertexIDs[i]] = vertices[i];
-    }
-
     std::vector<int> edgeIDs;
     _communication->broadcast(edgeIDs, rankBroadcaster);
     for (int i = 0; i < numberOfEdges; i++) {
-      PRECICE_ASSERT(vertexMap.find(edgeIDs[i * 2]) != vertexMap.end());
-      PRECICE_ASSERT(vertexMap.find(edgeIDs[i * 2 + 1]) != vertexMap.end());
+      PRECICE_ASSERT(vertexMap.count(edgeIDs[i * 2]) == 1);
+      PRECICE_ASSERT(vertexMap.count(edgeIDs[i * 2 + 1]) == 1);
       PRECICE_ASSERT(edgeIDs[i * 2] != edgeIDs[i * 2 + 1]);
-      mesh::Edge &e = mesh.createEdge(*vertexMap[edgeIDs[i * 2]], *vertexMap[edgeIDs[i * 2 + 1]]);
-      edges.push_back(&e);
+      mesh.createEdge(*vertexMap[edgeIDs[i * 2]], *vertexMap[edgeIDs[i * 2 + 1]]);
     }
   }
 
+  // Receive Triangles
   int numberOfTriangles = 0;
   _communication->broadcast(numberOfTriangles, rankBroadcaster);
   if (numberOfTriangles > 0) {
-    PRECICE_ASSERT((edges.size() > 0) || (numberOfTriangles == 0));
-    std::vector<int> edgeIDs;
-    _communication->broadcast(edgeIDs, rankBroadcaster);
-    std::map<int, mesh::Edge *> edgeMap;
-    for (int i = 0; i < numberOfEdges; i++) {
-      edgeMap[edgeIDs[i]] = edges[i];
-    }
-
     std::vector<int> triangleIDs;
     _communication->broadcast(triangleIDs, rankBroadcaster);
     for (int i = 0; i < numberOfTriangles; i++) {
-      PRECICE_ASSERT(edgeMap.find(triangleIDs[i * 3]) != edgeMap.end());
-      PRECICE_ASSERT(edgeMap.find(triangleIDs[i * 3 + 1]) != edgeMap.end());
-      PRECICE_ASSERT(edgeMap.find(triangleIDs[i * 3 + 2]) != edgeMap.end());
+      PRECICE_ASSERT(vertexMap.count(triangleIDs[i * 3]) == 1);
+      PRECICE_ASSERT(vertexMap.count(triangleIDs[i * 3 + 1]) == 1);
+      PRECICE_ASSERT(vertexMap.count(triangleIDs[i * 3 + 2]) == 1);
       PRECICE_ASSERT(triangleIDs[i * 3] != triangleIDs[i * 3 + 1]);
       PRECICE_ASSERT(triangleIDs[i * 3 + 1] != triangleIDs[i * 3 + 2]);
       PRECICE_ASSERT(triangleIDs[i * 3 + 2] != triangleIDs[i * 3]);
-      mesh.createTriangle(*edgeMap[triangleIDs[i * 3]], *edgeMap[triangleIDs[i * 3 + 1]], *edgeMap[triangleIDs[i * 3 + 2]]);
+      mesh.createTriangle(*vertexMap[triangleIDs[i * 3]], *vertexMap[triangleIDs[i * 3 + 1]], *vertexMap[triangleIDs[i * 3 + 2]]);
     }
   }
 }

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -163,7 +163,7 @@ void CommunicateMesh::receiveMesh(
   PRECICE_DEBUG("Number of triangles to receive: {}", numberOfTriangles);
   if (numberOfTriangles > 0) {
     std::vector<int> triangleIDs = _communication->receiveRange(rankSender, AsVectorTag<int>{});
-    PRECICE_ASSERT(triangleIDs.size() == numberOfTriangles*3);
+    PRECICE_ASSERT(triangleIDs.size() == numberOfTriangles * 3);
 
     for (int i = 0; i < numberOfTriangles; i++) {
       PRECICE_ASSERT(vertexMap.count(triangleIDs[i * 3]) == 1);

--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -59,8 +59,8 @@ void CommunicateMesh::sendMesh(
     return;
   }
 
-  // we need to send the vertexIDs first such that the right connectivity can be created later
-  // contrary to the normal sendMesh, this variant must also work for adding delta meshes
+  // We need to send the vertexIDs first. This is required as the receiver will
+  // end up with other vertexIDs after creating vertices.
   std::vector<int> vertexIDs(numberOfVertices);
   for (int i = 0; i < numberOfVertices; ++i) {
     vertexIDs[i] = meshVertices[i].getID();
@@ -134,8 +134,9 @@ void CommunicateMesh::receiveMesh(
     return;
   }
 
-  // we need to receive the vertexIDs first such that the right connectivity can be created later
-  // contrary to the normal receiveMesh, this variant must also work for adding delta meshes
+  // We need to receive the vertexIDs first. This is required as the vertices
+  // created above have different vertexIDs as the original mesh. We need a mapping
+  // from original to new vertexids.
   boost::container::flat_map<int, mesh::Vertex *> vertexMap;
   vertexMap.reserve(numberOfVertices);
   const std::vector<int> vertexIDs = _communication->receiveRange(rankSender, AsVectorTag<int>{});
@@ -199,8 +200,8 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
     return;
   }
 
-  // we need to send the vertexIDs first such that the right connectivity can be created later
-  // contrary to the normal sendMesh, this variant must also work for adding delta meshes
+  // We need to send the vertexIDs first. This is required as the receiver will
+  // end up with other vertexIDs after creating vertices.
   std::vector<int> vertexIDs(numberOfVertices);
   for (int i = 0; i < numberOfVertices; i++) {
     vertexIDs[i] = meshVertices[i].getID();
@@ -269,8 +270,9 @@ void CommunicateMesh::broadcastReceiveMesh(
     return;
   }
 
-  // we need to receive the vertexIDs first such that the right connectivity can be created later
-  // contrary to the normal receiveMesh, this variant must also work for adding delta meshes
+  // We need to receive the vertexIDs first. This is required as the vertices
+  // created above have different vertexIDs as the original mesh. We need a mapping
+  // from original to new vertexids.
   std::vector<int> vertexIDs;
   _communication->broadcast(vertexIDs, rankBroadcaster);
   boost::container::flat_map<VertexID, mesh::Vertex *> vertexMap;

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -32,31 +32,25 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
     }
   }
 
-  // Create a flat_map which can contain all edges of the original mesh.
-  // This prevents resizes during the map build-up.
-  boost::container::flat_map<EdgeID, Edge *> edgeMap;
-  edgeMap.reserve(source.edges().size());
-
   // Add all edges formed by the contributing vertices
   for (const Edge &edge : source.edges()) {
     VertexID vertexIndex1 = edge.vertex(0).getID();
     VertexID vertexIndex2 = edge.vertex(1).getID();
     if (vertexMap.count(vertexIndex1) == 1 &&
         vertexMap.count(vertexIndex2) == 1) {
-      Edge &e               = destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
-      edgeMap[edge.getID()] = &e;
+      destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
     }
   }
 
   // Add all triangles formed by the contributing edges
   for (const Triangle &triangle : source.triangles()) {
-    EdgeID edgeIndex1 = triangle.edge(0).getID();
-    EdgeID edgeIndex2 = triangle.edge(1).getID();
-    EdgeID edgeIndex3 = triangle.edge(2).getID();
-    if (edgeMap.count(edgeIndex1) == 1 &&
-        edgeMap.count(edgeIndex2) == 1 &&
-        edgeMap.count(edgeIndex3) == 1) {
-      destination.createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
+    VertexID vertexIndex1 = triangle.vertex(0).getID();
+    VertexID vertexIndex2 = triangle.vertex(1).getID();
+    VertexID vertexIndex3 = triangle.vertex(2).getID();
+    if (vertexMap.count(vertexIndex1) == 1 &&
+        vertexMap.count(vertexIndex2) == 1 &&
+        vertexMap.count(vertexIndex3) == 1) {
+      destination.createTriangle(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3]);
     }
   }
 }

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -130,6 +130,16 @@ Triangle &Mesh::createTriangle(
   return _triangles.back();
 }
 
+Triangle &Mesh::createTriangle(
+    Vertex &vertexOne,
+    Vertex &vertexTwo,
+    Vertex &vertexThree)
+{
+  auto nextID = _triangles.size();
+  _triangles.emplace_back(vertexOne, vertexTwo, vertexThree, nextID);
+  return _triangles.back();
+}
+
 Tetrahedron &Mesh::createTetrahedron(
     Vertex &vertexOne,
     Vertex &vertexTwo,

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -391,8 +391,6 @@ void Mesh::addMesh(
     vertexMap[vertex.getID()] = &v;
   }
 
-  boost::container::flat_map<EdgeID, Edge *> edgeMap;
-  edgeMap.reserve(deltaMesh.edges().size());
   // you cannot just take the vertices from the edge and add them,
   // since you need the vertices from the new mesh
   // (which may differ in IDs)
@@ -401,18 +399,17 @@ void Mesh::addMesh(
     VertexID vertexIndex2 = edge.vertex(1).getID();
     PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
                    (vertexMap.count(vertexIndex2) == 1));
-    Edge &e               = createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
-    edgeMap[edge.getID()] = &e;
+    createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
   }
 
   for (const Triangle &triangle : deltaMesh.triangles()) {
-    EdgeID edgeIndex1 = triangle.edge(0).getID();
-    EdgeID edgeIndex2 = triangle.edge(1).getID();
-    EdgeID edgeIndex3 = triangle.edge(2).getID();
-    PRECICE_ASSERT((edgeMap.count(edgeIndex1) == 1) &&
-                   (edgeMap.count(edgeIndex2) == 1) &&
-                   (edgeMap.count(edgeIndex3) == 1));
-    createTriangle(*edgeMap[edgeIndex1], *edgeMap[edgeIndex2], *edgeMap[edgeIndex3]);
+    VertexID vertexIndex1 = triangle.vertex(0).getID();
+    VertexID vertexIndex2 = triangle.vertex(1).getID();
+    VertexID vertexIndex3 = triangle.vertex(2).getID();
+    PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
+                   (vertexMap.count(vertexIndex2) == 1) &&
+                   (vertexMap.count(vertexIndex3) == 1));
+    createTriangle(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3]);
   }
   _index.clear();
 }

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -78,17 +78,25 @@ public:
   /// Returns const container holding all edges.
   const EdgeContainer &edges() const;
 
+  bool hasEdges() const { return !_edges.empty(); }
+
   /// Returns modifiable container holding all triangles.
   TriangleContainer &triangles();
 
   /// Returns const container holding all triangles.
   const TriangleContainer &triangles() const;
 
+  bool hasTriangles() const { return !_triangles.empty(); }
+
   /// Returns modifiable container holding all tetrahedra.
   TetraContainer &tetrahedra();
 
   /// Returns const container holding all tetrahedra.
   const TetraContainer &tetrahedra() const;
+
+  bool hasTetrahedra() const { return !_tetrahedra.empty(); }
+
+  bool hasConnectivity() const { return hasEdges() || hasTriangles() || hasTetrahedra(); }
 
   int getDimensions() const;
 
@@ -126,6 +134,18 @@ public:
       Edge &edgeOne,
       Edge &edgeTwo,
       Edge &edgeThree);
+
+  /**
+   * @brief Creates and initializes a Triangle object.
+   *
+   * @param[in] vertexOne Reference to first edge defining the Triangle.
+   * @param[in] vertexTwo Reference to second edge defining the Triangle.
+   * @param[in] vertexThree Reference to third edge defining the Triangle.
+   */
+  Triangle &createTriangle(
+      Vertex &vertexOne,
+      Vertex &vertexTwo,
+      Vertex &vertexThree);
 
   /**
    * @brief Creates and initializes a Tetrahedron object.

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -78,7 +78,10 @@ public:
   /// Returns const container holding all edges.
   const EdgeContainer &edges() const;
 
-  bool hasEdges() const { return !_edges.empty(); }
+  bool hasEdges() const
+  {
+    return !_edges.empty();
+  }
 
   /// Returns modifiable container holding all triangles.
   TriangleContainer &triangles();
@@ -86,7 +89,10 @@ public:
   /// Returns const container holding all triangles.
   const TriangleContainer &triangles() const;
 
-  bool hasTriangles() const { return !_triangles.empty(); }
+  bool hasTriangles() const
+  {
+    return !_triangles.empty();
+  }
 
   /// Returns modifiable container holding all tetrahedra.
   TetraContainer &tetrahedra();
@@ -94,9 +100,15 @@ public:
   /// Returns const container holding all tetrahedra.
   const TetraContainer &tetrahedra() const;
 
-  bool hasTetrahedra() const { return !_tetrahedra.empty(); }
+  bool hasTetrahedra() const
+  {
+    return !_tetrahedra.empty();
+  }
 
-  bool hasConnectivity() const { return hasEdges() || hasTriangles() || hasTetrahedra(); }
+  bool hasConnectivity() const
+  {
+    return hasEdges() || hasTriangles() || hasTetrahedra();
+  }
 
   int getDimensions() const;
 

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -5,11 +5,13 @@
 #include <algorithm>
 #include <boost/concept/assert.hpp>
 #include <boost/range/concepts.hpp>
+#include <iterator>
 #include "math/differences.hpp"
 #include "math/geometry.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Vertex.hpp"
 #include "utils/EigenIO.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice {
 namespace mesh {
@@ -24,54 +26,50 @@ Triangle::Triangle(
     Edge &edgeTwo,
     Edge &edgeThree,
     int   id)
-    : _edges({&edgeOne, &edgeTwo, &edgeThree}),
-      _id(id)
+    : _id(id)
 {
   PRECICE_ASSERT(edgeOne.getDimensions() == edgeTwo.getDimensions(),
                  edgeOne.getDimensions(), edgeTwo.getDimensions());
   PRECICE_ASSERT(edgeTwo.getDimensions() == edgeThree.getDimensions(),
                  edgeTwo.getDimensions(), edgeThree.getDimensions());
 
-  // Determine vertex map
-  Vertex &v0 = edge(0).vertex(0);
-  Vertex &v1 = edge(0).vertex(1);
+  PRECICE_ASSERT(edgeOne.connectedTo(edgeTwo), "Edge one and two are not connected.");
+  PRECICE_ASSERT(edgeOne.connectedTo(edgeThree), "Edge one and three are not connected.");
+  PRECICE_ASSERT(edgeTwo.connectedTo(edgeThree), "Edge two and three are not connected.");
 
-  if (&edge(1).vertex(0) == &v0) {
-    _vertexMap[0] = true;
-    _vertexMap[1] = false;
-  } else if (&edge(1).vertex(1) == &v0) {
-    _vertexMap[0] = true;
-    _vertexMap[1] = true;
-  } else if (&edge(1).vertex(0) == &v1) {
-    _vertexMap[0] = false;
-    _vertexMap[1] = false;
+  // Pick first 2 vertices from first edge
+  Vertex &v0 = edgeOne.vertex(0);
+  Vertex &v1 = edgeOne.vertex(1);
+
+  // Determine the third vertex using the second edge
+  Vertex *v2 = nullptr;
+  if ((v0 == edgeTwo.vertex(0)) || (v1 == edgeTwo.vertex(0))) {
+    v2 = &edgeTwo.vertex(1);
+  } else if ((v0 == edgeTwo.vertex(1)) || (v1 == edgeTwo.vertex(1))) {
+    v2 = &edgeTwo.vertex(0);
   } else {
-    PRECICE_ASSERT(&edge(1).vertex(1) == &v1);
-    _vertexMap[0] = false;
-    _vertexMap[1] = true;
+    PRECICE_UNREACHABLE("Edges don't form a triangle");
   }
 
-  if (_vertexMap[1] == 0) {
-    if (&edge(2).vertex(0) == &edge(1).vertex(1)) {
-      _vertexMap[2] = false;
-    } else {
-      PRECICE_ASSERT(&edge(2).vertex(1) == &edge(1).vertex(1));
-      _vertexMap[2] = true;
-    }
-  } else if (_vertexMap[1] == 1) {
-    if (&edge(2).vertex(0) == &edge(1).vertex(0)) {
-      _vertexMap[2] = false;
-    } else {
-      PRECICE_ASSERT(&edge(2).vertex(1) == &edge(1).vertex(0));
-      _vertexMap[2] = true;
-    }
-  }
+  _vertices = {&v0, &v1, v2};
+  std::sort(_vertices.begin(), _vertices.end(),
+            [](const Vertex *lhs, const Vertex *rhs) { return *lhs < *rhs; });
+}
 
-  PRECICE_ASSERT(
-      (&edge(0).vertex(_vertexMap[0]) != &edge(1).vertex(_vertexMap[1])) &&
-          (&edge(0).vertex(_vertexMap[0]) != &edge(2).vertex(_vertexMap[2])) &&
-          (&edge(1).vertex(_vertexMap[1]) != &edge(2).vertex(_vertexMap[2])),
-      "Triangle vertices are not unique!");
+Triangle::Triangle(
+    Vertex &vertexOne,
+    Vertex &vertexTwo,
+    Vertex &vertexThree,
+    int     id)
+    : _vertices({&vertexOne, &vertexTwo, &vertexThree}),
+      _id(id)
+{
+  PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),
+                 vertexOne.getDimensions(), vertexTwo.getDimensions());
+  PRECICE_ASSERT(vertexTwo.getDimensions() == vertexThree.getDimensions(),
+                 vertexTwo.getDimensions(), vertexThree.getDimensions());
+  std::sort(_vertices.begin(), _vertices.end(),
+            [](const Vertex *lhs, const Vertex *rhs) { return *lhs < *rhs; });
 }
 
 double Triangle::getArea() const
@@ -81,34 +79,35 @@ double Triangle::getArea() const
 
 Eigen::VectorXd Triangle::computeNormal() const
 {
-  Eigen::Vector3d vectorA = edge(1).getCenter() - edge(0).getCenter();
-  Eigen::Vector3d vectorB = edge(2).getCenter() - edge(0).getCenter();
+  Eigen::Vector3d vectorA = (vertex(1).getCoords() - vertex(0).getCoords()) / 2.0;
+  Eigen::Vector3d vectorB = (vertex(1).getCoords() - vertex(0).getCoords()) / 2.0;
+
   // Compute cross-product of vector A and vector B
   return vectorA.cross(vectorB).normalized();
 }
 
 int Triangle::getDimensions() const
 {
-  return _edges[0]->getDimensions();
+  return _vertices[0]->getDimensions();
 }
 
 const Eigen::VectorXd Triangle::getCenter() const
 {
-  return (_edges[0]->getCenter() + _edges[1]->getCenter() + _edges[2]->getCenter()) / 3.0;
+  return (_vertices[0]->getCoords() + _vertices[1]->getCoords() + _vertices[2]->getCoords()) / 3.0;
 }
 
 double Triangle::getEnclosingRadius() const
 {
   auto center = getCenter();
-  return std::max({(center - vertex(0).getCoords()).norm(),
-                   (center - vertex(1).getCoords()).norm(),
-                   (center - vertex(2).getCoords()).norm()});
+  return std::max({(center - _vertices[0]->getCoords()).norm(),
+                   (center - _vertices[1]->getCoords()).norm(),
+                   (center - _vertices[2]->getCoords()).norm()});
 }
 
 bool Triangle::operator==(const Triangle &other) const
 {
-  return std::is_permutation(_edges.begin(), _edges.end(), other._edges.begin(),
-                             [](const Edge *e1, const Edge *e2) { return *e1 == *e2; });
+  return std::is_permutation(_vertices.begin(), _vertices.end(), other._vertices.begin(),
+                             [](const Vertex *e1, const Vertex *e2) { return *e1 == *e2; });
 }
 
 bool Triangle::operator!=(const Triangle &other) const

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -48,9 +48,9 @@ public:
 
   /// Constructor based on 3 vertices
   Triangle(
-      Vertex &     VertexOne,
-      Vertex &     VertexTwo,
-      Vertex &     VertexThree,
+      Vertex &   VertexOne,
+      Vertex &   VertexTwo,
+      Vertex &   VertexThree,
       TriangleID id);
 
   /// Returns dimensionalty of space the triangle is embedded in.

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -22,7 +22,7 @@ class Vertex;
 namespace precice {
 namespace mesh {
 
-/// Triangle of a mesh, defined by three edges (and vertices).
+/// Triangle of a mesh, defined by three vertices.
 class Triangle {
 public:
   /// Type of the read-only const random-access iterator over Vertex coords
@@ -39,11 +39,18 @@ public:
   /// Fix for the Boost.Test versions 1.65.1 - 1.67
   using value_type = Vertex::RawCoords;
 
-  /// Constructor, the order of edges defines the outer normal direction.
+  /// Constructor based on 3 edges
   Triangle(
       Edge &     edgeOne,
       Edge &     edgeTwo,
       Edge &     edgeThree,
+      TriangleID id);
+
+  /// Constructor based on 3 vertices
+  Triangle(
+      Vertex &     VertexOne,
+      Vertex &     VertexTwo,
+      Vertex &     VertexThree,
       TriangleID id);
 
   /// Returns dimensionalty of space the triangle is embedded in.
@@ -66,12 +73,6 @@ public:
    * is determined on construction of the triangle.
    */
   const Vertex &vertex(int i) const;
-
-  /// Returns triangle edge with index 0, 1 or 2.
-  Edge &edge(int i);
-
-  /// Returns const triangle edge with index 0, 1 or 2.
-  const Edge &edge(int i) const;
 
   ///@name Iterators
   ///@{
@@ -123,11 +124,8 @@ public:
   bool operator!=(const Triangle &other) const;
 
 private:
-  /// Edges defining the triangle.
-  std::array<Edge *, 3> _edges;
-
-  /// Decider for choosing unique vertices from _edges.
-  std::array<bool, 3> _vertexMap;
+  /// Vertices defining the triangle.
+  std::array<Vertex *, 3> _vertices;
 
   /// ID of the triangle.
   TriangleID _id;
@@ -138,23 +136,13 @@ private:
 inline Vertex &Triangle::vertex(int i)
 {
   PRECICE_ASSERT((i >= 0) && (i < 3), i);
-  return edge(i).vertex(_vertexMap[i]);
+  return *_vertices[i];
 }
 
 inline const Vertex &Triangle::vertex(int i) const
 {
   PRECICE_ASSERT((i >= 0) && (i < 3), i);
-  return edge(i).vertex(_vertexMap[i]);
-}
-
-inline Edge &Triangle::edge(int i)
-{
-  return *_edges[i];
-}
-
-inline const Edge &Triangle::edge(int i) const
-{
-  return *_edges[i];
+  return *_vertices[i];
 }
 
 inline Triangle::iterator Triangle::begin()

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -57,6 +57,9 @@ public:
 
   inline bool operator!=(const Vertex &rhs) const;
 
+  /// Implements partial ordering by ID
+  inline bool operator<(const Vertex &rhs) const;
+
 private:
   /// Coordinates of the vertex
   std::array<double, 3> _coords;
@@ -127,6 +130,11 @@ inline bool Vertex::operator==(const Vertex &rhs) const
 inline bool Vertex::operator!=(const Vertex &rhs) const
 {
   return !(*this == rhs);
+}
+
+inline bool Vertex::operator<(const Vertex &rhs) const
+{
+  return _id < rhs._id;
 }
 
 /// Make Vertex printable

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -139,10 +139,16 @@ BOOST_AUTO_TEST_CASE(Demonstration)
       index++;
     }
 
+    BOOST_TEST(!mesh.hasEdges());
+    BOOST_TEST(!mesh.hasTriangles());
+
     // Create mesh edges
     Edge &e0 = mesh.createEdge(v0, v1);
     Edge &e1 = mesh.createEdge(v1, v2);
     Edge &e2 = mesh.createEdge(v2, v0);
+
+    BOOST_TEST(mesh.hasEdges());
+    BOOST_TEST(!mesh.hasTriangles());
 
     // Validate mesh edges state
     index = 0;
@@ -166,7 +172,12 @@ BOOST_AUTO_TEST_CASE(Demonstration)
 
       // Validate mesh triangle
       BOOST_TEST((*mesh.triangles().begin()).getID() == t->getID());
+      BOOST_TEST(mesh.hasTriangles());
+    } else {
+      BOOST_TEST(!mesh.hasTriangles());
     }
+
+    BOOST_TEST(mesh.hasEdges());
 
     // Create vertex data
     std::string dataName("MyData");

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -43,15 +43,6 @@ BOOST_AUTO_TEST_CASE(DirectionalEdges)
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
 
-  Edge &e1ref = triangle.edge(0);
-  BOOST_TEST(e1ref.getID() == e1.getID());
-
-  Edge &e2ref = triangle.edge(1);
-  BOOST_TEST(e2ref.getID() == e2.getID());
-
-  Edge &e3ref = triangle.edge(2);
-  BOOST_TEST(e3ref.getID() == e3.getID());
-
   int id = triangle.getID();
   BOOST_TEST(id == 0);
 
@@ -94,15 +85,6 @@ BOOST_AUTO_TEST_CASE(SecondFlipped)
 
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
-
-  Edge &e1ref = triangle.edge(0);
-  BOOST_TEST(e1ref.getID() == e1.getID());
-
-  Edge &e2ref = triangle.edge(1);
-  BOOST_TEST(e2ref.getID() == e2.getID());
-
-  Edge &e3ref = triangle.edge(2);
-  BOOST_TEST(e3ref.getID() == e3.getID());
 
   int id = triangle.getID();
   BOOST_TEST(id == 0);
@@ -148,15 +130,6 @@ BOOST_AUTO_TEST_CASE(ReversedFirstFlipped)
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
 
-  Edge &e1ref = triangle.edge(0);
-  BOOST_TEST(e1ref.getID() == e1.getID());
-
-  Edge &e2ref = triangle.edge(1);
-  BOOST_TEST(e2ref.getID() == e2.getID());
-
-  Edge &e3ref = triangle.edge(2);
-  BOOST_TEST(e3ref.getID() == e3.getID());
-
   int id = triangle.getID();
   BOOST_TEST(id == 0);
 
@@ -193,22 +166,13 @@ BOOST_AUTO_TEST_CASE(ReversedLastFlipped)
   Triangle triangle(e1, e3, e2, 0);
 
   Vertex &v1ref = triangle.vertex(0);
-  BOOST_TEST(v1ref.getID() == v2.getID());
+  BOOST_TEST(v1ref.getID() == v1.getID());
 
   Vertex &v2ref = triangle.vertex(1);
-  BOOST_TEST(v2ref.getID() == v1.getID());
+  BOOST_TEST(v2ref.getID() == v2.getID());
 
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
-
-  Edge &e1ref = triangle.edge(0);
-  BOOST_TEST(e1ref.getID() == e1.getID());
-
-  Edge &e2ref = triangle.edge(1);
-  BOOST_TEST(e2ref.getID() == e3.getID());
-
-  Edge &e3ref = triangle.edge(2);
-  BOOST_TEST(e3ref.getID() == e2.getID());
 
   int id = triangle.getID();
   BOOST_TEST(id == 0);


### PR DESCRIPTION
## Main changes of this PR

This PR simplifies triangles, by defining them in terms of vertices instead of edges.
This reduces their size in memory and avoids having to remap edge IDs in filter and communication operations.
It also simplifies handling triangles in tests.
The change is internal only and has no observable side effects in the API.

Major change is that triangles can now exist independent of edges.

In short:
* No breaking change
* lower memory footprint
* less communication while sending meshes
* faster filtering and sending of meshes
* A triangle ABC **doesn't** imply the existence of edges AB, BC, and AC any longer.

## Motivation and additional information

See #1153

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
