### PR TITLE
Remove connectivity ids internally

### DIFF
--- a/src/mapping/tests/PolationTest.cpp
+++ b/src/mapping/tests/PolationTest.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(EdgeInterpolation)
   PRECICE_TEST(1_rank);
   mesh::Vertex v1(Eigen::Vector3d(0.0, 0.0, 0.0), 0);
   mesh::Vertex v2(Eigen::Vector3d(0.0, 2.0, 0.0), 1);
-  mesh::Edge   edge(v1, v2, 0);
+  mesh::Edge   edge(v1, v2);
 
   Eigen::Vector3d location(0.0, 0.4, 0.0);
 
@@ -61,10 +61,10 @@ BOOST_AUTO_TEST_CASE(TriangleInterpolation)
   mesh::Vertex   v1(Eigen::Vector3d(0.0, 0.0, 0.0), 0);
   mesh::Vertex   v2(Eigen::Vector3d(2.0, 0.0, 0.0), 1);
   mesh::Vertex   v3(Eigen::Vector3d(1.0, 2.0, 0.0), 2);
-  mesh::Edge     e1(v1, v2, 0);
-  mesh::Edge     e2(v2, v3, 1);
-  mesh::Edge     e3(v1, v3, 2);
-  mesh::Triangle triangle(e1, e2, e3, 0);
+  mesh::Edge     e1(v1, v2);
+  mesh::Edge     e2(v2, v3);
+  mesh::Edge     e3(v1, v3);
+  mesh::Triangle triangle(e1, e2, e3);
   triangle.computeNormal();
 
   Eigen::Vector3d location(1.0, 0.6, 0.0);
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(EdgeExtrapolation)
   PRECICE_TEST(1_rank);
   mesh::Vertex v1(Eigen::Vector3d(0.0, 0.0, 0.0), 0);
   mesh::Vertex v2(Eigen::Vector3d(0.0, 2.0, 0.0), 1);
-  mesh::Edge   edge(v1, v2, 0);
+  mesh::Edge   edge(v1, v2);
 
   Eigen::Vector3d location(0.0, 3.0, 0.0);
 
@@ -113,10 +113,10 @@ BOOST_AUTO_TEST_CASE(TriangleExtrapolation)
   mesh::Vertex   v1(Eigen::Vector3d(0.0, 0.0, 0.0), 0);
   mesh::Vertex   v2(Eigen::Vector3d(2.0, 0.0, 0.0), 1);
   mesh::Vertex   v3(Eigen::Vector3d(1.0, 2.0, 0.0), 2);
-  mesh::Edge     e1(v1, v2, 0);
-  mesh::Edge     e2(v2, v3, 1);
-  mesh::Edge     e3(v1, v3, 2);
-  mesh::Triangle triangle(e1, e2, e3, 0);
+  mesh::Edge     e1(v1, v2);
+  mesh::Edge     e2(v2, v3);
+  mesh::Edge     e3(v1, v3);
+  mesh::Triangle triangle(e1, e2, e3);
   triangle.computeNormal();
 
   Eigen::Vector3d location(4.0, 0.6, 0.0);

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -11,18 +11,11 @@ namespace mesh {
 
 Edge::Edge(
     Vertex &vertexOne,
-    Vertex &vertexTwo,
-    EdgeID  id)
-    : _vertices({&vertexOne, &vertexTwo}),
-      _id(id)
+    Vertex &vertexTwo)
+    : _vertices({&vertexOne, &vertexTwo})
 {
   PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),
                  vertexOne.getDimensions(), vertexTwo.getDimensions());
-}
-
-EdgeID Edge::getID() const
-{
-  return _id;
 }
 
 double Edge::getLength() const

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -20,12 +20,10 @@ public:
    *
    * @param[in] vertexOne First Vertex object defining the edge.
    * @param[in] vertexTwo Second Vertex object defining the edge.
-   * @param[in] id Unique (among edges in one mesh) ID.
    */
   Edge(
       Vertex &vertexOne,
-      Vertex &vertexTwo,
-      EdgeID  id);
+      Vertex &vertexTwo);
 
   /// Returns number of spatial dimensions (2 or 3) the edge is embedded to.
   int getDimensions() const;
@@ -35,9 +33,6 @@ public:
 
   /// Returns the edge's vertex as const object with index 0 or 1.
   const Vertex &vertex(int i) const;
-
-  /// Returns the (among edges) unique ID of the edge.
-  EdgeID getID() const;
 
   /// Returns the length of the edge
   double getLength() const;
@@ -65,9 +60,6 @@ public:
 private:
   /// Pointers to Vertex objects defining the edge.
   std::array<Vertex *, 2> _vertices;
-
-  /// Unique (among edges) ID of the edge.
-  int _id;
 };
 
 // ------------------------------------------------------ HEADER IMPLEMENTATION

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -51,7 +51,7 @@ Mesh::EdgeContainer &Mesh::edges()
   return _edges;
 }
 
