### PR TITLE
Split CouplingScheme::advance into 4 steps

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -234,6 +234,89 @@ void BaseCouplingScheme::advance()
   }
 }
 
+CouplingScheme::ChangedMeshes BaseCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
+{
+  PRECICE_ASSERT(changes.empty());
+  return changes;
+}
+
+void BaseCouplingScheme::firstExchange()
+{
+  PRECICE_TRACE(_timeWindows, _time);
+  checkCompletenessRequiredActions();
+  PRECICE_ASSERT(_isInitialized, "Before calling advance() coupling scheme has to be initialized via initialize().");
+  _hasDataBeenReceived  = false;
+  _isTimeWindowComplete = false;
+
+  PRECICE_ASSERT(_couplingMode != Undefined);
+
+  if (reachedEndOfTimeWindow()) {
+
+    _timeWindows += 1; // increment window counter. If not converged, will be decremented again later.
+
+    exchangeFirstData();
+  }
+}
+
+CouplingScheme::ChangedMeshes BaseCouplingScheme::secondSynchronization(const CouplingScheme::ChangedMeshes &changes)
+{
+  PRECICE_ASSERT(changes.empty());
+  return changes;
+}
+
+void BaseCouplingScheme::secondExchange()
+{
+  PRECICE_TRACE(_timeWindows, _time);
+  checkCompletenessRequiredActions();
+  PRECICE_ASSERT(_isInitialized, "Before calling advance() coupling scheme has to be initialized via initialize().");
+  PRECICE_ASSERT(_couplingMode != Undefined);
+
+  // from first phase
+  PRECICE_ASSERT(!_hasDataBeenReceived);
+  PRECICE_ASSERT(!_isTimeWindowComplete);
+
+  if (reachedEndOfTimeWindow()) {
+
+    bool convergence = exchangeSecondDataAndAccelerate();
+
+    if (isImplicitCouplingScheme()) { // check convergence
+      if (not convergence) {          // repeat window
+        PRECICE_DEBUG("No convergence achieved");
+        requireAction(constants::actionReadIterationCheckpoint());
+        // The computed time window part equals the time window size, since the
+        // time window remainder is zero. Subtract the time window size and do another
+        // coupling iteration.
+        PRECICE_ASSERT(math::greater(_computedTimeWindowPart, 0.0));
+        _time = _time - _computedTimeWindowPart;
+        _timeWindows -= 1;
+      } else { // write output, prepare for next window
+        PRECICE_DEBUG("Convergence achieved");
+        advanceTXTWriters();
+        PRECICE_INFO("Time window completed");
+        _isTimeWindowComplete = true;
+        if (isCouplingOngoing()) {
+          PRECICE_DEBUG("Setting require create checkpoint");
+          requireAction(constants::actionWriteIterationCheckpoint());
+        }
+      }
+      //update iterations
+      _totalIterations++;
+      if (not convergence) {
+        _iterations++;
+      } else {
+        _iterations = 1;
+      }
+    } else {
+      PRECICE_INFO("Time window completed");
+      _isTimeWindowComplete = true;
+    }
+    if (isCouplingOngoing()) {
+      PRECICE_ASSERT(_hasDataBeenReceived);
+    }
+    _computedTimeWindowPart = 0.0; // reset window
+  }
+}
+
 void BaseCouplingScheme::storeExtrapolationData()
 {
   PRECICE_TRACE(_timeWindows);

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -180,6 +180,7 @@ bool BaseCouplingScheme::sendsInitializedData() const
   return _sendsInitializedData;
 }
 
+#if 0
 void BaseCouplingScheme::advance()
 {
   PRECICE_TRACE(_timeWindows, _time);
@@ -233,6 +234,7 @@ void BaseCouplingScheme::advance()
     _computedTimeWindowPart = 0.0; // reset window
   }
 }
