### PR TITLE
Configure gradient data requirement automatically

### DIFF
--- a/docs/changelog/1371.md
+++ b/docs/changelog/1371.md
@@ -1,0 +1,1 @@
+- Removed the explicit gradient data flag (`<data: ... gradient="on" />`) for nearest-neighbor-gradient mapping. The gradient data requirement will be deduced automaticall by preCICE.

--- a/docs/changelog/1371.md
+++ b/docs/changelog/1371.md
@@ -1,1 +1,1 @@
-- Removed the explicit gradient data flag (`<data: ... gradient="on" />`) for nearest-neighbor-gradient mapping. The gradient data requirement will be deduced automaticall by preCICE.
+- Removed the explicit gradient data flag (`<data: ... gradient="on" />`) for nearest-neighbor-gradient mapping. The gradient data requirement is now deduced automatically by preCICE.

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -29,8 +29,8 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", 2, 1_dataID);
-  dataScalar->setDataGradientRequired();
-  dataVector->setDataGradientRequired();
+  dataScalar->requireDataGradient();
+  dataVector->requireDataGradient();
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -27,8 +27,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   int dimensions = 2;
   // Create mesh to map from
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID, true);
-  mesh::PtrData dataVector = mesh.createData("dataVector", 2, 1_dataID, true);
+  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
+  mesh::PtrData dataVector = mesh.createData("dataVector", 2, 1_dataID);
+  dataScalar->setDataGradientRequired();
+  dataVector->setDataGradientRequired();
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -33,8 +33,8 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
-  dataScalar->setDataGradientRequired();
-  dataVector->setDataGradientRequired();
+  dataScalar->requireDataGradient();
+  dataVector->requireDataGradient();
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
-  dataScalar->setDataGradientRequired();
-  dataVector->setDataGradientRequired();
+  dataScalar->requireDataGradient();
+  dataVector->requireDataGradient();
   mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh.createVertex(Eigen::Vector3d::Constant(1.0));
 

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -31,9 +31,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   const int dimensions = 2;
   // Create mesh to map from
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID, true);
-  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID, true);
-
+  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
+  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
+  dataScalar->setDataGradientRequired();
+  dataVector->setDataGradientRequired();
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 
@@ -61,8 +62,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   const int dimensions = 3;
   // Create mesh to map from
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID, true);
-  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID, true);
+  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
+  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
+  dataScalar->setDataGradientRequired();
+  dataVector->setDataGradientRequired();
   mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh.createVertex(Eigen::Vector3d::Constant(1.0));
 

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
-  dataScalar->setDataGradientRequired();
-  dataVector->setDataGradientRequired();
+  dataScalar->requireDataGradient();
+  dataVector->requireDataGradient();
 
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
@@ -66,8 +66,8 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
-  dataScalar->setDataGradientRequired();
-  dataVector->setDataGradientRequired();
+  dataScalar->requireDataGradient();
+  dataVector->requireDataGradient();
 
   mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh.createVertex(Eigen::Vector3d::Constant(1.0));

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -32,8 +32,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   // Create mesh to map from
   int           dimensions = 2;
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID, true);
-  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID, true);
+  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
+  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
+  dataScalar->setDataGradientRequired();
+  dataVector->setDataGradientRequired();
 
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
@@ -62,8 +64,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   int dimensions = 3;
   // Create mesh to map from
   mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
-  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID, true);
-  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID, true);
+  mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
+  mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
+  dataScalar->setDataGradientRequired();
+  dataVector->setDataGradientRequired();
 
   mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh.createVertex(Eigen::Vector3d::Constant(1.0));

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -11,8 +11,8 @@ namespace mapping {
 Mapping::Mapping(
     Constraint constraint,
     int        dimensions,
-    bool       requireGradient)
-    : _requireGradient(requireGradient),
+    bool       requiresGradientData)
+    : _requiresGradientData(requiresGradientData),
       _constraint(constraint),
       _inputRequirement(MeshRequirement::UNDEFINED),
       _outputRequirement(MeshRequirement::UNDEFINED),
@@ -82,9 +82,9 @@ int Mapping::getDimensions() const
   return _dimensions;
 }
 
