### PR TITLE
Handle interrupts in communication

### DIFF
--- a/docs/changelog/1446.md
+++ b/docs/changelog/1446.md
@@ -1,0 +1,3 @@
+- Fixed interrupts during blocked communication leading to errors instead of restarts.
+- Improved error messages regarding communication issues.
+- Added error checking for asynchronous communication.

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -5,6 +5,7 @@
 
 #include "Communication.hpp"
 #include "Request.hpp"
+#include "com/ErrorHandling.hpp"
 #include "logging/LogMacros.hpp"
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
@@ -51,6 +52,7 @@ void Communication::reduceSum(precice::span<double const> itemsToSend, precice::
   for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(received, rank + _rankOffset);
     request->wait();
+    checkErrorCode(request->errorCode(), _log);
     for (size_t i = 0; i < itemsToReceive.size(); i++) {
       itemsToReceive[i] += received[i];
     }
@@ -64,6 +66,7 @@ void Communication::reduceSum(precice::span<double const> itemsToSend, precice::
 
   auto request = aSend(itemsToSend, primaryRank);
   request->wait();
+  checkErrorCode(request->errorCode(), _log);
 }
 
 void Communication::reduceSum(int itemToSend, int &itemToReceive)
@@ -76,6 +79,7 @@ void Communication::reduceSum(int itemToSend, int &itemToReceive)
   for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
+    checkErrorCode(request->errorCode(), _log);
     itemToReceive += itemToSend;
   }
 }
@@ -86,6 +90,7 @@ void Communication::reduceSum(int itemToSend, int &itemToReceive, Rank primaryRa
 
   auto request = aSend(itemToSend, primaryRank);
   request->wait();
+  checkErrorCode(request->errorCode(), _log);
 }
 
 /**
@@ -130,6 +135,7 @@ void Communication::allreduceSum(double itemToSend, double &itemToReceive)
   for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
+    checkErrorCode(request->errorCode(), _log);
     itemToReceive += itemToSend;
   }
 
@@ -148,6 +154,7 @@ void Communication::allreduceSum(double itemToSend, double &itemsToReceive, Rank
 
   auto request = aSend(itemToSend, primaryRank);
   request->wait();
+  checkErrorCode(request->errorCode(), _log);
   // receive reduced data from primary rank
   receive(itemsToReceive, primaryRank + _rankOffset);
 }
@@ -162,6 +169,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive)
   for (Rank rank : remoteCommunicatorRanks()) {
     auto request = aReceive(itemToSend, rank + _rankOffset);
     request->wait();
+    checkErrorCode(request->errorCode(), _log);
     itemToReceive += itemToSend;
   }
 
@@ -180,6 +188,7 @@ void Communication::allreduceSum(int itemToSend, int &itemToReceive, Rank primar
 
   auto request = aSend(itemToSend, primaryRank);
   request->wait();
+  checkErrorCode(request->errorCode(), _log);
   // receive reduced data from primary rank
   receive(itemToReceive, primaryRank + _rankOffset);
 }

--- a/src/com/ErrorHandling.cpp
+++ b/src/com/ErrorHandling.cpp
@@ -1,0 +1,16 @@
+#include "com/ErrorHandling.hpp"
+
+namespace precice::com {
+
+void checkErrorCode(boost::system::error_code ec, logging::Logger &_log)
+{
+  if (ec.value() == boost::system::errc::success) {
+    return;
+  }
+  if (ec.value() == boost::system::errc::connection_reset) {
+    PRECICE_ERROR("Connection was reset by another participant, which most likely exited unexpectedly (look there).");
+    return;
+  }
+  PRECICE_ERROR("Receiving data from another participant failed with a system error: {}.", ec.message());
+}
+} // namespace precice::com

--- a/src/com/ErrorHandling.hpp
+++ b/src/com/ErrorHandling.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <boost/system/error_code.hpp>
+#include <logging/Logger.hpp>
+
+namespace precice::com {
+/** Checks the error code of an async communication request.
+ *
+ * Will raise an error unless the error_code is success.
+ *
+ * @param[in] ec The error_code of the completed request
+ * @param[in] _log The logger to use for the potential error message
+ */
+void checkErrorCode(boost::system::error_code ec, logging::Logger &_log);
+} // namespace precice::com

--- a/src/com/MPIRequest.hpp
+++ b/src/com/MPIRequest.hpp
@@ -14,8 +14,14 @@ public:
 
   void wait() override;
 
+  boost::system::error_code errorCode() const noexcept override
+  {
+    return _ec;
+  }
+
 private:
-  MPI_Request _request;
+  boost::system::error_code _ec;
+  MPI_Request               _request;
 };
 } // namespace com
 } // namespace precice

--- a/src/com/Request.hpp
+++ b/src/com/Request.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/system/error_code.hpp>
 #include <vector>
 #include "com/SharedPointer.hpp"
 
@@ -12,9 +13,18 @@ public:
 
   virtual ~Request();
 
+  /// Non-blocking test whether the requests has completed
   virtual bool test() = 0;
 
+  /// Blocking wait until requests has completed
   virtual void wait() = 0;
+
+  /** Returns the error code of the completed request.
+   *
+   * @precondition either wait() has been called or
+   * test() has been called and returned true.
+   */
+  virtual boost::system::error_code errorCode() const = 0;
 };
 } // namespace com
 } // namespace precice