+#endif
 
 CouplingScheme::ChangedMeshes BaseCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
 {
@@ -272,7 +274,6 @@ void BaseCouplingScheme::secondExchange()
   PRECICE_ASSERT(_couplingMode != Undefined);
 
   // from first phase
-  PRECICE_ASSERT(!_hasDataBeenReceived);
   PRECICE_ASSERT(!_isTimeWindowComplete);
 
   if (reachedEndOfTimeWindow()) {

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -260,10 +260,9 @@ void BaseCouplingScheme::firstExchange()
   }
 }
 
-CouplingScheme::ChangedMeshes BaseCouplingScheme::secondSynchronization(const CouplingScheme::ChangedMeshes &changes)
+CouplingScheme::ChangedMeshes BaseCouplingScheme::secondSynchronization()
 {
-  PRECICE_ASSERT(changes.empty());
-  return changes;
+  return {};
 }
 
 void BaseCouplingScheme::secondExchange()

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -522,7 +522,11 @@ private:
    * @brief implements functionality for advance in base class.
    * @returns true, if iteration converged
    */
-  virtual bool exchangeDataAndAccelerate() = 0;
+  bool exchangeDataAndAccelerate()
+  {
+    exchangeFirstData();
+    return exchangeSecondDataAndAccelerate();
+  }
 
   virtual void exchangeFirstData()               = 0;
   virtual bool exchangeSecondDataAndAccelerate() = 0;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -195,13 +195,13 @@ public:
   /// Receives result of first advance, if this has to happen inside SolverInterface::initialize(), see CouplingScheme.hpp
   void receiveResultOfFirstAdvance() override final;
 
-  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
+  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override final;
 
-  void firstExchange() override;
+  void firstExchange() override final;
 
-  ChangedMeshes secondSynchronization(const ChangedMeshes &changes) override;
+  ChangedMeshes secondSynchronization() override final;
 
-  void secondExchange() override;
+  void secondExchange() override final;
 
   /// Adds a measure to determine the convergence of coupling iterations.
   void addConvergenceMeasure(

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -528,7 +528,13 @@ private:
     return exchangeSecondDataAndAccelerate();
   }
 
-  virtual void exchangeFirstData()               = 0;
+  /// Exchanges the first set of data
+  virtual void exchangeFirstData() = 0;
+
+  /** Exchanges the second set of data and accelerate in case of an implicit scheme
+   *
+   * @returns true, if iteration converged
+   */
   virtual bool exchangeSecondDataAndAccelerate() = 0;
 
   /**

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -195,11 +195,6 @@ public:
   /// Receives result of first advance, if this has to happen inside SolverInterface::initialize(), see CouplingScheme.hpp
   void receiveResultOfFirstAdvance() override final;
 
-  /**
-   * @brief Advances the coupling scheme.
-   */
-  void advance() override final;
-
   ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
 
   void firstExchange() override;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -200,6 +200,14 @@ public:
    */
   void advance() override final;
 
