### PR TITLE
Add gradient API functions to native bindings

### DIFF
--- a/docs/changelog/1374.md
+++ b/docs/changelog/1374.md
@@ -1,0 +1,1 @@
+- Added gradient related API functions to native Fortran and C bindings

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -433,35 +433,6 @@ void precicec_readScalarData(
     int     valueIndex,
     double *dataValue);
 
-/// @copydoc precice::SolverInterface::isGradientDataRequired())
-void precicec_isGradientDataRequired(int dataID);
-
-/// @copydoc precice::SolverInterface::writeScalarGradientData()
-void precicec_writeScalarGradientData(
-    int           dataID,
-    int           valueIndex,
-    const double *gradientValues);
-
-/// @copydoc precice::SolverInterface::writeBlockScalarGradientData
-void precicec_writeBlockScalarGradientData(
-    int           dataID,
-    int           size,
-    const int *   valueIndices,
-    const double *gradientValues);
-
-/// @copydoc precice::SolverInterface::writeVectorGradientData()
-void precicec_writeVectorGradientData(
-    int           dataID,
-    int           valueIndex,
-    const double *gradientValues);
-
-/// @copydoc precice::SolverInterface::writeBlockVectorGradientData())
-void precicec_writeBlockVectorGradientData(
-    int           dataID,
-    int           size,
-    const int *   valueIndices,
-    const double *gradientValues);
-
 /**
  * @brief Returns information on the version of preCICE.
  *
@@ -488,6 +459,35 @@ const char *precicec_actionReadIterationCheckpoint();
  * These API functions are \b experimental and may change in future versions.
  */
 ///@{
+
+/// @copydoc precice::SolverInterface::isGradientDataRequired())
+bool precicec_isGradientDataRequired(int dataID);
+
+/// @copydoc precice::SolverInterface::writeScalarGradientData()
+void precicec_writeScalarGradientData(
+    int           dataID,
+    int           valueIndex,
+    const double *gradientValues);
+
+/// @copydoc precice::SolverInterface::writeBlockScalarGradientData
+void precicec_writeBlockScalarGradientData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *gradientValues);
+
+/// @copydoc precice::SolverInterface::writeVectorGradientData()
+void precicec_writeVectorGradientData(
+    int           dataID,
+    int           valueIndex,
+    const double *gradientValues);
+
+/// @copydoc precice::SolverInterface::writeBlockVectorGradientData())
+void precicec_writeBlockVectorGradientData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *gradientValues);
 
 /**
  * @brief See precice::SolverInterface::setMeshAccessRegion().

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -433,11 +433,40 @@ void precicec_readScalarData(
     int     valueIndex,
     double *dataValue);
 
-/** 
+/// @copydoc precice::SolverInterface::isGradientDataRequired())
+void precicec_isGradientDataRequired(int dataID);
+
+/// @copydoc precice::SolverInterface::writeScalarGradientData()
+void precicec_writeScalarGradientData(
+    int           dataID,
+    int           valueIndex,
+    const double *gradientValues);
+
+/// @copydoc precice::SolverInterface::writeBlockScalarGradientData
+void precicec_writeBlockScalarGradientData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *gradientValues);
+
+/// @copydoc precice::SolverInterface::writeVectorGradientData()
+void precicec_writeVectorGradientData(
+    int           dataID,
+    int           valueIndex,
+    const double *gradientValues);
+
+/// @copydoc precice::SolverInterface::writeBlockVectorGradientData())
+void precicec_writeBlockVectorGradientData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *gradientValues);
+
+/**
  * @brief Returns information on the version of preCICE.
  *
  * Returns a semicolon-separated C-string containing:
- * 
+ *
  * 1) the version of preCICE
  * 2) the revision information of preCICE
  * 3) the configuration of preCICE including MPI, PETSC, PYTHON

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -460,10 +460,10 @@ const char *precicec_actionReadIterationCheckpoint();
  */
 ///@{
 
-/// @copydoc precice::SolverInterface::isGradientDataRequired())
+/// @copydoc precice::SolverInterface::isGradientDataRequired
 int precicec_isGradientDataRequired(int dataID);
 
