### PR TITLE
Improve basis function implementation

### DIFF
--- a/docs/changelog/1338.md
+++ b/docs/changelog/1338.md
@@ -1,0 +1,1 @@
+- Improved the basis function implementaiton of RBF mappings for faster evaluations.

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -38,7 +38,7 @@ class ThinPlateSplines : public NoCompactSupportBase {
 public:
   inline double evaluate(double radius) const
   {
-    return std::log(std::max(radius, 1e-14)) * math::pow_int<2>(radius);
+    return std::log(std::max(radius, math::NUMERICAL_ZERO_DIFFERENCE)) * math::pow_int<2>(radius);
   }
 };
 
@@ -189,7 +189,7 @@ public:
     double const p = radius * _r_inv;
     if (p >= 1)
       return 0.0;
-    return 1.0 - 30.0 * math::pow_int<2>(p) - 10.0 * math::pow_int<3>(p) + 45.0 * math::pow_int<4>(p) - 6.0 * math::pow_int<5>(p) - math::pow_int<3>(p) * 60.0 * std::log(std::max(p, 1e-15));
+    return 1.0 - 30.0 * math::pow_int<2>(p) - 10.0 * math::pow_int<3>(p) + 45.0 * math::pow_int<4>(p) - 6.0 * math::pow_int<5>(p) - math::pow_int<3>(p) * 60.0 * std::log(std::max(p, math::NUMERICAL_ZERO_DIFFERENCE));
   }
 
 private:

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -36,13 +36,9 @@ struct NoCompactSupportBase {
  */
 class ThinPlateSplines : public NoCompactSupportBase {
 public:
-  double evaluate(double radius) const
+  inline double evaluate(double radius) const
   {
-    double result = 0.0;
-    if (math::greater(radius, 0.0)) {
-      result = std::log(radius) * std::pow(radius, 2);
-    }
-    return result;
+    return std::log(std::max(radius, 1e-14)) * math::pow_int<2>(radius);
   }
 };
 
@@ -58,9 +54,9 @@ public:
   explicit Multiquadrics(double c)
       : _cPow2(std::pow(c, 2)) {}
 
-  double evaluate(double radius) const
+  inline double evaluate(double radius) const
   {
-    return std::sqrt(_cPow2 + std::pow(radius, 2));
+    return std::sqrt(_cPow2 + math::pow_int<2>(radius));
   }
 
 private:
@@ -84,9 +80,9 @@ public:
                   "Shape parameter for radial-basis-function inverse multiquadric has to be larger than zero. Please update the \"shape-parameter\" attribute.");
   }
 
-  double evaluate(double radius) const
+  inline double evaluate(double radius) const
   {
-    return 1.0 / std::sqrt(_cPow2 + std::pow(radius, 2));
+    return 1.0 / std::sqrt(_cPow2 + math::pow_int<2>(radius));
   }
 
 private:
@@ -104,7 +100,7 @@ private:
  */
 class VolumeSplines : public NoCompactSupportBase {
 public:
-  double evaluate(double radius) const
+  inline double evaluate(double radius) const
   {
     return std::abs(radius);
   }
@@ -141,12 +137,12 @@ public:
     return _supportRadius;
   }
 
-  double evaluate(const double radius) const
+  inline double evaluate(const double radius) const
   {
     if (radius > _supportRadius)
       return 0.0;
     else
-      return std::exp(-std::pow(_shape * radius, 2.0)) - _deltaY;
+      return std::exp(-math::pow_int<2>(_shape * radius)) - _deltaY;
   }
 
   /// Below that value the function is supposed to be zero. Defines the support radius if not explicitely given