+  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
+
+  void firstExchange() override;
+
+  ChangedMeshes secondSynchronization(const ChangedMeshes &changes) override;
+
+  void secondExchange() override;
+
   /// Adds a measure to determine the convergence of coupling iterations.
   void addConvergenceMeasure(
       int                         dataID,
@@ -520,6 +528,9 @@ private:
    * @returns true, if iteration converged
    */
   virtual bool exchangeDataAndAccelerate() = 0;
+
+  virtual void exchangeFirstData()               = 0;
+  virtual bool exchangeSecondDataAndAccelerate() = 0;
 
   /**
    * @brief interface to provide accelerated data, depending on coupling scheme being used

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -90,6 +90,44 @@ void CompositionalCouplingScheme::advance()
   _lastAddedTime = 0.0;
 }
 
+CouplingScheme::ChangedMeshes CompositionalCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
+{
+  PRECICE_ASSERT(changes.empty());
+  return changes;
+}
+
+void CompositionalCouplingScheme::firstExchange()
+{
+  // TODO implement correctly
+  PRECICE_TRACE();
+  bool moreSchemesToHandle = false;
+  do {
+    for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
+      if (not it->onHold) {
+        it->scheme->advance();
+      }
+    }
+    moreSchemesToHandle = determineActiveCouplingSchemes();
+    if (moreSchemesToHandle) {
+      // The new schemes to be handled in this advance also need the time that
+      // has been computed so far. This time can't be added in the solver call
+      // to addComputedTime(), since there the schemes are not active yet.
+      addComputedTime(_lastAddedTime);
+    }
+  } while (moreSchemesToHandle);
+  _lastAddedTime = 0.0;
+}
+
+CouplingScheme::ChangedMeshes CompositionalCouplingScheme::secondSynchronization(const CouplingScheme::ChangedMeshes &changes)
+{
+  PRECICE_ASSERT(changes.empty());
+  return changes;
+}
+
+void CompositionalCouplingScheme::secondExchange()
+{
+}
+
 void CompositionalCouplingScheme::finalize()
 {
   PRECICE_TRACE();

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -120,10 +120,9 @@ void CompositionalCouplingScheme::firstExchange()
   _lastAddedTime = 0.0;
 }
 
-CouplingScheme::ChangedMeshes CompositionalCouplingScheme::secondSynchronization(const CouplingScheme::ChangedMeshes &changes)
+CouplingScheme::ChangedMeshes CompositionalCouplingScheme::secondSynchronization()
 {
-  PRECICE_ASSERT(changes.empty());
-  return changes;
+  return {};
 }
 
 void CompositionalCouplingScheme::secondExchange()

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -70,6 +70,7 @@ void CompositionalCouplingScheme::addComputedTime(double timeToAdd)
 }
 
 #if 0
+// We keep this around as this is not working properly as of yet
 void CompositionalCouplingScheme::advance()
 {
   PRECICE_TRACE();
@@ -100,7 +101,10 @@ CouplingScheme::ChangedMeshes CompositionalCouplingScheme::firstSynchronization(
 
 void CompositionalCouplingScheme::firstExchange()
 {
-  // TODO implement correctly
+  // The iteration prevents the split into 4 steps.
+  // Conceptually, this only works if
+  // 1. all explicit schemes are handled first
+  // 2. (if present) only one implicit schemes is handled at the end
   PRECICE_TRACE();
   bool moreSchemesToHandle = false;
   do {

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -69,6 +69,7 @@ void CompositionalCouplingScheme::addComputedTime(double timeToAdd)
   _lastAddedTime += timeToAdd;
 }
 
+#if 0
 void CompositionalCouplingScheme::advance()
 {
   PRECICE_TRACE();
@@ -89,6 +90,7 @@ void CompositionalCouplingScheme::advance()
   } while (moreSchemesToHandle);
   _lastAddedTime = 0.0;
 }
+#endif
 
 CouplingScheme::ChangedMeshes CompositionalCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
 {

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -95,6 +95,14 @@ public:
   /// Exchanges data and updates the state of the coupling scheme.
   void advance() final override;
 
+  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
+
+  void firstExchange() override;
+
+  ChangedMeshes secondSynchronization(const ChangedMeshes &changes) override;
+
+  void secondExchange() override;
+
   /// Finalizes the coupling and disconnects communication.
   void finalize() final override;
 

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -99,7 +99,7 @@ public:
 
   void firstExchange() override;
 
-  ChangedMeshes secondSynchronization(const ChangedMeshes &changes) override;
+  ChangedMeshes secondSynchronization() override;
 
   void secondExchange() override;
 

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -93,7 +93,7 @@ public:
   void addComputedTime(double timeToAdd) final override;
 
   /// Exchanges data and updates the state of the coupling scheme.
-  void advance() final override;
+  //void advance() final override;
 
   ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -100,7 +100,11 @@ public:
    *
    * Does not necessarily advance in time.
    */
-  virtual void advance() = 0;
+  void advance()
+  {
+    firstExchange();
+    secondExchange();
+  }
 
   using ChangedMeshes = std::vector<MeshID>;
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -3,7 +3,9 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include "com/SharedPointer.hpp"
+#include "precice/types.hpp"
 
 namespace precice {
 namespace cplscheme {
@@ -99,6 +101,16 @@ public:
    * Does not necessarily advance in time.
    */
   virtual void advance() = 0;
+
+  using ChangedMeshes = std::vector<MeshID>;
+
+  virtual ChangedMeshes firstSynchronization(const ChangedMeshes &changes) = 0;
+
+  virtual void firstExchange() = 0;
+
+  virtual ChangedMeshes secondSynchronization(const ChangedMeshes &changes) = 0;
+
+  virtual void secondExchange() = 0;
 
   /// Finalizes the coupling and disconnects communication.
   virtual void finalize() = 0;

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -112,7 +112,7 @@ public:
 
   virtual void firstExchange() = 0;
 
-  virtual ChangedMeshes secondSynchronization(const ChangedMeshes &changes) = 0;
+  virtual ChangedMeshes secondSynchronization() = 0;
 
   virtual void secondExchange() = 0;
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -108,12 +108,35 @@ public:
 
   using ChangedMeshes = std::vector<MeshID>;
 
+  /** Synchronizes mesh changes with remote participants.
+   *
+   * @param[in] changes MeshIDs of locally changed meshes
+   *
+   * @returns MeshIDs of remotely changed meshes.
+   */
   virtual ChangedMeshes firstSynchronization(const ChangedMeshes &changes) = 0;
 
+  /** Exchanges the first set of data.
+   *
+   * @pre \ref firstSynchronization() was called
+   */
   virtual void firstExchange() = 0;
 
+  /** Receive mesh changes from remote participants in the second step.
+   * This is necessary as serial coupling schemes may have changed the mesh by now.
+   *
+   * @note local changes are covered by \ref firstSynchronization()
+   *
+   * @returns MeshIDs of remotely changed meshes.
+   *
+   * @pre \ref firstExchange() was called
+   */
   virtual ChangedMeshes secondSynchronization() = 0;
 
+  /** Exchanges the second set of data.
+   *
+   * @pre \ref secondSynchronization() was called
+   */
   virtual void secondExchange() = 0;
 
   /// Finalizes the coupling and disconnects communication.

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -91,6 +91,7 @@ void MultiCouplingScheme::exchangeInitialData()
   PRECICE_DEBUG("Initial data is exchanged in MultiCouplingScheme");
 }
 
+#if 0
 bool MultiCouplingScheme::exchangeDataAndAccelerate()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
@@ -128,6 +129,7 @@ bool MultiCouplingScheme::exchangeDataAndAccelerate()
   }
   return convergence;
 }