-bool Mapping::requireGradient() const
+bool Mapping::requiresGradientData() const
 {
-  return _requireGradient;
+  return _requiresGradientData;
 }
 
 void Mapping::map(int inputDataID,

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -47,7 +47,7 @@ public:
   };
 
   /// Constructor, takes mapping constraint.
-  Mapping(Constraint constraint, int dimensions, bool requireGradient = false);
+  Mapping(Constraint constraint, int dimensions, bool requiresGradientData = false);
 
   Mapping &operator=(Mapping &&) = delete;
 
@@ -141,7 +141,7 @@ protected:
   bool _hasComputedMapping = false;
 
   /// Flag if gradient data is required for the mapping
-  bool _requireGradient;
+  bool _requiresGradientData;
 
   /**
    * @brief Maps data using a conservative constraint

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -119,6 +119,9 @@ public:
    */
   virtual void scaleConsistentMapping(int inputDataID, int outputDataID) const;
 
+  /// Returns if the mapping needs gradient data
+  bool requireGradient() const;
+
 protected:
   /// Returns pointer to input mesh.
   mesh::PtrMesh input() const;
@@ -131,9 +134,6 @@ protected:
 
   /// Sets the mesh requirement for the output mesh.
   void setOutputRequirement(MeshRequirement requirement);
-
-  /// Returns if the mapping needs gradient data
-  bool requireGradient() const;
 
   int getDimensions() const;
 

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -119,8 +119,8 @@ public:
    */
   virtual void scaleConsistentMapping(int inputDataID, int outputDataID) const;
 
