### PR TITLE
Simplify implementation of DataContext.

### DIFF
--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -20,30 +20,15 @@ std::string DataContext::getDataName() const
   return _providedData->getName();
 }
 
-DataID DataContext::getFromDataID(size_t dataVectorIndex) const
-{
-  PRECICE_ASSERT(hasMapping());
-  PRECICE_ASSERT(dataVectorIndex < _fromData.size())
-  PRECICE_ASSERT(_fromData[dataVectorIndex]);
-  return _fromData[dataVectorIndex]->getID();
-}
-
 void DataContext::resetData()
 {
   // See also https://github.com/precice/precice/issues/1156.
   _providedData->toZero();
   if (hasMapping()) {
     PRECICE_ASSERT(hasWriteMapping());
-    std::for_each(_toData.begin(), _toData.end(), [](auto &data) { data->toZero(); });
+    // PRECICE_ASSERT(!hasReadMapping());  // we also need this assertion, because currently we also reset toData from read mappings, if a data context has a read and write mapping! Is this what we want?
+    std::for_each(_mappingContexts.begin(), _mappingContexts.end(), [](auto &context) { context.toData->toZero(); });
   }
-}
-
-DataID DataContext::getToDataID(size_t dataVectorIndex) const
-{
-  PRECICE_ASSERT(hasMapping());
-  PRECICE_ASSERT(dataVectorIndex < _toData.size())
-  PRECICE_ASSERT(_toData[dataVectorIndex]);
-  return _toData[dataVectorIndex]->getID();
 }
 
 DataID DataContext::getDataDimensions() const
@@ -64,23 +49,20 @@ MeshID DataContext::getMeshID() const
   return _mesh->getID();
 }
 
-void DataContext::appendMapping(MappingContext mappingContext, mesh::PtrData fromData, mesh::PtrData toData)
+void DataContext::appendMapping(MappingContext mappingContext)
 {
-  PRECICE_ASSERT(fromData);
-  PRECICE_ASSERT(toData);
+  PRECICE_ASSERT(mappingContext.fromData);
+  PRECICE_ASSERT(mappingContext.toData);
   // Make sure we don't append a mapping twice
 #ifndef NDEBUG
-  for (unsigned int i = 0; i < _mappingContexts.size(); ++i) {
-    PRECICE_ASSERT(!((_mappingContexts[i].mapping == mappingContext.mapping) && (_fromData[i] == fromData) && (_toData[i] == toData)), "The appended mapping already exists.");
+  for (auto &context : _mappingContexts) {
+    PRECICE_ASSERT(!((context.mapping == mappingContext.mapping) && (context.fromData == mappingContext.fromData) && (context.fromData == mappingContext.toData)), "The appended mapping already exists.");
   }
 #endif
   _mappingContexts.emplace_back(mappingContext);
-  PRECICE_ASSERT(fromData == _providedData || toData == _providedData, "Either fromData or toData has to equal _providedData.");
-  PRECICE_ASSERT(fromData->getName() == getDataName());
-  _fromData.emplace_back(fromData);
-  PRECICE_ASSERT(toData->getName() == getDataName());
-  _toData.emplace_back(toData);
-  PRECICE_ASSERT(_toData != _fromData);
+  PRECICE_ASSERT(mappingContext.fromData == _providedData || mappingContext.toData == _providedData, "Either fromData or toData has to equal _providedData.");
+  PRECICE_ASSERT(mappingContext.fromData->getName() == getDataName());
+  PRECICE_ASSERT(mappingContext.toData->getName() == getDataName());
 }
 
 bool DataContext::hasMapping() const
@@ -106,24 +88,24 @@ void DataContext::mapData()
 {
   PRECICE_ASSERT(hasMapping());
   // Execute the mapping
-  for (unsigned int i = 0; i < _mappingContexts.size(); ++i) {
-    const DataID fromDataID = getFromDataID(i);
-    const DataID toDataID   = getToDataID(i);
+  for (auto &context : _mappingContexts) {
     // Reset the toData before executing the mapping
-    _toData[i]->toZero();
-    _mappingContexts[i].mapping->map(fromDataID, toDataID);
-    PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, _toData[i]->values()));
+    context.toData->toZero();
+    const DataID fromDataID = context.fromData->getID();
+    const DataID toDataID   = context.toData->getID();
+    context.mapping->map(fromDataID, toDataID);
+    PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, context.toData->values()));
   }
 }
 
 bool DataContext::hasReadMapping() const
 {
-  return std::any_of(_toData.begin(), _toData.end(), [this](auto &data) { return data == _providedData; });
+  return std::any_of(_mappingContexts.begin(), _mappingContexts.end(), [this](auto &context) { return context.toData == _providedData; });
 }
 
 bool DataContext::hasWriteMapping() const
 {
-  return std::any_of(_fromData.begin(), _fromData.end(), [this](auto &data) { return data == _providedData; });
+  return std::any_of(_mappingContexts.begin(), _mappingContexts.end(), [this](auto &context) { return context.fromData == _providedData; });
 }
 
 } // namespace precice::impl

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -26,7 +26,7 @@ void DataContext::resetData()
   _providedData->toZero();
   if (hasMapping()) {
     PRECICE_ASSERT(hasWriteMapping());
-    // PRECICE_ASSERT(!hasReadMapping());  // we also need this assertion, because currently we also reset toData from read mappings, if a data context has a read and write mapping! Is this what we want?
+    PRECICE_ASSERT(!hasReadMapping());
     std::for_each(_mappingContexts.begin(), _mappingContexts.end(), [](auto &context) { context.toData->toZero(); });
   }
 }

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -80,7 +80,7 @@ public:
    * @param[in] mappingContext Context of the mapping
    * @param[in] meshContext Context of mesh this mapping is mapping from or to
    */
