### PR TITLE
Add second muscle test (failing)

### DIFF
--- a/tests/serial/compositional/OneActivatedMuscle.cpp
+++ b/tests/serial/compositional/OneActivatedMuscle.cpp
@@ -40,8 +40,8 @@ BOOST_AUTO_TEST_CASE(OneActivatedMuscle)
     auto stretchMeshID = interface.getMeshID("Stretch_M1SM_Mesh");
     interface.setMeshVertices(stretchMeshID, 1, signalCoords.data(), stretchVertexIDs.data());
 
-    activationDataID   = interface.getDataID("Activation1", activationMeshID);
-    stretchDataID      = interface.getDataID("Stretch1", stretchMeshID);
+    activationDataID    = interface.getDataID("Activation1", activationMeshID);
+    stretchDataID       = interface.getDataID("Stretch1", stretchMeshID);
     displacement1DataID = interface.getDataID("Displacement1", surfaceMeshID);
     traction1DataID     = interface.getDataID("Traction1", surfaceMeshID);
 
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(OneActivatedMuscle)
     auto stretchMeshID = interface.getMeshID("Stretch_M2SM_Mesh");
     interface.setMeshVertices(stretchMeshID, 1, signalCoords.data(), stretchVertexIDs.data());
 
-    stretchDataID      = interface.getDataID("Stretch2", stretchMeshID);
+    stretchDataID       = interface.getDataID("Stretch2", stretchMeshID);
     displacement2DataID = interface.getDataID("Displacement2", surfaceMeshID);
     traction2DataID     = interface.getDataID("Traction2", surfaceMeshID);
 
@@ -86,7 +86,6 @@ BOOST_AUTO_TEST_CASE(OneActivatedMuscle)
 
     displacement2DataID = interface.getDataID("Displacement2", surface2MeshID);
     traction2DataID     = interface.getDataID("Traction2", surface2MeshID);
-
   }
 
   std::cout << "Before initialize" << std::endl;
@@ -117,7 +116,7 @@ BOOST_AUTO_TEST_CASE(OneActivatedMuscle)
       BOOST_TEST(context.isNamed("M1"));
     }
 
-    std::cout << "Before advance" << std::endl;   
+    std::cout << "Before advance" << std::endl;
     interface.advance(timestepSize);
   }
 }

