### PR TITLE
Add CMake presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Makefile
 src/precice/impl/versions.hpp
 src/precice/Version.h
 .idea
+CMakeUserPresets.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,7 @@
       "name": "production",
       "inherits": "base",
       "displayName": "Production release",
-      "description": "Default release configuration as preCICE is intended to be used in production.",
+      "description": "Release configuration for preCICE used in production.",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON"
@@ -58,7 +58,7 @@
     {
       "name": "profiling",
       "inherits": "develop",
-      "displayName": "Profiling",
+      "displayName": "Profiling config",
       "description": "Profiling configuration",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,77 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "ON"
+      }
+    },
+    {
+      "name": "production",
+      "inherits": "base",
+      "displayName": "Production release",
+      "description": "Default release configuration as preCICE is intended to be used in production.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON"
+      }
+    },
+    {
+      "name": "develop",
+      "inherits": "base",
+      "displayName": "Development config",
+      "description": "Development config with default settings",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wno-unused-parameter"
+      },
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "uninitialized": true
+      }
+    },
+    {
+      "name": "debpkg",
+      "inherits": "production",
+      "displayName": "Debian package",
+      "description": "Build for the generation of Debian packages",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "/usr",
+        "CPACK_GENERATOR": "DEB",
+        "BUILD_TESTING": "OFF"
+      }
+    },
+    {
+      "name": "bigrelease",
+      "inherits": "production",
+      "displayName": "Big release",
+      "description": "Release build with log and assertions enabled",
+      "cacheVariables": {
+        "PRECICE_RELEASE_WITH_ASSERTIONS": "ON",
+        "PRECICE_RELEASE_WITH_DEBUG_LOG": "ON"
+      }
+    },
+    {
+      "name": "localinstall",
+      "inherits": "production",
+      "displayName": "Locally installed release",
+      "description": "Release build with local installation to ./installation",
+      "installDir": "${sourceDir}/installation"
+    },
+    {
+      "name": "profiling",
+      "inherits": "develop",
+      "displayName": "Profiling",
+      "description": "Profiling configuration",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wno-unused-parameter -fno-omit-frame-pointer"
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,7 +35,7 @@
       }
     },
     {
-      "name": "debpkg",
+      "name": "debian-package",
       "inherits": "production",
       "displayName": "Debian package",
       "description": "Build for the generation of Debian packages",
@@ -54,13 +54,6 @@
         "PRECICE_RELEASE_WITH_ASSERTIONS": "ON",
         "PRECICE_RELEASE_WITH_DEBUG_LOG": "ON"
       }
-    },
-    {
-      "name": "localinstall",
-      "inherits": "production",
-      "displayName": "Locally installed release",
-      "description": "Release build with local installation to ./installation",
-      "installDir": "${sourceDir}/installation"
     },
     {
       "name": "profiling",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,9 +20,19 @@
       }
     },
     {
+      "name": "production-audit",
+      "inherits": "production",
+      "displayName": "Production release with assertions",
+      "description": "Release build assertions enabled for auditting a specific run.",
+      "cacheVariables": {
+        "PRECICE_RELEASE_WITH_ASSERTIONS": "ON",
+        "PRECICE_RELEASE_WITH_DEBUG_LOG": "ON"
+      }
+    },
+    {
       "name": "develop",
       "inherits": "base",
-      "displayName": "Development config",
+      "displayName": "Development",
       "description": "Development config with default settings",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -46,19 +56,21 @@
       }
     },
     {
-      "name": "bigrelease",
-      "inherits": "production",
-      "displayName": "Big release",
-      "description": "Release build with log and assertions enabled",
+      "name": "optimized-debug",
+      "inherits": "base",
+      "displayName": "Optimized debug",
+      "description": "Optimized debug build log and assertions enabled",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "PRECICE_RELEASE_WITH_ASSERTIONS": "ON",
-        "PRECICE_RELEASE_WITH_DEBUG_LOG": "ON"
+        "PRECICE_RELEASE_WITH_DEBUG_LOG": "ON",
+        "CMAKE_CXX_FLAGS": "-fno-omit-frame-pointer"
       }
     },
     {
       "name": "profiling",
       "inherits": "develop",
-      "displayName": "Profiling config",
+      "displayName": "Profiling",
       "description": "Profiling configuration",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",


### PR DESCRIPTION
## Main changes of this PR

This PR adds CMake presets, which are available since CMake 3.19.
This is not supported by the Ubuntu 20.04 LTS, so I picked the CMake version 3.22 of Ubuntu 22.04 LTS as a baseline.

This PR adds the presets:
```
cmake --list-presets
Available configure presets:

  "production"   - Default production release
  "develop"      - Default development config
  "debpkg"       - Debian Package
  "bigrelease"   - Big release
  "localinstall" - Release with local installation
  "profiling"    - Profiling
```

One can easily switch to a new preset by running:
```
cmake --preset profiling
```

The default build directory is `./build`, the installation directory for `localinstall` is `./installation`.


## Motivation and additional information

This simplifies developers to use the appropriate flags and allows to quickly switch to a common setup without having to manually change variables.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
