### PR TITLE
Wrong RTree distance computation

### DIFF
--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -386,6 +386,24 @@ BOOST_AUTO_TEST_CASE(ProjectionToTriangle)
   }
 }
 
+BOOST_AUTO_TEST_CASE(CorrectTriangleDistance)
+{
+
+  // Document the issue
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh(new Mesh("MyMesh", 3, testing::nextMeshID()));
+  Index   indexTree(mesh);
+
+  mesh::Vertex &v1 = mesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  mesh::Vertex &v2 = mesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  mesh->createTriangle(v1, v2, v3);
+
+  auto matches = indexTree.getClosestTriangles(Eigen::Vector3d{0.1, 0.2, 0.3}, 4);
+  BOOST_REQUIRE(matches.size() == 1);
+  BOOST_TEST(matches[0].distance > 0.25);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Projection
 
 BOOST_AUTO_TEST_SUITE(Tetrahedra)


### PR DESCRIPTION
## Main changes of this PR

Added a 3D test with a triangle in the plane z = 0 and a point above it. `getClosestTriangles` should return a match with a distance that equals the z coordinate of the point, but it returns 0.
PR is a draft until a fix is found ?

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