+#endif
 
 void MultiCouplingScheme::exchangeFirstData()
 {

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -91,46 +91,6 @@ void MultiCouplingScheme::exchangeInitialData()
   PRECICE_DEBUG("Initial data is exchanged in MultiCouplingScheme");
 }
 
-#if 0
-bool MultiCouplingScheme::exchangeDataAndAccelerate()
-{
-  PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
-  // @todo implement MultiCouplingScheme for explicit coupling
-
-  PRECICE_DEBUG("Computed full length of iteration");
-
-  bool convergence = true;
-
-  if (_isController) {
-    for (auto &receiveExchange : _receiveDataVector) {
-      receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
-    }
-    checkDataHasBeenReceived();
-
-    convergence = doImplicitStep();
-    for (const auto &m2nPair : _m2ns) {
-      sendConvergence(m2nPair.second, convergence);
-    }
-
-    for (auto &sendExchange : _sendDataVector) {
-      sendData(_m2ns[sendExchange.first], sendExchange.second);
-    }
-  } else {
-    for (auto &sendExchange : _sendDataVector) {
-      sendData(_m2ns[sendExchange.first], sendExchange.second);
-    }
-
-    convergence = receiveConvergence(_m2ns[_controller]);
-
-    for (auto &receiveExchange : _receiveDataVector) {
-      receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
-    }
-    checkDataHasBeenReceived();
-  }
-  return convergence;
-}
-#endif
-
 void MultiCouplingScheme::exchangeFirstData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -116,7 +116,7 @@ private:
    * @brief Exchanges all data between the participants of the MultiCouplingScheme and applies acceleration.
    * @returns true, if iteration converged
    */
