### PR TITLE
Use central object library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,34 +253,33 @@ add_compile_definitions("$<$<CONFIG:DEBUG>:_GLIBCXX_ASSERTIONS>")
 print_empty()
 print_section("TARGETS & PACKAGES")
 
-# Add precice as an empty target
-add_library(precice)
-set_target_properties(precice PROPERTIES
-  # precice is a C++17 project
+# Core of preCICE bundling the sources and dependencies.
+# The main library and tests link against this.
+add_library(preciceCore OBJECT)
+set_target_properties(preciceCore PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED Yes
   CXX_EXTENSIONS No
-  VERSION ${preCICE_VERSION}
-  SOVERSION ${preCICE_SOVERSION}
+  POSITION_INDEPENDENT_CODE YES
   )
 
 # Setup release override options
 if(PRECICE_RELEASE_WITH_DEBUG_LOG)
-  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_DEBUG_LOG)
+  target_compile_definitions(preciceCore PUBLIC PRECICE_RELEASE_WITH_DEBUG_LOG)
 endif()
 
 if(PRECICE_RELEASE_WITH_TRACE_LOG)
-  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_TRACE_LOG)
+  target_compile_definitions(preciceCore PUBLIC PRECICE_RELEASE_WITH_TRACE_LOG)
 endif()
 
 if(PRECICE_RELEASE_WITH_ASSERTIONS)
-  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_ASSERTIONS)
+  target_compile_definitions(preciceCore PUBLIC PRECICE_RELEASE_WITH_ASSERTIONS)
 endif()
 
 
 # Setup Boost
