### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,8 +1,4 @@
 name: Code Style
-# Runs the check-format script from the repository.
-# The used docker image contains all required tools at the correct version.
-#
-# See https://github.com/precice/ci-images
 on:
   pull_request:
     paths:
@@ -13,9 +9,18 @@ on:
 jobs:
   formatting:
     runs-on: ubuntu-latest
-    container: precice/ci-formatting:latest
     steps:
       - name: Checkout preCICE
-        uses: actions/checkout@v2
-      - name: Check formatting
-        run: tools/formatting/check-format
+        uses: actions/checkout@v3
+      - name: Setup python
+        uses: action/setup-python@v3
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run checks
+        run: pre-commit run -a -v
+      - name: Git status
+        if: always()
+        run: git status
+      - name: Full diff
+        if: always()
+        run: git diff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,18 @@
 repos:
+# Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: 'v8.0.1'
   hooks:
   - id: clang-format
     exclude: "^thirdparty"
+# Official repo for default hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: 'v4.3.0'
   hooks:
   - id: check-xml
   - id: check-merge-conflict
   - id: mixed-line-ending
+# Custom repo for the preCICE configuration formatter
 - repo: https://github.com/precice/precice-pre-commit-hooks
   rev: 'v2.1'
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: 'v8.0.1'
+  hooks:
+  - id: clang-format
+    exclude: "^thirdparty"
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: 'v4.3.0'
+  hooks:
+  - id: check-xml
+  - id: check-merge-conflict
+  - id: mixed-line-ending
+- repo: https://github.com/precice/precice-pre-commit-hooks
+  rev: 'v2.1'
+  hooks:
+  - id: format-precice-config

--- a/docs/changelog/1359.md
+++ b/docs/changelog/1359.md
@@ -1,0 +1,1 @@
+- Added pre-commit configuration, which drastically simplifies contributing. Required formatting tools will now be installed by pre-commit.

--- a/tools/formatting/README.md
+++ b/tools/formatting/README.md
@@ -1,5 +1,11 @@
 # Formatting Tools
 
+## Moving to pre-commit
+
+With the introduction of pre-commit, these tools became mostly obsolete.
+To use, [install pre-commit](https://pre-commit.com/#install) and run `pre-commit install` at the root of the project.
+You can now force the formatting on all files with `pre-commit run -a`.
+
 ## check-format
 
 This bash-script checks the format of every c(pp) & h(pp) file in the current and parent directories against the clang-format style defined in a parent `.clang-format` file.


### PR DESCRIPTION
## Main changes of this PR

This PR adds pre-commit hooks to preCICE including:

* formatting of code using the correct version of clang-format
* formatting of [preCICE config files](https://github.com/precice/precice-pre-commit-hooks)
* checks for merge conflict markers
* checks for mixed line-endings in files
* checks for incorrect XML files (ignores namespaces :wink:)


This PR replaces the code check workflow and doesn't rely on https://pre-commit.ci/

## Motivation and additional information

Massive shoutout to @renefritze for showing us this tool!

Closes #1291

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
