### PR TITLE
Mesh connectivity preprocessing

### DIFF
--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -15,6 +15,9 @@ namespace mesh {
 /// Linear edge of a mesh, defined by two Vertex objects.
 class Edge {
 public:
+  /// Amount of vertices
+  static constexpr int vertexCount{2};
+
   /**
    * @brief Constructor.
    *
@@ -56,6 +59,13 @@ public:
 
   /// Not equal, implemented in terms of equal.
   bool operator!=(const Edge &other) const;
+
+  /// Weak ordering based on vertex ids
+  bool operator<(const Edge &other) const
+  {
+    return std::make_tuple(_vertices[0]->getID(), _vertices[1]->getID()) <
+           std::make_tuple(other._vertices[0]->getID(), other._vertices[1]->getID());
+  }
 
 private:
   /// Pointers to Vertex objects defining the edge, ordered by Vertex::getID().

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -1,7 +1,6 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <array>
-#include <bits/utility.h>
 #include <boost/container/flat_map.hpp>
 #include <functional>
 #include <memory>

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -401,7 +401,7 @@ void Mesh::removeDuplicates()
   auto lastEdge = std::unique(_edges.begin(), _edges.end());
   _edges        = EdgeContainer{_edges.begin(), lastEdge};
 
-  PRECICE_DEBUG("Deduplication removed {} tetrahedra ({} to {}), {} triangles ({} to {}), and {} edges ({} to {})",
+  PRECICE_DEBUG("Compression removed {} tetrahedra ({} to {}), {} triangles ({} to {}), and {} edges ({} to {})",
                 tetrahedraCnt - _tetrahedra.size(), tetrahedraCnt, _tetrahedra.size(),
                 triangleCnt - _triangles.size(), triangleCnt, _triangles.size(),
                 edgeCnt - _edges.size(), edgeCnt, _edges.size());

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <array>
+#include <bits/utility.h>
 #include <boost/container/flat_map.hpp>
 #include <functional>
 #include <memory>
@@ -16,6 +17,7 @@
 #include "logging/LogMacros.hpp"
 #include "math/geometry.hpp"
 #include "mesh/Data.hpp"
+#include "mesh/Vertex.hpp"
 #include "precice/types.hpp"
 #include "query/Index.hpp"
 #include "utils/EigenHelperFunctions.hpp"
@@ -372,6 +374,124 @@ const BoundingBox &Mesh::getBoundingBox() const
 void Mesh::expandBoundingBox(const BoundingBox &boundingBox)
 {
   _boundingBox.expandBy(boundingBox);
+}
+
+void Mesh::preprocess()
+{
+  removeDuplicates();
+  generateImplictPrimitives();
+}
+
+void Mesh::removeDuplicates()
+{
+  // Remove duplicate tetrahedra
+  auto tetrahedraCnt = _tetrahedra.size();
+  std::sort(_tetrahedra.begin(), _tetrahedra.end());
+  auto lastTetrahedron = std::unique(_tetrahedra.begin(), _tetrahedra.end());
+  _tetrahedra          = TetraContainer{_tetrahedra.begin(), lastTetrahedron};
+
+  // Remove duplicate triangles
+  auto triangleCnt = _triangles.size();
+  std::sort(_triangles.begin(), _triangles.end());
+  auto lastTriangle = std::unique(_triangles.begin(), _triangles.end());
+  _triangles        = TriangleContainer{_triangles.begin(), lastTriangle};
+
+  // Remove duplicate edges
+  auto edgeCnt = _edges.size();
+  std::sort(_edges.begin(), _edges.end());
+  auto lastEdge = std::unique(_edges.begin(), _edges.end());
+  _edges        = EdgeContainer{_edges.begin(), lastEdge};
+
+  PRECICE_DEBUG("Deduplication removed {} tetrahedra ({} to {}), {} triangles ({} to {}), and {} edges ({} to {})",
+                tetrahedraCnt - _tetrahedra.size(), tetrahedraCnt, _tetrahedra.size(),
+                triangleCnt - _triangles.size(), triangleCnt, _triangles.size(),
+                edgeCnt - _edges.size(), edgeCnt, _edges.size());
+}
+
+namespace {
+
+template <class Primitive, int... Indices>
+auto sortedVertexPtrsForImpl(Primitive &p, std::integer_sequence<int, Indices...>)
+{
+  std::array<Vertex *, Primitive::vertexCount> vs{&p.vertex(Indices)...};
+  std::sort(vs.begin(), vs.end());
+  return std::tuple_cat(vs);
+}
+
+/** returns a tuple of Vertex* sorted by ptr of the Primitive
+ * Requires Primitive to provide static constexpr vertexCount.
+ * Generates an integer sequence based on the vertexCount, which is then expanded to fill the array.
+ */
+template <class Primitive>
+auto sortedVertexPtrsFor(Primitive &p)
+{
+  return sortedVertexPtrsForImpl(p, std::make_integer_sequence<int, Primitive::vertexCount>{});
+}
+} // namespace
+
+void Mesh::generateImplictPrimitives()
+{
+  if (_triangles.empty() && _tetrahedra.empty()) {
+    PRECICE_DEBUG("No implicit primitives required");
+    return; // no implicit primitives
+  }
+
+  // count explicit primitives for debug
+  const auto explTriangles = _triangles.size();
+  const auto explEdges     = _triangles.size();
+
+  // First handle all explicit tetrahedra
+
+  // Build a set of all explicit triangles
+  using ExisitingTriangle = std::tuple<Vertex *, Vertex *, Vertex *>;
+  std::set<ExisitingTriangle> triangles;
+  for (auto &t : _triangles) {
+    triangles.insert(sortedVertexPtrsFor(t));
+  }
+
+  // Generate all missing implicit triangles of explicit tetrahedra
+  // Update the triangles set used by the implicit edge generation
+  auto createTriangleIfMissing = [&](Vertex *a, Vertex *b, Vertex *c) {
+    if (triangles.count({a, b, c}) == 0) {
+      triangles.emplace(a, b, c);
+      createTriangle(*a, *b, *c);
+    };
+  };
+  for (auto &t : _tetrahedra) {
+    auto [a, b, c, d] = sortedVertexPtrsFor(t);
+    // Make sure these are in the same order as above
+    createTriangleIfMissing(a, b, c);
+    createTriangleIfMissing(a, b, d);
+    createTriangleIfMissing(a, c, d);
+    createTriangleIfMissing(b, c, d);
+  }
+
+  // Second handle all triangles, both explicit and implicit from the tetrahedron phase
+  // Build an set of all explicit triangles
+  using ExisitingEdge = std::tuple<Vertex *, Vertex *>;
+  std::set<ExisitingEdge> edges;
+  for (auto &e : _edges) {
+    edges.emplace(sortedVertexPtrsFor(e));
+  }
+
+  // generate all missing implicit edges of implicit and explicit triangles
+  auto createEdgeIfMissing = [&](Vertex *a, Vertex *b) {
+    if (edges.count({a, b}) == 0) {
+      edges.emplace(a, b);
+      createEdge(*a, *b);
+    };
+  };
+  for (auto &t : _triangles) {
+    auto [a, b, c] = sortedVertexPtrsFor(t);
+    // Make sure these are in the same order as above
+    createEdgeIfMissing(a, b);
+    createEdgeIfMissing(a, c);
+    createEdgeIfMissing(b, c);
+  }
+
+  PRECICE_DEBUG("Generated {} implicit triangles and {} implicit edges",
+                _triangles.size() - explTriangles,
+                _edges.size() - explEdges);
 }
 
 bool Mesh::operator==(const Mesh &other) const

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -418,6 +418,10 @@ auto sortedVertexPtrsForImpl(Primitive &p, std::integer_sequence<int, Indices...
 }
 
 /** returns a tuple of Vertex* sorted by ptr of the Primitive
+ *
+ * This uniquely identifies a primitive, provides a weak order to allow sorting,
+ * and allows to directly fetch each Vertex to later create the primitive in the mesh.
+ *
  * Requires Primitive to provide static constexpr vertexCount.
  * Generates an integer sequence based on the vertexCount, which is then expanded to fill the array.
  */

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -284,15 +284,27 @@ public:
 
   bool operator!=(const Mesh &other) const;
 
+  /// Call preprocess() before index() to ensure correct projection handling
   const query::Index &index() const
   {
     return _index;
   }
 
+  /// Call preprocess() before index() to ensure correct projection handling
   query::Index &index()
   {
     return _index;
   }
+
+  /**
+   * Removes all duplicates and generates implicit primitives.
+   *
+   * This needs to be called for correct projection handling.
+   *
+   * @see removeDuplicates()
+   * @see generateImplictPrimitives()
+   */
+  void preprocess();
 
 private:
   mutable logging::Logger _log{"mesh::Mesh"};
@@ -351,6 +363,15 @@ private:
   BoundingBox _boundingBox;
 
   query::Index _index;
+
+  /// Removes all duplicate connectivity.
+  void removeDuplicates();
+
+  /** Generates implicit primitives for correct projection handling
+   *
+   * removeDuplicates() should be called first to avoid unnecessary filtering.
+   */
+  void generateImplictPrimitives();
 };
 
 std::ostream &operator<<(std::ostream &os, const Mesh &q);

