### PR TITLE
Utility function for volume integrals

### DIFF
--- a/src/mesh/Utils.cpp
+++ b/src/mesh/Utils.cpp
@@ -36,5 +36,35 @@ Eigen::VectorXd integrate(const PtrMesh &mesh, const PtrData &data)
   return integral;
 }
 
+Eigen::VectorXd integrateVolume(const PtrMesh &mesh, const PtrData &data)
+{
+  const int       valueDimensions = data->getDimensions();
+  const int       meshDimensions  = mesh->getDimensions();
+  const auto &    values          = data->values();
+  Eigen::VectorXd integral        = Eigen::VectorXd::Zero(valueDimensions);
+  if (meshDimensions == 2) {
+    for (const auto &face : mesh->triangles()) {
+      int vertex1 = face.vertex(0).getID() * valueDimensions;
+      int vertex2 = face.vertex(1).getID() * valueDimensions;
+      int vertex3 = face.vertex(2).getID() * valueDimensions;
+      for (int dim = 0; dim < valueDimensions; ++dim) {
+        integral(dim) += (face.getArea() / 3.0) * (values(vertex1 + dim) + values(vertex2 + dim) + values(vertex3 + dim));
+      }
+    }
+  } else {
+    for (const auto &tetra : mesh->tetrahedra()) {
+      int vertex1 = tetra.vertex(0).getID() * valueDimensions;
+      int vertex2 = tetra.vertex(1).getID() * valueDimensions;
+      int vertex3 = tetra.vertex(2).getID() * valueDimensions;
+      int vertex4 = tetra.vertex(3).getID() * valueDimensions;
+
+      for (int dim = 0; dim < valueDimensions; ++dim) {
+        integral(dim) += (tetra.getVolume() / 4.0) * (values(vertex1 + dim) + values(vertex2 + dim) + values(vertex3 + dim) + values(vertex4 + dim));
+      }
+    }
+  }
+  return integral;
+}
+
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/Utils.hpp
+++ b/src/mesh/Utils.hpp
@@ -136,5 +136,8 @@ std::array<Eigen::VectorXd, n> coordsFor(const std::array<Vertex *, n> &vertexPt
 /// Given the data and the mesh, this function returns the surface integral. Assumes no overlap exists for the mesh
 Eigen::VectorXd integrate(const PtrMesh &mesh, const PtrData &data);
 
+/// Given the data and the mesh, this function returns the volume integral. Assumes no overlap exists for the mesh
+Eigen::VectorXd integrateVolume(const PtrMesh &mesh, const PtrData &data);
+
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -655,7 +655,7 @@ struct UnitSquareFixture {
   Eigen::Vector2d x3{0.0, 1.0};
 };
 
-BOOST_FIXTURE_TEST_CASE(Integrate2DScalarDataVolume, UnitSquareFixture) 
+BOOST_FIXTURE_TEST_CASE(Integrate2DScalarDataVolume, UnitSquareFixture)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
@@ -672,7 +672,6 @@ BOOST_FIXTURE_TEST_CASE(Integrate2DScalarDataVolume, UnitSquareFixture)
   auto &e3 = mesh->createEdge(v3, v4);
   auto &e4 = mesh->createEdge(v1, v4);
   auto &e5 = mesh->createEdge(v1, v3);
-
 
   // 2 triangles as halves of a unit square
   mesh->createTriangle(e1, e2, e5);
@@ -694,7 +693,7 @@ BOOST_FIXTURE_TEST_CASE(Integrate2DScalarDataVolume, UnitSquareFixture)
   BOOST_TEST(result(0) == expected);
 }
 
-BOOST_FIXTURE_TEST_CASE(Integrate2DVectorDataVolume, UnitSquareFixture) 
+BOOST_FIXTURE_TEST_CASE(Integrate2DVectorDataVolume, UnitSquareFixture)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
@@ -731,23 +730,21 @@ BOOST_FIXTURE_TEST_CASE(Integrate2DVectorDataVolume, UnitSquareFixture)
   mesh->data(0)->values()(5) = 8.0;
   mesh->data(0)->values()(7) = 6.0;
 
-  auto   result   = mesh::integrateVolume(mesh, mesh->data(0));
+  auto            result = mesh::integrateVolume(mesh, mesh->data(0));
   Eigen::Vector2d expected(4.0, 5.0);
   BOOST_REQUIRE(result.size() == 2);
   BOOST_TEST(result(0) == expected(0));
   BOOST_TEST(result(1) == expected(1));
 }
 
