### PR TITLE
Add default interface for BSD flavors

### DIFF
--- a/docs/changelog/1332.md
+++ b/docs/changelog/1332.md
@@ -1,0 +1,1 @@
+- Added default network interface for BSD-flavored operating systems.

--- a/src/utils/networking.cpp
+++ b/src/utils/networking.cpp
@@ -8,7 +8,7 @@ std::string loopbackInterfaceName()
 {
 #if defined(__linux__)
   return "lo";
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(BSD)
   return "lo0";
 #elif defined(__WIN32)
   // Not required as we directly use the 127.0.0.1 under Windows


### PR DESCRIPTION
## Main changes of this PR

This PR adds `lo0` as the default network interface for BSD flavoured OSes.

## Motivation and additional information

Related to #1331

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
