### PR TITLE
Support waveform interpolation in read for multi-coupling

### DIFF
--- a/docs/changelog/1445.md
+++ b/docs/changelog/1445.md
@@ -1,0 +1,1 @@
+- Allow waveform interpolation for multi coupling

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -347,10 +347,6 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
       addCouplingScheme(scheme, accessor);
       _config = Config();
     } else if (_config.type == VALUE_MULTI) {
-      if (_experimental) {
-        int maxAllowedOrder = 0; // multi coupling scheme does not allow waveform iteration
-        checkWaveformOrderReadData(maxAllowedOrder);
-      }
       PRECICE_CHECK(_config.setController,
                     "One controller per MultiCoupling needs to be defined. "
                     "Please check the <participant name=... /> tags in the <coupling-scheme:... /> of your precice-config.xml. "

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -1,0 +1,149 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(MultiCoupling)
+/**
+ * @brief Test to run a simple coupling with first order waveform subcycling.
+ *
+ * Provides a dt argument to the read function. A first order waveform is used.
+ */
+BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank), "SolverThree"_on(1_rank));
+
+  SolverInterface precice(context.name, context.config(), 0, 1);
+
+  MeshID meshID;
+  DataID writeDataID;
+
+  typedef double (*DataFunction)(double);
+  std::vector<std::pair<DataID, DataFunction>> readDataPairs;
+
+  DataFunction dataOneFunction = [](double t) -> double {
+    return (double) (2 + t);
+  };
+  DataFunction dataTwoFunction = [](double t) -> double {
+    return (double) (10 + t);
+  };
+  DataFunction dataThreeFunction = [](double t) -> double {
+    return (double) (300 + t);
+  };
+  DataFunction writeFunction;
+
+  if (context.isNamed("SolverOne")) {
+    meshID         = precice.getMeshID("MeshOne");
+    writeDataID    = precice.getDataID("DataOne", meshID);
+    writeFunction  = dataOneFunction;
+    auto dataTwoId = precice.getDataID("DataTwo", meshID);
+    readDataPairs.push_back(std::make_pair(dataTwoId, dataTwoFunction));
+    auto dataThreeId = precice.getDataID("DataThree", meshID);
+    readDataPairs.push_back(std::make_pair(dataThreeId, dataThreeFunction));
+  } else if (context.isNamed("SolverTwo")) {
+    meshID         = precice.getMeshID("MeshTwo");
+    writeDataID    = precice.getDataID("DataTwo", meshID);
+    writeFunction  = dataTwoFunction;
+    auto dataOneId = precice.getDataID("DataOne", meshID);
+    readDataPairs.push_back(std::make_pair(dataOneId, dataOneFunction));
+  } else {
+    BOOST_TEST(context.isNamed("SolverThree"));
+    meshID         = precice.getMeshID("MeshThree");
+    writeDataID    = precice.getDataID("DataThree", meshID);
+    writeFunction  = dataThreeFunction;
+    auto dataOneId = precice.getDataID("DataOne", meshID);
+    readDataPairs.push_back(std::make_pair(dataOneId, dataOneFunction));
+  }
+
+  double   writeData, readData;
+  VertexID vertexID = precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+
+  int    nWindows        = 5; // perform 5 windows.
+  int    timestep        = 0;
+  int    timewindow      = 0;
+  double windowStartTime = 0;
+  int    windowStartStep = 0;
+  int    nSamples        = 4;
+  int    iterations      = 0;
+  double time            = 0;
+
+  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+    writeData = writeFunction(time);
+    precice.writeScalarData(writeDataID, vertexID, writeData);
+    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
+  }
+
+  double maxDt        = precice.initialize();
+  double windowDt     = maxDt;
+  double dt           = maxDt; // Timestep length desired by solver
+  double currentDt    = dt;    // Timestep length used by solver
+  double sampleDts[4] = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
+  double readTime; // time where we are reading
+  double sampleDt; // dt relative to timestep start, where we are sampling
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+      windowStartTime = time;
+      windowStartStep = timestep;
+      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+    }
+
+    for (int j = 0; j < nSamples; j++) {
+      sampleDt = sampleDts[j];
+      readTime = time + sampleDt;
+
+      for (auto readDataPair : readDataPairs) {
+        auto readDataID   = readDataPair.first;
+        auto readFunction = readDataPair.second;
+
+        precice.readScalarData(readDataID, vertexID, sampleDt, readData);
+
+        if (iterations == 0) { // always use constant extrapolation in first iteration (from initialize or writeData of second participant at end previous window).
+          BOOST_TEST(readData == readFunction(time));
+        } else if (iterations > 0) { // use linear interpolation in later iterations (additionally available writeData of second participant at end of this window).
+          BOOST_TEST(readData == readFunction(readTime));
+        } else {
+          BOOST_TEST(false); // unreachable!
+        }
+      }
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    time += currentDt;
+    writeData = writeFunction(time);
+    precice.writeScalarData(writeDataID, vertexID, writeData);
+    maxDt     = precice.advance(currentDt);
+    currentDt = dt > maxDt ? maxDt : dt;
+    BOOST_CHECK(currentDt == windowDt); // no subcycling.
+    timestep++;
+    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+      iterations++;
+      timestep = windowStartStep;
+      time     = windowStartTime;
+      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
+    }
+    if (precice.isTimeWindowComplete()) {
+      timewindow++;
+      iterations = 0;
+    }
+  }
+
+  precice.finalize();
+  BOOST_TEST(timestep == nWindows);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3" experimental="true">
+    <data:scalar name="DataOne" />
+    <data:scalar name="DataTwo" />
+    <data:scalar name="DataThree" />
+
+    <mesh name="MeshOne">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+      <use-data name="DataThree" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="DataOne" />
+      <use-data name="DataTwo" />
+    </mesh>
+
+    <mesh name="MeshThree">
+      <use-data name="DataOne" />
+      <use-data name="DataThree" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <use-mesh name="MeshOne" provide="yes" />
+      <write-data name="DataOne" mesh="MeshOne" />
+      <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+      <read-data name="DataThree" mesh="MeshOne" waveform-order="1" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshTwo" provide="yes" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="conservative" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshOne"
+        to="MeshTwo"
+        constraint="consistent" />
+      <write-data name="DataTwo" mesh="MeshTwo" />
+      <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    </participant>
+
+    <participant name="SolverThree">
+      <use-mesh name="MeshOne" from="SolverOne" />
+      <use-mesh name="MeshThree" provide="yes" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshThree"
+        to="MeshOne"
+        constraint="conservative" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshOne"
+        to="MeshThree"
+        constraint="consistent" />
+      <write-data name="DataThree" mesh="MeshThree" />
+      <read-data name="DataOne" mesh="MeshThree" waveform-order="1" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+    <m2n:sockets from="SolverOne" to="SolverThree" />
+
+    <coupling-scheme:multi>
+      <participant name="SolverOne" control="yes" />
+      <participant name="SolverTwo" />
+      <participant name="SolverThree" />
+      <max-time-windows value="5" />
+      <time-window-size value="2" />
+      <max-iterations value="3" />
+      <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
+      <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+      <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverThree" initialize="on" />
+      <exchange data="DataThree" mesh="MeshOne" from="SolverThree" to="SolverOne" initialize="on" />
+    </coupling-scheme:multi>
+  </solver-interface>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -161,6 +161,7 @@ target_sources(testprecice
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+    tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp


### PR DESCRIPTION
## Main changes of this PR

Also allow to use waveforms with multi-coupling and add tests.

## Motivation and additional information

In https://github.com/precice/precice/pull/1352 multi-coupling was still forbidden. This PR adds a test for multi-coupling and supports it.

Bigger picture: In #1171 multi coupling becomes more complicated, because different participants might write data from different meshes in time that the receiving solver has to handle. We should first get the simple multi coupling without subcycling working before approaching this bigger task.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
