### PR TITLE
Extend Linear Cell Interpolation Mapping to 3D

### DIFF
--- a/docs/changelog/1319.md
+++ b/docs/changelog/1319.md
@@ -1,0 +1,1 @@
+- Refactored RBF system assembly and RBF system solving into a dedicated class.

--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -15,7 +15,6 @@ LinearCellInterpolationMapping::LinearCellInterpolationMapping(
     int        dimensions)
     : BarycentricBaseMapping(constraint, dimensions)
 {
-  PRECICE_CHECK(getDimensions() == 2, "Volume mapping not available in 3D.");
   if (constraint == CONSISTENT) {
     setInputRequirement(Mapping::MeshRequirement::FULL);
     setOutputRequirement(Mapping::MeshRequirement::VERTEX);
@@ -36,7 +35,6 @@ void LinearCellInterpolationMapping::computeMapping()
   PRECICE_TRACE(input()->vertices().size(), output()->vertices().size());
   const std::string     baseEvent = "map.vci.computeMapping.From" + input()->getName() + "To" + output()->getName();
   precice::utils::Event e(baseEvent, precice::syncMode);
-  PRECICE_ASSERT(getDimensions() == 2, "Volume mapping not available in 3D.");
 
   // Setup Direction of Mapping
   mesh::PtrMesh origins, searchSpace;
@@ -61,8 +59,12 @@ void LinearCellInterpolationMapping::computeMapping()
       missingConnectivity = true;
     }
   } else {
-    // TODO, shouldn't be reached
-    PRECICE_ERROR("Linear Cell interpolation in 3D not implemented yet. This line should be unreachable");
+    if (!fVertices.empty() && searchSpace->tetrahedra().empty()) {
+      PRECICE_WARN("3D Mesh \"{}\" does not contain tetrahedra. "
+                   "Linear cell interpolation falls back to nearest projection mapping.",
+                   searchSpace->getName());
+      missingConnectivity = true;
+    }
   }
 
   // Amount of nearest elements to fetch for detailed comparison.

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -7,6 +7,7 @@
 #include "com/Communication.hpp"
 #include "impl/BasisFunctions.hpp"
 #include "mapping/RadialBasisFctBaseMapping.hpp"
+#include "mapping/RadialBasisFctSolver.hpp"
 #include "mesh/Filter.hpp"
 #include "precice/types.hpp"
 #include "utils/EigenHelperFunctions.hpp"
@@ -55,10 +56,7 @@ public:
 private:
   precice::logging::Logger _log{"mapping::RadialBasisFctMapping"};
 
-  Eigen::MatrixXd _matrixA;
-
-  Eigen::ColPivHouseholderQR<Eigen::MatrixXd> _qr;
-
+  RadialBasisFctSolver _rbfSolver;
   /// @copydoc RadialBasisFctBaseMapping::mapConservative
   virtual void mapConservative(DataID inputDataID, DataID outputDataID) override;
 
@@ -141,15 +139,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       globalOutMesh.addMesh(*outMesh);
     }
 
-    _matrixA = buildMatrixA(this->_basisFunction, globalInMesh, globalOutMesh, this->_deadAxis);
-    _qr      = buildMatrixCLU(this->_basisFunction, globalInMesh, this->_deadAxis).colPivHouseholderQr();
-
-    PRECICE_CHECK(_qr.isInvertible(),
-                  "The interpolation matrix of the RBF mapping from mesh {} to mesh {} is not invertable. "
-                  "This means that the mapping problem is not well-posed. "
-                  "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                  "by marking perpendicular axes as dead?",
-                  this->input()->getName(), this->output()->getName());
+    _rbfSolver = RadialBasisFctSolver{this->_basisFunction, globalInMesh, globalOutMesh, this->_deadAxis};
   }
   this->_hasComputedMapping = true;
   PRECICE_DEBUG("Compute Mapping is Completed.");
