### PR TITLE
Improve revision detection

### DIFF
--- a/cmake/cmake_refresh_git_revision.cmake
+++ b/cmake/cmake_refresh_git_revision.cmake
@@ -32,7 +32,7 @@ set(preCICE_REVISION "no-info [git failed to run]")
 
 if(("${PRECICE_REVISION_RET}" EQUAL "0") AND ("${PRECICE_REPO_RET}" EQUAL "0"))
   file(TO_CMAKE_PATH "${PRECICE_REPO_OUT}" _detected_path)
-  if("${CMAKE_SOURCE_DIR}" STREQUAL " ${_detected_path}")
+  if("${CMAKE_SOURCE_DIR}" STREQUAL "${_detected_path}")
     set(preCICE_REVISION "${PRECICE_REVISION_OUT}")
     message(STATUS "Revision status: ${preCICE_REVISION}")
   else()

--- a/cmake/cmake_refresh_git_revision.cmake
+++ b/cmake/cmake_refresh_git_revision.cmake
@@ -11,6 +11,15 @@
 #
 
 find_package(Git REQUIRED)
+
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} rev-parse --show-toplevel
+  RESULT_VARIABLE PRECICE_REPO_RET
+  OUTPUT_VARIABLE PRECICE_REPO_OUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+  )
+
 execute_process(
   COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
   RESULT_VARIABLE PRECICE_REVISION_RET
@@ -19,10 +28,17 @@ execute_process(
   ERROR_QUIET
   )
 
-set(preCICE_REVISION "no-info [Git failed/Not a repository]")
-if("${PRECICE_REVISION_RET}" EQUAL "0")
-  set(preCICE_REVISION "${PRECICE_REVISION_OUT}")
-  message(STATUS "Revision status: ${preCICE_REVISION}")
+set(preCICE_REVISION "no-info [git failed to run]")
+
+if(("${PRECICE_REVISION_RET}" EQUAL "0") AND ("${PRECICE_REPO_RET}" EQUAL "0"))
+  file(TO_CMAKE_PATH "${PRECICE_REPO_OUT}" _detected_path)
+  if("${CMAKE_SOURCE_DIR}" STREQUAL " ${_detected_path}")
+    set(preCICE_REVISION "${PRECICE_REVISION_OUT}")
+    message(STATUS "Revision status: ${preCICE_REVISION}")
+  else()
+    message(STATUS "Revision status: directory is not a git repository")
+    set(preCICE_REVISION "no-info [not a repository]")
+  endif()
 else()
   message(STATUS "Revision status: Detection failed")
 endif()

--- a/docs/changelog/1398.md
+++ b/docs/changelog/1398.md
@@ -1,0 +1,1 @@
+- Fixed the git revision detection picking up revisions of super-projects.


### PR DESCRIPTION
## Main changes of this PR

This PR improves the git revision detection by checking if preCICE itself is a git repository.

Unsuccessful git revisions are now also more descriptive:

Old:
```
no-info [Git failed/Not a repository]
```

New:
```
no-info [git failed to run]
no-info [not a repository]
```

## Motivation and additional information

Makes revisions easier to understand.
Prevents preCICE picking up revisions of super-projects.

Closes #1397

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