-Edge &Mesh::edge(EdgeID id)
+Edge &Mesh::registeredEdge(EdgeID id)
 {
   auto pos = _edgeRegister.find(id);
   PRECICE_ASSERT(pos != _edgeRegister.end())
@@ -104,7 +104,7 @@ Edge &Mesh::createEdge(
   return _edges.back();
 }
 
-std::pair<Edge &, EdgeID> Mesh::createEdgeWithID(
+std::pair<Edge &, EdgeID> Mesh::createRegisteredEdge(
     Vertex &vertexOne,
     Vertex &vertexTwo)
 {

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -51,6 +51,13 @@ Mesh::EdgeContainer &Mesh::edges()
   return _edges;
 }
 
+Edge &Mesh::edge(EdgeID id)
+{
+  auto pos = _edgeRegister.find(id);
+  PRECICE_ASSERT(pos != _edgeRegister.end())
+  return *pos->second;
+}
+
 const Mesh::EdgeContainer &Mesh::edges() const
 {
   return _edges;
@@ -95,6 +102,16 @@ Edge &Mesh::createEdge(
 {
   _edges.emplace_back(vertexOne, vertexTwo);
   return _edges.back();
+}
+
+std::pair<Edge &, EdgeID> Mesh::createEdgeWithID(
+    Vertex &vertexOne,
+    Vertex &vertexTwo)
+{
+  EdgeID nextID = _edges.size();
+  _edges.emplace_back(vertexOne, vertexTwo);
+  _edgeRegister.emplace(nextID, &_edges.back());
+  return {_edges.back(), nextID};
 }
 
 Triangle &Mesh::createTriangle(
@@ -207,7 +224,7 @@ bool Mesh::isValidVertexID(VertexID vertexID) const
 
 bool Mesh::isValidEdgeID(EdgeID edgeID) const
 {
-  return (0 <= edgeID) && (static_cast<size_t>(edgeID) < edges().size());
+  return _edgeRegister.count(edgeID) == 1;
 }
 
 void Mesh::allocateDataValues()
@@ -273,6 +290,7 @@ void Mesh::clear()
   _edges.clear();
   _vertices.clear();
   _index.clear();
+  _edgeRegister.clear();
 
   for (mesh::PtrData &data : _data) {
     data->values().resize(0);

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -97,24 +97,6 @@ Edge &Mesh::createEdge(
   return _edges.back();
 }
 
-Edge &Mesh::createUniqueEdge(
-    Vertex &vertexOne,
-    Vertex &vertexTwo)
-{
-  const std::array<VertexID, 2> vids{vertexOne.getID(), vertexTwo.getID()};
-  const auto                    eend = edges().end();
-  auto                          pos  = std::find_if(edges().begin(), eend,
-                          [&vids](const Edge &e) -> bool {
-                            const std::array<VertexID, 2> eids{e.vertex(0).getID(), e.vertex(1).getID()};
-                            return std::is_permutation(vids.begin(), vids.end(), eids.begin());
-                          });
-  if (pos != eend) {
-    return *pos;
-  } else {
-    return createEdge(vertexOne, vertexTwo);
-  }
-}
-
 Triangle &Mesh::createTriangle(
     Edge &edgeOne,
     Edge &edgeTwo,

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -93,8 +93,7 @@ Edge &Mesh::createEdge(
     Vertex &vertexOne,
     Vertex &vertexTwo)
 {
-  auto nextID = _edges.size();
-  _edges.emplace_back(vertexOne, vertexTwo, nextID);
+  _edges.emplace_back(vertexOne, vertexTwo);
   return _edges.back();
 }
 
@@ -125,8 +124,7 @@ Triangle &Mesh::createTriangle(
       edgeOne.connectedTo(edgeTwo) &&
       edgeTwo.connectedTo(edgeThree) &&
       edgeThree.connectedTo(edgeOne));
-  auto nextID = _triangles.size();
-  _triangles.emplace_back(edgeOne, edgeTwo, edgeThree, nextID);
+  _triangles.emplace_back(edgeOne, edgeTwo, edgeThree);
   return _triangles.back();
 }
 
@@ -136,7 +134,7 @@ Triangle &Mesh::createTriangle(
     Vertex &vertexThree)
 {
   auto nextID = _triangles.size();
-  _triangles.emplace_back(vertexOne, vertexTwo, vertexThree, nextID);
+  _triangles.emplace_back(vertexOne, vertexTwo, vertexThree);
   return _triangles.back();
 }
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -132,7 +132,6 @@ Triangle &Mesh::createTriangle(
     Vertex &vertexTwo,
     Vertex &vertexThree)
 {
-  auto nextID = _triangles.size();
   _triangles.emplace_back(vertexOne, vertexTwo, vertexThree);
   return _triangles.back();
 }
@@ -143,9 +142,7 @@ Tetrahedron &Mesh::createTetrahedron(
     Vertex &vertexThree,
     Vertex &vertexFour)
 {
-
-  auto nextID = _tetrahedra.size();
-  _tetrahedra.emplace_back(vertexOne, vertexTwo, vertexThree, vertexFour, nextID);
+  _tetrahedra.emplace_back(vertexOne, vertexTwo, vertexThree, vertexFour);
   return _tetrahedra.back();
 }
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -75,6 +75,9 @@ public:
   /// Returns modifiable container holding all edges.
   EdgeContainer &edges();
 
+  /// Returns modifiable container holding all edges.
+  Edge& edge(EdgeID id);
+
   /// Returns const container holding all edges.
   const EdgeContainer &edges() const;
 
@@ -122,6 +125,16 @@ public:
    * @param[in] vertexTwo Reference to second Vertex defining the Edge.
    */
   Edge &createEdge(
+      Vertex &vertexOne,
+      Vertex &vertexTwo);
+
+  /**
+   * @brief Creates and initializes an Edge object and returns an id.
+   *
+   * @param[in] vertexOne Reference to first Vertex defining the Edge.
+   * @param[in] vertexTwo Reference to second Vertex defining the Edge.
+   */
+  std::pair<Edge &, EdgeID> createEdgeWithID(
       Vertex &vertexOne,
       Vertex &vertexTwo);
 
@@ -331,6 +344,8 @@ private:
   BoundingBox _boundingBox;
 
   query::Index _index;
+
+  std::map<EdgeID, Edge *> _edgeRegister;
 };
 
 std::ostream &operator<<(std::ostream &os, const Mesh &q);

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -75,8 +75,8 @@ public:
   /// Returns modifiable container holding all edges.
   EdgeContainer &edges();
 
-  /// Returns edge with given id.
-  Edge& edge(EdgeID id);
+  /// Returns a registered edge with given id.
+  Edge& registeredEdge(EdgeID id);
 
   /// Returns const container holding all edges.
   const EdgeContainer &edges() const;
@@ -134,7 +134,7 @@ public:
    * @param[in] vertexOne Reference to first Vertex defining the Edge.
    * @param[in] vertexTwo Reference to second Vertex defining the Edge.
    */
-  std::pair<Edge &, EdgeID> createEdgeWithID(
+  std::pair<Edge &, EdgeID> createRegisteredEdge(
       Vertex &vertexOne,
       Vertex &vertexTwo);
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -126,16 +126,6 @@ public:
       Vertex &vertexTwo);
 
   /**
-   * @brief Creates and initializes an Edge object or returns an already existing one.
-   *
-   * @param[in] vertexOne Reference to first Vertex defining the Edge.
-   * @param[in] vertexTwo Reference to second Vertex defining the Edge.
-   */
-  Edge &createUniqueEdge(
-      Vertex &vertexOne,
-      Vertex &vertexTwo);
-
-  /**
    * @brief Creates and initializes a Triangle object.
    *
    * @param[in] edgeOne Reference to first edge defining the Triangle.

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -75,7 +75,7 @@ public:
   /// Returns modifiable container holding all edges.
   EdgeContainer &edges();
 
-  /// Returns modifiable container holding all edges.
+  /// Returns edge with given id.
   Edge& edge(EdgeID id);
 
   /// Returns const container holding all edges.

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -76,7 +76,7 @@ public:
   EdgeContainer &edges();
 
   /// Returns a registered edge with given id.
-  Edge& registeredEdge(EdgeID id);
+  Edge &registeredEdge(EdgeID id);
 
   /// Returns const container holding all edges.
   const EdgeContainer &edges() const;

--- a/src/mesh/Tetrahedron.cpp
+++ b/src/mesh/Tetrahedron.cpp
@@ -33,6 +33,9 @@ Tetrahedron::Tetrahedron(
           (&vertexTwo != &vertexFour) &&
           (&vertexThree != &vertexFour),
       "Tetrahedron vertices are not unique!");
+
+  std::sort(_vertices.begin(), _vertices.end(),
+            [](const Vertex *lhs, const Vertex *rhs) { return *lhs < *rhs; });
 }
 
 double Tetrahedron::getVolume() const

--- a/src/mesh/Tetrahedron.cpp
+++ b/src/mesh/Tetrahedron.cpp
@@ -11,10 +11,10 @@ namespace precice {
 namespace mesh {
 
 Tetrahedron::Tetrahedron(
-    Vertex &      vertexOne,
-    Vertex &      vertexTwo,
-    Vertex &      vertexThree,
-    Vertex &      vertexFour)
+    Vertex &vertexOne,
+    Vertex &vertexTwo,
+    Vertex &vertexThree,
+    Vertex &vertexFour)
     : _vertices({&vertexOne, &vertexTwo, &vertexThree, &vertexFour})
 {
   PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),

--- a/src/mesh/Tetrahedron.cpp
+++ b/src/mesh/Tetrahedron.cpp
@@ -14,10 +14,8 @@ Tetrahedron::Tetrahedron(
     Vertex &      vertexOne,
     Vertex &      vertexTwo,
     Vertex &      vertexThree,
-    Vertex &      vertexFour,
-    TetrahedronID id)
-    : _vertices({&vertexOne, &vertexTwo, &vertexThree, &vertexFour}),
-      _id(id)
+    Vertex &      vertexFour)
+    : _vertices({&vertexOne, &vertexTwo, &vertexThree, &vertexFour})
 {
   PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),
                  vertexOne.getDimensions(), vertexTwo.getDimensions());

--- a/src/mesh/Tetrahedron.hpp
+++ b/src/mesh/Tetrahedron.hpp
@@ -21,10 +21,10 @@ class Tetrahedron {
 public:
   /// Constructor, the order of vertices doesn't matter.
   Tetrahedron(
-      Vertex &      vertexOne,
-      Vertex &      vertexTwo,
-      Vertex &      vertexThree,
-      Vertex &      vertexFour);
+      Vertex &vertexOne,
+      Vertex &vertexTwo,
+      Vertex &vertexThree,
+      Vertex &vertexFour);
 
   /// Returns dimensionalty of space the Tetrahedron is embedded in.
   int getDimensions() const;

--- a/src/mesh/Tetrahedron.hpp
+++ b/src/mesh/Tetrahedron.hpp
@@ -24,8 +24,7 @@ public:
       Vertex &      vertexOne,
       Vertex &      vertexTwo,
       Vertex &      vertexThree,
-      Vertex &      vertexFour,
-      TetrahedronID id);
+      Vertex &      vertexFour);
 
   /// Returns dimensionalty of space the Tetrahedron is embedded in.
   int getDimensions() const;
@@ -39,9 +38,6 @@ public:
    * @brief Returns const tetrahedron vertex with index 0, 1, 2 or 3.
    */
   const Vertex &vertex(int i) const;
-
-  /// Returns a among Tetrahedrons globally unique ID.
-  TetrahedronID getID() const;
 
   /// Returns the unsigned volume of the tetrahedron
   double getVolume() const;
@@ -65,9 +61,6 @@ public:
 private:
   /// Vertices defining the Tetrahedron.
   std::array<Vertex *, 4> _vertices;
-
-  /// ID of the Tetrahedron.
-  TetrahedronID _id;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS
@@ -82,11 +75,6 @@ inline const Vertex &Tetrahedron::vertex(int i) const
 {
   PRECICE_ASSERT((i >= 0) && (i < 4), i);
   return *_vertices[i];
-}
-
-inline TetrahedronID Tetrahedron::getID() const
-{
-  return _id;
 }
 
 std::ostream &operator<<(std::ostream &os, const Tetrahedron &t);

--- a/src/mesh/Triangle.cpp
+++ b/src/mesh/Triangle.cpp
@@ -24,9 +24,7 @@ BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<const Triangle>) );
 Triangle::Triangle(
     Edge &edgeOne,
     Edge &edgeTwo,
-    Edge &edgeThree,
-    int   id)
-    : _id(id)
+    Edge &edgeThree)
 {
   PRECICE_ASSERT(edgeOne.getDimensions() == edgeTwo.getDimensions(),
                  edgeOne.getDimensions(), edgeTwo.getDimensions());
@@ -59,10 +57,8 @@ Triangle::Triangle(
 Triangle::Triangle(
     Vertex &vertexOne,
     Vertex &vertexTwo,
-    Vertex &vertexThree,
-    int     id)
-    : _vertices({&vertexOne, &vertexTwo, &vertexThree}),
-      _id(id)
+    Vertex &vertexThree)
+    : _vertices({&vertexOne, &vertexTwo, &vertexThree})
 {
   PRECICE_ASSERT(vertexOne.getDimensions() == vertexTwo.getDimensions(),
                  vertexOne.getDimensions(), vertexTwo.getDimensions());

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -41,15 +41,15 @@ public:
 
   /// Constructor based on 3 edges
   Triangle(
-      Edge &     edgeOne,
-      Edge &     edgeTwo,
-      Edge &     edgeThree);
+      Edge &edgeOne,
+      Edge &edgeTwo,
+      Edge &edgeThree);
 
   /// Constructor based on 3 vertices
   Triangle(
-      Vertex &   VertexOne,
-      Vertex &   VertexTwo,
-      Vertex &   VertexThree);
+      Vertex &VertexOne,
+      Vertex &VertexTwo,
+      Vertex &VertexThree);
 
   /// Returns dimensionalty of space the triangle is embedded in.
   int getDimensions() const;

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -43,15 +43,13 @@ public:
   Triangle(
       Edge &     edgeOne,
       Edge &     edgeTwo,
-      Edge &     edgeThree,
-      TriangleID id);
+      Edge &     edgeThree);
 
   /// Constructor based on 3 vertices
   Triangle(
       Vertex &   VertexOne,
       Vertex &   VertexTwo,
-      Vertex &   VertexThree,
-      TriangleID id);
+      Vertex &   VertexThree);
 
   /// Returns dimensionalty of space the triangle is embedded in.
   int getDimensions() const;
