### PR TITLE
Added tetrahedra support to filtering (+ general filtering tests)

### DIFF
--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -42,7 +42,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
     }
   }
 
-  // Add all triangles formed by the contributing edges
+  // Add all triangles formed by the contributing vertices
   for (const Triangle &triangle : source.triangles()) {
     VertexID vertexIndex1 = triangle.vertex(0).getID();
     VertexID vertexIndex2 = triangle.vertex(1).getID();
@@ -51,6 +51,20 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
         vertexMap.count(vertexIndex2) == 1 &&
         vertexMap.count(vertexIndex3) == 1) {
       destination.createTriangle(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3]);
+    }
+  }
+
+  // Add all tetrahedra formed by the contributing vertices
+  for (const Tetrahedron &tetra : source.tetrahedra()) {
+    VertexID vertexIndex1 = tetra.vertex(0).getID();
+    VertexID vertexIndex2 = tetra.vertex(1).getID();
+    VertexID vertexIndex3 = tetra.vertex(2).getID();
+    VertexID vertexIndex4 = tetra.vertex(3).getID();
+    if (vertexMap.count(vertexIndex1) == 1 &&
+        vertexMap.count(vertexIndex2) == 1 &&
+        vertexMap.count(vertexIndex3) == 1 &&
+        vertexMap.count(vertexIndex4) == 1) {
+      destination.createTetrahedron(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3], *vertexMap[vertexIndex4]);
     }
   }
 }

