### PR TITLE
Add option to disable precice-tools building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ option(BUILD_TESTING "Build tests" ON)
 option(PRECICE_ALWAYS_VALIDATE_LIBS "Validate libraries even after the validatation succeeded." OFF)
 option(PRECICE_ENABLE_C "Enable the native C bindings" ON)
 option(PRECICE_ENABLE_FORTRAN "Enable the native Fortran bindings" ON)
+option(PRECICE_BUILD_TOOLS "Build the \"precice-tools\" executable" ON)
 
 option(PRECICE_RELEASE_WITH_DEBUG_LOG "Enable debug logging in release builds" OFF)
 option(PRECICE_RELEASE_WITH_TRACE_LOG "Enable trace logging in release builds" OFF)
@@ -134,6 +135,15 @@ add_feature_info(FortranBindings PRECICE_ENABLE_FORTRAN
 
    This feature can be enabled/disabled by setting the PRECICE_ENABLE_FORTRAN CMake option.
   ")
+  add_feature_info(PreciceTools PRECICE_BUILD_TOOLS
+  "Build the \"precice-tools\" executable
+
+   preCICE offers in addition to the core library a variety of tools in order to check configuration
+   files or generate xml references. The tools are copmiled into an exectuable called \"precice-tools\".
+
+   This feature can be enabled/disabled by setting the PRECICE_BUILD_TOOLS CMake option.
+  ")
+
 
 feature_summary(WHAT ENABLED_FEATURES  DESCRIPTION "=== ENABLED FEATURES ===" QUIET_ON_EMPTY)
 feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "=== DISABLED FEATURES ===" QUIET_ON_EMPTY)
@@ -332,29 +342,30 @@ include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 #
 # Configuration of Target precice-tools
 #
+if (PRECICE_BUILD_TOOLS)
+  add_executable(precice-tools "src/drivers/main.cpp")
+  target_link_libraries(precice-tools
+    PRIVATE
+   precice
+   )
+  set_target_properties(precice-tools PROPERTIES
+    # precice is a C++14 project
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED Yes
+    CXX_EXTENSIONS No
+    )
 
-add_executable(precice-tools "src/drivers/main.cpp")
-target_link_libraries(precice-tools
-  PRIVATE
-  precice
-  )
-set_target_properties(precice-tools PROPERTIES
-  # precice is a C++14 project
-  CXX_STANDARD 14
-  CXX_STANDARD_REQUIRED Yes
-  CXX_EXTENSIONS No
-  )
-
-# Add link for backwards compatibility
-# TODO remove in 3.0.0
-add_custom_target(
-  binprecice
-  ALL
-  COMMAND ${CMAKE_COMMAND} -E create_symlink precice-tools binprecice
-  DEPENDS precice-tools
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  BYPRODUCTS binprecice
-  )
+  # Add link for backwards compatibility
+  # TODO remove in 3.0.0
+  add_custom_target(
+    binprecice
+    ALL
+    COMMAND ${CMAKE_COMMAND} -E create_symlink precice-tools binprecice
+    DEPENDS precice-tools
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    BYPRODUCTS binprecice
+    )
+endif()
 
 #
 # Configuration of Target testprecice
@@ -426,18 +437,24 @@ endif()
 # precice - the library
 # precice-tools - the precice binary
 include(GNUInstallDirs)
-install(TARGETS precice precice-tools
+install(TARGETS precice
   EXPORT preciceTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
   )
 
-# Install the binprecice link for backwards compatibility
-# TODO remove in 3.0.0
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/binprecice DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(PRECICE_BUILD_TOOLS)
+  install(TARGETS precice-tools
+    EXPORT preciceTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+  # Install the binprecice link for backwards compatibility
+  # TODO remove in 3.0.0
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/binprecice DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 if(BUILD_TESTING AND PRECICE_InstallTest)
   # Install the testprecice target
@@ -593,23 +610,25 @@ add_custom_target(
   USES_TERMINAL
   )
 
-add_custom_target(
-  format
-  COMMAND tools/formatting/format-all
-  WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
-  USES_TERMINAL
-  )
+if(PRECICE_BUILD_TOOLS)
+  add_custom_target(
+    format
+    COMMAND tools/formatting/format-all
+    WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
+    USES_TERMINAL
+    )
 
-add_custom_target(
-  sourcesIndex
-  COMMAND tools/building/updateSourceFiles.py
-  WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
-  USES_TERMINAL
-  )
+  add_custom_target(
+    sourcesIndex
+    COMMAND tools/building/updateSourceFiles.py
+    WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
+    USES_TERMINAL
+    )
 
-add_custom_target(
-  changelog
-  COMMAND tools/building/createChangelog
-  WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
-  USES_TERMINAL
-  )
+  add_custom_target(
+    changelog
+    COMMAND tools/building/createChangelog
+    WORKING_DIRECTORY ${preCICE_SOURCE_DIR}
+    USES_TERMINAL
+    )
+endif()

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -321,78 +321,80 @@ add_precice_test_run_solverdummies(c fortran)
 
 # Add tests for precice-tools
 
-function(add_tools_test)
-  cmake_parse_arguments(PARSE_ARGV 0 PAT "WILL_FAIL" "NAME;MATCH" "COMMAND")
-  set(PAT_FULL_NAME "precice.tools.${PAT_NAME}")
-  message(STATUS "Test ${PAT_FULL_NAME}")
-  add_test(
-    NAME ${PAT_FULL_NAME}
-    COMMAND ${PAT_COMMAND}
+if(PRECICE_BUILD_TOOLS)
+  function(add_tools_test)
+    cmake_parse_arguments(PARSE_ARGV 0 PAT "WILL_FAIL" "NAME;MATCH" "COMMAND")
+    set(PAT_FULL_NAME "precice.tools.${PAT_NAME}")
+    message(STATUS "Test ${PAT_FULL_NAME}")
+    add_test(
+      NAME ${PAT_FULL_NAME}
+      COMMAND ${PAT_COMMAND}
+      )
+    set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT} LABELS "tools;bin")
+    if(PAT_WILL_FAIL)
+      set_tests_properties(${PAT_FULL_NAME} PROPERTIES WILL_FAIL YES)
+    endif()
+    if(PAT_MATCH)
+      set_tests_properties(${PAT_FULL_NAME} PROPERTIES PASS_REGULAR_EXPRESSION "${PAT_MATCH}")
+    endif()
+  endfunction()
+
+
+  add_tools_test(
+    NAME noarg
+    COMMAND precice-tools
+    WILL_FAIL)
+
+  add_tools_test(
+    NAME invalidcmd
+    COMMAND precice-tools invalidcommand
+    WILL_FAIL)
+
+  add_tools_test(
+    NAME version
+    COMMAND precice-tools version
+    MATCH "${CMAKE_PROJECT_VERSION}"
     )
-  set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT} LABELS "tools;bin")
-  if(PAT_WILL_FAIL)
-    set_tests_properties(${PAT_FULL_NAME} PROPERTIES WILL_FAIL YES)
-  endif()
-  if(PAT_MATCH)
-    set_tests_properties(${PAT_FULL_NAME} PROPERTIES PASS_REGULAR_EXPRESSION "${PAT_MATCH}")
-  endif()
-endfunction()
 