-  bool exchangeDataAndAccelerate() override;
+  //bool exchangeDataAndAccelerate() override;
 
   void exchangeFirstData() override;
   bool exchangeSecondDataAndAccelerate() override;

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -118,6 +118,9 @@ private:
    */
   bool exchangeDataAndAccelerate() override;
 
+  void exchangeFirstData() override;
+  bool exchangeSecondDataAndAccelerate() override;
+
   /**
    * @brief MultiCouplingScheme applies acceleration to all CouplingData
    * @returns DataMap being accelerated

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -23,6 +23,7 @@ ParallelCouplingScheme::ParallelCouplingScheme(
     : BiCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, validDigits, firstParticipant,
                        secondParticipant, localParticipant, std::move(m2n), maxIterations, cplMode, dtMethod, extrapolationOrder) {}
 
+#if 0
 bool ParallelCouplingScheme::exchangeDataAndAccelerate()
 {
   bool convergence = true;
@@ -51,6 +52,7 @@ bool ParallelCouplingScheme::exchangeDataAndAccelerate()
 
   return convergence;
 }
+#endif
 
 void ParallelCouplingScheme::exchangeFirstData()
 {

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -23,37 +23,6 @@ ParallelCouplingScheme::ParallelCouplingScheme(
     : BiCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, validDigits, firstParticipant,
                        secondParticipant, localParticipant, std::move(m2n), maxIterations, cplMode, dtMethod, extrapolationOrder) {}
 
-#if 0
-bool ParallelCouplingScheme::exchangeDataAndAccelerate()
-{
-  bool convergence = true;
-
-  if (doesFirstStep()) { // first participant
-    PRECICE_DEBUG("Sending data...");
-    sendData(getM2N(), getSendData());
-    PRECICE_DEBUG("Receiving data...");
-    if (isImplicitCouplingScheme()) {
-      convergence = receiveConvergence(getM2N());
-    }
-    receiveData(getM2N(), getReceiveData());
-    checkDataHasBeenReceived();
-  } else { // second participant
-    PRECICE_DEBUG("Receiving data...");
-    receiveData(getM2N(), getReceiveData());
-    checkDataHasBeenReceived();
-    if (isImplicitCouplingScheme()) {
-      PRECICE_DEBUG("Perform acceleration (only second participant)...");
-      convergence = doImplicitStep();
-      sendConvergence(getM2N(), convergence);
-    }
-    PRECICE_DEBUG("Sending data...");
-    sendData(getM2N(), getSendData());
-  }
-
-  return convergence;
-}
-#endif
-
 void ParallelCouplingScheme::exchangeFirstData()
 {
   if (doesFirstStep()) { // first participant

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -63,7 +63,7 @@ private:
    * @brief Exchanges all data between the participants of the ParallelCouplingScheme and applies acceleration.
    * @returns true, if iteration converged
    */
-  bool exchangeDataAndAccelerate() override;
+  // bool exchangeDataAndAccelerate() override;
 
   void exchangeFirstData() override;
   bool exchangeSecondDataAndAccelerate() override;

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -59,13 +59,13 @@ public:
 private:
   logging::Logger _log{"cplscheme::ParallelCouplingScheme"};
 
+  /// Exchanges first set of data between the participants of the ParallelCouplingScheme
+  void exchangeFirstData() override;
+
   /**
-   * @brief Exchanges all data between the participants of the ParallelCouplingScheme and applies acceleration.
+   * @brief Exchanges the second set of data between the participants of the ParallelCouplingScheme and applies acceleration.
    * @returns true, if iteration converged
    */
-  // bool exchangeDataAndAccelerate() override;
-
-  void exchangeFirstData() override;
   bool exchangeSecondDataAndAccelerate() override;
 
   /**

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -65,6 +65,9 @@ private:
    */
   bool exchangeDataAndAccelerate() override;
 