@@ -159,14 +149,14 @@ template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::clear()
 {
   PRECICE_TRACE();
-  _matrixA                  = Eigen::MatrixXd();
-  _qr                       = Eigen::ColPivHouseholderQR<Eigen::MatrixXd>();
+  _rbfSolver.clear();
   this->_hasComputedMapping = false;
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID inputDataID, DataID outputDataID)
 {
+  precice::utils::Event e("map.rbf.mapData.From" + this->input()->getName() + "To" + this->output()->getName(), precice::syncMode);
   PRECICE_TRACE(inputDataID, outputDataID);
   using precice::com::AsVectorTag;
 
@@ -222,20 +212,16 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID inpu
 
     // Construct Eigen vectors
     Eigen::Map<Eigen::VectorXd> inputValues(globalInValues.data(), globalInValues.size());
-    Eigen::VectorXd             outputValues((_matrixA.cols() - this->getPolynomialParameters()) * valueDim);
+    Eigen::VectorXd             outputValues((_rbfSolver.getEvaluationMatrix().cols() - this->getPolynomialParameters()) * valueDim);
+    Eigen::VectorXd             in(_rbfSolver.getEvaluationMatrix().rows()); // rows == outputSize
     outputValues.setZero();
-
-    Eigen::VectorXd Au(_matrixA.cols());  // rows == n
-    Eigen::VectorXd in(_matrixA.rows());  // rows == outputSize
-    Eigen::VectorXd out(_matrixA.cols()); // rows == n
 
     for (int dim = 0; dim < valueDim; dim++) {
       for (int i = 0; i < in.size(); i++) { // Fill input data values
         in[i] = inputValues(i * valueDim + dim);
       }
 
-      Au  = _matrixA.transpose() * in;
-      out = _qr.solve(Au);
+      Eigen::VectorXd out = _rbfSolver.solveConservative(in);
 
       // Copy mapped data to output data values
       for (int i = 0; i < out.size() - this->getPolynomialParameters(); i++) {
@@ -288,6 +274,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID inpu
 template <typename RADIAL_BASIS_FUNCTION_T>
 void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputDataID, DataID outputDataID)
 {
+  precice::utils::Event e("map.rbf.mapData.From" + this->input()->getName() + "To" + this->output()->getName(), precice::syncMode);
   PRECICE_TRACE(inputDataID, outputDataID);
   using precice::com::AsVectorTag;
 
@@ -305,7 +292,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputD
 
     int valueDim = this->output()->data(outputDataID)->getDimensions();
 
-    std::vector<double> globalInValues((_matrixA.cols() - this->getPolynomialParameters()) * valueDim, 0.0);
+    std::vector<double> globalInValues((_rbfSolver.getEvaluationMatrix().cols() - this->getPolynomialParameters()) * valueDim, 0.0);
     std::vector<int>    outValuesSize;
 
     if (utils::IntraComm::isPrimary()) { // Parallel case
@@ -333,15 +320,14 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputD
       outValuesSize.push_back(this->output()->data(outputDataID)->values().size());
     }
 
-    Eigen::VectorXd p(_matrixA.cols());   // rows == n
-    Eigen::VectorXd in(_matrixA.cols());  // rows == n
-    Eigen::VectorXd out(_matrixA.rows()); // rows == outputSize
+    Eigen::VectorXd in(_rbfSolver.getEvaluationMatrix().cols()); // rows == n
     in.setZero();
 
     // Construct Eigen vectors
     Eigen::Map<Eigen::VectorXd> inputValues(globalInValues.data(), globalInValues.size());
 
-    Eigen::VectorXd outputValues((_matrixA.rows()) * valueDim);
+    Eigen::VectorXd outputValues((_rbfSolver.getEvaluationMatrix().rows()) * valueDim);
+    Eigen::VectorXd out;
     outputValues.setZero();
 
     // For every data dimension, perform mapping
@@ -351,8 +337,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputD
         in[i] = inputValues[i * valueDim + dim];
       }
 
-      p   = _qr.solve(in);
-      out = _matrixA * p;
+      out = _rbfSolver.solveConsistent(in);
 
       // Copy mapped data to output data values
       for (int i = 0; i < out.size(); i++) {
@@ -378,85 +363,5 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inputD
     this->output()->data(outputDataID)->values() = Eigen::Map<Eigen::VectorXd>(receivedValues.data(), receivedValues.size());
   }
 }
-
-// ------- Non-Member Functions ---------
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-static Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis)
-{
-  int inputSize  = inputMesh.vertices().size();
-  int dimensions = inputMesh.getDimensions();
-
-  int deadDimensions = 0;
-  for (int d = 0; d < dimensions; d++) {
-    if (deadAxis[d])
-      deadDimensions += 1;
-  }
-
-  int polyparams = 1 + dimensions - deadDimensions;
-  PRECICE_ASSERT(inputSize >= 1 + polyparams, inputSize);
-  int n = inputSize + polyparams; // Add linear polynom degrees
-
-  Eigen::MatrixXd matrixCLU(n, n);
-  matrixCLU.setZero();
-
-  for (int i = 0; i < inputSize; ++i) {
-    for (int j = i; j < inputSize; ++j) {
-      const auto &u   = inputMesh.vertices()[i].getCoords();
-      const auto &v   = inputMesh.vertices()[j].getCoords();
-      matrixCLU(i, j) = basisFunction.evaluate(utils::reduceVector((u - v), deadAxis).norm());
-    }
-
-    const auto reduced = utils::reduceVector(inputMesh.vertices()[i].getCoords(), deadAxis);
-
-    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
-      matrixCLU(i, inputSize + 1 + dim) = reduced[dim];
-    }
-    matrixCLU(i, inputSize) = 1.0;
-  }
-
-  matrixCLU.triangularView<Eigen::Lower>() = matrixCLU.transpose();
-
-  return matrixCLU;
-}
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-static Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
-{
-  int inputSize  = inputMesh.vertices().size();
-  int outputSize = outputMesh.vertices().size();
-  int dimensions = inputMesh.getDimensions();
-
-  int deadDimensions = 0;
-  for (int d = 0; d < dimensions; d++) {
-    if (deadAxis[d])
-      deadDimensions += 1;
-  }
-
-  int polyparams = 1 + dimensions - deadDimensions;
-  PRECICE_ASSERT(inputSize >= 1 + polyparams, inputSize);
-  int n = inputSize + polyparams; // Add linear polynom degrees
-
-  Eigen::MatrixXd matrixA(outputSize, n);
-  matrixA.setZero();
-
-  // Fill _matrixA with values
-  for (int i = 0; i < outputSize; ++i) {
-    for (int j = 0; j < inputSize; ++j) {
-      const auto &u = outputMesh.vertices()[i].getCoords();
-      const auto &v = inputMesh.vertices()[j].getCoords();
-      matrixA(i, j) = basisFunction.evaluate(utils::reduceVector((u - v), deadAxis).norm());
-    }
-
-    const auto reduced = utils::reduceVector(outputMesh.vertices()[i].getCoords(), deadAxis);
-
-    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
-      matrixA(i, inputSize + 1 + dim) = reduced[dim];
-    }
-    matrixA(i, inputSize) = 1.0;
-  }
-  return matrixA;
-}
-
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -1,0 +1,184 @@
+#include "mapping/impl/BasisFunctions.hpp"
+#include "precice/types.hpp"
+#include "utils/EigenHelperFunctions.hpp"
+#include "utils/Event.hpp"
+
+namespace precice {
+namespace mapping {
+
+class RadialBasisFctSolver {
+public:
+  /// Default constructor
+  RadialBasisFctSolver() = default;
+  /// Assembles the system matrices and computes the decomposition of the interpolation matrix
+  template <typename RADIAL_BASIS_FUNCTION_T>
+  RadialBasisFctSolver(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis);
+
+  /// Maps the given input data
+  Eigen::VectorXd solveConsistent(const Eigen::VectorXd &inputData) const;
+
+  /// Maps the given input data
+  Eigen::VectorXd solveConservative(const Eigen::VectorXd &inputData) const;
+
+  // Clear all stored matrices
+  void clear();
+
+  // Access to the evaluation matrix
+  const Eigen::MatrixXd &getEvaluationMatrix() const;
+
+private:
+  precice::logging::Logger _log{"mapping::RadialBasisFctSolver"};
+
+  Eigen::ColPivHouseholderQR<Eigen::MatrixXd> _qr;
+
+  Eigen::MatrixXd _matrixA;
+};
+
+// ------- Non-Member Functions ---------
+
+/// Deletes all dead directions from fullVector and returns a vector of reduced dimensionality.
+inline Eigen::VectorXd reduceVector(
+    const Eigen::VectorXd &  fullVector,
+    const std::vector<bool> &deadAxis)
+{
+  int deadDimensions = 0;
+  int dimensions     = deadAxis.size();
+  for (int d = 0; d < dimensions; d++) {
+    if (deadAxis[d])
+      deadDimensions += 1;
+  }
+  PRECICE_ASSERT(dimensions > deadDimensions, dimensions, deadDimensions);
+  Eigen::VectorXd reducedVector(dimensions - deadDimensions);
+  int             k = 0;
+  for (int d = 0; d < dimensions; d++) {
+    if (not deadAxis[d]) {
+      reducedVector[k] = fullVector[d];
+      k++;
+    }
+  }
+  return reducedVector;
+}
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, std::vector<bool> deadAxis)
+{
+  int inputSize  = inputMesh.vertices().size();
+  int dimensions = inputMesh.getDimensions();
+
+  int deadDimensions = 0;
+  for (int d = 0; d < dimensions; d++) {
+    if (deadAxis[d])
+      deadDimensions += 1;
+  }
+
+  int polyparams = 1 + dimensions - deadDimensions;
+  PRECICE_ASSERT(inputSize >= 1 + polyparams, inputSize);
+  int n = inputSize + polyparams; // Add linear polynom degrees
+
+  Eigen::MatrixXd matrixCLU(n, n);
+  matrixCLU.setZero();
+
+  for (int i = 0; i < inputSize; ++i) {
+    for (int j = i; j < inputSize; ++j) {
+      const auto &u   = inputMesh.vertices()[i].getCoords();
+      const auto &v   = inputMesh.vertices()[j].getCoords();
+      matrixCLU(i, j) = basisFunction.evaluate(reduceVector((u - v), deadAxis).norm());
+    }
+
+    const auto reduced = reduceVector(inputMesh.vertices()[i].getCoords(), deadAxis);
+
+    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
+      matrixCLU(i, inputSize + 1 + dim) = reduced[dim];
+    }
+    matrixCLU(i, inputSize) = 1.0;
+  }
+
+  matrixCLU.triangularView<Eigen::Lower>() = matrixCLU.transpose();
+
+  return matrixCLU;
+}
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
+{
+  int inputSize  = inputMesh.vertices().size();
+  int outputSize = outputMesh.vertices().size();
+  int dimensions = inputMesh.getDimensions();
+
+  int deadDimensions = 0;
+  for (int d = 0; d < dimensions; d++) {
+    if (deadAxis[d])
+      deadDimensions += 1;
+  }
+
+  int polyparams = 1 + dimensions - deadDimensions;
+  PRECICE_ASSERT(inputSize >= 1 + polyparams, inputSize);
+  int n = inputSize + polyparams; // Add linear polynom degrees
+
+  Eigen::MatrixXd matrixA(outputSize, n);
+  matrixA.setZero();
+
+  // Fill _matrixA with values
+  for (int i = 0; i < outputSize; ++i) {
+    for (int j = 0; j < inputSize; ++j) {
+      const auto &u = outputMesh.vertices()[i].getCoords();
+      const auto &v = inputMesh.vertices()[j].getCoords();
+      matrixA(i, j) = basisFunction.evaluate(reduceVector((u - v), deadAxis).norm());
+    }
+
+    const auto reduced = reduceVector(outputMesh.vertices()[i].getCoords(), deadAxis);
+
+    for (int dim = 0; dim < dimensions - deadDimensions; dim++) {
+      matrixA(i, inputSize + 1 + dim) = reduced[dim];
+    }
+    matrixA(i, inputSize) = 1.0;
+  }
+  return matrixA;
+}
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+RadialBasisFctSolver::RadialBasisFctSolver(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::Mesh &inputMesh, const mesh::Mesh &outputMesh, std::vector<bool> deadAxis)
+{
+  // First, assemble the interpolation matrix
+  _qr = buildMatrixCLU(basisFunction, inputMesh, deadAxis).colPivHouseholderQr();
+
+  PRECICE_CHECK(_qr.isInvertible(),
+                "The interpolation matrix of the RBF mapping from mesh {} to mesh {} is not invertable. "
+                "This means that the mapping problem is not well-posed. "
+                "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
+                "by marking perpendicular axes as dead?",
+                inputMesh.getName(), outputMesh.getName());
+
+  // Second, assemble evaluation matrix
+  _matrixA = buildMatrixA(basisFunction, inputMesh, outputMesh, deadAxis);
+}
+
+Eigen::VectorXd RadialBasisFctSolver::solveConservative(const Eigen::VectorXd &inputData) const
+{
+  // TODO: Avoid temporary allocations
+  PRECICE_ASSERT(inputData.size() == _matrixA.rows());
+  Eigen::VectorXd Au = _matrixA.transpose() * inputData;
+  PRECICE_ASSERT(Au.size() == _matrixA.cols());
+  return _qr.solve(Au);
+}
+
+Eigen::VectorXd RadialBasisFctSolver::solveConsistent(const Eigen::VectorXd &inputData) const
+{
+  PRECICE_ASSERT(inputData.size() == _matrixA.cols());
+  Eigen::VectorXd p = _qr.solve(inputData);
+  PRECICE_ASSERT(p.size() == _matrixA.cols());
+  return _matrixA * p;
+}
+
+void RadialBasisFctSolver::clear()
+{
+  _matrixA = Eigen::MatrixXd();
+  _qr      = Eigen::ColPivHouseholderQR<Eigen::MatrixXd>();
+}
+
+const Eigen::MatrixXd &RadialBasisFctSolver::getEvaluationMatrix() const
+{
+  return _matrixA;
+}
+} // namespace mapping
+} // namespace precice

