### PR TITLE
Improve encapsulation of CouplingData

### DIFF
--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -26,8 +26,7 @@ public:
   static const int PODFILTER     = 4;
 
   /// Map from data ID to data values.
-  using DataMap   = std::map<int, cplscheme::PtrCouplingData>;
-  using ValuesMap = std::map<int, Eigen::VectorXd>;
+  using DataMap = std::map<int, cplscheme::PtrCouplingData>;
 
   virtual ~Acceleration() {}
 

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -36,11 +36,11 @@ void AitkenAcceleration::initialize(const DataMap &cplData)
   checkDataIDs(cplData);
   size_t entries = 0;
   if (_dataIDs.size() == 1) {
-    entries = cplData.at(_dataIDs.at(0))->values().size();
+    entries = cplData.at(_dataIDs.at(0))->getSize();
   } else {
     PRECICE_ASSERT(_dataIDs.size() == 2);
-    entries = cplData.at(_dataIDs.at(0))->values().size() +
-              cplData.at(_dataIDs.at(1))->values().size();
+    entries = cplData.at(_dataIDs.at(0))->getSize() +
+              cplData.at(_dataIDs.at(1))->getSize();
   }
   double          initializer = std::numeric_limits<double>::max();
   Eigen::VectorXd toAppend    = Eigen::VectorXd::Constant(entries, initializer);

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -79,8 +79,8 @@ void BaseQNAcceleration::initialize(
 {
   PRECICE_TRACE(cplData.size());
   for (const DataMap::value_type &pair : cplData) {
-    PRECICE_ASSERT(pair.second->values().size() == pair.second->previousIteration().size(), "current and previousIteration have to be initialized and of identical size.",
-                   pair.second->values().size(), pair.second->previousIteration().size());
+    PRECICE_ASSERT(pair.second->getSize() == pair.second->getPreviousIterationSize(), "current and previousIteration have to be initialized and of identical size.",
+                   pair.second->getSize(), pair.second->getPreviousIterationSize());
   }
 
   if (std::any_of(cplData.cbegin(), cplData.cend(), [](const auto &p) { return p.second->hasGradient(); })) {
@@ -93,8 +93,8 @@ void BaseQNAcceleration::initialize(
   std::vector<size_t> subVectorSizes; //needed for preconditioner
 
   for (auto &elem : _dataIDs) {
-    entries += cplData.at(elem)->values().size();
-    subVectorSizes.push_back(cplData.at(elem)->values().size());
+    entries += cplData.at(elem)->getSize();
+    subVectorSizes.push_back(cplData.at(elem)->getSize());
   }
 
   _matrixCols.push_front(0);
@@ -156,7 +156,7 @@ void BaseQNAcceleration::initialize(
   for (const DataMap::value_type &pair : cplData) {
     if (not utils::contained(pair.first, _dataIDs)) {
       _secondaryDataIDs.push_back(pair.first);
-      int secondaryEntries            = pair.second->values().size();
+      int secondaryEntries            = pair.second->getSize();
       _secondaryResiduals[pair.first] = Eigen::VectorXd::Zero(secondaryEntries);
     }
   }
@@ -435,7 +435,7 @@ void BaseQNAcceleration::concatenateCouplingData(
 
   int offset = 0;
   for (int id : _dataIDs) {
-    int         size      = cplData.at(id)->values().size();
+    int         size      = cplData.at(id)->getSize();
     auto &      values    = cplData.at(id)->values();
     const auto &oldValues = cplData.at(id)->previousIteration();
     for (int i = 0; i < size; i++) {
@@ -453,7 +453,7 @@ void BaseQNAcceleration::splitCouplingData(
 
   int offset = 0;
   for (int id : _dataIDs) {
-    int   size       = cplData.at(id)->values().size();
+    int   size       = cplData.at(id)->getSize();
     auto &valuesPart = cplData.at(id)->values();
     for (int i = 0; i < size; i++) {
       valuesPart(i) = _values(i + offset);

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -47,7 +47,7 @@ void IQNILSAcceleration::initialize(
   // Fetch secondary data IDs, to be relaxed with same coefficients from IQN-ILS
   for (const DataMap::value_type &pair : cplData) {
     if (not utils::contained(pair.first, _dataIDs)) {
-      int secondaryEntries = pair.second->values().size();
+      int secondaryEntries = pair.second->getSize();
       utils::append(_secondaryOldXTildes[pair.first], Eigen::VectorXd(Eigen::VectorXd::Zero(secondaryEntries)));
     }
   }
@@ -60,8 +60,8 @@ void IQNILSAcceleration::updateDifferenceMatrices(
   for (int id : _secondaryDataIDs) {
     Eigen::VectorXd &secResiduals = _secondaryResiduals[id];
     PtrCouplingData  data         = cplData.at(id);
-    PRECICE_ASSERT(secResiduals.size() == data->values().size(),
-                   secResiduals.size(), data->values().size());
+    PRECICE_ASSERT(secResiduals.size() == data->getSize(),
+                   secResiduals.size(), data->getSize());
     secResiduals = data->values();
     secResiduals -= data->previousIteration();
   }
@@ -88,7 +88,7 @@ void IQNILSAcceleration::updateDifferenceMatrices(
       // Compute delta_x_tilde for secondary data
       for (int id : _secondaryDataIDs) {
         Eigen::MatrixXd &secW = _secondaryMatricesW[id];
-        PRECICE_ASSERT(secW.rows() == cplData.at(id)->values().size(), secW.rows(), cplData.at(id)->values().size());
+        PRECICE_ASSERT(secW.rows() == cplData.at(id)->getSize(), secW.rows(), cplData.at(id)->getSize());
         secW.col(0) = cplData.at(id)->values();
         secW.col(0) -= _secondaryOldXTildes[id];
       }
@@ -96,8 +96,8 @@ void IQNILSAcceleration::updateDifferenceMatrices(
 
     // Store x_tildes for secondary data
     for (int id : _secondaryDataIDs) {
-      PRECICE_ASSERT(_secondaryOldXTildes[id].size() == cplData.at(id)->values().size(),
-                     _secondaryOldXTildes[id].size(), cplData.at(id)->values().size());
+      PRECICE_ASSERT(_secondaryOldXTildes[id].size() == cplData.at(id)->getSize(),
+                     _secondaryOldXTildes[id].size(), cplData.at(id)->getSize());
       _secondaryOldXTildes[id] = cplData.at(id)->values();
     }
   }
@@ -111,8 +111,8 @@ void IQNILSAcceleration::computeUnderrelaxationSecondaryData(
 {
   //Store x_tildes for secondary data
   for (int id : _secondaryDataIDs) {
-    PRECICE_ASSERT(_secondaryOldXTildes.at(id).size() == cplData.at(id)->values().size(),
-                   _secondaryOldXTildes.at(id).size(), cplData.at(id)->values().size());
+    PRECICE_ASSERT(_secondaryOldXTildes.at(id).size() == cplData.at(id)->getSize(),
+                   _secondaryOldXTildes.at(id).size(), cplData.at(id)->getSize());
     _secondaryOldXTildes[id] = cplData.at(id)->values();
   }
 
@@ -212,9 +212,9 @@ void IQNILSAcceleration::computeQNUpdate(const DataMap &cplData, Eigen::VectorXd
     auto &          values = data->values();
     PRECICE_ASSERT(_secondaryMatricesW[id].cols() == c.size(), _secondaryMatricesW[id].cols(), c.size());
     values = _secondaryMatricesW[id] * c;
-    PRECICE_ASSERT(values.size() == data->previousIteration().size(), values.size(), data->previousIteration().size());
+    PRECICE_ASSERT(data->getSize() == data->getPreviousIterationSize(), data->getSize(), data->getPreviousIterationSize());
     values += data->previousIteration();
-    PRECICE_ASSERT(values.size() == _secondaryResiduals[id].size(), values.size(), _secondaryResiduals[id].size());
+    PRECICE_ASSERT(data->getSize() == _secondaryResiduals[id].size(), data->getSize(), _secondaryResiduals[id].size());
     values += _secondaryResiduals[id];
   }
 

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -19,7 +19,7 @@ CouplingData::CouplingData(
       _extrapolation(extrapolationOrder)
 {
   PRECICE_ASSERT(_data != nullptr);
-  _previousIteration = Eigen::VectorXd::Zero(_data->values().size());
+  _previousIteration = Eigen::VectorXd::Zero(getSize());
   PRECICE_ASSERT(_mesh != nullptr);
   PRECICE_ASSERT(_mesh.use_count() > 0);
 }
@@ -28,6 +28,12 @@ int CouplingData::getDimensions() const
 {
   PRECICE_ASSERT(_data != nullptr);
   return _data->getDimensions();
+}
+
+int CouplingData::getSize() const
+{
+  PRECICE_ASSERT(_data != nullptr);
+  return values().size();
 }
 
 Eigen::VectorXd &CouplingData::values()
@@ -75,6 +81,11 @@ const Eigen::VectorXd CouplingData::previousIteration() const
   return _previousIteration;
 }
 
+int CouplingData::getPreviousIterationSize() const
+{
+  return previousIteration().size();
+}
+
 int CouplingData::getMeshID()
 {
   return _mesh->getID();
@@ -97,7 +108,7 @@ std::vector<int> CouplingData::getVertexOffsets()
 
 void CouplingData::initializeExtrapolation()
 {
-  _extrapolation.initialize(values().size());
+  _extrapolation.initialize(getSize());
   storeIteration();
 }
 

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -20,6 +20,8 @@ public:
 
   int getDimensions() const;
 
+  int getSize() const;
+
   /// Returns a reference to the data values.
   Eigen::VectorXd &values();
 
@@ -43,6 +45,9 @@ public:
 
   /// returns data value from previous iteration
   const Eigen::VectorXd previousIteration() const;
+
+  /// returns size of previous iteration
+  int getPreviousIterationSize() const;
 
   /// get ID of this CouplingData's mesh. See Mesh::getID().
   int getMeshID();

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -143,10 +143,10 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   if (context.isNamed(nameParticipant0)) {
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(0.0, 0.0, 0.0)));
     BOOST_TEST(receiveCouplingData->values().size() == 3);
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 3);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->values()(0), 0.0));
     BOOST_TEST(sendCouplingData->values().size() == 1);
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(Fixture::isImplicitCouplingScheme(cplScheme));
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
     sendCouplingData->values() = Eigen::VectorXd::Constant(1, 4.0);
@@ -154,9 +154,9 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     cplScheme.initialize(0.0, 0);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 3);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(receiveCouplingData->previousIteration(), Eigen::Vector3d(0.0, 0.0, 0.0)));
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration()(0), 4.0));
     while (cplScheme.isCouplingOngoing()) {
       if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
@@ -178,17 +178,17 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     cplScheme.markActionFulfilled(constants::actionWriteInitialData());
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 0.0));
     BOOST_TEST(receiveCouplingData->values().size() == 1);
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     BOOST_TEST(sendCouplingData->values().size() == 3);
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 3);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 3);
     cplScheme.initialize(0.0, 0);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 4.0));
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->previousIteration()(0), 0.0));
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 3);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     while (cplScheme.isCouplingOngoing()) {
       if (cplScheme.isActionRequired(writeIterationCheckpoint)) {

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -478,8 +478,8 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   Fixture::initializeStorages(scheme);
   CouplingData *cplData = Fixture::getSendData(scheme, dataID);
   BOOST_CHECK(cplData); // no nullptr
-  BOOST_TEST(cplData->values().size() == 1);
-  BOOST_TEST(cplData->previousIteration().size() == 1);
+  BOOST_TEST(cplData->getSize() == 1);
+  BOOST_TEST(cplData->getPreviousIterationSize() == 1);
 
   Fixture::moveToNextWindow(scheme);
 
@@ -553,8 +553,8 @@ BOOST_AUTO_TEST_CASE(SecondOrder)
   Fixture::initializeStorages(scheme);
   CouplingData *cplData = Fixture::getSendData(scheme, dataID);
   BOOST_CHECK(cplData); // no nullptr
-  BOOST_TEST(cplData->values().size() == 1);
-  BOOST_TEST(cplData->previousIteration().size() == 1);
+  BOOST_TEST(cplData->getSize() == 1);
+  BOOST_TEST(cplData->getPreviousIterationSize() == 1);
 
   Fixture::moveToNextWindow(scheme);
 
@@ -1604,14 +1604,14 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   if (context.isNamed(nameParticipant0)) {
     // ensure that read data is uninitialized
-    BOOST_TEST(receiveCouplingData->values().size() == 3);
+    BOOST_TEST(receiveCouplingData->getSize() == 3);
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(0.0, 0.0, 0.0)));
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 3);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(receiveCouplingData->previousIteration(), Eigen::Vector3d(0.0, 0.0, 0.0)));
     // ensure that write data is uninitialized
