### PR TITLE
Extend warning about MPI ports with OpenMPI

### DIFF
--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -181,7 +181,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
                     "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
 #ifdef OMPI_MAJOR_VERSION
-      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:mpi-multiple-ports />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.");
+      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:mpi-multiple-ports />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems. Ignore this warning if participants find each other and the simulation starts.");
 #endif
       comFactory = std::make_shared<com::MPIPortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
@@ -197,7 +197,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
                     tagName);
 #else
 #ifdef OMPI_MAJOR_VERSION
-      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:{} />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems.", tagName);
+      PRECICE_WARN("preCICE was compiled with OpenMPI and configured to use <m2n:{} />, which can cause issues in connection build-up. Consider switching to sockets if you encounter problems. Ignore this warning if participants find each other and the simulation starts.", tagName);
 #endif
       comFactory = std::make_shared<com::MPISinglePortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();


### PR DESCRIPTION
## Main changes of this PR


## Motivation and additional information

It looks like the warning about MPI ports sounds too intimidating, and users end up using Sockets even if everything is alright with MPI ports.
Main reason seems to be that "if you encounter problems" is too vague.
This adds a clarification on when to ignore this warning.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> N/A
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features. -> N/A
* [ ] I sticked to CMake version 3.16.3. -> N/A
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

@fsimonis: Do I understand correctly that if the simulation starts, no other related issues are expected?

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