--- a/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
+++ b/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
@@ -19,7 +19,7 @@ using namespace precice::mesh;
 BOOST_AUTO_TEST_SUITE(MappingTests)
 BOOST_AUTO_TEST_SUITE(LinearCellInterpolationMapping)
 
-BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
+BOOST_AUTO_TEST_CASE(Consistent)
 {
   PRECICE_TEST(1_rank);
   int dimensions = 2;
@@ -158,6 +158,71 @@ BOOST_AUTO_TEST_CASE(Conservative)
   // Check expected value, and conservation
   BOOST_CHECK(equals(expected, outValuesScalar));
   BOOST_CHECK(equals(netForce, outValuesScalar.sum()));
+}
+
+BOOST_AUTO_TEST_CASE(ConsistentOneTetra3D)
+{
+  PRECICE_TEST(1_rank);
+  int dimensions = 3;
+  using testing::equals;
+
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
+  PtrData inDataScalar   = inMesh->createData("InDataScalar", 1, 0_dataID);
+  int     inDataScalarID = inDataScalar->getID();
+
+  Vertex &inVertexA = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  Vertex &inVertexB = inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  Vertex &inVertexC = inMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  Vertex &inVertexD = inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 1.0));
+
+  inMesh->allocateDataValues();
+
+  // Create a tetra
+  inMesh->createTetrahedron(inVertexA, inVertexB, inVertexC, inVertexD);
+  // Create triangle in the plane z = 0
+  inMesh->createTriangle(inVertexA, inVertexB, inVertexC);
+  // Add edge BD to check fall-back on edge
+  inMesh->createEdge(inVertexB, inVertexD);
+
+  Eigen::VectorXd &inValuesScalar = inDataScalar->values();
+  inValuesScalar << 1.0, 2.0, 3.0, 4.0; //1 + x + 2y + 3z
+
+  BOOST_CHECK(!inMesh->tetrahedra().empty());
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
+  PtrData outDataScalar   = outMesh->createData("OutDataScalar", 1, 2_dataID);
+  int     outDataScalarID = outDataScalar->getID();
+
+  // Center and the 4 vertices (expected: average then 4 values)
+  outMesh->createVertex(Eigen::Vector3d::Constant(0.25));
+  outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  outMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  outMesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  outMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 1.0));
+  // Point below the triangle ABC -> fallback to triangle. Expected projection on triangle.
+  outMesh->createVertex(Eigen::Vector3d(1.0 / 3, 1.0 / 3, -0.1));
+  // Point close to the triangle ACD (which isn't set!).
+  // Wanted behavior: NN => 3.0. Actual behavior: 3.6 because of fall-back to edge. See issue #1304
+  outMesh->createVertex(Eigen::Vector3d(-0.1, 0.8, 0.5));
+  // Point inside the triangle BCD (not set) -> Check it is inside the tetra. Expected: 0.2*2+0.3*3+0.5*4 = 3.3
+  outMesh->createVertex(Eigen::Vector3d(0.2, 0.3, 0.5));
+  // Point on the the edge BD for fall-back. Expected: 0.4*3 + 0.6*4 = 3.6
+  outMesh->createVertex(Eigen::Vector3d(0, 0.4, 0.6));
+
+  outMesh->allocateDataValues();
+
+  // Setup mapping with mapping coordinates and geometry used
+  precice::mapping::LinearCellInterpolationMapping mapping(mapping::Mapping::CONSISTENT, dimensions);
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+  mapping.computeMapping();
+  mapping.map(inDataScalarID, outDataScalarID);
+  const Eigen::VectorXd &outValuesScalar = outDataScalar->values();
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+
+  // Check expected
+  Eigen::VectorXd expected(outMesh->vertices().size());
+  expected << 2.5, 1.0, 2.0, 3.0, 4.0, 2.0, 3.6, 3.3, 3.6;
+  BOOST_CHECK(equals(expected, outValuesScalar));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -11,6 +11,7 @@
 
 #include "Edge.hpp"
 #include "Mesh.hpp"
