### PR TITLE
Make areas of triangles positive in 2D + Removed dead code

### DIFF
--- a/src/math/geometry.cpp
+++ b/src/math/geometry.cpp
@@ -15,71 +15,6 @@ namespace geometry {
 
 logging::Logger _log("math::geometry");
 
-bool segmentsIntersect(
-    const Eigen::Ref<const Eigen::Vector2d> &a,
-    const Eigen::Ref<const Eigen::Vector2d> &b,
-    const Eigen::Ref<const Eigen::Vector2d> &c,
-    const Eigen::Ref<const Eigen::Vector2d> &d,
-    bool                                     countTouchingAsIntersection)
-{
-  PRECICE_ASSERT(a.size() == 2, a.size());
-  PRECICE_ASSERT(b.size() == 2, b.size());
-  PRECICE_ASSERT(c.size() == 2, c.size());
-  PRECICE_ASSERT(d.size() == 2, d.size());
-
-  if (countTouchingAsIntersection) {
-    if (between(a, b, c)) {
-      return true;
-    } else if (between(a, b, d)) {
-      return true;
-    } else if (between(c, d, a)) {
-      return true;
-    } else if (between(c, d, b)) {
-      return true;
-    }
-  }
-
-  double abc = triangleArea(a, b, c);
-  double abd = triangleArea(a, b, d);
-  double cda = triangleArea(c, d, a);
-  double cdb = triangleArea(c, d, b);
-
-  double circABC = (a - b).norm() + (b - c).norm() + (c - a).norm();
-  double circABD = (a - b).norm() + (b - d).norm() + (d - a).norm();
-  double circCDA = (c - d).norm() + (d - a).norm() + (a - c).norm();
-  double circCDB = (c - d).norm() + (d - b).norm() + (b - c).norm();
-
-  abc /= circABC;
-  abd /= circABD;
-  cda /= circCDA;
-  cdb /= circCDB;
-
-  // Check, if one point lies on line defined by segment and the other not (-> xor).
-  // If true, either one point is between, which means the segments are
-  // touching only, or the segments are neither touching nor intersecting
-  // (-> false). This case of touching segments is detected in the beginning
-  // of this function, if countTouchingAsIntersection is true. Otherwise,
-  // it should not be counted (-> false).
-  using utils::xOR;
-
-  if (xOR(std::abs(abc) <= math::NUMERICAL_ZERO_DIFFERENCE,
-          std::abs(abd) <= math::NUMERICAL_ZERO_DIFFERENCE)) {
-    return false;
-  }
-  if (xOR(std::abs(cda) <= math::NUMERICAL_ZERO_DIFFERENCE,
-          std::abs(cdb) <= math::NUMERICAL_ZERO_DIFFERENCE)) {
-    return false;
-  }
-
-  // Check, whether the segments are intersecting in the real sense.
-  bool isFirstSegmentBetween  = xOR(abc > -math::NUMERICAL_ZERO_DIFFERENCE,
-                                   abd > -math::NUMERICAL_ZERO_DIFFERENCE);
-  bool isSecondSegmentBetween = xOR(cda > -math::NUMERICAL_ZERO_DIFFERENCE,
-                                    cdb > -math::NUMERICAL_ZERO_DIFFERENCE);
-
-  return isFirstSegmentBetween && isSecondSegmentBetween;
-}
-
 bool lineIntersection(
     const Eigen::Ref<const Eigen::Vector2d> &a,
     const Eigen::Ref<const Eigen::Vector2d> &b,
@@ -169,7 +104,7 @@ double triangleArea(
     A -= a;
     Eigen::Vector2d B = c;
     B -= a;
-    return 0.5 * (A(0) * B(1) - A(1) * B(0));
+    return 0.5 * std::fabs(A(0) * B(1) - A(1) * B(0));
   } else {
     PRECICE_ASSERT(a.size() == 3, a.size());
     Eigen::Vector3d A = b;
@@ -205,47 +140,6 @@ Eigen::Vector2d projectVector(
     reducedDim++;
   }
   return projectedVector;
-}
-
-int containedInTriangle(
-    const Eigen::Vector2d &triangleVertex0,
-    const Eigen::Vector2d &triangleVertex1,
-    const Eigen::Vector2d &triangleVertex2,
-    const Eigen::Vector2d &testPoint)
-{
-  double area0 = triangleArea(triangleVertex0, triangleVertex1, testPoint);
-  double area1 = triangleArea(triangleVertex1, triangleVertex2, testPoint);
-  double area2 = triangleArea(triangleVertex2, triangleVertex0, testPoint);
-
-  double length01 = (triangleVertex0 - triangleVertex1).norm();
-  double length12 = (triangleVertex1 - triangleVertex2).norm();
-  double length20 = (triangleVertex2 - triangleVertex0).norm();
-  double length1t = (triangleVertex1 - testPoint).norm();
-  double length2t = (triangleVertex2 - testPoint).norm();
-  double length0t = (triangleVertex0 - testPoint).norm();
-  double scale0   = length01 + length1t + length0t;
-  double scale1   = length12 + length2t + length1t;
-  double scale2   = length20 + length0t + length2t;
-  area0 /= scale0;
-  area1 /= scale1;
-  area2 /= scale2;
-
-  int sign0       = math::sign(area0);
-  int sign1       = math::sign(area1);
-  int sign2       = math::sign(area2);
-  int absSumSigns = std::abs(sign0 + sign1 + sign2);
-  if (absSumSigns == 3) {
-    // In triangle
-    return CONTAINED;
-  } else if (absSumSigns == 2) {
-    // On triangle edge
-    return TOUCHING;
-  } else if (std::abs(sign0) + std::abs(sign1) + std::abs(sign2) == 1) {
-    // On triangle vertex
-    return TOUCHING;
-  }
-  // Outside of triangle
-  return NOT_CONTAINED;
 }
 
 ConvexityResult isConvexQuad(std::array<Eigen::VectorXd, 4> coords)

--- a/src/math/geometry.hpp
+++ b/src/math/geometry.hpp
@@ -20,31 +20,6 @@ enum ResultConstants {
 };
 
 /**
- * @brief Determines, if to line segments intersect properly or improperly
- *
- * Works only for Dim2.
- * The method first checks, if one of the segment end points lies on the
- * other segment. If yes, this is improper intersection, and considered
- * to be valid.
- * Then, it checks, if it is true for both segments, that one point of
- * the other segment lies right of the segment and the other point left
- * of it. Then, the segments do intersect each other properly.
- *
- * @param[in] a First point of line segment 1
- * @param[in] b Second point of line segment 1
- * @param[in] c First point of line segment 2
- * @param[in] d Second point of line segment 2
- *
- * @return True, if interseting. False, otherwise
- */
-bool segmentsIntersect(
-    const Eigen::Ref<const Eigen::Vector2d> &a,
-    const Eigen::Ref<const Eigen::Vector2d> &b,
-    const Eigen::Ref<const Eigen::Vector2d> &c,
-    const Eigen::Ref<const Eigen::Vector2d> &d,
-    bool                                     countTouchingAsIntersection);
-
-/**
  * @brief Determines the intersection point of two lines, if one exists.
  *
  * Works only for Dim2.
@@ -155,20 +130,6 @@ double tetraVolume(
 Eigen::Vector2d projectVector(
     const Eigen::Vector3d &vector,
     const int              indexDimensionToRemove);
-
-/**
- * @brief Tests if a vertex is contained in a triangle.
- *
- * @return One of:
- *         - CONTAINED
- *         - NOT_CONTAINED
- *         - TOUCHING
- */
-int containedInTriangle(
-    const Eigen::Vector2d &triangleVertex0,
-    const Eigen::Vector2d &triangleVertex1,
-    const Eigen::Vector2d &triangleVertex2,
-    const Eigen::Vector2d &testPoint);
 
 /**
  * @brief Tests, if a vertex is contained in a hyperrectangle.

--- a/src/math/tests/GeometryTest.cpp
+++ b/src/math/tests/GeometryTest.cpp
@@ -104,7 +104,8 @@ BOOST_AUTO_TEST_CASE(TriangleArea)
     b << 0.0, 1.0;
     c << 1.0, 0.0;
     area = geometry::triangleArea(a, b, c);
-    BOOST_TEST(area == -0.5);
+    // Areas are not signed.
+    BOOST_TEST(area == 0.5);
   }
   { // 3D
     Eigen::Vector3d a, b, c;
@@ -115,32 +116,6 @@ BOOST_AUTO_TEST_CASE(TriangleArea)
     area = geometry::triangleArea(a, b, c);
     BOOST_CHECK(area == 0.5 * sqrt(2.0));
   }
-}
-
-BOOST_AUTO_TEST_CASE(SegmentsIntersect)
-{
-  PRECICE_TEST(1_rank);
-  Eigen::Vector2d a(0, 0), b(1, 0), c(0.5, 0), d(0, 0.5);
-  BOOST_CHECK(geometry::segmentsIntersect(a, b, c, d, true));
-  BOOST_CHECK(!geometry::segmentsIntersect(a, b, c, d, false));
-
-  c(1) = -0.2;
-  BOOST_CHECK(geometry::segmentsIntersect(a, b, c, d, false));
-
-  // Test case motivated from bug
-  a << 0.23104429, 1.87753905;
-  b << 0.22608634, 1.88114120;
-  c << 0.23058985, 1.87733882;
-  d << 0.23058985, 1.87846349;
-  BOOST_CHECK(geometry::segmentsIntersect(a, b, c, d, false));
-
-  // Another bug motivated test, T-intersection slightly above numerical accuracy
-  a << 1.0, 1.0;
-  b << 0.0, 1.0;
-  c << 1.0 - (10.0 * NUMERICAL_ZERO_DIFFERENCE), 1.1;
-  d << 1.0 - (10.0 * NUMERICAL_ZERO_DIFFERENCE), 0.9;
-  BOOST_CHECK(geometry::segmentsIntersect(a, b, c, d, false));
-  BOOST_CHECK(geometry::segmentsIntersect(c, d, a, b, false));
 }
 
 BOOST_AUTO_TEST_CASE(SegmentPlaneIntersection)
@@ -233,64 +208,6 @@ BOOST_AUTO_TEST_CASE(ProjectVector)
   vector2D = geometry::projectVector(vector3D, 0);
   vectorExpected << 2.0, 3.0;
   BOOST_CHECK(equals(vector2D, vectorExpected));
-}
-
-BOOST_AUTO_TEST_CASE(ContainedInTriangle)
-{
-  PRECICE_TEST(1_rank);
-  Eigen::Vector2d triangleVertex0(0.0, 0.0);
-  Eigen::Vector2d triangleVertex1(1.0, 0.0);
-  Eigen::Vector2d triangleVertex2(0.0, 1.0);
-  Eigen::Vector2d point(0.25, 0.25);
-
-  // Contained point
-  int result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::CONTAINED);
-
-  // Not contained points
-  point << -1.0, -1.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::NOT_CONTAINED);
-  point << 1.0, 1.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::NOT_CONTAINED);
-  point << 2.0, 0.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::NOT_CONTAINED);
-  point << 0.0, 2.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::NOT_CONTAINED);
-
-  // Touching points
-  point << 0.0, 0.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::TOUCHING);
-  point << 1.0, 0.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::TOUCHING);
-  point << 0.0, 1.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::TOUCHING);
-  point << 0.5, 0.0;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::TOUCHING);
-  point << 0.0, 0.5;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::TOUCHING);
-  point << 0.5, 0.5;
-  result = geometry::containedInTriangle(
-      triangleVertex0, triangleVertex1, triangleVertex2, point);
-  BOOST_TEST(result == geometry::TOUCHING);
 }
 
 BOOST_AUTO_TEST_CASE(ContainedInHyperrectangle)


### PR DESCRIPTION
## Main changes of this PR

Previously, `Triangle::getArea()` had a different behavior depending on the dimension: in 2D it returns a signed area (depending on the ordering of vertices) but a positive area in 3D. This breaks computations of volumetric integrals (https://github.com/precice/precice/pull/1317), and seems to be legacy code, as this signed are was never used (since there were no 2D triangles before!)
Now, this area is positive. It breaks unit tests of unused functions, so these tests & relevant functions have been removed too.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
