### PR TITLE
Changed NP behavior for some edge cases

### DIFF
--- a/docs/changelog/1351.md
+++ b/docs/changelog/1351.md
@@ -1,0 +1,1 @@
+- Fixed nearest-projection mapping behvior to map to the closest primitive instead of the highest-dimensional primitive available.

--- a/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
+++ b/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(ConsistentOneTetra3D)
   // Point below the triangle ABC -> fallback to triangle. Expected projection on triangle.
   outMesh->createVertex(Eigen::Vector3d(1.0 / 3, 1.0 / 3, -0.1));
   // Point close to the triangle ACD (which isn't set!).
-  // Wanted behavior: NN => 3.0. Actual behavior: 3.6 because of fall-back to edge. See issue #1304
+  // Wanted behavior: NN => 3.0. Incorrect behavior: 3.6 in case of fall-back to edge. See issue #1304
   outMesh->createVertex(Eigen::Vector3d(-0.1, 0.8, 0.5));
   // Point inside the triangle BCD (not set) -> Check it is inside the tetra. Expected: 0.2*2+0.3*3+0.5*4 = 3.3
   outMesh->createVertex(Eigen::Vector3d(0.2, 0.3, 0.5));
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(ConsistentOneTetra3D)
 
   // Check expected
   Eigen::VectorXd expected(outMesh->vertices().size());
-  expected << 2.5, 1.0, 2.0, 3.0, 4.0, 2.0, 3.6, 3.3, 3.6;
+  expected << 2.5, 1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 3.3, 3.6;
   BOOST_CHECK(equals(expected, outValuesScalar));
 }
 

--- a/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
+++ b/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(Consistent)
   outMesh->createVertex(Eigen::Vector2d(2.5 / 3, 1. / 3));
   outMesh->createVertex(Eigen::Vector2d(-10.0, 0.25));
   // Check fall back on nearest neighbor
-  outMesh->createVertex(Eigen::Vector2d(-0.1, -0.1)); // Currently maps to opposite edge
+  outMesh->createVertex(Eigen::Vector2d(-0.1, -0.1)); // Fall back to NN expected
   outMesh->createVertex(Eigen::Vector2d(2.5, -1.0));
   outMesh->createVertex(Eigen::Vector2d(2.5, 10.0));
 
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(Consistent)
 
   // Check expected
   Eigen::VectorXd expected(outMesh->vertices().size());
-  expected << 2.0, 1.0, 2.0, 3.0, 1.49, 2.25, 1.5, 2.5, 2.0, 3.0;
+  expected << 2.0, 1.0, 2.0, 3.0, 1.49, 2.25, 1.5, 1.0, 2.0, 3.0;
   BOOST_CHECK(equals(expected, outValuesScalar));
 }
 

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -655,7 +655,8 @@ BOOST_AUTO_TEST_CASE(AvoidClosestTriangle)
 
   const auto &values = runNPMapping(mapping::Mapping::CONSISTENT, inMesh, inData, outMesh, outData);
 