-  /// Returns if the mapping needs gradient data
-  bool requireGradient() const;
+  /// Returns whether the mapping requires gradient data
+  bool requiresGradientData() const;
 
 protected:
   /// Returns pointer to input mesh.

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -20,10 +20,10 @@ namespace mapping {
 NearestNeighborBaseMapping::NearestNeighborBaseMapping(
     Constraint  constraint,
     int         dimensions,
-    bool        requireGradient,
+    bool        requiresGradientData,
     std::string mappingName,
     std::string mappingNameShort)
-    : Mapping(constraint, dimensions, requireGradient),
+    : Mapping(constraint, dimensions, requiresGradientData),
       mappingName(mappingName),
       mappingNameShort(mappingNameShort)
 {
@@ -86,7 +86,7 @@ void NearestNeighborBaseMapping::clear()
   _vertexIndices.clear();
   _hasComputedMapping = false;
 
-  if (requireGradient())
+  if (requiresGradientData())
     _offsetsMatched.clear();
 
   if (getConstraint() == CONSISTENT) {

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -59,9 +59,8 @@ void NearestNeighborGradientMapping::mapConsistent(DataID inputDataID, DataID ou
   PRECICE_TRACE(inputDataID, outputDataID);
   precice::utils::Event e("map." + mappingNameShort + ".mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
-  PRECICE_CHECK(input()->data(inputDataID)->hasGradient(), "Mesh \"{}\" does not contain gradient data. Using Nearest Neighbor Gradient requires gradient data for all vertices. "
-                                                           "Check if hasGradient flag in the Data object was successfully initialized.",
-                input()->getName());
+  PRECICE_ASSERT(input()->data(inputDataID)->hasGradient(), "Mesh \"{}\" does not contain gradient data. Using Nearest Neighbor Gradient requires gradient data.",
+                 input()->getName());
 
   /// Check if input has gradient data, else send Error
   if (input()->vertices().empty()) {

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -59,8 +59,8 @@ void NearestNeighborGradientMapping::mapConsistent(DataID inputDataID, DataID ou
   PRECICE_TRACE(inputDataID, outputDataID);
   precice::utils::Event e("map." + mappingNameShort + ".mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
 
-  PRECICE_CHECK(input()->data(inputDataID)->hasGradient(), "Mesh \"{}\" does not contain gradient data. Using Nearest Neighbor Gradient requires gradient data for each vertices.",
-                "Check if hasGradient flag in the Data object was successfully initialized.",
+  PRECICE_CHECK(input()->data(inputDataID)->hasGradient(), "Mesh \"{}\" does not contain gradient data. Using Nearest Neighbor Gradient requires gradient data for all vertices. "
+                                                           "Check if hasGradient flag in the Data object was successfully initialized.",
                 input()->getName());
 
   /// Check if input has gradient data, else send Error

--- a/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
@@ -26,8 +26,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inDataScalar = inMesh->createData("InDataScalar", 1, 0_dataID);
   PtrData inDataVector = inMesh->createData("InDataVector", 2, 1_dataID);
-  inDataScalar->setDataGradientRequired();
-  inDataVector->setDataGradientRequired();
+  inDataScalar->requireDataGradient();
+  inDataVector->requireDataGradient();
   int     inDataScalarID = inDataScalar->getID();
   int     inDataVectorID = inDataVector->getID();
   Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -117,8 +117,8 @@ BOOST_AUTO_TEST_CASE(ConsistentGradientNotConstant)
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
   PtrData inDataScalar = inMesh->createData("InDataScalar", 1, 0_dataID);
   PtrData inDataVector = inMesh->createData("InDataVector", 2, 1_dataID);
-  inDataScalar->setDataGradientRequired();
-  inDataVector->setDataGradientRequired();
+  inDataScalar->requireDataGradient();
+  inDataVector->requireDataGradient();
   int     inDataScalarID = inDataScalar->getID();
   int     inDataVectorID = inDataVector->getID();
   Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -149,8 +149,8 @@ BOOST_AUTO_TEST_CASE(ConsistentGradientNotConstant)
   PtrData outDataVector   = outMesh->createData("OutDataVector", 2, 3_dataID);
   int     outDataScalarID = outDataScalar->getID();
   int     outDataVectorID = outDataVector->getID();
-  Vertex &outVertex0      = outMesh->createVertex(Eigen::Vector2d::Constant(0.1));
-  Vertex &outVertex1      = outMesh->createVertex(Eigen::Vector2d::Constant(1.1));
+  outMesh->createVertex(Eigen::Vector2d::Constant(0.1));
+  outMesh->createVertex(Eigen::Vector2d::Constant(1.1));
   outMesh->allocateDataValues();
 
   // Setup mapping with mapping coordinates and geometry used

--- a/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
@@ -24,8 +24,10 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inDataScalar   = inMesh->createData("InDataScalar", 1, 0_dataID, true);
-  PtrData inDataVector   = inMesh->createData("InDataVector", 2, 1_dataID, true);
+  PtrData inDataScalar = inMesh->createData("InDataScalar", 1, 0_dataID);
+  PtrData inDataVector = inMesh->createData("InDataVector", 2, 1_dataID);
+  inDataScalar->setDataGradientRequired();
+  inDataVector->setDataGradientRequired();
   int     inDataScalarID = inDataScalar->getID();
   int     inDataVectorID = inDataVector->getID();
   Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));
@@ -113,8 +115,10 @@ BOOST_AUTO_TEST_CASE(ConsistentGradientNotConstant)
 
   // Create mesh to map from
   PtrMesh inMesh(new Mesh("InMesh", dimensions, testing::nextMeshID()));
-  PtrData inDataScalar   = inMesh->createData("InDataScalar", 1, 0_dataID, true);
-  PtrData inDataVector   = inMesh->createData("InDataVector", 2, 1_dataID, true);
+  PtrData inDataScalar = inMesh->createData("InDataScalar", 1, 0_dataID);
+  PtrData inDataVector = inMesh->createData("InDataVector", 2, 1_dataID);
+  inDataScalar->setDataGradientRequired();
+  inDataVector->setDataGradientRequired();
   int     inDataScalarID = inDataScalar->getID();
   int     inDataVectorID = inDataVector->getID();
   Vertex &inVertex0      = inMesh->createVertex(Eigen::Vector2d::Constant(0.0));

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -22,12 +22,12 @@ Data::Data(
     std::string name,
     DataID      id,
     int         dimensions,
-    int         spacialDimensions)
+    int         spatialDimensions)
     : _values(),
       _name(std::move(name)),
       _id(id),
       _dimensions(dimensions),
-      _spatialDimensions(spacialDimensions)
+      _spatialDimensions(spatialDimensions)
 {
   PRECICE_ASSERT(dimensions > 0, dimensions);
 }
@@ -75,7 +75,7 @@ bool Data::hasGradient() const
   return _hasGradient;
 }
 
-void Data::setDataGradientRequired()
+void Data::requireDataGradient()
 {
   _hasGradient = true;
 };

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -13,8 +13,7 @@ Data::Data()
     : _name(""),
       _id(-1),
       _dimensions(0),
-      _spatialDimensions(-1),
-      _hasGradient(false)
+      _spatialDimensions(-1)
 {
   PRECICE_ASSERT(false);
 }
@@ -23,14 +22,12 @@ Data::Data(
     std::string name,
     DataID      id,
     int         dimensions,
-    int         spacialDimensions,
-    bool        hasGradient)
+    int         spacialDimensions)
     : _values(),
       _name(std::move(name)),
       _id(id),
       _dimensions(dimensions),
-      _spatialDimensions(spacialDimensions),
-      _hasGradient(hasGradient)
+      _spatialDimensions(spacialDimensions)
 {
   PRECICE_ASSERT(dimensions > 0, dimensions);
 }
@@ -77,6 +74,11 @@ bool Data::hasGradient() const
 {
   return _hasGradient;
 }
+
+void Data::setDataGradientRequired()
+{
+  _hasGradient = true;
+};
 
 int Data::getDimensions() const
 {

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -100,7 +100,7 @@ private:
   /// Dimensionality of one data value.
   int _dimensions;
 
-  /// Spacial Dimension of one element -> number of rows (only 2, 3 allowed for 2D, 3D).
+  /// Spatial Dimension of one element -> number of rows (only 2, 3 allowed for 2D, 3D).
   int _spatialDimensions;
 
   /// Whether gradient data is available or not

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -49,7 +49,7 @@ public:
       std::string name,
       DataID      id,
       int         dimension,
-      int         spacialDimensions = -1);
+      int         spatialDimensions = -1);
 
   /// Returns a reference to the data values.
   Eigen::VectorXd &values();
@@ -76,7 +76,7 @@ public:
   bool hasGradient() const;
 
   /// Set the additional requirement of gradient data
-  void setDataGradientRequired();
+  void requireDataGradient();
 
   /// Returns the mesh dimension (i.e., number of rows) of one gradient data value .
   int getSpatialDimensions() const;
@@ -103,7 +103,7 @@ private:
   /// Spacial Dimension of one element -> number of rows (only 2, 3 allowed for 2D, 3D).
   int _spatialDimensions;
 
-  /// Flag if the gradient data is available
+  /// Whether gradient data is available or not
   bool _hasGradient = false;
 };
 

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -49,8 +49,7 @@ public:
       std::string name,
       DataID      id,
       int         dimension,
-      int         spacialDimensions = -1,
-      bool        hasGradient       = false);
+      int         spacialDimensions = -1);
 
   /// Returns a reference to the data values.
   Eigen::VectorXd &values();
