### PR TITLE
Add failing test to reproduce first-participant + initData problem

### DIFF
--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
@@ -1,0 +1,80 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Explicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief Test to run a simple serial coupling where the first participant prescribes the time window size and data is initialized.
+ *
+ * Ensures that time window sizes are passed correctly and that reading and writing is possible.
+ */
+BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipantInitData)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  SolverInterface precice(context.name, context.config(), 0, 1);
+
+  MeshID meshID;
+  DataID writeDataID;
+  DataID readDataID;
+
+  // SolverOne prescribes these, thus SolverTwo expect these (we use "first-participant" as dt method)
+  std::vector<double> timestepSizes{1.0, 2.0, 3.0};
+
+  // some dummy values, to check the actual values is not the point of this test,
+  // but more to test whether reading / writing is possible at all
+  double expectedDataValue = 2.5;
+  double actualDataValue   = -1.0;
+
+  if (context.isNamed("SolverOne")) {
+    meshID      = precice.getMeshID("MeshOne");
+    writeDataID = precice.getDataID("DataOne", meshID);
+    readDataID  = precice.getDataID("DataTwo", meshID);
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshID      = precice.getMeshID("MeshTwo");
+    writeDataID = precice.getDataID("DataTwo", meshID);
+    readDataID  = precice.getDataID("DataOne", meshID);
+  }
+
+  VertexID vertexID = precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   dt       = precice.initialize();
+  precice.markActionFulfilled(precice::constants::actionWriteInitialData());
+  precice.initializeData();
+
+  for (int i = 0; i < timestepSizes.size(); i++) {
+    BOOST_TEST(precice.isCouplingOngoing());
+    precice.writeScalarData(writeDataID, vertexID, expectedDataValue);
+
+    if (context.isNamed("SolverOne")) {
+      precice.advance(timestepSizes.at(i));
+    } else if (context.isNamed("SolverTwo")) {
+      BOOST_TEST(dt == timestepSizes.at(i));
+      dt = precice.advance(dt);
+    }
+
+    precice.readScalarData(readDataID, vertexID, actualDataValue);
+    BOOST_TEST(actualDataValue == expectedDataValue);
+  }
+
+  BOOST_TEST(not precice.isCouplingOngoing());
+  precice.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Explicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3">
+    <data:scalar name="DataOne" />
+    <data:scalar name="DataTwo" />
+
+    <mesh name="MeshOne">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="on" />
+      <write-data name="DataOne" mesh="MeshOne" />
+      <read-data name="DataTwo" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshTwo" provide="on" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="conservative" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="consistent" />
+      <write-data name="DataTwo" mesh="MeshTwo" />
+      <read-data name="DataOne" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time value="6" />
+      <time-window-size method="first-participant" />
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="true" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -166,6 +166,7 @@ target_sources(testprecice
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
     tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
+    tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp


### PR DESCRIPTION
## Main changes of this PR

Adds the remaining failing test from #1307 
Needs breaking changes to be fixed, see also #1347


## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
