### PR TITLE
Using volume primitives in Watchpoint if available

### DIFF
--- a/docs/changelog/1361.md
+++ b/docs/changelog/1361.md
@@ -1,0 +1,1 @@
+- Changed behavior of Watchpoints to look for cell interpolation instead of boundary interpolation, if possible.

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -59,7 +59,7 @@ void WatchPoint::initialize()
   PRECICE_TRACE();
 
   if (_mesh->vertices().size() > 0) {
-    auto match        = _mesh->index().findNearestProjection(_point, 4);
+    auto match        = _mesh->index().findCellOrProjection(_point, 4);
     _interpolation    = std::make_unique<mapping::Polation>(match.polation);
     _shortestDistance = match.distance;
   }

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -554,13 +554,13 @@ BOOST_AUTO_TEST_CASE(VolumetricParallel)
   } break;
   case 1: {
     mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
-    mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+    mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
     mesh->createEdge(v1, v2);
   } break;
   case 2: {
-    mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, -1.0));
-    mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(1.0, 0.0, -1.0));
-    mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector3d(0.0, 1.0, -1.0));
+    mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+    mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+    mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 1.0));
     mesh->createTriangle(v1, v2, v3);
   } break;
 
@@ -579,7 +579,7 @@ BOOST_AUTO_TEST_CASE(VolumetricParallel)
   mesh->allocateDataValues();
 
   // Data is (1, 2, 3, 4) on the tetra, other ranks agree on their subset
-  for (int i = 0; i < context.rank; ++i) {
+  for (int i = 0; i <= context.rank; ++i) {
     doubleValues(i) = i + 1;
   }
 

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE(VolumetricInterpolation3D)
   {
     auto result   = readDoublesFromTXTFile(filename1, 5);
     auto expected = std::vector<double>{
-        0.0, 0.25, 0.25, 0.25, 1.75};
+        0.0, 0.25, 0.25, 0.25, 2.5};
     BOOST_TEST(result.size() == expected.size());
     for (size_t i = 0; i < result.size(); ++i) {
       BOOST_TEST_CONTEXT("entry index: " << i)

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -379,6 +379,166 @@ BOOST_AUTO_TEST_CASE(Reinitalize)
   }
 }
 
