### PR TITLE
Extract RBF solver into a separate class

### DIFF
--- a/docs/changelog/1319.md
+++ b/docs/changelog/1319.md
@@ -1,0 +1,1 @@
+- Refactored RBF system assembly and RBF system solving into a dedicated class.

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -156,6 +156,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::clear()
 template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID inputDataID, DataID outputDataID)
 {
+  precice::utils::Event e("map.rbf.mapData.From" + this->input()->getName() + "To" + this->output()->getName(), precice::syncMode);
   PRECICE_TRACE(inputDataID, outputDataID);
   using precice::com::AsVectorTag;
 
@@ -273,6 +274,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID inpu
 template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputDataID, DataID outputDataID)
 {
+  precice::utils::Event e("map.rbf.mapData.From" + this->input()->getName() + "To" + this->output()->getName(), precice::syncMode);
   PRECICE_TRACE(inputDataID, outputDataID);
   using precice::com::AsVectorTag;
 

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -3,11 +3,11 @@
 #include <Eigen/Core>
 #include <Eigen/QR>
 
-#include "RadialBasisFctSolver.h"
 #include "com/CommunicateMesh.hpp"
 #include "com/Communication.hpp"
 #include "impl/BasisFunctions.hpp"
 #include "mapping/RadialBasisFctBaseMapping.hpp"
+#include "mapping/RadialBasisFctSolver.hpp"
 #include "mesh/Filter.hpp"
 #include "precice/types.hpp"
 #include "utils/EigenHelperFunctions.hpp"

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -212,8 +212,8 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID inpu
 
     // Construct Eigen vectors
     Eigen::Map<Eigen::VectorXd> inputValues(globalInValues.data(), globalInValues.size());
-    Eigen::VectorXd             outputValues((_rbfSolver._matrixA.cols() - this->getPolynomialParameters()) * valueDim);
-    Eigen::VectorXd             in(_rbfSolver._matrixA.rows()); // rows == outputSize
+    Eigen::VectorXd             outputValues((_rbfSolver.getEvaluationMatrix().cols() - this->getPolynomialParameters()) * valueDim);
+    Eigen::VectorXd             in(_rbfSolver.getEvaluationMatrix().rows()); // rows == outputSize
     outputValues.setZero();
 
     for (int dim = 0; dim < valueDim; dim++) {
@@ -292,7 +292,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputD
 
     int valueDim = this->output()->data(outputDataID)->getDimensions();
 
-    std::vector<double> globalInValues((_rbfSolver._matrixA.cols() - this->getPolynomialParameters()) * valueDim, 0.0);
+    std::vector<double> globalInValues((_rbfSolver.getEvaluationMatrix().cols() - this->getPolynomialParameters()) * valueDim, 0.0);
     std::vector<int>    outValuesSize;
 
     if (utils::IntraComm::isPrimary()) { // Parallel case
@@ -320,13 +320,13 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputD
       outValuesSize.push_back(this->output()->data(outputDataID)->values().size());
     }
 
-    Eigen::VectorXd in(_rbfSolver._matrixA.cols()); // rows == n
+    Eigen::VectorXd in(_rbfSolver.getEvaluationMatrix().cols()); // rows == n
     in.setZero();
 
     // Construct Eigen vectors
     Eigen::Map<Eigen::VectorXd> inputValues(globalInValues.data(), globalInValues.size());
 
-    Eigen::VectorXd outputValues((_rbfSolver._matrixA.rows()) * valueDim);
+    Eigen::VectorXd outputValues((_rbfSolver.getEvaluationMatrix().rows()) * valueDim);
     Eigen::VectorXd out;
     outputValues.setZero();
 

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -139,7 +139,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       globalOutMesh.addMesh(*outMesh);
     }
 
-    _rbfSolver.computeDecomposition(this->_basisFunction, globalInMesh, globalOutMesh, this->_deadAxis);
+    _rbfSolver = RadialBasisFctSolver{this->_basisFunction, globalInMesh, globalOutMesh, this->_deadAxis};
   }
   this->_hasComputedMapping = true;
   PRECICE_DEBUG("Compute Mapping is Completed.");

--- a/src/mapping/RadialBasisFctSolver.h
+++ b/src/mapping/RadialBasisFctSolver.h
@@ -48,7 +48,7 @@ void RadialBasisFctSolver::computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFun
                 "This means that the mapping problem is not well-posed. "
                 "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
                 "by marking perpendicular axes as dead?",
-                "this->input()->getName()", " this->output()->getName()");
+                inputMesh.getName(), outputMesh.getName());
 
   // Second, assemble evaluation matrix
   _matrixA = buildMatrixA(basisFunction, inputMesh, outputMesh, deadAxis);

