### PR TITLE
Update release workflow to consider target OS for packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     container: '${{ matrix.TARGET }}'
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        TARGET: ["ubuntu:20.04", "ubuntu:21.04", "ubuntu:21.10", "ubuntu:22.04", "debian:11"]
+        TARGET: ["ubuntu:20.04", "ubuntu:22.04", "debian:11"]
     steps:
       - uses: actions/checkout@v2
       - name: Generate build directory

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/hotfix_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/hotfix_pull_request_template.md
@@ -12,6 +12,7 @@ Only the release manager should update this post (even tickboxes, due to race co
 * [ ] Create branch `hotfix-vX.Y.Z` from `main`. If needed, `git rebase main`.
 * [ ] Commit fixes to the hotfix branch
 * [ ] Check code base w.r.t code formatting (run [`precice/tools/formatting/check-format`](https://github.com/precice/precice/blob/develop/tools/formatting/check-format)) and reformat if required (run [`precice/tools/formatting/format-all`](https://github.com/precice/precice/blob/develop/tools/formatting/format-all))
+* [ ] Update the list of operating systems for the package generation in `.github/workflows/release.yml`
 * [ ] Run `tools/releasing/bumpversion.sh MAJOR.MINOR.PATCH` to bump the version
 * [ ] Look over the updated `CHANGELOG.md` of the hotfix branch (all)
    * Check for merged lines

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -15,6 +15,7 @@ Only the release manager should update this post (even tickboxes, due to race co
 * [ ] Make sure you have the latest `develop` and `main` branches locally.
 * [ ] Merge `main` to `develop` ( This should result in no commits )
 * [ ] Check code base w.r.t code formatting (run [`precice/tools/formatting/check-format`](https://github.com/precice/precice/blob/develop/tools/formatting/check-format)) and reformat if required (run [`precice/tools/formatting/format-all`](https://github.com/precice/precice/blob/develop/tools/formatting/format-all))
+* [ ] Update the list of operating systems for the package generation in `.github/workflows/release.yml`
 * [ ] Create branch `release-vX.Y.Z` from develop. If needed, `git rebase develop`.
 * [ ] Run `tools/releasing/bumpversion.sh MAJOR.MINOR.PATCH` to bump the version
 * [ ] Look over the updated `CHANGELOG.md` of the release branch (all)


### PR DESCRIPTION
## Main changes of this PR
Update release workflow to consider target OS for package generation in release pipeline.

## Motivation and additional information
The pipeline will fail in case we have outdated systems in our matrix.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->
## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