@@ -100,9 +98,6 @@ public:
   /// Computes the normal of the triangle.
   Eigen::VectorXd computeNormal() const;
 
-  /// Returns a among triangles globally unique ID.
-  TriangleID getID() const;
-
   /// Returns the surface area of the triangle
   double getArea() const;
 
@@ -126,9 +121,6 @@ public:
 private:
   /// Vertices defining the triangle.
   std::array<Vertex *, 3> _vertices;
-
-  /// ID of the triangle.
-  TriangleID _id;
 };
 
 // --------------------------------------------------------- HEADER DEFINITIONS
@@ -173,11 +165,6 @@ inline Triangle::const_iterator Triangle::cbegin() const
 inline Triangle::const_iterator Triangle::cend() const
 {
   return end();
-}
-
-inline TriangleID Triangle::getID() const
-{
-  return _id;
 }
 
 std::ostream &operator<<(std::ostream &os, const Triangle &t);

--- a/src/mesh/tests/EdgeTest.cpp
+++ b/src/mesh/tests/EdgeTest.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(Edges)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector3d::Constant(0.0), 0);
   Vertex v2(Vector3d::Constant(1.0), 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
 
   BOOST_TEST(edge.getDimensions() == 3);
   VectorXd coords1 = edge.vertex(0).getCoords();
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(Dimensions2D)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector2d::Constant(0.0), 0);
   Vertex v2(Vector2d::Constant(1.0), 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
   BOOST_TEST(edge.getDimensions() == 2);
 
   double expectedLenght = std::sqrt(2.0);
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(Dimensions2DX)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector2d::Constant(0.0), 0);
   Vertex v2(Vector2d{1, 0}, 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
   BOOST_TEST(edge.getDimensions() == 2);
 
   double expectedLenght = std::sqrt(1.0);
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(Dimensions2DY)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector2d::Constant(0.0), 0);
   Vertex v2(Vector2d{0, 1}, 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
   BOOST_TEST(edge.getDimensions() == 2);
 
   double expectedLenght = std::sqrt(1.0);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(Dimensions3DX)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector3d::Constant(0.0), 0);
   Vertex v2(Vector3d{1, 0, 0}, 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
   BOOST_TEST(edge.getDimensions() == 3);
 
   double expectedLenght = std::sqrt(1.0);
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(Dimensions3DY)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector3d::Constant(0.0), 0);
   Vertex v2(Vector3d{0, 1, 0}, 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
   BOOST_TEST(edge.getDimensions() == 3);
 
   double expectedLenght = std::sqrt(1.0);
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(Dimensions3DZ)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector3d::Constant(0.0), 0);
   Vertex v2(Vector3d{0, 0, 1}, 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
   BOOST_TEST(edge.getDimensions() == 3);
 
   double expectedLenght = std::sqrt(1.0);
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(Dimensions3D)
   PRECICE_TEST(1_rank);
   Vertex v1(Vector3d::Constant(0.0), 0);
   Vertex v2(Vector3d::Constant(1.0), 1);
-  Edge   edge(v1, v2, 0);
+  Edge   edge(v1, v2);
   BOOST_TEST(edge.getDimensions() == 3);
 
   double expectedLenght = std::sqrt(3.0);
@@ -146,10 +146,10 @@ BOOST_AUTO_TEST_CASE(EdgeEquality)
   Vertex v1(Vector3d(0, 0, 0), 0);
   Vertex v2(Vector3d(0, 0, 1), 0);
   Vertex v3(Vector3d(0, 0, 2), 0);
-  Edge   edge1(v1, v2, 0);
-  Edge   edge2(v2, v1, 1);
-  Edge   edge3(v1, v3, 0);
-  Edge   edge4(v1, v3, 0);
+  Edge   edge1(v1, v2);
+  Edge   edge2(v2, v1);
+  Edge   edge3(v1, v3);
+  Edge   edge4(v1, v3);
   BOOST_TEST(edge1 == edge2);
   BOOST_TEST(edge1 != edge3);
   BOOST_TEST(edge3 == edge4);
@@ -160,14 +160,14 @@ BOOST_AUTO_TEST_CASE(EdgeWKTPrint)
   PRECICE_TEST(1_rank);
   Vertex            v1(Vector2d(1., 2.), 0);
   Vertex            v2(Vector2d(2., 3.), 0);
-  Edge              e1(v1, v2, 0);
+  Edge              e1(v1, v2);
   std::stringstream e1stream;
   e1stream << e1;
   std::string e1str("LINESTRING (1 2, 2 3)");
   BOOST_TEST(e1str == e1stream.str());
   Vertex            v3(Vector3d(1., 2., 3.), 0);
   Vertex            v4(Vector3d(3., 2., 1.), 0);
-  Edge              e2(v3, v4, 0);
+  Edge              e2(v3, v4);
   std::stringstream e2stream;
   e2stream << e2;
   std::string e2str("LINESTRING (1 2 3, 3 2 1)");
@@ -182,12 +182,12 @@ BOOST_AUTO_TEST_CASE(EdgeConnectedTo)
   Vertex v3(Vector3d(0, 0, 3), 0);
   Vertex v4(Vector3d(0, 0, 4), 0);
 
-  Edge edge1(v1, v2, 0);
-  Edge edge2(v2, v3, 0);
+  Edge edge1(v1, v2);
+  Edge edge2(v2, v3);
   BOOST_TEST(edge1.connectedTo(edge2));
   BOOST_TEST(edge2.connectedTo(edge1));
 
-  Edge edge3(v3, v4, 0);
+  Edge edge3(v3, v4);
   BOOST_TEST(!edge1.connectedTo(edge3));
   BOOST_TEST(!edge3.connectedTo(edge1));
   BOOST_TEST(edge2.connectedTo(edge3));

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -266,36 +266,6 @@ BOOST_AUTO_TEST_CASE(MeshWKTPrint)
   BOOST_TEST(reference == sstream.str());
 }
 
