### PR TITLE
Add version info of dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ endif()
 find_package(Boost 1.71.0 REQUIRED
   COMPONENTS filesystem log log_setup program_options system thread unit_test_framework
   )
+message(STATUS "Found Boost ${Boost_VERSION}")
 
 # Eigen
 if(TPL_ENABLE_EIGEN3)
@@ -173,10 +174,12 @@ if(TPL_ENABLE_EIGEN3)
   xsdk_tpl_require(EIGEN3 EIGEN3_INCLUDE_DIR)
 endif()
 find_package(Eigen3 3.2 REQUIRED)
+message(STATUS "Found Eigen ${Eigen3_VERSION}")
 precice_validate_eigen()
 
 # LibXML2
 find_package(LibXml2 REQUIRED)
+message(STATUS "Found LibXml2 ${LIBXML2_VERSION_STRING}")
 precice_validate_libxml2()
 
 # nlohmann/JSON
@@ -219,6 +222,7 @@ if (PRECICE_PETScMapping)
   endif()
   find_package(PETSc 3.12 REQUIRED)
   # No validation required as PETSc does this internally
+  message(STATUS "Found PETSc ${PETSc_VERSION}")
 else()
   message(STATUS "PETSc support disabled")
 endif()
@@ -226,6 +230,7 @@ endif()
 # Option Python
 if (PRECICE_PythonActions)
   find_package(Python3 REQUIRED COMPONENTS Development NumPy)
+  message(STATUS "Found Python ${Python3_VERSION} with NumPy ${Python3_NumPy_VERSION}")
   precice_validate_libpython()
   precice_validate_numpy()
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ if(TPL_ENABLE_EIGEN3)
   xsdk_tpl_require(EIGEN3 EIGEN3_INCLUDE_DIR)
 endif()
 find_package(Eigen3 3.2 REQUIRED)
-message(STATUS "Found Eigen ${Eigen3_VERSION}")
+message(STATUS "Found Eigen ${EIGEN3_VERSION}")
 precice_validate_eigen()
 
 # LibXML2

--- a/docs/changelog/1430.md
+++ b/docs/changelog/1430.md
@@ -1,0 +1,1 @@
+- Added dependency versions to the CMake output.


### PR DESCRIPTION
## Main changes of this PR

This PR adds the versions of dependencies to the CMake output.

## Motivation and additional information

This should make it easier for preCICE users and developers to detect conflicting versions.

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] I ran `make format` to ensure everything is formatted correctly.
* [ ] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
