### PR TITLE
Improve compatibility with applications using Boost.Log

### DIFF
--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -177,6 +177,7 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
   using sink_ptr = typename boost::shared_ptr<sink_t>;
 
   static std::vector<sink_ptr> activeSinks;
+
   //remove active sinks
   for (auto &sink : activeSinks) {
     boost::log::core::get()->remove_sink(sink);
@@ -185,9 +186,15 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
   }
   activeSinks.clear();
 
+  // If logging sinks are disabled, then we are done
+  if (!enabled) {
+    return;
+  }
+
   // Add the default config
-  if (configs.empty())
+  if (configs.empty()) {
     configs.emplace_back();
+  }
 
   // Create new sinks
   for (const auto &config : configs) {

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -211,7 +211,7 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
     backend->auto_flush(true);
     boost::shared_ptr<sink_t> sink(new sink_t(backend));
     sink->set_formatter(boost::log::parse_formatter(config.format));
-    // We extend the filter here to remove all log entries not originating from preCICE.
+    // We extend the filter here to filter all log entries not originating from preCICE.
     sink->set_filter(boost::log::parse_filter("( " + config.filter + " ) and %preCICE%"));
     boost::log::core::get()->add_sink(sink);
     activeSinks.emplace_back(std::move(sink));

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -145,9 +145,11 @@ void BackendConfiguration::setOption(std::string key, std::string value)
     filter = value;
   if (key == "format")
     format = value;
-  if (key == "enabled") {
-    enabled = utils::convertStringToBool(value);
-  }
+}
+
+void BackendConfiguration::setEnabled(bool enabled)
+{
+  this->enabled = enabled;
 }
 
 void setupLogging(LoggingConfiguration configs, bool enabled)
