### PR TITLE
Disable PETSc error handler

### DIFF
--- a/docs/changelog/1434.md
+++ b/docs/changelog/1434.md
@@ -1,0 +1,1 @@
+- Disabled the default PETSc signal handler in case preCICE needs to initialize PETSc.

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -80,6 +80,8 @@ void Petsc::initialize(
   PetscInitialized(&petscIsInitialized);
   if (not petscIsInitialized) {
     PETSC_COMM_WORLD = comm;
+    // Disable the default signal handler
+    PetscOptionsSetValue(NULL, "-no_signal_handler", NULL);
     PetscErrorCode ierr;
     ierr = PetscInitialize(argc, argv, "", nullptr);
     CHKERRV(ierr);

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -84,7 +84,6 @@ void Petsc::initialize(
     ierr = PetscInitialize(argc, argv, "", nullptr);
     CHKERRV(ierr);
     weInitialized = true;
-    PetscPushErrorHandler(&PetscMPIAbortErrorHandler, nullptr);
   }
 #endif // not PRECICE_NO_PETSC
 }

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -81,7 +81,7 @@ void Petsc::initialize(
   if (not petscIsInitialized) {
     PETSC_COMM_WORLD = comm;
     // Disable the default signal handler
-    PetscOptionsSetValue(NULL, "-no_signal_handler", NULL);
+    PetscOptionsSetValue(nullptr, "-no_signal_handler", nullptr);
     PetscErrorCode ierr;
     ierr = PetscInitialize(argc, argv, "", nullptr);
     CHKERRV(ierr);


### PR DESCRIPTION
## Main changes of this PR

This PR disables the PETSc error handler, which is a common source of confusion among users of preCICE.

## Motivation and additional information

The error handler often attracted blame and attention towards preCICE or PETSc, despite errors being part of the user code.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