+  void exchangeFirstData() override;
+  bool exchangeSecondDataAndAccelerate() override;
+
   /**
    * @brief ParallelCouplingScheme applies acceleration to all CouplingData
    * @returns DataMap being accelerated

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -87,6 +87,7 @@ void SerialCouplingScheme::performReceiveOfFirstAdvance()
   }
 }
 
+#if 0
 bool SerialCouplingScheme::exchangeDataAndAccelerate()
 {
   bool convergence = true;
@@ -120,6 +121,7 @@ bool SerialCouplingScheme::exchangeDataAndAccelerate()
 
   return convergence;
 }
+#endif
 
 void SerialCouplingScheme::exchangeFirstData()
 {

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -87,42 +87,6 @@ void SerialCouplingScheme::performReceiveOfFirstAdvance()
   }
 }
 
-#if 0
-bool SerialCouplingScheme::exchangeDataAndAccelerate()
-{
-  bool convergence = true;
-
-  if (doesFirstStep()) { // first participant
-    PRECICE_DEBUG("Sending data...");
-    sendTimeWindowSize();
-    sendData(getM2N(), getSendData());
-    PRECICE_DEBUG("Receiving data...");
-    if (isImplicitCouplingScheme()) {
-      convergence = receiveConvergence(getM2N());
-    }
-    receiveData(getM2N(), getReceiveData());
-    checkDataHasBeenReceived();
-  } else { // second participant
-    if (isImplicitCouplingScheme()) {
-      PRECICE_DEBUG("Test Convergence and accelerate...");
-      convergence = doImplicitStep();
-      sendConvergence(getM2N(), convergence);
-    }
-    PRECICE_DEBUG("Sending data...");
-    sendData(getM2N(), getSendData());
-    // the second participant does not want new data in the last iteration of the last time window
-    if (isCouplingOngoing() || (isImplicitCouplingScheme() && not convergence)) {
-      receiveAndSetTimeWindowSize();
-      PRECICE_DEBUG("Receiving data...");
-      receiveData(getM2N(), getReceiveData());
-      checkDataHasBeenReceived();
-    }
-  }
-
-  return convergence;
-}
-#endif
-
 void SerialCouplingScheme::exchangeFirstData()
 {
   _converged = true;
@@ -135,11 +99,6 @@ void SerialCouplingScheme::exchangeFirstData()
     if (isImplicitCouplingScheme()) {
       _converged = receiveConvergence(getM2N());
     }
-    /*
-    PRECICE_DEBUG("Receiving data...");
-    receiveData(getM2N(), getReceiveData());
-    checkDataHasBeenReceived();
-    */
   } else { // second participant
     if (isImplicitCouplingScheme()) {
       PRECICE_DEBUG("Test Convergence and accelerate...");
@@ -148,18 +107,7 @@ void SerialCouplingScheme::exchangeFirstData()
     }
     PRECICE_DEBUG("Sending data...");
     sendData(getM2N(), getSendData());
-    /*
-    // the second participant does not want new data in the last iteration of the last time window
-    if (isCouplingOngoing() || (isImplicitCouplingScheme() && not _converged)) {
-      receiveAndSetTimeWindowSize();
-      PRECICE_DEBUG("Receiving data...");
-      receiveData(getM2N(), getReceiveData());
-      checkDataHasBeenReceived();
-    }
-    */
   }
-
-  //return convergence;
 }
 
 bool SerialCouplingScheme::exchangeSecondDataAndAccelerate()

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -83,13 +83,13 @@ private:
    */
   void performReceiveOfFirstAdvance() override final;
 
+  /// Exchanges the first set of data between the participants of the SerialCouplingSchemes
+  void exchangeFirstData() override;
+
   /**
-   * @brief Exchanges data between the participants of the SerialCouplingSchemes and applies acceleration.
+   * @brief Exchanges the second set of data between the participants of the SerialCouplingSchemes
    * @returns true, if iteration converged
    */
-  //bool exchangeDataAndAccelerate() override;
-
-  void exchangeFirstData() override;
   bool exchangeSecondDataAndAccelerate() override;
 
   /**

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -89,6 +89,9 @@ private:
    */
   bool exchangeDataAndAccelerate() override;
 
