### PR TITLE
Remove incorrect warning for waveform order zero and serial coupling schemes

### DIFF
--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -979,12 +979,6 @@ void CouplingSchemeConfiguration::addDataToBeExchanged(
     if (from == accessor) {
       scheme.addDataToSend(exchange.data, exchange.mesh, requiresInitialization);
     } else if (to == accessor) {
-      // Checks for a serial coupling scheme, where initial data is received by first participant.
-      if (!scheme.doesFirstStep() && requiresInitialization && (_config.type == VALUE_SERIAL_EXPLICIT || _config.type == VALUE_SERIAL_IMPLICIT) && getWaveformUsedOrder(accessor, dataName) == 0) // the order of the statements is crucial! getWaveformUsedOrder should be called last, because it may run into an error, if the data is initialized, but not defined as read data (for example Integration/Serial/AitkenAcceleration)
-      {
-        PRECICE_WARN("In serial coupling, initialized data received by the second participant will only be used if a waveform order > 0 is set. You can avoid unnecessary data initialization by setting initialize=\"false\" in the <exchange data=\"{}\" mesh=\"{}\" from=\"{}\" to=\"{}\" initialize=\"{}\" /> tag in the <coupling-scheme:... /> of your precice-config.xml. If you want to use the initial data, please consider increasing the waveform-order in the <read-data name=\"{}\" mesh=\"{}\" /> tag in the <participant ... /> named \"{}\". ",
-                     dataName, meshName, from, to, requiresInitialization, dataName, meshName, to);
-      }
       scheme.addDataToReceive(exchange.data, exchange.mesh, requiresInitialization);
     } else {
       PRECICE_ASSERT(_config.type == VALUE_MULTI);


### PR DESCRIPTION
## Main changes of this PR

Removes warning that tells user to not initialize data of second participant in serial coupling, if waveform order is zero. Initialization actually becomes reasonable in this case, if the user wants to sample at the starting time (we cannot know whether the user will sample or not, because the sampling happens over the API).

This PR also removes the warning to avoid the test `Integration/Serial/Time/Implicit/SerialCoupling/ReadWriteScalarDataWithWaveformSamplingZero` to trigger the warning. The test is correct and should not trigger any warning that suggests a change (because this will lead to a failure of the test).

## Motivation and additional information

This change is motivated by #1422. See this change in the test: https://github.com/precice/precice/commit/270cc0844bb3cdb1b0bea9997825c421d092bbfc#diff-52e93df8fe0311c9dcda9c30ccdb04ac3fd7d92fc5f7576ae6b261a40e23fb83L81-R81: At the beginning of the window we now get the data from the last window or initial data, even for zeroth order waveforms. This makes data initialization relevant for all coupling schemes and participants, if a user wants to sample the function at the beginning of the simulation time.

See also comments under https://github.com/precice/precice/pull/1414#discussion_r983736569 for further discussion.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite. (not relevant)
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