@@ -75,6 +74,9 @@ public:
 
   /// Returns if the data contains gradient data
   bool hasGradient() const;
+
+  /// Set the additional requirement of gradient data
+  void setDataGradientRequired();
 
   /// Returns the mesh dimension (i.e., number of rows) of one gradient data value .
   int getSpatialDimensions() const;
@@ -102,7 +104,7 @@ private:
   int _spatialDimensions;
 
   /// Flag if the gradient data is available
-  bool _hasGradient;
+  bool _hasGradient = false;
 };
 
 } // namespace mesh

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -156,8 +156,7 @@ Tetrahedron &Mesh::createTetrahedron(
 PtrData &Mesh::createData(
     const std::string &name,
     int                dimension,
-    DataID             id,
-    bool               withGradient)
+    DataID             id)
 {
   PRECICE_TRACE(name, dimension);
   for (const PtrData &data : _data) {
@@ -167,7 +166,7 @@ PtrData &Mesh::createData(
                   name, _name, name);
   }
   //#rows = dimensions of current mesh #columns = dimensions of corresponding data set
-  PtrData data(new Data(name, id, dimension, _dimensions, withGradient));
+  PtrData data(new Data(name, id, dimension, _dimensions));
   _data.push_back(data);
   return _data.back();
 }

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -176,8 +176,7 @@ public:
   /// Create only data for vertex
   PtrData &createData(const std::string &name,
                       int                dimension,
-                      DataID             id,
-                      bool               withGradient = false);
+                      DataID             id);
 
   /// Allows access to all data
   const DataContainer &data() const;

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -15,14 +15,9 @@ DataConfiguration::DataConfiguration(xml::XMLTag &parent)
   auto attrName = XMLAttribute<std::string>(ATTR_NAME)
                       .setDocumentation("Unique name for the data set.");
 