--- a/src/com/SocketRequest.cpp
+++ b/src/com/SocketRequest.cpp
@@ -6,12 +6,13 @@ SocketRequest::SocketRequest()
 {
 }
 
-void SocketRequest::complete()
+void SocketRequest::complete(boost::system::error_code ec)
 {
   {
     std::lock_guard<std::mutex> lock(_completeMutex);
 
     _complete = true;
+    _ec       = ec;
   }
 
   _completeCondition.notify_one();

--- a/src/com/SocketRequest.hpp
+++ b/src/com/SocketRequest.hpp
@@ -10,14 +10,20 @@ class SocketRequest : public Request {
 public:
   SocketRequest();
 
-  void complete();
+  void complete(boost::system::error_code ec);
 
   bool test() override;
 
   void wait() override;
 
+  boost::system::error_code errorCode() const noexcept override
+  {
+    return _ec;
+  }
+
 private:
-  bool _complete;
+  boost::system::error_code _ec;
+  bool                      _complete;
 
   std::condition_variable _completeCondition;
   std::mutex              _completeMutex;

--- a/src/com/SocketSendQueue.cpp
+++ b/src/com/SocketSendQueue.cpp
@@ -20,7 +20,7 @@ SocketSendQueue::~SocketSendQueue()
 
 void SocketSendQueue::dispatch(std::shared_ptr<Socket>      sock,
                                boost::asio::const_buffers_1 data,
-                               std::function<void()>        callback)
+                               Callback                     callback)
 {
   std::lock_guard<std::mutex> lock(_queueMutex);
   _itemQueue.push_back({std::move(sock), std::move(data), std::move(callback)});
@@ -45,8 +45,8 @@ void SocketSendQueue::process()
   _ready = false;
   asio::async_write(*(item.sock),
                     item.data,
-                    [item, this](boost::system::error_code const &, std::size_t) {
-                      item.callback();
+                    [item, this](boost::system::error_code const &ec, std::size_t) {
+                      item.callback(ec);
                       this->sendCompleted();
                     });
 }

--- a/src/com/SocketSendQueue.hpp
+++ b/src/com/SocketSendQueue.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
 #include <deque>
 #include <functional>
 #include <memory>
@@ -17,6 +18,8 @@ class SocketSendQueue {
 public:
   using Socket = boost::asio::ip::tcp::socket;
 
+  using Callback = std::function<void(boost::system::error_code)>;
+
   SocketSendQueue() = default;
   ~SocketSendQueue();
 
@@ -24,7 +27,7 @@ public:
   SocketSendQueue &operator=(SocketSendQueue const &) = delete;
 
   /// Put data in the queue, start processing the queue.
-  void dispatch(std::shared_ptr<Socket> sock, boost::asio::const_buffers_1 data, std::function<void()> callback);
+  void dispatch(std::shared_ptr<Socket> sock, boost::asio::const_buffers_1 data, Callback callback);
 
   /// Notifies the queue that the last asynchronous send operation has completed.
   void sendCompleted();
@@ -36,7 +39,7 @@ private:
   struct SendItem {
     std::shared_ptr<Socket>      sock;
     boost::asio::const_buffers_1 data;
-    std::function<void()>        callback;
+    Callback                     callback;
   };
 
   /// The queue, containing items to asynchronously send using boost.asio.

--- a/src/m2n/PointToPointCommunication.hpp
+++ b/src/m2n/PointToPointCommunication.hpp
@@ -181,9 +181,12 @@ private:
 
   bool _isConnected = false;
 
-  std::list<std::pair<std::shared_ptr<com::Request>,
-                      std::shared_ptr<std::vector<double>>>>
-      bufferedRequests;
+  struct BufferedRequest {
+    std::shared_ptr<com::Request>        request;
+    std::shared_ptr<std::vector<double>> buffer;
+  };
+
+  std::vector<BufferedRequest> bufferedRequests;
 };
 } // namespace m2n
 } // namespace precice

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -8,6 +8,7 @@
 #include "com/CommunicateBoundingBox.hpp"
 #include "com/CommunicateMesh.hpp"
 #include "com/Communication.hpp"
+#include "com/ErrorHandling.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/M2N.hpp"
@@ -642,6 +643,7 @@ void ReceivedPartition::createOwnerInformation()
     // wait until all aReceives are complete.
     for (auto &rqst : vertexNumberRequests) {
       rqst->wait();
+      com::checkErrorCode(rqst->errorCode(), _log);
     }
 
     // Exchange list of shared vertices with the neighbor
@@ -671,6 +673,7 @@ void ReceivedPartition::createOwnerInformation()
     // wait until all aSends are complete.
     for (auto &rqst : vertexListRequests) {
       rqst->wait();
+      com::checkErrorCode(rqst->errorCode(), _log);
     }
 
     // #5: Second round assignment according to the number of owned vertices

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -64,6 +64,8 @@ target_sources(precice
     src/com/CommunicationFactory.hpp
     src/com/ConnectionInfoPublisher.cpp
     src/com/ConnectionInfoPublisher.hpp
+    src/com/ErrorHandling.cpp
+    src/com/ErrorHandling.hpp
     src/com/MPICommunication.cpp
     src/com/MPICommunication.hpp
     src/com/MPIDirectCommunication.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR:
- Extends robustness of the socket communication, correctly handling interrupts
- Extends messages for all communication types, especially handling the remote participant crashing.
- Correctly handles failing async requests
- Adds error messages for async requests

## Motivation and additional information

Closes #1443

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
