### PR TITLE
Extend RBF solver to handle subsets of the mesh

### DIFF
--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -145,7 +145,8 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       globalOutMesh.addMesh(*outMesh);
     }
 
-    _rbfSolver = RadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>{this->_basisFunction, globalInMesh, globalOutMesh, this->_deadAxis, _polynomial};
+    _rbfSolver = RadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>{this->_basisFunction, globalInMesh, boost::irange<Eigen::Index>(0, globalInMesh.vertices().size()),
+                                                               globalOutMesh, boost::irange<Eigen::Index>(0, globalOutMesh.vertices().size()), this->_deadAxis, _polynomial};
   }
   this->_hasComputedMapping = true;
   PRECICE_DEBUG("Compute Mapping is Completed.");


### PR DESCRIPTION
## Main changes of this PR
Extends the RBF solver class to handle a given set of IDs, build the corresponding mapping matrices and execute a mapping based on these IDs.

## Motivation and additional information
This is required for the partition of unity mapping in order to select specific vertices forming a partition, where we want to solve the RBF system.

## Author's checklist

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