-target_compile_definitions(precice PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
-target_link_libraries(precice PRIVATE
+target_compile_definitions(preciceCore PUBLIC BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
+target_link_libraries(preciceCore PUBLIC
   Boost::boost
   Boost::filesystem
   Boost::log
@@ -291,59 +290,72 @@ target_link_libraries(precice PRIVATE
   Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
-  target_compile_definitions(precice PRIVATE _GNU_SOURCE)
-  target_link_libraries(precice PRIVATE ${CMAKE_DL_LIBS})
+  target_compile_definitions(preciceCore PUBLIC _GNU_SOURCE)
+  target_link_libraries(preciceCore PUBLIC ${CMAKE_DL_LIBS})
 endif()
 
 # Setup Eigen3
-target_link_libraries(precice PRIVATE Eigen3::Eigen)
-target_compile_definitions(precice PRIVATE "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
+target_link_libraries(preciceCore PUBLIC Eigen3::Eigen)
+target_compile_definitions(preciceCore PUBLIC "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
 
 # Setup LIBXML2
-target_link_libraries(precice PRIVATE LibXml2::LibXml2)
+target_link_libraries(preciceCore PUBLIC LibXml2::LibXml2)
 
 # Setup JSON
-target_link_libraries(precice PRIVATE JSON fmt-header-only)
+target_link_libraries(preciceCore PUBLIC JSON fmt-header-only)
 
 # Setup MPI
 if (PRECICE_MPICommunication)
-  target_link_libraries(precice PRIVATE MPI::MPI_CXX)
+  target_link_libraries(preciceCore PUBLIC MPI::MPI_CXX)
 else()
-  target_compile_definitions(precice PRIVATE PRECICE_NO_MPI)
+  target_compile_definitions(preciceCore PUBLIC PRECICE_NO_MPI)
 endif()
 
 # Setup PETSC
 if (PRECICE_PETScMapping AND PRECICE_MPICommunication)
-  target_link_libraries(precice PRIVATE PETSc::PETSc)
+  target_link_libraries(preciceCore PUBLIC PETSc::PETSc)
 else()
-  target_compile_definitions(precice PRIVATE PRECICE_NO_PETSC)
+  target_compile_definitions(preciceCore PUBLIC PRECICE_NO_PETSC)
 endif()
 
 # Option Python
 if (PRECICE_PythonActions)
-  target_link_libraries(precice PRIVATE Python3::NumPy Python3::Python)
-  target_compile_definitions(precice PRIVATE NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
+  target_link_libraries(preciceCore PUBLIC Python3::NumPy Python3::Python)
+  target_compile_definitions(preciceCore PUBLIC NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
 else()
-  target_compile_definitions(precice PRIVATE PRECICE_NO_PYTHON)
+  target_compile_definitions(preciceCore PUBLIC PRECICE_NO_PYTHON)
 endif()
 
+# Includes configuration for the core
+target_include_directories(preciceCore PUBLIC
+  $<BUILD_INTERFACE:${preCICE_SOURCE_DIR}/src>
+  $<BUILD_INTERFACE:${preCICE_BINARY_DIR}/src>
+  $<INSTALL_INTERFACE:include>
+  )
 
-# File Configuration
-include(GenerateVersionInformation)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/DetectGitRevision.cmake)
-configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp" @ONLY)
-configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
+# Add precice as an empty target
+add_library(precice)
+set_target_properties(precice PROPERTIES
+  VERSION ${preCICE_VERSION}
+  SOVERSION ${preCICE_SOVERSION}
+  )
 
-# Includes Configuration
 target_include_directories(precice PUBLIC
   $<BUILD_INTERFACE:${preCICE_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${preCICE_BINARY_DIR}/src>
   $<INSTALL_INTERFACE:include>
   )
 
+target_link_libraries(precice PRIVATE preciceCore)
+
 # Sources Configuration
 include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 
+# File Configuration
+include(GenerateVersionInformation)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/DetectGitRevision.cmake)
+configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp" @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
 
 #
 # Configuration of Target precice-tools
@@ -379,21 +391,9 @@ IF (BUILD_TESTING)
   add_executable(testprecice "src/testing/main.cpp")
   target_link_libraries(testprecice
     PRIVATE
-    Threads::Threads
-    precice
-    Eigen3::Eigen
-    fmt-header-only
-    Boost::boost
-    Boost::filesystem
-    Boost::log
-    Boost::log_setup
-    Boost::program_options
-    Boost::system
-    Boost::thread
-    Boost::unit_test_framework
+    preciceCore
     )
   set_target_properties(testprecice PROPERTIES
-    # precice is a C++17 project
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED Yes
     CXX_EXTENSIONS No
@@ -402,18 +402,6 @@ IF (BUILD_TESTING)
     ${preCICE_SOURCE_DIR}/src
     ${preCICE_SOURCE_DIR}/tests
     )
-  # Copy needed properties from the lib to the executatble. This is necessary as
-  # this executable uses the library source, not only the interface.
-  copy_target_property(precice testprecice COMPILE_DEFINITIONS)
-  copy_target_property(precice testprecice COMPILE_OPTIONS)
-
-  # Testprecice fully depends on MPI and PETSc.
-  if(PRECICE_MPICommunication)
-    target_link_libraries(testprecice PRIVATE MPI::MPI_CXX)
-  endif()
-  if(PRECICE_MPICommunication AND PRECICE_PETScMapping)
-    target_link_libraries(testprecice PRIVATE PETSc::PETSc)
-  endif()
 
   message(STATUS "Including test sources")
   # Test Sources Configuration

--- a/extras/bindings/c/CMakeLists.txt
+++ b/extras/bindings/c/CMakeLists.txt
@@ -2,9 +2,13 @@ set_property(TARGET precice PROPERTY PUBLIC_HEADER
   ${CMAKE_CURRENT_LIST_DIR}/include/precice/SolverInterfaceC.h
   APPEND)
 
-target_sources(precice PRIVATE
+target_sources(preciceCore PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/include/precice/SolverInterfaceC.h
   ${CMAKE_CURRENT_LIST_DIR}/src/SolverInterfaceC.cpp
+  )
+
+target_include_directories(preciceCore PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   )
 
 target_include_directories(precice PUBLIC

--- a/extras/bindings/fortran/CMakeLists.txt
+++ b/extras/bindings/fortran/CMakeLists.txt
@@ -2,9 +2,13 @@ set_property(TARGET precice PROPERTY PUBLIC_HEADER
   ${CMAKE_CURRENT_LIST_DIR}/include/precice/SolverInterfaceFortran.hpp
   APPEND)
 
-target_sources(precice PRIVATE
+target_sources(preciceCore PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/src/SolverInterfaceFortran.cpp
   ${CMAKE_CURRENT_LIST_DIR}/include/precice/SolverInterfaceFortran.hpp
+  )
+
+target_include_directories(preciceCore PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   )
 
 target_include_directories(precice PUBLIC

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -2,7 +2,7 @@
 # This file lists all sources that will be compiles into the precice library
 #
 
-target_sources(precice
+target_sources(preciceCore
     PRIVATE
     ${CMAKE_BINARY_DIR}/src/precice/impl/versions.cpp
     ${CMAKE_BINARY_DIR}/src/precice/impl/versions.hpp

--- a/tools/building/updateSourceFiles.py
+++ b/tools/building/updateSourceFiles.py
@@ -104,7 +104,7 @@ SOURCES_BASE = """#
 # This file lists all sources that will be compiles into the precice library
 #
 
-target_sources(precice
+target_sources(preciceCore
     PRIVATE
     {}
     )


### PR DESCRIPTION
## Main changes of this PR

This PR bundles the precice sources and dependencies into a central object library `preciceCore`.

This "library" is then linked against by the actual library `precice` and the unit tests `testprecice`.


## Motivation and additional information

Reduce duplication of information in the `CMakeLists.txt`.

This is a required step to hiding non-API symbols #623 and simplifies adding benchmarks.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