@@ -200,6 +202,10 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
 
   // Create new sinks
   for (const auto &config : configs) {
+    if (!config.enabled) {
+      continue;
+    }
+
     boost::shared_ptr<StreamBackend> backend;
     if (config.type == "file")
       backend = boost::make_shared<StreamBackend>(boost::shared_ptr<std::ostream>(new std::ofstream(config.output)));

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -202,8 +202,7 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
       << bl::expressions::message;
 
   // Remove active preCICE sinks
-  using sink_t   = typename boost::log::sinks::sink;
-  using sink_ptr = typename boost::shared_ptr<sink_t>;
+  using sink_ptr = typename boost::shared_ptr<boost::log::sinks::sink>;
 
   static std::vector<sink_ptr> activeSinks;
   for (auto &sink : activeSinks) {

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -217,7 +217,8 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
   // We do this by adding a NullSink.
   // We need to exit after the sink removal as the default sink exists before
   // the log configuration is parsed.
-  if (!enabled) {
+  if (auto noconfigs = std::none_of(configs.begin(), configs.end(), [](const auto &config) { return config.enabled; });
+      !enabled || noconfigs) {
     auto sink = boost::make_shared<NullSink>();
     boost::log::core::get()->add_sink(sink);
     activeSinks.emplace_back(std::move(sink));

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -187,6 +187,8 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
   activeSinks.clear();
 
   // If logging sinks are disabled, then we are done
+  // We need to exit after the sink removal as the default sink exists before
+  // the log configuration is parsed.
   if (!enabled) {
     return;
   }

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -172,7 +172,7 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
       << bl::expressions::attr<std::string>("Function") << ": "
       << bl::expressions::message;
 
-  // Remove active sinks
+  // Remove active preCICE sinks
   using sink_t   = typename boost::log::sinks::synchronous_sink<StreamBackend>;
   using sink_ptr = typename boost::shared_ptr<sink_t>;
 

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -219,8 +219,13 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
     backend->auto_flush(true);
     boost::shared_ptr<sink_t> sink(new sink_t(backend));
     sink->set_formatter(boost::log::parse_formatter(config.format));
-    // We extend the filter here to filter all log entries not originating from preCICE.
-    sink->set_filter(boost::log::parse_filter("( " + config.filter + " ) and %preCICE%"));
+
+    if (config.filter.empty()) {
+      sink->set_filter(boost::log::expressions::attr<bool>("preCICE") == true);
+    } else {
+      // We extend the filter here to filter all log entries not originating from preCICE.
+      sink->set_filter(boost::log::parse_filter("%preCICE% & ( " + config.filter + " )"));
+    }
     boost::log::core::get()->add_sink(sink);
     activeSinks.emplace_back(std::move(sink));
   }

--- a/src/logging/LogConfiguration.hpp
+++ b/src/logging/LogConfiguration.hpp
@@ -36,18 +36,26 @@ void setupLogging(std::string const &logConfigFile = "log.conf");
 void setupLogging(LoggingConfiguration configs, bool enabled = true);
 
 /// Sets the current MPI rank as a logging attribute
+/// @see GlobalLoggingConfig
 void setMPIRank(int const rank);
 
 /// Sets the name of the current participant as a logging attribute
+/// @see GlobalLoggingConfig
 void setParticipant(std::string const &name);
 
 /// Locks the configuration, ignoring any future calls to setupLogging()
+/// @see GlobalLoggingConfig
 void lockConf();
 
-/** The global lock for the log configuration.
- * This variable is always initialized to false and can only be modified by calling lockConf()
- */
-extern bool _precice_logging_config_lock;
+/// Holds global logging data in a central place
+struct GlobalLoggingConfig {
+  std::string participant{""};
+  int         rank{-1};
+  bool        locked{false};
+};
+
+/// Returns the global logging configuration
+GlobalLoggingConfig &getGlobalLoggingConfig();
 
 } // namespace logging
 } // namespace precice

--- a/src/logging/LogConfiguration.hpp
+++ b/src/logging/LogConfiguration.hpp
@@ -21,6 +21,9 @@ struct BackendConfiguration {
 
   /// Sets on option, overwrites default values.
   void setOption(std::string key, std::string value);
+
+  /// Sets weather the sink is enabled or disabled
+  void setEnabled(bool enabled);
 };
 
 /// Holds the configuration of the logging system

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -77,15 +77,15 @@ boost::log::record precice_feature<BaseT>::open_record_unlocked(ArgsT const &arg
   using boost::log::attributes::constant;
   boost::log::attribute_set &attrs = BaseT::attributes();
   {
-    auto res = BaseT::add_attribute_unlocked("Line", constant<int>(line_value));
+    [[maybe_unused]] auto res = BaseT::add_attribute_unlocked("Line", constant<int>(line_value));
     PRECICE_ASSERT(res.second);
   }
   {
-    auto res = BaseT::add_attribute_unlocked("File", constant<std::string>(file_value));
+    [[maybe_unused]] auto res = BaseT::add_attribute_unlocked("File", constant<std::string>(file_value));
     PRECICE_ASSERT(res.second);
   }
   {
-    auto res = BaseT::add_attribute_unlocked("Function", constant<std::string>(func_value));
+    [[maybe_unused]] auto res = BaseT::add_attribute_unlocked("Function", constant<std::string>(func_value));
     PRECICE_ASSERT(res.second);
   }
 

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -11,8 +11,7 @@
 #include "logging/LogConfiguration.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace logging {
+namespace precice::logging {
 
 /// A feature that adds \ref LogLocation info to log attributes
 template <class BaseT>
@@ -197,5 +196,4 @@ void Logger::trace(LogLocation loc, const std::string &mess) noexcept
 
 #undef PRECICE_LOG_IMPL
 
-} // namespace logging
-} // namespace precice
+} // namespace precice::logging

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -21,11 +21,6 @@ public:
   using char_type       = typename BaseT::char_type;
   using threading_model = typename BaseT::threading_model;
 
-  precice_feature()                             = default;
-  precice_feature(const precice_feature &other) = default;
-  template <typename ArgsT>
-  precice_feature(ArgsT const &args){};
-
   using open_record_lock = typename boost::log::strictest_lock<
       boost::lock_guard<threading_model>,
       typename BaseT::open_record_lock,

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -1,22 +1,123 @@
-#include "Logger.hpp"
 #include <boost/log/attributes/constant.hpp>
-#include <boost/log/attributes/mutable_constant.hpp>
+#include <boost/log/attributes/function.hpp>
 #include <boost/log/attributes/named_scope.hpp>
-#include <boost/log/core.hpp>
-#include <boost/log/expressions.hpp>
+#include <boost/log/attributes/timer.hpp>
+#include <boost/log/sources/severity_feature.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
-#include <iosfwd>
 #include <utility>
