### PR TITLE
Rename master branch to main branch

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -2,7 +2,7 @@ name: Build and Test macOS
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     paths:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ name: Build and Test
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     paths:

--- a/docs/documents/060_release.dox
+++ b/docs/documents/060_release.dox
@@ -13,8 +13,8 @@ We use versioning inspired by semantic versioning: https://semver.org/
 Guidelines
 ------------------
 
-- Use ```git cherrypick``` to backport small bug fixes from develop to master. That constitutes a revision release, i.e. increment last digit.
-- For bigger bug fixes, branch from master, fix the bug and merge back into master. Then merge master to develop.
+- Use ```git cherrypick``` to backport small bug fixes from develop to main. That constitutes a revision release, i.e. increment last digit.
+- For bigger bug fixes, branch from main, fix the bug and merge back into main. Then merge main to develop.
 - Use coding days to release.
 - Update ```CHANGELOG.md``` with all user notable changes. Whenever such a change is pushed to develop, update the changelog for the upcoming release.
 - Copy the changelog entries for the release to the GitHub releases page.
@@ -23,14 +23,14 @@ Guidelines
 Minor or major release step-by-step
 ------------------
 
-1. Merge master to develop
+1. Merge main to develop
 2. Do regression tests (SU2/CalculiX, OpenFOAM, Alya, 1D-ElasticTube, SuperMUC, ...) at develop
 3. Look over CHANGELOG and add things if necessary
 4. Bump version in CMakeLists.txt, the debian changelog, and language bindings (python: APPVERSION; see https://github.com/precice/precice/blob/develop/src/precice/bindings/python/setup.py#L13)
 5. Draft message to mailing list
 6. Update documentation
 7. Fix potential problems in develop
-8. Merge develop to master
+8. Merge develop to main
 9. Tag release (on GitHub) and merge back to develop
 10. Send email and do marketing
 

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -12,8 +12,8 @@ Only the release manager should update this post (even tickboxes, due to race co
 * [ ] Look over entries in [`docs/changelog`](https://github.com/precice/precice/blob/develop/docs/changelog)) (all)
    * Add missing entries, if necessary
    * Fix wording and tense
-* [ ] Make sure you have the latest `develop` and `master` branches locally.
-* [ ] Merge master to develop ( This should result in no commits )
+* [ ] Make sure you have the latest `develop` and `main` branches locally.
+* [ ] Merge main to develop ( This should result in no commits )
 * [ ] Check code base w.r.t code formatting (run [`precice/tools/formatting/check-format`](https://github.com/precice/precice/blob/develop/tools/formatting/check-format)) and reformat if required (run [`precice/tools/formatting/format-all`](https://github.com/precice/precice/blob/develop/tools/formatting/format-all))
 * [ ] Create branch `release-vX.Y.Z` from develop. If needed, `git rebase develop`.
 * [ ] Run `tools/releasing/bumpversion.sh MAJOR.MINOR.PATCH` to bump the version
@@ -37,7 +37,7 @@ Only the release manager should update this post (even tickboxes, due to race co
 
 ## Step by step guide
 
-* [ ] Open PR from `release-vX.Y.Z` to `master` (use [this template](https://github.com/precice/precice/blob/add_PR_template/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md))
+* [ ] Open PR from `release-vX.Y.Z` to `main` (use [this template](https://github.com/precice/precice/blob/add_PR_template/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md))
 * [ ] Do regression tests using the release branch (specific revision) _list below :arrow_down:_ (all)
 * [ ] Fix potential problems in develop (all)
 * [ ] Rebase the relase branch on develop (all)
@@ -50,11 +50,11 @@ Only the release manager should update this post (even tickboxes, due to race co
       * `_config.yml`
       * `_data/sidebars/docs_sidebar.yml`
 * [ ] Approve the PR with at least two reviews (all)
-* [ ] Merge PR to master ( use `git merge --no-ff release-vX.Y.Z` )
-* [ ] Tag release on master `vX.Y.Z` and verify by running `git describe --tags`
+* [ ] Merge PR to main ( use `git merge --no-ff release-vX.Y.Z` )
+* [ ] Tag release on main `vX.Y.Z` and verify by running `git describe --tags`
 * [ ] Merge back to develop and verify by running `git describe --tags`
 * [ ] Tripple check that you haven't messed anything up. (You can always discard local changes)
-* [ ] Push master and push the `vX.Y.Z` tag
+* [ ] Push main and push the `vX.Y.Z` tag
 * [ ] Push develop
 * [ ] Wait for the release pipeline
   * [ ] [To create a new draft release on GitHub](https://github.com/precice/precice/releases)
@@ -69,7 +69,7 @@ Use the following branches:
 * precice `release-vX.Y.Z`
 * pyprecice `python-bindings-vX.Y.Z.1`
 * matlab-bindings `matlab-bindings-vX.Y.Z.1`
-* rest `master`
+* rest `main`
 
 Run all these tests manually on your system. If you succeed, please write a comment with the revisions of the components that you used below. Example: https://github.com/precice/precice/pull/507#issuecomment-530432289 and update the table.
 
@@ -119,12 +119,12 @@ Run all these tests manually on your system. If you succeed, please write a comm
 
 ### Release new version for bindings (to ensure compatibility with newest preCICE version)
 
-- [ ] [Fortan module](https://github.com/precice/fortran-module/compare/master...develop)
+- [ ] [Fortan module](https://github.com/precice/fortran-module/compare/main...develop)
 - [ ] [MATLAB bindings](https://github.com/precice/matlab-bindings/blob/develop/docs/ReleaseGuide.md)
 - [ ] [python bindings](https://github.com/precice/python-bindings/blob/develop/docs/ReleaseGuide.md)
 - [ ] [Julia bindings](https://github.com/precice/PreCICE.jl)
 
-### (only if breaking changes) Open PRs or issues `develop -> master` for all adapters
+### (only if breaking changes) Open PRs or issues `develop -> main` for all adapters
 
 - [ ] [athlet-adapter](https://github.com/precice/athlet-adapter/compare/master...develop)
 - [ ] [calculix-adapter](https://github.com/precice/calculix-adapter/compare/master...develop)
@@ -138,7 +138,7 @@ Run all these tests manually on your system. If you succeed, please write a comm
 - [ ] [openfoam-adapter](https://github.com/precice/openfoam-adapter/compare/master...develop)
 - [ ] [su2-adapter](https://github.com/precice/su2-adapter/compare/master...develop)
 
-### (only if breaking changes) Open PRs or issues `develop -> master` for all other tools
+### (only if breaking changes) Open PRs or issues `develop -> main` for all other tools
 
 - [ ] [aste](https://github.com/precice/aste/compare/master...develop)
 - [ ] [elastictube1d](https://github.com/precice/elastictube1d/compare/master...develop)


### PR DESCRIPTION
## Main changes of this PR
Changes affecting the renaming of our `master` branch to `main` branch.

## Motivation and additional information
As documented by [GitHub](https://github.com/github/renaming), web requests to the `master` branch will automatically be forwarded to the `main` branch. Considering that we don't develop directly on the `master` branch, this change should be fully backwards compatible.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
