### PR TITLE
Fix for generating Ninja files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,6 @@ if (PRECICE_BUILD_TOOLS)
     COMMAND ${CMAKE_COMMAND} -E create_symlink precice-tools binprecice
     DEPENDS precice-tools
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    BYPRODUCTS binprecice
     )
 endif()
 


### PR DESCRIPTION
## Main changes of this PR

With removing `BYPRODUCTS binprecice`, I was able to generate ninja files.

>
`Ninja requires custom command byproducts to be explicit.`
(https://cmake.org/cmake/help/latest/policy/CMP0058.html)

It seems to be CMake/Ninja doesn't like using same names for `BYPRODUCTS` and the target name. That's why CMake/Ninja is complaining since `binprecice` is  defined as both `BYPRODUCT` and custom target. 

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->
closes #1468 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
