### PR TITLE
Add output support for gradient data

### DIFF
--- a/docs/changelog/1315.md
+++ b/docs/changelog/1315.md
@@ -1,0 +1,1 @@
+- Added support to export gradient data in VTK exporting

--- a/docs/changelog/1315.md
+++ b/docs/changelog/1315.md
@@ -1,1 +1,3 @@
 - Added support to export gradient data in VTK exporting
+- Scalar gradients are written to vector <ScalarDataname>_gradient `v0_dx,v0_dy,v0_dz,v1_dx ...`
+- Vector gradients are written to vectors <VectorDataname>_dx/dy/dz `v0x_dx,v0y_dx,v0z_dz, ...`

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -21,7 +21,7 @@ namespace io {
 void ExportVTK::doExport(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh & mesh)
+    const mesh::Mesh  &mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
   PRECICE_ASSERT(name != std::string(""));
@@ -44,7 +44,7 @@ void ExportVTK::doExport(
 }
 
 void ExportVTK::exportMesh(
-    std::ofstream &   outFile,
+    std::ofstream    &outFile,
     const mesh::Mesh &mesh)
 {
   PRECICE_TRACE(mesh.getName());
@@ -119,7 +119,7 @@ void ExportVTK::exportMesh(
 }
 
 void ExportVTK::exportData(
-    std::ofstream &   outFile,
+    std::ofstream    &outFile,
     const mesh::Mesh &mesh)
 {
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
@@ -163,23 +163,23 @@ void ExportVTK::exportData(
 void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
 {
   const int spaceDim = mesh.getDimensions();
-  for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
-    if (data->hasGradient()) {
+  for (const mesh::PtrData &data : mesh.data()) {
+    if (data->hasGradient()) { // Check whether this data has gradient
       auto &gradientValues = data->gradientValues();
-      if (data->getDimensions() == 1) {
+      if (data->getDimensions() == 1) { // Scalar data, create a vector <dataname>_gradient
         outFile << "VECTORS " << data->getName() << "_gradient"
                 << " double\n";
         for (int i = 0; i < gradientValues.cols(); i++) {
-          int j = 0;
+          int j = 0; // Dimension counter
           for (; j < gradientValues.rows(); j++) {
             outFile << gradientValues.coeff(j, i) << " ";
           }
-          if (j < 3) {
+          if (j < 3) { // If 2D data add additonal zero as third component
             outFile << '0';
           }
           outFile << "\n";
         }
-      } else {
+      } else { // Vector data, write n vector for n dimension <dataname>_(dx/dy/dz)
         outFile << "VECTORS " << data->getName() << "_dx"
                 << " double\n";
         for (int i = 0; i < gradientValues.cols(); i += spaceDim) {
@@ -187,7 +187,7 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
           for (; j < gradientValues.rows(); j++) {
             outFile << gradientValues.coeff(j, i) << " ";
           }
-          if (j < 3) {
+          if (j < 3) { // If 2D data add additonal zero as third component
             outFile << '0';
           }
           outFile << "\n";
@@ -201,14 +201,14 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
           for (; j < gradientValues.rows(); j++) {
             outFile << gradientValues.coeff(j, i) << " ";
           }
-          if (j < 3) {
+          if (j < 3) { // If 2D data add additonal zero as third component
             outFile << '0';
           }
           outFile << "\n";
         }
         outFile << "\n";
 
-        if (spaceDim == 3) {
+        if (spaceDim == 3) { // dz is only for 3D data
           outFile << "VECTORS " << data->getName() << "_dz"
                   << " double\n";
           for (int i = 2; i < gradientValues.cols(); i += spaceDim) {
@@ -216,7 +216,7 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
             for (; j < gradientValues.rows(); j++) {
               outFile << gradientValues.coeff(j, i) << " ";
             }
-            if (j < 3) {
+            if (j < 3) { // If 2D data add additonal zero as third component
               outFile << '0';
             }
             outFile << "\n";
@@ -231,10 +231,10 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
 void ExportVTK::initializeWriting(
     std::ofstream &filestream)
 {
-  //size_t pos = fullFilename.rfind(".vtk");
-  //if ((pos == std::string::npos) || (pos != fullFilename.size()-4)){
-  //  fullFilename += ".vtk";
-  //}
+  // size_t pos = fullFilename.rfind(".vtk");
+  // if ((pos == std::string::npos) || (pos != fullFilename.size()-4)){
+  //   fullFilename += ".vtk";
+  // }
   filestream.setf(std::ios::showpoint);
   filestream.setf(std::ios::scientific);
   filestream << std::setprecision(std::numeric_limits<double>::max_digits10);
@@ -250,7 +250,7 @@ void ExportVTK::writeHeader(
 
 void ExportVTK::writeVertex(
     const Eigen::VectorXd &position,
-    std::ostream &         outFile)
+    std::ostream          &outFile)
 {
   if (position.size() == 2) {
     outFile << position(0) << "  " << position(1) << "  " << 0.0 << '\n';

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -169,9 +169,9 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
       if (data->getDimensions() == 1) { // Scalar data, create a vector <dataname>_gradient
         outFile << "VECTORS " << data->getName() << "_gradient"
                 << " double\n";
-        for (int i = 0; i < gradientValues.cols(); i++) {
-          int j = 0; // Dimension counter
-          for (; j < gradientValues.rows(); j++) {
+        for (int i = 0; i < gradientValues.cols(); i++) { // Loop over vertices
+          int j = 0;                                      // Dimension counter
+          for (; j < gradientValues.rows(); j++) {        // Loop over space directions
             outFile << gradientValues.coeff(j, i) << " ";
           }
           if (j < 3) { // If 2D data add additonal zero as third component
@@ -182,9 +182,9 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
       } else { // Vector data, write n vector for n dimension <dataname>_(dx/dy/dz)
         outFile << "VECTORS " << data->getName() << "_dx"
                 << " double\n";
-        for (int i = 0; i < gradientValues.cols(); i += spaceDim) {
+        for (int i = 0; i < gradientValues.cols(); i += spaceDim) { // Loop over vertices
           int j = 0;
-          for (; j < gradientValues.rows(); j++) {
+          for (; j < gradientValues.rows(); j++) { // Loop over components
             outFile << gradientValues.coeff(j, i) << " ";
           }
           if (j < 3) { // If 2D data add additonal zero as third component
@@ -196,9 +196,9 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
 
         outFile << "VECTORS " << data->getName() << "_dy"
                 << " double\n";
-        for (int i = 1; i < gradientValues.cols(); i += spaceDim) {
+        for (int i = 1; i < gradientValues.cols(); i += spaceDim) { // Loop over vertices
           int j = 0;
-          for (; j < gradientValues.rows(); j++) {
+          for (; j < gradientValues.rows(); j++) { // Loop over components
             outFile << gradientValues.coeff(j, i) << " ";
           }
           if (j < 3) { // If 2D data add additonal zero as third component
@@ -211,9 +211,9 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
         if (spaceDim == 3) { // dz is only for 3D data
           outFile << "VECTORS " << data->getName() << "_dz"
                   << " double\n";
-          for (int i = 2; i < gradientValues.cols(); i += spaceDim) {
+          for (int i = 2; i < gradientValues.cols(); i += spaceDim) { // Loop over vertices
             int j = 0;
-            for (; j < gradientValues.rows(); j++) {
+            for (; j < gradientValues.rows(); j++) { // Loop over components
               outFile << gradientValues.coeff(j, i) << " ";
             }
             if (j < 3) { // If 2D data add additonal zero as third component

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -21,7 +21,7 @@ namespace io {
 void ExportVTK::doExport(
     const std::string &name,
     const std::string &location,
-    const mesh::Mesh  &mesh)
+    const mesh::Mesh & mesh)
 {
   PRECICE_TRACE(name, location, mesh.getName());
   PRECICE_ASSERT(name != std::string(""));
@@ -44,7 +44,7 @@ void ExportVTK::doExport(
 }
 
 void ExportVTK::exportMesh(
-    std::ofstream    &outFile,
+    std::ofstream &   outFile,
     const mesh::Mesh &mesh)
 {
   PRECICE_TRACE(mesh.getName());
@@ -119,7 +119,7 @@ void ExportVTK::exportMesh(
 }
 
 void ExportVTK::exportData(
-    std::ofstream    &outFile,
+    std::ofstream &   outFile,
     const mesh::Mesh &mesh)
 {
   outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
@@ -250,7 +250,7 @@ void ExportVTK::writeHeader(
 
 void ExportVTK::writeVertex(
     const Eigen::VectorXd &position,
-    std::ostream          &outFile)
+    std::ostream &         outFile)
 {
   if (position.size() == 2) {
     outFile << position(0) << "  " << position(1) << "  " << 0.0 << '\n';

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -61,7 +61,7 @@ private:
       const mesh::Mesh &mesh);
 
   void exportGradient(
-      std::ofstream    &outFile,
+      std::ofstream &   outFile,
       const mesh::Mesh &mesh);
 };
 

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -59,6 +59,10 @@ private:
   void exportData(
       std::ofstream &   outFile,
       const mesh::Mesh &mesh);
+
+  void exportGradient(
+      std::ofstream    &outFile,
+      const mesh::Mesh &mesh);
 };
 
 } // namespace io

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_SUITE(VTKExport)
 
 using namespace precice;
 
-BOOST_AUTO_TEST_CASE(ExportDatawithGradient)
+BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
 {
   PRECICE_TEST(1_rank)
   int dimensions = 2;

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -4,6 +4,7 @@
 #include "io/Export.hpp"
 #include "io/ExportVTK.hpp"
 #include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 
@@ -19,6 +20,37 @@ BOOST_AUTO_TEST_SUITE(IOTests)
 BOOST_AUTO_TEST_SUITE(VTKExport)
 
 using namespace precice;
+
+BOOST_AUTO_TEST_CASE(ExportDatawithGradient)
+{
+  PRECICE_TEST(1_rank)
+  int dimensions = 2;
+  // Create mesh to map from
+  mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
+  mesh::PtrData dataScalar   = mesh.createData("dataScalar", 1, 0_dataID, true);
+  mesh::PtrData dataVector   = mesh.createData("dataVector", 2, 1_dataID, true);
+  int           dataScalarID = dataScalar->getID();
+  int           dataVectorID = dataVector->getID();
+  mesh::Vertex &vertex0      = mesh.createVertex(Eigen::Vector2d::Constant(0.0));
+  mesh::Vertex &vertex1      = mesh.createVertex(Eigen::Vector2d::Constant(1.0));
+
+  // Create data
+  mesh.allocateDataValues();
+  Eigen::VectorXd &valuesScalar = dataScalar->values();
+  Eigen::VectorXd &valuesVector = dataVector->values();
+  valuesScalar << 1.0, 2.0;
+  valuesVector << 1.0, 2.0, 3.0, 4.0;
+
+  // Create corresponding gradient data (all gradient values = const = 1)
+  Eigen::MatrixXd &inGradValuesScalar = dataScalar->gradientValues();
+  Eigen::MatrixXd &inGradValuesVector = dataVector->gradientValues();
+  inGradValuesScalar.setOnes();
+  inGradValuesVector.setOnes();
+  io::ExportVTK exportVTK;
+  std::string   filename = "io-VTKExport-ExportDatawithGradient";
+  std::string   location = "";
+  exportVTK.doExport(filename, location, mesh);
+}
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -27,12 +27,10 @@ BOOST_AUTO_TEST_CASE(ExportDatawithGradient)
   int dimensions = 2;
   // Create mesh to map from
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData dataScalar   = mesh.createData("dataScalar", 1, 0_dataID, true);
-  mesh::PtrData dataVector   = mesh.createData("dataVector", 2, 1_dataID, true);
-  int           dataScalarID = dataScalar->getID();
-  int           dataVectorID = dataVector->getID();
-  mesh::Vertex &vertex0      = mesh.createVertex(Eigen::Vector2d::Constant(0.0));
-  mesh::Vertex &vertex1      = mesh.createVertex(Eigen::Vector2d::Constant(1.0));
+  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID, true);
+  mesh::PtrData dataVector = mesh.createData("dataVector", 2, 1_dataID, true);
+  mesh.createVertex(Eigen::Vector2d::Constant(0.0));
+  mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 
   // Create data
   mesh.allocateDataValues();
@@ -42,10 +40,10 @@ BOOST_AUTO_TEST_CASE(ExportDatawithGradient)
   valuesVector << 1.0, 2.0, 3.0, 4.0;
 
   // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &inGradValuesScalar = dataScalar->gradientValues();
-  Eigen::MatrixXd &inGradValuesVector = dataVector->gradientValues();
-  inGradValuesScalar.setOnes();
-  inGradValuesVector.setOnes();
+  Eigen::MatrixXd &gradValuesScalar = dataScalar->gradientValues();
+  Eigen::MatrixXd &gradValuesVector = dataVector->gradientValues();
+  gradValuesScalar.setOnes();
+  gradValuesVector.setOnes();
   io::ExportVTK exportVTK;
   std::string   filename = "io-VTKExport-ExportDatawithGradient";
   std::string   location = "";


### PR DESCRIPTION
## Main changes of this PR

Adds support for exporting gradient data to VTK file formats

* [x] Add to VTK 
<del> [ ] Add to VTU and VTP files. </del>

## Motivation and additional information

Related to #1302 

NNG mapping adds a new dataset to preCICE for gradients. For development and debugging purposes, it might be needed to visualize gradient datasets.

This PR adds export for gradient dataset.

The naming convention would be `<dataname>_[dx/dy/dz]` (vectors) for vector data and `<dataname>_gradient` (vector) for scalar data.

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