-  auto attrHasGradient = makeXMLAttribute(ATTR_HAS_GRADIENT, false)
-                             .setDocumentation(
-                                 "If this attribute is set to \"on\", the data must have gradient values");
-
   XMLTag tagScalar(*this, VALUE_SCALAR, XMLTag::OCCUR_ARBITRARY, TAG);
   tagScalar.setDocumentation("Defines a scalar data set to be assigned to meshes.");
   tagScalar.addAttribute(attrName);
-  tagScalar.addAttribute(attrHasGradient);
   parent.addSubtag(tagScalar);
 
   XMLTag tagVector(*this, VALUE_VECTOR, XMLTag::OCCUR_ARBITRARY, TAG);
@@ -30,7 +25,6 @@ DataConfiguration::DataConfiguration(xml::XMLTag &parent)
                              "components of each data entry depends on the spatial dimensions set "
                              "in tag <solver-interface>.");
   tagVector.addAttribute(attrName);
-  tagVector.addAttribute(attrHasGradient);
   parent.addSubtag(tagVector);
 }
 

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -63,10 +63,9 @@ void DataConfiguration::xmlTagCallback(
   if (tag.getNamespace() == TAG) {
     PRECICE_ASSERT(_dimensions != 0);
     const std::string &name           = tag.getStringAttributeValue(ATTR_NAME);
-    bool               hasGradient    = tag.getBooleanAttributeValue(ATTR_HAS_GRADIENT);
     const std::string &typeName       = tag.getName();
     int                dataDimensions = getDataDimensions(typeName);
-    addData(name, dataDimensions, hasGradient);
+    addData(name, dataDimensions);
   } else {
     PRECICE_ASSERT(false, "Received callback from an unknown tag.", tag.getName());
   }
@@ -80,30 +79,16 @@ void DataConfiguration::xmlEndTagCallback(
 
 void DataConfiguration::addData(
     const std::string &name,
-    int                dataDimensions,
-    bool               hasGradient)
+    int                dataDimensions)
 {
-  if (hasGradient) {
-
-    ConfiguredData data(name, dataDimensions, hasGradient);
-    // Check if data with same name has been added already
-    for (auto &elem : _data) {
-      PRECICE_CHECK(elem.name != data.name,
-                    "Data \"{0}\" has already been defined. Please rename or remove one of the data tags with name=\"{0}\".",
-                    data.name);
-    }
-    _data.push_back(data);
-  } else {
-
-    // Check if data with same name has been added already
-    for (auto &elem : _data) {
-      PRECICE_CHECK(elem.name != name,
-                    "Data \"{0}\" has already been defined. Please rename or remove one of the data tags with name=\"{0}\".",
-                    name);
-    }
-
-    _data.push_back({name, dataDimensions});
+  // Check if data with same name has been added already
+  for (auto &elem : _data) {
+    PRECICE_CHECK(elem.name != name,
+                  "Data \"{0}\" has already been defined. Please rename or remove one of the data tags with name=\"{0}\".",
+                  name);
   }
+
+  _data.push_back({name, dataDimensions});
 }
 
 int DataConfiguration::getDataDimensions(

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -50,11 +50,10 @@ public:
 private:
   mutable logging::Logger _log{"mesh::DataConfiguration"};
 
-  const std::string TAG               = "data";
-  const std::string ATTR_NAME         = "name";
-  const std::string VALUE_VECTOR      = "vector";
-  const std::string VALUE_SCALAR      = "scalar";
-  const std::string ATTR_HAS_GRADIENT = "gradient";
+  const std::string TAG          = "data";
+  const std::string ATTR_NAME    = "name";
+  const std::string VALUE_VECTOR = "vector";
+  const std::string VALUE_SCALAR = "scalar";
 
   /// Dimension of space.
   int _dimensions = 0;

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -16,13 +16,11 @@ public:
   struct ConfiguredData {
     std::string name;
     int         dimensions;
-    bool        hasGradient;
 
     ConfiguredData(
         const std::string &name,
-        int                dimensions,
-        bool               hasGradient = false)
-        : name(name), dimensions(dimensions), hasGradient(hasGradient) {}
+        int                dimensions)
+        : name(name), dimensions(dimensions) {}
   };
 
   DataConfiguration(xml::XMLTag &parent);
@@ -47,9 +45,7 @@ public:
    * @param[in] name Unique name of the data.
    * @param[in] dataDimensions Dimensionality (1: scalar, 2,3: vector) of data.
    */
-  void addData(const std::string &name,
-               int                dataDimensions,
-               bool               hasGradient = false);
+  void addData(const std::string &name, int dataDimensions);
 
 private:
   mutable logging::Logger _log{"mesh::DataConfiguration"};

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -86,7 +86,7 @@ void MeshConfiguration::xmlTagCallback(
     bool        found = false;
     for (const DataConfiguration::ConfiguredData &data : _dataConfig->data()) {
       if (data.name == name) {
-        _meshes.back()->createData(data.name, data.dimensions, _dataIDManager.getFreeID(), data.hasGradient);
+        _meshes.back()->createData(data.name, data.dimensions, _dataIDManager.getFreeID());
         found = true;
         break;
       }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -546,6 +546,10 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                         "Please add a use-mesh node with name=\"{}\" and provide=\"true\".",
                         participant->getName(), dataContext.getMeshName(), dataContext.getMeshName());
           dataContext.appendMappingConfiguration(mappingContext, meshContext);
+          // Enable gradient data if required
+          if (mappingContext.mapping->requireGradient() == true) {
+            mappingContext.mapping->getInputMesh()->data(dataContext.getDataName())->setDataGradientRequired();
+          }
           dataFound = true;
         }
       }
@@ -567,7 +571,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
       if (mappingContext.toMeshID == toMeshID) {
         // Second we look for the "from" mesh ID
         impl::MeshContext &meshContext = participant->meshContext(mappingContext.fromMeshID);
-        // If this is true, we actually found a proper configuraiton
+        // If this is true, we actually found a proper configuration
         // If it is false, we look for another "from" mesh ID, because we might have multiple read and write mappings
         if (meshContext.mesh->hasDataName(dataContext.getDataName())) {
           // Check, if the toMesh is a provided mesh
@@ -576,6 +580,10 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                         "Please add a use-mesh node with name=\"{}\" and provide=\"true\".",
                         participant->getName(), dataContext.getMeshName(), dataContext.getMeshName());
           dataContext.appendMappingConfiguration(mappingContext, meshContext);
+          // Enable gradient data if required
+          if (mappingContext.mapping->requireGradient() == true) {
+            mappingContext.mapping->getInputMesh()->data(dataContext.getDataName())->setDataGradientRequired();
+          }
           dataFound = true;
         }
       }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -547,8 +547,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                         participant->getName(), dataContext.getMeshName(), dataContext.getMeshName());
           dataContext.appendMappingConfiguration(mappingContext, meshContext);
           // Enable gradient data if required
