### PR TITLE
Cleanup Partitioning Data in Communication

### DIFF
--- a/src/acceleration/impl/ParallelMatrixOperations.cpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.cpp
@@ -1,3 +1,4 @@
+#include "com/Communication.hpp"
 #ifndef PRECICE_NO_MPI
 
 #include "acceleration/impl/ParallelMatrixOperations.hpp"
@@ -35,28 +36,9 @@ void ParallelMatrixOperations::establishCircularCommunication()
   com::PtrCommunication cyclicCommLeft  = com::PtrCommunication(new com::MPIPortsCommunication("."));
   com::PtrCommunication cyclicCommRight = com::PtrCommunication(new com::MPIPortsCommunication("."));
 
-  const auto size     = utils::IntraComm::getSize();
-  const auto rank     = utils::IntraComm::getRank();
-  const int  prevProc = (rank - 1 + size) % size;
-  const int  nextProc = (rank + 1) % size;
-
-  std::string prefix   = "MVQNCyclicComm";
-  std::string prevName = prefix + std::to_string(prevProc);
-  std::string thisName = prefix + std::to_string(rank);
-  std::string nextName = prefix + std::to_string(nextProc);
-  if ((rank % 2) == 0) {
-    cyclicCommLeft->prepareEstablishment(prevName, thisName);
-    cyclicCommLeft->acceptConnection(prevName, thisName, "", 0);
-    cyclicCommLeft->cleanupEstablishment(prevName, thisName);
-
-    cyclicCommRight->requestConnection(thisName, nextName, "", 0, 1);
-  } else {
-    cyclicCommRight->requestConnection(thisName, nextName, "", 0, 1);
-
-    cyclicCommLeft->prepareEstablishment(prevName, thisName);
-    cyclicCommLeft->acceptConnection(prevName, thisName, "", 0);
-    cyclicCommLeft->cleanupEstablishment(prevName, thisName);
-  }
+  const auto size = utils::IntraComm::getSize();
+  const auto rank = utils::IntraComm::getRank();
+  com::connectCircularComm("MVQNCyclicComm", "", rank, size, *cyclicCommLeft, *cyclicCommRight);
 
   _cyclicCommLeft  = std::move(cyclicCommLeft);
   _cyclicCommRight = std::move(cyclicCommRight);

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -372,7 +372,7 @@ void connectCircularComm(
 {
   PRECICE_ASSERT(!left.isConnected());
   PRECICE_ASSERT(!right.isConnected());
-  PRECICE_ASSERT(rank < size);
+  PRECICE_ASSERT(rank >= 0 && rank < size && size > 0);
 
   if (size == 1) {
     return;

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -384,5 +384,18 @@ private:
   logging::Logger _log{"com::Communication"};
 };
 
+/** Establishes a circular communication for the given participant.
+ *
+ * rank "0" connects left to rank "size-1"
+ * rank "size" connects right to rank "0"
+ */
+void connectCircularComm(
+    std::string const & participantName,
+    std::string const & tag,
+    int                 rank,
+    int                 size,
+    com::Communication &left,
+    com::Communication &right);
+
 } // namespace com
 } // namespace precice

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createEdge(v1, v2);
     mesh.createEdge(v2, v3);
     mesh.createEdge(v3, v1);
-    mesh.getVertexOffsets() = {3, 3, 6, 7};
+    mesh.setVertexOffsets({3, 3, 6, 7});
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Edge &e3 = mesh.createEdge(v3, v1);
     mesh.createTriangle(e1, e2, e3);
 
-    mesh.getVertexOffsets() = {3, 3, 6, 7};
+    mesh.setVertexOffsets({3, 3, 6, 7});
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
 
