### PR TITLE
Handle tetrahedra in partitioning

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -11,6 +11,7 @@
 
 #include "Edge.hpp"
 #include "Mesh.hpp"
+#include "Tetrahedron.hpp"
 #include "Triangle.hpp"
 #include "logging/LogMacros.hpp"
 #include "math/geometry.hpp"
@@ -410,6 +411,19 @@ void Mesh::addMesh(
                    (vertexMap.count(vertexIndex2) == 1) &&
                    (vertexMap.count(vertexIndex3) == 1));
     createTriangle(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3]);
+  }
+
+  for (const Tetrahedron &tetra : deltaMesh.tetrahedra()) {
+    VertexID vertexIndex1 = tetra.vertex(0).getID();
+    VertexID vertexIndex2 = tetra.vertex(1).getID();
+    VertexID vertexIndex3 = tetra.vertex(2).getID();
+    VertexID vertexIndex4 = tetra.vertex(3).getID();
+
+    PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
+                   (vertexMap.count(vertexIndex2) == 1) &&
+                   (vertexMap.count(vertexIndex3) == 1) &&
+                   (vertexMap.count(vertexIndex4) == 1));
+    createTetrahedron(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3], *vertexMap[vertexIndex4]);
   }
   _index.clear();
 }

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -857,8 +857,6 @@ BOOST_AUTO_TEST_CASE(AddMesh)
   subMesh->createEdge(v14, v15);
   subMesh->createTriangle(v11, v13, v15);
   subMesh->createTriangle(v11, v13, v14);
-
-  subMesh->createTetrahedron(v01, v02, v03, v04);
   subMesh->createTetrahedron(v11, v12, v13, v14);
   subMesh->createTetrahedron(v15, v12, v13, v14);
 

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -829,5 +829,45 @@ BOOST_FIXTURE_TEST_CASE(Integrate3DVectorDataVolume, OneTetraFixture)
 
 BOOST_AUTO_TEST_SUITE_END() // VolumeIntegrals
 
+BOOST_AUTO_TEST_CASE(AddMesh)
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh globalMesh = std::make_shared<Mesh>("Mesh1", 3, testing::nextMeshID());
+  PtrMesh subMesh    = std::make_shared<Mesh>("Mesh2", 3, testing::nextMeshID());
+
+  // Fill globalMesh, then subMesh, then add and check the result is the sul
+  auto &v01 = globalMesh->createVertex(Eigen::Vector3d{0.0, 0.0, 0.0});
+  auto &v02 = globalMesh->createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
+  auto &v03 = globalMesh->createVertex(Eigen::Vector3d{0.0, 1.0, 0.0});
+  auto &v04 = globalMesh->createVertex(Eigen::Vector3d{0.0, 0.0, 1.0});
+
+  // Add some elements of all kind to global
+  globalMesh->createEdge(v01, v02);
+  globalMesh->createTriangle(v01, v02, v03);
+  globalMesh->createTetrahedron(v01, v02, v03, v04);
+
+  auto &v11 = subMesh->createVertex(Eigen::Vector3d{0.0, 0.0, 0.0});
+  auto &v12 = subMesh->createVertex(Eigen::Vector3d{2.0, 0.0, 0.0});
+  auto &v13 = subMesh->createVertex(Eigen::Vector3d{0.0, 4.0, 0.0});
+  auto &v14 = subMesh->createVertex(Eigen::Vector3d{0.0, 0.0, 3.0});
+  auto &v15 = subMesh->createVertex(Eigen::Vector3d{5.0, 0.0, 1.0});
+
+  // Add some elements of all kind to sub mesh
+  subMesh->createEdge(v11, v12);
+  subMesh->createEdge(v14, v15);
+  subMesh->createTriangle(v11, v13, v15);
+  subMesh->createTriangle(v11, v13, v14);
+
+  subMesh->createTetrahedron(v01, v02, v03, v04);
+  subMesh->createTetrahedron(v11, v12, v13, v14);
+  subMesh->createTetrahedron(v15, v12, v13, v14);
+
+  globalMesh->addMesh(*subMesh);
+  BOOST_TEST(globalMesh->vertices().size() == 9);
+  BOOST_TEST(globalMesh->edges().size() == 3);
+  BOOST_TEST(globalMesh->triangles().size() == 3);
+  BOOST_TEST(globalMesh->tetrahedra().size() == 3);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Mesh
 BOOST_AUTO_TEST_SUITE_END() // Mesh


### PR DESCRIPTION
## Main changes of this PR

Followup of https://github.com/precice/precice/pull/1325. Tetrahedra weren't added when gathering meshes.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