-          if (mappingContext.mapping->requireGradient() == true) {
-            mappingContext.enableGradientData(dataContext.getDataName());
+          if (mappingContext.mapping->requiresGradientData() == true) {
+            mappingContext.requireGradientData(dataContext.getDataName());
           }
           dataFound = true;
         }
@@ -581,8 +581,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                         participant->getName(), dataContext.getMeshName(), dataContext.getMeshName());
           dataContext.appendMappingConfiguration(mappingContext, meshContext);
           // Enable gradient data if required
-          if (mappingContext.mapping->requireGradient() == true) {
-            mappingContext.enableGradientData(dataContext.getDataName());
+          if (mappingContext.mapping->requiresGradientData() == true) {
+            mappingContext.requireGradientData(dataContext.getDataName());
           }
           dataFound = true;
         }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -548,7 +548,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
           dataContext.appendMappingConfiguration(mappingContext, meshContext);
           // Enable gradient data if required
           if (mappingContext.mapping->requireGradient() == true) {
-            mappingContext.mapping->getInputMesh()->data(dataContext.getDataName())->setDataGradientRequired();
+            mappingContext.enableGradientData(dataContext.getDataName());
           }
           dataFound = true;
         }
@@ -582,7 +582,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
           dataContext.appendMappingConfiguration(mappingContext, meshContext);
           // Enable gradient data if required
           if (mappingContext.mapping->requireGradient() == true) {
-            mappingContext.mapping->getInputMesh()->data(dataContext.getDataName())->setDataGradientRequired();
+            mappingContext.enableGradientData(dataContext.getDataName());
           }
           dataFound = true;
         }

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -29,7 +29,7 @@ struct MappingContext {
   /// Enables gradient data in the corresponding 'from' data class
   void requireGradientData(const std::string &dataName)
   {
-    mapping->getInputMesh()->data(dataName)->setDataGradientRequired();
+    mapping->getInputMesh()->data(dataName)->requireDataGradient();
   }
 };
 

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "mapping/Mapping.hpp"
 #include "mapping/SharedPointer.hpp"
 #include "mapping/config/MappingConfiguration.hpp"