--- a/src/mapping/RadialBasisFctSolver.h
+++ b/src/mapping/RadialBasisFctSolver.h
@@ -57,6 +57,7 @@ void RadialBasisFctSolver::computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFun
 Eigen::VectorXd RadialBasisFctSolver::solveConservative(const Eigen::VectorXd &inputData) const
 {
   // TODO: Avoid temporary allocations
+  PRECICE_ASSERT(inputData.size() == _matrixA.rows());
   Eigen::VectorXd Au = _matrixA.transpose() * inputData;
   PRECICE_ASSERT(Au.size() == _matrixA.cols());
   return _qr.solve(Au);
@@ -64,6 +65,7 @@ Eigen::VectorXd RadialBasisFctSolver::solveConservative(const Eigen::VectorXd &i
 
 Eigen::VectorXd RadialBasisFctSolver::solveConsistent(const Eigen::VectorXd &inputData) const
 {
+  PRECICE_ASSERT(inputData.size() == _matrixA.cols());
   Eigen::VectorXd p = _qr.solve(inputData);
   PRECICE_ASSERT(p.size() == _matrixA.cols());
   return _matrixA * p;

--- a/src/mapping/RadialBasisFctSolver.h
+++ b/src/mapping/RadialBasisFctSolver.h
@@ -1,0 +1,179 @@
+#include "impl/BasisFunctions.hpp"
+#include "precice/types.hpp"
+#include "utils/EigenHelperFunctions.hpp"
+#include "utils/Event.hpp"
+
+namespace precice {
+extern bool syncMode;
+
+struct RadialBasisFctSolver {
+public:
+  RadialBasisFctSolver() = default;
+
+  /// Assembles the system matrices and computes the decomposition of the interpolation matrix
+  template <typename RADIAL_BASIS_FUNCTION_T>
+  void computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
+
+  /// Maps the given input data
+  Eigen::VectorXd solveConsistent(const Eigen::VectorXd &inputData) const;
+
+  /// Maps the given input data
+  Eigen::VectorXd solveConservative(const Eigen::VectorXd &inputData) const;
+
+  // Clear all stored matrices
+  void clear();
+
+  Eigen::MatrixXd _matrixA;
+
+private:
+  precice::logging::Logger _log{"mapping::RadialBasisFctSolver"};
+
+  Eigen::ColPivHouseholderQR<Eigen::MatrixXd> _qr;
+};
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+static Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis);
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+static Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+void RadialBasisFctSolver::computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
+{
+  // First, assemble the interpolation matrix
+  _qr = buildMatrixCLU(basisFunction, inputMesh, deadAxis).colPivHouseholderQr();
+
+  PRECICE_CHECK(_qr.isInvertible(),
+                "The interpolation matrix of the RBF mapping from mesh {} to mesh {} is not invertable. "
+                "This means that the mapping problem is not well-posed. "
+                "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                "by marking perpendicular axes as dead?",
+                "this->input()->getName()", " this->output()->getName()");
+
+  // Second, assemble evaluation matrix
+  _matrixA = buildMatrixA(basisFunction, inputMesh, outputMesh, deadAxis);
+}
+
+Eigen::VectorXd RadialBasisFctSolver::solveConservative(const Eigen::VectorXd &inputData) const
+{
+  // TODO: Avoid temporary allocations
+  Eigen::VectorXd Au = _matrixA.transpose() * inputData;
+  PRECICE_ASSERT(Au.size() == _matrixA.cols());
+  return _qr.solve(Au);
+}
+
+Eigen::VectorXd RadialBasisFctSolver::solveConsistent(const Eigen::VectorXd &inputData) const
+{
+  Eigen::VectorXd p = _qr.solve(inputData);
+  PRECICE_ASSERT(p.size() == _matrixA.cols());
+  return _matrixA * p;
+}
+
+void RadialBasisFctSolver::clear()
+{
+  _matrixA = Eigen::MatrixXd();
+  _qr      = Eigen::ColPivHouseholderQR<Eigen::MatrixXd>();
+}
+
+// ------- Non-Member Functions ---------
+
+/// Deletes all dead directions from fullVector and returns a vector of reduced dimensionality.
+static inline Eigen::VectorXd reduceVector(
+    const Eigen::VectorXd &  fullVector,
+    const std::vector<bool> &deadAxis)
+{
+  int deadDimensions = 0;
+  int dimensions     = deadAxis.size();
+  for (int d = 0; d < dimensions; d++) {
+    if (deadAxis[d])
+      deadDimensions += 1;
+  }
+  PRECICE_ASSERT(dimensions > deadDimensions, dimensions, deadDimensions);
+  Eigen::VectorXd reducedVector(dimensions - deadDimensions);
+  int             k = 0;
+  for (int d = 0; d < dimensions; d++) {
+    if (not deadAxis[d]) {
+      reducedVector[k] = fullVector[d];
+      k++;
+    }
+  }
+  return reducedVector;
+}
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+static Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis)
+{
+  int inputSize  = inputMesh.vertices().size();
+  int dimensions = inputMesh.getDimensions();
+
+  int deadDimensions = 0;
+  for (int d = 0; d < dimensions; d++) {
+    if (deadAxis[d])
+      deadDimensions += 1;
+  }
+
+  int polyparams = 1 + dimensions - deadDimensions;
+  PRECICE_ASSERT(inputSize >= 1 + polyparams, inputSize);
+  int n = inputSize + polyparams; // Add linear polynom degrees
+
+  Eigen::MatrixXd matrixCLU(n, n);
+  matrixCLU.setZero();
+
+  for (int i = 0; i < inputSize; ++i) {
+    for (int j = i; j < inputSize; ++j) {
+      const auto &u   = inputMesh.vertices()[i].getCoords();
+      const auto &v   = inputMesh.vertices()[j].getCoords();
+      matrixCLU(i, j) = basisFunction.evaluate(reduceVector((u - v), deadAxis).norm());
+    }
+
+    const auto reduced = reduceVector(inputMesh.vertices()[i].getCoords(), deadAxis);
+
+    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
+      matrixCLU(i, inputSize + 1 + dim) = reduced[dim];
+    }
+    matrixCLU(i, inputSize) = 1.0;
+  }
+
+  matrixCLU.triangularView<Eigen::Lower>() = matrixCLU.transpose();
+
+  return matrixCLU;
+}
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+static Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
+{
+  int inputSize  = inputMesh.vertices().size();
+  int outputSize = outputMesh.vertices().size();
+  int dimensions = inputMesh.getDimensions();
+
+  int deadDimensions = 0;
+  for (int d = 0; d < dimensions; d++) {
+    if (deadAxis[d])
+      deadDimensions += 1;
+  }
+
+  int polyparams = 1 + dimensions - deadDimensions;
+  PRECICE_ASSERT(inputSize >= 1 + polyparams, inputSize);
+  int n = inputSize + polyparams; // Add linear polynom degrees
+
+  Eigen::MatrixXd matrixA(outputSize, n);
+  matrixA.setZero();
+
+  // Fill _matrixA with values
+  for (int i = 0; i < outputSize; ++i) {
+    for (int j = 0; j < inputSize; ++j) {
+      const auto &u = outputMesh.vertices()[i].getCoords();
+      const auto &v = inputMesh.vertices()[j].getCoords();
+      matrixA(i, j) = basisFunction.evaluate(reduceVector((u - v), deadAxis).norm());
+    }
+
+    const auto reduced = reduceVector(outputMesh.vertices()[i].getCoords(), deadAxis);
+
+    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
+      matrixA(i, inputSize + 1 + dim) = reduced[dim];
+    }
+    matrixA(i, inputSize) = 1.0;
+  }
+  return matrixA;
+}
+} // namespace precice

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -33,10 +33,10 @@ private:
 };
 
 template <typename RADIAL_BASIS_FUNCTION_T>