+#include "Tetrahedron.hpp"
 #include "Triangle.hpp"
 #include "logging/LogMacros.hpp"
 #include "math/geometry.hpp"
@@ -410,6 +411,19 @@ void Mesh::addMesh(
                    (vertexMap.count(vertexIndex2) == 1) &&
                    (vertexMap.count(vertexIndex3) == 1));
     createTriangle(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3]);
+  }
+
+  for (const Tetrahedron &tetra : deltaMesh.tetrahedra()) {
+    VertexID vertexIndex1 = tetra.vertex(0).getID();
+    VertexID vertexIndex2 = tetra.vertex(1).getID();
+    VertexID vertexIndex3 = tetra.vertex(2).getID();
+    VertexID vertexIndex4 = tetra.vertex(3).getID();
+
+    PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
+                   (vertexMap.count(vertexIndex2) == 1) &&
+                   (vertexMap.count(vertexIndex3) == 1) &&
+                   (vertexMap.count(vertexIndex4) == 1));
+    createTetrahedron(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3], *vertexMap[vertexIndex4]);
   }
   _index.clear();
 }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1036,8 +1036,8 @@ void SolverInterfaceImpl::setMeshTetrahedron(
     PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID), errorInvalidVertexID(thirdVertexID));
     PRECICE_CHECK(mesh->isValidVertexID(fourthVertexID), errorInvalidVertexID(fourthVertexID));
     mesh::Vertex &A = mesh->vertices()[firstVertexID];