-BOOST_AUTO_TEST_CASE(CreateUniqueEdge)
-{
-  PRECICE_TEST(1_rank);
-  int             dim = 3;
-  Mesh            mesh1("Mesh1", dim, testing::nextMeshID());
-  auto &          mesh = mesh1;
-  Eigen::VectorXd coords0(dim);
-  Eigen::VectorXd coords1(dim);
-  Eigen::VectorXd coords2(dim);
-  coords0 << 0.0, 0.0, 0.0;
-  coords1 << 1.0, 0.0, 0.0;
-  coords2 << 0.0, 0.0, 1.0;
-  Vertex &v0 = mesh.createVertex(coords0);
-  Vertex &v1 = mesh.createVertex(coords1);
-  Vertex &v2 = mesh.createVertex(coords2);
-
-  Edge &e01a = mesh.createEdge(v0, v1); // LINESTRING (0 0 0, 1 0 0)
-  mesh.createEdge(v0, v1);              // LINESTRING (0 0 0, 1 0 0)
-  BOOST_TEST(mesh.edges().size() == 2);
-
-  Edge &e01c = mesh.createUniqueEdge(v0, v1); // LINESTRING (0 0 0, 1 0 0)
-  BOOST_TEST(mesh.edges().size() == 2);
-  BOOST_TEST(e01a == e01c);
-
-  mesh.createUniqueEdge(v1, v2); // LINESTRING (0 0 0, 1 0 0)
-  BOOST_TEST(mesh.edges().size() == 3);
-  mesh.createUniqueEdge(v1, v2); // LINESTRING (0 0 0, 1 0 0)
-  BOOST_TEST(mesh.edges().size() == 3);
-}
-
 BOOST_AUTO_TEST_CASE(ResizeDataGrow)
 {
   PRECICE_TEST(1_rank);

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -148,30 +148,14 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     Edge &e2 = mesh.createEdge(v2, v0);
 
     BOOST_TEST(mesh.hasEdges());
+    BOOST_TEST(mesh.edges().size() == 3);
     BOOST_TEST(!mesh.hasTriangles());
-
-    // Validate mesh edges state
-    index = 0;
-    for (Edge &edge : mesh.edges()) {
-      if (index == 0) {
-        BOOST_TEST(edge.getID() == e0.getID());
-      } else if (index == 1) {
-        BOOST_TEST(edge.getID() == e1.getID());
-      } else if (index == 2) {
-        BOOST_TEST(edge.getID() == e2.getID());
-      } else {
-        BOOST_TEST(false);
-      }
-      index++;
-    }
 
     Triangle *t = nullptr;
     if (dim == 3) {
       // Create triangle
       t = &mesh.createTriangle(e0, e1, e2);
 
-      // Validate mesh triangle
-      BOOST_TEST((*mesh.triangles().begin()).getID() == t->getID());
       BOOST_TEST(mesh.hasTriangles());
     } else {
       BOOST_TEST(!mesh.hasTriangles());
@@ -409,7 +393,7 @@ BOOST_AUTO_TEST_CASE(EdgeLength)
   coords1 << 0.0, 1.0, 0.0;
   Vertex v0{coords0, 0};
   Vertex v1{coords1, 1};
-  Edge   e(v0, v1, 0);
+  Edge   e(v0, v1);
   BOOST_TEST(edgeLength(e) == std::sqrt(2));
 }
 

--- a/src/mesh/tests/TetrahedronTest.cpp
+++ b/src/mesh/tests/TetrahedronTest.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(BasicTetra)
   Vertex v3(coords3, 2);
   Vertex v4(coords4, 3);
 
-  Tetrahedron tetra(v1, v2, v3, v4, 0);
+  Tetrahedron tetra(v1, v2, v3, v4);
 
   Vertex &v1ref = tetra.vertex(0);
   BOOST_TEST(v1ref.getID() == v1.getID());
@@ -40,9 +40,6 @@ BOOST_AUTO_TEST_CASE(BasicTetra)
 
   Vertex &v4ref = tetra.vertex(3);
   BOOST_TEST(v4ref.getID() == v4.getID());
-
-  TetrahedronID id = tetra.getID();
-  BOOST_TEST(id == 0);
 
   Vector3d center = tetra.getCenter();
   BOOST_TEST(testing::equals(center, (coords1 + coords2 + coords3 + coords4) / 4));
@@ -73,7 +70,7 @@ BOOST_AUTO_TEST_CASE(WeirdTetra)
   Vertex v3(coords3, 2);
   Vertex v4(coords4, 3);
 
-  Tetrahedron tetra(v1, v2, v3, v4, 0);
+  Tetrahedron tetra(v1, v2, v3, v4);
 
   Vertex &v1ref = tetra.vertex(0);
   BOOST_TEST(v1ref.getID() == v1.getID());
@@ -86,9 +83,6 @@ BOOST_AUTO_TEST_CASE(WeirdTetra)
 
   Vertex &v4ref = tetra.vertex(3);
   BOOST_TEST(v4ref.getID() == v4.getID());
-
-  TetrahedronID id = tetra.getID();
-  BOOST_TEST(id == 0);
 
   Vector3d center = tetra.getCenter();
   BOOST_TEST(testing::equals(center, (coords1 + coords2 + coords3 + coords4) / 4));
@@ -117,9 +111,9 @@ BOOST_AUTO_TEST_CASE(TetrahedronEquality)
   Vertex v4(coords4, 3);
   Vertex v5(coords5, 4);
 
-  Tetrahedron tetra1(v1, v2, v3, v4, 0);
-  Tetrahedron tetra2(v3, v1, v2, v4, 0);
-  Tetrahedron tetra3(v1, v2, v3, v5, 0);
+  Tetrahedron tetra1(v1, v2, v3, v4);
+  Tetrahedron tetra2(v3, v1, v2, v4);
+  Tetrahedron tetra3(v1, v2, v3, v5);
 
   BOOST_TEST(tetra1 == tetra2);
   BOOST_TEST(tetra1 != tetra3);
@@ -134,7 +128,7 @@ BOOST_AUTO_TEST_CASE(TetrahedronWKTPrint)
   Vertex v3(Eigen::Vector3d(0., 1., 0.), 2);
   Vertex v4(Eigen::Vector3d(0., 0., 1.), 3);
 
-  Tetrahedron       t1(v1, v2, v3, v4, 0);
+  Tetrahedron       t1(v1, v2, v3, v4);
   std::stringstream stream;
   stream << t1;
   std::string t1string("MULTILINESTRING ((0 0 0, 1 0 0), (0 0 0, 0 1 0), (0 0 0, 0 0 1), (1 0 0, 0 1 0), (1 0 0, 0 0 1), (0 1 0, 0 0 1))");

--- a/src/mesh/tests/TriangleTest.cpp
+++ b/src/mesh/tests/TriangleTest.cpp
@@ -28,11 +28,11 @@ BOOST_AUTO_TEST_CASE(DirectionalEdges)
   Vertex v2(coords2, 1);
   Vertex v3(coords3, 2);
 
-  Edge e1(v1, v2, 0);
-  Edge e2(v2, v3, 1);
-  Edge e3(v3, v1, 2);
+  Edge e1(v1, v2);
+  Edge e2(v2, v3);
+  Edge e3(v3, v1);
 
-  Triangle triangle(e1, e2, e3, 0);
+  Triangle triangle(e1, e2, e3);
 
   Vertex &v1ref = triangle.vertex(0);
   BOOST_TEST(v1ref.getID() == v1.getID());
@@ -42,9 +42,6 @@ BOOST_AUTO_TEST_CASE(DirectionalEdges)
 
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
-
-  int id = triangle.getID();
-  BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
   BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
@@ -71,11 +68,11 @@ BOOST_AUTO_TEST_CASE(SecondFlipped)
   Vertex   v2(coords2, 1);
   Vertex   v3(coords3, 2);
 
-  Edge e1(v1, v2, 0);
-  Edge e2(v3, v2, 1);
-  Edge e3(v3, v1, 2);
+  Edge e1(v1, v2);
+  Edge e2(v3, v2);
+  Edge e3(v3, v1);
 
-  Triangle triangle(e1, e2, e3, 0);
+  Triangle triangle(e1, e2, e3);
 
   Vertex &v1ref = triangle.vertex(0);
   BOOST_TEST(v1ref.getID() == v1.getID());
@@ -85,9 +82,6 @@ BOOST_AUTO_TEST_CASE(SecondFlipped)
 
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
-
-  int id = triangle.getID();
-  BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
   BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
@@ -115,11 +109,11 @@ BOOST_AUTO_TEST_CASE(ReversedFirstFlipped)
   Vertex v2(coords2, 1);
   Vertex v3(coords3, 2);
 
-  Edge e1(v1, v2, 0);
-  Edge e2(v3, v2, 1);
-  Edge e3(v1, v3, 2);
+  Edge e1(v1, v2);
+  Edge e2(v3, v2);
+  Edge e3(v1, v3);
 
-  Triangle triangle(e1, e2, e3, 0);
+  Triangle triangle(e1, e2, e3);
 
   Vertex &v1ref = triangle.vertex(0);
   BOOST_TEST(v1ref.getID() == v1.getID());
@@ -129,9 +123,6 @@ BOOST_AUTO_TEST_CASE(ReversedFirstFlipped)
 
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
-
-  int id = triangle.getID();
-  BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
   BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
@@ -159,11 +150,11 @@ BOOST_AUTO_TEST_CASE(ReversedLastFlipped)
   Vertex v2(coords2, 1);
   Vertex v3(coords3, 2);
 
-  Edge e1(v1, v2, 0);
-  Edge e2(v3, v2, 1);
-  Edge e3(v3, v1, 2);
+  Edge e1(v1, v2);
+  Edge e2(v3, v2);
+  Edge e3(v3, v1);
 
-  Triangle triangle(e1, e3, e2, 0);
+  Triangle triangle(e1, e3, e2);
 
   Vertex &v1ref = triangle.vertex(0);
   BOOST_TEST(v1ref.getID() == v1.getID());
@@ -173,9 +164,6 @@ BOOST_AUTO_TEST_CASE(ReversedLastFlipped)
 
   Vertex &v3ref = triangle.vertex(2);
   BOOST_TEST(v3ref.getID() == v3.getID());
-
-  int id = triangle.getID();
-  BOOST_TEST(id == 0);
 
   Vector3d normal = triangle.computeNormal();
   BOOST_TEST((coords2 - coords1).dot(normal) == 0.0);
@@ -203,11 +191,11 @@ BOOST_AUTO_TEST_CASE(RangeAccess)
   Vertex v1(coords2, 1);
   Vertex v2(coords3, 2);
 
-  Edge e0(v0, v1, 0);
-  Edge e1(v1, v2, 1);
-  Edge e2(v2, v0, 2);
+  Edge e0(v0, v1);
+  Edge e1(v1, v2);
+  Edge e2(v2, v0);
 
-  Triangle triangle(e0, e1, e2, 0);
+  Triangle triangle(e0, e1, e2);
 
   {
     // Test begin(), end()
@@ -265,23 +253,23 @@ BOOST_AUTO_TEST_CASE(TriangleEquality)
   Vertex v3(coords3, 2);
   Vertex v4(coords4, 0);
 
-  Edge e1(v1, v2, 0);
-  Edge e2(v3, v2, 1);
-  Edge e3(v3, v1, 2);
-  Edge e4(v2, v4, 0);
-  Edge e5(v4, v3, 1);
+  Edge e1(v1, v2);
+  Edge e2(v3, v2);
+  Edge e3(v3, v1);
+  Edge e4(v2, v4);
+  Edge e5(v4, v3);
 
   //    *
   //  * *
   // ****
-  Triangle triangle1(e1, e3, e2, 0);
-  Triangle triangle2(e1, e2, e3, 1);
+  Triangle triangle1(e1, e3, e2);
+  Triangle triangle2(e1, e2, e3);
   BOOST_TEST(triangle1 == triangle2);
   //    *
   //    * *
   //    ****
-  Triangle triangle3(e2, e4, e5, 0);
-  Triangle triangle4(e2, e4, e5, 0);
+  Triangle triangle3(e2, e4, e5);
+  Triangle triangle4(e2, e4, e5);
   BOOST_TEST(triangle1 == triangle2);
   BOOST_TEST(triangle1 != triangle3);
   BOOST_TEST(triangle4 == triangle3);
@@ -293,10 +281,10 @@ BOOST_AUTO_TEST_CASE(TriangleWKTPrint)
   Vertex            v1(Eigen::Vector3d(0., 0., 0.), 0);
   Vertex            v2(Eigen::Vector3d(0., 1., 0.), 0);
   Vertex            v3(Eigen::Vector3d(1., 0., 0.), 0);
-  Edge              e1(v1, v2, 0);
-  Edge              e2(v2, v3, 0);
-  Edge              e3(v3, v1, 0);
-  Triangle          t1(e1, e2, e3, 0);
+  Edge              e1(v1, v2);
+  Edge              e2(v2, v3);
+  Edge              e3(v3, v1);
+  Triangle          t1(e1, e2, e3);
   std::stringstream stream;
   stream << t1;
   std::string t1string("POLYGON ((0 0 0, 0 1 0, 1 0 0, 0 0 0))");

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -886,9 +886,9 @@ void SolverInterfaceImpl::setMeshTriangleWithEdges(
                   "setMeshTriangleWithEdges() was called with vertices located at identical coordinates (IDs: {}, {}, {}).",
                   firstVertexID, secondVertexID, thirdVertexID);
     mesh::Edge *edges[3];
-    edges[0] = &mesh->createUniqueEdge(*vertices[0], *vertices[1]);
-    edges[1] = &mesh->createUniqueEdge(*vertices[1], *vertices[2]);
-    edges[2] = &mesh->createUniqueEdge(*vertices[2], *vertices[0]);
+    edges[0] = &mesh->createEdge(*vertices[0], *vertices[1]);
+    edges[1] = &mesh->createEdge(*vertices[1], *vertices[2]);
+    edges[2] = &mesh->createEdge(*vertices[2], *vertices[0]);
 
     mesh->createTriangle(*edges[0], *edges[1], *edges[2]);
   }
@@ -943,11 +943,11 @@ void SolverInterfaceImpl::setMeshQuad(
 
     // The new edge, e[4], is the shortest diagonal of the quad
     if (distance1 <= distance2) {
-      auto &diag = mesh->createUniqueEdge(*chain.vertices[0], *chain.vertices[2]);
+      auto &diag = mesh->createEdge(*chain.vertices[0], *chain.vertices[2]);
       mesh->createTriangle(*chain.edges[3], *chain.edges[0], diag);
       mesh->createTriangle(*chain.edges[1], *chain.edges[2], diag);
     } else {
-      auto &diag = mesh->createUniqueEdge(*chain.vertices[1], *chain.vertices[3]);
+      auto &diag = mesh->createEdge(*chain.vertices[1], *chain.vertices[3]);
       mesh->createTriangle(*chain.edges[0], *chain.edges[1], diag);
       mesh->createTriangle(*chain.edges[2], *chain.edges[3], diag);
     }
@@ -993,10 +993,10 @@ void SolverInterfaceImpl::setMeshQuadWithEdges(
 
     // Vertices are now in the order: V0-V1-V2-V3-V0.
     // The order now identifies all outer edges of the quad.
-    auto &edge0 = mesh.createUniqueEdge(*reordered[0], *reordered[1]);
-    auto &edge1 = mesh.createUniqueEdge(*reordered[1], *reordered[2]);
-    auto &edge2 = mesh.createUniqueEdge(*reordered[2], *reordered[3]);
-    auto &edge3 = mesh.createUniqueEdge(*reordered[3], *reordered[0]);
+    auto &edge0 = mesh.createEdge(*reordered[0], *reordered[1]);
+    auto &edge1 = mesh.createEdge(*reordered[1], *reordered[2]);
+    auto &edge2 = mesh.createEdge(*reordered[2], *reordered[3]);
+    auto &edge3 = mesh.createEdge(*reordered[3], *reordered[0]);
 
     // Use the shortest diagonal to split the quad into 2 triangles.
     // Vertices are now in V0-V1-V2-V3-V0 order. The new edge, e[4] is either 0-2 or 1-3
@@ -1005,11 +1005,11 @@ void SolverInterfaceImpl::setMeshQuadWithEdges(
 
     // The new edge, e[4], is the shortest diagonal of the quad
     if (distance1 <= distance2) {
-      auto &diag = mesh.createUniqueEdge(*reordered[0], *reordered[2]);
+      auto &diag = mesh.createEdge(*reordered[0], *reordered[2]);
       mesh.createTriangle(edge0, edge1, diag);
       mesh.createTriangle(edge2, edge3, diag);
     } else {
-      auto &diag = mesh.createUniqueEdge(*reordered[1], *reordered[3]);
+      auto &diag = mesh.createEdge(*reordered[1], *reordered[3]);
       mesh.createTriangle(edge3, edge0, diag);
       mesh.createTriangle(edge1, edge2, diag);
     }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -822,7 +822,7 @@ int SolverInterfaceImpl::setMeshEdge(
     PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), errorInvalidVertexID(secondVertexID));
     mesh::Vertex &v0 = mesh->vertices()[firstVertexID];
     mesh::Vertex &v1 = mesh->vertices()[secondVertexID];
-    return mesh->createEdgeWithID(v0, v1).second;
+    return mesh->createRegisteredEdge(v0, v1).second;
   }
   return -1;
 }
@@ -847,9 +847,9 @@ void SolverInterfaceImpl::setMeshTriangle(
     PRECICE_CHECK(utils::unique_elements(utils::make_array(firstEdgeID, secondEdgeID, thirdEdgeID)),
                   "setMeshTriangle() was called with repeated Edge IDs ({}, {}, {}).",
                   firstEdgeID, secondEdgeID, thirdEdgeID);
-    mesh::Edge &e0 = mesh->edge(firstEdgeID);
-    mesh::Edge &e1 = mesh->edge(secondEdgeID);
-    mesh::Edge &e2 = mesh->edge(thirdEdgeID);
+    mesh::Edge &e0 = mesh->registeredEdge(firstEdgeID);
+    mesh::Edge &e1 = mesh->registeredEdge(secondEdgeID);
+    mesh::Edge &e2 = mesh->registeredEdge(thirdEdgeID);
     PRECICE_CHECK(e0.connectedTo(e1) && e1.connectedTo(e2) && e2.connectedTo(e0),
                   "setMeshTriangle() was called with Edge IDs ({}, {}, {}), which identify unconnected Edges.",
                   firstEdgeID, secondEdgeID, thirdEdgeID);
@@ -919,8 +919,8 @@ void SolverInterfaceImpl::setMeshQuad(
                   "The four edge ID's are not unique. Please check that the edges that form the quad are correct.");
 
     auto chain = mesh::asChain(utils::make_array(
-        &mesh->edge(firstEdgeID), &mesh->edge(secondEdgeID),
-        &mesh->edge(thirdEdgeID), &mesh->edge(fourthEdgeID)));
+        &mesh->registeredEdge(firstEdgeID), &mesh->registeredEdge(secondEdgeID),
+        &mesh->registeredEdge(thirdEdgeID), &mesh->registeredEdge(fourthEdgeID)));
     PRECICE_CHECK(chain.connected, "The four edges are not connect. Please check that the edges that form the quad are correct.");
 
     auto coords = mesh::coordsFor(chain.vertices);

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -822,7 +822,7 @@ int SolverInterfaceImpl::setMeshEdge(
     PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), errorInvalidVertexID(secondVertexID));
     mesh::Vertex &v0 = mesh->vertices()[firstVertexID];
     mesh::Vertex &v1 = mesh->vertices()[secondVertexID];
