### PR TITLE
Fix missing check output

### DIFF
--- a/docs/changelog/1477.md
+++ b/docs/changelog/1477.md
@@ -1,0 +1,1 @@
+- Fixed `precice-tools check` not displaying errors if the logger is disabled in the checked config.

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -29,6 +29,21 @@ void printConfigReference(std::ostream &out, ConfigReferenceType reftype)
 
 void checkConfiguration(const std::string &filename, const std::string &participant, int size)
 {
+  logging::setupLogging({[] {
+    logging::BackendConfiguration config;
+
+    // Console output
+    config.format = "%ColorizedSeverity%%Message%";
+    config.filter = "%Severity% >= info";
+    config.type   = "stream";
+    config.output = "stdout";
+
+    return config;
+  }()});
+
+  // Lock the logging configuration to prevent the parser from changing it
+  logging::lockConf();
+
   fmt::print("Checking {} for syntax and basic setup issues...\n", filename);
   config::Configuration config;
   logging::setMPIRank(0);

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -33,7 +33,7 @@ void checkConfiguration(const std::string &filename, const std::string &particip
     logging::BackendConfiguration config;
 
     // Console output
-    config.format = "%ColorizedSeverity%%Message%";
+    config.format = "precice-tools: %ColorizedSeverity%%Message%";
     config.filter = "%Severity% >= info";
     config.type   = "stream";
     config.output = "stdout";


### PR DESCRIPTION
## Main changes of this PR

`precice-tools check config.xml` does not output anything if the logger is disabled.

This PR enforces a fixed logging sink.

## Motivation and additional information

Undisplayed errors are not helpful

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