-    mesh::Vertex &B = mesh->vertices()[thirdVertexID];
-    mesh::Vertex &C = mesh->vertices()[firstVertexID];
+    mesh::Vertex &B = mesh->vertices()[secondVertexID];
+    mesh::Vertex &C = mesh->vertices()[thirdVertexID];
     mesh::Vertex &D = mesh->vertices()[fourthVertexID];
 
     // Also add underlying primitives (4 triangles, 6 edges)

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -270,8 +270,17 @@ ProjectionMatch Index::findCellOrProjection(const Eigen::VectorXd &location, int
     // If no triangle is found, fall-back on NP
     return findNearestProjection(location, n);
   } else {
-    PRECICE_UNREACHABLE("Volume coupling 3D not  implemented");
-    return findTriangleProjection(location, n);
+
+    // Find correct tetra, or fall back to NP
+    auto matchedTetra = getEnclosingTetrahedra(location);
+    for (const auto &match : matchedTetra) {
+      // Matches are raw indices, not (indices, distance) pairs
+      auto polation = mapping::Polation(location, _mesh->tetrahedra()[match]);
+      if (polation.isInterpolation()) {
+        return {polation, 0.0};
+      }
+    }
+    return findNearestProjection(location, n);
   }
 }
 

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -190,6 +190,7 @@ target_sources(precice
     src/mapping/Polation.hpp
     src/mapping/RadialBasisFctBaseMapping.hpp
     src/mapping/RadialBasisFctMapping.hpp
+    src/mapping/RadialBasisFctSolver.hpp
     src/mapping/SharedPointer.hpp
     src/mapping/config/MappingConfiguration.cpp
     src/mapping/config/MappingConfiguration.hpp

--- a/src/utils/EigenHelperFunctions.cpp
+++ b/src/utils/EigenHelperFunctions.cpp
@@ -55,27 +55,5 @@ void append(
   v(n) = value;
 }
 
-Eigen::VectorXd reduceVector(
-    const Eigen::VectorXd &  fullVector,
-    const std::vector<bool> &deadAxis)
-{
-  int deadDimensions = 0;
-  int dimensions     = deadAxis.size();
-  for (int d = 0; d < dimensions; d++) {
-    if (deadAxis[d])
-      deadDimensions += 1;
-  }
-  PRECICE_ASSERT(dimensions > deadDimensions, dimensions, deadDimensions);
-  Eigen::VectorXd reducedVector(dimensions - deadDimensions);
-  int             k = 0;
-  for (int d = 0; d < dimensions; d++) {
-    if (not deadAxis[d]) {
-      reducedVector[k] = fullVector[d];
-      k++;
-    }
-  }
-  return reducedVector;
-}
-
 } // namespace utils
 } // namespace precice

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -15,9 +15,6 @@ void appendFront(Eigen::MatrixXd &A, Eigen::VectorXd &v);
 
 void removeColumnFromMatrix(Eigen::MatrixXd &A, int col);
 