-static Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis);
+Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis);
 
 template <typename RADIAL_BASIS_FUNCTION_T>
-static Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
+Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
 
 template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctSolver::computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
@@ -86,7 +86,7 @@ const Eigen::MatrixXd &RadialBasisFctSolver::getEvaluationMatrix() const
 // ------- Non-Member Functions ---------
 
 /// Deletes all dead directions from fullVector and returns a vector of reduced dimensionality.
-static inline Eigen::VectorXd reduceVector(
+inline Eigen::VectorXd reduceVector(
     const Eigen::VectorXd &  fullVector,
     const std::vector<bool> &deadAxis)
 {
@@ -109,7 +109,7 @@ static inline Eigen::VectorXd reduceVector(
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>
-static Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis)
+Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis)
 {
   int inputSize  = inputMesh.vertices().size();
   int dimensions = inputMesh.getDimensions();
@@ -148,7 +148,7 @@ static Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, con
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>
-static Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
+Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
 {
   int inputSize  = inputMesh.vertices().size();
   int outputSize = outputMesh.vertices().size();

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -8,9 +8,11 @@ namespace mapping {
 
 class RadialBasisFctSolver {
 public:
+  /// Default constructor
+  RadialBasisFctSolver() = default;
   /// Assembles the system matrices and computes the decomposition of the interpolation matrix
   template <typename RADIAL_BASIS_FUNCTION_T>
-  void computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
+  RadialBasisFctSolver(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
 
   /// Maps the given input data
   Eigen::VectorXd solveConsistent(const Eigen::VectorXd &inputData) const;
@@ -135,7 +137,7 @@ Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>
-void RadialBasisFctSolver::computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
+RadialBasisFctSolver::RadialBasisFctSolver(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
 {
   // First, assemble the interpolation matrix
   _qr = buildMatrixCLU(basisFunction, inputMesh, deadAxis).colPivHouseholderQr();

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -21,12 +21,15 @@ public:
   // Clear all stored matrices
   void clear();
 
-  Eigen::MatrixXd _matrixA;
+  // Access to the evaluation matrix
+  const Eigen::MatrixXd &getEvaluationMatrix() const;
 
 private:
   precice::logging::Logger _log{"mapping::RadialBasisFctSolver"};
 
   Eigen::ColPivHouseholderQR<Eigen::MatrixXd> _qr;
+
+  Eigen::MatrixXd _matrixA;
 };
 
 template <typename RADIAL_BASIS_FUNCTION_T>
@@ -73,6 +76,11 @@ void RadialBasisFctSolver::clear()
 {
   _matrixA = Eigen::MatrixXd();
   _qr      = Eigen::ColPivHouseholderQR<Eigen::MatrixXd>();
+}
+
+const Eigen::MatrixXd &RadialBasisFctSolver::getEvaluationMatrix() const
+{
+  return _matrixA;
 }
 
 // ------- Non-Member Functions ---------

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -1,15 +1,13 @@
-#include "impl/BasisFunctions.hpp"
+#include "mapping/impl/BasisFunctions.hpp"
 #include "precice/types.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Event.hpp"
 
 namespace precice {
-extern bool syncMode;
+namespace mapping {
 
-struct RadialBasisFctSolver {
+class RadialBasisFctSolver {
 public:
-  RadialBasisFctSolver() = default;
-
   /// Assembles the system matrices and computes the decomposition of the interpolation matrix
   template <typename RADIAL_BASIS_FUNCTION_T>
   void computeDecomposition(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
@@ -178,4 +176,5 @@ static Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const
   }
   return matrixA;
 }
+} // namespace mapping
 } // namespace precice

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -190,7 +190,7 @@ target_sources(precice
     src/mapping/Polation.hpp
     src/mapping/RadialBasisFctBaseMapping.hpp
     src/mapping/RadialBasisFctMapping.hpp
-    src/mapping/RadialBasisFctSolver.h
+    src/mapping/RadialBasisFctSolver.hpp
     src/mapping/SharedPointer.hpp
     src/mapping/config/MappingConfiguration.cpp
     src/mapping/config/MappingConfiguration.hpp

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -190,6 +190,7 @@ target_sources(precice
     src/mapping/Polation.hpp
     src/mapping/RadialBasisFctBaseMapping.hpp
     src/mapping/RadialBasisFctMapping.hpp
+    src/mapping/RadialBasisFctSolver.h
     src/mapping/SharedPointer.hpp
     src/mapping/config/MappingConfiguration.cpp
     src/mapping/config/MappingConfiguration.hpp

--- a/src/utils/EigenHelperFunctions.cpp
+++ b/src/utils/EigenHelperFunctions.cpp
@@ -55,27 +55,5 @@ void append(
   v(n) = value;
 }
 
-Eigen::VectorXd reduceVector(
-    const Eigen::VectorXd &  fullVector,
-    const std::vector<bool> &deadAxis)
-{
-  int deadDimensions = 0;
-  int dimensions     = deadAxis.size();
-  for (int d = 0; d < dimensions; d++) {
-    if (deadAxis[d])
-      deadDimensions += 1;
-  }
-  PRECICE_ASSERT(dimensions > deadDimensions, dimensions, deadDimensions);
-  Eigen::VectorXd reducedVector(dimensions - deadDimensions);
-  int             k = 0;
-  for (int d = 0; d < dimensions; d++) {
-    if (not deadAxis[d]) {
-      reducedVector[k] = fullVector[d];
-      k++;
-    }
-  }
-  return reducedVector;
-}
-
 } // namespace utils
 } // namespace precice

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -15,9 +15,6 @@ void appendFront(Eigen::MatrixXd &A, Eigen::VectorXd &v);
 
 void removeColumnFromMatrix(Eigen::MatrixXd &A, int col);
 
-/// Deletes all dead directions from fullVector and returns a vector of reduced dimensionality.
-Eigen::VectorXd reduceVector(const Eigen::VectorXd &fullVector, const std::vector<bool> &deadAxis);
-
 void append(Eigen::VectorXd &v, double value);
 
 template <typename Derived1>


### PR DESCRIPTION
## Main changes of this PR
Shifts the assembly and solving of the Eigen RBF mapping to a separate class.

## Motivation and additional information
Related to #1273: we want to reuse the same RBF kernel for both mapping variants. This reduces and avoids duplication in the long run, since #1166 will add additional complexity in the individual steps. 

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