-
 namespace precice {
 namespace impl {
 
@@ -25,6 +25,12 @@ struct MappingContext {
 
   /// True, if data has been mapped already.
   bool hasMappedData = false;
+
+  /// Enables gradient data in the corresponding 'from' data class
+  void enableGradientData(const std::string &dataName)
+  {
+    mapping->getInputMesh()->data(dataName)->setDataGradientRequired();
+  }
 };
 
 } // namespace impl

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -27,7 +27,7 @@ struct MappingContext {
   bool hasMappedData = false;
 
   /// Enables gradient data in the corresponding 'from' data class
-  void enableGradientData(const std::string &dataName)
+  void requireGradientData(const std::string &dataName)
   {
     mapping->getInputMesh()->data(dataName)->setDataGradientRequired();
   }

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
@@ -52,6 +52,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
     interface.initialize();
+    BOOST_TEST(interface.isGradientDataRequired(dataID) == false);
     Eigen::Vector2d values;
     interface.advance(1.0);
     interface.readBlockScalarData(dataID, 2, vertexIDs, values.data());
@@ -66,12 +67,12 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)
     double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
-    int    dataID    = interface.getDataID("Data2", meshID);
+    int dataID = interface.getDataID("Data2", meshID);
+    BOOST_TEST(interface.isGradientDataRequired(dataID));
     double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
 
     interface.writeBlockScalarData(dataID, 6, vertexIDs, values);
 
-    BOOST_TEST(interface.isGradientDataRequired(dataID));
     if (interface.isGradientDataRequired(dataID)) {
 
       double gradientValues[12] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
@@ -2,7 +2,7 @@
 <precice-configuration>
   <solver-interface dimensions="2" experimental="on">
     <data:scalar name="Data1" />
-    <data:scalar name="Data2" gradient="on" />
+    <data:scalar name="Data2" />
 
     <mesh name="MeshOne">
       <use-data name="Data1" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
@@ -53,8 +53,10 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
     BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
+    BOOST_TEST(interface.isGradientDataRequired(dataID2) == false);
     interface.initialize();
     BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
+    BOOST_TEST(interface.isGradientDataRequired(dataID2) == false);
     Eigen::Vector4d values;
     interface.advance(1.0);
     interface.readBlockVectorData(dataID2, 2, vertexIDs, values.data());
@@ -69,8 +71,13 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
     int             vertexIDs[6];
     double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
+
+    DataID dataID1 = interface.getDataID("Data1", meshID);
+    DataID dataID2 = interface.getDataID("Data2", meshID);
+    BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
+    BOOST_TEST(interface.isGradientDataRequired(dataID2) == true);
+
     interface.initialize();
-    DataID dataID2    = interface.getDataID("Data2", meshID);
     double values[12] = {1.0, 1.0,
                          2.0, 2.0,
                          3.0, 3.0,
@@ -80,6 +87,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
 
     interface.writeBlockVectorData(dataID2, 6, vertexIDs, values);
 
+    BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
     BOOST_TEST(interface.isGradientDataRequired(dataID2) == true);
 
     if (interface.isGradientDataRequired(dataID2)) {

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
@@ -2,7 +2,7 @@
 <precice-configuration>
   <solver-interface dimensions="2" experimental="on">
     <data:scalar name="Data1" />
-    <data:vector name="Data2" gradient="on" />
+    <data:vector name="Data2" />
 
     <mesh name="MeshOne">
       <use-data name="Data1" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
@@ -2,7 +2,7 @@
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
     <data:scalar name="Data1" />
-    <data:vector name="Data2" gradient="on" />
+    <data:vector name="Data2" />
 
     <mesh name="MeshOne">
       <use-data name="Data1" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
@@ -61,6 +61,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)
 
       cplInterface.writeScalarData(dataAID, 0, 3.0);
       Vector3d valueGradDataA(1.0, 2.0, 3.0);
+      BOOST_TEST(cplInterface.isGradientDataRequired(dataAID));
       cplInterface.writeScalarGradientData(dataAID, 0, valueGradDataA.data());
 
       maxDt = cplInterface.advance(maxDt);
@@ -79,7 +80,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)
     double maxDt   = cplInterface.initialize();
     int    dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int    dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
-
+    BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == false);
     double valueDataB = 1.0;
     cplInterface.writeScalarData(dataBID, 0, valueDataB);
 

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
-    <data:scalar name="DataOne" gradient="on" />
+    <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
     <mesh name="MeshOne">

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
-    <data:vector name="DataOne" gradient="on" />
+    <data:vector name="DataOne" />
     <data:vector name="DataTwo" />
 
     <mesh name="MeshOne">

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
@@ -2,7 +2,7 @@
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
     <data:vector name="DataOne" />
-    <data:scalar name="DataTwo" gradient="on" />
+    <data:scalar name="DataTwo" />
 
     <mesh name="MeshOne">
       <use-data name="DataOne" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
@@ -52,6 +52,8 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
     double maxDt   = cplInterface.initialize();
     int    dataAID = cplInterface.getDataID("DataOne", meshOneID);
     int    dataBID = cplInterface.getDataID("DataTwo", meshOneID);
+    BOOST_TEST(cplInterface.isGradientDataRequired(dataAID) == false);
+    BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == false);
 
     Vector3d valueDataA(1.0, 1.0, 1.0);
     cplInterface.writeVectorData(dataAID, 0, valueDataA.data());