-/// Deletes all dead directions from fullVector and returns a vector of reduced dimensionality.
-Eigen::VectorXd reduceVector(const Eigen::VectorXd &fullVector, const std::vector<bool> &deadAxis);
-
 void append(Eigen::VectorXd &v, double value);
 
 template <typename Derived1>

--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -170,4 +170,93 @@ void testMappingVolumeOneTriangleConservative(const std::string configFile, cons
   }
 }
 
+void testMappingVolumeOneTetra(const std::string configFile, const TestContext &context)
+{
+  using precice::testing::equals;
+
+  precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+
+  std::vector<precice::VertexID> vertexIDs;
+
+  if (context.isNamed("SolverOne")) {
+    auto meshID = interface.getMeshID("MeshOne");
+    auto dataID = interface.getDataID("DataOne", meshID);
+
+    std::vector<double> coords{0.0, 0.0, 0.0,
+                               1.0, 0.0, 0.0,
+                               0.0, 1.0, 0.0,
+                               0.0, 0.0, 1.0};
+    vertexIDs.resize(coords.size() / 3);
+
+    interface.setMeshVertices(meshID, vertexIDs.size(), coords.data(), vertexIDs.data());
+
+    BOOST_TEST(vertexIDs[0] != -1, "Vertex A is invalid");
+    BOOST_TEST(vertexIDs[1] != -1, "Vertex B is invalid");
+    BOOST_TEST(vertexIDs[2] != -1, "Vertex C is invalid");
+    BOOST_TEST(vertexIDs[3] != -1, "Vertex D is invalid");
+
+    interface.setMeshTetrahedron(meshID, vertexIDs[0], vertexIDs[1], vertexIDs[2], vertexIDs[3]);
+
+    BOOST_CHECK(interface.getMeshVertexSize(meshID) == 4);
+
+    auto &mesh = precice::testing::WhiteboxAccessor::impl(interface).mesh("MeshOne");
+    // setMeshTetrahedron currently adds underlying connectivity
+    BOOST_REQUIRE(mesh.vertices().size() == 4);
+    BOOST_REQUIRE(mesh.edges().size() == 6);
+    BOOST_REQUIRE(mesh.triangles().size() == 4);
+    BOOST_REQUIRE(mesh.tetrahedra().size() == 1);
+
+    BOOST_TEST(equals(mesh.tetrahedra()[0].getVolume(), 1.0 / 6), "Tetrahedron volume must be 1/6");
+
+    // Initialize, write data, advance and finalize
+    double dt = interface.initialize();
+    BOOST_TEST(!mesh.tetrahedra().empty(), "Tetrahedra must still be stored");
+    BOOST_TEST(interface.isCouplingOngoing(), "Sending participant must advance once.");
+
+    // Send 1 + 5x - 3y + 9z
+    std::vector<double> values{1.0, 6.0, -2.0, 8.0};
+    interface.writeBlockScalarData(dataID, 4, vertexIDs.data(), values.data());
+
+    interface.advance(dt);
+    BOOST_TEST(!interface.isCouplingOngoing(), "Sending participant must advance only once.");
+    interface.finalize();
+
+  } else {
+    auto meshID = interface.getMeshID("MeshTwo");
+    auto dataID = interface.getDataID("DataOne", meshID);
+
+    std::vector<double> coords{0.25, 0.25, 0.25};
+    vertexIDs.resize(coords.size() / 2);
+
+    interface.setMeshVertices(meshID, vertexIDs.size(), coords.data(), vertexIDs.data());
+
+    // Initialize, read data, advance and finalize. Check expected mapping
+    double dt = interface.initialize();
+    BOOST_TEST(interface.isCouplingOngoing(), "Receiving participant must advance once.");
+
+    // If "read" mapping, check received mesh, including connectivity
+    if (precice::testing::WhiteboxAccessor::impl(interface).hasMesh("MeshOne")) {
+      auto &mesh = precice::testing::WhiteboxAccessor::impl(interface).mesh("MeshOne");
+      BOOST_CHECK(mesh.vertices().size() == 4);
+      BOOST_CHECK(mesh.edges().size() == 6);
+      BOOST_CHECK(mesh.triangles().size() == 4);
+      BOOST_CHECK(mesh.tetrahedra().size() == 1);
+    }
+
+    interface.advance(dt);
+    BOOST_TEST(!interface.isCouplingOngoing(), "Receiving participant must advance only once.");
+
+    //Check expected VS read
+    Eigen::VectorXd expected(1);
+    Eigen::VectorXd readData(1);
+    // Expected value in the middle of the tetra is the average of inputs (13.0/4)
+    expected << 13.0 / 4;
+
+    interface.readBlockScalarData(dataID, expected.size(), vertexIDs.data(), readData.data());
+    BOOST_CHECK(equals(expected, readData));
+
+    interface.finalize();
+  }
+}
+
 #endif

