### PR TITLE
Fix the triangle distance calculation

### DIFF
--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -81,11 +81,12 @@ void LinearCellInterpolationMapping::computeMapping()
 
   for (const auto &fVertex : fVertices) {
     // Find tetrahedra (3D) or triangle (2D) or fall-back on NP
-    auto match = index.findCellOrProjection(fVertex.getCoords(), nnearest);
+    auto match    = index.findCellOrProjection(fVertex.getCoords(), nnearest);
+    auto distance = match.polation.distance();
     _interpolations.push_back(std::move(match.polation));
-    if (!math::equals(match.distance, 0.0)) {
+    if (!math::equals(distance, 0.0)) {
       // Only push when fall-back occurs, so the number of entries is the number of vertices outside the domain
-      fallbackStatistics(match.distance);
+      fallbackStatistics(distance);
     }
   }
 

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -61,9 +61,11 @@ void NearestNeighborBaseMapping::computeMapping()
 
   auto &index = searchSpace->index();
   for (size_t i = 0; i < verticesSize; ++i) {
-    const auto &matchedVertex = index.getClosestVertex(sourceVertices[i].getCoords());
+    const auto &sourceCoords  = sourceVertices[i].getCoords();
+    const auto &matchedVertex = index.getClosestVertex(sourceCoords);
     _vertexIndices[i]         = matchedVertex.index;
-    distanceStatistics(matchedVertex.distance);
+    auto distance             = (sourceCoords - searchSpace->vertices()[matchedVertex.index].getCoords()).norm();
+    distanceStatistics(distance);
   }
 
   // For gradient mapping, the calculation of offsets between source and matched vertex necessary

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -64,7 +64,10 @@ void NearestNeighborBaseMapping::computeMapping()
     const auto &sourceCoords  = sourceVertices[i].getCoords();
     const auto &matchedVertex = index.getClosestVertex(sourceCoords);
     _vertexIndices[i]         = matchedVertex.index;
-    auto distance             = (sourceCoords - searchSpace->vertices()[matchedVertex.index].getCoords()).norm();
+
+    // Compute distance between input and output vertiex for the stats
+    const auto &matchCoords = searchSpace->vertices()[matchedVertex.index].getCoords();
+    auto        distance    = (sourceCoords - matchCoords).norm();
     distanceStatistics(distance);
   }
 

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -42,21 +42,6 @@ NearestProjectionMapping::NearestProjectionMapping(
   }
 }
 