--- a/src/mesh/Tetrahedron.hpp
+++ b/src/mesh/Tetrahedron.hpp
@@ -2,14 +2,11 @@
 
 #include <array>
 #include <iostream>
+#include <tuple>
+
+#include "mesh/Vertex.hpp"
 #include "precice/types.hpp"
 #include "utils/assertion.hpp"
-
-namespace precice {
-namespace mesh {
-class Vertex;
-}
-} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
@@ -19,6 +16,9 @@ namespace mesh {
 /// Tetrahedron of a mesh, defined by 4 vertices
 class Tetrahedron {
 public:
+  /// Amount of vertices
+  static constexpr int vertexCount{4};
+
   /** Constructor based on 4 vertices
    *
    * The vertices will be sorted by Vertex::getID().
@@ -61,6 +61,13 @@ public:
 
   /// Not equal, implemented in terms of equal.
   bool operator!=(const Tetrahedron &other) const;
+
+  /// Weak ordering based on vertex ids
+  bool operator<(const Tetrahedron &other) const
+  {
+    return std::make_tuple(_vertices[0]->getID(), _vertices[1]->getID(), _vertices[2]->getID(), _vertices[3]->getID()) <
+           std::make_tuple(other._vertices[0]->getID(), other._vertices[1]->getID(), other._vertices[2]->getID(), other._vertices[3]->getID());
+  }
 
 private:
   /// Vertices defining the Tetrahedron.

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <tuple>
 
 #include "math/differences.hpp"
 #include "mesh/Edge.hpp"
@@ -38,6 +39,9 @@ public:
 
   /// Fix for the Boost.Test versions 1.65.1 - 1.67
   using value_type = Vertex::RawCoords;
+
+  /// Amount of vertices
+  static constexpr int vertexCount{3};
 
   /// Constructor based on 3 edges
   Triangle(
@@ -121,6 +125,13 @@ public:
 
   /// Not equal, implemented in terms of equal.
   bool operator!=(const Triangle &other) const;
+
+  /// Weak ordering based on vertex ids
+  bool operator<(const Triangle &other) const
+  {
+    return std::make_tuple(_vertices[0]->getID(), _vertices[1]->getID(), _vertices[2]->getID()) <
+           std::make_tuple(other._vertices[0]->getID(), other._vertices[1]->getID(), other._vertices[2]->getID());
+  }
 
 private:
   /// Vertices defining the triangle, sorted by Vertex::getID()

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -821,7 +821,9 @@ BOOST_AUTO_TEST_CASE(AddMesh)
   BOOST_TEST(globalMesh->tetrahedra().size() == 3);
 }
 
-BOOST_AUTO_TEST_CASE(RemoveDuplicates)
+BOOST_AUTO_TEST_SUITE(PreProcess);
+
+BOOST_AUTO_TEST_CASE(DuplicateEdges)
 {
   PRECICE_TEST(1_rank);
   Mesh mesh{"Mesh1", 3, 0};
@@ -844,33 +846,18 @@ BOOST_AUTO_TEST_CASE(RemoveDuplicates)
   };
   BOOST_TEST(mesh.edges().size() == 1004);
 
-  mesh.createTriangle(v1, v2, v3);
-  mesh.createTriangle(v2, v3, v4);
-  for (int i = 0; i < 1000; ++i) {
-    mesh.createTriangle(v2, v3, v4);
-  };
-  BOOST_TEST(mesh.triangles().size() == 1002);
-
-  // creates edges 1-3 and 2-4
   mesh.preprocess();
 
-  BOOST_TEST(mesh.edges().size() == 5);
-  BOOST_TEST(mesh.triangles().size() == 2);
+  BOOST_TEST(mesh.edges().size() == 3);
+  BOOST_TEST(mesh.triangles().empty());
+  BOOST_TEST(mesh.tetrahedra().empty());
 
-  std::vector<Edge> expectedEdges{{v1, v2}, {v1, v3}, {v2, v3}, {v3, v4}, {v2, v4}};
+  std::vector<Edge> expectedEdges{{v1, v2}, {v2, v3}, {v3, v4}};
   for (auto &e : expectedEdges) {
     auto cnt = std::count(mesh.edges().begin(), mesh.edges().end(), e);
     BOOST_TEST(cnt == 1);
   }
-
-  std::vector<Triangle> expectedTriangles{{v1, v2, v3}, {v2, v3, v4}};
-  for (auto &t : expectedTriangles) {
-    auto cnt = std::count(mesh.triangles().begin(), mesh.triangles().end(), t);
-    BOOST_TEST(cnt == 1);
-  }
 }
-
-BOOST_AUTO_TEST_SUITE(PreProcess);
 
 BOOST_AUTO_TEST_CASE(SingleTriangle)
 {
@@ -1054,7 +1041,7 @@ BOOST_AUTO_TEST_CASE(Mixed)
   BOOST_TEST(mesh.tetrahedra().size() == 1);
 }
 
-BOOST_AUTO_TEST_CASE(RemoveDuplicates)
+BOOST_AUTO_TEST_CASE(Complex)
 {
   PRECICE_TEST(1_rank);
   Mesh mesh{"Mesh1", 3, 0};

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -1,12 +1,11 @@
 #include <Eigen/Core>
-#include <Eigen/src/Core/Matrix.h>
 #include <algorithm>
-#include <boost/test/tools/old/interface.hpp>
 #include <deque>
 #include <iosfwd>
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "logging/Logger.hpp"
 #include "mesh/BoundingBox.hpp"
 #include "mesh/Data.hpp"

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -871,5 +871,239 @@ BOOST_AUTO_TEST_CASE(RemoveDuplicates)
   }
 }
 
+BOOST_AUTO_TEST_SUITE(PreProcess);
+
+BOOST_AUTO_TEST_CASE(SingleTriangle)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+
+  mesh.createTriangle(v1, v2, v3);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 3);
+  BOOST_TEST(mesh.triangles().size() == 1);
+  BOOST_TEST(mesh.tetrahedra().size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(SingleTriangulatedQuad)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+
+  mesh.createTriangle(v1, v2, v3);
+  mesh.createTriangle(v2, v3, v4);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 5);
+  BOOST_TEST(mesh.triangles().size() == 2);
+  BOOST_TEST(mesh.tetrahedra().size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(SingleTetrahedron)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.3, 0.3, 1.0));
+
+  mesh.createTetrahedron(v1, v2, v3, v4);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 6);
+  BOOST_TEST(mesh.triangles().size() == 4);
+  BOOST_TEST(mesh.tetrahedra().size() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(TouchingTetrahedra)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.3, 0.3, 1.0));
+  auto &v5 = mesh.createVertex(Eigen::Vector3d(0.3, 0.3, -1.0));
+
+  mesh.createTetrahedron(v1, v2, v3, v4);
+  mesh.createTetrahedron(v1, v2, v3, v5);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 9);
+  BOOST_TEST(mesh.triangles().size() == 7);
+  BOOST_TEST(mesh.tetrahedra().size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(SingleTriangle2ImplicitEdges)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+
+  mesh.createTriangle(v1, v2, v3);
+  mesh.createEdge(v2, v3);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 3);
+  BOOST_TEST(mesh.triangles().size() == 1);
+  BOOST_TEST(mesh.tetrahedra().size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(SingleTriangle1ImplicitEdges)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+
+  mesh.createTriangle(v1, v2, v3);
+  mesh.createEdge(v1, v2);
+  mesh.createEdge(v2, v3);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 3);
+  BOOST_TEST(mesh.triangles().size() == 1);
+  BOOST_TEST(mesh.tetrahedra().size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(SingleTetrahedron3ImplicitTriangles)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.3, 0.3, 1.0));
+
+  mesh.createTetrahedron(v1, v2, v3, v4);
+  mesh.createTriangle(v1, v2, v3);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 6);
+  BOOST_TEST(mesh.triangles().size() == 4);
+  BOOST_TEST(mesh.tetrahedra().size() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(SingleTetrahedronNoImplicitTriangles)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.3, 0.3, 1.0));
+
+  mesh.createTetrahedron(v1, v2, v3, v4);
+  mesh.createTriangle(v1, v2, v3);
+  mesh.createTriangle(v1, v2, v4);
+  mesh.createTriangle(v3, v4, v1);
+  mesh.createTriangle(v3, v4, v2);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 6);
+  BOOST_TEST(mesh.triangles().size() == 4);
+  BOOST_TEST(mesh.tetrahedra().size() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(Mixed)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(0.0, 1.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.3, 0.3, 1.0));
+
+  mesh.createTetrahedron(v1, v2, v3, v4);
+  mesh.createTriangle(v1, v2, v3);
+  mesh.createEdge(v3, v4);
+
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 6);
+  BOOST_TEST(mesh.triangles().size() == 4);
+  BOOST_TEST(mesh.tetrahedra().size() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveDuplicates)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(3.0, 4.0, 0.0));
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.0, 8.0, 0.0));
+
+  mesh.createEdge(v1, v2);
+  mesh.createEdge(v2, v3);
+  mesh.createEdge(v3, v4);
+
+  // add single duplicate
+  mesh.createEdge(v3, v4);
+
+  // add 1000 duplicates
+  for (int i = 0; i < 1000; ++i) {
+    mesh.createEdge(v2, v3);
+  };
+  BOOST_TEST(mesh.edges().size() == 1004);
+
+  mesh.createTriangle(v1, v2, v3);
+  mesh.createTriangle(v2, v3, v4);
+  for (int i = 0; i < 1000; ++i) {
+    mesh.createTriangle(v2, v3, v4);
+  };
+  BOOST_TEST(mesh.triangles().size() == 1002);
+
+  // creates edges 1-3 and 2-4
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 5);
+  BOOST_TEST(mesh.triangles().size() == 2);
+
+  std::vector<Edge> expectedEdges{{v1, v2}, {v1, v3}, {v2, v3}, {v3, v4}, {v2, v4}};
+  for (auto &e : expectedEdges) {
+    auto cnt = std::count(mesh.edges().begin(), mesh.edges().end(), e);
+    BOOST_TEST(cnt == 1);
+  }
+
+  std::vector<Triangle> expectedTriangles{{v1, v2, v3}, {v2, v3, v4}};
+  for (auto &t : expectedTriangles) {
+    auto cnt = std::count(mesh.triangles().begin(), mesh.triangles().end(), t);
+    BOOST_TEST(cnt == 1);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END();
 BOOST_AUTO_TEST_SUITE_END() // Mesh
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 #include <Eigen/src/Core/Matrix.h>
 #include <algorithm>
+#include <boost/test/tools/old/interface.hpp>
 #include <deque>
 #include <iosfwd>
 #include <memory>
@@ -819,6 +820,55 @@ BOOST_AUTO_TEST_CASE(AddMesh)
   BOOST_TEST(globalMesh->edges().size() == 3);
   BOOST_TEST(globalMesh->triangles().size() == 3);
   BOOST_TEST(globalMesh->tetrahedra().size() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveDuplicates)
+{
+  PRECICE_TEST(1_rank);
+  Mesh mesh{"Mesh1", 3, 0};
+
+  auto &v1 = mesh.createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
+  auto &v2 = mesh.createVertex(Eigen::Vector3d(3.0, 0.0, 0.0));
+  auto &v3 = mesh.createVertex(Eigen::Vector3d(3.0, 4.0, 0.0));
+  auto &v4 = mesh.createVertex(Eigen::Vector3d(0.0, 8.0, 0.0));
+
+  mesh.createEdge(v1, v2);
+  mesh.createEdge(v2, v3);
+  mesh.createEdge(v3, v4);
+
+  // add single duplicate
+  mesh.createEdge(v3, v4);
+
+  // add 1000 duplicates
+  for (int i = 0; i < 1000; ++i) {
+    mesh.createEdge(v2, v3);
+  };
+  BOOST_TEST(mesh.edges().size() == 1004);
+
+  mesh.createTriangle(v1, v2, v3);
+  mesh.createTriangle(v2, v3, v4);
+  for (int i = 0; i < 1000; ++i) {
+    mesh.createTriangle(v2, v3, v4);
+  };
+  BOOST_TEST(mesh.triangles().size() == 1002);
+
+  // creates edges 1-3 and 2-4
+  mesh.preprocess();
+
+  BOOST_TEST(mesh.edges().size() == 5);
+  BOOST_TEST(mesh.triangles().size() == 2);
+
+  std::vector<Edge> expectedEdges{{v1, v2}, {v1, v3}, {v2, v3}, {v3, v4}, {v2, v4}};
+  for (auto &e : expectedEdges) {
+    auto cnt = std::count(mesh.edges().begin(), mesh.edges().end(), e);
+    BOOST_TEST(cnt == 1);
+  }
+
+  std::vector<Triangle> expectedTriangles{{v1, v2, v3}, {v2, v3, v4}};
+  for (auto &t : expectedTriangles) {
+    auto cnt = std::count(mesh.triangles().begin(), mesh.triangles().end(), t);
+    BOOST_TEST(cnt == 1);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Mesh

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -265,10 +265,9 @@ public:
    * Use requiresMeshConnectivityFor() to check if the current participant can make use of the connectivity.
    *
    *
-   * Always set the mesh connectivity of the highest dimensionality available.
-   * preCICE ensures the existence of hierarchical entries for the projection fallback.
-   * Prefer to use bulk versions, as they allows preCICE to efficiently avoid duplicates.
-   * preCICE removes all connectivity duplicates in initialize().
+   * Only set the mesh connectivity that you require.
+   * preCICE removes all connectivity duplicates in initialize() and ensures
+   * the existence of hierarchical entries for the projection fallback.
    *
    * Examples:
    *
@@ -468,8 +467,6 @@ public:
    *
    * @note The order of vertices does not matter.
    *
-   * @warning For setting multiple triangle, prefer the vastly more efficient setMeshTriangles().
-   *
    * @param[in] meshID ID of the mesh to add the triangle to
    * @param[in] firstVertexID ID of the first vertex of the triangle
    * @param[in] secondVertexID ID of the second vertex of the triangle
@@ -512,8 +509,6 @@ public:
    * The planar quad will be triangulated, maximizing area-to-circumference.
    *
    * @warning The order of vertices does not matter, however, only planar quads are allowed.
-   *
-   * @warning For setting multiple quads, prefer the vastly more efficient setMeshQuads().
    *
    * @param[in] meshID ID of the mesh to add the Quad to
    * @param[in] firstVertexID ID of the first vertex of the Quad
@@ -559,8 +554,6 @@ public:
    * @brief Set tetrahedron in 3D mesh from vertex ID
    *
    * @note The order of vertices does not matter.
-   *
-   * @warning For setting multiple tetrahedra, prefer the vastly more efficient setMeshTetrahedra().
    *
    * @param[in] meshID ID of the mesh to add the Tetrahedron to
    * @param[in] firstVertexID ID of the first vertex of the Tetrahedron

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -264,15 +264,19 @@ public:
    * Connectivity is optional.
    * Use requiresMeshConnectivityFor() to check if the current participant can make use of the connectivity.
    *
-   * Only set the mesh connectivity that you require and use the face/cell elements that your solver provides.
-   * preCICE removes all connectivity duplicates in initialize() and ensures
-   * the existence of hierarchical entries for the projection fallback.
+   * Only set the mesh connectivity that you require for your use-case and use the face/cell elements that your solver provides.
+   * preCICE removes all connectivity duplicates in initialize().
    *
-   * Examples for hierarchical entries:
+   * We recommend you to do the following depending on your case:
    *
-   * - setting triangle ABC ensures the existence of edges AB, BC, and AC.
-   * - setting triangles ABC and BCD separately will result in duplicate BC edges.
-   * - setting quad ABCD ensures the existence of triangles ABC ABD ACD BCD and edges AB AC AD BC BD CD.
+   * - **2D surface coupling:** Use setMeshEdge() and setMeshEdges() to specify the coupling interface.
+   * - **2D volume coupling:** Use setMeshTriangle() and setMeshTriangles() to specify the coupling area.
+   * - **3D surface coupling:** Use setMeshTriangle() and setMeshTriangles() to specify the coupling interface.
+   * - **3D volume coupling:** Use setMeshTetrahedron() and setMeshTetrahedra() to specify the coupling volume.
+   *
+   * As an alternative to triangles, preCICE supports **planar** quads using setMeshQuad() and setMeshQuads().
+   * These quads will be triangulated by preCICE, hence specifying triangles is generally preferred.
+   * Before using quads, we recommended to check if your solver provides a way to traverse triangulated faces.
    *
    *@{
    */

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -426,6 +426,8 @@ public:
   /**
    * @brief Sets a mesh edge from vertex IDs
    *
+   * Ignored if preCICE doesn't require connectivity for the mesh.
+   *
    * @note The order of vertices does not matter.
    *
    * @param[in] meshID ID of the mesh to add the edge to
@@ -444,6 +446,7 @@ public:
    *
    * vertices contain pairs of vertex indices for each edge to define.
    * The format follows: e1a, e1b, e2a, e2b, ...
+   * Ignored if preCICE doesn't require connectivity for the mesh.
    *
    * @note The order of vertices per edge does not matter.
    *
@@ -487,6 +490,7 @@ public:
    *
    * vertices contain triples of vertex indices for each triangle to define.
    * The format follows: t1a, t1b, t1c, t2a, t2b, t2c, ...
+   * Ignored if preCICE doesn't require connectivity for the mesh.
    *
    * @note The order of vertices per triangle does not matter.
    *
@@ -507,6 +511,7 @@ public:
    * @brief Sets a planar surface mesh quadrangle from vertex IDs.
    *
    * The planar quad will be triangulated, maximizing area-to-circumference.
+   * Ignored if preCICE doesn't require connectivity for the mesh.
    *
    * @warning The order of vertices does not matter, however, only planar quads are allowed.
    *
@@ -534,6 +539,7 @@ public:
    * The format follows: q1a, q1b, q1c, q1d, q2a, q2b, q2c, q2d, ...
    *
    * Each planar quad will be triangulated, maximizing area-to-circumference.
+   * Ignored if preCICE doesn't require connectivity for the mesh.
    *
    * @warning The order of vertices per quad does not matter, however, only planar quads are allowed.
    *
@@ -577,6 +583,7 @@ public:
    *
    * vertices contain quadruples of vertex indices for each tetrahedron to define.
    * The format follows: t1a, t1b, t1c, t1d, t2a, t2b, t2c, t2d, ...
+   * Ignored if preCICE doesn't require connectivity for the mesh.
    *
    * @note The order of vertices per tetrahedron does not matter.
    *

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -264,12 +264,11 @@ public:
    * Connectivity is optional.
    * Use requiresMeshConnectivityFor() to check if the current participant can make use of the connectivity.
    *
-   *
-   * Only set the mesh connectivity that you require.
+   * Only set the mesh connectivity that you require and use the face/cell elements that your solver provides.
    * preCICE removes all connectivity duplicates in initialize() and ensures
    * the existence of hierarchical entries for the projection fallback.
    *
-   * Examples:
+   * Examples for hierarchical entries:
    *
    * - setting triangle ABC ensures the existence of edges AB, BC, and AC.
    * - setting triangles ABC and BCD separately will result in duplicate BC edges.

--- a/src/precice/impl/CommonErrorMessages.hpp
+++ b/src/precice/impl/CommonErrorMessages.hpp
@@ -16,7 +16,7 @@ inline std::string errorInvalidEdgeID(int eid)
   return "The given EdgeID \"" + std::to_string(eid) + "\" is invalid. Check that it originated from a call to setMeshEdge().";
 }
 
-static constexpr auto errorInvalidVertexIDRange = "The given range of VertexIDs contains invalid IDs at offsets [{},{}). Check that they originated from calls to setMeshVertex() or setMeshVertices().";
+static constexpr auto errorInvalidVertexIDRange = "The given range of VertexIDs contains invalid IDs at offsets [{},{}]. Check that they originated from calls to setMeshVertex() or setMeshVertices().";
 
 } // namespace impl
 

--- a/src/precice/impl/CommonErrorMessages.hpp
+++ b/src/precice/impl/CommonErrorMessages.hpp
@@ -16,6 +16,8 @@ inline std::string errorInvalidEdgeID(int eid)
   return "The given EdgeID \"" + std::to_string(eid) + "\" is invalid. Check that it originated from a call to setMeshEdge().";
 }
 
+static constexpr auto errorInvalidVertexIDRange = "The given range of VertexIDs contains invalid IDs at offsets [{},{}). Check that they originated from calls to setMeshVertex() or setMeshVertices().";
+
 } // namespace impl
 
 } // namespace precice

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -914,13 +914,11 @@ void SolverInterfaceImpl::setMeshQuad(
     auto coords = mesh::coordsFor(mesh, vertexIDs);
     PRECICE_CHECK(utils::unique_elements(coords),
                   "The four vertices that form the quad are not unique. The resulting shape may be a point, line or triangle."
-                  "Please check that the adapter sends the four unique vertices that form the quad, or that the mesh on the interface "
-                  "is composed of quads. A mix of triangles and quads are not supported.");
+                  "Please check that the adapter sends the four unique vertices that form the quad, or that the mesh on the interface is composed of quads.");
 
     auto convexity = math::geometry::isConvexQuad(coords);
     PRECICE_CHECK(convexity.convex, "The given quad is not convex. "
-                                    "Please check that the adapter send the four correct vertices or that the interface is composed of quads. "
-                                    "A mix of triangles and quads are not supported.");
+                                    "Please check that the adapter send the four correct vertices or that the interface is composed of quads.");
     auto reordered = utils::reorder_array(convexity.vertexOrder, mesh::vertexPtrsFor(mesh, vertexIDs));
 
     // Vertices are now in the order: V0-V1-V2-V3-V0.
@@ -975,14 +973,12 @@ void SolverInterfaceImpl::setMeshQuads(
     auto coords = mesh::coordsFor(mesh, vertexIDs);
     PRECICE_CHECK(utils::unique_elements(coords),
                   "The four vertices that form the quad nr {} are not unique. The resulting shape may be a point, line or triangle."
-                  "Please check that the adapter sends the four unique vertices that form the quad, or that the mesh on the interface "
-                  "is composed of quads. A mix of triangles and quads are not supported.",
+                  "Please check that the adapter sends the four unique vertices that form the quad, or that the mesh on the interface is composed of quads.",
                   i);
 
     auto convexity = math::geometry::isConvexQuad(coords);
     PRECICE_CHECK(convexity.convex, "The given quad nr {} is not convex. "
-                                    "Please check that the adapter send the four correct vertices or that the interface is composed of quads. "
-                                    "A mix of triangles and quads are not supported.",
+                                    "Please check that the adapter send the four correct vertices or that the interface is composed of quads.",
                   i);
     auto reordered = utils::reorder_array(convexity.vertexOrder, mesh::vertexPtrsFor(mesh, vertexIDs));
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -278,14 +278,14 @@ double SolverInterfaceImpl::initialize()
   Event                    e("initialize", precice::syncMode);
   utils::ScopedEventPrefix sep("initialize/");
 
-  PRECICE_DEBUG("Compressing provided meshes");
-  Event e1("mesh compression", precice::syncMode);
+  PRECICE_DEBUG("Preprocessing provided meshes");
   for (MeshContext *meshContext : _accessor->usedMeshContexts()) {
     if (meshContext->provideMesh) {
+      auto &mesh = *(meshContext->mesh);
+      Event e("preprocess." + mesh.getName(), precice::syncMode);
       meshContext->mesh->preprocess();
     }
   }
-  e1.stop();
 
   // Setup communication
 

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -799,9 +799,15 @@ void SolverInterfaceImpl::setMeshEdges(
   }
 
   mesh::PtrMesh &mesh = context.mesh;
-  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
-    PRECICE_CHECK(mesh->isValidVertexID(vid), impl::errorInvalidVertexID(vid));
-  });
+  {
+    auto [first, last] = utils::find_first_range(vertices, vertices + size * 2, [&mesh](VertexID vid) {
+      return !mesh->isValidVertexID(vid);
+    });
+    PRECICE_CHECK(first == last,
+                  impl::errorInvalidVertexIDRange,
+                  std::distance(vertices, first),
+                  std::distance(vertices, last));
+  }
 
   for (int i = 0; i < size; ++i) {
     auto aid = vertices[2 * i];
@@ -860,9 +866,15 @@ void SolverInterfaceImpl::setMeshTriangles(
   }
 
   mesh::PtrMesh &mesh = context.mesh;
-  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
-    PRECICE_CHECK(mesh->isValidVertexID(vid), impl::errorInvalidVertexID(vid));
-  });
+  {
+    auto [first, last] = utils::find_first_range(vertices, vertices + size * 3, [&mesh](VertexID vid) {
+      return !mesh->isValidVertexID(vid);
+    });
+    PRECICE_CHECK(first == last,
+                  impl::errorInvalidVertexIDRange,
+                  std::distance(vertices, first),
+                  std::distance(vertices, last));
+  }
 
   for (int i = 0; i < size; ++i) {
     auto aid = vertices[3 * i];
@@ -941,9 +953,15 @@ void SolverInterfaceImpl::setMeshQuads(
   }
 
   mesh::Mesh &mesh = *(context.mesh);
-  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
-    PRECICE_CHECK(mesh.isValidVertexID(vid), impl::errorInvalidVertexID(vid));
-  });
+  {
+    auto [first, last] = utils::find_first_range(vertices, vertices + size * 4, [&mesh](VertexID vid) {
+      return !mesh.isValidVertexID(vid);
+    });
+    PRECICE_CHECK(first == last,
+                  impl::errorInvalidVertexIDRange,
+                  std::distance(vertices, first),
+                  std::distance(vertices, last));
+  }
 
   for (int i = 0; i < size; ++i) {
     auto aid = vertices[4 * i];
@@ -1024,9 +1042,15 @@ void SolverInterfaceImpl::setMeshTetrahedra(
   }
 
   mesh::PtrMesh &mesh = context.mesh;
-  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
-    PRECICE_CHECK(mesh->isValidVertexID(vid), impl::errorInvalidVertexID(vid));
-  });
+  {
+    auto [first, last] = utils::find_first_range(vertices, vertices + size * 4, [&mesh](VertexID vid) {
+      return !mesh->isValidVertexID(vid);
+    });
+    PRECICE_CHECK(first == last,
+                  impl::errorInvalidVertexIDRange,
+                  std::distance(vertices, first),
+                  std::distance(vertices, last));
+  }
 
   for (int i = 0; i < size; ++i) {
     auto aid = vertices[4 * i];

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -800,10 +800,11 @@ void SolverInterfaceImpl::setMeshEdges(
 
   mesh::PtrMesh &mesh = context.mesh;
   {
-    auto [first, last] = utils::find_first_range(vertices, vertices + size * 2, [&mesh](VertexID vid) {
+    auto end           = std::next(vertices, size * 2);
+    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
       return !mesh->isValidVertexID(vid);
     });
-    PRECICE_CHECK(first == last,
+    PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
                   std::distance(vertices, first),
                   std::distance(vertices, last));
@@ -867,10 +868,11 @@ void SolverInterfaceImpl::setMeshTriangles(
 
   mesh::PtrMesh &mesh = context.mesh;
   {
-    auto [first, last] = utils::find_first_range(vertices, vertices + size * 3, [&mesh](VertexID vid) {
+    auto end           = std::next(vertices, size * 3);
+    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
       return !mesh->isValidVertexID(vid);
     });
-    PRECICE_CHECK(first == last,
+    PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
                   std::distance(vertices, first),
                   std::distance(vertices, last));
@@ -952,10 +954,11 @@ void SolverInterfaceImpl::setMeshQuads(
 
   mesh::Mesh &mesh = *(context.mesh);
   {
-    auto [first, last] = utils::find_first_range(vertices, vertices + size * 4, [&mesh](VertexID vid) {
+    auto end           = std::next(vertices, size * 4);
+    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
       return !mesh.isValidVertexID(vid);
     });
-    PRECICE_CHECK(first == last,
+    PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
                   std::distance(vertices, first),
                   std::distance(vertices, last));
@@ -1039,10 +1042,11 @@ void SolverInterfaceImpl::setMeshTetrahedra(
 
   mesh::PtrMesh &mesh = context.mesh;
   {
-    auto [first, last] = utils::find_first_range(vertices, vertices + size * 4, [&mesh](VertexID vid) {
+    auto end           = std::next(vertices, size * 4);
+    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
       return !mesh->isValidVertexID(vid);
     });
-    PRECICE_CHECK(first == last,
+    PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
                   std::distance(vertices, first),
                   std::distance(vertices, last));

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -278,6 +278,15 @@ double SolverInterfaceImpl::initialize()
   Event                    e("initialize", precice::syncMode);
   utils::ScopedEventPrefix sep("initialize/");
 
+  PRECICE_DEBUG("Compressing provided meshes");
+  Event e1("mesh compression", precice::syncMode);
+  for (MeshContext *meshContext : _accessor->usedMeshContexts()) {
+    if (meshContext->provideMesh) {
+      meshContext->mesh->preprocess();
+    }
+  }
+  e1.stop();
+
   // Setup communication
 
   PRECICE_INFO("Setting up primary communication to coupling partner/s");
@@ -333,7 +342,6 @@ double SolverInterfaceImpl::initialize()
   for (auto &context : _accessor->readDataContexts()) {
     context.initializeWaveform();
   }
-
   _meshLock.lockAll();
 
   if (_couplingScheme->sendsInitializedData()) {
@@ -783,8 +791,22 @@ void SolverInterfaceImpl::setMeshEdges(
     int        size,
     const int *vertices)
 {
+  PRECICE_TRACE(meshID, size);
+  PRECICE_REQUIRE_MESH_MODIFY(meshID);
+  MeshContext &context = _accessor->usedMeshContext(meshID);
+  if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
+    return;
+  }
+
+  mesh::PtrMesh &mesh = context.mesh;
+  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
+    PRECICE_CHECK(mesh->isValidVertexID(vid), impl::errorInvalidVertexID(vid));
+  });
+
   for (int i = 0; i < size; ++i) {
-    setMeshEdge(meshID, vertices[2 * i], vertices[2 * i + 1]);
+    auto aid = vertices[2 * i];
+    auto bid = vertices[2 * i + 1];
+    mesh->createEdge(mesh->vertices()[aid], mesh->vertices()[bid]);
   }
 }
 
@@ -830,8 +852,25 @@ void SolverInterfaceImpl::setMeshTriangles(
     int        size,
     const int *vertices)
 {
+  PRECICE_TRACE(meshID, size);
+  PRECICE_REQUIRE_MESH_MODIFY(meshID);
+  MeshContext &context = _accessor->usedMeshContext(meshID);
+  if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
+    return;
+  }
+
+  mesh::PtrMesh &mesh = context.mesh;
+  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
+    PRECICE_CHECK(mesh->isValidVertexID(vid), impl::errorInvalidVertexID(vid));
+  });
+
   for (int i = 0; i < size; ++i) {
-    setMeshTriangle(meshID, vertices[3 * i], vertices[3 * i + 1], vertices[3 * i + 2]);
+    auto aid = vertices[3 * i];
+    auto bid = vertices[3 * i + 1];
+    auto cid = vertices[3 * i + 2];
+    mesh->createTriangle(mesh->vertices()[aid],
+                         mesh->vertices()[bid],
+                         mesh->vertices()[cid]);
   }
 }
 
@@ -873,26 +912,18 @@ void SolverInterfaceImpl::setMeshQuad(
     auto reordered = utils::reorder_array(convexity.vertexOrder, mesh::vertexPtrsFor(mesh, vertexIDs));
 
     // Vertices are now in the order: V0-V1-V2-V3-V0.
-    // The order now identifies all outer edges of the quad.
-    auto &edge0 = mesh.createEdge(*reordered[0], *reordered[1]);
-    auto &edge1 = mesh.createEdge(*reordered[1], *reordered[2]);
-    auto &edge2 = mesh.createEdge(*reordered[2], *reordered[3]);
-    auto &edge3 = mesh.createEdge(*reordered[3], *reordered[0]);
-
     // Use the shortest diagonal to split the quad into 2 triangles.
     // Vertices are now in V0-V1-V2-V3-V0 order. The new edge, e[4] is either 0-2 or 1-3
-    double distance1 = (reordered[0]->getCoords() - reordered[2]->getCoords()).norm();
-    double distance2 = (reordered[1]->getCoords() - reordered[3]->getCoords()).norm();
+    double distance02 = (reordered[0]->getCoords() - reordered[2]->getCoords()).norm();
+    double distance13 = (reordered[1]->getCoords() - reordered[3]->getCoords()).norm();
 
     // The new edge, e[4], is the shortest diagonal of the quad
-    if (distance1 <= distance2) {
-      auto &diag = mesh.createEdge(*reordered[0], *reordered[2]);
-      mesh.createTriangle(edge0, edge1, diag);
-      mesh.createTriangle(edge2, edge3, diag);
+    if (distance02 <= distance13) {
+      mesh.createTriangle(*reordered[0], *reordered[2], *reordered[1]);
+      mesh.createTriangle(*reordered[0], *reordered[2], *reordered[3]);
     } else {
-      auto &diag = mesh.createEdge(*reordered[1], *reordered[3]);
-      mesh.createTriangle(edge3, edge0, diag);
-      mesh.createTriangle(edge1, edge2, diag);
+      mesh.createTriangle(*reordered[1], *reordered[3], *reordered[0]);
+      mesh.createTriangle(*reordered[1], *reordered[3], *reordered[2]);
     }
   }
 }
@@ -902,8 +933,53 @@ void SolverInterfaceImpl::setMeshQuads(
     int        size,
     const int *vertices)
 {
+  PRECICE_TRACE(meshID, size);
+  PRECICE_REQUIRE_MESH_MODIFY(meshID);
+  MeshContext &context = _accessor->usedMeshContext(meshID);
+  if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
+    return;
+  }
+
+  mesh::Mesh &mesh = *(context.mesh);
+  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
+    PRECICE_CHECK(mesh.isValidVertexID(vid), impl::errorInvalidVertexID(vid));
+  });
+
   for (int i = 0; i < size; ++i) {
-    setMeshQuad(meshID, vertices[4 * i], vertices[4 * i + 1], vertices[4 * i + 2], vertices[4 * i + 3]);
+    auto aid = vertices[4 * i];
+    auto bid = vertices[4 * i + 1];
+    auto cid = vertices[4 * i + 2];
+    auto did = vertices[4 * i + 3];
+
+    auto vertexIDs = utils::make_array(aid, bid, cid, did);
+    PRECICE_CHECK(utils::unique_elements(vertexIDs), "The four vertex ID's of the quad nr {} are not unique. Please check that the vertices that form the quad are correct.", i);
+
+    auto coords = mesh::coordsFor(mesh, vertexIDs);
+    PRECICE_CHECK(utils::unique_elements(coords),
+                  "The four vertices that form the quad nr {} are not unique. The resulting shape may be a point, line or triangle."
+                  "Please check that the adapter sends the four unique vertices that form the quad, or that the mesh on the interface "
+                  "is composed of quads. A mix of triangles and quads are not supported.",
+                  i);
+
+    auto convexity = math::geometry::isConvexQuad(coords);
+    PRECICE_CHECK(convexity.convex, "The given quad nr {} is not convex. "
+                                    "Please check that the adapter send the four correct vertices or that the interface is composed of quads. "
+                                    "A mix of triangles and quads are not supported.",
+                  i);
+    auto reordered = utils::reorder_array(convexity.vertexOrder, mesh::vertexPtrsFor(mesh, vertexIDs));
+
+    // Use the shortest diagonal to split the quad into 2 triangles.
+    // Vertices are now in V0-V1-V2-V3-V0 order. The new edge, e[4] is either 0-2 or 1-3
+    double distance02 = (reordered[0]->getCoords() - reordered[2]->getCoords()).norm();
+    double distance13 = (reordered[1]->getCoords() - reordered[3]->getCoords()).norm();
+
+    if (distance02 <= distance13) {
+      mesh.createTriangle(*reordered[0], *reordered[2], *reordered[1]);
+      mesh.createTriangle(*reordered[0], *reordered[2], *reordered[3]);
+    } else {
+      mesh.createTriangle(*reordered[1], *reordered[3], *reordered[0]);
+      mesh.createTriangle(*reordered[1], *reordered[3], *reordered[2]);
+    }
   }
 }
 
@@ -931,20 +1007,6 @@ void SolverInterfaceImpl::setMeshTetrahedron(
     mesh::Vertex &C = mesh->vertices()[thirdVertexID];
     mesh::Vertex &D = mesh->vertices()[fourthVertexID];
 
-    // Also add underlying primitives (4 triangles, 6 edges)
-    // Tetra ABCD is made of triangles ABC, ABD, ACD, BCD
-    mesh::Edge &AB = mesh->createEdge(A, B);
-    mesh::Edge &BC = mesh->createEdge(B, C);
-    mesh::Edge &CD = mesh->createEdge(C, D);
-    mesh::Edge &DA = mesh->createEdge(D, A);
-    mesh::Edge &AC = mesh->createEdge(A, C);
-    mesh::Edge &BD = mesh->createEdge(B, D);
-
-    mesh->createTriangle(AB, BC, AC);
-    mesh->createTriangle(AB, BD, DA);
-    mesh->createTriangle(AC, CD, DA);
-    mesh->createTriangle(BC, CD, BD);
-
     mesh->createTetrahedron(A, B, C, D);
   }
 }
@@ -954,8 +1016,27 @@ void SolverInterfaceImpl::setMeshTetrahedra(
     int        size,
     const int *vertices)
 {
+  PRECICE_TRACE(meshID, size);
+  PRECICE_REQUIRE_MESH_MODIFY(meshID);
+  MeshContext &context = _accessor->usedMeshContext(meshID);
+  if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
+    return;
+  }
+
+  mesh::PtrMesh &mesh = context.mesh;
+  utils::for_each_unique(vertices, vertices + size, [&_log = _log, &mesh](VertexID vid) {
+    PRECICE_CHECK(mesh->isValidVertexID(vid), impl::errorInvalidVertexID(vid));
+  });
+
   for (int i = 0; i < size; ++i) {
-    setMeshTetrahedron(meshID, vertices[4 * i], vertices[4 * i + 1], vertices[4 * i + 2], vertices[4 * i + 3]);
+    auto aid = vertices[4 * i];
+    auto bid = vertices[4 * i + 1];
+    auto cid = vertices[4 * i + 2];
+    auto did = vertices[4 * i + 3];
+    mesh->createTetrahedron(mesh->vertices()[aid],
+                            mesh->vertices()[bid],
+                            mesh->vertices()[cid],
+                            mesh->vertices()[did]);
   }
 }
 

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -5,6 +5,7 @@
 #include <fmt/ostream.h>
 #include <functional>
 #include <iterator>
+#include <set>
 #include <type_traits>
 #include <utility>
 
@@ -156,6 +157,20 @@ template <class InputIt, class Size, class InOutIt>
 void add_n(InputIt first, Size count, InOutIt result)
 {
   std::transform(first, std::next(first, count), result, result, std::plus{});
+}
+
+/// Calls each value in the range of [first, last[ exactly once.
+template <class InputIt, class Unary>
+void for_each_unique(InputIt first, InputIt last, Unary func)
+{
+  using Inner = std::remove_cv_t<std::remove_reference_t<decltype(*first)>>;
+  std::set<Inner> seen;
+  std::for_each(first, last, [&seen, &func](const auto &elem) {
+    if (seen.count(elem) == 0) {
+      seen.insert(elem);
+      func(elem);
+    }
+  });
 }
 
 } // namespace utils

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -177,12 +177,17 @@ void for_each_unique(InputIt first, InputIt last, Unary func)
 template <class InputIt, class Predicate>
 std::pair<InputIt, InputIt> find_first_range(InputIt first, InputIt last, Predicate p)
 {
-  auto start = std::find_if(first, last, p);
-  if (start == last) { // nothing found
+  auto firstMatch = std::find_if(first, last, p);
+  if (firstMatch == last) { // nothing found
     return {last, last};
   }
-  auto stop = std::find_if_not(start, last, p);
-  return {start, stop};
+  auto trailing = firstMatch;
+  auto next     = std::next(firstMatch);
+  while (next != last && p(*next)) {
+    ++trailing;
+    ++next;
+  }
+  return {firstMatch, trailing};
 }
 
 } // namespace utils

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -173,6 +173,18 @@ void for_each_unique(InputIt first, InputIt last, Unary func)
   });
 }
 
+/// Finds the first range in [first, last[ that fulfills a predicate
+template <class InputIt, class Predicate>
+std::pair<InputIt, InputIt> find_first_range(InputIt first, InputIt last, Predicate p)
+{
+  auto start = std::find_if(first, last, p);
+  if (start == last) { // nothing found
+    return {last, last};
+  }
+  auto stop = std::find_if_not(start, last, p);
+  return {start, stop};
+}
+
 } // namespace utils
 } // namespace precice
 

--- a/src/utils/tests/AlgorithmTest.cpp
+++ b/src/utils/tests/AlgorithmTest.cpp
@@ -1,6 +1,7 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <array>
+#include <boost/test/unit_test_suite.hpp>
 #include <functional>
 #include <ostream>
 #include <string>
@@ -191,6 +192,110 @@ BOOST_AUTO_TEST_CASE(ScramblePointer)
 }
 
 BOOST_AUTO_TEST_SUITE_END() // ReorderArray
+
+BOOST_AUTO_TEST_SUITE(FindFirstRange)
+
+BOOST_AUTO_TEST_CASE(NoMatch)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{0, 1, 2, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return false; });
+  BOOST_TEST((first == v.end()));
+  BOOST_TEST((last == v.end()));
+}
+
+BOOST_AUTO_TEST_CASE(AllMatch)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{0, 1, 2, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return true; });
+  BOOST_TEST((first == v.begin()));
+  BOOST_TEST((last == v.end() - 1));
+}
+
+BOOST_AUTO_TEST_CASE(BeginSingle)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{0, 1, 2, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 0; });
+  BOOST_TEST((first == v.begin()));
+  BOOST_TEST((last == v.begin()));
+}
+
+BOOST_AUTO_TEST_CASE(BeginMultiple)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{0, 0, 2, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 0; });
+  BOOST_TEST((first == v.begin()));
+  BOOST_TEST((last == v.begin() + 1));
+}
+
+BOOST_AUTO_TEST_CASE(EndSingle)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{0, 1, 2, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 3; });
+  BOOST_TEST((first == v.end() - 1));
+  BOOST_TEST((last == first));
+}
+
+BOOST_AUTO_TEST_CASE(EndMultiple)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{1, 2, 3, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 3; });
+  BOOST_TEST((first == v.end() - 2));
+  BOOST_TEST((last == v.end() - 1));
+}
+
+BOOST_AUTO_TEST_CASE(MiddleSingle)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{1, 2, 3, 4};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 2; });
+  BOOST_TEST((first == v.begin() + 1));
+  BOOST_TEST((last == first));
+}
+
+BOOST_AUTO_TEST_CASE(MiddleMultiple)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{1, 2, 2, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 2; });
+  BOOST_TEST((first == v.begin() + 1));
+  BOOST_TEST((last == v.begin() + 2));
+}
+
+BOOST_AUTO_TEST_CASE(MultipleRangesSingleMatch)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{1, 2, 3, 4, 5, 3};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 3; });
+  BOOST_TEST((first == v.begin() + 2));
+  BOOST_TEST((last == first));
+}
+
+BOOST_AUTO_TEST_CASE(MultipleRangesMultipleMatches)
+{
+  PRECICE_TEST(1_rank);
+  std::vector v{1, 2, 2, 4, 2, 2};
+
+  auto [first, last] = utils::find_first_range(v.begin(), v.end(), [](int i) { return i == 2; });
+  BOOST_TEST((first == v.begin() + 1));
+  BOOST_TEST((last == v.begin() + 2));
+}
+
+BOOST_AUTO_TEST_SUITE_END() // FindRange
 
 BOOST_AUTO_TEST_SUITE_END() // Algorithm
 

--- a/tests/serial/mapping-nearest-projection/helpers.cpp
+++ b/tests/serial/mapping-nearest-projection/helpers.cpp
@@ -176,14 +176,17 @@ void testQuadMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFu
     auto &mesh = testing::WhiteboxAccessor::impl(interface).mesh("MeshOne");
     BOOST_REQUIRE(mesh.vertices().size() == 4);
     if (defineEdgesExplicitly) {
-      BOOST_REQUIRE(mesh.edges().size() == 9);
+      BOOST_REQUIRE(mesh.edges().size() == 4);
     } else {
-      BOOST_REQUIRE(mesh.edges().size() == 5);
+      BOOST_REQUIRE(mesh.edges().empty());
     }
     BOOST_REQUIRE(mesh.triangles().size() == 2);
 
     // Initialize, thus sending the mesh.
     double maxDt = interface.initialize();
+    BOOST_TEST(mesh.edges().size() == 5);
+    BOOST_TEST(mesh.triangles().size() == 2);
+
     BOOST_TEST(interface.isCouplingOngoing(), "Sending participant should have to advance once!");
 
     // Write the data to be send.
@@ -275,9 +278,9 @@ void testQuadMappingNearestProjectionTallKite(bool defineEdgesExplicitly, bool u
     auto &mesh = testing::WhiteboxAccessor::impl(interface).mesh("MeshOne");
     BOOST_REQUIRE(mesh.vertices().size() == 4);
     if (defineEdgesExplicitly) {
-      BOOST_REQUIRE(mesh.edges().size() == 9);
+      BOOST_REQUIRE(mesh.edges().size() == 4);
     } else {
-      BOOST_REQUIRE(mesh.edges().size() == 5);
+      BOOST_REQUIRE(mesh.edges().empty());
     }
     BOOST_REQUIRE(mesh.triangles().size() == 2);
 
@@ -334,9 +337,9 @@ void testQuadMappingNearestProjectionWideKite(bool defineEdgesExplicitly, bool u
     auto &mesh = testing::WhiteboxAccessor::impl(interface).mesh("MeshOne");
     BOOST_REQUIRE(mesh.vertices().size() == 4);
     if (defineEdgesExplicitly) {
-      BOOST_REQUIRE(mesh.edges().size() == 9);
+      BOOST_REQUIRE(mesh.edges().size() == 4);
     } else {
-      BOOST_REQUIRE(mesh.edges().size() == 5);
+      BOOST_REQUIRE(mesh.edges().empty());
     }
     BOOST_REQUIRE(mesh.triangles().size() == 2);
 

--- a/tests/serial/mapping-scaled-consistent/helpers.cpp
+++ b/tests/serial/mapping-scaled-consistent/helpers.cpp
@@ -45,11 +45,13 @@ void testQuadMappingScaledConsistent(const std::string configFile, const TestCon
 
     auto &mesh = testing::WhiteboxAccessor::impl(interface).mesh("MeshOne");
     BOOST_REQUIRE(mesh.vertices().size() == 4);
-    BOOST_REQUIRE(mesh.edges().size() == 5);
+    BOOST_REQUIRE(mesh.edges().empty());
     BOOST_REQUIRE(mesh.triangles().size() == 2);
 
     // Initialize, thus sending the mesh.
     double maxDt = interface.initialize();
+    BOOST_TEST(mesh.edges().size() == 5);
+    BOOST_TEST(mesh.triangles().size() == 2);
     BOOST_TEST(interface.isCouplingOngoing(), "Sending participant should have to advance once!");
 
     // Write the data to be send.

--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -186,14 +186,17 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
     auto &mesh = precice::testing::WhiteboxAccessor::impl(interface).mesh("MeshOne");
     // setMeshTetrahedron currently adds underlying connectivity
     BOOST_REQUIRE(mesh.vertices().size() == 4);
-    BOOST_REQUIRE(mesh.edges().size() == 6);
-    BOOST_REQUIRE(mesh.triangles().size() == 4);
+    BOOST_REQUIRE(mesh.edges().empty());
+    BOOST_REQUIRE(mesh.triangles().empty());
     BOOST_REQUIRE(mesh.tetrahedra().size() == 1);
 
     BOOST_TEST(equals(mesh.tetrahedra()[0].getVolume(), 1.0 / 6), "Tetrahedron volume must be 1/6");
 
     // Initialize, write data, advance and finalize
     double dt = interface.initialize();
+    BOOST_REQUIRE(mesh.edges().size() == 6);
+    BOOST_REQUIRE(mesh.triangles().size() == 4);
+    BOOST_REQUIRE(mesh.tetrahedra().size() == 1);
     BOOST_TEST(!mesh.tetrahedra().empty(), "Tetrahedra must still be stored");
     BOOST_TEST(interface.isCouplingOngoing(), "Sending participant must advance once.");
 
@@ -295,14 +298,17 @@ void testMappingVolumeOneTetraConservative(const std::string configFile, const T
     auto &mesh = precice::testing::WhiteboxAccessor::impl(interface).mesh("MeshTwo");
     // setMeshTetrahedron currently adds underlying connectivity
     BOOST_REQUIRE(mesh.vertices().size() == 4);
-    BOOST_REQUIRE(mesh.edges().size() == 6);
-    BOOST_REQUIRE(mesh.triangles().size() == 4);
+    BOOST_REQUIRE(mesh.edges().empty());
+    BOOST_REQUIRE(mesh.triangles().empty());
     BOOST_REQUIRE(mesh.tetrahedra().size() == 1);
 
     BOOST_TEST(equals(mesh.tetrahedra()[0].getVolume(), 1.0 / 6), "Tetrahedron volume must be 1/6");
 
     // Initialize, read data, advance and finalize. Check expected mapping
     double dt = interface.initialize();
+    BOOST_REQUIRE(mesh.edges().size() == 6);
+    BOOST_REQUIRE(mesh.triangles().size() == 4);
+    BOOST_REQUIRE(mesh.tetrahedra().size() == 1);
     BOOST_TEST(interface.isCouplingOngoing(), "Receiving participant must advance once.");
 
     interface.advance(dt);


### PR DESCRIPTION
## Main changes of this PR

This PR adds:
- Weak ordering to primitives, making them sortable
- Add pre-process to mesh which
  - firstly removes duplicates of explicitly specified primitives (user), and
  - secondly adds missing implicit primitives. (edges of triangles etc)
- Fix integration tests
- Add pre-processing tests

## Motivation and additional information

Closes #1321 and closes #1153

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
