### PR TITLE
Document config-formatter in tools README.md

### DIFF
--- a/tools/formatting/README.md
+++ b/tools/formatting/README.md
@@ -12,6 +12,10 @@ This bash-script checks the format of every c(pp) & h(pp) file in the current an
 It returns 0 if everything is formatted correctly.
 Otherwise, it displays the list of files that do not match the format and returns 1.
 
+## cofig-formatter
+
+This Python script formats preCICE configuration files (XML) and prints it on the terminal. Use as `python3 config-formatter precice-config.xml`.
+
 ## format-all
 
 This bash-script applies the format of a parent `.clang-format` to every c(pp) & h(pp) file in the current and child directories. To format the complete codebase, run the script from the root directory.

--- a/tools/formatting/README.md
+++ b/tools/formatting/README.md
@@ -14,7 +14,7 @@ Otherwise, it displays the list of files that do not match the format and return
 
 ## cofig-formatter
 
-This Python script formats preCICE configuration files (XML) and prints it on the terminal. Use as `python3 config-formatter precice-config.xml`.
+This Python script formats preCICE configuration files (XML). Use as `python3 config-formatter -i precice-config.xml` to format `precice-config.xml` inline.
 
 ## format-all
 

--- a/tools/formatting/README.md
+++ b/tools/formatting/README.md
@@ -12,7 +12,7 @@ This bash-script checks the format of every c(pp) & h(pp) file in the current an
 It returns 0 if everything is formatted correctly.
 Otherwise, it displays the list of files that do not match the format and returns 1.
 
-## cofig-formatter
+## config-formatter
 
 This Python script formats preCICE configuration files (XML). Use as `python3 config-formatter -i precice-config.xml` to format `precice-config.xml` inline.
 


### PR DESCRIPTION
## Main changes of this PR

Adds `config-formatter` to the `README.md` of `tools/formatting`.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* I added a test to cover the proposed changes in our test suite. -> N/A
* I sticked to C++17 features. -> N/A
* I sticked to CMake version 3.16.3. -> N/A
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* @fsimonis is there any reason this was not documented here? I see that we have it in https://precice.org/community-contribute-to-precice.html#optional-help-us-with-some-checks
