### PR TITLE
Add xSDK membership badge in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 </a>
 
 **Project Quality**  
+[![xSDK Policy Compatibility](https://img.shields.io/badge/xSDK-member-brightgreen)](https://github.com/xsdk-project/xsdk-policy-compatibility/blob/master/precice-policy-compatibility.md)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3895/badge)](https://bestpractices.coreinfrastructure.org/projects/3895)
 [![CodeFactor](https://www.codefactor.io/repository/github/precice/precice/badge)](https://www.codefactor.io/repository/github/precice/precice)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/precice/precice.svg?logo=lgtm&logoWidth=18&label=lgtm%3AC%2B%2B)](https://lgtm.com/projects/g/precice/precice/context:cpp)


### PR DESCRIPTION
## Main changes of this PR

Adds a custom badge "xSDK:member" to README.md, linking to the [xSDK Community Policy Compatibility for preCICE](https://github.com/xsdk-project/xsdk-policy-compatibility/blob/master/precice-policy-compatibility.md).

[![xSDK Policy Compatibility](https://img.shields.io/badge/xSDK-member-brightgreen)](https://github.com/xsdk-project/xsdk-policy-compatibility/blob/master/precice-policy-compatibility.md) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3895/badge)](https://bestpractices.coreinfrastructure.org/projects/3895)

## Motivation and additional information

We already have a badge to the [OpenSSF CII Best Practices page for preCICE](https://bestpractices.coreinfrastructure.org/projects/3895). I think that being a member of xSDK is another quality assurance, and the policies we (@fsimonis) implemented are interesting to expose to users.

## Author's checklist

* I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> N/A
* I ran `make format` to ensure everything is formatted correctly. -> N/A
* I sticked to C++14 features. -> N/A
* I sticked to CMake version 3.16.3. -> N/A
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

@fsimonis please merge if you agree with adding such a badge in the README.

