### PR TITLE
Internal support for volumetric scale-consistent mapping

### DIFF
--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -24,8 +24,8 @@ extern bool syncMode;
 
 namespace mapping {
 
-BarycentricBaseMapping::BarycentricBaseMapping(Constraint constraint, int dimensions)
-    : Mapping(constraint, dimensions)
+BarycentricBaseMapping::BarycentricBaseMapping(Constraint constraint, int dimensions, Mapping::CouplingKind kind)
+    : Mapping(constraint, dimensions, false, kind)
 {
 }
 

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -14,7 +14,7 @@ namespace mapping {
  */
 class BarycentricBaseMapping : public Mapping {
 public:
-  BarycentricBaseMapping(Constraint constraint, int dimensions);
+  BarycentricBaseMapping(Constraint constraint, int dimensions, Mapping::CouplingKind kind);
 
   /// Destructor, empty.
   virtual ~BarycentricBaseMapping() = default;

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -20,7 +20,7 @@ public:
   virtual ~BarycentricBaseMapping() = default;
 
   /// Computes the projections and interpolation relations. Must be done by inherited subclass
-  virtual void computeMapping() = 0;
+  virtual void computeMapping() override = 0;
 
   /// Removes a computed mapping.
   virtual void clear() final;

--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -13,7 +13,7 @@ namespace mapping {
 LinearCellInterpolationMapping::LinearCellInterpolationMapping(
     Constraint constraint,
     int        dimensions)
-    : BarycentricBaseMapping(constraint, dimensions)
+    : BarycentricBaseMapping(constraint, dimensions, Mapping::CouplingKind::VOLUME)
 {
   PRECICE_CHECK(getDimensions() == 2, "Volume mapping not available in 3D.");
   if (constraint == CONSISTENT) {

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -129,20 +129,14 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
   bool requiresTriangles = (spaceDimension == 2 and _couplingKind == CouplingKind::VOLUME) or (spaceDimension == 3 and _couplingKind == CouplingKind::SURFACE);
   bool requiresTetra     = (spaceDimension == 3 and _couplingKind == CouplingKind::VOLUME);
 
-  if (not input()->vertices().empty()) {
-    if ((requiresEdges and input()->edges().empty()) or
-        (requiresTriangles and input()->triangles().empty()) or (requiresTetra and input()->tetrahedra().empty())) {
-      PRECICE_ERROR("Connectivity information is missing for the mesh {}. "
-                    "Scaled consistent mapping requires connectivity information.",
-                    input()->getName());
-    }
-  }
-  if (not output()->vertices().empty()) {
-    if ((requiresEdges and output()->edges().empty()) or
-        (requiresTriangles and output()->triangles().empty()) or (requiresTetra and output()->tetrahedra().empty())) {
-      PRECICE_ERROR("Connectivity information is missing for the mesh {}. "
-                    "Scaled consistent mapping requires connectivity information.",
-                    output()->getName());
+  for (mesh::PtrMesh mesh : {input(), output()}) {
+    if (not mesh->vertices().empty()) {
+      if ((requiresEdges and mesh->edges().empty()) or
+          (requiresTriangles and mesh->triangles().empty()) or (requiresTetra and mesh->tetrahedra().empty())) {
+        PRECICE_ERROR("Connectivity information is missing for the mesh {}. "
+                      "Scaled consistent mapping requires connectivity information.",
+                      mesh->getName());
+      }
     }
   }
 

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -19,8 +19,9 @@ Mapping::Mapping(
       _outputRequirement(MeshRequirement::UNDEFINED),
       _input(),
       _output(),
-      _dimensions(dimensions),
-      _couplingKind(couplingKind)
+      _couplingKind(couplingKind),
+      _dimensions(dimensions)
+
 {
 }
 
@@ -118,6 +119,7 @@ void Mapping::map(int inputDataID,
 
 void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
 {
+  logging::Logger _log{"mapping::Mapping"};
   // Only serial participant is supported for scale-consistent mapping
   PRECICE_ASSERT((not utils::IntraComm::isPrimary()) and (not utils::IntraComm::isSecondary()));
 
@@ -130,7 +132,6 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
   if (not input()->vertices().empty()) {
     if ((requiresEdges and input()->edges().empty()) or
         (requiresTriangles and input()->triangles().empty()) or (requiresTetra and input()->tetrahedra().empty())) {
-      logging::Logger _log{"mapping::Mapping"};
       PRECICE_ERROR("Connectivity information is missing for the mesh {}. "
                     "Scaled consistent mapping requires connectivity information.",
                     input()->getName());
@@ -139,7 +140,6 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
   if (not output()->vertices().empty()) {
     if ((requiresEdges and output()->edges().empty()) or
         (requiresTriangles and output()->triangles().empty()) or (requiresTetra and output()->tetrahedra().empty())) {
-      logging::Logger _log{"mapping::Mapping"};
       PRECICE_ERROR("Connectivity information is missing for the mesh {}. "
                     "Scaled consistent mapping requires connectivity information.",
                     output()->getName());
@@ -164,11 +164,10 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
 
   // Create reshape the output values vector to matrix
   Eigen::Map<Eigen::MatrixXd> outputValuesMatrix(outputValues.data(), valueDimensions, outputValues.size() / valueDimensions);
-  logging::Logger             _log{"mapping::Mapping"};
 
   // Scale in each direction
   Eigen::VectorXd scalingFactor = integralInput.array() / integralOutput.array();
-  PRECICE_DEBUG("Scale factor: {}", scalingFactor);
+  PRECICE_DEBUG("Scale factor in scale-consistent mapping: {}", scalingFactor);
   outputValuesMatrix.array().colwise() *= scalingFactor.array();
 }
 

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -157,7 +157,7 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
     integralInput  = mesh::integrate(input(), input()->data(inputDataID));
     integralOutput = mesh::integrate(output(), output()->data(outputDataID));
   } else {
-  PRECICE_ASSERT(_couplingKind == CouplingKind::...)
+    PRECICE_ASSERT(_couplingKind == CouplingKind::...)
     integralInput  = mesh::integrateVolume(input(), input()->data(inputDataID));
     integralOutput = mesh::integrateVolume(output(), output()->data(outputDataID));
   }

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -157,6 +157,7 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
     integralInput  = mesh::integrate(input(), input()->data(inputDataID));
     integralOutput = mesh::integrate(output(), output()->data(outputDataID));
   } else {
+  PRECICE_ASSERT(_couplingKind == CouplingKind::...)
     integralInput  = mesh::integrateVolume(input(), input()->data(inputDataID));
     integralOutput = mesh::integrateVolume(output(), output()->data(outputDataID));
   }

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -17,9 +17,9 @@ Mapping::Mapping(
       _constraint(constraint),
       _inputRequirement(MeshRequirement::UNDEFINED),
       _outputRequirement(MeshRequirement::UNDEFINED),
+      _couplingKind(couplingKind),
       _input(),
       _output(),
-      _couplingKind(couplingKind),
       _dimensions(dimensions)
 
 {

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -163,7 +163,7 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
 
   // Create reshape the output values vector to matrix
   Eigen::Map<Eigen::MatrixXd> outputValuesMatrix(outputValues.data(), valueDimensions, outputValues.size() / valueDimensions);
-  logging::Logger _log{"mapping::Mapping"};
+  logging::Logger             _log{"mapping::Mapping"};
 
   // Scale in each direction
   Eigen::VectorXd scalingFactor = integralInput.array() / integralOutput.array();

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -11,9 +11,9 @@ namespace mapping {
 Mapping::Mapping(
     Constraint            constraint,
     int                   dimensions,
-    bool                  requireGradient,
+    bool                  requiresGradientData,
     Mapping::CouplingKind couplingKind)
-    : _requireGradientData(requiresGradientData),
+    : _requiresGradientData(requiresGradientData),
       _constraint(constraint),
       _inputRequirement(MeshRequirement::UNDEFINED),
       _outputRequirement(MeshRequirement::UNDEFINED),

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -157,7 +157,7 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID) const
     integralInput  = mesh::integrate(input(), input()->data(inputDataID));
     integralOutput = mesh::integrate(output(), output()->data(outputDataID));
   } else {
-    PRECICE_ASSERT(_couplingKind == CouplingKind::...)
+    PRECICE_ASSERT(_couplingKind == CouplingKind::VOLUME)
     integralInput  = mesh::integrateVolume(input(), input()->data(inputDataID));
     integralOutput = mesh::integrateVolume(output(), output()->data(outputDataID));
   }

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -46,8 +46,21 @@ public:
     FULL = 2
   };
 
+  /**
+   * @brief Specifices what kind of integrals to compute for scaled-consistent mapping.
+   * 
+   * Scaled-Consistent mappings conserve integrals, but they must be computed differently 
+   * depending on the nature of the coupling. It can be either SURFACE coupling (e.g. pressure to conserve forces)
+   * or VOLUMETRIC coupling (e.g. density to preserve mass).
+   * 
+   */
+  enum class CouplingKind {
+    SURFACE,
+    VOLUME,
+  };
+
   /// Constructor, takes mapping constraint.
-  Mapping(Constraint constraint, int dimensions, bool requireGradient = false);
+  Mapping(Constraint constraint, int dimensions, bool requireGradient = false, CouplingKind couplingKind = CouplingKind::SURFACE);
 
   Mapping &operator=(Mapping &&) = delete;
 
@@ -168,6 +181,9 @@ private:
 
   /// Requirement on output mesh.
   MeshRequirement _outputRequirement;
+
+  /// Determines whether to use surface integrals or volume integrals if needed
+  CouplingKind _couplingKind;
 
   /// Pointer to input mesh.
   mesh::PtrMesh _input;

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -18,11 +18,11 @@ extern bool syncMode;
 namespace mapping {
 
 NearestNeighborBaseMapping::NearestNeighborBaseMapping(
-    Constraint  constraint,
-    int         dimensions,
-    bool        requireGradient,
-    std::string mappingName,
-    std::string mappingNameShort,
+    Constraint            constraint,
+    int                   dimensions,
+    bool                  requireGradient,
+    std::string           mappingName,
+    std::string           mappingNameShort,
     Mapping::CouplingKind kind)
     : Mapping(constraint, dimensions, requireGradient, kind),
       mappingName(mappingName),

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -22,8 +22,9 @@ NearestNeighborBaseMapping::NearestNeighborBaseMapping(
     int         dimensions,
     bool        requireGradient,
     std::string mappingName,
-    std::string mappingNameShort)
-    : Mapping(constraint, dimensions, requireGradient),
+    std::string mappingNameShort,
+    Mapping::CouplingKind kind)
+    : Mapping(constraint, dimensions, requireGradient, kind),
       mappingName(mappingName),
       mappingNameShort(mappingNameShort)
 {

--- a/src/mapping/NearestNeighborBaseMapping.hpp
+++ b/src/mapping/NearestNeighborBaseMapping.hpp
@@ -19,7 +19,7 @@ public:
    * @param[in] dimensions Dimensionality of the meshes
    */
   NearestNeighborBaseMapping(Constraint constraint, int dimensions, bool hasGradient, std::string mappingName,
-                             std::string mappingNameShort);
+                             std::string mappingNameShort, Mapping::CouplingKind kind = Mapping::CouplingKind::SURFACE);
 
   /// Destructor, empty.
   virtual ~NearestNeighborBaseMapping() = default;

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -16,8 +16,8 @@ extern bool syncMode;
 namespace mapping {
 
 NearestNeighborGradientMapping::NearestNeighborGradientMapping(
-    Constraint constraint,
-    int        dimensions,
+    Constraint            constraint,
+    int                   dimensions,
     Mapping::CouplingKind couplingKind)
     : NearestNeighborBaseMapping(constraint, dimensions, true, "NearestNeighborGradientMapping", "nng", couplingKind)
 {

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -17,8 +17,9 @@ namespace mapping {
 
 NearestNeighborGradientMapping::NearestNeighborGradientMapping(
     Constraint constraint,
-    int        dimensions)
-    : NearestNeighborBaseMapping(constraint, dimensions, true, "NearestNeighborGradientMapping", "nng")
+    int        dimensions,
+    Mapping::CouplingKind couplingKind)
+    : NearestNeighborBaseMapping(constraint, dimensions, true, "NearestNeighborGradientMapping", "nng", couplingKind)
 {
   PRECICE_ASSERT(!hasConstraint(CONSERVATIVE));
 

--- a/src/mapping/NearestNeighborGradientMapping.hpp
+++ b/src/mapping/NearestNeighborGradientMapping.hpp
@@ -17,7 +17,7 @@ public:
    * @param[in] constraint Specifies mapping to be consistent or conservative.
    * @param[in] dimensions Dimensionality of the meshes
    */
-  NearestNeighborGradientMapping(Constraint constraint, int dimensions);
+  NearestNeighborGradientMapping(Constraint constraint, int dimensions, Mapping::CouplingKind couplingKind = CouplingKind::SURFACE);
 
   /// Calculates the offsets needed for the gradient mappings after calculating the matched vertices
   void onMappingComputed(mesh::PtrMesh origins, mesh::PtrMesh searchSpace) override;

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -15,8 +15,8 @@ extern bool syncMode;
 namespace mapping {
 
 NearestNeighborMapping::NearestNeighborMapping(
-    Constraint constraint,
-    int        dimensions,
+    Constraint            constraint,
+    int                   dimensions,
     Mapping::CouplingKind kind)
     : NearestNeighborBaseMapping(constraint, dimensions, false, "NearestNeighborMapping", "nn", kind)
 {

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -16,8 +16,9 @@ namespace mapping {
 
 NearestNeighborMapping::NearestNeighborMapping(
     Constraint constraint,
-    int        dimensions)
-    : NearestNeighborBaseMapping(constraint, dimensions, false, "NearestNeighborMapping", "nn")
+    int        dimensions,
+    Mapping::CouplingKind kind)
+    : NearestNeighborBaseMapping(constraint, dimensions, false, "NearestNeighborMapping", "nn", kind)
 {
   if (hasConstraint(SCALEDCONSISTENT)) {
     setInputRequirement(Mapping::MeshRequirement::FULL);

--- a/src/mapping/NearestNeighborMapping.hpp
+++ b/src/mapping/NearestNeighborMapping.hpp
@@ -17,7 +17,7 @@ public:
    * @param[in] constraint Specifies mapping to be consistent or conservative.
    * @param[in] dimensions Dimensionality of the meshes
    */
-  NearestNeighborMapping(Constraint constraint, int dimensions);
+  NearestNeighborMapping(Constraint constraint, int dimensions, Mapping::CouplingKind kind = Mapping::CouplingKind::SURFACE);
 
 protected:
   /// @copydoc Mapping::mapConservative

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -27,7 +27,7 @@ namespace mapping {
 NearestProjectionMapping::NearestProjectionMapping(
     Constraint constraint,
     int        dimensions)
-    : BarycentricBaseMapping(constraint, dimensions)
+    : BarycentricBaseMapping(constraint, dimensions, Mapping::CouplingKind::SURFACE)
 {
   if (constraint == CONSISTENT) {
     setInputRequirement(Mapping::MeshRequirement::FULL);

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -67,7 +67,8 @@ public:
       std::array<bool, 3>            deadAxis,
       double                         solverRtol    = 1e-9,
       Polynomial                     polynomial    = Polynomial::SEPARATE,
-      Preallocation                  preallocation = Preallocation::TREE);
+      Preallocation                  preallocation = Preallocation::TREE,
+      Mapping::CouplingKind          kind          = Mapping::CouplingKind::SURFACE);
 
   /// Deletes the PETSc objects and the _deadAxis array
   virtual ~PetRadialBasisFctMapping();
@@ -178,8 +179,9 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping(
     std::array<bool, 3>            deadAxis,
     double                         solverRtol,
     Polynomial                     polynomial,
-    Preallocation                  preallocation)
-    : RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>(constraint, dimensions, function, deadAxis),
+    Preallocation                  preallocation,
+    Mapping::CouplingKind          kind)
+    : RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>(constraint, dimensions, function, deadAxis, kind),
       _matrixC("C"),
       _matrixQ("Q"),
       _matrixA("A"),

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -37,7 +37,8 @@ public:
       Constraint              constraint,
       int                     dimensions,
       RADIAL_BASIS_FUNCTION_T function,
-      std::array<bool, 3>     deadAxis);
+      std::array<bool, 3>     deadAxis,
+      Mapping::CouplingKind   kind = Mapping::CouplingKind::SURFACE);
 
   virtual ~RadialBasisFctBaseMapping() = default;
 
@@ -83,8 +84,9 @@ RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctBaseMapping(
     Constraint              constraint,
     int                     dimensions,
     RADIAL_BASIS_FUNCTION_T function,
-    std::array<bool, 3>     deadAxis)
-    : Mapping(constraint, dimensions),
+    std::array<bool, 3>     deadAxis,
+    Mapping::CouplingKind   kind)
+    : Mapping(constraint, dimensions, false, kind),
       _basisFunction(function)
 {
   if (constraint == SCALEDCONSISTENT) {

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -45,7 +45,8 @@ public:
       Mapping::Constraint     constraint,
       int                     dimensions,
       RADIAL_BASIS_FUNCTION_T function,
-      std::array<bool, 3>     deadAxis);
+      std::array<bool, 3>     deadAxis,
+      Mapping::CouplingKind   kind = Mapping::CouplingKind::SURFACE);
 
   /// Computes the mapping coefficients from the in- and output mesh.
   virtual void computeMapping() override;
@@ -71,8 +72,9 @@ RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctMapping(
     Mapping::Constraint     constraint,
     int                     dimensions,
     RADIAL_BASIS_FUNCTION_T function,
-    std::array<bool, 3>     deadAxis)
-    : RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>(constraint, dimensions, function, deadAxis)
+    std::array<bool, 3>     deadAxis,
+    Mapping::CouplingKind   kind)
+    : RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>(constraint, dimensions, function, deadAxis, kind)
 {
 }
 

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -235,5 +235,83 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentNonIncremental)
   BOOST_TEST(inValues(3) * scaleFactor == outValues(3));
 }
 
+BOOST_AUTO_TEST_CASE(ScaledConsistentVolume2D)
+{
+  PRECICE_TEST(1_rank);
+  int dimensions = 2;
+
+  // Create mesh to map from
+  PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
+  PtrData inData    = inMesh->createData("InData", 1, 0_dataID);
+  int     inDataID  = inData->getID();
+
+  // One square with 3 triangles
+  Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &inVertex1 = inMesh->createVertex(Eigen::Vector2d{1.0, 0.0});
+  Vertex &inVertex2 = inMesh->createVertex(Eigen::Vector2d{1.0, 1.0});
+  Vertex &inVertex3 = inMesh->createVertex(Eigen::Vector2d{0.0, 1.0});
+  Vertex &inVertex4 = inMesh->createVertex(Eigen::Vector2d{0.5, 1.0});
+
+  inMesh->createTriangle(inVertex0, inVertex1, inVertex4);
+  inMesh->createTriangle(inVertex0, inVertex3, inVertex4);
+  inMesh->createTriangle(inVertex1, inVertex2, inVertex4);
+
+  inMesh->allocateDataValues();
+  Eigen::VectorXd &inValues = inData->values();
+  inValues(0)               = 1.0;
+  inValues(1)               = 2.0;
+  inValues(2)               = 3.0;
+  inValues(3)               = 4.0;
+  inValues(4)               = 5.0;
+
+  // Create mesh to map to
+  PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
+  PtrData outData    = outMesh->createData("OutData", 1, 1_dataID);
+  int     outDataID  = outData->getID();
+
+  // Unit square as 2 triangles
+  Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  Vertex &outVertex1 = outMesh->createVertex(Eigen::Vector2d(1.0, 0.0));
+  Vertex &outVertex2 = outMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
+  Vertex &outVertex3 = outMesh->createVertex(Eigen::Vector2d(0.0, 1.0));
+
+  outMesh->createTriangle(outVertex0, outVertex1, outVertex2);
+  outMesh->createTriangle(outVertex0, outVertex2, outVertex3);
+
+  outMesh->allocateDataValues();
+
+  // Setup mapping with mapping coordinates and geometry used
+  precice::mapping::NearestNeighborMapping mapping(mapping::Mapping::SCALEDCONSISTENT, dimensions);
+
+  mapping.setMeshes(inMesh, outMesh);
+  BOOST_TEST(mapping.hasComputedMapping() == false);
+
+  mapping.computeMapping();
+  mapping.map(inDataID, outDataID);
+
+  Eigen::VectorXd &outValues = outData->values();
+  BOOST_TEST(mapping.hasComputedMapping() == true);
+
+  auto inputIntegral  = mesh::integrateVolume(inMesh, inData);
+  auto outputIntegral = mesh::integrateVolume(outMesh, outData);
+
+  Eigen::VectorXd expectedIntegral(1);
+  expectedIntegral << 3.0;
+
+  BOOST_TEST(inputIntegral(0) == expectedIntegral(0));
+
+  for (int dim = 0; dim < inputIntegral.size(); ++dim) {
+    BOOST_TEST(inputIntegral(dim) == outputIntegral(dim));
+  }
+
+  double scaleFactor = outValues(0) / inValues(0);
+  BOOST_TEST(scaleFactor != 1.0);
+
+  BOOST_TEST(math::equals(inValues(0) * scaleFactor, outValues(0)));
+  BOOST_TEST(inValues(1) * scaleFactor == outValues(1));
+  BOOST_TEST(inValues(2) * scaleFactor == outValues(2));
+  BOOST_TEST(inValues(3) * scaleFactor == outValues(3));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -242,8 +242,8 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentVolume2D)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inData    = inMesh->createData("InData", 1, 0_dataID);
-  int     inDataID  = inData->getID();
+  PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
+  int     inDataID = inData->getID();
 
   // One square with 3 triangles
   Vertex &inVertex0 = inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -266,8 +266,8 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentVolume2D)
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
-  PtrData outData    = outMesh->createData("OutData", 1, 1_dataID);
-  int     outDataID  = outData->getID();
+  PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
+  int     outDataID = outData->getID();
 
   // Unit square as 2 triangles
   Vertex &outVertex0 = outMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentVolume2D)
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used
-  precice::mapping::NearestNeighborMapping mapping(mapping::Mapping::SCALEDCONSISTENT, dimensions);
+  precice::mapping::NearestNeighborMapping mapping(mapping::Mapping::SCALEDCONSISTENT, dimensions, precice::mapping::Mapping::CouplingKind::VOLUME);
 
   mapping.setMeshes(inMesh, outMesh);
   BOOST_TEST(mapping.hasComputedMapping() == false);


### PR DESCRIPTION
## Main changes of this PR

Scale-consistent mapping can now be configured to use volume integrals instead of surface integrals. API support will come in a later PR; this one focuses on internal support.
Integral type is given to the mapping constructor and stored.

## Motivation and additional information

See https://github.com/precice/precice/issues/1318 for discussion about future API.
NP mapping always use surface mode, and LCI mapping the volume mode. All the other mappings can use either, with default to surface for backward compatibility.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
