### PR TITLE
Fixed missing event in Barycentric mappings

### DIFF
--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -39,6 +39,7 @@ void BarycentricBaseMapping::clear()
 void BarycentricBaseMapping::mapConservative(DataID inputDataID, DataID outputDataID)
 {
   PRECICE_TRACE(inputDataID, outputDataID);
+  precice::utils::Event e("map.bbm.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
   PRECICE_ASSERT(getConstraint() == CONSERVATIVE, getConstraint());
   PRECICE_DEBUG("Map conservative");
   PRECICE_ASSERT(_interpolations.size() == input()->vertices().size(),
@@ -66,6 +67,7 @@ void BarycentricBaseMapping::mapConservative(DataID inputDataID, DataID outputDa
 void BarycentricBaseMapping::mapConsistent(DataID inputDataID, DataID outputDataID)
 {
   PRECICE_TRACE(inputDataID, outputDataID);
+  precice::utils::Event e("map.bbm.mapData.From" + input()->getName() + "To" + output()->getName(), precice::syncMode);
   PRECICE_DEBUG("Map consistent");
   PRECICE_ASSERT(_interpolations.size() == output()->vertices().size(),
                  _interpolations.size(), output()->vertices().size());


### PR DESCRIPTION
## Main changes of this PR

In BarycentricBaseMapping, events for timing the mapping were missing. This is now fixed.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
