### PR TITLE
Replace actions with explicit calls

### DIFF
--- a/docs/changelog/1487.md
+++ b/docs/changelog/1487.md
@@ -1,3 +1,4 @@
 - Replaced `isActionRequired()` and `markActionFulfilled()` with explicit calls `requiresInitialData()`, `requiresReadingCheckpoint()`, and `requiresWritingCheckpoint()`. Invoking these functions is a promise to preCICE that the caller fulfills the requirement.
 - Removed `precice::constants` from the C++ API and the C and Fortran bindings.
 - Added `precicef_get_version_information_` to Fortran bindings.
+- Renamed `isMeshConnectivityRequired()` to `requiresMeshConnectivityFor()`

--- a/docs/changelog/1487.md
+++ b/docs/changelog/1487.md
@@ -2,3 +2,4 @@
 - Removed `precice::constants` from the C++ API and the C and Fortran bindings.
 - Added `precicef_get_version_information_` to Fortran bindings.
 - Renamed `isMeshConnectivityRequired()` to `requiresMeshConnectivityFor()`
+- Renamed `isGradientDataRequired()` to `requiresGradientDataFor()`

--- a/docs/changelog/1487.md
+++ b/docs/changelog/1487.md
@@ -1,0 +1,3 @@
+- Replaced `isActionRequired()` and `markActionFulfilled()` with explicit calls `requiresInitialData()`, `requiresReadingCheckpoint()`, and `requiresWritingCheckpoint()`. Invoking these functions is a promise to preCICE that the caller fulfills the requirement.
+- Removed `precice::constants` from the C++ API and the C and Fortran bindings.
+- Added `precicef_get_version_information_` to Fortran bindings.

--- a/examples/solverdummies/c/solverdummy.c
+++ b/examples/solverdummies/c/solverdummy.c
@@ -37,9 +37,6 @@ int main(int argc, char **argv)
   printf("DUMMY: Running solver dummy with preCICE config file \"%s\" and participant name \"%s\".\n",
          configFileName, participantName);
 
