### PR TITLE
Add a warning when gradient data is used in QN acceleration

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -83,6 +83,11 @@ void BaseQNAcceleration::initialize(
                    pair.second->values().size(), pair.second->previousIteration().size());
   }
 
+  if (std::any_of(cplData.cbegin(), cplData.cend(), [](const auto &p) { return p.second->hasGradient(); })) {
+    PRECICE_WARN("Gradient data required by the configured mapping is not yet accelerated with quasi-Newton acceleration schemes, which might lead to numerical issues. "
+                 "Consider switching to a different acceleration scheme or a different data mapping scheme.");
+  }
+
   checkDataIDs(cplData);
   size_t              entries = 0;
   std::vector<size_t> subVectorSizes; //needed for preconditioner

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -84,7 +84,7 @@ void BaseQNAcceleration::initialize(
   }
 
   if (std::any_of(cplData.cbegin(), cplData.cend(), [](const auto &p) { return p.second->hasGradient(); })) {
-    PRECICE_WARN("Gradient data required by the configured mapping is not yet accelerated with quasi-Newton acceleration schemes, which might lead to numerical issues. "
+    PRECICE_WARN("Gradient data, which is required by at least one of the configured data mappings, is not yet compatible with quasi-Newton acceleration. This combination might lead to numerical issues. "
                  "Consider switching to a different acceleration scheme or a different data mapping scheme.");
   }
 


### PR DESCRIPTION
## Main changes of this PR
...which is currently incompatible.

## Motivation and additional information
Extending the QN scheme to handle the additional gradient data is non trivial, as the implementation relies on registered `dataID`s, which we don't have in case of gradient data (gradients are part of the data object itself).

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
