### PR TITLE
Handle solverdummy arguments properly

### DIFF
--- a/examples/solverdummies/c/solverdummy.c
+++ b/examples/solverdummies/c/solverdummy.c
@@ -23,16 +23,16 @@ int main(int argc, char **argv)
   const char *writeDataName;
   const char *readDataName;
 
-  const char *configFileName  = argv[1];
-  const char *participantName = argv[2];
-
   if (argc != 3) {
-    printf("Usage: ./solverdummy configFile solverName\n\n");
+    printf("The solverdummy was called without arguments. Usage: ./solverdummy configFile solverName\n\n");
     printf("Parameter description\n");
     printf("  configurationFile: Path and filename of preCICE configuration\n");
     printf("  solverName:        SolverDummy participant name in preCICE configuration\n");
     return 1;
   }
+
+  const char *configFileName  = argv[1];
+  const char *participantName = argv[2];
 
   printf("DUMMY: Running solver dummy with preCICE config file \"%s\" and participant name \"%s\".\n",
          configFileName, participantName);

--- a/examples/solverdummies/c/solverdummy.c
+++ b/examples/solverdummies/c/solverdummy.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
   const char *readDataName;
 
   if (argc != 3) {
-    printf("The solverdummy was called without arguments. Usage: ./solverdummy configFile solverName\n\n");
+    printf("The solverdummy was called with an incorrect number of arguments. Usage: ./solverdummy configFile solverName\n\n");
     printf("Parameter description\n");
     printf("  configurationFile: Path and filename of preCICE configuration\n");
     printf("  solverName:        SolverDummy participant name in preCICE configuration\n");

--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv)
   using namespace precice::constants;
 
   if (argc != 3) {
-    std::cout << "The solverdummy was called without arguments. Usage: ./solverdummy configFile solverName\n\n";
+    std::cout << "The solverdummy was called with an incorrect number of arguments. Usage: ./solverdummy configFile solverName\n\n";
     std::cout << "Parameter description\n";
     std::cout << "  configurationFile: Path and filename of preCICE configuration\n";
     std::cout << "  solverName:        SolverDummy participant name in preCICE configuration\n";

--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -10,19 +10,19 @@ int main(int argc, char **argv)
   using namespace precice;
   using namespace precice::constants;
 
+  if (argc != 3) {
+    std::cout << "The solverdummy was called without arguments. Usage: ./solverdummy configFile solverName\n\n";
+    std::cout << "Parameter description\n";
+    std::cout << "  configurationFile: Path and filename of preCICE configuration\n";
+    std::cout << "  solverName:        SolverDummy participant name in preCICE configuration\n";
+    return EXIT_FAILURE;
+  }
+
   std::string configFileName(argv[1]);
   std::string solverName(argv[2]);
   std::string meshName;
   std::string dataWriteName;
   std::string dataReadName;
-
-  if (argc != 3) {
-    std::cout << "Usage: ./solverdummy configFile solverName\n\n";
-    std::cout << "Parameter description\n";
-    std::cout << "  configurationFile: Path and filename of preCICE configuration\n";
-    std::cout << "  solverName:        SolverDummy participant name in preCICE configuration\n";
-    return 1;
-  }
 
   std::cout << "DUMMY: Running solver dummy with preCICE config file \"" << configFileName << "\" and participant name \"" << solverName << "\".\n";
 


### PR DESCRIPTION
## Main changes of this PR

See details in #1447. There was already a check for the cpp solverdummy, but it was in the wrong place. I don't think a changelog entry is necessary.

Closes #1447 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