-  const char *writeItCheckp = precicec_actionWriteIterationCheckpoint();
-  const char *readItCheckp  = precicec_actionReadIterationCheckpoint();
-
   precicec_createSolverInterface(participantName, configFileName, solverProcessIndex, solverProcessSize);
 
   if (strcmp(participantName, "SolverOne") == 0) {
@@ -75,13 +72,16 @@ int main(int argc, char **argv)
 
   free(vertices);
 
+  if (precicec_requiresInitialData()) {
+    printf("DUMMY: Writing initial data\n");
+  }
+
   dt = precicec_initialize();
 
   while (precicec_isCouplingOngoing()) {
 
-    if (precicec_isActionRequired(writeItCheckp)) {
+    if (precicec_requiresWritingCheckpoint()) {
       printf("DUMMY: Writing iteration checkpoint \n");
-      precicec_markActionFulfilled(writeItCheckp);
     }
 
     precicec_readBlockVectorData(readDataID, numberOfVertices, vertexIDs, readData);
@@ -94,9 +94,8 @@ int main(int argc, char **argv)
 
     dt = precicec_advance(dt);
 
-    if (precicec_isActionRequired(readItCheckp)) {
+    if (precicec_requiresReadingCheckpoint()) {
       printf("DUMMY: Reading iteration checkpoint \n");
-      precicec_markActionFulfilled(readItCheckp);
     } else {
       printf("DUMMY: Advancing in time \n");
     }

--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -8,7 +8,6 @@ int main(int argc, char **argv)
   int commSize = 1;
 
   using namespace precice;
-  using namespace precice::constants;
 
   if (argc != 3) {
     std::cout << "The solverdummy was called with an incorrect number of arguments. Usage: ./solverdummy configFile solverName\n\n";
@@ -61,13 +60,16 @@ int main(int argc, char **argv)
 
   interface.setMeshVertices(meshID, numberOfVertices, vertices.data(), vertexIDs.data());
 
+  if (interface.requiresInitialData()) {
+    std::cout << "DUMMY: Writing initial data\n";
+  }
+
   double dt = interface.initialize();
 
   while (interface.isCouplingOngoing()) {
 
-    if (interface.isActionRequired(actionWriteIterationCheckpoint())) {
+    if (interface.requiresWritingCheckpoint()) {
       std::cout << "DUMMY: Writing iteration checkpoint\n";
-      interface.markActionFulfilled(actionWriteIterationCheckpoint());
     }
 
     interface.readBlockVectorData(readDataID, numberOfVertices, vertexIDs.data(), readData.data());
@@ -80,9 +82,8 @@ int main(int argc, char **argv)
 
     dt = interface.advance(dt);
 
-    if (interface.isActionRequired(actionReadIterationCheckpoint())) {
+    if (interface.requiresReadingCheckpoint()) {
       std::cout << "DUMMY: Reading iteration checkpoint\n";
-      interface.markActionFulfilled(actionReadIterationCheckpoint());
     } else {
       std::cout << "DUMMY: Advancing in time\n";
     }

--- a/examples/solverdummies/fortran/solverdummy.f90
+++ b/examples/solverdummies/fortran/solverdummy.f90
@@ -1,22 +1,13 @@
 PROGRAM main
   IMPLICIT NONE
   CHARACTER*512                   :: config
-  CHARACTER*50                    :: participantName, meshName, writeInitialData, readItCheckp, writeItCheckp
+  CHARACTER*50                    :: participantName, meshName
   CHARACTER*50                    :: readDataName, writeDataName
   INTEGER                         :: rank, commsize, ongoing, dimensions, meshID, bool, numberOfVertices, i,j
   INTEGER                         :: readDataID, writeDataID
   DOUBLE PRECISION                :: dt
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: vertices, writeData, readData
   INTEGER, DIMENSION(:), ALLOCATABLE :: vertexIDs
-
-  ! Constants in f90 have to be prefilled with blanks to be compatible with preCICE
-  writeInitialData(1:50)='                                                  '
-  readItCheckp(1:50)='                                                  '
-  writeItCheckp(1:50)='                                                  '
-
-  CALL precicef_action_write_initial_data(writeInitialData)
-  CALL precicef_action_read_iter_checkp(readItCheckp)
-  CALL precicef_action_write_iter_checkp(writeItCheckp)
 
   WRITE (*,*) 'DUMMY: Starting Fortran solver dummy...'
 
@@ -63,7 +54,7 @@ PROGRAM main
   CALL precicef_get_data_id(readDataName,meshID,readDataID)
   CALL precicef_get_data_id(writeDataName,meshID,writeDataID)
 
-  CALL precicef_is_action_required(writeInitialData, bool)
+  CALL precicef_requires_initial_data(bool)
   IF (bool.EQ.1) THEN
     WRITE (*,*) 'DUMMY: Writing initial data'
   ENDIF
@@ -72,11 +63,10 @@ PROGRAM main
   CALL precicef_is_coupling_ongoing(ongoing)
   DO WHILE (ongoing.NE.0)
 
-    CALL precicef_is_action_required(writeItCheckp, bool)
+    CALL precicef_requires_writing_checkpoint(bool)
 
     IF (bool.EQ.1) THEN
       WRITE (*,*) 'DUMMY: Writing iteration checkpoint'
-      CALL precicef_mark_action_fulfilled(writeItCheckp)
     ENDIF
 
     CALL precicef_read_bvdata(readDataID, numberOfVertices, vertexIDs, readData)
@@ -89,10 +79,9 @@ PROGRAM main
 
     CALL precicef_advance(dt)
 
-    CALL precicef_is_action_required(readItCheckp, bool)
+    CALL precicef_requires_reading_checkpoint(bool)
     IF (bool.EQ.1) THEN
       WRITE (*,*) 'DUMMY: Reading iteration checkpoint'
-      CALL precicef_mark_action_fulfilled(readItCheckp)
     ELSE
       WRITE (*,*) 'DUMMY: Advancing in time'
     ENDIF

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -449,8 +449,8 @@ PRECICE_API const char *precicec_getVersionInformation();
  */
 ///@{
 
-/// @copydoc precice::SolverInterface::isGradientDataRequired
-PRECICE_API int precicec_isGradientDataRequired(int dataID);
+/// @copydoc precice::SolverInterface::requiresGradientDataFor
+PRECICE_API int precicec_requiresGradientDataFor(int dataID);
 
 /// @copydoc precice::SolverInterface::writeScalarGradientData
 PRECICE_API void precicec_writeScalarGradientData(

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -129,8 +129,8 @@ PRECICE_API int precicec_hasMesh(const char *meshName);
  */
 PRECICE_API int precicec_getMeshID(const char *meshName);
 
-/// @copydoc precice::SolverInterface::isMeshConnectivityRequired()
-PRECICE_API int precicec_isMeshConnectivityRequired(int meshID);
+/// @copydoc precice::SolverInterface::requiresMeshConnectivityFor()
+PRECICE_API int precicec_requiresMeshConnectivityFor(int meshID);
 
 /**
  * @brief Creates a mesh vertex

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -103,22 +103,14 @@ PRECICE_API int precicec_isTimeWindowComplete();
 ///@name Action Methods
 ///@{
 
-/**
- * @brief Checks if the provided action is required.
- * @param[in] action the name of the action
- * @returns whether the action is required
- */
-PRECICE_API int precicec_isActionRequired(const char *action);
+/// @copydoc precice::SolverInterface::requiresInitialData()
+PRECICE_API int precicec_requiresInitialData();
 
-/**
- * @brief Indicates preCICE that a required action has been fulfilled by a solver.
- * @pre The solver fulfilled the specified action.
- *
- * @param[in] action the name of the action
- */
-PRECICE_API void precicec_markActionFulfilled(const char *action);
+/// @copydoc precice::SolverInterface::requiresWritingCheckpoint()
+PRECICE_API int precicec_requiresWritingCheckpoint();
 
-///@}
+/// @copydoc precice::SolverInterface::requiresReadingCheckpoint()
+PRECICE_API int precicec_requiresReadingCheckpoint();
 
 ///@name Mesh Access
 ///@anchor precice-mesh-access
@@ -449,15 +441,6 @@ PRECICE_API void precicec_readScalarData(
  * 3) the configuration of preCICE including MPI, PETSC, PYTHON
  */
 PRECICE_API const char *precicec_getVersionInformation();
-
-// @brief Name of action for writing initial data.
-PRECICE_API const char *precicec_actionWriteInitialData();
-
-// @brief Name of action for writing iteration checkpoint
-PRECICE_API const char *precicec_actionWriteIterationCheckpoint();
-
-// @brief Name of action for reading iteration checkpoint.
-PRECICE_API const char *precicec_actionReadIterationCheckpoint();
 
 ///@}
 

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -151,10 +151,10 @@ int precicec_getDataID(const char *dataName, int meshID)
   return impl->getDataID(stringDataName, meshID);
 }
 
-int precicec_isMeshConnectivityRequired(int meshID)
+int precicec_requiresMeshConnectivityFor(int meshID)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  if (impl->isMeshConnectivityRequired(meshID)) {
+  if (impl->requiresMeshConnectivityFor(meshID)) {
     return 1;
   }
   return 0;

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -358,10 +358,10 @@ void precicec_readScalarData(
   impl->readScalarData(dataID, valueIndex, *dataValue);
 }
 
-int precicec_isGradientDataRequired(int dataID)
+int precicec_requiresGradientDataFor(int dataID)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  if (impl->isGradientDataRequired(dataID)) {
+  if (impl->requiresGradientDataFor(dataID)) {
     return 1;
   }
   return 0;

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -102,21 +102,22 @@ int precicec_isTimeWindowComplete()
   return 0;
 }
 
-int precicec_isActionRequired(const char *action)
+int precicec_requiresInitialData()
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  PRECICE_ASSERT(action != nullptr);
-  if (impl->isActionRequired(std::string(action))) {
-    return 1;
-  }
-  return 0;
+  return impl->requiresInitialData() ? 1 : 0;
 }
 
-void precicec_markActionFulfilled(const char *action)
+int precicec_requiresWritingCheckpoint()
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  PRECICE_ASSERT(action != nullptr);
-  impl->markActionFulfilled(std::string(action));
+  return impl->requiresWritingCheckpoint() ? 1 : 0;
+}
+
+int precicec_requiresReadingCheckpoint()
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  return impl->requiresReadingCheckpoint() ? 1 : 0;
 }
 
 int precicec_hasMesh(const char *meshName)
@@ -407,21 +408,6 @@ void precicec_writeBlockVectorGradientData(
 const char *precicec_getVersionInformation()
 {
   return precice::versionInformation;
-}
-
-const char *precicec_actionWriteInitialData()
-{
-  return precice::constants::actionWriteInitialData().c_str();
-}
-
-const char *precicec_actionWriteIterationCheckpoint()
-{
-  return precice::constants::actionWriteIterationCheckpoint().c_str();
-}
-
-const char *precicec_actionReadIterationCheckpoint()
-{
-  return precice::constants::actionReadIterationCheckpoint().c_str();
 }
 
 void precicec_setMeshAccessRegion(

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -247,9 +247,9 @@ PRECICE_API void precicef_get_data_id_(
  * IN:  meshID
  * OUT: required(1:true, 0:false)
  *
- * @copydoc precice::SolverInterface::isMeshConnectivityRequired()
+ * @copydoc precice::SolverInterface::requiresMeshConnectivityFor()
  */
-PRECICE_API void precicef_is_mesh_connectivity_required_(
+PRECICE_API void precicef_requires_mesh_connectivity_for_(
     const int *meshID,
     int *      required);
 

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -121,54 +121,43 @@ PRECICE_API void precicef_is_coupling_ongoing_(int *isOngoing);
 PRECICE_API void precicef_is_time_window_complete_(int *isComplete);
 
 /**
- * @deprecated Forwards to precicef_is_action_required_
- *
  * Fortran syntax:
- * precicef_action_required(
- *   CHARACTER action(*),
+ * precicef_requires_initial_data_(
  *   INTEGER   isRequired )
  *
- * IN:  action
+ * IN:  -
  * OUT: isRequired(1:true, 0:false)
  *
- * @copydoc precice::SolverInterface::isActionRequired()
- *
+ * @copydoc precice::SolverInterface::requiresInitialData()
  */
-[[deprecated("Use precicef_is_action_required_(...) with the same arguments instead.")]] void precicef_action_required_(
-    const char *action,
-    int *       isRequired,
-    int         lengthAction);
+PRECICE_API void precicef_requires_initial_data_(
+    int *isRequired);
 
 /**
  * Fortran syntax:
- * precicef_is_action_required(
- *   CHARACTER action(*),
+ * precicef_requires_reading_checkpoint_(
  *   INTEGER   isRequired )
  *
- * IN:  action
+ * IN:  -
  * OUT: isRequired(1:true, 0:false)
  *
- * @copydoc precice::SolverInterface::isActionRequired()
- *
+ * @copydoc precice::SolverInterface::requiresReadingCheckpoint()
  */
-PRECICE_API void precicef_is_action_required_(
-    const char *action,
-    int *       isRequired,
-    int         lengthAction);
+PRECICE_API void precicef_requires_reading_checkpoint_(
+    int *isRequired);
 
 /**
  * Fortran syntax:
- * precicef_mark_action_fulfilled( CHARACTER action(*) )
+ * precicef_requires_writing_checkpoint_(
+ *   INTEGER   isRequired )
  *
- * IN:  action
- * OUT: -
+ * IN:  -
+ * OUT: isRequired(1:true, 0:false)
  *
- * @copydoc precice::SolverInterface::markActionFulfilled()
- *
+ * @copydoc precice::SolverInterface::requiresWritingCheckpoint()
  */
-PRECICE_API void precicef_mark_action_fulfilled_(
-    const char *action,
-    int         lengthAction);
+PRECICE_API void precicef_requires_writing_checkpoint_(
+    int *isRequired);
 
 /**
  * Fortran syntax:
@@ -663,36 +652,6 @@ PRECICE_API void precicef_read_sdata_(
     const int *dataID,
     const int *valueIndex,
     double *   dataValue);
-
-/**
- * @brief Name of action for writing iteration checkpoint.
- *
- * Fortran syntax:
- * precicef_action_write_iter_checkpoint( CHARACTER nameAction(*) )
- */
-PRECICE_API void precicef_action_write_iter_checkp_(
-    char *nameAction,
-    int   lengthNameAction);
-
-/**
- * @brief Name of action for writing initial data.
- *
- * FortranSyntax:
- * precicef_action_write_initial_data( CHARACTER nameAction(*) )
- */
-PRECICE_API void precicef_action_write_initial_data_(
-    char *nameAction,
-    int   lengthNameAction);
-
-/**
- * @brief Name of action for reading iteration checkpoint.
- *
- * Fortran syntax:
- * precicef_action_read_iter_checkpoint( CHARACTER nameAction(*) )
- */
-PRECICE_API void precicef_action_read_iter_checkp_(
-    char *nameAction,
-    int   lengthNameAction);
 
 PRECICE_API void precicef_get_version_information_(
     char *versionInfo,

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -664,16 +664,16 @@ PRECICE_API void precicef_get_version_information_(
 
 /**
  * Fortran syntax:
- * precicef_is_gradient_data_required_(
+ * precicef_requires_gradient_data_for_(
  *   INTEGER dataID,
  *   INTEGER required )
  *
  * IN:  dataID
  * OUT: required(1:true, 0:false)
  *
- * @copydoc precice::SolverInterface::isGradientDataRequired
+ * @copydoc precice::SolverInterface::requiresGradientDataFor
  */
-PRECICE_API void precicef_is_gradient_data_required_(const int *dataID, int *required);
+PRECICE_API void precicef_requires_gradient_data_for_(const int *dataID, int *required);
 
 /**
  * Fortran syntax:

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -439,10 +439,10 @@ void precicef_get_mesh_vertices_and_IDs_(
   impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
 }
 
-void precicef_is_gradient_data_required_(const int *dataID, int *required)
+void precicef_requires_gradient_data_for_(const int *dataID, int *required)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  if (impl->isGradientDataRequired(*dataID)) {
+  if (impl->requiresGradientDataFor(*dataID)) {
     *required = 1;
   } else {
     *required = 0;

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -112,46 +112,25 @@ void precicef_is_time_window_complete_(
   }
 }
 
-void precicef_action_required_(
-    const char *action,
-    int *       isRequired,
-    int         lengthAction)
-{
-  precicef_is_action_required_(action, isRequired, lengthAction);
-}
-
-void precicef_is_action_required_(
-    const char *action,
-    int *       isRequired,
-    int         lengthAction)
+void precicef_requires_initial_data_(
+    int *isRequired)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  // PRECICE_ASSERT(lengthAction > 1);
-  // std::cout << "lengthAction: " << lengthAction << '\n';
-  // std::cout << "Action:";
-  // for (int i=0; i < lengthAction; i++){
-  //   std::cout << " a[" << i << "]=\"" << action[i] << "\"";
-  // }
-  // std::cout << '\n';
-  int strippedLength = precice::impl::strippedLength(action, lengthAction);
-  // std::cout << "strippedLength: " << strippedLength << '\n';
-  // PRECICE_ASSERT(strippedLength > 1);
-  string stringAction(action, strippedLength);
-  if (impl->isActionRequired(stringAction)) {
-    *isRequired = 1;
-  } else {
-    *isRequired = 0;
-  }
+  *isRequired = impl->requiresInitialData() ? 1 : 0;
 }
 
-void precicef_mark_action_fulfilled_(
-    const char *action,
-    int         lengthAction)
+void precicef_requires_writing_checkpoint_(
+    int *isRequired)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  int    strippedLength = precice::impl::strippedLength(action, lengthAction);
-  string stringAction(action, strippedLength);
-  impl->markActionFulfilled(stringAction);
+  *isRequired = impl->requiresWritingCheckpoint() ? 1 : 0;
+}
+
+void precicef_requires_reading_checkpoint_(
+    int *isRequired)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  *isRequired = impl->requiresReadingCheckpoint() ? 1 : 0;
 }
 
 void precicef_has_mesh_(
@@ -429,39 +408,6 @@ int precice::impl::strippedLength(
     i--;
   }
   return i + 1;
-}
-
-void precicef_action_write_iter_checkp_(
-    char *nameAction,
-    int   lengthNameAction)
-{
-  const std::string &name = precice::constants::actionWriteIterationCheckpoint();
-  PRECICE_ASSERT(name.size() < (size_t) lengthNameAction, name.size(), lengthNameAction);
-  for (size_t i = 0; i < name.size(); i++) {
-    nameAction[i] = name[i];
-  }
-}
-
-void precicef_action_write_initial_data_(
-    char *nameAction,
-    int   lengthNameAction)
-{
-  const std::string &name = precice::constants::actionWriteInitialData();
-  PRECICE_ASSERT(name.size() < (size_t) lengthNameAction, name.size(), lengthNameAction);
-  for (size_t i = 0; i < name.size(); i++) {
-    nameAction[i] = name[i];
-  }
-}
-
-void precicef_action_read_iter_checkp_(
-    char *nameAction,
-    int   lengthNameAction)
-{
-  const std::string &name = precice::constants::actionReadIterationCheckpoint();
-  PRECICE_ASSERT(name.size() < (size_t) lengthNameAction, name.size(), lengthNameAction);
-  for (size_t i = 0; i < name.size(); i++) {
-    nameAction[i] = name[i];
-  }
 }
 
 void precicef_get_version_information_(

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -187,12 +187,12 @@ void precicef_get_data_id_(
   *dataID = impl->getDataID(stringDataName, *meshID);
 }
 
-void precicef_is_mesh_connectivity_required_(
+void precicef_requires_mesh_connectivity_for_(
     const int *meshID,
     int *      required)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  if (impl->isMeshConnectivityRequired(*meshID)) {
+  if (impl->requiresMeshConnectivityFor(*meshID)) {
     *required = 1;
   } else {
     *required = 0;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -168,6 +168,9 @@ public:
   /// Returns true, if the given action has to be performed by the accessor.
   bool isActionRequired(const std::string &actionName) const override final;
 
+  /// Returns true, if the given action has to be performed by the accessor.
+  bool isActionFulfilled(const std::string &actionName) const override final;
+
   /// Tells the coupling scheme that the accessor has performed the given action.
   void markActionFulfilled(const std::string &actionName) override final;
 
@@ -437,7 +440,9 @@ private:
   /// True, if coupling has been initialized.
   bool _isInitialized = false;
 
-  std::set<std::string> _actions;
+  std::set<std::string> _requiredActions;
+
+  std::set<std::string> _fulfilledActions;
 
   /// Responsible for monitoring iteration count over time window.
   std::shared_ptr<io::TXTTableWriter> _iterationsWriter;

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -251,13 +251,29 @@ bool CompositionalCouplingScheme::isActionRequired(
   return isRequired;
 }
 
+bool CompositionalCouplingScheme::isActionFulfilled(
+    const std::string &actionName) const
+{
+  PRECICE_TRACE(actionName);
+  bool isFulfilled = false;
+  for (const Scheme &scheme : _couplingSchemes) {
+    if (not scheme.onHold) {
+      isFulfilled |= scheme.scheme->isActionFulfilled(actionName);
+    }
+  }
+  PRECICE_DEBUG("return {}", isFulfilled);
+  return isFulfilled;
+}
+
 void CompositionalCouplingScheme::markActionFulfilled(
     const std::string &actionName)
 {
   PRECICE_TRACE(actionName);
   for (const Scheme &scheme : _couplingSchemes) {
     if (not scheme.onHold) {
-      scheme.scheme->markActionFulfilled(actionName);
+      if (scheme.scheme->isActionRequired(actionName)) {
+        scheme.scheme->markActionFulfilled(actionName);
+      }
     }
   }
 }

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -195,6 +195,9 @@ public:
    */
   bool isActionRequired(const std::string &actionName) const final override;
 
+  /// Returns true, if the given action has been performed by the accessor.
+  bool isActionFulfilled(const std::string &actionName) const final override;
+
   /// Tells the coupling scheme that the accessor has performed the given action.
   void markActionFulfilled(const std::string &actionName) final override;
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -165,6 +165,9 @@ public:
   /// Returns true, if the given action has to be performed by the accessor.
   virtual bool isActionRequired(const std::string &actionName) const = 0;
 
+  /// Returns true, if the given action has already been performed by the accessor.
+  virtual bool isActionFulfilled(const std::string &actionName) const = 0;
+
   /// Tells the coupling scheme that the accessor has performed the given action.
   virtual void markActionFulfilled(const std::string &actionName) = 0;
 

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -180,6 +180,11 @@ public:
    */
   bool isActionRequired(const std::string &actionName) const override final;
 
+  bool isActionFulfilled(const std::string &actionName) const override final
+  {
+    return true;
+  }
+
   /**
    * @brief Not implemented.
    */

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -83,7 +83,7 @@ void runCoupling(
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
     cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
 
     while (cplScheme.isCouplingOngoing()) {
       dataValues0(index) += stepsizeData0;
@@ -107,7 +107,7 @@ void runCoupling(
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
         } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -125,7 +125,7 @@ void runCoupling(
         BOOST_TEST(iterationCount < *iterValidIterations);
         BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
         cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-        BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+        BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
         // The written data value is decreased in a regular manner, in order
         // to achieve a predictable convergence.
         stepsizeData0 -= 1.0;
@@ -148,7 +148,7 @@ void runCoupling(
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
     cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
 
     while (cplScheme.isCouplingOngoing()) {
       Eigen::VectorXd currentData(3);
@@ -175,7 +175,7 @@ void runCoupling(
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
         } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -195,7 +195,7 @@ void runCoupling(
         // The load checkpoint action requires to fallback to the cplScheme of the
         // first implicit iteration of the current timestep/time.
         cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-        BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+        BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
         // The written data value is decreased in a regular manner, in order
         // to achieve a predictable convergence.
         //stepsizeData1 -= 1.0;
@@ -248,7 +248,7 @@ void runCouplingWithSubcycling(
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
     cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
 
     double maxTimestepLength      = cplScheme.getNextTimestepMaxLength();
     double computedTimestepLength = maxTimestepLength / 2.0;
@@ -273,7 +273,7 @@ void runCouplingWithSubcycling(
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
         } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -296,7 +296,7 @@ void runCouplingWithSubcycling(
           BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
           // The written data value is decreased in a regular manner, in order
           // to achieve a predictable convergence.
           stepsizeData0 -= 1.0;
@@ -329,7 +329,7 @@ void runCouplingWithSubcycling(
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
     cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
 
     double maxTimestepLength       = cplScheme.getNextTimestepMaxLength();
     double preferredTimestepLength = maxTimestepLength / 2.5;
@@ -359,7 +359,7 @@ void runCouplingWithSubcycling(
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
         } else {
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -382,7 +382,7 @@ void runCouplingWithSubcycling(
           BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
           BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
           cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
           // The written data value is decreased in a regular manner, in order
           // to achieve a predictable convergence.
           stepsizeData1.array() -= 1.0;

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -89,9 +89,9 @@ std::set<int> SolverInterface::getMeshIDs() const
   return _impl->getMeshIDs();
 }
 
-bool SolverInterface::isMeshConnectivityRequired(int meshID) const
+bool SolverInterface::requiresMeshConnectivityFor(int meshID) const
 {
-  return _impl->isMeshConnectivityRequired(meshID);
+  return _impl->requiresMeshConnectivityFor(meshID);
 }
 
 bool SolverInterface::isGradientDataRequired(int dataID) const

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -94,9 +94,9 @@ bool SolverInterface::requiresMeshConnectivityFor(int meshID) const
   return _impl->requiresMeshConnectivityFor(meshID);
 }
 
-bool SolverInterface::isGradientDataRequired(int dataID) const
+bool SolverInterface::requiresGradientDataFor(int dataID) const
 {
-  return _impl->isGradientDataRequired(dataID);
+  return _impl->requiresGradientDataFor(dataID);
 }
 
 bool SolverInterface::hasData(

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -57,16 +57,19 @@ bool SolverInterface::isTimeWindowComplete() const
   return _impl->isTimeWindowComplete();
 }
 
-bool SolverInterface::isActionRequired(
-    const std::string &action) const
+bool SolverInterface::requiresInitialData()
 {
-  return _impl->isActionRequired(action);
+  return _impl->requiresInitialData();
 }
 
-void SolverInterface::markActionFulfilled(
-    const std::string &action)
+bool SolverInterface::requiresReadingCheckpoint()
 {
-  _impl->markActionFulfilled(action);
+  return _impl->requiresReadingCheckpoint();
+}
+
+bool SolverInterface::requiresWritingCheckpoint()
+{
+  return _impl->requiresWritingCheckpoint();
 }
 
 bool SolverInterface::hasMesh(
@@ -380,24 +383,5 @@ void SolverInterface::getMeshVerticesAndIDs(const int meshID,
 {
   _impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
 }
-
-namespace constants {
-
-const std::string &actionWriteInitialData()
-{
-  return cplscheme::constants::actionWriteInitialData();
-}
-
-const std::string &actionWriteIterationCheckpoint()
-{
-  return cplscheme::constants::actionWriteIterationCheckpoint();
-}
-
-const std::string &actionReadIterationCheckpoint()
-{
-  return cplscheme::constants::actionReadIterationCheckpoint();
-}
-
-} // namespace constants
 
 } // namespace precice

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -214,37 +214,47 @@ public:
 
   ///@}
 
-  ///@name Action Methods
+  ///@name Requirements
   ///@{
 
-  /**
-   * @brief Checks if the provided action is required.
+  /** Checks if the participant is required to provide initial data.
    *
-   * @param[in] action the name of the action
-   * @returns whether the action is required
+   * If true, then the participant needs to write initial data to defined vertices
+   * prior to calling initialize().
    *
-   * Some features of preCICE require a solver to perform specific actions, in
-   * order to be in valid state for a coupled simulation. A solver is made
-   * eligible to use those features, by querying for the required actions,
-   * performing them on demand, and calling markActionFulfilled() to signalize
-   * preCICE the correct behavior of the solver.
-   *
-   * @see markActionFulfilled()
-   * @see cplscheme::constants
+   * @pre initialize() has not yet been called
    */
-  bool isActionRequired(const std::string &action) const;
+  bool requiresInitialData();
 
-  /**
-   * @brief Indicates preCICE that a required action has been fulfilled by a solver.
+  /** Checks if the participant is required to write an iteration checkpoint.
    *
-   * @pre The solver fulfilled the specified action.
+   * If true, the participant is required to write an iteration checkpoint before
+   * calling advance().
    *
-   * @param[in] action the name of the action
+   * preCICE refuses to proceed if writing a checkpoint is required,
+   * but this method isn't called prior to advance().
    *
-   * @see requireAction()
-   * @see cplscheme::constants
+   * @pre initialize() has been called
+   *
+   * @see requiresReadingCheckpoint()
    */
-  void markActionFulfilled(const std::string &action);
+  bool requiresWritingCheckpoint();
+
+  /** Checks if the participant is required to read an iteration checkpoint.
+   *
+   * If true, the participant is required to read an iteration checkpoint before
+   * calling advance().
+   *
+   * preCICE refuses to proceed if reading a checkpoint is required,
+   * but this method isn't called prior to advance().
+   *
+   * @note This function returns false before the first call to advance().
+   *
+   * @pre initialize() has been called
+   *
+   * @see requiresWritingCheckpoint()
+   */
+  bool requiresReadingCheckpoint();
 
   ///@}
 
@@ -1214,18 +1224,5 @@ private:
   // @brief To allow white box tests.
   friend struct testing::WhiteboxAccessor;
 };
-
-namespace constants {
-
-// @brief Name of action for writing initial data.
-PRECICE_API const std::string &actionWriteInitialData();
-
-// @brief Name of action for writing iteration checkpoint
-PRECICE_API const std::string &actionWriteIterationCheckpoint();
-
-// @brief Name of action for reading iteration checkpoint.
-PRECICE_API const std::string &actionReadIterationCheckpoint();
-
-} // namespace constants
 
 } // namespace precice

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -1072,7 +1072,7 @@ public:
    * @param[in] dataID the id of the data
    * @returns whether gradient is required
    */
-  bool isGradientDataRequired(int dataID) const;
+  bool requiresGradientDataFor(int dataID) const;
 
   /**
    * @brief Writes vector gradient data given as block.

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -262,7 +262,7 @@ public:
    * @anchor precice-mesh-access
    *
    * Connectivity is optional.
-   * Use isMeshConnectivityRequired() to check if the current participant can make use of the connectivity.
+   * Use requiresMeshConnectivityFor() to check if the current participant can make use of the connectivity.
    *
    *
    * Always set the mesh connectivity of the highest dimensionality available.
@@ -328,7 +328,7 @@ public:
    * @param[in] meshID the id of the mesh
    * @returns whether connectivity is required
    */
-  bool isMeshConnectivityRequired(int meshID) const;
+  bool requiresMeshConnectivityFor(int meshID) const;
 
   /**
    * @brief Creates a mesh vertex
@@ -454,7 +454,7 @@ public:
    *
    * @pre vertices were added to the mesh with the ID meshID
    *
-   * @see isMeshConnectivityRequired()
+   * @see requiresMeshConnectivityFor()
    */
   void setMeshEdges(
       int        meshID,
@@ -477,7 +477,7 @@ public:
    *
    * @pre edges with firstVertexID, secondVertexID, and thirdVertexID were added to the mesh with the ID meshID
    *
-   * @see isMeshConnectivityRequired()
+   * @see requiresMeshConnectivityFor()
    */
   void setMeshTriangle(
       int meshID,
@@ -499,7 +499,7 @@ public:
    *
    * @pre vertices were added to the mesh with the ID meshID
    *
-   * @see isMeshConnectivityRequired()
+   * @see requiresMeshConnectivityFor()
    */
   void setMeshTriangles(
       int        meshID,
@@ -523,7 +523,7 @@ public:
    *
    * @pre vertices with firstVertexID, secondVertexID, thirdVertexID, and fourthVertexID were added to the mesh with the ID meshID
    *
-   * @see isMeshConnectivityRequired()
+   * @see requiresMeshConnectivityFor()
    */
   void setMeshQuad(
       int meshID,
@@ -548,7 +548,7 @@ public:
    *
    * @pre vertices were added to the mesh with the ID meshID
    *
-   * @see isMeshConnectivityRequired()
+   * @see requiresMeshConnectivityFor()
    */
   void setMeshQuads(
       int        meshID,
@@ -570,7 +570,7 @@ public:
    *
    * @pre vertices with firstVertexID, secondVertexID, thirdVertexID, and fourthVertexID were added to the mesh with the ID meshID
    *
-   * @see isMeshConnectivityRequired()
+   * @see requiresMeshConnectivityFor()
    */
   void setMeshTetrahedron(
       int meshID,
@@ -593,7 +593,7 @@ public:
    *
    * @pre vertices were added to the mesh with the ID meshID
    *
-   * @see isMeshConnectivityRequired()
+   * @see requiresMeshConnectivityFor()
    */
   void setMeshTetrahedra(
       int        meshID,

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -618,7 +618,7 @@ bool SolverInterfaceImpl::requiresMeshConnectivityFor(int meshID) const
   return context.meshRequirement == mapping::Mapping::MeshRequirement::FULL;
 }
 
-bool SolverInterfaceImpl::isGradientDataRequired(int dataID) const
+bool SolverInterfaceImpl::requiresGradientDataFor(int dataID) const
 {
   PRECICE_VALIDATE_DATA_ID(dataID);
   // Read data never requires gradients
@@ -1102,7 +1102,7 @@ void SolverInterfaceImpl::writeScalarGradientData(
   PRECICE_CHECK(_state != State::Finalized, "writeScalarGradientData(...) cannot be called after finalize().")
   PRECICE_REQUIRE_DATA_WRITE(dataID);
 
-  if (isGradientDataRequired(dataID)) {
+  if (requiresGradientDataFor(dataID)) {
     PRECICE_DEBUG("Gradient value = {}", Eigen::Map<const Eigen::VectorXd>(gradientValues, _dimensions).format(utils::eigenio::debug()));
     PRECICE_CHECK(gradientValues != nullptr, "writeScalarGradientData() was called with gradientValues == nullptr");
 
@@ -1161,7 +1161,7 @@ void SolverInterfaceImpl::writeBlockScalarGradientData(
   if (size == 0)
     return;
 
-  if (isGradientDataRequired(dataID)) {
+  if (requiresGradientDataFor(dataID)) {
 
     PRECICE_CHECK(valueIndices != nullptr, "writeBlockScalarGradientData() was called with valueIndices == nullptr");
     PRECICE_CHECK(gradientValues != nullptr, "writeBlockScalarGradientData() was called with gradientValues == nullptr");
@@ -1209,7 +1209,7 @@ void SolverInterfaceImpl::writeVectorGradientData(
   PRECICE_CHECK(_state != State::Finalized, "writeVectorGradientData(...) cannot be called after finalize().")
   PRECICE_REQUIRE_DATA_WRITE(dataID);
 
-  if (isGradientDataRequired(dataID)) {
+  if (requiresGradientDataFor(dataID)) {
 
     PRECICE_CHECK(gradientValues != nullptr, "writeVectorGradientData() was called with gradientValue == nullptr");
 
@@ -1259,7 +1259,7 @@ void SolverInterfaceImpl::writeBlockVectorGradientData(
   if (size == 0)
     return;
 
-  if (isGradientDataRequired(dataID)) {
+  if (requiresGradientDataFor(dataID)) {
 
     PRECICE_CHECK(valueIndices != nullptr, "writeBlockVectorGradientData() was called with valueIndices == nullptr");
     PRECICE_CHECK(gradientValues != nullptr, "writeBlockVectorGradientData() was called with gradientValues == nullptr");

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -611,7 +611,7 @@ int SolverInterfaceImpl::getDataID(
   return _accessor->getUsedDataID(dataName, meshID);
 }
 
-bool SolverInterfaceImpl::isMeshConnectivityRequired(int meshID) const
+bool SolverInterfaceImpl::requiresMeshConnectivityFor(int meshID) const
 {
   PRECICE_VALIDATE_MESH_ID(meshID);
   MeshContext &context = _accessor->usedMeshContext(meshID);

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -147,8 +147,8 @@ public:
   /// @copydoc SolverInterface::requiresMeshConnectivityFor
   bool requiresMeshConnectivityFor(int meshID) const;
 
-  /// @copydoc SolverInterface::isGradientDataRequired
-  bool isGradientDataRequired(int dataID) const;
+  /// @copydoc SolverInterface::requiresGradientDataFor
+  bool requiresGradientDataFor(int dataID) const;
 
   /// @copydoc SolverInterface::setMeshVertex
   int setMeshVertex(

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -114,14 +114,17 @@ public:
 
   ///@}
 
-  ///@name Action Methods
+  ///@name Requirements
   ///@{
 
-  /// @copydoc SolverInterface::isActionRequired
-  bool isActionRequired(const std::string &action) const;
+  /// @copydoc SolverInterface::requiresInitialData
+  bool requiresInitialData();
 
-  /// @copydoc SolverInterface::markActionFulfilled
-  void markActionFulfilled(const std::string &action);
+  /// @copydoc SolverInterface::requiresReadingCheckpoint
+  bool requiresReadingCheckpoint();
+
+  /// @copydoc SolverInterface::requiresWritingCheckpoint
+  bool requiresWritingCheckpoint();
 
   ///@}
 

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -144,8 +144,8 @@ public:
   /// @copydoc SolverInterface::getMeshIDs
   std::set<int> getMeshIDs() const;
 
-  /// @copydoc SolverInterface::isMeshConnectivityRequired
-  bool isMeshConnectivityRequired(int meshID) const;
+  /// @copydoc SolverInterface::requiresMeshConnectivityFor
+  bool requiresMeshConnectivityFor(int meshID) const;
 
   /// @copydoc SolverInterface::isGradientDataRequired
   bool isGradientDataRequired(int dataID) const;

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -43,8 +43,6 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
 {
   Eigen::Vector2d coordOneA{0.0, 0.0};
   Eigen::Vector2d coordOneB{1.0, 0.0};
-  std::string     writeIterCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string     readIterCheckpoint(constants::actionReadIterationCheckpoint());
 
   double valueA1 = 1.0;
   double valueA2 = 1.5;
@@ -68,14 +66,12 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
       BOOST_TEST(cplInterface.isCouplingOngoing());
       while (cplInterface.isCouplingOngoing()) {
         cplInterface.writeScalarData(dataABID, vertex1, valueA1);
-        if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-          cplInterface.markActionFulfilled(writeIterCheckpoint);
+        if (cplInterface.requiresWritingCheckpoint()) {
         }
 
         cplInterface.advance(maxDt);
 
-        if (cplInterface.isActionRequired(readIterCheckpoint)) {
-          cplInterface.markActionFulfilled(readIterCheckpoint);
+        if (cplInterface.requiresReadingCheckpoint()) {
         }
         cplInterface.readScalarData(dataBAID, vertex1, valueRead);
       }
@@ -93,14 +89,12 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
       BOOST_TEST(cplInterface.isCouplingOngoing());
       while (cplInterface.isCouplingOngoing()) {
         cplInterface.writeScalarData(dataABID, vertex2, valueA2);
-        if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-          cplInterface.markActionFulfilled(writeIterCheckpoint);
+        if (cplInterface.requiresWritingCheckpoint()) {
         }
 
         cplInterface.advance(maxDt);
 
-        if (cplInterface.isActionRequired(readIterCheckpoint)) {
-          cplInterface.markActionFulfilled(readIterCheckpoint);
+        if (cplInterface.requiresReadingCheckpoint()) {
         }
         cplInterface.readScalarData(dataBAID, vertex2, valueRead);
       }
@@ -133,14 +127,12 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
       cplInterface.writeScalarData(dataBAID, vertex2, valueB2);
       cplInterface.writeScalarData(dataBCID, vertex3, valueB1);
       cplInterface.writeScalarData(dataBCID, vertex4, valueB2);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataABID, vertex1, valueReadA1);
       cplInterface.readScalarData(dataABID, vertex2, valueReadA2);
@@ -171,14 +163,12 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
 
       cplInterface.writeScalarData(dataCBID, vertex1, valueC1);
       cplInterface.writeScalarData(dataCBID, vertex2, valueC2);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataBCID, vertex1, valueRead1);
       cplInterface.readScalarData(dataBCID, vertex2, valueRead2);

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
     interface.initialize();
-    BOOST_TEST(interface.isGradientDataRequired(dataID) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID) == false);
     Eigen::Vector2d values;
     interface.advance(1.0);
     interface.readBlockScalarData(dataID, 2, vertexIDs, values.data());
@@ -68,12 +68,12 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)
     interface.setMeshVertices(meshID, 6, positions, vertexIDs);
     interface.initialize();
     int dataID = interface.getDataID("Data2", meshID);
-    BOOST_TEST(interface.isGradientDataRequired(dataID));
+    BOOST_TEST(interface.requiresGradientDataFor(dataID));
     double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
 
     interface.writeBlockScalarData(dataID, 6, vertexIDs, values);
 
-    if (interface.isGradientDataRequired(dataID)) {
+    if (interface.requiresGradientDataFor(dataID)) {
 
       double gradientValues[12] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
       interface.writeBlockScalarGradientData(dataID, 6, vertexIDs, gradientValues);

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
@@ -52,11 +52,11 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
     double xCoord       = context.rank * 0.4 + 0.05;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
     interface.setMeshVertices(meshID, 2, positions, vertexIDs);
-    BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
-    BOOST_TEST(interface.isGradientDataRequired(dataID2) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID1) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID2) == false);
     interface.initialize();
-    BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
-    BOOST_TEST(interface.isGradientDataRequired(dataID2) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID1) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID2) == false);
     Eigen::Vector4d values;
     interface.advance(1.0);
     interface.readBlockVectorData(dataID2, 2, vertexIDs, values.data());
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
 
     DataID dataID1 = interface.getDataID("Data1", meshID);
     DataID dataID2 = interface.getDataID("Data2", meshID);
-    BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
-    BOOST_TEST(interface.isGradientDataRequired(dataID2) == true);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID1) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID2) == true);
 
     interface.initialize();
     double values[12] = {1.0, 1.0,
@@ -87,10 +87,10 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
 
     interface.writeBlockVectorData(dataID2, 6, vertexIDs, values);
 
-    BOOST_TEST(interface.isGradientDataRequired(dataID1) == false);
-    BOOST_TEST(interface.isGradientDataRequired(dataID2) == true);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID1) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID2) == true);
 
-    if (interface.isGradientDataRequired(dataID2)) {
+    if (interface.requiresGradientDataFor(dataID2)) {
       double gradientValues[36];
       for (int i = 0; i < 36; i++) {
         gradientValues[i] = 1.0;

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
       interface.advance(1.0);
       interface.readBlockVectorData(dataID, 1, &vertexIDs[0], values.data());
       Eigen::Vector3d expected(21.1, 24.8, 28.5);
-      BOOST_TEST(interface.isGradientDataRequired(dataID) == false);
+      BOOST_TEST(interface.requiresGradientDataFor(dataID) == false);
       BOOST_TEST(testing::equals(values, expected));
       interface.readBlockVectorData(dataID, 1, &vertexIDs[1], values.data());
       Eigen::Vector3d expected2(2.3, 4.2, 6.1);
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
       interface.advance(1.0);
       interface.readBlockVectorData(dataID, 1, vertexIDs.data(), values.data());
       Eigen::Vector3d expected(1., 2., 3.);
-      BOOST_TEST(interface.isGradientDataRequired(dataID) == false);
+      BOOST_TEST(interface.requiresGradientDataFor(dataID) == false);
       BOOST_TEST(testing::equals(values, expected));
     }
     interface.finalize();
@@ -81,9 +81,9 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
 
       interface.writeBlockVectorData(dataID, 4, vertexIDs.data(), values.data());
 
-      BOOST_TEST(interface.isGradientDataRequired(dataID) == true);
+      BOOST_TEST(interface.requiresGradientDataFor(dataID) == true);
 
-      if (interface.isGradientDataRequired(dataID)) {
+      if (interface.requiresGradientDataFor(dataID)) {
         std::vector<double> gradientValues;
         for (unsigned int i = 0; i < 36; ++i) {
           gradientValues.emplace_back(i);
@@ -100,9 +100,9 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
 
       interface.writeBlockVectorData(dataID, 1, vertexIDs.data(), values.data());
 
-      BOOST_TEST(interface.isGradientDataRequired(dataID) == true);
+      BOOST_TEST(interface.requiresGradientDataFor(dataID) == true);
 
-      if (interface.isGradientDataRequired(dataID)) {
+      if (interface.requiresGradientDataFor(dataID)) {
         std::vector<double> gradientValues;
         for (int i = 0; i < 9; ++i) {
           gradientValues.emplace_back(-i);

--- a/tests/parallel/quasi-newton/helpers.cpp
+++ b/tests/parallel/quasi-newton/helpers.cpp
@@ -54,8 +54,7 @@ void runTestQN(std::string const &config, TestContext const &context)
   int iterations = 0;
 
   while (interface.isCouplingOngoing()) {
-    if (interface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-      interface.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+    if (interface.requiresWritingCheckpoint()) {
     }
 
     interface.readBlockScalarData(readDataID, 4, vertexIDs, inValues);
@@ -85,8 +84,7 @@ void runTestQN(std::string const &config, TestContext const &context)
     interface.writeBlockScalarData(writeDataID, 4, vertexIDs, outValues);
     interface.advance(1.0);
 
-    if (interface.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-      interface.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+    if (interface.requiresReadingCheckpoint()) {
     }
     iterations++;
   }
@@ -150,8 +148,7 @@ void runTestQNEmptyPartition(std::string const &config, TestContext const &conte
   int iterations = 0;
 
   while (interface.isCouplingOngoing()) {
-    if (interface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-      interface.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+    if (interface.requiresWritingCheckpoint()) {
     }
 
     if ((context.isNamed("SolverOne") and context.isPrimary()) or
@@ -187,8 +184,7 @@ void runTestQNEmptyPartition(std::string const &config, TestContext const &conte
     }
     interface.advance(1.0);
 
-    if (interface.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-      interface.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+    if (interface.requiresReadingCheckpoint()) {
     }
     iterations++;
   }

--- a/tests/serial/AitkenAcceleration.cpp
+++ b/tests/serial/AitkenAcceleration.cpp
@@ -12,7 +12,6 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
 
   using Eigen::Vector2d;
-  using namespace precice::constants;
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
   Vector2d                 vertex{0.0, 0.0};
@@ -26,10 +25,14 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
     double value = 1.0;
     interface.writeScalarData(dataID, vertexID, value);
 
-    interface.markActionFulfilled(actionWriteIterationCheckpoint());
+    interface.requiresWritingCheckpoint();
     interface.advance(dt);
-    interface.markActionFulfilled(actionReadIterationCheckpoint());
+    interface.requiresReadingCheckpoint();
+
+    interface.requiresWritingCheckpoint();
     interface.advance(dt);
+    interface.requiresReadingCheckpoint();
+
     BOOST_TEST(not interface.isCouplingOngoing());
     interface.finalize();
 
@@ -40,15 +43,18 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
     int                   dataID   = interface.getDataID("Data", meshID);
 
     double dt = interface.initialize();
-    interface.markActionFulfilled(actionWriteIterationCheckpoint());
+    interface.requiresWritingCheckpoint();
     interface.advance(dt);
+    interface.requiresReadingCheckpoint();
 
     double value = -1.0;
     interface.readScalarData(dataID, vertexID, value);
     BOOST_TEST(value == 0.1); // due to initial underrelaxation
 
-    interface.markActionFulfilled(actionReadIterationCheckpoint());
+    interface.requiresWritingCheckpoint();
     interface.advance(dt);
+    interface.requiresReadingCheckpoint();
+
     BOOST_TEST(not interface.isCouplingOngoing());
     interface.finalize();
   }

--- a/tests/serial/TestExplicitWithDataMultipleReadWrite.cpp
+++ b/tests/serial/TestExplicitWithDataMultipleReadWrite.cpp
@@ -160,6 +160,8 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataMultipleReadWrite)
     Eigen::VectorXd writePositions(size * 3);
     vertexIDs[0] = cplInterface.setMeshVertex(meshTwoID, writePositions.data());
 
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
+
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
 
@@ -209,7 +211,6 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataMultipleReadWrite)
     BOOST_TEST(Vector3d(7.0, 7.0, 7.0) == writeDataA);
     cplInterface.writeVectorData(dataAID, vertexIDs[0], writeDataA.data());
 
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
     while (cplInterface.isCouplingOngoing()) {
       // multiple writeBlockScalarData

--- a/tests/serial/TestImplicit.cpp
+++ b/tests/serial/TestImplicit.cpp
@@ -18,7 +18,6 @@ BOOST_AUTO_TEST_CASE(TestImplicit)
   double initialStateChange = 5.0;
   double stateChange        = initialStateChange;
   int    computedTimesteps  = 0;
-  using namespace precice::constants;
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
 
@@ -45,13 +44,11 @@ BOOST_AUTO_TEST_CASE(TestImplicit)
 
     double maxDt = interface.initialize();
     while (interface.isCouplingOngoing()) {
-      if (interface.isActionRequired(actionWriteIterationCheckpoint())) {
-        interface.markActionFulfilled(actionWriteIterationCheckpoint());
+      if (interface.requiresWritingCheckpoint()) {
         checkpoint     = state;
         iterationCount = 1;
       }
-      if (interface.isActionRequired(actionReadIterationCheckpoint())) {
-        interface.markActionFulfilled(actionReadIterationCheckpoint());
+      if (interface.requiresReadingCheckpoint()) {
         state = checkpoint;
       }
       iterationCount++;
@@ -75,13 +72,11 @@ BOOST_AUTO_TEST_CASE(TestImplicit)
     interface.setMeshVertex(meshID, pos);
     double maxDt = interface.initialize();
     while (interface.isCouplingOngoing()) {
-      if (interface.isActionRequired(actionWriteIterationCheckpoint())) {
-        interface.markActionFulfilled(actionWriteIterationCheckpoint());
+      if (interface.requiresWritingCheckpoint()) {
         checkpoint     = state;
         iterationCount = 1;
       }
-      if (interface.isActionRequired(actionReadIterationCheckpoint())) {
-        interface.markActionFulfilled(actionReadIterationCheckpoint());
+      if (interface.requiresReadingCheckpoint()) {
         state = checkpoint;
         iterationCount++;
       }

--- a/tests/serial/TestReadAPI.cpp
+++ b/tests/serial/TestReadAPI.cpp
@@ -1,3 +1,4 @@
+#include <boost/test/tools/old/interface.hpp>
 #ifndef PRECICE_NO_MPI
 
 #include "testing/Testing.hpp"
@@ -29,13 +30,14 @@ BOOST_AUTO_TEST_CASE(TestReadAPI)
     int dataAID = cplInterface.getDataID("DataOne", meshOneID);
     int dataBID = cplInterface.getDataID("DataTwo", meshOneID);
 
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
+
     // writeVectorData
     writeDataA[0] = 7.0;
     writeDataA[1] = 7.0;
     writeDataA[2] = 7.0;
     cplInterface.writeVectorData(dataAID, vertexIDs[0], writeDataA.data());
 
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
 
     // readBlockScalarData without waveform
@@ -65,11 +67,9 @@ BOOST_AUTO_TEST_CASE(TestReadAPI)
     readDataB[0] = 0;
 
     while (cplInterface.isCouplingOngoing()) {
-      if (cplInterface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-        cplInterface.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
-      if (cplInterface.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-        cplInterface.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
 
       // writeVectorData
@@ -123,11 +123,12 @@ BOOST_AUTO_TEST_CASE(TestReadAPI)
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
 
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
+
     // writeScalarData
     writeDataB[0] = 3.0;
     cplInterface.writeScalarData(dataBID, vertexIDs[0], writeDataB[0]);
 
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
 
     // readBlockVectorData without waveform
@@ -165,11 +166,9 @@ BOOST_AUTO_TEST_CASE(TestReadAPI)
     readDataA[2] = 0;
 
     while (cplInterface.isCouplingOngoing()) {
-      if (cplInterface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-        cplInterface.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
-      if (cplInterface.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-        cplInterface.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
 
       // writeScalarData

--- a/tests/serial/access-received-mesh/Implicit.cpp
+++ b/tests/serial/access-received-mesh/Implicit.cpp
@@ -58,8 +58,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
 
     std::vector<double> readData(ownIDs.size(), -10);
     while (couplingInterface.isCouplingOngoing()) {
-      if (couplingInterface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-        couplingInterface.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+      if (couplingInterface.requiresWritingCheckpoint()) {
       }
 
       // Write data
@@ -68,8 +67,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
       dt = couplingInterface.advance(dt);
       couplingInterface.readBlockScalarData(ownDataID, ownIDs.size(),
                                             ownIDs.data(), readData.data());
-      if (couplingInterface.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-        couplingInterface.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+      if (couplingInterface.requiresReadingCheckpoint()) {
       }
 
       // Expected data according to the writeData
@@ -110,8 +108,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
     std::vector<double> readData(ownIDs.size(), -10);
 
     while (couplingInterface.isCouplingOngoing()) {
-      if (couplingInterface.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-        couplingInterface.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+      if (couplingInterface.requiresWritingCheckpoint()) {
       }
 
       // Write data
@@ -120,8 +117,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
       dt = couplingInterface.advance(dt);
       couplingInterface.readBlockScalarData(ownDataID, ownIDs.size(),
                                             ownIDs.data(), readData.data());
-      if (couplingInterface.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-        couplingInterface.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+      if (couplingInterface.requiresReadingCheckpoint()) {
       }
 
       // Expected data according to the writeData

--- a/tests/serial/action-timings/ActionTimingsExplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsExplicit.cpp
@@ -16,7 +16,6 @@ BOOST_AUTO_TEST_CASE(ActionTimingsExplicit)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
-  using namespace precice::constants;
   using namespace precice;
   SolverInterface interface(context.name, context.config(), 0, 1);
 
@@ -49,12 +48,10 @@ BOOST_AUTO_TEST_CASE(ActionTimingsExplicit)
   action::RecorderAction::reset();
   std::vector<double> writeData(dimensions, writeValue);
   std::vector<double> readData(dimensions, -1);
-  const std::string & cowid = actionWriteInitialData();
 
-  if (interface.isActionRequired(cowid)) {
+  if (interface.requiresInitialData()) {
     BOOST_TEST(context.isNamed("SolverTwo"));
     interface.writeVectorData(writeDataID, vertexID, writeData.data());
-    interface.markActionFulfilled(cowid);
   }
 
   dt = interface.initialize();

--- a/tests/serial/convergence-measures/helpers.cpp
+++ b/tests/serial/convergence-measures/helpers.cpp
@@ -8,7 +8,6 @@
 void testConvergenceMeasures(const std::string configFile, TestContext const &context, std::vector<int> &expectedIterations)
 {
   using Eigen::Vector2d;
-  using namespace precice::constants;
 
   std::string meshName = context.isNamed("SolverOne") ? "MeshOne" : "MeshTwo";
 
@@ -27,9 +26,8 @@ void testConvergenceMeasures(const std::string configFile, TestContext const &co
   int timestep             = 0;
 
   while (interface.isCouplingOngoing()) {
-    if (interface.isActionRequired(actionWriteIterationCheckpoint())) {
+    if (interface.requiresWritingCheckpoint()) {
       numberOfIterations = 0;
-      interface.markActionFulfilled(actionWriteIterationCheckpoint());
     }
 
     if (context.isNamed("SolverTwo")) {
@@ -41,8 +39,7 @@ void testConvergenceMeasures(const std::string configFile, TestContext const &co
     ++numberOfAdvanceCalls;
     ++numberOfIterations;
 
-    if (interface.isActionRequired(actionReadIterationCheckpoint())) {
-      interface.markActionFulfilled(actionReadIterationCheckpoint());
+    if (interface.requiresReadingCheckpoint()) {
     } else { //converged
       BOOST_TEST(numberOfIterations == expectedIterations.at(timestep));
       ++timestep;

--- a/tests/serial/initialize-data/Explicit.cpp
+++ b/tests/serial/initialize-data/Explicit.cpp
@@ -1,3 +1,4 @@
+#include <boost/test/tools/old/interface.hpp>
 #ifndef PRECICE_NO_MPI
 
 #include "testing/Testing.hpp"
@@ -46,11 +47,12 @@ BOOST_AUTO_TEST_CASE(Explicit)
     int      meshTwoID = cplInterface.getMeshID("MeshTwo");
     Vector3d pos       = Vector3d::Zero();
     cplInterface.setMeshVertex(meshTwoID, pos.data());
+
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
     cplInterface.writeScalarData(dataBID, 0, 2.0);
     //tell preCICE that data has been written and call initializeData
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double   maxDt = cplInterface.initialize();
     Vector3d valueDataA;
     cplInterface.readVectorData(dataAID, 0, valueDataA.data());

--- a/tests/serial/initialize-data/ImplicitBoth.cpp
+++ b/tests/serial/initialize-data/ImplicitBoth.cpp
@@ -19,8 +19,6 @@ BOOST_AUTO_TEST_CASE(ImplicitBoth)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
-  using namespace precice::constants;
-
   SolverInterface couplingInterface(context.name, context.config(), 0, 1);
 
   int         dimensions = couplingInterface.getDimensions();
@@ -52,26 +50,22 @@ BOOST_AUTO_TEST_CASE(ImplicitBoth)
   double              dt = 0;
   std::vector<double> writeData(dimensions, writeValue);
   std::vector<double> readData(dimensions, -1);
-  const std::string & cowid = actionWriteInitialData();
 
-  if (couplingInterface.isActionRequired(cowid)) {
+  if (couplingInterface.requiresInitialData()) {
     couplingInterface.writeVectorData(writeDataID, vertexID, writeData.data());
-    couplingInterface.markActionFulfilled(cowid);
   }
 
   dt = couplingInterface.initialize();
 
   while (couplingInterface.isCouplingOngoing()) {
-    if (couplingInterface.isActionRequired(actionWriteIterationCheckpoint())) {
-      couplingInterface.markActionFulfilled(actionWriteIterationCheckpoint());
+    if (couplingInterface.requiresWritingCheckpoint()) {
     }
     couplingInterface.readVectorData(readDataID, vertexID, readData.data());
     BOOST_TEST(expectedReadValue == readData.at(0));
     BOOST_TEST(expectedReadValue == readData.at(1));
     couplingInterface.writeVectorData(writeDataID, vertexID, writeData.data());
     dt = couplingInterface.advance(dt);
-    if (couplingInterface.isActionRequired(actionReadIterationCheckpoint())) {
-      couplingInterface.markActionFulfilled(actionReadIterationCheckpoint());
+    if (couplingInterface.requiresReadingCheckpoint()) {
     }
   }
   couplingInterface.finalize();

--- a/tests/serial/initialize-data/helpers.cpp
+++ b/tests/serial/initialize-data/helpers.cpp
@@ -28,10 +28,12 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
     int      meshTwoID = cplInterface.getMeshID("MeshTwo");
     Vector3d pos       = Vector3d::Zero();
     cplInterface.setMeshVertex(meshTwoID, pos.data());
+
+    //tell preCICE that data has been written
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
+
     int dataID = cplInterface.getDataID("Data", meshTwoID);
     cplInterface.writeScalarData(dataID, 0, 2.0);
-    //tell preCICE that data has been written and call initialize
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     cplInterface.initialize();
     cplInterface.finalize();
   }

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
@@ -78,12 +78,13 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)
 
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
     BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == false);
+
     double valueDataB = 1.0;
     cplInterface.writeScalarData(dataBID, 0, valueDataB);
 
     //tell preCICE that data has been written and call initialize
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
 
     while (cplInterface.isCouplingOngoing()) {

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)
 
       cplInterface.writeScalarData(dataAID, 0, 3.0);
       Vector3d valueGradDataA(1.0, 2.0, 3.0);
-      BOOST_TEST(cplInterface.isGradientDataRequired(dataAID));
+      BOOST_TEST(cplInterface.requiresGradientDataFor(dataAID));
       cplInterface.writeScalarGradientData(dataAID, 0, valueGradDataA.data());
 
       maxDt = cplInterface.advance(maxDt);
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
     BOOST_REQUIRE(cplInterface.requiresInitialData());
-    BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == false);
+    BOOST_TEST(cplInterface.requiresGradientDataFor(dataBID) == false);
 
     double valueDataB = 1.0;
     cplInterface.writeScalarData(dataBID, 0, valueDataB);

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
@@ -55,7 +55,6 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadVector)
 
     Vector3d valueDataB;
 
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
     cplInterface.readVectorData(dataBID, 0, valueDataB.data());
     Vector3d expected(2.0, 3.0, 4.0);
@@ -85,11 +84,11 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadVector)
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
 
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
     Vector3d valueDataB(2.0, 3.0, 4.0);
     cplInterface.writeVectorData(dataBID, 0, valueDataB.data());
 
     //tell preCICE that data has been written and call initialize
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
 
     Vector3d valueDataA;

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp
@@ -42,7 +42,6 @@ BOOST_AUTO_TEST_SUITE(MappingNearestNeighborGradient)
 BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteScalar)
 {
 
-  //precice.isActionRequired(precice::constants::actionWriteInitialData()
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   using Eigen::Vector2d;
   using Eigen::Vector3d;
@@ -78,6 +77,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteScalar)
 
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
 
     double   valueDataB = 1.0;
     Vector3d valueGradDataB(1.0, 1.0, 1.0);
@@ -85,7 +85,6 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteScalar)
     cplInterface.writeScalarGradientData(dataBID, 0, valueGradDataB.data());
 
     //tell preCICE that data has been written and call initialize
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
 
     Vector3d valueDataA;

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
@@ -51,8 +51,8 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
     cplInterface.setMeshVertex(meshOneID, posOne.data());
     int dataAID = cplInterface.getDataID("DataOne", meshOneID);
     int dataBID = cplInterface.getDataID("DataTwo", meshOneID);
-    BOOST_TEST(cplInterface.isGradientDataRequired(dataAID) == false);
-    BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == false);
+    BOOST_TEST(cplInterface.requiresGradientDataFor(dataAID) == false);
+    BOOST_TEST(cplInterface.requiresGradientDataFor(dataBID) == false);
     BOOST_REQUIRE(cplInterface.requiresInitialData());
 
     Vector3d valueDataA(1.0, 1.0, 1.0);
@@ -85,8 +85,8 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
 
     int dataAID = cplInterface.getDataID("DataOne", meshTwoID);
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
-    BOOST_TEST(cplInterface.isGradientDataRequired(dataAID) == false);
-    BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == true);
+    BOOST_TEST(cplInterface.requiresGradientDataFor(dataAID) == false);
+    BOOST_TEST(cplInterface.requiresGradientDataFor(dataBID) == true);
     BOOST_REQUIRE(cplInterface.requiresInitialData());
 
     Vector3d                    valueDataB(2.0, 3.0, 4.0);

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
@@ -53,11 +53,11 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
     int dataBID = cplInterface.getDataID("DataTwo", meshOneID);
     BOOST_TEST(cplInterface.isGradientDataRequired(dataAID) == false);
     BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == false);
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
 
     Vector3d valueDataA(1.0, 1.0, 1.0);
     cplInterface.writeVectorData(dataAID, 0, valueDataA.data());
 
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
 
     Vector3d valueDataB;
@@ -87,6 +87,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
     int dataBID = cplInterface.getDataID("DataTwo", meshTwoID);
     BOOST_TEST(cplInterface.isGradientDataRequired(dataAID) == false);
     BOOST_TEST(cplInterface.isGradientDataRequired(dataBID) == true);
+    BOOST_REQUIRE(cplInterface.requiresInitialData());
 
     Vector3d                    valueDataB(2.0, 3.0, 4.0);
     Eigen::Matrix<double, 3, 3> gradient;
@@ -95,7 +96,6 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
     cplInterface.writeVectorGradientData(dataBID, 0, gradient.data());
 
     //tell preCICE that data has been written and call initialize
-    cplInterface.markActionFulfilled(precice::constants::actionWriteInitialData());
     double maxDt = cplInterface.initialize();
 
     Vector3d valueDataA;

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
@@ -62,9 +62,9 @@ BOOST_AUTO_TEST_CASE(GradientTestUnidirectionalReadScalar)
     int    indices[2] = {0, 1};
     cplInterface.writeBlockScalarData(dataID, 2, indices, values);
 
-    BOOST_TEST(cplInterface.isGradientDataRequired(dataID) == true);
+    BOOST_TEST(cplInterface.requiresGradientDataFor(dataID) == true);
 
-    if (cplInterface.isGradientDataRequired(dataID)) {
+    if (cplInterface.requiresGradientDataFor(dataID)) {
       double gradientValues[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
       cplInterface.writeBlockScalarGradientData(dataID, 2, indices, gradientValues);
     }

--- a/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
@@ -30,9 +30,9 @@ void testVectorGradientFunctions(const TestContext &context, const bool writeBlo
     int    indices[2] = {0, 1};
     interface.writeBlockVectorData(dataID, 2, indices, values);
 
-    BOOST_TEST(interface.isGradientDataRequired(dataID) == true);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID) == true);
 
-    if (interface.isGradientDataRequired(dataID)) {
+    if (interface.requiresGradientDataFor(dataID)) {
 
       std::vector<double> gradientValues({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
                                           10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0});
@@ -62,7 +62,7 @@ void testVectorGradientFunctions(const TestContext &context, const bool writeBlo
     interface.setMeshVertex(meshTwoID, posTwo.data());
 
     double maxDt = interface.initialize();
-    BOOST_TEST(interface.isGradientDataRequired(dataID) == false);
+    BOOST_TEST(interface.requiresGradientDataFor(dataID) == false);
     BOOST_TEST(interface.isCouplingOngoing(), "Receiving participant should have to advance once!");
 
     double valueData[6];

--- a/tests/serial/mapping-nearest-projection/helpers.cpp
+++ b/tests/serial/mapping-nearest-projection/helpers.cpp
@@ -71,7 +71,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFuncti
 
     // Write the data to be send.
     int dataAID = interface.getDataID("DataOne", meshOneID);
-    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+    BOOST_TEST(!interface.requiresGradientDataFor(dataAID));
 
     interface.writeScalarData(dataAID, idA, valOneA);
     interface.writeScalarData(dataAID, idB, valOneB);
@@ -99,7 +99,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFuncti
 
     // Read the mapped data from the mesh.
     int dataAID = interface.getDataID("DataOne", meshTwoID);
-    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+    BOOST_TEST(!interface.requiresGradientDataFor(dataAID));
 
     double valueA, valueB, valueC;
     interface.readScalarData(dataAID, idA, valueA);

--- a/tests/serial/mapping-rbf-gaussian/helpers.cpp
+++ b/tests/serial/mapping-rbf-gaussian/helpers.cpp
@@ -65,7 +65,7 @@ void testRBFMapping(const std::string configFile, const TestContext &context)
     BOOST_TEST(interface.isCouplingOngoing(), "Sending participant should have to advance once!");
     // Write the data to be send.
     int dataAID = interface.getDataID("DataOne", meshOneID);
-    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+    BOOST_TEST(!interface.requiresGradientDataFor(dataAID));
 
     interface.writeBlockScalarData(dataAID, nCoords, ids.data(), values.data());
 
@@ -90,7 +90,7 @@ void testRBFMapping(const std::string configFile, const TestContext &context)
 
     // Read the mapped data from the mesh.
     int dataAID = interface.getDataID("DataOne", meshTwoID);
-    BOOST_TEST(!interface.isGradientDataRequired(dataAID));
+    BOOST_TEST(!interface.requiresGradientDataFor(dataAID));
 
     double valueA, valueB, valueC;
     interface.readScalarData(dataAID, idA, valueA);

--- a/tests/serial/mesh-requirements/NearestNeighborA.cpp
+++ b/tests/serial/mesh-requirements/NearestNeighborA.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(NearestNeighborA)
   PRECICE_TEST(1_rank);
   precice::SolverInterface interface("A", context.config(), 0, 1);
   auto                     meshID = interface.getMeshID("MeshA");
-  BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
+  BOOST_TEST(!interface.requiresMeshConnectivityFor(meshID));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/mesh-requirements/NearestNeighborB.cpp
+++ b/tests/serial/mesh-requirements/NearestNeighborB.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(NearestNeighborB)
   PRECICE_TEST(1_rank);
   precice::SolverInterface interface("B", context.config(), 0, 1);
   auto                     meshID = interface.getMeshID("MeshB");
-  BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
+  BOOST_TEST(!interface.requiresMeshConnectivityFor(meshID));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/mesh-requirements/NearestProjection2DA.cpp
+++ b/tests/serial/mesh-requirements/NearestProjection2DA.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(NearestProjection2DA)
   PRECICE_TEST(1_rank);
   precice::SolverInterface interface("A", context.config(), 0, 1);
   auto                     meshID = interface.getMeshID("MeshA");
-  BOOST_TEST(interface.isMeshConnectivityRequired(meshID));
+  BOOST_TEST(interface.requiresMeshConnectivityFor(meshID));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/mesh-requirements/NearestProjection2DB.cpp
+++ b/tests/serial/mesh-requirements/NearestProjection2DB.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(NearestProjection2DB)
   PRECICE_TEST(1_rank);
   precice::SolverInterface interface("B", context.config(), 0, 1);
   auto                     meshID = interface.getMeshID("MeshB");
-  BOOST_TEST(!interface.isMeshConnectivityRequired(meshID));
+  BOOST_TEST(!interface.requiresMeshConnectivityFor(meshID));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/multi-coupling/MultiCoupling.cpp
+++ b/tests/serial/multi-coupling/MultiCoupling.cpp
@@ -36,9 +36,6 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
   data << 4.0, 5.0;
   datas.push_back(data);
 
-  std::string writeIterCheckpoint(precice::constants::actionWriteIterationCheckpoint());
-  std::string readIterCheckpoint(precice::constants::actionReadIterationCheckpoint());
-
   if (context.isNamed("SOLIDZ1") ||
       context.isNamed("SOLIDZ2") ||
       context.isNamed("SOLIDZ3")) {
@@ -76,12 +73,10 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
       precice.writeVectorData(dataWriteID, vertexIDs.at(i), datas.at(i).data());
     }
 
-    if (precice.isActionRequired(writeIterCheckpoint)) {
-      precice.markActionFulfilled(writeIterCheckpoint);
+    if (precice.requiresWritingCheckpoint()) {
     }
     precice.advance(0.0001);
-    if (precice.isActionRequired(readIterCheckpoint)) {
-      precice.markActionFulfilled(readIterCheckpoint);
+    if (precice.requiresReadingCheckpoint()) {
     }
 
     for (size_t i = 0; i < 4; i++) {
@@ -135,12 +130,10 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
       precice.writeVectorData(dataWriteID3, vertexIDs3.at(i), datas.at(i).data());
     }
 
-    if (precice.isActionRequired(writeIterCheckpoint)) {
-      precice.markActionFulfilled(writeIterCheckpoint);
+    if (precice.requiresWritingCheckpoint()) {
     }
     precice.advance(0.0001);
-    if (precice.isActionRequired(readIterCheckpoint)) {
-      precice.markActionFulfilled(readIterCheckpoint);
+    if (precice.requiresReadingCheckpoint()) {
     }
 
     precice.finalize();

--- a/tests/serial/multi-coupling/helpers.cpp
+++ b/tests/serial/multi-coupling/helpers.cpp
@@ -11,8 +11,6 @@ using namespace precice;
 void multiCouplingThreeSolvers(const std::string configFile, const TestContext &context)
 {
   Eigen::Vector2d coordOneA{0.0, 0.0};
-  std::string     writeIterCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string     readIterCheckpoint(constants::actionReadIterationCheckpoint());
 
   double valueA = 1.0;
   double valueB = 2.0;
@@ -31,14 +29,12 @@ void multiCouplingThreeSolvers(const std::string configFile, const TestContext &
     BOOST_TEST(cplInterface.isCouplingOngoing());
     while (cplInterface.isCouplingOngoing()) {
       cplInterface.writeScalarData(dataABID, vertexID, valueA);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataBAID, vertexID, valueRead);
     }
@@ -64,14 +60,12 @@ void multiCouplingThreeSolvers(const std::string configFile, const TestContext &
     while (cplInterface.isCouplingOngoing()) {
       cplInterface.writeScalarData(dataBAID, vertexID1, valueB);
       cplInterface.writeScalarData(dataBCID, vertexID2, valueB);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataABID, vertexID1, valueReadA);
       cplInterface.readScalarData(dataCBID, vertexID2, valueReadC);
@@ -96,14 +90,12 @@ void multiCouplingThreeSolvers(const std::string configFile, const TestContext &
     while (cplInterface.isCouplingOngoing()) {
 
       cplInterface.writeScalarData(dataCBID, vertexID, valueC);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataBCID, vertexID, valueRead);
     }
@@ -117,8 +109,6 @@ void multiCouplingThreeSolvers(const std::string configFile, const TestContext &
 void multiCouplingFourSolvers(const std::string configFile, const TestContext &context)
 {
   Eigen::Vector2d coordOneA{0.0, 0.0};
-  std::string     writeIterCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string     readIterCheckpoint(constants::actionReadIterationCheckpoint());
 
   if (context.isNamed("SolverA")) {
     SolverInterface cplInterface("SolverA", configFile, 0, 1);
@@ -134,14 +124,12 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
     BOOST_TEST(cplInterface.isCouplingOngoing());
     while (cplInterface.isCouplingOngoing()) {
       cplInterface.writeScalarData(dataABID, vertexID, valueWrite);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataBAID, vertexID, valueRead);
     }
@@ -165,14 +153,12 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
     while (cplInterface.isCouplingOngoing()) {
       cplInterface.writeScalarData(dataBAID, vertexID1, valueWriteA);
       cplInterface.writeScalarData(dataBCID, vertexID2, valueWriteC);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataABID, vertexID1, valueReadA);
       cplInterface.readScalarData(dataCBID, vertexID2, valueReadC);
@@ -198,14 +184,12 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
     while (cplInterface.isCouplingOngoing()) {
       cplInterface.writeScalarData(dataCBID, vertexID1, valueWriteA);
       cplInterface.writeScalarData(dataCDID, vertexID2, valueWriteC);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataBCID, vertexID1, valueReadA);
       cplInterface.readScalarData(dataDCID, vertexID2, valueReadC);
@@ -225,14 +209,12 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
     BOOST_TEST(cplInterface.isCouplingOngoing());
     while (cplInterface.isCouplingOngoing()) {
       cplInterface.writeScalarData(dataDCID, vertexID, valueWrite);
-      if (cplInterface.isActionRequired(writeIterCheckpoint)) {
-        cplInterface.markActionFulfilled(writeIterCheckpoint);
+      if (cplInterface.requiresWritingCheckpoint()) {
       }
 
       cplInterface.advance(maxDt);
 
-      if (cplInterface.isActionRequired(readIterCheckpoint)) {
-        cplInterface.markActionFulfilled(readIterCheckpoint);
+      if (cplInterface.requiresReadingCheckpoint()) {
       }
       cplInterface.readScalarData(dataCDID, vertexID, valueRead);
     }

--- a/tests/serial/multiple-mappings/MultipleReadFromMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleReadFromMappings.cpp
@@ -13,7 +13,6 @@ BOOST_AUTO_TEST_CASE(MultipleReadFromMappings)
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
 
   using Eigen::Vector2d;
-  using namespace precice::constants;
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
   Vector2d                 vertex{0.0, 0.0};

--- a/tests/serial/multiple-mappings/MultipleReadToMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleReadToMappings.cpp
@@ -13,7 +13,6 @@ BOOST_AUTO_TEST_CASE(MultipleReadToMappings)
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
 
   using Eigen::Vector2d;
-  using namespace precice::constants;
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
   Vector2d                 vertex{0.0, 0.0};

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappings.cpp
@@ -13,7 +13,6 @@ BOOST_AUTO_TEST_CASE(MultipleWriteFromMappings)
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
 
   using Eigen::Vector2d;
-  using namespace precice::constants;
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
   Vector2d                 vertex1{0.0, 0.0};

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.cpp
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.cpp
@@ -13,7 +13,6 @@ BOOST_AUTO_TEST_CASE(MultipleWriteFromMappingsAndData)
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
 
   using Eigen::Vector2d;
-  using namespace precice::constants;
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
   Vector2d                 vertex1{0.0, 0.0};

--- a/tests/serial/multiple-mappings/MultipleWriteToMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleWriteToMappings.cpp
@@ -13,7 +13,6 @@ BOOST_AUTO_TEST_CASE(MultipleWriteToMappings)
   PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
 
   using Eigen::Vector2d;
-  using namespace precice::constants;
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
   Vector2d                 vertex{0.0, 0.0};

--- a/tests/serial/three-solvers/helpers.cpp
+++ b/tests/serial/three-solvers/helpers.cpp
@@ -13,9 +13,6 @@
  */
 void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCallsOfAdvance, TestContext const &context)
 {
-  std::string writeIterCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterCheckpoint(constants::actionReadIterationCheckpoint());
-  std::string writeInitData(constants::actionWriteInitialData());
 
   int callsOfAdvance = 0;
 
@@ -27,18 +24,15 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
     precice.setMeshVertex(meshAID, Eigen::Vector2d(0, 0).data());
     precice.setMeshVertex(meshBID, Eigen::Vector2d(1, 1).data());
 
-    if (precice.isActionRequired(writeInitData)) {
-      precice.markActionFulfilled(writeInitData);
+    if (precice.requiresInitialData()) {
     }
     double dt = precice.initialize();
 
     while (precice.isCouplingOngoing()) {
-      if (precice.isActionRequired(writeIterCheckpoint)) {
-        precice.markActionFulfilled(writeIterCheckpoint);
+      if (precice.requiresWritingCheckpoint()) {
       }
       dt = precice.advance(dt);
-      if (precice.isActionRequired(readIterCheckpoint)) {
-        precice.markActionFulfilled(readIterCheckpoint);
+      if (precice.requiresReadingCheckpoint()) {
       }
       callsOfAdvance++;
     }
@@ -50,18 +44,15 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
     MeshID meshID = precice.getMeshID("MeshC");
     precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
 
-    if (precice.isActionRequired(writeInitData)) {
-      precice.markActionFulfilled(writeInitData);
+    if (precice.requiresInitialData()) {
     }
     double dt = precice.initialize();
 
     while (precice.isCouplingOngoing()) {
-      if (precice.isActionRequired(writeIterCheckpoint)) {
-        precice.markActionFulfilled(writeIterCheckpoint);
+      if (precice.requiresWritingCheckpoint()) {
       }
       dt = precice.advance(dt);
-      if (precice.isActionRequired(readIterCheckpoint)) {
-        precice.markActionFulfilled(readIterCheckpoint);
+      if (precice.requiresReadingCheckpoint()) {
       }
       callsOfAdvance++;
     }
@@ -74,18 +65,15 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
     MeshID meshID = precice.getMeshID("MeshD");
     precice.setMeshVertex(meshID, Eigen::Vector2d(0, 0).data());
 
-    if (precice.isActionRequired(writeInitData)) {
-      precice.markActionFulfilled(writeInitData);
+    if (precice.requiresInitialData()) {
     }
     double dt = precice.initialize();
 
     while (precice.isCouplingOngoing()) {
-      if (precice.isActionRequired(writeIterCheckpoint)) {
-        precice.markActionFulfilled(writeIterCheckpoint);
+      if (precice.requiresWritingCheckpoint()) {
       }
       dt = precice.advance(dt);
-      if (precice.isActionRequired(readIterCheckpoint)) {
-        precice.markActionFulfilled(readIterCheckpoint);
+      if (precice.requiresReadingCheckpoint()) {
       }
       callsOfAdvance++;
     }

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
@@ -64,10 +64,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   double time       = 0;
   int    timewindow = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt = precice.initialize();

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -64,10 +64,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   int    timewindow = 0;
   double time       = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt = precice.initialize();

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipantInitData)
   }
 
   VertexID vertexID = precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-  precice.markActionFulfilled(precice::constants::actionWriteInitialData());
+  precice.requiresInitialData(); // TODO fix
   double dt = precice.initialize();
 
   for (int i = 0; i < timestepSizes.size(); i++) {

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -63,10 +63,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   int    timewindow = 0;
   double time       = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt = precice.initialize();

--- a/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
@@ -51,17 +51,15 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
   double currentDt = dt;                   // Timestep length used by solver
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       totalCompletedTimesteps += timestepsInThisWindow;
       timestepsInThisWindow = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     maxDt     = precice.advance(currentDt);
     currentDt = dt > maxDt ? maxDt : dt;
     totalSolves++;
     timestepsInThisWindow++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+    if (precice.requiresReadingCheckpoint()) {
       timestepsInThisWindow = 0;
     }
   }

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -79,10 +79,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   int    iterations      = 0;
   double time            = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt     = precice.initialize();
@@ -91,10 +90,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   double currentDt = dt;                   // Timestep length used by solver
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
 
     for (auto &readDataPair : readDataPairs) {
@@ -121,11 +119,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
     currentDt = dt > maxDt ? maxDt : dt;
     BOOST_CHECK(currentDt == windowDt / nSubsteps); // no subcycling.
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -76,10 +76,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
   int    iterations      = 0;
   double time            = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt        = precice.initialize();
@@ -91,10 +90,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
   double sampleDt; // dt relative to timestep start, where we are sampling
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
 
     for (int j = 0; j < nSamples; j++) {
@@ -125,11 +123,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
     currentDt = dt > maxDt ? maxDt : dt;
     BOOST_CHECK(currentDt == windowDt); // no subcycling.
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -67,10 +67,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   int    iterations      = 0;
   double time            = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt = precice.initialize();
@@ -81,10 +80,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual timestep length; must fit into remaining time in window
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
 
     precice.readScalarData(readDataID, vertexID, readData);
@@ -107,11 +105,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
     maxDt     = precice.advance(currentDt);
     currentDt = dt > maxDt ? maxDt : dt;
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       iterations++;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -65,10 +65,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
   int    iterations      = 0;
   double time            = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt        = precice.initialize();
@@ -80,10 +79,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
   double sampleDt; // dt relative to timestep start, where we are sampling
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
 
     for (int j = 0; j < nSamples; j++) {
@@ -109,11 +107,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
     currentDt = dt > maxDt ? maxDt : dt;
     BOOST_CHECK(currentDt == windowDt); // no subcycling.
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -75,10 +75,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
   double sampleDt; // dt relative to timestep start, where we are sampling
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     for (int j = 0; j < nSamples; j++) {
       sampleDt = sampleDts[j];
@@ -108,11 +107,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
     currentDt = dt > maxDt ? maxDt : dt;
     BOOST_CHECK(currentDt == windowDt); // no subcycling.
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
@@ -62,10 +62,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
   int    timewindow = 0;
   int    timewindowCheckpoint;
   double time = 0;
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt     = precice.initialize();
@@ -81,11 +80,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
   double readTime; // time where we are reading from the reference solution
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint       = time;
       timewindowCheckpoint = timewindow;
       iterations           = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
 
     for (int j = 0; j < nSamples; j++) {
@@ -109,11 +107,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time       = timeCheckpoint;
       timewindow = timewindowCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
@@ -65,10 +65,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   int    timestepCheckpoint;
   double time = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt    = precice.initialize();
@@ -80,11 +79,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   int    iterations;
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint     = time;
       timestepCheckpoint = timestep;
       iterations         = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     double readTime;
     readTime = time + currentDt;
@@ -111,11 +109,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time     = timeCheckpoint;
       timestep = timestepCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
@@ -63,10 +63,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
   int    timestepCheckpoint;
   double time = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt    = precice.initialize();
@@ -78,11 +77,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
   int    iterations;
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint     = time;
       timestepCheckpoint = timestep;
       iterations         = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     double readTime;
     if (context.isNamed("SolverOne")) {
@@ -121,11 +119,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time     = timeCheckpoint;
       timestep = timestepCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
@@ -62,10 +62,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
   int    timestep  = 0;
   double time      = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt    = precice.initialize();
@@ -78,11 +77,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
   int    iterations;
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint     = time;
       timestepCheckpoint = timestep;
       iterations         = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     double readTime;
     readTime = timeCheckpoint + windowDt;
@@ -109,11 +107,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time     = timeCheckpoint;
       timestep = timestepCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
@@ -53,8 +53,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipant)
   VertexID vertexID = precice.setMeshVertex(meshID, Eigen::Vector3d(0.0, 0.0, 0.0).data());
   double   dt       = precice.initialize();
 
-  if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-    precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+  if (precice.requiresWritingCheckpoint()) {
   }
 
   for (auto iterationSizes : timestepSizes) {
@@ -70,11 +69,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipant)
         dt = precice.advance(dt);
       }
 
-      if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
-        precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
+      if (precice.requiresReadingCheckpoint()) {
       }
-      if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
-        precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
+      if (precice.requiresWritingCheckpoint()) {
       }
 
       precice.readScalarData(readDataID, vertexID, actualDataValue);

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -68,10 +68,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   int    iterations      = 0;
   double time            = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt = precice.initialize();
@@ -82,10 +81,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual timestep length; must fit into remaining time in window
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
 
     precice.readScalarData(readDataID, vertexID, readData);
@@ -104,11 +102,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
     maxDt     = precice.advance(currentDt);
     currentDt = dt > maxDt ? maxDt : dt;
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       iterations++;

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -68,10 +68,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
   double readTime; // time where we are reading
   double sampleDt; // dt relative to timestep start, where we are sampling
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt        = precice.initialize();
@@ -81,10 +80,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
   double sampleDts[4] = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     for (int j = 0; j < nSamples; j++) {
       sampleDt = sampleDts[j];
@@ -106,11 +104,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
     currentDt = dt > maxDt ? maxDt : dt;
     BOOST_CHECK(currentDt == windowDt); // no subcycling.
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -75,10 +75,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
   double sampleDt; // dt relative to timestep start, where we are sampling
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       windowStartTime = time;
       windowStartStep = timestep;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     for (int j = 0; j < nSamples; j++) {
       sampleDt = sampleDts[j];
@@ -109,11 +108,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
     currentDt = dt > maxDt ? maxDt : dt;
     BOOST_CHECK(currentDt == windowDt); // no subcycling.
     timestep++;
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) { // at end of window and we have to repeat it.
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;
       timestep = windowStartStep;
       time     = windowStartTime;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint()); // this test does not care about checkpointing, but we have to make the action
     }
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
@@ -69,10 +69,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
   double sampleDt; // dt relative to timestep start, where we are sampling
   double readDt;   // dt relative to timestep start for readTime
   double readTime; // time where we are reading from the reference solution
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt        = precice.initialize();
@@ -82,11 +81,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
   double readDts[4]   = {0.0, currentDt, currentDt, currentDt};
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint       = time;
       timewindowCheckpoint = timewindow;
       iterations           = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     for (int j = 0; j < nSamples; j++) {
       sampleDt = sampleDts[j];
@@ -107,11 +105,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time       = timeCheckpoint;
       timewindow = timewindowCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
@@ -68,10 +68,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   double timeCheckpoint     = time;
   int    iterations         = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt    = precice.initialize();
@@ -81,11 +80,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   double currentDt = dt;                  // Timestep length used by solver
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint     = time;
       timestepCheckpoint = timestep;
       iterations         = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     double readTime;
     readTime = time + currentDt;
@@ -111,11 +109,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time     = timeCheckpoint;
       timestep = timestepCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
@@ -66,10 +66,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
   double timeCheckpoint     = time;
   int    iterations         = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt    = precice.initialize();
@@ -79,11 +78,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
   double currentDt = dt;                  // Timestep length used by solver
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint     = time;
       timestepCheckpoint = timestep;
       iterations         = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     double readTime;
     if (context.isNamed("SolverOne")) {
@@ -121,11 +119,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time     = timeCheckpoint;
       timestep = timestepCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
@@ -66,10 +66,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
   double timeCheckpoint     = time;
   int    iterations         = 0;
 
-  if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
+  if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
-    precice.markActionFulfilled(precice::constants::actionWriteInitialData());
   }
 
   double maxDt    = precice.initialize();
@@ -79,11 +78,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
   double currentDt = dt;                  // Timestep length used by solver
 
   while (precice.isCouplingOngoing()) {
-    if (precice.isActionRequired(precice::constants::actionWriteIterationCheckpoint())) {
+    if (precice.requiresWritingCheckpoint()) {
       timeCheckpoint     = time;
       timestepCheckpoint = timestep;
       iterations         = 0;
-      precice.markActionFulfilled(precice::constants::actionWriteIterationCheckpoint());
     }
     double readTime;
     readTime = timeCheckpoint + windowDt;
@@ -108,11 +106,10 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
     writeData = writeFunction(time);
     precice.writeScalarData(writeDataID, vertexID, writeData);
     maxDt = precice.advance(currentDt);
-    if (precice.isActionRequired(precice::constants::actionReadIterationCheckpoint())) {
+    if (precice.requiresReadingCheckpoint()) {
       time     = timeCheckpoint;
       timestep = timestepCheckpoint;
       iterations++;
-      precice.markActionFulfilled(precice::constants::actionReadIterationCheckpoint());
     }
     currentDt = dt > maxDt ? maxDt : dt;
   }


### PR DESCRIPTION
## Main changes of this PR

This PR
* replaces `isActionRequired` and `markActionFulfilled` with explicit calls `requiresInitialData()`, `requiresReadingCheckpoint()`, `requiresWritingCheckpoint()`
* removes `precice::constants`
* extends CouplingScheme to keep track of required as well as fulfilled actions. This allows to check if something was required after it was fulfilled.

## Motivation and additional information

Closes #719

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