+#include <utils/assertion.hpp>
+
+#include "logging/LogConfiguration.hpp"
+#include "logging/Logger.hpp"
 
 namespace precice {
 namespace logging {
+
+/// A feature that adds \ref LogLocation info to log attributes
+template <class BaseT>
+class precice_feature : public BaseT {
+public:
+  using char_type       = typename BaseT::char_type;
+  using threading_model = typename BaseT::threading_model;
+
+  precice_feature()                             = default;
+  precice_feature(const precice_feature &other) = default;
+  template <typename ArgsT>
+  precice_feature(ArgsT const &args){};
+
+  using open_record_lock = typename boost::log::strictest_lock<
+      boost::lock_guard<threading_model>,
+      typename BaseT::open_record_lock,
+      typename BaseT::add_attribute_lock,
+      typename BaseT::remove_attribute_lock>::type;
+
+protected:
+  template <typename ArgsT>
+  boost::log::record open_record_unlocked(ArgsT const &args);
+};
+
+/// Provides keywords to pass \ref LogLocation related info to the precice_feature
+/// @see PRECICE_LOG_IMPL
+namespace keywords {
+BOOST_PARAMETER_KEYWORD(line_ns, line);
+BOOST_PARAMETER_KEYWORD(file_ns, file);
+BOOST_PARAMETER_KEYWORD(func_ns, func);
+} // namespace keywords
+
+namespace {
+/// Runs the function F on end of lifetime.
+template <class F>
+struct ScopeExit {
+  F _f;
+  ScopeExit(F f)
+      : _f(f){};
+  ~ScopeExit()
+  {
+    _f();
+  }
+};
+} // namespace
+
+/// Adds log attributes to the current logger based on the \ref LogLocation info
+template <typename BaseT>
+template <typename ArgsT>
+boost::log::record precice_feature<BaseT>::open_record_unlocked(ArgsT const &args)
+{
+  // Extract the named argument from the parameters pack
+  int         line_value = args[keywords::line | -1];
+  std::string file_value = args[keywords::file | std::string()];
+  std::string func_value = args[keywords::func | std::string()];
+
+  PRECICE_ASSERT(line_value >= 0);
+  PRECICE_ASSERT(!file_value.empty());
+  PRECICE_ASSERT(!func_value.empty());
+
+  // Process extracted tags
+  using boost::log::attributes::constant;
+  boost::log::attribute_set &attrs = BaseT::attributes();
+  {
+    auto res = BaseT::add_attribute_unlocked("Line", constant<int>(line_value));
+    PRECICE_ASSERT(res.second);
+  }
+  {
+    auto res = BaseT::add_attribute_unlocked("File", constant<std::string>(file_value));
+    PRECICE_ASSERT(res.second);
+  }
+  {
+    auto res = BaseT::add_attribute_unlocked("Function", constant<std::string>(func_value));
+    PRECICE_ASSERT(res.second);
+  }
+
+  ScopeExit guard([&attrs] {
+    attrs.erase("Line");
+    attrs.erase("File");
+    attrs.erase("Function");
+  });
+
+  // Forward the call to the base feature
+  return BaseT::open_record_unlocked(args);
+}
+
+/// Required by \ref BoostLogger to use \ref precice_feature
+struct precice_log : public boost::mpl::quote1<precice_feature> {
+};
+
+/// The boost logger that combines required featrues
+template <class BaseLogger>
+using BoostLogger = boost::log::sources::basic_composite_logger<
+    char,
+    BaseLogger,
+    boost::log::sources::single_thread_model,
+    boost::log::sources::features<
+        boost::log::sources::severity<boost::log::trivial::severity_level>,
+        precice_log>>;
 
 /** The implementation of logging::Logger
  *
  * @note The point of using a pimpl for the logger is to remove boost::log from logger.hpp
  */
-class Logger::LoggerImpl : public boost::log::sources::severity_logger<boost::log::trivial::severity_level> {
+class Logger::LoggerImpl : public BoostLogger<Logger::LoggerImpl> {
 public:
   /** Creates a Boost logger for the said module.
    * @param[in] module the name of the module.
@@ -24,30 +125,34 @@ public:
   explicit LoggerImpl(const std::string &module);
 };
 
+/// Registers attributes that don't depend on the \ref LogLocation
 Logger::LoggerImpl::LoggerImpl(const std::string &module)
 {
-  add_attribute("Module", boost::log::attributes::constant<std::string>(module));
-
   namespace attrs = boost::log::attributes;
-  namespace log   = boost::log;
-  log::add_common_attributes();
-  log::core::get()->add_global_attribute("Scope", attrs::named_scope());
-  log::core::get()->add_global_attribute("Participant", attrs::mutable_constant<std::string>(""));
-  log::core::get()->add_global_attribute("Rank", attrs::mutable_constant<int>(0));
-  log::core::get()->add_global_attribute("Line", attrs::mutable_constant<int>(0));
-  log::core::get()->add_global_attribute("File", attrs::mutable_constant<std::string>(""));
-  log::core::get()->add_global_attribute("Function", attrs::mutable_constant<std::string>(""));
+
+  // The preCICE attribute marks attribute values that originate from preCICE
+  add_attribute("preCICE", attrs::constant<bool>(true));
+  add_attribute("Participant", attrs::make_function<std::string>([] { return getGlobalLoggingConfig().participant; }));
+  add_attribute("Rank", attrs::make_function<int>([] { return getGlobalLoggingConfig().rank; }));
+
+  // Constant attributes
+  add_attribute("Module", attrs::constant<std::string>(module));
+
+  // Ensure, boost-provided attributes are present
+  add_attribute("TimeStamp", attrs::local_clock());
+  add_attribute("Runtime", attrs::timer());
+  add_attribute("Scope", attrs::named_scope());
 }
 
 Logger::Logger(std::string module)
     : _impl(new LoggerImpl{std::move(module)}) {}
 
-// This is required for the std::unique_ptr.
+/// This is required for the std::unique_ptr.
 Logger::~Logger() = default;
 
-// Extracts the name saved in the attribute "Module"
+/// Implements a deep copy of the implementation
 Logger::Logger(const Logger &other)
-    : Logger{other._impl->get_attributes().find("Module")->second.get_value().extract_or_throw<std::string>()}
+    : _impl(std::make_unique<LoggerImpl>(*other._impl))
 {
 }
 
@@ -64,21 +169,14 @@ void Logger::swap(Logger &other) noexcept
   _impl.swap(other._impl);
 }
 
-namespace {
-/// Sets the log location in the boost core
-void setLogLocation(LogLocation loc)
-{
-  boost::log::attribute_cast<boost::log::attributes::mutable_constant<int>>(boost::log::core::get()->get_global_attributes()["Line"]).set(loc.line);
-  boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["File"]).set(loc.file);
-  boost::log::attribute_cast<boost::log::attributes::mutable_constant<std::string>>(boost::log::core::get()->get_global_attributes()["Function"]).set(loc.func);
-}
-} // namespace
+/// Convenience macro that automatically passes \ref LogLocation info to the logger
+#define PRECICE_LOG_IMPL(lg, sev, loc) \
+  BOOST_LOG_STREAM_WITH_PARAMS((lg), (boost::log::keywords::severity = (sev))(keywords::line = (loc.line))(keywords::file = (loc.file))(keywords::func = (loc.func)))
 
 void Logger::error(LogLocation loc, const std::string &mess) noexcept
 {
   try {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::error) << mess;
+    PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::error, loc) << mess;
   } catch (...) {
   }
 }
@@ -86,8 +184,7 @@ void Logger::error(LogLocation loc, const std::string &mess) noexcept
 void Logger::warning(LogLocation loc, const std::string &mess) noexcept
 {
   try {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::warning) << mess;
+    PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::warning, loc) << mess;
   } catch (...) {
   }
 }
@@ -95,8 +192,7 @@ void Logger::warning(LogLocation loc, const std::string &mess) noexcept
 void Logger::info(LogLocation loc, const std::string &mess) noexcept
 {
   try {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::info) << mess;
+    PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::info, loc) << mess;
   } catch (...) {
   }
 }
@@ -104,8 +200,7 @@ void Logger::info(LogLocation loc, const std::string &mess) noexcept
 void Logger::debug(LogLocation loc, const std::string &mess) noexcept
 {
   try {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::debug) << mess;
+    PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::debug, loc) << mess;
   } catch (...) {
   }
 }
@@ -113,11 +208,12 @@ void Logger::debug(LogLocation loc, const std::string &mess) noexcept
 void Logger::trace(LogLocation loc, const std::string &mess) noexcept
 {
   try {
-    setLogLocation(loc);
-    BOOST_LOG_SEV(*_impl, boost::log::trivial::severity_level::trace) << mess;
+    PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::trace, loc) << mess;
   } catch (...) {
   }
 }
+
+#undef PRECICE_LOG_IMPL
 
 } // namespace logging
 } // namespace precice

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -3,8 +3,7 @@
 #include <memory>
 #include <string>
 
-namespace precice {
-namespace logging {
+namespace precice::logging {
 
 /// Struct used to capture the original location of a log request
 struct LogLocation {
@@ -45,8 +44,7 @@ private:
   std::unique_ptr<LoggerImpl> _impl;
 };
 
-} // namespace logging
-} // namespace precice
+} // namespace precice::logging
 
 // Include LogMacros here, because using it works only together with a Logger
 #include "LogMacros.hpp"

--- a/src/logging/config/LogConfiguration.cpp
+++ b/src/logging/config/LogConfiguration.cpp
@@ -17,12 +17,13 @@ LogConfiguration::LogConfiguration(
   tagLog.setDocumentation("Configures logging sinks based on Boost log.");
 
   auto attrLogEnabled = makeXMLAttribute("enabled", true)
-                            .setDocumentation("Enables logging");
+                            .setDocumentation("Enables the creation of log sinks. Disable sinks if you plan to setup Boost.log in your application.");
   tagLog.addAttribute(attrLogEnabled);
 
   XMLTag tagSink(*this, "sink", XMLTag::OCCUR_ARBITRARY);
   tagSink.setDocumentation("Contains the configuration of a single log sink, which allows fine grained control of what to log where. "
-                           "Available attributes in filter and format strings are `%Severity%`, `%ColorizedSeverity%`, `%File%`, `%Line%`, `%Function%`, `%Module%`, `%Rank%`, and `%Participant%`");
+                           "Available attributes in filter and format strings are `%TimeStamp%`, `%Runtime%`, `%Severity%`, `%ColorizedSeverity%`, `%File%`, `%Line%`, `%Function%`, `%Module%`, `%Rank%`, and `%Participant%`. "
+                           "The boolean attribute `%preCICE%` is `true` for all log entries originating from preCICE.");
   auto attrType = XMLAttribute<std::string>("type")
                       .setDocumentation("The type of sink.")
                       .setOptions({"stream", "file"})

--- a/src/logging/config/LogConfiguration.cpp
+++ b/src/logging/config/LogConfiguration.cpp
@@ -17,7 +17,9 @@ LogConfiguration::LogConfiguration(
   tagLog.setDocumentation("Configures logging sinks based on Boost log.");
 
   auto attrLogEnabled = makeXMLAttribute("enabled", true)
-                            .setDocumentation("Enables the creation of log sinks. Disable sinks if you plan to setup Boost.log in your application.");
+                            .setDocumentation("Enables the creation of log sinks. "
+                                              "Disable sinks if you prefer to handle preCICE logs in your application using boost.log.");
+
   tagLog.addAttribute(attrLogEnabled);
 
   XMLTag tagSink(*this, "sink", XMLTag::OCCUR_ARBITRARY);

--- a/src/logging/config/LogConfiguration.cpp
+++ b/src/logging/config/LogConfiguration.cpp
@@ -61,13 +61,13 @@ void LogConfiguration::xmlTagCallback(
 {
   PRECICE_TRACE(tag.getFullName());
 
-  if (tag.getName() == "sink" and tag.getBooleanAttributeValue("enabled")) {
+  if (tag.getName() == "sink") {
     precice::logging::BackendConfiguration config;
     config.setOption("type", tag.getStringAttributeValue("type"));
     config.setOption("output", tag.getStringAttributeValue("output"));
     config.setOption("filter", tag.getStringAttributeValue("filter"));
     config.setOption("format", tag.getStringAttributeValue("format"));
-    config.setOption("enabled", "true"); // Not needed, but correct.
+    config.setEnabled(tag.getBooleanAttributeValue("enabled"));
     _logconfig.push_back(config);
   }
 }


### PR DESCRIPTION
## Main changes of this PR

This PR mainly
- Reduces logger dependence on `boost::log::core`. preCICE will not change existing configuration. 
- Adds the log attributes `preCICE` (always true) for tagging preCICE log entries as well as `Runtime` as it may come in handy.
- Updates the logger to use a "feature" for logging `LogLocation` information.
- Extend the documentation of `<log>`
- Fix `<log enable="false">` being ignored.


## Motivation and additional information

These changes allow handle cases where the application/solver/adapter uses Boost.Log itself. (Including ASTE https://github.com/precice/aste/issues/73)
Log entries can now be filtered internally (so preCICE sinks only display preCICE messages) and by the application (using ` and not %preCICE%` in the filter).

Closes #1305 
Related to https://github.com/precice/aste/pull/136

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