+  add_tools_test(
+    NAME versionopt
+    COMMAND precice-tools --version
+    MATCH "${CMAKE_PROJECT_VERSION}"
+    )
 
-add_tools_test(
-  NAME noarg
-  COMMAND precice-tools
-  WILL_FAIL)
+  add_tools_test(
+    NAME markdown
+    COMMAND precice-tools md
+    MATCH "# precice-configuration"
+    )
 
-add_tools_test(
-  NAME invalidcmd
-  COMMAND precice-tools invalidcommand
-  WILL_FAIL)
+  add_tools_test(
+    NAME xml
+    COMMAND precice-tools xml
+    MATCH "<!-- TAG precice-configuration"
+    )
 
-add_tools_test(
-  NAME version
-  COMMAND precice-tools version
-  MATCH "${CMAKE_PROJECT_VERSION}"
-  )
+  add_tools_test(
+    NAME dtd
+    COMMAND precice-tools dtd
+    MATCH "<!ELEMENT precice-configuration"
+    )
 
-add_tools_test(
-  NAME versionopt
-  COMMAND precice-tools --version
-  MATCH "${CMAKE_PROJECT_VERSION}"
-  )
+  add_tools_test(
+    NAME check.file
+    COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml
+    )
 
-add_tools_test(
-  NAME markdown
-  COMMAND precice-tools md
-  MATCH "# precice-configuration"
-  )
+  add_tools_test(
+    NAME check.file+name
+    COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo
+    )
 
-add_tools_test(
-  NAME xml
-  COMMAND precice-tools xml
-  MATCH "<!-- TAG precice-configuration"
-  )
-
-add_tools_test(
-  NAME dtd
-  COMMAND precice-tools dtd
-  MATCH "<!ELEMENT precice-configuration"
-  )
-
-add_tools_test(
-  NAME check.file
-  COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml
-  )
-
-add_tools_test(
-  NAME check.file+name
-  COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo
-  )
-
-add_tools_test(
-  NAME check.file+name+size
-  COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
-  )
+  add_tools_test(
+    NAME check.file+name+size
+    COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
+    )
+endif()
 
 # Add a separate target to test only the base
 add_custom_target(


### PR DESCRIPTION
## Main changes of this PR
Introduces a cmake option to disable the building of `precice-tools`

## Motivation and additional information
Building them might be undesired. The default flag (`ON`) delivers fully backward compatibility.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [x] Check handling of install targets

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
