### PR TITLE
Added tolerance to isInterpolation check

### DIFF
--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -1,5 +1,6 @@
 #include "mapping/Polation.hpp"
 #include "math/barycenter.hpp"
+#include "math/differences.hpp"
 
 namespace precice {
 namespace mapping {

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -70,7 +70,7 @@ const std::vector<WeightedElement> &Polation::getWeightedElements() const
 
 bool Polation::isInterpolation() const
 {
-  return std::all_of(_weightedElements.begin(), _weightedElements.end(), [tol](const mapping::WeightedElement &elem) { return precice::math::greaterEquals(elem.weight, 0.0); });
+  return std::all_of(_weightedElements.begin(), _weightedElements.end(), [](const mapping::WeightedElement &elem) { return precice::math::greaterEquals(elem.weight, 0.0); });
 }
 
 std::ostream &operator<<(std::ostream &os, const WeightedElement &w)

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -68,9 +68,9 @@ const std::vector<WeightedElement> &Polation::getWeightedElements() const
   return _weightedElements;
 }
 
-bool Polation::isInterpolation(double tol) const
+bool Polation::isInterpolation() const
 {
-  return std::all_of(_weightedElements.begin(), _weightedElements.end(), [tol](const mapping::WeightedElement &elem) { return precice::math::greaterEquals(elem.weight, 0.0, tol); });
+  return std::all_of(_weightedElements.begin(), _weightedElements.end(), [tol](const mapping::WeightedElement &elem) { return precice::math::greaterEquals(elem.weight, 0.0); });
 }
 
 std::ostream &operator<<(std::ostream &os, const WeightedElement &w)

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -68,9 +68,9 @@ const std::vector<WeightedElement> &Polation::getWeightedElements() const
   return _weightedElements;
 }
 
-bool Polation::isInterpolation() const
+bool Polation::isInterpolation(double tol) const
 {
-  return std::all_of(_weightedElements.begin(), _weightedElements.end(), [](const mapping::WeightedElement &elem) { return elem.weight >= 0.0; });
+  return std::all_of(_weightedElements.begin(), _weightedElements.end(), [tol](const mapping::WeightedElement &elem) { return precice::math::greaterEquals(elem.weight, 0.0, tol); });
 }
 
 std::ostream &operator<<(std::ostream &os, const WeightedElement &w)

--- a/src/mapping/Polation.hpp
+++ b/src/mapping/Polation.hpp
@@ -3,6 +3,7 @@
 #include <iosfwd>
 #include <vector>
 #include "Eigen/Core"
+#include "math/differences.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Tetrahedron.hpp"
 #include "mesh/Triangle.hpp"
@@ -39,7 +40,7 @@ public:
   const std::vector<WeightedElement> &getWeightedElements() const;
 
   /// Check whether all the weights are positive, which means it is interpolation
-  bool isInterpolation() const;
+  bool isInterpolation(double tol = math::NUMERICAL_ZERO_DIFFERENCE) const;
 
 private:
   std::vector<WeightedElement> _weightedElements;

--- a/src/mapping/Polation.hpp
+++ b/src/mapping/Polation.hpp
@@ -3,7 +3,6 @@
 #include <iosfwd>
 #include <vector>
 #include "Eigen/Core"
-#include "math/differences.hpp"
 #include "mesh/Edge.hpp"
 #include "mesh/Tetrahedron.hpp"
 #include "mesh/Triangle.hpp"

--- a/src/mapping/Polation.hpp
+++ b/src/mapping/Polation.hpp
@@ -40,7 +40,7 @@ public:
   const std::vector<WeightedElement> &getWeightedElements() const;
 
   /// Check whether all the weights are positive, which means it is interpolation
-  bool isInterpolation(double tol = math::NUMERICAL_ZERO_DIFFERENCE) const;
+  bool isInterpolation() const;
 
 private:
   std::vector<WeightedElement> _weightedElements;

--- a/src/mapping/tests/PolationTest.cpp
+++ b/src/mapping/tests/PolationTest.cpp
@@ -190,5 +190,53 @@ BOOST_AUTO_TEST_CASE(TetrahedronExtrapolation)
   }
 }
 
+BOOST_AUTO_TEST_CASE(PolationToleranceEdge)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex v1(Eigen::Vector3d(1.0, 0.0, 0.0), 0);
+  mesh::Vertex v2(Eigen::Vector3d(0.0, 1.0, 0.0), 1);
+
+  mesh::Edge edge(v1, v2, 0);
+
+  Eigen::Vector3d location(1 + 1e-15, -1e-16, 0.0);
+
+  Polation polation(location, edge);
+
+  BOOST_TEST(polation.isInterpolation());
+}
+
+BOOST_AUTO_TEST_CASE(PolationToleranceTriangle)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex v1(Eigen::Vector3d(1.0, 0.0, 0.0), 0);
+  mesh::Vertex v2(Eigen::Vector3d(0.0, 1.0, 0.0), 1);
+  mesh::Vertex v3(Eigen::Vector3d(0.0, 0.0, 0.0), 2);
+
+  mesh::Triangle triangle(v1, v2, v3, 0);
+
+  Eigen::Vector3d location(0.5 + 1e-15, 0.5 + 1e-15, 1e-14);
+
+  Polation polation(location, triangle);
+
+  BOOST_TEST(polation.isInterpolation());
+}
+
+BOOST_AUTO_TEST_CASE(PolationToleranceTetra)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex v1(Eigen::Vector3d(1.0, 0.0, 0.0), 0);
+  mesh::Vertex v2(Eigen::Vector3d(0.0, 1.0, 0.0), 1);
+  mesh::Vertex v3(Eigen::Vector3d(0.0, 0.0, 1.0), 2);
+  mesh::Vertex v4(Eigen::Vector3d(0.0, 0.0, 0.0), 3);
+
+  mesh::Tetrahedron tetra(v1, v2, v3, v4, 0);
+
+  Eigen::Vector3d location(1 - 1e-15, -1e-15, -1e-15);
+
+  Polation polation(location, tetra);
+
+  BOOST_TEST(polation.isInterpolation());
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Interpolation
 BOOST_AUTO_TEST_SUITE_END() // Mapping


### PR DESCRIPTION
## Main changes of this PR
In Barycentric mappings (NP and Linear Cell Interpolation) we check that the coefficients of an interpolation are positive (because if they're not, it's act `x >= 0` statement. This is replaced by a check with tolerance to avoid bad behavior when a coefficient is close to zero.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