@@ -85,6 +87,8 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
     double maxDt   = cplInterface.initialize();
     int    dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int    dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
+    BOOST_TEST(cplInterface.isGradientDataRequired(dataAID) == false);
+    BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == true);
 
     Vector2d                    valueDataB(2.0, 3.0);
     Eigen::Matrix<double, 3, 3> gradient;

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
@@ -2,7 +2,7 @@
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
     <data:vector name="DataOne" />
-    <data:vector name="DataTwo" gradient="on" />
+    <data:vector name="DataTwo" />
 
     <mesh name="MeshOne">
       <use-data name="DataOne" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
-    <data:vector name="DataA" gradient="on" />
+    <data:vector name="DataA" />
     <data:scalar name="DataB" />
 
     <mesh name="MeshA">

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
-    <data:scalar name="DataA" gradient="on" />
+    <data:scalar name="DataA" />
     <data:scalar name="DataB" />
 
     <mesh name="MeshA">

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
   <solver-interface dimensions="3" experimental="on">
-    <data:vector name="DataA" gradient="on" />
+    <data:vector name="DataA" />
     <data:scalar name="DataB" />
 
     <mesh name="MeshA">

--- a/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
@@ -62,6 +62,7 @@ void testVectorGradientFunctions(const TestContext &context, const bool writeBlo
     interface.setMeshVertex(meshTwoID, posTwo.data());
 
     double maxDt = interface.initialize();
+    BOOST_TEST(interface.isGradientDataRequired(dataID) == false);
     BOOST_TEST(interface.isCouplingOngoing(), "Receiving participant should have to advance once!");
 
     double valueData[6];


### PR DESCRIPTION
## Main changes of this PR
Removes the `<data: ...  gradient="on" />` flag from the xml configuration and deduces the information automatically based on the configured mappings. Currently, only the `nearest-neighbor-gradient-mapping` requires gradient data.

## Motivation and additional information
Improves the usability, as the user doesn't have to change obvious things in different places and prevents unnecessary gradient data allocation due to global gradient enabling/disabling. Related to #1252. 
Note that this change is non-breaking as this feature is still experimental.

EDIT: This also resolved part two of #1252, i.e., gradients are now only communicated if it is really required by the mapping configuration.

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
