### PR TITLE
Add a success statement to the config check

### DIFF
--- a/docs/changelog/1406.md
+++ b/docs/changelog/1406.md
@@ -1,0 +1,1 @@
+- Added success statement to `precice-tools check valid-config.xml`, which used to output nothing.

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -1,7 +1,9 @@
 #include "precice/Tooling.hpp"
 
+#include "fmt/color.h"
 #include "precice/config/Configuration.hpp"
 #include "precice/impl/versions.hpp"
+#include "utils/fmt.hpp"
 #include "xml/Printer.hpp"
 
 namespace precice {
@@ -34,6 +36,7 @@ void checkConfiguration(const std::string &filename, const std::string &particip
       0,
       size};
   xml::configure(config.getXMLTag(), context, filename);
+  fmt::print("{}: {}\n", filename, fmt::styled("correct", fmt::emphasis::bold | fg(fmt::color::green)));
 }
 
 } // namespace tooling

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -29,6 +29,7 @@ void printConfigReference(std::ostream &out, ConfigReferenceType reftype)
 
 void checkConfiguration(const std::string &filename, const std::string &participant, int size)
 {
+  fmt::print("Checking {} for syntax and basic setup issues...\n", filename);
   config::Configuration config;
   logging::setMPIRank(0);
   xml::ConfigurationContext context{
@@ -36,7 +37,7 @@ void checkConfiguration(const std::string &filename, const std::string &particip
       0,
       size};
   xml::configure(config.getXMLTag(), context, filename);
-  fmt::print("{}: {}\n", filename, fmt::styled("correct", fmt::emphasis::bold | fg(fmt::color::green)));
+  fmt::print(fmt::emphasis::bold | fg(fmt::color::green), "No major issues detected\n", filename);
 }
 
 } // namespace tooling


### PR DESCRIPTION
## Main changes of this PR

Adds a success statement to `precice-tools check`.

Checking correctly formatted file will now result in
```
$ precice-tools check valid-config.xml
Checking valid-config.xml for syntax and basic setup issues...
No major issues detected
```

I used the new style support from libfmt to format the last line bold and green.

## Motivation and additional information

Closes #1405
See #1393 

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++14 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