-namespace {
-struct MatchType {
-  double distance;
-  int    index;
-
-  MatchType() = default;
-  MatchType(double d, int i)
-      : distance(d), index(i){};
-  constexpr bool operator<(MatchType const &other) const
-  {
-    return distance < other.distance;
-  };
-};
-} // namespace
-
 void NearestProjectionMapping::computeMapping()
 {
   PRECICE_TRACE(input()->vertices().size(), output()->vertices().size());
@@ -107,8 +92,8 @@ void NearestProjectionMapping::computeMapping()
     // Nearest projection element is edge for 2d if exists, if not, it is the nearest vertex
     // Nearest projection element is triangle for 3d if exists, if not the edge and at the worst case it is the nearest vertex
     auto match = index.findNearestProjection(fVertex.getCoords(), nnearest);
+    distanceStatistics(match.polation.distance());
     _interpolations.push_back(std::move(match.polation));
-    distanceStatistics(match.distance);
   }
 
   if (distanceStatistics.empty()) {

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -9,6 +9,7 @@ namespace mapping {
 Polation::Polation(const Eigen::VectorXd &location, const mesh::Vertex &element)
 {
   _weightedElements.emplace_back(WeightedElement{element.getID(), 1.0});
+  // The projection in this case is simply the nearest point.
   _distance = (location - element.getCoords()).norm();
 }
 
@@ -74,11 +75,8 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Tetrahedron &ele
   _weightedElements.emplace_back(WeightedElement{C.getID(), bcoords(2)});
   _weightedElements.emplace_back(WeightedElement{D.getID(), bcoords(3)});
 
-  Eigen::VectorXd projection = A.getCoords() * bcoords(0) +
-                               B.getCoords() * bcoords(1) +
-                               C.getCoords() * bcoords(2) +
-                               D.getCoords() * bcoords(3);
-  _distance = (location - projection).norm();
+  // There is no projection happing, so the distance is always 0.
+  _distance = 0.0;
 }
 
 const std::vector<WeightedElement> &Polation::getWeightedElements() const

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -1,13 +1,15 @@
 #include "mapping/Polation.hpp"
+#include <Eigen/src/Core/Matrix.h>
 #include "math/barycenter.hpp"
 #include "math/differences.hpp"
 
 namespace precice {
 namespace mapping {
 
-Polation::Polation(const mesh::Vertex &element)
+Polation::Polation(const Eigen::VectorXd &location, const mesh::Vertex &element)
 {
   _weightedElements.emplace_back(WeightedElement{element.getID(), 1.0});
+  _distance = (location - element.getCoords()).norm();
 }
 
 Polation::Polation(const Eigen::VectorXd &location, const mesh::Edge &element)
@@ -23,6 +25,10 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Edge &element)
 
   _weightedElements.emplace_back(WeightedElement{A.getID(), bcoords(0)});
   _weightedElements.emplace_back(WeightedElement{B.getID(), bcoords(1)});
+
+  Eigen::VectorXd projection = A.getCoords() * bcoords(0) +
+                               B.getCoords() * bcoords(1);
+  _distance = (location - projection).norm();
 }
 
 Polation::Polation(const Eigen::VectorXd &location, const mesh::Triangle &element)
@@ -41,6 +47,11 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Triangle &elemen
   _weightedElements.emplace_back(WeightedElement{A.getID(), bcoords(0)});
   _weightedElements.emplace_back(WeightedElement{B.getID(), bcoords(1)});
   _weightedElements.emplace_back(WeightedElement{C.getID(), bcoords(2)});
+
+  Eigen::VectorXd projection = A.getCoords() * bcoords(0) +
+                               B.getCoords() * bcoords(1) +
+                               C.getCoords() * bcoords(2);
+  _distance = (location - projection).norm();
 }
 
 Polation::Polation(const Eigen::VectorXd &location, const mesh::Tetrahedron &element)
@@ -62,6 +73,12 @@ Polation::Polation(const Eigen::VectorXd &location, const mesh::Tetrahedron &ele
   _weightedElements.emplace_back(WeightedElement{B.getID(), bcoords(1)});
   _weightedElements.emplace_back(WeightedElement{C.getID(), bcoords(2)});
   _weightedElements.emplace_back(WeightedElement{D.getID(), bcoords(3)});
+
+  Eigen::VectorXd projection = A.getCoords() * bcoords(0) +
+                               B.getCoords() * bcoords(1) +
+                               C.getCoords() * bcoords(2) +
+                               D.getCoords() * bcoords(3);
+  _distance = (location - projection).norm();
 }
 
 const std::vector<WeightedElement> &Polation::getWeightedElements() const
@@ -72,6 +89,11 @@ const std::vector<WeightedElement> &Polation::getWeightedElements() const
 bool Polation::isInterpolation() const
 {
   return std::all_of(_weightedElements.begin(), _weightedElements.end(), [](const mapping::WeightedElement &elem) { return precice::math::greaterEquals(elem.weight, 0.0); });
+}
+
+double Polation::distance() const
+{
+  return _distance;
 }
 
 std::ostream &operator<<(std::ostream &os, const WeightedElement &w)

--- a/src/mapping/Polation.hpp
+++ b/src/mapping/Polation.hpp
@@ -24,7 +24,7 @@ struct WeightedElement {
 class Polation {
 public:
   /// Calculate projection to a vertex. Weight is always 1.0
-  Polation(const mesh::Vertex &element);
+  Polation(const Eigen::VectorXd &location, const mesh::Vertex &element);
 
   /// Calculate projection to an edge
   Polation(const Eigen::VectorXd &location, const mesh::Edge &element);
@@ -41,8 +41,12 @@ public:
   /// Check whether all the weights are positive, which means it is interpolation
   bool isInterpolation() const;
 
+  /// Returns the projection distance
+  double distance() const;
+
 private:
   std::vector<WeightedElement> _weightedElements;
+  double                       _distance;
 };
 
 /// Make the WeightedElement printable

--- a/src/mapping/tests/PolationTest.cpp
+++ b/src/mapping/tests/PolationTest.cpp
@@ -58,6 +58,30 @@ BOOST_AUTO_TEST_CASE(EdgeInterpolation)
   }
 }
 
