### PR TITLE
Upgrade preCICE C++ standard to C++17

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Short rational why preCICE needs this change. If this is already described in an
 * [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
 * [ ] I added a test to cover the proposed changes in our test suite.
 * [ ] I ran `make format` to ensure everything is formatted correctly.
-* [ ] I sticked to C++14 features.
+* [ ] I sticked to C++17 features.
 * [ ] I sticked to CMake version 3.16.3.
 * [ ] I squashed / am about to squash all commits that should be seen as one.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,8 @@ print_section("TARGETS & PACKAGES")
 # Add precice as an empty target
 add_library(precice)
 set_target_properties(precice PROPERTIES
-  # precice is a C++14 project
-  CXX_STANDARD 14
+  # precice is a C++17 project
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED Yes
   CXX_EXTENSIONS No
   VERSION ${preCICE_VERSION}
@@ -350,8 +350,8 @@ if (PRECICE_BUILD_TOOLS)
    precice
    )
   set_target_properties(precice-tools PROPERTIES
-    # precice is a C++14 project
-    CXX_STANDARD 14
+    # precice is a C++17 project
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED Yes
     CXX_EXTENSIONS No
     )
@@ -389,8 +389,8 @@ IF (BUILD_TESTING)
     Boost::unit_test_framework
     )
   set_target_properties(testprecice PROPERTIES
-    # precice is a C++14 project
-    CXX_STANDARD 14
+    # precice is a C++17 project
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED Yes
     CXX_EXTENSIONS No
     )

--- a/docs/changelog/1413.md
+++ b/docs/changelog/1413.md
@@ -1,0 +1,1 @@
+- Increased the minimum required C++ version from 14 to 17.


### PR DESCRIPTION
## Main changes of this PR
Lifts the preCICE C++ standard to C++17.

## Motivation and additional information
Related to #1201. This PR only updates the CMake/compiler configuration and does not apply any C++17 code changes. However, it opens the door for C++17 related code upgrades.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