-  BOOST_TEST(values(0) == 1.0);
+  // Interpolatin triangle is further than NN => fall back on NN
+  BOOST_TEST(values(0) == 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(PickClosestTriangle)
@@ -699,7 +700,7 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
 
   PtrMesh inMesh(new mesh::Mesh("InMesh", 3, testing::nextMeshID()));
   PtrData inData = inMesh->createData("InData", 1, 0_dataID);
-  // Close edge
+  // Close edge ->
   auto &vc0 = inMesh->createVertex(Eigen::Vector3d(0, 0, 0));
   auto &vc1 = inMesh->createVertex(Eigen::Vector3d(0, 2, 0));
   inMesh->createEdge(vc0, vc1);
@@ -711,7 +712,7 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
   makeTriangle(inMesh, vf0, vf1, vf2);
 
   inMesh->allocateDataValues();
-  inData->values() << 0, 0, 1, 1, 1;
+  inData->values() << 0, 1, 2, 2, 2;
 
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
   PtrData outData = outMesh->createData("OutData", 1, 1_dataID);
@@ -721,7 +722,9 @@ BOOST_AUTO_TEST_CASE(PreferTriangleOverEdge)
 
   const auto &values = runNPMapping(mapping::Mapping::CONSISTENT, inMesh, inData, outMesh, outData);
 
-  BOOST_TEST(values(0) == 1.0);
+  // Distance to triangle > distance to NN > distance to edge => Interpolation on edge
+  // Projection is on the middle of the edge => (0+1)/2 = 0.5
+  BOOST_TEST(values(0) == 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(TriangleDistances)

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -305,7 +305,7 @@ ProjectionMatch Index::findEdgeProjection(const Eigen::VectorXd &location, int n
     return closestVertex;
   }
 
-  // Prefer the closet vertex if it closer than the closest edge
+  // Prefer the closest vertex if it closer than the closest edge
   auto min = std::min_element(candidates.begin(), candidates.end());
   if (min->polation.distance() > closestVertex.polation.distance()) {
     return closestVertex;

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -116,10 +116,10 @@ private:
   ProjectionMatch findVertexProjection(const Eigen::VectorXd &location);
 
   /// Find closest edge interpolation element. If cannot be found, it falls back to vertex projection
-  ProjectionMatch findEdgeProjection(const Eigen::VectorXd &location, int n);
+  ProjectionMatch findEdgeProjection(const Eigen::VectorXd &location, int n, ProjectionMatch closestVertex);
 
   /// Find closest face interpolation element. If cannot be found, it falls back to first edge interpolation element, then vertex if necessary
-  ProjectionMatch findTriangleProjection(const Eigen::VectorXd &location, int n);
+  ProjectionMatch findTriangleProjection(const Eigen::VectorXd &location, int n, ProjectionMatch closestVertex);
 };
 
 } // namespace query


### PR DESCRIPTION
## Main changes of this PR

When doing nearest-projection (including the fall-back of linear cell interpolation), we check that the projection we use is closer than the nearest neighbor. If not, we use the NN instead. See #1304 for context.

### Changed test cases

#### PreferTriangleOverEdge

Consider an edge starting at the origin and moving in the y direction (from (0,0,0) to (0,2,0)) and a triangle living in the plane x = 3. We want to project the point (1,1,1). Before this PR, preCICE tries to map to the triangle, succeeds and thus doesn't check the edge.
Now, we project into the triangle, see that the projection is further than the nearest neighbor vertex (one of the edge), so we decide to reject it. Then we fall back on edges and accept the projection on that edge. **An edge was preferred to a triangle.**

#### AvoidClosestTriangle

Consider two disconnected triangles and a vertex such that only one triangle contains its projection, but it's the furthest of the triangles. Before this PR, we favored interpolation on triangle. Now, we reject this triangle because the projection is further than the nearest neighbor (a vertex from the other triangle). Since the other triangle yields an extrapolation, we reject it, fall-back on edges (there are none) then on vertices. **The far triangle was replaced by the nearest vertex of the other triange**

#### LinearCellInterpolation unit test
See https://github.com/precice/precice/issues/1304: a point fromthe lower-left "AC" region now maps to B, the nearest neighbor.

## Motivation and additional information

### 

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

- Current implementation is a bit suboptimal in 3D: when finding triangle projection, we compare it to NN, and if we fall-back on edges, the NN is recomputed. We could refactor this to gain efficiency at the cost of readability. Let's first discuss the concept.
- Most edge cases happen in volume coupling. If we don't want to change NP for some reason (backward compatibility etc) we could design an "alternative NP" that is only used for the fall-back of LCI. 

Typical example in volume coupling: round domain with different discretizations.
![image](https://user-images.githubusercontent.com/84379125/176970631-e5bafe85-aeb4-4ef8-ac29-93ed9f050d55.png)
The vertex can't be mapped to the nearest edges (it'd be an extrapolation) so it gets mapped to the *opposite* edge.
(In practice, the pentagon would be triangulated and an edge inside it would probably match too)

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next

 to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