+  void exchangeFirstData() override;
+  bool exchangeSecondDataAndAccelerate() override;
+
   /**
    * @brief SerialCouplingSchemes applies acceleration to send data
    * @returns DataMap being accelerated
@@ -97,6 +100,8 @@ private:
   {
     return getSendData();
   }
+
+  bool _converged = false;
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -87,7 +87,7 @@ private:
    * @brief Exchanges data between the participants of the SerialCouplingSchemes and applies acceleration.
    * @returns true, if iteration converged
    */
-  bool exchangeDataAndAccelerate() override;
+  //bool exchangeDataAndAccelerate() override;
 
   void exchangeFirstData() override;
   bool exchangeSecondDataAndAccelerate() override;

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -24,22 +24,6 @@ void DummyCouplingScheme::initialize(
   _iterations    = 1;
 }
 
-#if 0
-void DummyCouplingScheme::advance()
-{
-  PRECICE_ASSERT(_isInitialized);
-  PRECICE_ASSERT(_isOngoing);
-  if (_iterations == _numberIterations) {
-    if (_timesteps == _maxTimesteps) {
-      _isOngoing = false;
-    }
-    _timesteps++;
-    _iterations = 0;
-  }
-  _iterations++;
-}
-#endif
-
 CouplingScheme::ChangedMeshes DummyCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
 {
   PRECICE_ASSERT(_isInitialized);

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -24,6 +24,7 @@ void DummyCouplingScheme::initialize(
   _iterations    = 1;
 }
 
+#if 0
 void DummyCouplingScheme::advance()
 {
   PRECICE_ASSERT(_isInitialized);
@@ -37,6 +38,7 @@ void DummyCouplingScheme::advance()
   }
   _iterations++;
 }
+#endif
 
 CouplingScheme::ChangedMeshes DummyCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
 {

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -54,12 +54,11 @@ void DummyCouplingScheme::firstExchange()
   PRECICE_ASSERT(_isOngoing);
 }
 
-CouplingScheme::ChangedMeshes DummyCouplingScheme::secondSynchronization(const CouplingScheme::ChangedMeshes &changes)
+CouplingScheme::ChangedMeshes DummyCouplingScheme::secondSynchronization()
 {
   PRECICE_ASSERT(_isInitialized);
   PRECICE_ASSERT(_isOngoing);
-  PRECICE_ASSERT(changes.empty());
-  return changes;
+  return {};
 }
 
 void DummyCouplingScheme::secondExchange()

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -1,5 +1,6 @@
 #include "DummyCouplingScheme.hpp"
 #include "../Constants.hpp"