-
 struct OneTetraFixture {
   Eigen::Vector3d x1{0.0, 0.0, 0.0};
   Eigen::Vector3d x2{1.0, 0.0, 0.0};
   Eigen::Vector3d x3{0.0, 1.0, 0.0};
   Eigen::Vector3d x4{0.0, 0.0, 1.0};
-  
 };
 
-BOOST_FIXTURE_TEST_CASE(Integrate3DScalarDataVolume, OneTetraFixture) 
+BOOST_FIXTURE_TEST_CASE(Integrate3DScalarDataVolume, OneTetraFixture)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
@@ -760,11 +757,9 @@ BOOST_FIXTURE_TEST_CASE(Integrate3DScalarDataVolume, OneTetraFixture)
 
   mesh->allocateDataValues();
 
-  mesh->createTetrahedron(v1, v2, v3, v4); 
+  mesh->createTetrahedron(v1, v2, v3, v4);
 
-
-  
-  BOOST_REQUIRE(mesh->tetrahedra()[0].getVolume() == 1./6);
+  BOOST_REQUIRE(mesh->tetrahedra()[0].getVolume() == 1. / 6);
   BOOST_REQUIRE(mesh->tetrahedra().size() == 1);
 
   // Integrand is 1 + 2x + 4y + 6z integrated over one tetra
@@ -779,7 +774,7 @@ BOOST_FIXTURE_TEST_CASE(Integrate3DScalarDataVolume, OneTetraFixture)
   BOOST_TEST(result(0) == expected);
 }
 
-BOOST_FIXTURE_TEST_CASE(Integrate3DVectorDataVolume, OneTetraFixture) 
+BOOST_FIXTURE_TEST_CASE(Integrate3DVectorDataVolume, OneTetraFixture)
 {
   PRECICE_TEST(1_rank);
   PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
@@ -792,37 +787,34 @@ BOOST_FIXTURE_TEST_CASE(Integrate3DVectorDataVolume, OneTetraFixture)
 
   mesh->allocateDataValues();
 
-  mesh->createTetrahedron(v1, v2, v3, v4); 
+  mesh->createTetrahedron(v1, v2, v3, v4);
 
-
-  
-  BOOST_REQUIRE(mesh->tetrahedra()[0].getVolume() == 1./6);
+  BOOST_REQUIRE(mesh->tetrahedra()[0].getVolume() == 1. / 6);
   BOOST_REQUIRE(mesh->tetrahedra().size() == 1);
 
   // Integrand is (1 + 2x + 4y + 6z, 1, 1-x-y-z) integrated over one tetra
-  mesh->data(0)->values()(0*3) = 1.0;
-  mesh->data(0)->values()(1*3) = 3.0;
-  mesh->data(0)->values()(2*3) = 5.0;
-  mesh->data(0)->values()(3*3) = 7.0;
+  mesh->data(0)->values()(0 * 3) = 1.0;
+  mesh->data(0)->values()(1 * 3) = 3.0;
+  mesh->data(0)->values()(2 * 3) = 5.0;
+  mesh->data(0)->values()(3 * 3) = 7.0;
 
-  mesh->data(0)->values()(0*3+1) = 1.0;
-  mesh->data(0)->values()(1*3+1) = 1.0;
-  mesh->data(0)->values()(2*3+1) = 1.0;
-  mesh->data(0)->values()(3*3+1) = 1.0;
+  mesh->data(0)->values()(0 * 3 + 1) = 1.0;
+  mesh->data(0)->values()(1 * 3 + 1) = 1.0;
+  mesh->data(0)->values()(2 * 3 + 1) = 1.0;
+  mesh->data(0)->values()(3 * 3 + 1) = 1.0;
 
-  mesh->data(0)->values()(0*3+2) = 1.0;
-  mesh->data(0)->values()(1*3+2) = 0.0;
-  mesh->data(0)->values()(2*3+2) = 0.0;
-  mesh->data(0)->values()(3*3+2) = 0.0;
+  mesh->data(0)->values()(0 * 3 + 2) = 1.0;
+  mesh->data(0)->values()(1 * 3 + 2) = 0.0;
+  mesh->data(0)->values()(2 * 3 + 2) = 0.0;
+  mesh->data(0)->values()(3 * 3 + 2) = 0.0;
 
-  auto   result   = mesh::integrateVolume(mesh, mesh->data(0));
+  auto            result = mesh::integrateVolume(mesh, mesh->data(0));
   Eigen::Vector3d expected(4.0 / 6, 1.0 / 6, 1.0 / 24);
   BOOST_REQUIRE(result.size() == 3);
   BOOST_TEST(result(0) == expected(0));
   BOOST_TEST(result(1) == expected(1));
   BOOST_TEST(result(2) == expected(2));
 }