--- a/src/mesh/tests/FilterTest.cpp
+++ b/src/mesh/tests/FilterTest.cpp
@@ -1,0 +1,159 @@
+#include <Eigen/Core>
+#include <iosfwd>
+#include <string>
+#include "logging/Logger.hpp"
+#include "mesh/Filter.hpp"
+#include "mesh/Mesh.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+using namespace precice;
+using namespace Eigen;
+
+BOOST_AUTO_TEST_SUITE(MeshTests)
+BOOST_AUTO_TEST_SUITE(FilterTests)
+
+BOOST_AUTO_TEST_CASE(Vertices2D)
+{
+  PRECICE_TEST(1_rank);
+
+  mesh::Mesh dest("2D dest", 2, testing::nextMeshID());
+  mesh::Mesh src("2D src", 2, testing::nextMeshID());
+
+  auto &v0 = dest.createVertex(Vector2d::Constant(4.0)); // Add dummy data to check additivity
+  auto &v1 = src.createVertex(Vector2d::Constant(3.0));
+  auto &v2 = src.createVertex(Vector2d::Constant(2.0));
+
+  v1.tag();
+
+  auto p = [](const mesh::Vertex &v) { return v.isTagged(); };
+
+  mesh::filterMesh(dest, src, p);
+
+  // dest should contain Constante(4) and Constant(3), but not Constant(2)
+  BOOST_TEST(dest.vertices().size() == 2);
+  BOOST_TEST(dest.vertices()[0] == v0);
+  BOOST_TEST(dest.vertices()[1] == v1);
+}
+
+BOOST_AUTO_TEST_CASE(Vertices3D)
+{
+  PRECICE_TEST(1_rank);
+
+  mesh::Mesh dest("3D dest", 3, testing::nextMeshID());
+  mesh::Mesh src("3D src", 3, testing::nextMeshID());
+
+  auto &v0 = dest.createVertex(Vector3d::Constant(4.0)); // Add dummy data to check additivity
+  auto &v1 = src.createVertex(Vector3d::Constant(3.0));
+  auto &v2 = src.createVertex(Vector3d::Constant(2.0));
+
+  v1.tag();
+
+  auto p = [](const mesh::Vertex &v) { return v.isTagged(); };
+
+  mesh::filterMesh(dest, src, p);
+
+  // dest should contain Constante(4) and Constant(3), but not Constant(2)
+  BOOST_TEST(dest.vertices().size() == 2);
+  BOOST_TEST(dest.vertices()[0] == v0);
+  BOOST_TEST(dest.vertices()[1] == v1);
+}
+
+BOOST_AUTO_TEST_CASE(Edges)
+{
+  PRECICE_TEST(1_rank);
+
+  mesh::Mesh dest("3D dest", 3, testing::nextMeshID());
+  mesh::Mesh src("3D src", 3, testing::nextMeshID());
+
+  auto &v0 = dest.createVertex(Vector3d::Constant(4.0)); // Add dummy data to check additivity
+  auto &v1 = src.createVertex(Vector3d::Constant(0.0));
+  auto &v2 = src.createVertex(Vector3d::Constant(1.0));
+  auto &v3 = src.createVertex(Vector3d::Constant(2.0));
+
+  auto &e0 = src.createEdge(v1, v2);
+  auto &e1 = src.createEdge(v2, v3);
+
+  v1.tag();
+  v2.tag();
+
+  auto p = [](const mesh::Vertex &v) { return v.isTagged(); };
+
+  mesh::filterMesh(dest, src, p);
+
+  BOOST_TEST(dest.vertices().size() == 3);
+  BOOST_TEST(dest.vertices()[0] == v0);
+  BOOST_TEST(dest.vertices()[1] == v1);
+  BOOST_TEST(dest.vertices()[2] == v2);
+
+  // Only e0 should survive
+  BOOST_TEST(dest.edges().size() == 1);
+  BOOST_TEST(dest.edges()[0] == e0);
+}
+
+BOOST_AUTO_TEST_CASE(Triangles)
+{
+  PRECICE_TEST(1_rank);
+
+  mesh::Mesh dest("3D dest", 3, testing::nextMeshID());
+  mesh::Mesh src("3D src", 3, testing::nextMeshID());
+
+  auto &v0 = dest.createVertex(Vector3d::Constant(4.0)); // Add dummy data to check additivity
+  auto &v1 = src.createVertex(Vector3d::Constant(0.0));
+  auto &v2 = src.createVertex(Vector3d{1.0, 0.0, 0.0});
+  auto &v3 = src.createVertex(Vector3d{0.0, 1.0, 0.0});
+  auto &v4 = src.createVertex(Vector3d{0.0, 0.0, 1.0});
+
+  auto &t1 = src.createTriangle(v1, v2, v3);
+  auto &t2 = src.createTriangle(v2, v3, v4);
+
+  v1.tag();
+  v2.tag();
+  v3.tag();
+
+  auto p = [](const mesh::Vertex &v) { return v.isTagged(); };
+
+  mesh::filterMesh(dest, src, p);
+
+  BOOST_TEST(dest.vertices().size() == 4);
+
+  // Only t1 should survive (because v4 not passed)
+  BOOST_TEST(dest.triangles().size() == 1);
+  BOOST_TEST(dest.triangles()[0] == t1);
+}
+
+BOOST_AUTO_TEST_CASE(Tetrahedra)
+{
+  PRECICE_TEST(1_rank);
+
+  mesh::Mesh dest("3D dest", 3, testing::nextMeshID());
+  mesh::Mesh src("3D src", 3, testing::nextMeshID());
+
+  auto &v0 = dest.createVertex(Vector3d::Constant(4.0)); // Add dummy data to check additivity
+  auto &v1 = src.createVertex(Vector3d::Constant(0.0));
+  auto &v2 = src.createVertex(Vector3d{1.0, 0.0, 0.0});
+  auto &v3 = src.createVertex(Vector3d{0.0, 1.0, 0.0});
+  auto &v4 = src.createVertex(Vector3d{0.0, 0.0, 1.0});
+  auto &v5 = src.createVertex(Vector3d{0.0, 2.0, 1.0});
+
+  auto &t1 = src.createTetrahedron(v1, v2, v3, v4);
+  auto &t2 = src.createTetrahedron(v2, v3, v4, v5);
+
+  v1.tag();
+  v2.tag();
+  v3.tag();
+  v4.tag();
+
+  auto p = [](const mesh::Vertex &v) { return v.isTagged(); };
+
+  mesh::filterMesh(dest, src, p);
+
+  BOOST_TEST(dest.vertices().size() == 5);
+
+  // Only t1 should survive (because v5 not passed)
+  BOOST_TEST(dest.tetrahedra().size() == 1);
+  BOOST_TEST(dest.tetrahedra()[0] == t1);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Filter
+BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -52,6 +52,7 @@ target_sources(testprecice
     src/mesh/tests/BoundingBoxTest.cpp
     src/mesh/tests/DataConfigurationTest.cpp
     src/mesh/tests/EdgeTest.cpp
+    src/mesh/tests/FilterTest.cpp
     src/mesh/tests/MeshTest.cpp
     src/mesh/tests/TetrahedronTest.cpp
     src/mesh/tests/TriangleTest.cpp


### PR DESCRIPTION
## Main changes of this PR

`filterMesh` now also adds tetrahedra if any are present.
Various filtering tests are added.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
