### PR TITLE
Added tetrahedra communication

### DIFF
--- a/src/com/CommunicateMesh.cpp
+++ b/src/com/CommunicateMesh.cpp
@@ -283,7 +283,7 @@ void CommunicateMesh::broadcastSendMesh(const mesh::Mesh &mesh)
       tetraIDs[i * 4]     = meshTetrahedra[i].vertex(0).getID();
       tetraIDs[i * 4 + 1] = meshTetrahedra[i].vertex(1).getID();
       tetraIDs[i * 4 + 2] = meshTetrahedra[i].vertex(2).getID();
-      tetraIDs[i * 4 + 3] = meshTetrahedra[i].vertex(2).getID();
+      tetraIDs[i * 4 + 3] = meshTetrahedra[i].vertex(3).getID();
     }
     _communication->broadcast(tetraIDs);
   }


### PR DESCRIPTION
## Main changes of this PR

When communicating meshes (`sendMesh, receiveMesh, broadcastSendMesh, broadcastReceiveMesh`), tetrahedra are now communicated.

## Motivation and additional information

Part of https://github.com/precice/precice/issues/468, necessary to extend Linear Cell Interpolation mapping to 3D.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