-    BOOST_TEST(sendCouplingData->values().size() == 1);
+    BOOST_TEST(sendCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->values()(0), 0.0));
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration()(0), 0.0));
 
     BOOST_TEST(Fixture::isImplicitCouplingScheme(cplScheme));
@@ -1620,18 +1620,18 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(!cplScheme.hasDataBeenReceived());
     // ensure that initial data was read
-    BOOST_TEST(receiveCouplingData->values().size() == 3);
+    BOOST_TEST(receiveCouplingData->getSize() == 3);
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 3);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(receiveCouplingData->previousIteration(), Eigen::Vector3d(0.0, 0.0, 0.0)));
     // ensure that write data is still uninitialized
-    BOOST_TEST(sendCouplingData->values().size() == 1);
+    BOOST_TEST(sendCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->values()(0), 0.0));
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration()(0), 0.0));
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     // set write data
-    sendCouplingData->values() = Eigen::VectorXd::Constant(sendCouplingData->values().size(), 4.0);
+    sendCouplingData->values() = Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0);
     while (cplScheme.isCouplingOngoing()) {
       if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
         cplScheme.markActionFulfilled(writeIterationCheckpoint);
@@ -1650,25 +1650,25 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     v << 1.0, 2.0, 3.0;
     sendCouplingData->values() = v;
     cplScheme.markActionFulfilled(constants::actionWriteInitialData());
-    BOOST_TEST(receiveCouplingData->values().size() == 1);
+    BOOST_TEST(receiveCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 0.0));
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 1);
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 1); // here, previousIteration is correctly initialized, see above
-    BOOST_TEST(sendCouplingData->values().size() == 3);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1); // here, previousIteration is correctly initialized, see above
+    BOOST_TEST(sendCouplingData->getSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 3); // here, previousIteration is correctly initialized, see above
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 3); // here, previousIteration is correctly initialized, see above
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(!cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
-    BOOST_TEST(receiveCouplingData->values().size() == 1);
+    BOOST_TEST(receiveCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 4.0));
-    BOOST_TEST(receiveCouplingData->previousIteration().size() == 1);
+    BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->previousIteration()(0), 0.0));
-    BOOST_TEST(sendCouplingData->values().size() == 3);
+    BOOST_TEST(sendCouplingData->getSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
-    BOOST_TEST(sendCouplingData->previousIteration().size() == 3);
+    BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     while (cplScheme.isCouplingOngoing()) {
       if (cplScheme.isActionRequired(writeIterationCheckpoint)) {


### PR DESCRIPTION
## Main changes of this PR

Introduce CouplingData::getSize and CouplingData::getPreviousIterationSize for better encapsulation.

## Motivation and additional information

Less calls to CouplingData::values(), when it is not needed.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