-    return mesh->createEdge(v0, v1).getID();
+    return mesh->createEdgeWithID(v0, v1).second;
   }
   return -1;
 }
@@ -847,9 +847,9 @@ void SolverInterfaceImpl::setMeshTriangle(
     PRECICE_CHECK(utils::unique_elements(utils::make_array(firstEdgeID, secondEdgeID, thirdEdgeID)),
                   "setMeshTriangle() was called with repeated Edge IDs ({}, {}, {}).",
                   firstEdgeID, secondEdgeID, thirdEdgeID);
-    mesh::Edge &e0 = mesh->edges()[firstEdgeID];
-    mesh::Edge &e1 = mesh->edges()[secondEdgeID];
-    mesh::Edge &e2 = mesh->edges()[thirdEdgeID];
+    mesh::Edge &e0 = mesh->edge(firstEdgeID);
+    mesh::Edge &e1 = mesh->edge(secondEdgeID);
+    mesh::Edge &e2 = mesh->edge(thirdEdgeID);
     PRECICE_CHECK(e0.connectedTo(e1) && e1.connectedTo(e2) && e2.connectedTo(e0),
                   "setMeshTriangle() was called with Edge IDs ({}, {}, {}), which identify unconnected Edges.",
                   firstEdgeID, secondEdgeID, thirdEdgeID);
@@ -919,8 +919,8 @@ void SolverInterfaceImpl::setMeshQuad(
                   "The four edge ID's are not unique. Please check that the edges that form the quad are correct.");
 
     auto chain = mesh::asChain(utils::make_array(
-        &mesh->edges()[firstEdgeID], &mesh->edges()[secondEdgeID],
-        &mesh->edges()[thirdEdgeID], &mesh->edges()[fourthEdgeID]));
+        &mesh->edge(firstEdgeID), &mesh->edge(secondEdgeID),
+        &mesh->edge(thirdEdgeID), &mesh->edge(fourthEdgeID)));
     PRECICE_CHECK(chain.connected, "The four edges are not connect. Please check that the edges that form the quad are correct.");
 
     auto coords = mesh::coordsFor(chain.vertices);

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -268,8 +268,8 @@ BOOST_AUTO_TEST_CASE(Query3DFullEdge)
   auto            results = indexTree.getClosestEdges(location, 2);
 
   BOOST_TEST(results.size() == 2);