-/// @copydoc precice::SolverInterface::writeScalarGradientData()
+/// @copydoc precice::SolverInterface::writeScalarGradientData
 void precicec_writeScalarGradientData(
     int           dataID,
     int           valueIndex,
@@ -476,13 +476,13 @@ void precicec_writeBlockScalarGradientData(
     const int *   valueIndices,
     const double *gradientValues);
 
-/// @copydoc precice::SolverInterface::writeVectorGradientData()
+/// @copydoc precice::SolverInterface::writeVectorGradientData
 void precicec_writeVectorGradientData(
     int           dataID,
     int           valueIndex,
     const double *gradientValues);
 
-/// @copydoc precice::SolverInterface::writeBlockVectorGradientData())
+/// @copydoc precice::SolverInterface::writeBlockVectorGradientData
 void precicec_writeBlockVectorGradientData(
     int           dataID,
     int           size,

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -461,7 +461,7 @@ const char *precicec_actionReadIterationCheckpoint();
 ///@{
 
 /// @copydoc precice::SolverInterface::isGradientDataRequired())
-bool precicec_isGradientDataRequired(int dataID);
+int precicec_isGradientDataRequired(int dataID);
 
 /// @copydoc precice::SolverInterface::writeScalarGradientData()
 void precicec_writeScalarGradientData(

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -373,6 +373,50 @@ void precicec_readScalarData(
   impl->readScalarData(dataID, valueIndex, *dataValue);
 }
 
+void precicec_isGradientDataRequired(int dataID)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->isGradientDataRequired(dataID);
+}
+
+void precicec_writeScalarGradientData(
+    int           dataID,
+    int           valueIndex,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeScalarGradientData(dataID, valueIndex, gradientValues);
+}
+
+void precicec_writeBlockScalarGradientData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeBlockScalarGradientData(dataID, size, valueIndices, gradientValues);
+}
+
+void precicec_writeVectorGradientData(
+    int           dataID,
+    int           valueIndex,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeVectorGradientData(dataID, valueIndex, gradientValues);
+}
+
+void precicec_writeBlockVectorGradientData(
+    int           dataID,
+    int           size,
+    const int *   valueIndices,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeBlockVectorGradientData(dataID, size, valueIndices, gradientValues);
+}
+
 const char *precicec_getVersionInformation()
 {
   return precice::versionInformation;

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -373,10 +373,13 @@ void precicec_readScalarData(
   impl->readScalarData(dataID, valueIndex, *dataValue);
 }
 
-bool precicec_isGradientDataRequired(int dataID)
+int precicec_isGradientDataRequired(int dataID)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  return impl->isGradientDataRequired(dataID);
+  if (impl->isGradientDataRequired(dataID)) {
+    return 1;
+  }
+  return 0;
 }
 
 void precicec_writeScalarGradientData(

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -373,10 +373,10 @@ void precicec_readScalarData(
   impl->readScalarData(dataID, valueIndex, *dataValue);
 }
 
-void precicec_isGradientDataRequired(int dataID)
+bool precicec_isGradientDataRequired(int dataID)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->isGradientDataRequired(dataID);
+  return impl->isGradientDataRequired(dataID);
 }
 
 void precicec_writeScalarGradientData(

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -773,6 +773,91 @@ void precicef_get_version_information_(
 
 /**
  * Fortran syntax:
+ * precicef_is_gradient_data_required_(
+ *   INTEGER dataID,
+ *   INTEGER required )
+ *
+ * IN:  dataID
+ * OUT: required(1:true, 0:false)
+ *
+ * @copydoc precice::SolverInterface::isGradientDataRequired()
+ */
+void precicef_is_gradient_data_required_(const int *dataID, int *required);
+
+/**
+ * Fortran syntax:
+ * precicef_write_sgradient_data_(
+ *   INTEGER dataID,
+ *   INTEGER valueIndex,
+ *   DOUBLE PRECISION gradientValues )
+ *
+ * IN:  dataID, valueIndex, gradientValues
+ * OUT: -
+ *
+ * @copydoc precice::SolverInterface::writeScalarGradientData()
+ */
+void precicef_write_sgradient_data_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *gradientValues);
+
+/**
+ * Fortran syntax:
+ * precicef_write_bsgradient_data_(
+ *   INTEGER dataID,
+ *   INTEGER size,
+ *   INTEGER valueIndices,
+ *   DOUBLE PRECISION gradientValues )
+ *
+ * IN:  dataID, size, valueIndices, gradientValues
+ * OUT: -
+ *
+ * @copydoc precice::SolverInterface::writeBlockScalarGradientData
+ */
+void precicef_write_bsgradient_data_(
+    const int *   dataID,
+    const int *   size,
+    const int *   valueIndices,
+    const double *gradientValues);
+
+/**
+ * Fortran syntax:
+ * precicef_write_vgradient_data_(
+ *   INTEGER dataID,
+ *   INTEGER valueIndex,
+ *   DOUBLE PRECISION gradientValues )
+ *
+ * IN:  dataID, valueIndex, gradientValues
+ * OUT: -
+ *
+ * @copydoc precice::SolverInterface::writeVectorGradientData()
+ */
+void precicef_write_vgradient_data_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *gradientValues);
+
+/**
+ * Fortran syntax:
+ * precicef_write_bvgradient_data_(
+ *   INTEGER dataID,
+ *   INTEGER size,
+ *   INTEGER valueIndices,
+ *   DOUBLE PRECISION gradientValues )
+ *
+ * IN:  dataID, size, valueIndices, gradientValues
+ * OUT: -
+ *
+ * @copydoc precice::SolverInterface::writeBlockVectorGradientData()
+ */
+void precicef_write_bvgradient_data_(
+    const int *   dataID,
+    const int *   size,
+    const int *   valueIndices,
+    const double *gradientValues);
+
+/**
+ * Fortran syntax:
  * precicef_set_mesh_access_region_(
  *   INTEGER          meshID,
  *   DOUBLE PRECISION bounding_box(dim*2))

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -780,7 +780,7 @@ void precicef_get_version_information_(
  * IN:  dataID
  * OUT: required(1:true, 0:false)
  *
- * @copydoc precice::SolverInterface::isGradientDataRequired()
+ * @copydoc precice::SolverInterface::isGradientDataRequired
  */
 void precicef_is_gradient_data_required_(const int *dataID, int *required);
 
@@ -794,7 +794,7 @@ void precicef_is_gradient_data_required_(const int *dataID, int *required);
  * IN:  dataID, valueIndex, gradientValues
  * OUT: -
  *
- * @copydoc precice::SolverInterface::writeScalarGradientData()
+ * @copydoc precice::SolverInterface::writeScalarGradientData
  */
 void precicef_write_sgradient_data_(
     const int *   dataID,
@@ -830,7 +830,7 @@ void precicef_write_bsgradient_data_(
  * IN:  dataID, valueIndex, gradientValues
  * OUT: -
  *
- * @copydoc precice::SolverInterface::writeVectorGradientData()
+ * @copydoc precice::SolverInterface::writeVectorGradientData
  */
 void precicef_write_vgradient_data_(
     const int *   dataID,
@@ -848,7 +848,7 @@ void precicef_write_vgradient_data_(
  * IN:  dataID, size, valueIndices, gradientValues
  * OUT: -
  *
- * @copydoc precice::SolverInterface::writeBlockVectorGradientData()
+ * @copydoc precice::SolverInterface::writeBlockVectorGradientData
  */
 void precicef_write_bvgradient_data_(
     const int *   dataID,

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -548,6 +548,54 @@ void precicef_get_mesh_vertices_and_IDs_(
   impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
 }
 
+void precicef_is_gradient_data_required_(const int *dataID, int *required)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  if (impl->isGradientDataRequired(*dataID)) {
+    *required = 1;
+  } else {
+    *required = 0;
+  }
+}
+
+void precicef_write_sgradient_data_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeScalarGradientData(*dataID, *valueIndex, gradientValues);
+}
+
+void precicef_write_bsgradient_data_(
+    const int *   dataID,
+    const int *   size,
+    const int *   valueIndices,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeBlockScalarGradientData(*dataID, *size, valueIndices, gradientValues);
+}
+
+void precicef_write_vgradient_data_(
+    const int *   dataID,
+    const int *   valueIndex,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeVectorGradientData(*dataID, *valueIndex, gradientValues);
+}
+
+void precicef_write_bvgradient_data_(
+    const int *   dataID,
+    const int *   size,
+    const int *   valueIndices,
+    const double *gradientValues)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->writeBlockVectorGradientData(*dataID, *size, valueIndices, gradientValues);
+}
+
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
## Main changes of this PR
Adds the `write*Gradient` and `isGradientDataRequired` API functions to our native fortran and C bindings.

## Motivation and additional information
As part of #1252 
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