+BOOST_AUTO_TEST_CASE(EdgeProjectedInterpolation)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex v1(Eigen::Vector3d(0.0, 0.0, 0.0), 0);
+  mesh::Vertex v2(Eigen::Vector3d(0.0, 2.0, 0.0), 1);
+  mesh::Edge   edge(v1, v2, 0);
+
+  Eigen::Vector3d location(0.0, 0.4, 0.12);
+
+  Polation polation(location, edge);
+
+  std::vector<int>    expectedIndices = {0, 1};
+  std::vector<double> expectedWeights = {0.8, 0.2};
+
+  BOOST_TEST(polation.getWeightedElements().size() == 2);
+  BOOST_TEST(polation.isInterpolation());
+  BOOST_TEST(polation.distance() == 0.12);
+
+  for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
+    BOOST_TEST(polation.getWeightedElements().at(i).weight == expectedWeights.at(i));
+    BOOST_TEST(polation.getWeightedElements().at(i).vertexID == expectedIndices.at(i));
+  }
+}
+
 BOOST_AUTO_TEST_CASE(TriangleInterpolation)
 {
   PRECICE_TEST(1_rank);
@@ -88,6 +112,36 @@ BOOST_AUTO_TEST_CASE(TriangleInterpolation)
   }
 }
 