@@ -177,31 +173,29 @@ private:
 class CompactThinPlateSplinesC2 : public CompactSupportBase {
 public:
   explicit CompactThinPlateSplinesC2(double supportRadius)
-      : _r(supportRadius)
   {
-    PRECICE_CHECK(math::greater(_r, 0.0),
+    PRECICE_CHECK(math::greater(supportRadius, 0.0),
                   "Support radius for radial-basis-function compact thin-plate-splines c2 has to be larger than zero. Please update the \"support-radius\" attribute.");
+    _r_inv = 1. / supportRadius;
   }
 
   double getSupportRadius() const
   {
-    return _r;
+    return 1. / _r_inv;
   }
 
-  double evaluate(double radius) const
+  inline double evaluate(double radius) const
   {
-    if (radius >= _r)
+    double const p = radius * _r_inv;
+    if (p >= 1)
       return 0.0;
-    double const p = radius / _r;
-    using std::log;
-    using std::pow;
-    return 1.0 - 30.0 * pow(p, 2.0) - 10.0 * pow(p, 3.0) + 45.0 * pow(p, 4.0) - 6.0 * pow(p, 5.0) - 60.0 * log(pow(p, pow(p, 3.0)));
+    return 1.0 - 30.0 * math::pow_int<2>(p) - 10.0 * math::pow_int<3>(p) + 45.0 * math::pow_int<4>(p) - 6.0 * math::pow_int<5>(p) - math::pow_int<3>(p) * 60.0 * std::log(std::max(p, 1e-15));
   }
 
 private:
   logging::Logger _log{"mapping::CompactThinPlateSplinesC2"};
 
-  double const _r;
+  double _r_inv;
 };
 
 /**
@@ -217,28 +211,29 @@ private:
 class CompactPolynomialC0 : public CompactSupportBase {
 public:
   explicit CompactPolynomialC0(double supportRadius)
-      : _r(supportRadius)
   {
-    PRECICE_CHECK(math::greater(_r, 0.0),
+    PRECICE_CHECK(math::greater(supportRadius, 0.0),
                   "Support radius for radial-basis-function compact polynomial c0 has to be larger than zero. Please update the \"support-radius\" attribute.");
+    _r_inv = 1. / supportRadius;
   }
 
   double getSupportRadius() const
   {
-    return _r;
+    return 1. / _r_inv;
   }
 
-  double evaluate(double radius) const
+  inline double evaluate(double radius) const
   {
-    if (radius >= _r)
+    double p = radius * _r_inv;
+    if (p >= 1)
       return 0.0;
-    return std::pow(1.0 - radius / _r, 2.0);
+    return math::pow_int<2>(1.0 - p);
   }
 
 private:
   logging::Logger _log{"mapping::CompactPolynomialC0"};
 
-  double const _r;
+  double _r_inv;
 };
 
 /**
@@ -254,30 +249,30 @@ private:
 class CompactPolynomialC6 : public CompactSupportBase {
 public:
   explicit CompactPolynomialC6(double supportRadius)
-      : _r(supportRadius)
   {
-    PRECICE_CHECK(math::greater(_r, 0.0),
+    PRECICE_CHECK(math::greater(supportRadius, 0.0),
                   "Support radius for radial-basis-function compact polynomial c6 has to be larger than zero. Please update the \"support-radius\" attribute.");
+
+    _r_inv = 1. / supportRadius;
   }
 
   double getSupportRadius() const
   {
-    return _r;
+    return 1. / _r_inv;
   }
 
-  double evaluate(double radius) const
+  inline double evaluate(double radius) const
   {
-    if (radius >= _r)
+    double p = radius * _r_inv;
+    if (p >= 1)
       return 0.0;
-    double p = radius / _r;
-    using std::pow;
-    return pow(1.0 - p, 8.0) * (32.0 * pow(p, 3.0) + 25.0 * pow(p, 2.0) + 8.0 * p + 1.0);
+    return math::pow_int<8>(1.0 - p) * (32.0 * math::pow_int<3>(p) + 25.0 * math::pow_int<2>(p) + 8.0 * p + 1.0);
   }
 
 private:
   logging::Logger _log{"mapping::CompactPolynomialC6"};
 
-  double const _r;
+  double _r_inv;
 };
 
 } // namespace mapping

--- a/src/math/math.hpp
+++ b/src/math/math.hpp
@@ -18,5 +18,18 @@ inline int sign(double number)
   return 0;
 }
 
+/// Computes the power of an integer (x^iexp) using recursion, which is much faster than std::pow(x, iexp)
+template <int iexp, typename T>
+inline constexpr T pow_int(const T x)
+{
+  static_assert(iexp >= 0, "Exponent must be an integer greater zero.");
+
+  if (iexp == 0)
+    return static_cast<T>(1.);
+  else
+    // exponentiation by squaring
+    return ((iexp % 2 == 1) ? x * pow_int<iexp / 2>(x * x) : pow_int<iexp / 2>(x * x));
+}
+
 } // namespace math
 } // namespace precice

--- a/src/math/math.hpp
+++ b/src/math/math.hpp
@@ -18,11 +18,11 @@ inline int sign(double number)
   return 0;
 }
 
-/// Computes the power of an integer (x^iexp) using recursion, which is much faster than std::pow(x, iexp)
+/// Computes the power of a given number by an integral exponent given at compile time, which is much faster than std::pow(x, iexp)
 template <int iexp, typename T>
 inline constexpr T pow_int(const T x)
 {
-  static_assert(iexp >= 0, "Exponent must be an integer greater zero.");
+  static_assert(iexp >= 0, "Exponent must be an integer greater or equal to zero.");
 
   if (iexp == 0)
     return static_cast<T>(1.);

--- a/src/math/tests/MathTest.cpp
+++ b/src/math/tests/MathTest.cpp
@@ -1,0 +1,17 @@
+#include "logging/LogMacros.hpp"
+#include "logging/Logger.hpp"
+#include "math/math.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(MathTests)
+
+BOOST_AUTO_TEST_CASE(IntegerExponent)
+{
+  PRECICE_TEST(1_rank);
+  BOOST_TEST(math::pow_int<4>(4.2) == std::pow(4.2, 4));
+  BOOST_TEST(math::pow_int<3>(7.2) == std::pow(7.2, 3));
+}
+BOOST_AUTO_TEST_SUITE_END() // Math

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -49,6 +49,7 @@ target_sources(testprecice
     src/math/tests/BarycenterTest.cpp
     src/math/tests/DifferencesTest.cpp
     src/math/tests/GeometryTest.cpp
+    src/math/tests/MathTest.cpp
     src/mesh/tests/BoundingBoxTest.cpp
     src/mesh/tests/DataConfigurationTest.cpp
     src/mesh/tests/EdgeTest.cpp


### PR DESCRIPTION
## Main changes of this PR
Switches the basis function implementation from using `std::pow` to a pow variant relying on recursion.

## Motivation and additional information
The main problem is that `std::pow` operates on a `double` exponent (there is no `int` variant), but we use it in the basis function implementation only for integer exponents. The basis function evaluation routine is heavily performance critical. With the changes here, we get a considerable performance gain in both RBF implementations (Eigen and PETSc). Here some timings for the (expensive) computation of matrix A as well as the overall mapping computation:

[result-asmA.pdf](https://github.com/precice/precice/files/8966071/result-asmA.pdf)

[result-computet.pdf](https://github.com/precice/precice/files/8966064/result-computet.pdf)

Example: For the c6 Wendland RBF, we see a speed-up of ~4.

Also related to #1320 

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