-
 
 BOOST_AUTO_TEST_SUITE_END() // VolumeIntegrals
 

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -646,5 +646,185 @@ BOOST_AUTO_TEST_CASE(Integrate3DVectorData)
 
 BOOST_AUTO_TEST_SUITE_END() // Utils
 
+BOOST_AUTO_TEST_SUITE(VolumeIntegrals)
+
+struct UnitSquareFixture {
+  Eigen::Vector2d x0{0.0, 0.0};
+  Eigen::Vector2d x1{1.0, 0.0};
+  Eigen::Vector2d x2{1.0, 1.0};
+  Eigen::Vector2d x3{0.0, 1.0};
+};
+
+BOOST_FIXTURE_TEST_CASE(Integrate2DScalarDataVolume, UnitSquareFixture) 
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
+  mesh->createData("Data", 1, 0_dataID);
+
+  auto &v1 = mesh->createVertex(x0);
+  auto &v2 = mesh->createVertex(x1);
+  auto &v3 = mesh->createVertex(x2);
+  auto &v4 = mesh->createVertex(x3);
+  mesh->allocateDataValues();
+
+  auto &e1 = mesh->createEdge(v1, v2);
+  auto &e2 = mesh->createEdge(v2, v3);
+  auto &e3 = mesh->createEdge(v3, v4);
+  auto &e4 = mesh->createEdge(v1, v4);
+  auto &e5 = mesh->createEdge(v1, v3);
+
+
+  // 2 triangles as halves of a unit square
+  mesh->createTriangle(e1, e2, e5);
+  mesh->createTriangle(e3, e4, e5);
+
+  BOOST_REQUIRE(mesh->triangles()[0].getArea() == 0.5);
+  BOOST_REQUIRE(mesh->triangles()[1].getArea() == 0.5);
+  BOOST_REQUIRE(mesh->triangles().size() == 2);
+
+  // Integrand is 1 + 4x + 2y integrated over unit square: 4
+  mesh->data(0)->values()(0) = 1.0;
+  mesh->data(0)->values()(1) = 3.0;
+  mesh->data(0)->values()(2) = 7.0;
+  mesh->data(0)->values()(3) = 5.0;
+
+  auto   result   = mesh::integrateVolume(mesh, mesh->data(0));
+  double expected = 4.0;
+  BOOST_REQUIRE(result.size() == 1);
+  BOOST_TEST(result(0) == expected);
+}
+
+BOOST_FIXTURE_TEST_CASE(Integrate2DVectorDataVolume, UnitSquareFixture) 
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 2, testing::nextMeshID());
+  mesh->createData("Data", 2, 0_dataID);
+
+  auto &v1 = mesh->createVertex(x0);
+  auto &v2 = mesh->createVertex(x1);
+  auto &v3 = mesh->createVertex(x2);
+  auto &v4 = mesh->createVertex(x3);
+  mesh->allocateDataValues();
+
+  auto &e1 = mesh->createEdge(v1, v2);
+  auto &e2 = mesh->createEdge(v2, v3);
+  auto &e3 = mesh->createEdge(v3, v4);
+  auto &e4 = mesh->createEdge(v1, v4);
+  auto &e5 = mesh->createEdge(v1, v3);
+
+  // 2 triangles as halves of a unit square
+  mesh->createTriangle(e1, e2, e5);
+  mesh->createTriangle(e3, e4, e5);
+
+  BOOST_REQUIRE(mesh->triangles()[0].getArea() == 0.5);
+  BOOST_REQUIRE(mesh->triangles()[1].getArea() == 0.5);
+  BOOST_REQUIRE(mesh->triangles().size() == 2);
+
+  // Integrand of 1st component is 1 + 4x + 2y integrated over unit square: 4
+  mesh->data(0)->values()(0) = 1.0;
+  mesh->data(0)->values()(2) = 3.0;
+  mesh->data(0)->values()(4) = 7.0;
+  mesh->data(0)->values()(6) = 5.0;
+  // Integrand of 1st component is 1 + 4x + 2y integrated over unit square: 4
+  mesh->data(0)->values()(1) = 2.0;
+  mesh->data(0)->values()(3) = 4.0;
+  mesh->data(0)->values()(5) = 8.0;
+  mesh->data(0)->values()(7) = 6.0;
+
+  auto   result   = mesh::integrateVolume(mesh, mesh->data(0));
+  Eigen::Vector2d expected(4.0, 5.0);
+  BOOST_REQUIRE(result.size() == 2);
+  BOOST_TEST(result(0) == expected(0));
+  BOOST_TEST(result(1) == expected(1));
+}
+
+
+struct OneTetraFixture {
+  Eigen::Vector3d x1{0.0, 0.0, 0.0};
+  Eigen::Vector3d x2{1.0, 0.0, 0.0};
+  Eigen::Vector3d x3{0.0, 1.0, 0.0};
+  Eigen::Vector3d x4{0.0, 0.0, 1.0};
+  
+};
+
+BOOST_FIXTURE_TEST_CASE(Integrate3DScalarDataVolume, OneTetraFixture) 
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
+  mesh->createData("Data", 1, 0_dataID);
+
+  auto &v1 = mesh->createVertex(x1);
+  auto &v2 = mesh->createVertex(x2);
+  auto &v3 = mesh->createVertex(x3);
+  auto &v4 = mesh->createVertex(x4);
+
+  mesh->allocateDataValues();
+
+  mesh->createTetrahedron(v1, v2, v3, v4); 
+
+
+  
+  BOOST_REQUIRE(mesh->tetrahedra()[0].getVolume() == 1./6);
+  BOOST_REQUIRE(mesh->tetrahedra().size() == 1);
+
+  // Integrand is 1 + 2x + 4y + 6z integrated over one tetra
+  mesh->data(0)->values()(0) = 1.0;
+  mesh->data(0)->values()(1) = 3.0;
+  mesh->data(0)->values()(2) = 5.0;
+  mesh->data(0)->values()(3) = 7.0;
+
+  auto   result   = mesh::integrateVolume(mesh, mesh->data(0));
+  double expected = 4.0 / 6;
+  BOOST_REQUIRE(result.size() == 1);
+  BOOST_TEST(result(0) == expected);
+}
+
+BOOST_FIXTURE_TEST_CASE(Integrate3DVectorDataVolume, OneTetraFixture) 
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
+  mesh->createData("Data", 3, 0_dataID);
+
+  auto &v1 = mesh->createVertex(x1);
+  auto &v2 = mesh->createVertex(x2);
+  auto &v3 = mesh->createVertex(x3);
+  auto &v4 = mesh->createVertex(x4);
+
+  mesh->allocateDataValues();
+
+  mesh->createTetrahedron(v1, v2, v3, v4); 
+
+
+  
+  BOOST_REQUIRE(mesh->tetrahedra()[0].getVolume() == 1./6);
+  BOOST_REQUIRE(mesh->tetrahedra().size() == 1);
+
+  // Integrand is (1 + 2x + 4y + 6z, 1, 1-x-y-z) integrated over one tetra
+  mesh->data(0)->values()(0*3) = 1.0;
+  mesh->data(0)->values()(1*3) = 3.0;
+  mesh->data(0)->values()(2*3) = 5.0;
+  mesh->data(0)->values()(3*3) = 7.0;
+
+  mesh->data(0)->values()(0*3+1) = 1.0;
+  mesh->data(0)->values()(1*3+1) = 1.0;
+  mesh->data(0)->values()(2*3+1) = 1.0;
+  mesh->data(0)->values()(3*3+1) = 1.0;
+
+  mesh->data(0)->values()(0*3+2) = 1.0;
+  mesh->data(0)->values()(1*3+2) = 0.0;
+  mesh->data(0)->values()(2*3+2) = 0.0;
+  mesh->data(0)->values()(3*3+2) = 0.0;
+
+  auto   result   = mesh::integrateVolume(mesh, mesh->data(0));
+  Eigen::Vector3d expected(4.0 / 6, 1.0 / 6, 1.0 / 24);
+  BOOST_REQUIRE(result.size() == 3);
+  BOOST_TEST(result(0) == expected(0));
+  BOOST_TEST(result(1) == expected(1));
+  BOOST_TEST(result(2) == expected(2));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END() // VolumeIntegrals
+
 BOOST_AUTO_TEST_SUITE_END() // Mesh
 BOOST_AUTO_TEST_SUITE_END() // Mesh


### PR DESCRIPTION
## Main changes of this PR

Added a function (`integrateVolume`) to compute volume integrals of data on a mesh with connectivity. It is similar to the current `integrate` function that does surface integrals, but it uses triangles/tetrahedra instead of edges/tetra (depending on the dimension).

## Motivation and additional information

Superset of #1314, the diff will be smaller once it its merged. Only `Utils.hpp`, `Utils.cpp`, `MeshTests.cpp` are actually changed here.
Future usage for scaled-consistent mapping in the context of volumetric coupling, or for watch-point integrals on volumes.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
- Should we rename `integrate` to `integrateSurface` for consistency ?
- New tests are on `MeshTests.cpp` as they were for surface integrals. This file is getting large, shouldn't we split it with a test file like `IntegralTests.cpp`?
