### PR TITLE
Fix no-return type warnings in release builds

### DIFF
--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -392,14 +392,12 @@ ParticipantConfiguration::getParticipants() const
   return _participants;
 }
 
-const impl::PtrParticipant ParticipantConfiguration::getParticipant(std::string participantName) const
+const impl::PtrParticipant ParticipantConfiguration::getParticipant(const std::string &participantName) const
 {
-  for (const precice::impl::PtrParticipant &participant : _participants) {
-    if (participant->getName() == participantName) {
-      return participant;
-    }
-  }
-  PRECICE_ASSERT(false, "Did not find participant of given name");
+  auto participant = std::find_if(_participants.begin(), _participants.end(), [&participantName](const auto &p) { return p->getName() == participantName; });
+  PRECICE_ASSERT(participant != _participants.end(), "Did not find participant \"{}\"", participantName);
+
+  return *participant;
 }
 
 partition::ReceivedPartition::GeometricFilter ParticipantConfiguration::getGeoFilter(const std::string &geoFilter) const

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -55,7 +55,7 @@ public:
   const std::vector<impl::PtrParticipant> &getParticipants() const;
 
   /// Returns a participant with the given name
-  const impl::PtrParticipant getParticipant(std::string participantName) const;
+  const impl::PtrParticipant getParticipant(const std::string &participantName) const;
 
 private:
   struct WatchPointConfig {

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -142,14 +142,12 @@ ReadDataContext &Participant::readDataContext(DataID dataID)
   return it->second;
 }
 
-ReadDataContext &Participant::readDataContext(std::string dataName)
+ReadDataContext &Participant::readDataContext(const std::string &dataName)
 {
-  for (auto &dataContext : readDataContexts()) {
-    if (dataContext.getDataName() == dataName) {
-      return dataContext;
-    }
-  }
-  PRECICE_ASSERT(false, "ReadData with given name not found.");
+  auto dataContext = std::find_if(readDataContexts().begin(), readDataContexts().end(), [&dataName](const auto &d) { return d.getDataName() == dataName; });
+  PRECICE_ASSERT(dataContext != readDataContexts().end(), "Did not find read data \"{}\".", dataName);
+
+  return *dataContext;
 }
 
 const WriteDataContext &Participant::writeDataContext(DataID dataID) const

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -135,7 +135,7 @@ public:
    * Provides access to \ref ReadDataContext
    * @pre there exists a \ref ReadDataContext for \ref dataName
    */
-  ReadDataContext &readDataContext(std::string dataName);
+  ReadDataContext &readDataContext(const std::string &dataName);
 
   /** Provides access to \ref WriteDataContext
    * @pre there exists a \ref WriteDataContext for \ref dataID

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -62,12 +62,10 @@ void Storage::clear(bool keepZero)
 
 Eigen::VectorXd Storage::getValueAtOrAfter(double before)
 {
-  for (auto &sample : _sampleStorage) {
-    if (math::greaterEquals(sample.first, before)) {
-      return sample.second;
-    }
-  }
-  PRECICE_ASSERT(false, "no value found!");
+  auto sample = std::find_if(_sampleStorage.begin(), _sampleStorage.end(), [&before](const auto &s) { return math::greaterEquals(s.first, before); });
+  PRECICE_ASSERT(sample != _sampleStorage.end(), "no value found!");
+
+  return (*sample).second;
 }
 
 Eigen::VectorXd Storage::getTimes()

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -65,7 +65,7 @@ Eigen::VectorXd Storage::getValueAtOrAfter(double before)
   auto sample = std::find_if(_sampleStorage.begin(), _sampleStorage.end(), [&before](const auto &s) { return math::greaterEquals(s.first, before); });
   PRECICE_ASSERT(sample != _sampleStorage.end(), "no value found!");
 
-  return (*sample).second;
+  return sample->second;
 }
 
 Eigen::VectorXd Storage::getTimes()


### PR DESCRIPTION
## Main changes of this PR

Fixes `-Wreturn-type` compiler warnings in release build. Probably introduced in #1366 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
