### PR TITLE
Extend docs of isTimeWindowComplete

### DIFF
--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -275,8 +275,8 @@ public:
    *   than the time window.
    * - An implicit coupling iteration is not yet converged.
    *
-   * A time window is complete if neither reason holds: If we reach the
-   * end of the time window in the last implicit coupling iteration.
+   * Hence, a time window is complete if we reach the end of the time window
+   * and the implicit coupling has converged.
    *
    * For implicit coupling this condition is equivalent with the requirement to
    * write an iteration checkpoint. This is, however, not the case for explicit

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -266,15 +266,21 @@ public:
   [[deprecated("Will be removed in 3.0.0. See https://github.com/precice/precice/issues/1223 and comment, if you need this function.")]] bool isWriteDataRequired(double computedTimestepLength) const;
 
   /**
-   * @brief Checks if the current coupling window is completed.
+   * @brief Checks if the current time window is completed.
    *
-   * @returns whether the current coupling window is complete.
+   * @returns whether the current time window is complete.
    *
-   * The following reasons require several solver time steps per time window
-   * step:
+   * The following reasons require several solver time steps per time window:
    * - A solver chooses to perform subcycling, i.e. using a smaller timestep
-   *   than the time window..
+   *   than the time window.
    * - An implicit coupling iteration is not yet converged.
+   *
+   * A coupling window is complete if neither reason holds: If we reach the
+   * end of the time window in the last implicit coupling iteration.
+   *
+   * For implicit coupling this condition is equivalent with the requirement to
+   * write an iteration checkpoint. This is, however, not the case for explicit
+   * coupling.
    *
    * @pre initialize() has been called successfully.
    */

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -275,7 +275,7 @@ public:
    *   than the time window.
    * - An implicit coupling iteration is not yet converged.
    *
-   * A coupling window is complete if neither reason holds: If we reach the
+   * A time window is complete if neither reason holds: If we reach the
    * end of the time window in the last implicit coupling iteration.
    *
    * For implicit coupling this condition is equivalent with the requirement to


### PR DESCRIPTION
## Main changes of this PR

Extend docs of isTimeWindowComplete

## Motivation and additional information

This API function is very often leading to questions:
- At the end of every iteration or only at the end of the last iteration?
- Why do I need this function if it is equivalent with "write its check"?

I hope this additional doc clarifies these questions.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Do you understand the docs changes?

<!-- add more questions/tasks if necessary -->