-  virtual void appendMappingConfiguration(const MappingContext &mappingContext, const MeshContext &meshContext) = 0;
+  virtual void appendMappingConfiguration(MappingContext &mappingContext, const MeshContext &meshContext) = 0;
 
 protected:
   /**
@@ -97,22 +97,14 @@ protected:
   /// Unique data this context is associated with
   mesh::PtrData _providedData;
 
-  /// If a mapping exists, collection of mesh::PtrData the mapping maps from.
-  std::vector<mesh::PtrData> _fromData;
-
-  /// If a mapping exists, collection of mesh::PtrData the mapping maps from.
-  std::vector<mesh::PtrData> _toData;
-
   /**
    * @brief Helper to append a mappingContext, fromData and toData to the corresponding data containers
    *
    * @param mappingContext MappingContext this DataContext will be associated to.
-   * @param fromData Data the mapping maps from.
-   * @param toData Data the mapping maps to.
    *
    * @note Only unique mappings may be appended. In case the same mapping is appended twice, an error is raised.
    */
-  void appendMapping(MappingContext mappingContext, mesh::PtrData fromData, mesh::PtrData toData);
+  void appendMapping(MappingContext mappingContext);
 
   /**
    * @brief Informs the user whether this DataContext has any read mapping.
@@ -133,24 +125,6 @@ private:
   mesh::PtrMesh _mesh;
 
   static logging::Logger _log;
-
-  /**
-   * @brief Get the ID of the data in the _fromDatas container. Used for performing the mapping outside of this class.
-   *
-   * @param[in] dataVectorIndex Index of the '_fromDatas' container this data context holds
-   *
-   * @return DataID ID of _fromDatas.
-   */
-  DataID getFromDataID(size_t dataVectorIndex) const;
-
-  /**
-   * @brief Get the ID of the data in the _toDatas container. Used for performing the mapping outside of this class.
-   *
-   * @param[in] dataVectorIndex Index of the '_toDatas' vector this data context holds
-   *
-   * @return DataID ID of _toDatas.
-   */
-  DataID getToDataID(size_t dataVectorIndex) const;
 
   /**
    * @brief Informs the user whether this DataContext has any _mappingContext.

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -12,10 +12,16 @@ struct MappingContext {
   mapping::PtrMapping mapping;
 
   /// id of mesh from which is mapped
-  int fromMeshID = -1;
+  MeshID fromMeshID = -1;
 
   /// id of mesh to which is mapped
-  int toMeshID = -1;
+  MeshID toMeshID = -1;
+
+  /// data which is mapped from mesh
+  mesh::PtrData fromData = nullptr;
+
+  /// data which is mapped to mesh
+  mesh::PtrData toData = nullptr;
 
   /// Time of execution of mapping.
   mapping::MappingConfiguration::Timing timing = mapping::MappingConfiguration::INITIAL;

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -15,13 +15,15 @@ ReadDataContext::ReadDataContext(
   _waveform = std::make_shared<time::Waveform>(interpolationOrder);
 }
 
-void ReadDataContext::appendMappingConfiguration(const MappingContext &mappingContext, const MeshContext &meshContext)
+void ReadDataContext::appendMappingConfiguration(MappingContext &mappingContext, const MeshContext &meshContext)
 {
   PRECICE_ASSERT(!hasReadMapping(), "The read data context must be unique. Otherwise we would have an ambiguous read data operation on the user side.")
   PRECICE_ASSERT(meshContext.mesh->hasDataName(getDataName()));
   mesh::PtrData data = meshContext.mesh->data(getDataName());
   PRECICE_ASSERT(data != _providedData, "Data the read mapping is mapping from needs to be different from _providedData");
-  appendMapping(mappingContext, data, _providedData);
+  mappingContext.fromData = data;
+  mappingContext.toData   = _providedData;
+  appendMapping(mappingContext);
   PRECICE_ASSERT(hasReadMapping());
 }
 

--- a/src/precice/impl/ReadDataContext.hpp
+++ b/src/precice/impl/ReadDataContext.hpp
@@ -46,7 +46,7 @@ public:
    *
    * @note Note that read mapping contexts have to be unique and and this function may only be called once for a given ReadDataContext
    */