--- a/tests/serial/compositional/OneActivatedMuscle.cpp
+++ b/tests/serial/compositional/OneActivatedMuscle.cpp
@@ -1,0 +1,129 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <boost/test/tools/detail/per_element_manip.hpp>
+#include <precice/SolverInterface.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Compositional)
+BOOST_AUTO_TEST_CASE(OneActivatedMuscle)
+{
+  PRECICE_TEST("M1SM"_on(1_rank), "M2SM"_on(1_rank), "M1"_on(1_rank), "Tendon"_on(1_rank));
+
+  std::cout << "Before constructor" << std::endl;
+  precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+
+  const std::vector<double> surfaceCoords{1, 0, 2, 0};
+  const std::vector<double> signalCoords{0, 0};
+
+  int              activationDataID, stretchDataID, displacement1DataID, traction1DataID, displacement2DataID, traction2DataID, crossStretchDataID;
+  std::vector<int> surface1VertexIDs(2);
+  std::vector<int> surface2VertexIDs(2);
+  std::vector<int> activationVertexIDs(1);
+  std::vector<int> stretchVertexIDs(1);
+  std::vector<int> crossStretchVertexIDs(1);
+
+  double timestepSize = 1.0;
+
+  if (context.isNamed("M1SM")) {
+
+    auto surfaceMeshID = interface.getMeshID("Surface_Mesh1");
+
+    interface.setMeshVertices(surfaceMeshID, 2, surfaceCoords.data(), surface1VertexIDs.data());
+
+    auto activationMeshID = interface.getMeshID("Activation_M1SM_Mesh");
+    interface.setMeshVertices(activationMeshID, 1, signalCoords.data(), activationVertexIDs.data());
+
+    auto stretchMeshID = interface.getMeshID("Stretch_M1SM_Mesh");
+    interface.setMeshVertices(stretchMeshID, 1, signalCoords.data(), stretchVertexIDs.data());
+
+    activationDataID   = interface.getDataID("Activation1", activationMeshID);
+    stretchDataID      = interface.getDataID("Stretch1", stretchMeshID);
+    displacement1DataID = interface.getDataID("Displacement1", surfaceMeshID);
+    traction1DataID     = interface.getDataID("Traction1", surfaceMeshID);
+
+  } else if (context.isNamed("M2SM")) {
+
+    auto surfaceMeshID = interface.getMeshID("Surface_Mesh2");
+    interface.setMeshVertices(surfaceMeshID, 2, surfaceCoords.data(), surface2VertexIDs.data());
+
+    auto stretchMeshID = interface.getMeshID("Stretch_M2SM_Mesh");
+    interface.setMeshVertices(stretchMeshID, 1, signalCoords.data(), stretchVertexIDs.data());
+
+    stretchDataID      = interface.getDataID("Stretch2", stretchMeshID);
+    displacement2DataID = interface.getDataID("Displacement2", surfaceMeshID);
+    traction2DataID     = interface.getDataID("Traction2", surfaceMeshID);
+
+  } else if (context.isNamed("M1")) {
+
+    auto stretchMeshID = interface.getMeshID("Stretch_M1_Mesh");
+    interface.setMeshVertices(stretchMeshID, 1, signalCoords.data(), stretchVertexIDs.data());
+
+    auto crossStretchMeshID = interface.getMeshID("Stretch_M1_Cross_Mesh");
+    interface.setMeshVertices(crossStretchMeshID, 1, signalCoords.data(), crossStretchVertexIDs.data());
+
+    auto activationMeshID = interface.getMeshID("Activation_M1_Mesh");
+    interface.setMeshVertices(activationMeshID, 1, signalCoords.data(), activationVertexIDs.data());
+
+    stretchDataID      = interface.getDataID("Stretch1", stretchMeshID);
+    crossStretchDataID = interface.getDataID("Stretch2", crossStretchMeshID);
+    activationDataID   = interface.getDataID("Activation1", activationMeshID);
+
+  } else {
+    BOOST_TEST(context.isNamed("Tendon"));
+
+    auto surface1MeshID = interface.getMeshID("SurfaceTendon_Mesh1");
+    interface.setMeshVertices(surface1MeshID, 2, surfaceCoords.data(), surface1VertexIDs.data());
+
+    auto surface2MeshID = interface.getMeshID("SurfaceTendon_Mesh2");
+    interface.setMeshVertices(surface2MeshID, 2, surfaceCoords.data(), surface2VertexIDs.data());
+
+    displacement1DataID = interface.getDataID("Displacement1", surface1MeshID);
+    traction1DataID     = interface.getDataID("Traction1", surface1MeshID);
+
+    displacement2DataID = interface.getDataID("Displacement2", surface2MeshID);
+    traction2DataID     = interface.getDataID("Traction2", surface2MeshID);
+
+  }
+
+  std::cout << "Before initialize" << std::endl;
+  interface.initialize();
+
+  for (int timestep = 0; timestep < 2; ++timestep) {
+
+    std::vector<double> tractions1{1.2, 3.4};
+    std::vector<double> displacements1{4.2, 1.4};
+    std::vector<double> tractions2{1.2, 3.7};
+    std::vector<double> displacements2{4.1, 1.4};
+
+    if (context.isNamed("M1SM")) {
+
+      interface.writeBlockScalarData(displacement1DataID, 2, surface1VertexIDs.data(), displacements1.data());
+
+    } else if (context.isNamed("Tendon")) {
+
+      //interface.markActionFulfilled(precice::constants::actionWriteInitialData());
+
+      std::vector<double> receivedDisplacements{0.0, 0.0};
+      interface.readBlockScalarData(displacement1DataID, 2, surface1VertexIDs.data(), receivedDisplacements.data());
+      BOOST_TEST(receivedDisplacements == displacements1, boost::test_tools::per_element());
+
+    } else if (context.isNamed("M2SM")) {
+
+    } else {
+      BOOST_TEST(context.isNamed("M1"));
+    }
+
+    std::cout << "Before advance" << std::endl;   
+    interface.advance(timestepSize);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Compositional
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/compositional/OneActivatedMuscle.xml
+++ b/tests/serial/compositional/OneActivatedMuscle.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface>
+    <data:scalar name="Stretch1" />
+    <data:scalar name="Stretch2" />
+    <data:scalar name="Activation1" />
+    <data:scalar name="Traction1" />
+    <data:scalar name="Displacement1" />
+    <data:scalar name="Traction2" />
+    <data:scalar name="Displacement2" />
+
+    <mesh name="Surface_Mesh1">
+      <use-data name="Traction1" />
+      <use-data name="Displacement1" />
+    </mesh>
+
+    <mesh name="SurfaceTendon_Mesh1">
+      <use-data name="Traction1" />
+      <use-data name="Displacement1" />
+    </mesh>
+
+    <mesh name="Surface_Mesh2">
+      <use-data name="Traction2" />
+      <use-data name="Displacement2" />
+    </mesh>
+
+    <mesh name="SurfaceTendon_Mesh2">
+      <use-data name="Traction2" />
+      <use-data name="Displacement2" />
+    </mesh>
+
+    <mesh name="Activation_M1_Mesh">
+      <use-data name="Activation1" />
+    </mesh>
+
+    <mesh name="Activation_M1SM_Mesh">
+      <use-data name="Activation1" />
+    </mesh>
+
+    <mesh name="Stretch_M1_Mesh">
+      <use-data name="Stretch1" />
+    </mesh>
+
+    <mesh name="Stretch_M1_Cross_Mesh">
+      <use-data name="Stretch2" />
+    </mesh>
+
+    <mesh name="Stretch_M1SM_Mesh">
+      <use-data name="Stretch1" />
+    </mesh>
+
+    <mesh name="Stretch_M2SM_Mesh">
+      <use-data name="Stretch2" />
+    </mesh>
+
+    <participant name="M1SM">
+      <use-mesh name="Surface_Mesh1" provide="yes" />
+      <use-mesh name="SurfaceTendon_Mesh1" from="Tendon" />
+      <use-mesh name="Activation_M1SM_Mesh" provide="yes" />
+      <use-mesh name="Stretch_M1SM_Mesh" provide="yes" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="Surface_Mesh1"
+        to="SurfaceTendon_Mesh1"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="SurfaceTendon_Mesh1"
+        to="Surface_Mesh1"
+        constraint="consistent" />
+      <read-data name="Activation1" mesh="Activation_M1SM_Mesh" />
+      <write-data name="Stretch1" mesh="Stretch_M1SM_Mesh" />
+      <write-data name="Displacement1" mesh="Surface_Mesh1" />
+      <read-data name="Traction1" mesh="Surface_Mesh1" />
+    </participant>
+
+    <participant name="M2SM">
+      <use-mesh name="Surface_Mesh2" provide="yes" />
+      <use-mesh name="SurfaceTendon_Mesh2" from="Tendon" />
+      <use-mesh name="Stretch_M2SM_Mesh" provide="yes" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="Surface_Mesh2"
+        to="SurfaceTendon_Mesh2"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="SurfaceTendon_Mesh2"
+        to="Surface_Mesh2"
+        constraint="consistent" />
+      <write-data name="Stretch2" mesh="Stretch_M2SM_Mesh" />
+      <read-data name="Displacement2" mesh="Surface_Mesh2" />
+      <write-data name="Traction2" mesh="Surface_Mesh2" />
+    </participant>
+
+    <participant name="Tendon">
+      <use-mesh name="SurfaceTendon_Mesh1" provide="yes" />
+      <use-mesh name="SurfaceTendon_Mesh2" provide="yes" />
+      <read-data name="Displacement1" mesh="SurfaceTendon_Mesh1" />
+      <write-data name="Traction1" mesh="SurfaceTendon_Mesh1" />
+      <write-data name="Displacement2" mesh="SurfaceTendon_Mesh2" />
+      <read-data name="Traction2" mesh="SurfaceTendon_Mesh2" />
+    </participant>
+
+    <participant name="M1">
+      <use-mesh name="Activation_M1_Mesh" provide="yes" />
+      <use-mesh name="Activation_M1SM_Mesh" from="M1SM" />
+      <use-mesh name="Stretch_M1_Mesh" provide="yes" />
+      <use-mesh name="Stretch_M1_Cross_Mesh" provide="yes" />
+      <use-mesh name="Stretch_M1SM_Mesh" from="M1SM" />
+      <use-mesh name="Stretch_M2SM_Mesh" from="M2SM" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="Activation_M1_Mesh"
+        to="Activation_M1SM_Mesh"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="Stretch_M2SM_Mesh"
+        to="Stretch_M1_Cross_Mesh"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="Stretch_M1SM_Mesh"
+        to="Stretch_M1_Mesh"
+        constraint="consistent" />
+      <read-data name="Stretch2" mesh="Stretch_M1_Cross_Mesh" />
+      <read-data name="Stretch1" mesh="Stretch_M1_Mesh" />
+      <write-data name="Activation1" mesh="Activation_M1_Mesh" />
+    </participant>
+
+    <m2n:sockets from="M1" to="M1SM" />
+    <m2n:sockets from="M1SM" to="Tendon" />
+    <m2n:sockets from="Tendon" to="M2SM" />
+    <m2n:sockets from="M2SM" to="M1" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="M2SM" second="M1" />
+      <time-window-size value="1" />
+      <max-time-windows value="2" />
+      <exchange data="Stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M1" />
+    </coupling-scheme:serial-explicit>
+
+    <coupling-scheme:serial-explicit>
+      <participants first="M1SM" second="M1" />
+      <time-window-size value="1" />
+      <max-time-windows value="2" />
+      <exchange data="Stretch1" mesh="Stretch_M1SM_Mesh" from="M1SM" to="M1" />
+      <exchange data="Activation1" mesh="Activation_M1SM_Mesh" from="M1" to="M1SM" />
+    </coupling-scheme:serial-explicit>
+
+    <coupling-scheme:multi>
+      <participant name="Tendon" control="yes"/>
+      <participant name="M1SM"/>
+      <participant name="M2SM"/>
+      <time-window-size value="1" />
+      <max-time-windows value="2" />
+      <exchange data="Displacement1" mesh="SurfaceTendon_Mesh1" from="M1SM" to="Tendon" />
+      <exchange data="Traction1" mesh="SurfaceTendon_Mesh1" from="Tendon" to="M1SM" />
+      <exchange data="Displacement2" mesh="SurfaceTendon_Mesh2" from="Tendon" to="M2SM" />
+      <exchange data="Traction2" mesh="SurfaceTendon_Mesh2" from="M2SM" to="Tendon" />
+      <max-iterations value="1" />
+      <min-iteration-convergence-measure
+        min-iterations="1"
+        data="Displacement2"
+        mesh="SurfaceTendon_Mesh2" />
+    </coupling-scheme:multi>
+
+
+  </solver-interface>
+
+</precice-configuration>

--- a/tests/serial/compositional/OneActivatedMuscle.xml
+++ b/tests/serial/compositional/OneActivatedMuscle.xml
@@ -150,9 +150,9 @@
     </coupling-scheme:serial-explicit>
 
     <coupling-scheme:multi>
-      <participant name="Tendon" control="yes"/>
-      <participant name="M1SM"/>
-      <participant name="M2SM"/>
+      <participant name="Tendon" control="yes" />
+      <participant name="M1SM" />
+      <participant name="M2SM" />
       <time-window-size value="1" />
       <max-time-windows value="2" />
       <exchange data="Displacement1" mesh="SurfaceTendon_Mesh1" from="M1SM" to="Tendon" />
@@ -165,8 +165,5 @@
         data="Displacement2"
         mesh="SurfaceTendon_Mesh2" />
     </coupling-scheme:multi>
-
-
   </solver-interface>
-
 </precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -75,6 +75,7 @@ target_sources(testprecice
     tests/serial/circular/Explicit.cpp
     tests/serial/circular/helper.hpp
     tests/serial/compositional/TwoActivatedMuscles.cpp
+    tests/serial/compositional/OneActivatedMuscle.cpp
     tests/serial/convergence-measures/helpers.cpp
     tests/serial/convergence-measures/helpers.hpp
     tests/serial/convergence-measures/testConvergenceMeasures1.cpp


### PR DESCRIPTION
## Main changes of this PR

Add a  second muscle test.

## Motivation and additional information

The OneActivatedMuscle test consists of 4 participants: M1, M1SM, Tendon and M2SM

@uekerman  test does not pass!

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