+#include "cplscheme/CouplingScheme.hpp"
 #include "logging/LogMacros.hpp"
 
 namespace precice::cplscheme::tests {
@@ -24,6 +25,42 @@ void DummyCouplingScheme::initialize(
 }
 
 void DummyCouplingScheme::advance()
+{
+  PRECICE_ASSERT(_isInitialized);
+  PRECICE_ASSERT(_isOngoing);
+  if (_iterations == _numberIterations) {
+    if (_timesteps == _maxTimesteps) {
+      _isOngoing = false;
+    }
+    _timesteps++;
+    _iterations = 0;
+  }
+  _iterations++;
+}
+
+CouplingScheme::ChangedMeshes DummyCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
+{
+  PRECICE_ASSERT(_isInitialized);
+  PRECICE_ASSERT(_isOngoing);
+  PRECICE_ASSERT(changes.empty());
+  return changes;
+}
+
+void DummyCouplingScheme::firstExchange()
+{
+  PRECICE_ASSERT(_isInitialized);
+  PRECICE_ASSERT(_isOngoing);
+}
+
+CouplingScheme::ChangedMeshes DummyCouplingScheme::secondSynchronization(const CouplingScheme::ChangedMeshes &changes)
+{
+  PRECICE_ASSERT(_isInitialized);
+  PRECICE_ASSERT(_isOngoing);
+  PRECICE_ASSERT(changes.empty());
+  return changes;
+}
+
+void DummyCouplingScheme::secondExchange()
 {
   PRECICE_ASSERT(_isInitialized);
   PRECICE_ASSERT(_isOngoing);

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -79,7 +79,7 @@ public:
 
   void firstExchange() override;
 
-  ChangedMeshes secondSynchronization(const ChangedMeshes &changes) override;
+  ChangedMeshes secondSynchronization() override;
 
   void secondExchange() override;
 

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -75,6 +75,14 @@ public:
    */
   void advance() override final;
 
+  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
+
+  void firstExchange() override;
+
+  ChangedMeshes secondSynchronization(const ChangedMeshes &changes) override;
+
+  void secondExchange() override;
+
   /**
    * @brief
    */

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -73,7 +73,7 @@ public:
   /**
    * @brief
    */
-  void advance() override final;
+  //void advance() override final;
 
   ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -420,6 +420,7 @@ double SolverInterfaceImpl::advance(
   [[maybe_unused]] auto changes1 = _couplingScheme->firstSynchronization({});
   _couplingScheme->firstExchange();
   [[maybe_unused]] auto changes2 = _couplingScheme->secondSynchronization();
+  _couplingScheme->secondExchange();
 
   if (_couplingScheme->isTimeWindowComplete()) {
     for (auto &context : _accessor->readDataContexts()) {

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -417,9 +417,12 @@ double SolverInterfaceImpl::advance(
   }
 
   PRECICE_DEBUG("Advance coupling scheme");
-  [[maybe_unused]] auto changes1 = _couplingScheme->firstSynchronization({});
+  // Orchestrate local and remote mesh changes
+  std::vector<MeshID>   localChanges;
+  [[maybe_unused]] auto remoteChanges1 = _couplingScheme->firstSynchronization(localChanges);
   _couplingScheme->firstExchange();
-  [[maybe_unused]] auto changes2 = _couplingScheme->secondSynchronization();
+  // Orchestrate remote mesh changes (local ones were handled in the first sync)
+  [[maybe_unused]] auto remoteChanges2 = _couplingScheme->secondSynchronization();
   _couplingScheme->secondExchange();
 
   if (_couplingScheme->isTimeWindowComplete()) {

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -417,7 +417,9 @@ double SolverInterfaceImpl::advance(
   }
 
   PRECICE_DEBUG("Advance coupling scheme");
-  _couplingScheme->advance();
+  [[maybe_unused]] auto changes1 = _couplingScheme->firstSynchronization({});
+  _couplingScheme->firstExchange();
+  [[maybe_unused]] auto changes2 = _couplingScheme->secondSynchronization();
 
   if (_couplingScheme->isTimeWindowComplete()) {
     for (auto &context : _accessor->readDataContexts()) {


### PR DESCRIPTION
## Main changes of this PR

This PR splits CouplingScheme::advance into 4 steps:

1. `ChangedMeshes firstSynchronization(const ChangedMeshes &changes);`
2. `void firstExchange();`
3. `ChangedMeshes secondSynchronization();`
4. `void secondExchange();`

Steps 1 and 3 are placeholders for the upcoming reinitalization/mesh reset feature.
The design is as follows:

The first synchronization receives remote mesh changes and broadcasts local mesh changes.
After the first exchange, remote serial coupling schemes hand back to their solvers.
The second synchronization receives remote mesh changes in case of a remote serial coupling scheme changing the mesh.
The second exchange then generally also performs some kind of acceleration if enabled.

## Motivation and additional information

See #1303

`CouplingScheme::advance()` is implemented in terms of `CouplingScheme::firstExchange()` followed by `CouplingScheme::secondExchange()`, which keeps all Coupling Scheme tests intact.

`CompositionalCouplingScheme` currently **cannot be implemented** in this way and will perform the full coupling in `firstExchange`.
Reason for this is:

1. It strictly follows the order of cpl-schemes defined in the configuration.
2. It will stop at implicit coupling schemes. Hence, these steps can only be called correctly in these groups.
3. Even if all explicit schemes proceed the implicit schemes, then multiple schemes will still lead to incorrect order.

Solution is:
* Allow only a single implicit coupling scheme
* Always run the implicit scheme after all explicit schemes

Alternatively: Don't allow adaptive meshes if more than one implicit scheme is used. (This allows to use the currently implemented fallback)

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