-  BOOST_TEST(results.at(0).index == eld.getID());
-  BOOST_TEST(results.at(1).index == elr.getID());
+  BOOST_TEST(mesh->edges().at(results.at(0).index) == eld);
+  BOOST_TEST(mesh->edges().at(results.at(1).index) == elr);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Edge
@@ -310,10 +310,10 @@ BOOST_AUTO_TEST_CASE(Query3DFullTriangle)
 
   auto results = indexTree.getClosestTriangles(location, 3);
   BOOST_TEST(results.size() == 3);
-  BOOST_TEST(results.at(0).index == tlb.getID());
-  BOOST_TEST(results.at(1).index == tlt.getID());
-  BOOST_TEST(results.at(2).index == trt.getID());
-  BOOST_TEST(results.at(2).index != trb.getID());
+  BOOST_TEST(mesh->triangles().at(results.at(0).index) == tlb);
+  BOOST_TEST(mesh->triangles().at(results.at(1).index) == tlt);
+  BOOST_TEST(mesh->triangles().at(results.at(2).index) == trt);
+  BOOST_TEST(mesh->triangles().at(results.at(2).index) != trb);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Triangle


### PR DESCRIPTION
## Main changes of this PR

This is a follow-up of #1311 and related to #1153

This PR removes the internal ids of mesh connectivity primitives such as edges and triangles.
They are now simply groups of pointers to vertices.

To keep the EdgeIDs of the API functional, I added `Edge& edge(EdgeID)` and `pair<Edge&, EdgeID> createEdgeWithID(v0, v1)` to the `Mesh`.
If the user calls `setMeshEdge()`, then the mesh will register the created edge and associate it with the EdgeID using a separate map.
All other created edges will be id-less.

## Motivation and additional information

This slightly reduces the memory-footprint of edges and triangles.
Not having to deal with ids also makes testing easier.

This opens the door for:
* simplifying the current API to vertex-only #1153
* adding a simple version of `setMeshTetrahedron`
* adding efficient bulk versions e.g. `setMeshEdges` or `setMeshTriangles` #465
* removing duplicates in `initialize` (this will invalidate the ids returned by `setMeshEdge`, but changing the mesh after initialize is invalid anyhow) for provided meshes. This will speed up mapping, indexing and repartitioning and reduce communication.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