+BOOST_AUTO_TEST_CASE(VolumetricInterpolation2D)
+{
+  PRECICE_TEST(1_rank);
+  using namespace mesh;
+  using Eigen::VectorXd;
+  // Setup geometry
+  std::string name("triangle");
+  PtrMesh     mesh(new Mesh(name, 2, testing::nextMeshID()));
+
+  mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
+  mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
+  mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
+  mesh->createEdge(v1, v2);
+  mesh->createEdge(v2, v3);
+  mesh->createEdge(v3, v1);
+  mesh->createTriangle(v1, v2, v3);
+
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
+  PtrData vectorData   = mesh->createData("VectorData", 2, 1_dataID);
+  auto &  doubleValues = doubleData->values();
+  auto &  vectorValues = vectorData->values();
+  mesh->allocateDataValues();
+
+  // Data is (1,1,2) for the scalar, and same for each vector component.
+  doubleValues.setConstant(1.0);
+  doubleValues(2) = 2.0;
+  vectorValues.setConstant(1.0);
+  vectorValues(4) = 2.0;
+  vectorValues(5) = 2.0;
+
+  std::string filename0("precice-WatchPointTest-volumetric2d-0.log");
+  std::string filename1("precice-WatchPointTest-volumetric2d-1.log");
+
+  // this scope forces the filestreams to be closed
+  {
+    // Create watchpoints
+    Eigen::Vector2d  pointToWatch0(0.1, 0.5);
+    impl::WatchPoint watchpoint0(pointToWatch0, mesh, filename0);
+    Eigen::Vector2d  pointToWatch1(0.25, 0.25);
+    impl::WatchPoint watchpoint1(pointToWatch1, mesh, filename1);
+
+    // Initialize
+    watchpoint0.initialize();
+    watchpoint1.initialize();
+
+    // Write output
+    watchpoint0.exportPointData(0.0);
+    watchpoint1.exportPointData(0.0);
+  }
+
+  // File Format: Time  Coordinate0  Coordinate1  DoubleData  VectorData0  VectorData1
+  BOOST_TEST_CONTEXT("Validating watchpoint0")
+  {
+    auto result   = readDoublesFromTXTFile(filename0, 6);
+    auto expected = std::vector<double>{
+        0.0, 0.1, 0.5, 1.5, 1.5, 1.5};
+    BOOST_TEST(result.size() == expected.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      BOOST_TEST_CONTEXT("entry index: " << i)
+      {
+        using testing::equals;
+        BOOST_TEST(equals(result.at(i), expected.at(i)));
+      }
+    }
+  }
+
+  BOOST_TEST_CONTEXT("Validating watchpoint1")
+  {
+    auto result   = readDoublesFromTXTFile(filename1, 6);
+    auto expected = std::vector<double>{
+        0.0, 0.25, 0.25, 1.25, 1.25, 1.25};
+    BOOST_TEST(result.size() == expected.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      BOOST_TEST_CONTEXT("entry index: " << i)
+      {
+        using testing::equals;
+        BOOST_TEST(equals(result.at(i), expected.at(i)));
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(VolumetricInterpolation3D)
+{
+  PRECICE_TEST(1_rank);
+  using namespace mesh;
+  using Eigen::VectorXd;
+  // Setup geometry
+  std::string name("triangle");
+  PtrMesh     mesh(new Mesh(name, 3, testing::nextMeshID()));
+
+  mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  mesh::Vertex &v4 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 1.0));
+
+  mesh->createTetrahedron(v1, v2, v3, v4);
+
+  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
+  auto &  doubleValues = doubleData->values();
+  mesh->allocateDataValues();
+
+  // Data is (1,1,2) for the scalar, and same for each vector component.
+  doubleValues(0) = 1.0;
+  doubleValues(1) = 2.0;
+  doubleValues(2) = 3.0;
+  doubleValues(3) = 4.0;
+
+  std::string filename0("precice-WatchPointTest-volumetric3d-0.log");
+  std::string filename1("precice-WatchPointTest-volumetric3d-1.log");
+
+  // this scope forces the filestreams to be closed
+  {
+    // Create watchpoints
+    Eigen::Vector3d  pointToWatch0(0.1, 0.5, 0.2);
+    impl::WatchPoint watchpoint0(pointToWatch0, mesh, filename0);
+    Eigen::Vector3d  pointToWatch1(0.25, 0.25, 0.25);
+    impl::WatchPoint watchpoint1(pointToWatch1, mesh, filename1);
+
+    // Initialize
+    watchpoint0.initialize();
+    watchpoint1.initialize();
+
+    // Write output
+    watchpoint0.exportPointData(0.0);
+    watchpoint1.exportPointData(0.0);
+  }
+
+  // File Format: Time  Coordinate0  Coordinate1 Coordinate2 DoubleData
+  BOOST_TEST_CONTEXT("Validating watchpoint0")
+  {
+    auto result   = readDoublesFromTXTFile(filename0, 5);
+    auto expected = std::vector<double>{
+        0.0, 0.1, 0.5, 0.2, 2.7};
+    BOOST_TEST(result.size() == expected.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      BOOST_TEST_CONTEXT("entry index: " << i)
+      {
+        using testing::equals;
+        BOOST_TEST(equals(result.at(i), expected.at(i)));
+      }
+    }
+  }
+
+  BOOST_TEST_CONTEXT("Validating watchpoint1")
+  {
+    auto result   = readDoublesFromTXTFile(filename1, 5);
+    auto expected = std::vector<double>{
+        0.0, 0.25, 0.25, 0.25, 1.75};
+    BOOST_TEST(result.size() == expected.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      BOOST_TEST_CONTEXT("entry index: " << i)
+      {
+        using testing::equals;
+        BOOST_TEST(equals(result.at(i), expected.at(i)));
+      }
+    }
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END() // Precice


### PR DESCRIPTION
## Main changes of this PR

If a Watchpoint watches a point inside the domain, it interpolates on the cell instead of looking for a projection on a boundary element. If there is none (no 2D triangle or no 3D tetra), fall-back to previous behavior, * à la* Nearest-Projection

## Motivation and additional information
More accurate watchpoint when used in volumetric coupling

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