-  void appendMappingConfiguration(const MappingContext &mappingContext, const MeshContext &meshContext) override;
+  void appendMappingConfiguration(MappingContext &mappingContext, const MeshContext &meshContext) override;
 
   /**
    * @brief Samples data at a given point in time within the current time window

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -17,12 +17,14 @@ mesh::PtrData WriteDataContext::providedData()
   return _providedData;
 }
 
-void WriteDataContext::appendMappingConfiguration(const MappingContext &mappingContext, const MeshContext &meshContext)
+void WriteDataContext::appendMappingConfiguration(MappingContext &mappingContext, const MeshContext &meshContext)
 {
   PRECICE_ASSERT(meshContext.mesh->hasDataName(getDataName()));
   mesh::PtrData data = meshContext.mesh->data(getDataName());
   PRECICE_ASSERT(data != _providedData, "Data the write mapping is mapping to needs to be different from _providedData");
-  appendMapping(mappingContext, _providedData, data);
+  mappingContext.fromData = _providedData;
+  mappingContext.toData   = data;
+  appendMapping(mappingContext);
   PRECICE_ASSERT(hasWriteMapping());
 }
 

--- a/src/precice/impl/WriteDataContext.hpp
+++ b/src/precice/impl/WriteDataContext.hpp
@@ -40,7 +40,7 @@ public:
    * @param[in] mappingContext Context of write mapping
    * @param[in] meshContext Context of mesh this write mapping is mapping to (_toData)
    */
-  void appendMappingConfiguration(const MappingContext &mappingContext, const MeshContext &meshContext) override;
+  void appendMappingConfiguration(MappingContext &mappingContext, const MeshContext &meshContext) override;
 
 private:
   static logging::Logger _log;

--- a/src/testing/DataContextFixture.cpp
+++ b/src/testing/DataContextFixture.cpp
@@ -14,12 +14,12 @@ int DataContextFixture::getProvidedDataID(precice::impl::DataContext &dataContex
 
 int DataContextFixture::getFromDataID(precice::impl::DataContext &dataContext, int dataVectorIndex)
 {
-  return dataContext.getFromDataID(dataVectorIndex);
+  return dataContext._mappingContexts[dataVectorIndex].fromData->getID();
 }
 
 int DataContextFixture::getToDataID(precice::impl::DataContext &dataContext, int dataVectorIndex)
 {
-  return dataContext.getToDataID(dataVectorIndex);
+  return dataContext._mappingContexts[dataVectorIndex].toData->getID();
 }
 
 bool DataContextFixture::hasMapping(precice::impl::DataContext &dataContext)


### PR DESCRIPTION
## Main changes of this PR

* Move DataPtr inside MappingContext.
* Use range-based for loops in DataContext.
* Simplify access of data properties vie context (does not require detour over std::vector in DataContext anymore)

## Motivation and additional information

Helpful in scope of #1414 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release. (not needed?)
* [ ] I added a test to cover the proposed changes in our test suite. (not needed?)
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