-    mesh.getVertexOffsets() = {3, 6, 9, 12};
+    mesh.setVertexOffsets({3, 6, 9, 12});
   } else if (context.isRank(1)) {
     mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
     mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createEdge(v1, v2);
     mesh.createEdge(v2, v3);
     mesh.createEdge(v3, v1);
-    mesh.getVertexOffsets() = {3, 3, 6, 7};
+    mesh.setVertexOffsets({3, 3, 6, 7});
   } else if (context.isRank(1)) {
     // nothing
   } else if (context.isRank(2)) {
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Edge &e2 = mesh.createEdge(v2, v3);
     mesh::Edge &e3 = mesh.createEdge(v3, v1);
     mesh.createTriangle(e1, e2, e3);
-    mesh.getVertexOffsets() = {3, 3, 6, 7};
+    mesh.setVertexOffsets({3, 3, 6, 7});
 
   } else if (context.isRank(1)) {
     // nothing
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
 
-    mesh.getVertexOffsets() = {3, 6, 9, 12};
+    mesh.setVertexOffsets({3, 6, 9, 12});
   } else if (context.isRank(1)) {
     mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
     mesh::Vertex &v2  = mesh.createVertex(Eigen::Vector3d{-1.0, -1.0, 0.0});

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createEdge(v1, v2);
     mesh.createEdge(v2, v3);
     mesh.createEdge(v3, v1);
-    mesh.getVertexOffsets() = {3, 3, 6, 7};
+    mesh.setVertexOffsets({3, 3, 6, 7});
 
   } else if (context.isRank(1)) {
     // nothing
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh::Edge &e3 = mesh.createEdge(v3, v1);
     mesh.createTriangle(e1, e2, e3);
 
-    mesh.getVertexOffsets() = {3, 3, 6, 7};
+    mesh.setVertexOffsets({3, 3, 6, 7});
 
   } else if (context.isRank(1)) {
     // nothing
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh::Edge &eo1 = mesh.createEdge(vo, v1);
     mesh::Edge &e2o = mesh.createEdge(v2, vo);
     mesh.createTriangle(eo1, e12, e2o);
-    mesh.getVertexOffsets() = {3, 6, 9, 12};
+    mesh.setVertexOffsets({3, 6, 9, 12});
 
   } else if (context.isRank(1)) {
     mesh::Vertex &v1  = mesh.createVertex(Eigen::Vector3d{1.0, -1.0, 0.0});
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
 
     mesh.createTetrahedron(v000, v001, v011, v111);
     mesh.createTetrahedron(v000, v010, v011, v111);
-    mesh.getVertexOffsets() = {4, 8, 8, 12};
+    mesh.setVertexOffsets({4, 8, 8, 12});
 
   } else if (context.isRank(1)) {
     mesh::Vertex &v000 = mesh.createVertex(Eigen::Vector3d{0.0, 0.0, 0.0});

--- a/src/m2n/DistributedCommunication.hpp
+++ b/src/m2n/DistributedCommunication.hpp
@@ -117,7 +117,7 @@ public:
   using CommunicationMap = std::map<int, std::vector<int>>;
 
   /// Broadcasts an int to connected ranks on remote participant
-  virtual void broadcastSend(const int &itemToSend) = 0;
+  virtual void broadcastSend(int itemToSend) = 0;
 
   /**
    * @brief Receives an int per connected rank on remote participant

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -68,6 +68,7 @@ void GatherScatterCommunication::send(precice::span<double const> itemsToSend, i
   // Gather data
   if (utils::IntraComm::isSecondary()) { // Secondary rank
     if (!itemsToSend.empty()) {
+      PRECICE_DEBUG("Gathering {} elements", itemsToSend.size());
       utils::IntraComm::getCommunication()->send(itemsToSend, 0);
     }
   } else { // Primary rank or coupling mode
@@ -83,9 +84,11 @@ void GatherScatterCommunication::send(precice::span<double const> itemsToSend, i
         globalItemsToSend[vertexDistribution[0][i] * valueDimension + j] += itemsToSend[i * valueDimension + j];
       }
     }
+    PRECICE_DEBUG("Items to send so far ({}) {}", globalItemsToSend.size(), globalItemsToSend);
 
-    // Secondary ranks data
+    // Gather data from secondary ranks
     for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
+      PRECICE_DEBUG("START {}", secondaryRank);
       PRECICE_ASSERT(utils::IntraComm::getCommunication() != nullptr);
       PRECICE_ASSERT(utils::IntraComm::getCommunication()->isConnected());
 

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -192,7 +192,7 @@ void GatherScatterCommunication::requestPreConnection(
   PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
 }
 
-void GatherScatterCommunication::broadcastSend(const int &itemToSend)
+void GatherScatterCommunication::broadcastSend(int itemToSend)
 {
   PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
 }

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -66,115 +66,116 @@ void GatherScatterCommunication::send(precice::span<double const> itemsToSend, i
 {
   PRECICE_TRACE(itemsToSend.size());
 
-  // Gather data
+  // Gather data on secondary ranks
   if (utils::IntraComm::isSecondary()) { // Secondary rank
     if (!itemsToSend.empty()) {
-      PRECICE_DEBUG("Gathering {} elements", itemsToSend.size());
+      PRECICE_DEBUG("Providing {} elements to gather step", itemsToSend.size());
       utils::IntraComm::getCommunication()->send(itemsToSend, 0);
     }
-  } else { // Primary rank or coupling mode
-    PRECICE_ASSERT(utils::IntraComm::getRank() == 0);
-    const auto &vertexDistribution = _mesh->getVertexDistribution();
-    int         globalSize         = _mesh->getGlobalNumberOfVertices() * valueDimension;
-    PRECICE_DEBUG("Global Size = {}", globalSize);
-    std::vector<double> globalItemsToSend(globalSize);
-
-    // Primary rank data
-    PRECICE_ASSERT(vertexDistribution.count(0) > 0);
-    const auto &primaryDistribution = vertexDistribution.at(0);
-    for (size_t i = 0; i < primaryDistribution.size(); ++i) {
-      utils::add_n(&itemsToSend[i * valueDimension], valueDimension, &globalItemsToSend[primaryDistribution[i] * valueDimension]);
-    }
-    PRECICE_DEBUG("Items to send so far ({}) {}", globalItemsToSend.size(), globalItemsToSend);
-
-    // Gather data from secondary ranks
-    for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
-      PRECICE_DEBUG("START {}", secondaryRank);
-      PRECICE_ASSERT(utils::IntraComm::getCommunication() != nullptr);
-      PRECICE_ASSERT(utils::IntraComm::getCommunication()->isConnected());
-
-      auto iter = vertexDistribution.find(secondaryRank);
-      if (iter == vertexDistribution.end()) {
-        continue;
-      }
-      const auto &secondaryDistribution = iter->second;
-
-      int secondaryRankSize = secondaryDistribution.size() * valueDimension;
-      PRECICE_DEBUG("Secondary Size = {}", secondaryRankSize);
-      if (secondaryDistribution.empty()) {
-        continue;
-      }
-      std::vector<double> secondaryRankValues(secondaryRankSize);
-      utils::IntraComm::getCommunication()->receive(span<double>{secondaryRankValues}, secondaryRank);
-      for (size_t i = 0; i < secondaryDistribution.size(); ++i) {
-        utils::add_n(&secondaryRankValues[i * valueDimension], valueDimension, &globalItemsToSend[secondaryDistribution[i] * valueDimension]);
-      }
-    }
-
-    // Send data to other primary
-    _com->sendRange(globalItemsToSend, 0);
+    return;
   }
+
+  // Primary rank or coupling mode
+  PRECICE_ASSERT(utils::IntraComm::getRank() == 0);
+  const auto &vertexDistribution = _mesh->getVertexDistribution();
+  int         globalSize         = _mesh->getGlobalNumberOfVertices() * valueDimension;
+  PRECICE_DEBUG("Gathering data on primary ({} elements)", globalSize);
+  std::vector<double> globalItemsToSend(globalSize);
+
+  // Directly copy primary rank data
+  PRECICE_ASSERT(vertexDistribution.count(0) > 0);
+  const auto &primaryDistribution = vertexDistribution.at(0);
+  for (size_t i = 0; i < primaryDistribution.size(); ++i) {
+    utils::add_n(&itemsToSend[i * valueDimension], valueDimension, &globalItemsToSend[primaryDistribution[i] * valueDimension]);
+  }
+  PRECICE_DEBUG("Directly gathered {} entries from primary", primaryDistribution.size() * valueDimension);
+
+  // Gather data from secondary ranks
+  for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
+    PRECICE_ASSERT(utils::IntraComm::getCommunication() != nullptr);
+    PRECICE_ASSERT(utils::IntraComm::getCommunication()->isConnected());
+
+    auto iter = vertexDistribution.find(secondaryRank);
+    if (iter == vertexDistribution.end()) {
+      continue;
+    }
+    const auto &secondaryDistribution = iter->second;
+
+    int secondaryRankSize = secondaryDistribution.size() * valueDimension;
+    PRECICE_DEBUG("Gathering {} entries from secondary rank {}", secondaryRankSize, secondaryRank);
+    if (secondaryDistribution.empty()) {
+      continue;
+    }
+    std::vector<double> secondaryRankValues(secondaryRankSize);
+    utils::IntraComm::getCommunication()->receive(span<double>{secondaryRankValues}, secondaryRank);
+    for (size_t i = 0; i < secondaryDistribution.size(); ++i) {
+      utils::add_n(&secondaryRankValues[i * valueDimension], valueDimension, &globalItemsToSend[secondaryDistribution[i] * valueDimension]);
+    }
+  }
+
+  // Send data to other primary
+  PRECICE_DEBUG("Sending gathered data to other participant");
+  _com->sendRange(globalItemsToSend, 0);
 }
 
 void GatherScatterCommunication::receive(precice::span<double> itemsToReceive, int valueDimension)
 {
   PRECICE_TRACE(itemsToReceive.size());
 
-  std::vector<double> globalItemsToReceive;
-
-  // Receive data at primary
-  if (not utils::IntraComm::isSecondary()) {
-    int globalSize = _mesh->getGlobalNumberOfVertices() * valueDimension;
-    PRECICE_DEBUG("Global Size = {}", globalSize);
-
-    globalItemsToReceive = _com->receiveRange(0, com::AsVectorTag<double>{});
-    PRECICE_ASSERT(globalItemsToReceive.size() == static_cast<std::size_t>(globalSize));
-  }
-
-  // Scatter data
+  // Secondary ranks receive scattered data
   if (utils::IntraComm::isSecondary()) { // Secondary rank
     if (!itemsToReceive.empty()) {
-      PRECICE_DEBUG("itemsToRec[0] = {}", itemsToReceive[0]);
       auto received = utils::IntraComm::getCommunication()->receiveRange(0, com::AsVectorTag<double>{});
+      PRECICE_ASSERT(!received.empty());
+      PRECICE_DEBUG("Received scattered data starting with {}", received[0]);
       std::copy(received.begin(), received.end(), itemsToReceive.begin());
-      PRECICE_DEBUG("itemsToRec[0] = {}", itemsToReceive[0]);
     }
-  } else { // Primary rank or coupling mode
-    PRECICE_ASSERT(utils::IntraComm::getRank() == 0);
-    const auto &vertexDistribution = _mesh->getVertexDistribution();
+    return;
+  }
 
-    // Primary rank data
-    PRECICE_ASSERT(vertexDistribution.count(0) > 0);
-    const auto &primaryDistribution = vertexDistribution.at(0);
-    for (size_t i = 0; i < primaryDistribution.size(); ++i) {
-      std::copy_n(&globalItemsToReceive[primaryDistribution[i] * valueDimension], valueDimension, &itemsToReceive[i * valueDimension]);
+  // Primary rank receives and scatters the data
+  PRECICE_ASSERT(not utils::IntraComm::isSecondary());
+
+  int globalSize = _mesh->getGlobalNumberOfVertices() * valueDimension;
+  PRECICE_DEBUG("Receiving {} elements from other participant to scatter", globalSize);
+
+  auto globalItemsToReceive = _com->receiveRange(0, com::AsVectorTag<double>{});
+  PRECICE_ASSERT(globalItemsToReceive.size() == static_cast<std::size_t>(globalSize));
+
+  const auto &vertexDistribution = _mesh->getVertexDistribution();
+
+  // Directly copy primary rank data
+  PRECICE_ASSERT(vertexDistribution.count(0) > 0);
+  const auto &primaryDistribution = vertexDistribution.at(0);
+  for (size_t i = 0; i < primaryDistribution.size(); ++i) {
+    std::copy_n(&globalItemsToReceive[primaryDistribution[i] * valueDimension], valueDimension, &itemsToReceive[i * valueDimension]);
+  }
+  PRECICE_DEBUG("Directly extracted {} data entries for primary", primaryDistribution.size() * valueDimension);
+
+  // Extract and scatter data to secondary ranks
+  for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
+    PRECICE_ASSERT(utils::IntraComm::getCommunication() != nullptr);
+    PRECICE_ASSERT(utils::IntraComm::getCommunication()->isConnected());
+
+    auto iter = vertexDistribution.find(secondaryRank);
+    if (iter == vertexDistribution.end()) {
+      continue;
+    }
+    const auto &secondaryDistribution = iter->second;
+
+    int secondarySize = secondaryDistribution.size() * valueDimension;
+    PRECICE_DEBUG("Scattering {} entries to secondary {}", secondarySize, secondarySize);
+    if (secondaryDistribution.empty()) {
+      continue;
     }
 
-    // Secondary ranks data
-    for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
-      PRECICE_ASSERT(utils::IntraComm::getCommunication() != nullptr);
-      PRECICE_ASSERT(utils::IntraComm::getCommunication()->isConnected());
-
-      auto iter = vertexDistribution.find(secondaryRank);
-      if (iter == vertexDistribution.end()) {
-        continue;
-      }
-      const auto &secondaryDistribution = iter->second;
-
-      int secondarySize = secondaryDistribution.size() * valueDimension;
-      PRECICE_DEBUG("Secondary Size = {}", secondarySize);
-      if (secondaryDistribution.empty()) {
-        continue;
-      }
-
-      std::vector<double> secondaryRankValues(secondarySize);
-      for (size_t i = 0; i < secondaryDistribution.size(); ++i) {
-        std::copy_n(&globalItemsToReceive[secondaryDistribution[i] * valueDimension], valueDimension, &secondaryRankValues[i * valueDimension]);
-      }
-      utils::IntraComm::getCommunication()->sendRange(secondaryRankValues, secondaryRank);
-      PRECICE_DEBUG("secondaryRankValues[0] = {}", secondaryRankValues[0]);
+    std::vector<double> secondaryRankValues(secondarySize);
+    for (size_t i = 0; i < secondaryDistribution.size(); ++i) {
+      std::copy_n(&globalItemsToReceive[secondaryDistribution[i] * valueDimension], valueDimension, &secondaryRankValues[i * valueDimension]);
     }
-  } // Primary
+    PRECICE_DEBUG("Scattering data starting with {} to rank {}", secondaryRankValues[0], secondaryRank);
+    utils::IntraComm::getCommunication()->sendRange(secondaryRankValues, secondaryRank);
+  }
 }
 
 void GatherScatterCommunication::acceptPreConnection(

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -78,7 +78,7 @@ void GatherScatterCommunication::send(precice::span<double const> itemsToSend, i
   // Primary rank or coupling mode
   PRECICE_ASSERT(utils::IntraComm::getRank() == 0);
   const auto &vertexDistribution = _mesh->getVertexDistribution();
-  int         globalSize         = _mesh->getGlobalNumberOfVertices() * valueDimension;
+  const int   globalSize         = _mesh->getGlobalNumberOfVertices() * valueDimension;
   PRECICE_DEBUG("Gathering data on primary ({} elements)", globalSize);
   std::vector<double> globalItemsToSend(globalSize);
 
@@ -136,7 +136,7 @@ void GatherScatterCommunication::receive(precice::span<double> itemsToReceive, i
   // Primary rank receives and scatters the data
   PRECICE_ASSERT(not utils::IntraComm::isSecondary());
 
-  int globalSize = _mesh->getGlobalNumberOfVertices() * valueDimension;
+  const int globalSize = _mesh->getGlobalNumberOfVertices() * valueDimension;
   PRECICE_DEBUG("Receiving {} elements from other participant to scatter", globalSize);
 
   auto globalItemsToReceive = _com->receiveRange(0, com::AsVectorTag<double>{});

--- a/src/m2n/GatherScatterCommunication.hpp
+++ b/src/m2n/GatherScatterCommunication.hpp
@@ -88,7 +88,7 @@ public:
   void receive(precice::span<double> itemsToReceive, int valueDimension) override;
 
   /// Broadcasts an int to connected ranks on remote participant. Not available for GatherScatterCommunication.
-  void broadcastSend(const int &itemToSend) override;
+  void broadcastSend(int itemToSend) override;
 
   /**
    * @brief Receives an int per connected rank on remote participant. Not available for GatherScatterCommunication.

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -269,7 +269,7 @@ void M2N::scatterAllCommunicationMap(std::map<int, std::vector<int>> &localCommu
   _distComs[meshID]->scatterAllCommunicationMap(localCommunicationMap);
 }
 
-void M2N::broadcastSend(int &itemToSend, mesh::Mesh &mesh)
+void M2N::broadcastSend(int itemToSend, mesh::Mesh &mesh)
 {
   PRECICE_ASSERT(utils::IntraComm::isParallel(),
                  "This method can only be used for parallel participants");

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -170,7 +170,7 @@ public:
   void scatterAllCommunicationMap(std::map<int, std::vector<int>> &localCommunicationMap, mesh::Mesh &mesh);
 
   /// Broadcasts an int to connected ranks on remote participant (concerning the given mesh)
-  void broadcastSend(int &itemToSend, mesh::Mesh &mesh);
+  void broadcastSend(int itemToSend, mesh::Mesh &mesh);
 
   /// All ranks receive an array of doubles (different for each rank).
   /// The values received can be gradient data

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -637,7 +637,7 @@ void PointToPointCommunication::receive(precice::span<double> itemsToReceive, in
   }
 }
 
-void PointToPointCommunication::broadcastSend(const int &itemToSend)
+void PointToPointCommunication::broadcastSend(int itemToSend)
 {
   for (auto &connectionData : _connectionDataVector) {
     _communication->send(itemToSend, connectionData.remoteRank);

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -313,8 +313,8 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected(), "Already connected.");
 
-  mesh::Mesh::VertexDistribution &vertexDistribution = _mesh->getVertexDistribution();
-  mesh::Mesh::VertexDistribution  requesterVertexDistribution;
+  mesh::Mesh::VertexDistribution vertexDistribution = _mesh->getVertexDistribution();
+  mesh::Mesh::VertexDistribution requesterVertexDistribution;
 
   if (not utils::IntraComm::isSecondary()) {
     PRECICE_DEBUG("Exchange vertex distribution between both primary ranks");
@@ -332,6 +332,9 @@ void PointToPointCommunication::acceptConnection(std::string const &acceptorName
   PRECICE_DEBUG("Broadcast vertex distributions");
   Event e1("m2n.broadcastVertexDistributions", precice::syncMode);
   m2n::broadcast(vertexDistribution);
+  if (utils::IntraComm::isSecondary()) {
+    _mesh->setVertexDistribution(vertexDistribution);
+  }
   m2n::broadcast(requesterVertexDistribution);
   e1.stop();
 
@@ -437,8 +440,8 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected(), "Already connected.");
 
-  mesh::Mesh::VertexDistribution &vertexDistribution = _mesh->getVertexDistribution();
-  mesh::Mesh::VertexDistribution  acceptorVertexDistribution;
+  mesh::Mesh::VertexDistribution vertexDistribution = _mesh->getVertexDistribution();
+  mesh::Mesh::VertexDistribution acceptorVertexDistribution;
 
   if (not utils::IntraComm::isSecondary()) {
     PRECICE_DEBUG("Exchange vertex distribution between both primary ranks");
@@ -457,6 +460,9 @@ void PointToPointCommunication::requestConnection(std::string const &acceptorNam
   PRECICE_DEBUG("Broadcast vertex distributions");
   Event e1("m2n.broadcastVertexDistributions", precice::syncMode);
   m2n::broadcast(vertexDistribution);
+  if (utils::IntraComm::isSecondary()) {
+    _mesh->setVertexDistribution(vertexDistribution);
+  }
   m2n::broadcast(acceptorVertexDistribution);
   e1.stop();
 

--- a/src/m2n/PointToPointCommunication.hpp
+++ b/src/m2n/PointToPointCommunication.hpp
@@ -102,7 +102,7 @@ public:
   void receive(precice::span<double> itemsToReceive, int valueDimension = 1) override;
 
   /// Broadcasts an int to connected ranks on remote participant
-  void broadcastSend(const int &itemToSend) override;
+  void broadcastSend(int itemToSend) override;
 
   /**
    * @brief Receives an int per connected rank on remote participant

--- a/src/m2n/tests/GatherScatterCommunicationTest.cpp
+++ b/src/m2n/tests/GatherScatterCommunicationTest.cpp
@@ -31,12 +31,7 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
     m2n->createDistributedCommunication(pMesh);
 
     pMesh->setGlobalNumberOfVertices(numberOfVertices);
-    pMesh->getVertexDistribution()[0].push_back(0);
-    pMesh->getVertexDistribution()[0].push_back(1);
-    pMesh->getVertexDistribution()[0].push_back(2);
-    pMesh->getVertexDistribution()[0].push_back(3);
-    pMesh->getVertexDistribution()[0].push_back(4);
-    pMesh->getVertexDistribution()[0].push_back(5);
+    pMesh->setVertexDistribution({{0, {0, 1, 2, 3, 4, 5}}});
 
     m2n->acceptSecondaryRanksConnection("Part1", "Part2");
     Eigen::VectorXd values = Eigen::VectorXd::Zero(numberOfVertices);
@@ -58,13 +53,7 @@ BOOST_AUTO_TEST_CASE(GatherScatterTest)
 
     if (context.isPrimary()) {
       pMesh->setGlobalNumberOfVertices(numberOfVertices);
-      pMesh->getVertexDistribution()[0].push_back(0);
-      pMesh->getVertexDistribution()[0].push_back(1);
-      pMesh->getVertexDistribution()[0].push_back(3);
-      pMesh->getVertexDistribution()[2].push_back(2);
-      pMesh->getVertexDistribution()[2].push_back(3);
-      pMesh->getVertexDistribution()[2].push_back(4);
-      pMesh->getVertexDistribution()[2].push_back(5);
+      pMesh->setVertexDistribution({{0, {0, 1, 3}}, {2, {2, 3, 4, 5}}});
 
       Eigen::Vector3d values(0.0, 0.0, 0.0);
       m2n->receive(values, pMesh->getID(), valueDimension);

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -58,17 +58,7 @@ void runP2PComTest1(const TestContext &context, com::PtrCommunicationFactory cf)
     if (context.isPrimary()) {
       mesh->setGlobalNumberOfVertices(10);
 
-      mesh->getVertexDistribution()[0].push_back(0);
-      mesh->getVertexDistribution()[0].push_back(1);
-      mesh->getVertexDistribution()[0].push_back(3);
-      mesh->getVertexDistribution()[0].push_back(5);
-      mesh->getVertexDistribution()[0].push_back(7);
-
-      mesh->getVertexDistribution()[1].push_back(1);
-      mesh->getVertexDistribution()[1].push_back(2);
-      mesh->getVertexDistribution()[1].push_back(4);
-      mesh->getVertexDistribution()[1].push_back(5);
-      mesh->getVertexDistribution()[1].push_back(6);
+      mesh->setVertexDistribution({{0, {0, 1, 3, 5, 7}}, {1, {1, 2, 4, 5, 6}}});
 
       data         = {10, 20, 40, 60, 80};
       expectedData = {10 + 2, 4 * 20 + 3, 40 + 2, 4 * 60 + 3, 80 + 2};
@@ -81,17 +71,7 @@ void runP2PComTest1(const TestContext &context, com::PtrCommunicationFactory cf)
     if (context.isPrimary()) {
       mesh->setGlobalNumberOfVertices(10);
 
-      mesh->getVertexDistribution()[0].push_back(1);
-      mesh->getVertexDistribution()[0].push_back(2);
-      mesh->getVertexDistribution()[0].push_back(5);
-      mesh->getVertexDistribution()[0].push_back(6);
-
-      mesh->getVertexDistribution()[1].push_back(0);
-      mesh->getVertexDistribution()[1].push_back(1);
-      mesh->getVertexDistribution()[1].push_back(3);
-      mesh->getVertexDistribution()[1].push_back(4);
-      mesh->getVertexDistribution()[1].push_back(5);
-      mesh->getVertexDistribution()[1].push_back(7);
+      mesh->setVertexDistribution({{0, {1, 2, 5, 6}}, {1, {0, 1, 3, 4, 5, 7}}});
 
       data.assign(4, -1);
       expectedData = {2 * 20, 30, 2 * 60, 70};
@@ -134,17 +114,7 @@ void runP2PComTest2(const TestContext &context, com::PtrCommunicationFactory cf)
     if (context.isPrimary()) {
       mesh->setGlobalNumberOfVertices(10);
 
-      mesh->getVertexDistribution()[0].push_back(0);
-      mesh->getVertexDistribution()[0].push_back(1);
-      mesh->getVertexDistribution()[0].push_back(3);
-      mesh->getVertexDistribution()[0].push_back(5);
-      mesh->getVertexDistribution()[0].push_back(7);
-
-      mesh->getVertexDistribution()[1].push_back(1);
-      mesh->getVertexDistribution()[1].push_back(2);
-      mesh->getVertexDistribution()[1].push_back(4);
-      mesh->getVertexDistribution()[1].push_back(5);
-      mesh->getVertexDistribution()[1].push_back(6);
+      mesh->setVertexDistribution({{0, {0, 1, 3, 5, 7}}, {1, {1, 2, 4, 5, 6}}});
 
       data         = {10, 20, 40, 60, 80};
       expectedData = {10 + 2, 4 * 20 + 3, 2 * 40 + 3, 4 * 60 + 3, 80 + 2};
@@ -157,17 +127,7 @@ void runP2PComTest2(const TestContext &context, com::PtrCommunicationFactory cf)
     if (context.isPrimary()) {
       mesh->setGlobalNumberOfVertices(10);
 
-      mesh->getVertexDistribution()[0].push_back(1);
-      mesh->getVertexDistribution()[0].push_back(3);
-      mesh->getVertexDistribution()[0].push_back(5);
-      mesh->getVertexDistribution()[0].push_back(6);
-
-      mesh->getVertexDistribution()[1].push_back(0);
-      mesh->getVertexDistribution()[1].push_back(1);
-      mesh->getVertexDistribution()[1].push_back(3);
-      mesh->getVertexDistribution()[1].push_back(4);
-      mesh->getVertexDistribution()[1].push_back(5);
-      mesh->getVertexDistribution()[1].push_back(7);
+      mesh->setVertexDistribution({{0, {1, 3, 5, 6}}, {1, {0, 1, 3, 4, 5, 7}}});
 
       data.assign(4, -1);
       expectedData = {2 * 20, 40, 2 * 60, 70};

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -205,19 +205,19 @@ void runSameConnectionTest(const TestContext &context, com::PtrCommunicationFact
   if (context.isNamed("A")) {
     if (context.isPrimary()) {
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
     } else {
 
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     }
   } else {
     BOOST_TEST(context.isNamed("B"));
     if (context.isPrimary()) {
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
     } else {
 
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     }
   }
 
@@ -261,19 +261,19 @@ void runCrossConnectionTest(const TestContext &context, com::PtrCommunicationFac
   if (context.isNamed("A")) {
     if (context.isPrimary()) {
 
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     } else {
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
     }
   } else {
     BOOST_TEST(context.isNamed("B"));
     if (context.isPrimary()) {
 
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     } else {
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
     }
   }
 
@@ -316,14 +316,14 @@ void runEmptyConnectionTest(const TestContext &context, com::PtrCommunicationFac
   if (context.isNamed("A")) {
     if (context.isPrimary()) {
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
 
     } else {
     }
   } else {
     BOOST_TEST(context.isNamed("B"));
     if (context.isPrimary()) {
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
 
     } else {
     }
@@ -366,7 +366,7 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
       mesh::Vertex &v2 = mesh->createVertex(position);
       mesh->createEdge(v1, v2);
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
 
     } else {
       Eigen::VectorXd position(dimensions);
@@ -376,15 +376,15 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
       mesh::Vertex &v2 = mesh->createVertex(position);
       mesh->createEdge(v1, v2);
 
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     }
   } else {
     BOOST_TEST(context.isNamed("B"));
     if (context.isPrimary()) {
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
 
     } else {
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     }
   }
 
@@ -431,7 +431,7 @@ void runP2PComLocalCommunicationMapTest(const TestContext &context, com::PtrComm
 
       // The numbers are chosen in this way to make it easy to test weather
       // correct values are communicated or not!
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
       localCommunicationMap[0].push_back(102);
       localCommunicationMap[0].push_back(1022);
       localCommunicationMap[0].push_back(10222);
@@ -443,7 +443,7 @@ void runP2PComLocalCommunicationMapTest(const TestContext &context, com::PtrComm
 
       // The numbers are chosen in this way to make it easy to test weather
       // correct values are communicated or not!
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
       localCommunicationMap[0].push_back(112);
       localCommunicationMap[0].push_back(1122);
       localCommunicationMap[0].push_back(11222);
@@ -455,11 +455,11 @@ void runP2PComLocalCommunicationMapTest(const TestContext &context, com::PtrComm
     BOOST_TEST(context.isNamed("B"));
     if (context.isPrimary()) {
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
 
     } else {
 
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     }
   }
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -319,31 +319,6 @@ const Mesh::VertexDistribution &Mesh::getVertexDistribution() const
   return _vertexDistribution;
 }
 
-std::vector<int> &Mesh::getVertexOffsets()
-{
-  return _vertexOffsets;
-}
-
-const std::vector<int> &Mesh::getVertexOffsets() const
-{
-  return _vertexOffsets;
-}
-
-void Mesh::setVertexOffsets(std::vector<int> &vertexOffsets)
-{
-  _vertexOffsets = vertexOffsets;
-}
-
-int Mesh::getGlobalNumberOfVertices() const
-{
-  return _globalNumberOfVertices;
-}
-
-void Mesh::setGlobalNumberOfVertices(int num)
-{
-  _globalNumberOfVertices = num;
-}
-
 Eigen::VectorXd Mesh::getOwnedVertexData(DataID dataID)
 {
 

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -309,16 +309,6 @@ void Mesh::clearPartitioning()
   _globalNumberOfVertices = 0;
 }
 
-Mesh::VertexDistribution &Mesh::getVertexDistribution()
-{
-  return _vertexDistribution;
-}
-
-const Mesh::VertexDistribution &Mesh::getVertexDistribution() const
-{
-  return _vertexDistribution;
-}
-
 Eigen::VectorXd Mesh::getOwnedVertexData(DataID dataID)
 {
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -232,12 +232,12 @@ public:
   }
 
   /// Returns a mapping from rank to used (not necessarily owned) vertex IDs
-  VertexDistribution const &getVertexDistribution() const
+  const VertexDistribution &getVertexDistribution() const
   {
     return _vertexDistribution;
   }
 
-  VertexOffsets const &getVertexOffsets() const
+  const VertexOffsets &getVertexOffsets() const
   {
     return _vertexOffsets;
   }

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -229,16 +229,25 @@ public:
 
   VertexDistribution const &getVertexDistribution() const;
 
-  std::vector<int> &getVertexOffsets();
+  std::vector<int> const &getVertexOffsets() const
+  {
+    return _vertexOffsets;
+  }
 
-  const std::vector<int> &getVertexOffsets() const;
+  void setVertexOffsets(const std::vector<int> &vertexOffsets)
+  {
+    _vertexOffsets = vertexOffsets;
+  }
 
-  /// Only used for tests
-  void setVertexOffsets(std::vector<int> &vertexOffsets);
+  int getGlobalNumberOfVertices() const
+  {
+    return _globalNumberOfVertices;
+  }
 
-  int getGlobalNumberOfVertices() const;
-
-  void setGlobalNumberOfVertices(int num);
+  void setGlobalNumberOfVertices(int num)
+  {
+    _globalNumberOfVertices = num;
+  }
 
   // Get the data of owned vertices for given data ID
   Eigen::VectorXd getOwnedVertexData(DataID dataID);

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -51,6 +51,8 @@ public:
   /// A mapping from remote local ranks to the IDs that must be communicated
   using CommunicationMap = std::map<Rank, std::vector<VertexID>>;
 
+  using VertexOffsets = std::vector<int>;
+
   /// Use if the id of the mesh is not necessary
   static constexpr MeshID MESH_ID_UNDEFINED{-1};
 
@@ -235,13 +237,13 @@ public:
     return _vertexDistribution;
   }
 
-  std::vector<int> const &getVertexOffsets() const
+  VertexOffsets const &getVertexOffsets() const
   {
     return _vertexOffsets;
   }
 
   /// Only used for tests
-  void setVertexOffsets(std::vector<int> vertexOffsets)
+  void setVertexOffsets(VertexOffsets vertexOffsets)
   {
     _vertexOffsets = std::move(vertexOffsets);
   }
@@ -338,7 +340,7 @@ private:
    * The last entry holds the total number of vertices.
    * Needed for the matrix-matrix multiplication of the IMVJ acceleration.
    */
-  std::vector<int> _vertexOffsets;
+  VertexOffsets _vertexOffsets;
 
   /**
    * @brief Number of unique vertices for complete distributed mesh.

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -224,9 +224,9 @@ public:
   /// Clears the partitioning information
   void clearPartitioning();
 
-  void setVertexDistribution(const VertexDistribution &vd)
+  void setVertexDistribution(VertexDistribution vd)
   {
-    _vertexDistribution = vd;
+    _vertexDistribution = std::move(vd);
   }
 
   /// Returns a mapping from rank to used (not necessarily owned) vertex IDs
@@ -241,9 +241,9 @@ public:
   }
 
   /// Only used for tests
-  void setVertexOffsets(const std::vector<int> &vertexOffsets)
+  void setVertexOffsets(std::vector<int> vertexOffsets)
   {
-    _vertexOffsets = vertexOffsets;
+    _vertexOffsets = std::move(vertexOffsets);
   }
 
   int getGlobalNumberOfVertices() const
@@ -269,9 +269,9 @@ public:
   }
 
   /// Returns a vector of connected ranks
-  void setConnectedRanks(const std::vector<Rank> ranks)
+  void setConnectedRanks(std::vector<Rank> ranks)
   {
-    _connectedRanks = ranks;
+    _connectedRanks = std::move(ranks);
   }
 
   /// Returns a mapping from remote local connected ranks to the corresponding vertex IDs

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -224,16 +224,23 @@ public:
   /// Clears the partitioning information
   void clearPartitioning();
 
-  /// Returns a mapping from rank to used (not necessarily owned) vertex IDs
-  VertexDistribution &getVertexDistribution();
+  void setVertexDistribution(const VertexDistribution &vd)
+  {
+    _vertexDistribution = vd;
+  }
 
-  VertexDistribution const &getVertexDistribution() const;
+  /// Returns a mapping from rank to used (not necessarily owned) vertex IDs
+  VertexDistribution const &getVertexDistribution() const
+  {
+    return _vertexDistribution;
+  }
 
   std::vector<int> const &getVertexOffsets() const
   {
     return _vertexOffsets;
   }
 
+  /// Only used for tests
   void setVertexOffsets(const std::vector<int> &vertexOffsets)
   {
     _vertexOffsets = vertexOffsets;

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -247,9 +247,15 @@ public:
   void tagAll();
 
   /// Returns a vector of connected ranks
-  std::vector<Rank> &getConnectedRanks()
+  const std::vector<Rank> &getConnectedRanks() const
   {
     return _connectedRanks;
+  }
+
+  /// Returns a vector of connected ranks
+  void setConnectedRanks(const std::vector<Rank> ranks)
+  {
+    _connectedRanks = ranks;
   }
 
   /// Returns a mapping from remote local connected ranks to the corresponding vertex IDs

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -134,7 +134,7 @@ void ProvidedPartition::prepare()
       _mesh->vertices()[i].setGlobalIndex(i);
     }
 
-    std::vector<int> vertexOffsets(utils::IntraComm::getSize());
+    mesh::Mesh::VertexOffsets vertexOffsets(utils::IntraComm::getSize());
     vertexOffsets[0]           = numberOfVertices;
     int globalNumberOfVertices = numberOfVertices;
 
@@ -200,7 +200,7 @@ void ProvidedPartition::prepare()
     _mesh->setGlobalNumberOfVertices(globalNumberOfVertices);
 
     // receive set vertex offsets
-    std::vector<int> vertexOffsets;
+    mesh::Mesh::VertexOffsets vertexOffsets;
     utils::IntraComm::getCommunication()->broadcast(vertexOffsets, 0);
     PRECICE_DEBUG("My vertex offsets: {}", vertexOffsets);
     PRECICE_ASSERT(_mesh->getVertexOffsets().empty());
@@ -290,10 +290,10 @@ void ProvidedPartition::compareBoundingBoxes()
 
     // primary rank receives feedback map (map of other participant ranks -> connected ranks at this participant)
     // from other participants primary rank
-    std::vector<int> connectedRanksList = _m2ns[0]->getPrimaryRankCommunication()->receiveRange(0, com::AsVectorTag<int>{});
-    remoteConnectionMapSize             = connectedRanksList.size();
+    std::vector<Rank> connectedRanksList = _m2ns[0]->getPrimaryRankCommunication()->receiveRange(0, com::AsVectorTag<Rank>{});
+    remoteConnectionMapSize              = connectedRanksList.size();
 
-    std::map<int, std::vector<int>> remoteConnectionMap;
+    mesh::Mesh::CommunicationMap remoteConnectionMap;
     for (auto &rank : connectedRanksList) {
       remoteConnectionMap[rank] = {-1};
     }
@@ -322,10 +322,10 @@ void ProvidedPartition::compareBoundingBoxes()
     }());
 
   } else { // Secondary rank
-    std::vector<int> connectedRanksList;
+    std::vector<Rank> connectedRanksList;
     utils::IntraComm::getCommunication()->broadcast(connectedRanksList, 0);
 
-    std::map<int, std::vector<int>> remoteConnectionMap;
+    mesh::Mesh::CommunicationMap remoteConnectionMap;
     if (!connectedRanksList.empty()) {
       for (Rank rank : connectedRanksList) {
         remoteConnectionMap[rank] = {-1};

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -290,14 +290,17 @@ void ProvidedPartition::compareBoundingBoxes()
     }
 
     // primary rank checks which ranks are connected to it
-    _mesh->getConnectedRanks().clear();
-    for (auto &remoteRank : remoteConnectionMap) {
-      for (auto &includedRank : remoteRank.second) {
-        if (utils::IntraComm::getRank() == includedRank) {
-          _mesh->getConnectedRanks().push_back(remoteRank.first);
+    _mesh->setConnectedRanks([&] {
+      std::vector<Rank> ranks;
+      for (auto &remoteRank : remoteConnectionMap) {
+        for (auto &includedRank : remoteRank.second) {
+          if (utils::IntraComm::getRank() == includedRank) {
+            ranks.push_back(remoteRank.first);
+          }
         }
       }
-    }
+      return ranks;
+    }());
 
   } else { // Secondary rank
     std::vector<int> connectedRanksList;
@@ -311,14 +314,17 @@ void ProvidedPartition::compareBoundingBoxes()
       com::CommunicateBoundingBox(utils::IntraComm::getCommunication()).broadcastReceiveConnectionMap(remoteConnectionMap);
     }
 
-    _mesh->getConnectedRanks().clear();
-    for (const auto &remoteRank : remoteConnectionMap) {
-      for (int includedRanks : remoteRank.second) {
-        if (utils::IntraComm::getRank() == includedRanks) {
-          _mesh->getConnectedRanks().push_back(remoteRank.first);
+    _mesh->setConnectedRanks([&] {
+      std::vector<Rank> ranks;
+      for (const auto &remoteRank : remoteConnectionMap) {
+        for (int includedRanks : remoteRank.second) {
+          if (utils::IntraComm::getRank() == includedRanks) {
+            ranks.push_back(remoteRank.first);
+          }
         }
       }
-    }
+      return ranks;
+    }());
   }
 }
 

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -414,14 +414,15 @@ void ReceivedPartition::compareBoundingBoxes()
     std::vector<int>                connectedRanksList; // local ranks with any connection
 
     // connected ranks for primary rank
-    _mesh->getConnectedRanks().clear();
+    std::vector<Rank> connectedRanks;
     for (auto &remoteBB : remoteBBMap) {
       if (_bb.overlapping(remoteBB.second)) {
-        _mesh->getConnectedRanks().push_back(remoteBB.first); //connected remote ranks for this rank
+        connectedRanks.push_back(remoteBB.first); //connected remote ranks for this rank
       }
     }
-    if (not _mesh->getConnectedRanks().empty()) {
-      connectionMap[0] = _mesh->getConnectedRanks();
+    _mesh->setConnectedRanks(connectedRanks);
+    if (not connectedRanks.empty()) {
+      connectionMap[0] = connectedRanks;
       connectedRanksList.push_back(0);
     }
 
@@ -445,15 +446,16 @@ void ReceivedPartition::compareBoundingBoxes()
   } else {
     PRECICE_ASSERT(utils::IntraComm::isSecondary());
 
-    _mesh->getConnectedRanks().clear();
+    std::vector<Rank> connectedRanks;
     for (const auto &remoteBB : remoteBBMap) {
       if (_bb.overlapping(remoteBB.second)) {
-        _mesh->getConnectedRanks().push_back(remoteBB.first);
+        connectedRanks.push_back(remoteBB.first);
       }
     }
+    _mesh->setConnectedRanks(connectedRanks);
 
     // send connected ranks to primary rank
-    utils::IntraComm::getCommunication()->sendRange(_mesh->getConnectedRanks(), 0);
+    utils::IntraComm::getCommunication()->sendRange(connectedRanks, 0);
   }
 }
 

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
       mesh->createEdge(v3, v4);
       mesh->createEdge(v4, v1);
 
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
 
     } else {
       Eigen::VectorXd position(dimensions);
@@ -531,14 +531,14 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
       mesh->createEdge(v3, v4);
       mesh->createEdge(v4, v1);
 
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     }
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
     if (context.isPrimary()) {
-      mesh->getConnectedRanks().push_back(0);
+      mesh->setConnectedRanks({0});
     } else {
-      mesh->getConnectedRanks().push_back(1);
+      mesh->setConnectedRanks({1});
     }
   }
   mesh->computeBoundingBox();

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -12,6 +12,7 @@
 #include "com/SharedPointer.hpp"
 #include "com/SocketCommunication.hpp"
 #include "com/SocketCommunicationFactory.hpp"
+#include "logging/LogConfiguration.hpp"
 #include "m2n/DistributedComFactory.hpp"
 #include "m2n/GatherScatterComFactory.hpp"
 #include "m2n/M2N.hpp"
@@ -184,6 +185,8 @@ void TestContext::initializeIntraComm()
   // Establish a consistent state for all tests
   utils::IntraComm::configure(rank, size);
   utils::IntraComm::getCommunication().reset();
+  logging::setMPIRank(rank);
+  logging::setParticipant(name);
 
   if (!_initIntraComm || hasSize(1))
     return;

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -152,6 +152,16 @@ auto reorder_array(const std::array<Index, n> &order, const std::array<T, n> &el
   return reordered;
 }
 
+template <class InputIt, class Size, class OutputIt>
+void add_n(InputIt first, Size count, OutputIt result)
+{
+  while (count-- > 0) {
+    *result += *first;
+    ++result;
+    ++first;
+  }
+}
+
 } // namespace utils
 } // namespace precice
 

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -152,14 +152,10 @@ auto reorder_array(const std::array<Index, n> &order, const std::array<T, n> &el
   return reordered;
 }
 
-template <class InputIt, class Size, class OutputIt>
-void add_n(InputIt first, Size count, OutputIt result)
+template <class InputIt, class Size, class InOutIt>
+void add_n(InputIt first, Size count, InOutIt result)
 {
-  while (count-- > 0) {
-    *result += *first;
-    ++result;
-    ++first;
-  }
+  std::transform(first, std::next(first, count), result, result, std::plus{});
 }
 
 } // namespace utils


### PR DESCRIPTION
## Main changes of this PR

This PR is a general cleanup of communication classes. It will

- Move circular connection setup to Communication.hpp
- Encapsulates paritioning information in Mesh for easier future refactoring (ConnectedRanks, vertexOffsets,  VertexDistribution)
- Cleanup, simplify and improve logging in GatherScatterCommunication

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
