### PR TITLE
Added Polation constructor for tetra

### DIFF
--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -42,6 +42,27 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Triangle &elemen
   _weightedElements.emplace_back(WeightedElement{C.getID(), bcoords(2)});
 }
 
+Polation::Polation(const Eigen::VectorXd &location, const mesh::Tetrahedron &element)
+{
+  PRECICE_ASSERT(location.size() == element.getDimensions(), location.size(), element.getDimensions());
+  auto &A = element.vertex(0);
+  auto &B = element.vertex(1);
+  auto &C = element.vertex(2);
+  auto &D = element.vertex(3);
+
+  const auto bcoords = math::barycenter::calcBarycentricCoordsForTetrahedron(
+      A.getCoords(),
+      B.getCoords(),
+      C.getCoords(),
+      D.getCoords(),
+      location);
+
+  _weightedElements.emplace_back(WeightedElement{A.getID(), bcoords(0)});
+  _weightedElements.emplace_back(WeightedElement{B.getID(), bcoords(1)});
+  _weightedElements.emplace_back(WeightedElement{C.getID(), bcoords(2)});
+  _weightedElements.emplace_back(WeightedElement{D.getID(), bcoords(3)});
+}
+
 const std::vector<WeightedElement> &Polation::getWeightedElements() const
 {
   return _weightedElements;

--- a/src/mapping/Polation.hpp
+++ b/src/mapping/Polation.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "Eigen/Core"
 #include "mesh/Edge.hpp"
+#include "mesh/Tetrahedron.hpp"
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
 
@@ -30,6 +31,9 @@ public:
 
   /// Calculate projection to a triangle
   Polation(const Eigen::VectorXd &location, const mesh::Triangle &element);
+
+  /// Calculate projection to a tetrahedron
+  Polation(const Eigen::VectorXd &location, const mesh::Tetrahedron &element);
 
   /// Get the weights and indices of the calculated interpolation
   const std::vector<WeightedElement> &getWeightedElements() const;

--- a/src/mapping/tests/PolationTest.cpp
+++ b/src/mapping/tests/PolationTest.cpp
@@ -136,5 +136,59 @@ BOOST_AUTO_TEST_CASE(TriangleExtrapolation)
   }
 }
 
+BOOST_AUTO_TEST_CASE(TetrahedronInterpolation)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex v1(Eigen::Vector3d(1.0, 0.0, 0.0), 0);
+  mesh::Vertex v2(Eigen::Vector3d(0.0, 1.0, 0.0), 1);
+  mesh::Vertex v3(Eigen::Vector3d(0.0, 0.0, 1.0), 2);
+  mesh::Vertex v4(Eigen::Vector3d(0.0, 0.0, 0.0), 3);
+
+  mesh::Tetrahedron tetra(v1, v2, v3, v4, 0);
+
+  Eigen::Vector3d location(0.15, 0.25, 0.40);
+
+  Polation polation(location, tetra);
+
+  std::vector<int>    expectedIndices = {0, 1, 2, 3};
+  std::vector<double> expectedWeights = {0.15, 0.25, 0.40, 0.20};
+
+  BOOST_TEST(polation.getWeightedElements().size() == 4);
+  BOOST_TEST(polation.isInterpolation());
+
+  for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
+
+    BOOST_TEST(polation.getWeightedElements().at(i).weight == expectedWeights.at(i));
+    BOOST_TEST(polation.getWeightedElements().at(i).vertexID == expectedIndices.at(i));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(TetrahedronExtrapolation)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex v1(Eigen::Vector3d(1.0, 0.0, 0.0), 0);
+  mesh::Vertex v2(Eigen::Vector3d(0.0, 1.0, 0.0), 1);
+  mesh::Vertex v3(Eigen::Vector3d(0.0, 0.0, 1.0), 2);
+  mesh::Vertex v4(Eigen::Vector3d(0.0, 0.0, 0.0), 3);
+
+  mesh::Tetrahedron tetra(v1, v2, v3, v4, 0);
+
+  Eigen::Vector3d location(-0.15, 0.25, 0.40);
+
+  Polation polation(location, tetra);
+
+  std::vector<int>    expectedIndices = {0, 1, 2, 3};
+  std::vector<double> expectedWeights = {-0.15, 0.25, 0.40, 0.50};
+
+  BOOST_TEST(polation.getWeightedElements().size() == 4);
+  BOOST_TEST(polation.isInterpolation());
+
+  for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
+
+    BOOST_TEST(polation.getWeightedElements().at(i).weight == expectedWeights.at(i));
+    BOOST_TEST(polation.getWeightedElements().at(i).vertexID == expectedIndices.at(i));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Interpolation
 BOOST_AUTO_TEST_SUITE_END() // Mapping

--- a/src/mapping/tests/PolationTest.cpp
+++ b/src/mapping/tests/PolationTest.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(TetrahedronExtrapolation)
   std::vector<double> expectedWeights = {-0.15, 0.25, 0.40, 0.50};
 
   BOOST_TEST(polation.getWeightedElements().size() == 4);
-  BOOST_TEST(polation.isInterpolation());
+  BOOST_TEST(not polation.isInterpolation());
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
 


### PR DESCRIPTION
## Main changes of this PR

Can now construct a Polation object with a tetrahedron.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