--- a/tests/serial/mapping-volume/helpers.hpp
+++ b/tests/serial/mapping-volume/helpers.hpp
@@ -9,5 +9,7 @@ using precice::testing::TestContext;
 
 void testMappingVolumeOneTriangle(const std::string configFile, const TestContext &context);
 void testMappingVolumeOneTriangleConservative(const std::string configFile, const TestContext &context);
+void testMappingVolumeOneTetra(const std::string configFile, const TestContext &context);
+void testMappingVolumeOneTetraConservative(const std::string configFile, const TestContext &context);
 
 #endif

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -115,6 +115,8 @@ target_sources(testprecice
     tests/serial/mapping-scaled-consistent/helpers.hpp
     tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.cpp
     tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.cpp
+    tests/serial/mapping-volume/OneTetraRead.cpp
+    tests/serial/mapping-volume/OneTetraWrite.cpp
     tests/serial/mapping-volume/OneTriangleConservativeRead.cpp
     tests/serial/mapping-volume/OneTriangleConservativeWrite.cpp
     tests/serial/mapping-volume/OneTriangleRead.cpp


### PR DESCRIPTION
## Main changes of this PR

Now that preCICE includes tetrahedra and the required indexing routines, we can extend LCI mapping for volumetric coupling in 3D simulations

## Motivation and additional information

Part of #468 
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
