### PR TITLE
Fix test names to match directory name in NNG

### DIFF
--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
@@ -34,7 +34,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_SUITE(ParallelGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Bidirectional test : Read: Scalar & NNG - Write: Scalar & NN (Parallel Coupling)
 BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
@@ -34,7 +34,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_SUITE(ParallelGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Bidirectional test : Read: Vector & NNG - Write: Scalar & NN (Parallel Coupling)
 BOOST_AUTO_TEST_CASE(GradientTestParallelVector)

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
@@ -25,7 +25,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_SUITE(ParallelGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Bidirectional test : Read: Vector & NNG - Write: Scalar & NN
 BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
@@ -34,7 +34,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_SUITE(SerialGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Bidirectional test : Read: Vector & NN - Write: Scalar & NNG (Parallel coupling)
 BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
@@ -36,7 +36,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_SUITE(SerialGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Bidirectional test : Read: Vector & NNG - Write: Vector & NN (Serial coupling)
 BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadVector)

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp
@@ -36,7 +36,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_SUITE(SerialGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Bidirectional test : Read: Vector & NN - Write: Scalar & NNG (Serial coupling)
 BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteScalar)

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
@@ -34,7 +34,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_SUITE(SerialGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Read : NN & Vector - Write : NNG & Vector (Parallel Coupling Scheme)
 BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.cpp
@@ -10,7 +10,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_SUITE(SerialGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Unidirectional Nearest Neighbor Gradient Read Mapping
 BOOST_AUTO_TEST_CASE(GradientTestUnidirectionalReadBlockVector)

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
@@ -34,7 +34,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_SUITE(SerialGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Unidirectional Nearest Neighbor Gradient Read Mapping
 // Also to test writeBlockScalarGradientData method

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.cpp
@@ -10,7 +10,7 @@ using precice::testing::TestContext;
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_SUITE(SerialGradientMappingTests)
+BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 
 // Unidirectional Nearest Neighbor Gradient Read Mapping
 BOOST_AUTO_TEST_CASE(GradientTestUnidirectionalReadVector)


### PR DESCRIPTION
## Main changes of this PR
Fix test names to match directory name in nearest-neighbor-gradient tests as required by our naming conventions.

## Motivation and additional information
...as pointed out by @BenjaminRodenberg 

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