+BOOST_AUTO_TEST_CASE(TriangleProjectedInterpolation)
+{
+  PRECICE_TEST(1_rank);
+  mesh::Vertex   v1(Eigen::Vector3d(0.0, 0.0, 0.0), 0);
+  mesh::Vertex   v2(Eigen::Vector3d(2.0, 0.0, 0.0), 1);
+  mesh::Vertex   v3(Eigen::Vector3d(1.0, 2.0, 0.0), 2);
+  mesh::Edge     e1(v1, v2, 0);
+  mesh::Edge     e2(v2, v3, 1);
+  mesh::Edge     e3(v1, v3, 2);
+  mesh::Triangle triangle(e1, e2, e3, 0);
+  triangle.computeNormal();
+
+  Eigen::Vector3d location(1.0, 0.6, 0.14);
+
+  Polation polation(location, triangle);
+
+  std::vector<int>    expectedIndices = {0, 1, 2};
+  std::vector<double> expectedWeights = {0.35, 0.35, 0.3};
+
+  BOOST_TEST(polation.getWeightedElements().size() == 3);
+  BOOST_TEST(polation.isInterpolation());
+  BOOST_TEST(polation.distance() == 0.14);
+
+  for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
+
+    BOOST_TEST(polation.getWeightedElements().at(i).weight == expectedWeights.at(i));
+    BOOST_TEST(polation.getWeightedElements().at(i).vertexID == expectedIndices.at(i));
+  }
+}
+
 BOOST_AUTO_TEST_CASE(EdgeExtrapolation)
 {
   PRECICE_TEST(1_rank);
@@ -104,6 +158,8 @@ BOOST_AUTO_TEST_CASE(EdgeExtrapolation)
 
   BOOST_TEST(polation.getWeightedElements().size() == 2);
   BOOST_TEST(not polation.isInterpolation());
+  // The distance to projection is still 0
+  BOOST_TEST(polation.distance() == 0);
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
     BOOST_TEST(polation.getWeightedElements().at(i).weight == expectedWeights.at(i));
@@ -132,6 +188,8 @@ BOOST_AUTO_TEST_CASE(TriangleExtrapolation)
 
   BOOST_TEST(polation.getWeightedElements().size() == 3);
   BOOST_TEST(not polation.isInterpolation());
+  // The distance to projection is still 0
+  BOOST_TEST(polation.distance() == 0);
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
 
@@ -187,6 +245,8 @@ BOOST_AUTO_TEST_CASE(TetrahedronExtrapolation)
 
   BOOST_TEST(polation.getWeightedElements().size() == 4);
   BOOST_TEST(not polation.isInterpolation());
+  // There is no projection distance as such. This should always be 0
+  BOOST_TEST(polation.distance() == 0);
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
 

--- a/src/mapping/tests/PolationTest.cpp
+++ b/src/mapping/tests/PolationTest.cpp
@@ -16,15 +16,17 @@ BOOST_AUTO_TEST_SUITE(Interpolation)
 BOOST_AUTO_TEST_CASE(VertexInterpolation)
 {
   PRECICE_TEST(1_rank);
-  mesh::Vertex vertex(Eigen::Vector3d(1.0, 2.0, 0.0), 0);
+  Eigen::Vector3d location(0.0, 0.0, 0.0);
+  mesh::Vertex    vertex(Eigen::Vector3d(1.0, 2.0, 0.0), 0);
 
-  Polation polation(vertex);
+  Polation polation(location, vertex);
 
   std::vector<int>    expectedIndices = {0};
   std::vector<double> expectedWeights = {1.0};
 
   BOOST_TEST(polation.getWeightedElements().size() == 1);
   BOOST_TEST(polation.isInterpolation());
+  BOOST_TEST(polation.distance() == vertex.getCoords().norm());
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
     BOOST_TEST(polation.getWeightedElements().at(i).weight == expectedWeights.at(i));
@@ -48,6 +50,7 @@ BOOST_AUTO_TEST_CASE(EdgeInterpolation)
 
   BOOST_TEST(polation.getWeightedElements().size() == 2);
   BOOST_TEST(polation.isInterpolation());
+  BOOST_TEST(polation.distance() == 0);
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
     BOOST_TEST(polation.getWeightedElements().at(i).weight == expectedWeights.at(i));
@@ -76,6 +79,7 @@ BOOST_AUTO_TEST_CASE(TriangleInterpolation)
 
   BOOST_TEST(polation.getWeightedElements().size() == 3);
   BOOST_TEST(polation.isInterpolation());
+  BOOST_TEST(polation.distance() == 0);
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
 
@@ -155,6 +159,7 @@ BOOST_AUTO_TEST_CASE(TetrahedronInterpolation)
 
   BOOST_TEST(polation.getWeightedElements().size() == 4);
   BOOST_TEST(polation.isInterpolation());
+  BOOST_TEST(polation.distance() == 0);
 
   for (size_t i = 0; i < polation.getWeightedElements().size(); ++i) {
 

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -60,8 +60,8 @@ void WatchPoint::initialize()
 
   if (_mesh->vertices().size() > 0) {
     auto match        = _mesh->index().findCellOrProjection(_point, 4);
-    _interpolation    = std::make_unique<mapping::Polation>(match.polation);
-    _shortestDistance = match.distance;
+    _shortestDistance = match.polation.distance();
+    _interpolation    = std::make_unique<mapping::Polation>(std::move(match.polation));
   }
 
   if (utils::IntraComm::isSecondary()) {

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -262,7 +262,7 @@ ProjectionMatch Index::findCellOrProjection(const Eigen::VectorXd &location, int
     for (const auto &match : matchedTriangles) {
       auto polation = mapping::Polation(location, _mesh->triangles()[match.index]);
       if (polation.isInterpolation()) {
-        return {polation, 0.0};
+        return {std::move(polation)};
       }
     }
 
@@ -276,7 +276,7 @@ ProjectionMatch Index::findCellOrProjection(const Eigen::VectorXd &location, int
       // Matches are raw indices, not (indices, distance) pairs
       auto polation = mapping::Polation(location, _mesh->tetrahedra()[match]);
       if (polation.isInterpolation()) {
-        return {polation, 0.0};
+        return {std::move(polation)};
       }
     }
     return findNearestProjection(location, n);
@@ -285,9 +285,8 @@ ProjectionMatch Index::findCellOrProjection(const Eigen::VectorXd &location, int
 
 ProjectionMatch Index::findVertexProjection(const Eigen::VectorXd &location)
 {
-  auto              match = getClosestVertex(location);
-  mapping::Polation polation{location, _mesh->vertices()[match.index]};
-  return {polation, polation.distance()};
+  auto match = getClosestVertex(location);
+  return {mapping::Polation{location, _mesh->vertices()[match.index]}};
 }
 
 ProjectionMatch Index::findEdgeProjection(const Eigen::VectorXd &location, int n)
@@ -297,7 +296,7 @@ ProjectionMatch Index::findEdgeProjection(const Eigen::VectorXd &location, int n
   for (const auto &match : getClosestEdges(location, n)) {
     auto polation = mapping::Polation(location, _mesh->edges()[match.index]);
     if (polation.isInterpolation()) {
-      candidates.push_back({polation, polation.distance()});
+      candidates.emplace_back(std::move(polation));
     }
   }
   // Pick the smallest candidate by distance
@@ -316,7 +315,7 @@ ProjectionMatch Index::findTriangleProjection(const Eigen::VectorXd &location, i
   for (const auto &match : getClosestTriangles(location, n)) {
     auto polation = mapping::Polation(location, _mesh->triangles()[match.index]);
     if (polation.isInterpolation()) {
-      candidates.push_back({polation, polation.distance()});
+      candidates.emplace_back(std::move(polation));
     }
   }
   // Pick the smallest candidate by distance

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -30,7 +30,7 @@ template <class Tag>
 struct MatchType {
   MatchID index{NO_MATCH};
   MatchType() = default;
-  MatchType(MatchID i)
+  explicit MatchType(MatchID i)
       : index(i){};
 };
 

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -43,12 +43,21 @@ using TetraMatch    = MatchType<struct TetraTag>;
 
 /// Struct representing a projection match
 struct ProjectionMatch {
+  ProjectionMatch(const mapping::Polation &p)
+      : polation(p) {}
+  ProjectionMatch(mapping::Polation &&p)
+      : polation(std::move(p)) {}
+
+  ProjectionMatch(const ProjectionMatch &other) = default;
+  ProjectionMatch(ProjectionMatch &&other)      = default;
+  ProjectionMatch &operator=(const ProjectionMatch &other) = default;
+  ProjectionMatch &operator=(ProjectionMatch &&other) = default;
+
   mapping::Polation polation;
-  Distance          distance;
 
   constexpr bool operator<(ProjectionMatch const &other) const
   {
-    return distance < other.distance;
+    return polation.distance() < other.polation.distance();
   };
 };
 

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -55,7 +55,7 @@ struct ProjectionMatch {
 
   mapping::Polation polation;
 
-  constexpr bool operator<(ProjectionMatch const &other) const
+  bool operator<(ProjectionMatch const &other) const
   {
     return polation.distance() < other.polation.distance();
   };

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -25,19 +25,13 @@ constexpr MatchID NO_MATCH{-1};
 using Distance = double;
 constexpr double INVALID_DISTANCE{-1};
 
-/// Struct to hold index and distance information of the closest primitive
+/// Struct to hold the index of a primitive match
 template <class Tag>
 struct MatchType {
-  Distance distance{INVALID_DISTANCE};
-  MatchID  index{NO_MATCH};
+  MatchID index{NO_MATCH};
   MatchType() = default;
-  MatchType(Distance d, MatchID i)
-      : distance(d), index(i){};
-
-  constexpr bool operator<(MatchType const &other) const
-  {
-    return distance < other.distance;
-  };
+  MatchType(MatchID i)
+      : index(i){};
 };
 
 /// Match tags for each primitive type
@@ -51,6 +45,11 @@ using TetraMatch    = MatchType<struct TetraTag>;
 struct ProjectionMatch {
   mapping::Polation polation;
   Distance          distance;
+
+  constexpr bool operator<(ProjectionMatch const &other) const
+  {
+    return distance < other.distance;
+  };
 };
 
 /// Class to query the index trees of the mesh

--- a/src/query/tests/RTreeAdapterTests.cpp
+++ b/src/query/tests/RTreeAdapterTests.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 #include <algorithm>
-#include <math.h>
+#include <boost/geometry.hpp>
+#include <cmath>
 #include <ostream>
 #include <vector>
 #include "logging/Logger.hpp"

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -101,7 +101,6 @@ BOOST_AUTO_TEST_CASE(Query2DVertex)
 
   auto result = indexTree.getClosestVertex(location);
   BOOST_TEST(mesh->vertices().at(result.index).getCoords() == Eigen::Vector2d(0, 1));
-  BOOST_TEST(result.distance == 0.28284271247461906);
 }
 
 BOOST_AUTO_TEST_CASE(Query3DVertex)
@@ -113,7 +112,6 @@ BOOST_AUTO_TEST_CASE(Query3DVertex)
 
   auto result = indexTree.getClosestVertex(location);
   BOOST_TEST(mesh->vertices().at(result.index).getCoords() == Eigen::Vector3d(1, 0, 1));
-  BOOST_TEST(result.distance == 0.28284271247461906);
 }
 
 BOOST_AUTO_TEST_CASE(Query3DFullVertex)
@@ -268,8 +266,9 @@ BOOST_AUTO_TEST_CASE(Query3DFullEdge)
   auto            results = indexTree.getClosestEdges(location, 2);
 
   BOOST_TEST(results.size() == 2);
-  BOOST_TEST(results.at(0).index == eld.getID());
-  BOOST_TEST(results.at(1).index == elr.getID());
+  std::set<EdgeID> rset{results.at(0).index, results.at(1).index};
+  BOOST_TEST(rset.count(elr.getID()) == 1);
+  BOOST_TEST(rset.count(eld.getID()) == 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Edge
@@ -310,10 +309,11 @@ BOOST_AUTO_TEST_CASE(Query3DFullTriangle)
 
   auto results = indexTree.getClosestTriangles(location, 3);
   BOOST_TEST(results.size() == 3);
-  BOOST_TEST(results.at(0).index == tlb.getID());
-  BOOST_TEST(results.at(1).index == tlt.getID());
-  BOOST_TEST(results.at(2).index == trt.getID());
-  BOOST_TEST(results.at(2).index != trb.getID());
+
+  std::set<TriangleID> rset{results.at(0).index, results.at(1).index, results.at(2).index};
+  BOOST_TEST(rset.count(tlb.getID()) == 1);
+  BOOST_TEST(rset.count(tlt.getID()) == 1);
+  BOOST_TEST(rset.count(trt.getID()) == 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Triangle
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(ProjectionToTriangle)
   auto match = indexTree.findNearestProjection(location, 1);
 
   BOOST_TEST(match.polation.getWeightedElements().size() == 3); // Check number of weights
-  BOOST_TEST(match.distance == 0.0);                            // Check the distance
+  BOOST_TEST(match.distance == 0.1);                            // Check the distance
   BOOST_TEST(match.polation.isInterpolation());
 
   for (int i = 0; i < static_cast<int>(match.polation.getWeightedElements().size()); ++i) {

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(ProjectionToVertex)
   auto match = indexTree.findNearestProjection(location, 1);
 
   BOOST_TEST(match.polation.getWeightedElements().size() == 1); // Check number of weights
-  BOOST_TEST(match.distance == 1.0);                            // Check the distance
+  BOOST_TEST(match.polation.distance() == 1.0);                 // Check the distance
   BOOST_TEST(match.polation.isInterpolation());
 
   for (int i = 0; i < static_cast<int>(match.polation.getWeightedElements().size()); ++i) {
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(ProjectionToEdge)
   auto match = indexTree.findNearestProjection(location, 1);
 
   BOOST_TEST(match.polation.getWeightedElements().size() == 2); // Check number of weights
-  BOOST_TEST(match.distance == 1.0);                            // Check the distance
+  BOOST_TEST(match.polation.distance() == 1.0);                 // Check the distance
   BOOST_TEST(match.polation.isInterpolation());
 
   for (int i = 0; i < static_cast<int>(match.polation.getWeightedElements().size()); ++i) {
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(ProjectionToTriangle)
   auto match = indexTree.findNearestProjection(location, 1);
 
   BOOST_TEST(match.polation.getWeightedElements().size() == 3); // Check number of weights
-  BOOST_TEST(match.distance == 0.1);                            // Check the distance
+  BOOST_TEST(match.polation.distance() == 0.1);                 // Check the distance
   BOOST_TEST(match.polation.isInterpolation());
 
   for (int i = 0; i < static_cast<int>(match.polation.getWeightedElements().size()); ++i) {


### PR DESCRIPTION
## Main changes of this PR

This PR fixes issues with the triangle to point distance calculation of the mesh index.
Index methods `getClosestX` now don't returned matches sorted by distance anymore, but simply the IDs of the matches.

Closes #1388

## Motivation and additional information

Boost geometry was used to calculate distances of a location to n-closest primitives.
This distance calculation returned 0 for the triangle case where the location projection was inside the triangle.
So, the reported projection metrics for triangles in NP were reporting the wrong distance.
Also, this may have lead to further away triangles with correct projection getting picked over closer ones.

Most of these issues do not show up in surface coupling with nearest-projection mapping.
This would require very coarse and thin geometries, where opposing triangles get considered. Then the opposing may be picked first.
Of course, this case is common once a fallback is required in volume coupling.

The root course of this issue is that implementations of boost geometry don't always work with polygons and rings in 3D.
This can be reproduced with a `boost::model::ring` and a `boost::model::point`.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Do you understand the error?
* [ ] Do you understand the fix?
* [ ] Does the changelog entry make sense? Is it formatted correctly?
