### PR TITLE
Change global mesh names in RBF mapping to actual names

### DIFF
--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -117,8 +117,8 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
 
   } else { // Parallel Primary rank or Serial
 
-    mesh::Mesh globalInMesh("globalInMesh", inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
-    mesh::Mesh globalOutMesh("globalOutMesh", outMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
+    mesh::Mesh globalInMesh(inMesh->getName(), inMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
+    mesh::Mesh globalOutMesh(outMesh->getName(), outMesh->getDimensions(), mesh::Mesh::MESH_ID_UNDEFINED);
 
     if (utils::IntraComm::isPrimary()) {
       {

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -202,7 +202,7 @@ RadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctSolver(RADIAL_BASIS
   }
 
   PRECICE_CHECK(decompositionSuccessful,
-                "The interpolation matrix of the RBF mapping from mesh {} to mesh {} is not invertable. "
+                "The interpolation matrix of the RBF mapping from mesh \"{}\" to mesh \"{}\" is not invertable. "
                 "This means that the mapping problem is not well-posed. "
                 "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
                 "by marking perpendicular axes as dead?",


### PR DESCRIPTION
## Main changes of this PR

Changes the mesh names in the RBF mapping class to the actual names, such that the RBF solver class can report the correct mesh names when checking for convergence.

## Motivation and additional information

Resolves #1437 
