### PR TITLE
WIP: Remove receiveResultOfFirstAdvance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,35 +253,34 @@ add_compile_definitions("$<$<CONFIG:DEBUG>:_GLIBCXX_ASSERTIONS>")
 print_empty()
 print_section("TARGETS & PACKAGES")
 
-# Core of preCICE bundling the sources and dependencies.
-# The main library and tests link against this.
-add_library(preciceCore OBJECT)
-set_target_properties(preciceCore PROPERTIES
+# Add precice as an empty target
+add_library(precice)
+set_target_properties(precice PROPERTIES
+  # precice is a C++17 project
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED Yes
   CXX_EXTENSIONS No
-  POSITION_INDEPENDENT_CODE YES
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN YES
+  VERSION ${preCICE_VERSION}
+  SOVERSION ${preCICE_SOVERSION}
   )
 
 # Setup release override options
 if(PRECICE_RELEASE_WITH_DEBUG_LOG)
-  target_compile_definitions(preciceCore PUBLIC PRECICE_RELEASE_WITH_DEBUG_LOG)
+  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_DEBUG_LOG)
 endif()
 
 if(PRECICE_RELEASE_WITH_TRACE_LOG)
-  target_compile_definitions(preciceCore PUBLIC PRECICE_RELEASE_WITH_TRACE_LOG)
+  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_TRACE_LOG)
 endif()
 
 if(PRECICE_RELEASE_WITH_ASSERTIONS)
-  target_compile_definitions(preciceCore PUBLIC PRECICE_RELEASE_WITH_ASSERTIONS)
+  target_compile_definitions(precice PRIVATE PRECICE_RELEASE_WITH_ASSERTIONS)
 endif()
 
 
 # Setup Boost
-target_compile_definitions(preciceCore PUBLIC BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
-target_link_libraries(preciceCore PUBLIC
+target_compile_definitions(precice PRIVATE BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
+target_link_libraries(precice PRIVATE
   Boost::boost
   Boost::filesystem
   Boost::log
@@ -292,68 +291,42 @@ target_link_libraries(preciceCore PUBLIC
   Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
-  target_compile_definitions(preciceCore PUBLIC _GNU_SOURCE)
-  target_link_libraries(preciceCore PUBLIC ${CMAKE_DL_LIBS})
+  target_compile_definitions(precice PRIVATE _GNU_SOURCE)
+  target_link_libraries(precice PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
 # Setup Eigen3
-target_link_libraries(preciceCore PUBLIC Eigen3::Eigen)
-target_compile_definitions(preciceCore PUBLIC "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
+target_link_libraries(precice PRIVATE Eigen3::Eigen)
+target_compile_definitions(precice PRIVATE "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")
 
 # Setup LIBXML2
-target_link_libraries(preciceCore PUBLIC LibXml2::LibXml2)
+target_link_libraries(precice PRIVATE LibXml2::LibXml2)
 
 # Setup JSON
-target_link_libraries(preciceCore PUBLIC JSON fmt-header-only)
+target_link_libraries(precice PRIVATE JSON fmt-header-only)
 
 # Setup MPI
 if (PRECICE_MPICommunication)
-  target_link_libraries(preciceCore PUBLIC MPI::MPI_CXX)
+  target_link_libraries(precice PRIVATE MPI::MPI_CXX)
 else()
-  target_compile_definitions(preciceCore PUBLIC PRECICE_NO_MPI)
+  target_compile_definitions(precice PRIVATE PRECICE_NO_MPI)
 endif()
 
 # Setup PETSC
 if (PRECICE_PETScMapping AND PRECICE_MPICommunication)
-  target_link_libraries(preciceCore PUBLIC PETSc::PETSc)
+  target_link_libraries(precice PRIVATE PETSc::PETSc)
 else()
-  target_compile_definitions(preciceCore PUBLIC PRECICE_NO_PETSC)
+  target_compile_definitions(precice PRIVATE PRECICE_NO_PETSC)
 endif()
 
 # Option Python
 if (PRECICE_PythonActions)
-  target_link_libraries(preciceCore PUBLIC Python3::NumPy Python3::Python)
-  target_compile_definitions(preciceCore PUBLIC NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
+  target_link_libraries(precice PRIVATE Python3::NumPy Python3::Python)
+  target_compile_definitions(precice PRIVATE NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
 else()
-  target_compile_definitions(preciceCore PUBLIC PRECICE_NO_PYTHON)
+  target_compile_definitions(precice PRIVATE PRECICE_NO_PYTHON)
 endif()
 
-# Includes configuration for the core
-target_include_directories(preciceCore PUBLIC
-  $<BUILD_INTERFACE:${preCICE_SOURCE_DIR}/src>
-  $<BUILD_INTERFACE:${preCICE_BINARY_DIR}/src>
-  $<INSTALL_INTERFACE:include>
-  )
-
-# Add precice as an empty target
-add_library(precice)
-set_target_properties(precice PROPERTIES
-  VERSION ${preCICE_VERSION}
-  SOVERSION ${preCICE_SOVERSION}
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN YES
-  )
-
-target_include_directories(precice PUBLIC
-  $<BUILD_INTERFACE:${preCICE_SOURCE_DIR}/src>
-  $<BUILD_INTERFACE:${preCICE_BINARY_DIR}/src>
-  $<INSTALL_INTERFACE:include>
-  )
-
-target_link_libraries(precice PRIVATE preciceCore)
-
-# Sources Configuration
-include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 
 # File Configuration
 include(GenerateVersionInformation)
@@ -361,18 +334,16 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/DetectGitRevision.cmake)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp" @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
 
-# Setup export header
-include(GenerateExportHeader)
-GENERATE_EXPORT_HEADER(preciceCore
-  EXPORT_FILE_NAME "src/precice/export.h"
-  BASE_NAME PRECICE
-  EXPORT_MACRO_NAME PRECICE_API
-  INCLUDE_GUARD_NAME PRECICE_EXPORT
+# Includes Configuration
+target_include_directories(precice PUBLIC
+  $<BUILD_INTERFACE:${preCICE_SOURCE_DIR}/src>
+  $<BUILD_INTERFACE:${preCICE_BINARY_DIR}/src>
+  $<INSTALL_INTERFACE:include>
   )
 
-# Add the export header to the public headers of the preCICE lib
-set_property(TARGET precice PROPERTY PUBLIC_HEADER
-    ${CMAKE_BINARY_DIR}/src/precice/export.h)
+# Sources Configuration
+include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
+
 
 #
 # Configuration of Target precice-tools
@@ -408,9 +379,21 @@ IF (BUILD_TESTING)
   add_executable(testprecice "src/testing/main.cpp")
   target_link_libraries(testprecice
     PRIVATE
-    preciceCore
+    Threads::Threads
+    precice
+    Eigen3::Eigen
+    fmt-header-only
+    Boost::boost
+    Boost::filesystem
+    Boost::log
+    Boost::log_setup
+    Boost::program_options
+    Boost::system
+    Boost::thread
+    Boost::unit_test_framework
     )
   set_target_properties(testprecice PROPERTIES
+    # precice is a C++17 project
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED Yes
     CXX_EXTENSIONS No
@@ -419,6 +402,18 @@ IF (BUILD_TESTING)
     ${preCICE_SOURCE_DIR}/src
     ${preCICE_SOURCE_DIR}/tests
     )
+  # Copy needed properties from the lib to the executatble. This is necessary as
+  # this executable uses the library source, not only the interface.
+  copy_target_property(precice testprecice COMPILE_DEFINITIONS)
+  copy_target_property(precice testprecice COMPILE_OPTIONS)
+
+  # Testprecice fully depends on MPI and PETSc.
+  if(PRECICE_MPICommunication)
+    target_link_libraries(testprecice PRIVATE MPI::MPI_CXX)
+  endif()
+  if(PRECICE_MPICommunication AND PRECICE_PETScMapping)
+    target_link_libraries(testprecice PRIVATE PETSc::PETSc)
+  endif()
 
   message(STATUS "Including test sources")
   # Test Sources Configuration

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -192,9 +192,6 @@ public:
    */
   void initialize(double startTime, int startTimeWindow) override final;
 
-  /// Receives result of first advance, if this has to happen inside SolverInterface::initialize(), see CouplingScheme.hpp
-  void receiveResultOfFirstAdvance() override final;
-
   /**
    * @brief Advances the coupling scheme.
    */
@@ -236,11 +233,30 @@ protected:
   /// Map that links DataID to CouplingData
   typedef std::map<int, PtrCouplingData> DataMap;
 
-  /// Sends data sendDataIDs given in mapCouplingData with communication.
+  /**
+   * @brief Sends data sendDataIDs given in mapCouplingData with communication.
+   *
+   * @param m2n M2N used for communication
+   * @param sendData DataMap associated with sent data
+   */
   void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData);
 
-  /// Receives data receiveDataIDs given in mapCouplingData with communication.
+  /**
+   * @brief Receives data receiveDataIDs given in mapCouplingData with communication.
+   *
+   * @param m2n M2N used for communication
+   * @param receiveData DataMap associated with received data
+   */
   void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData);
+
+  /**
+   * @brief Initialized receiveData with zero values.
+   *
+   * This function is called instead of receive data, if no initial data is received to initialize data with zero
+   *
+   * @param receiveData DataMap associated with received data
+   */
+  void initializeZeroReceiveData(const DataMap &receiveData);
 
   /**
    * @brief interface to provide all CouplingData, depending on coupling scheme being used
@@ -505,13 +521,12 @@ private:
   virtual void exchangeInitialData() = 0;
 
   /**
-   * @brief implements functionality for receiveResultOfFirstAdvance
+   * @brief Receives result of first advance, if this has to happen inside BaseCouplingScheme::initialize()
+   *
+   * This is only relevant for the second participant of the SerialCouplingScheme, because other coupling schemes only
+   * receive initial data in initialize.
    */
-  virtual void performReceiveOfFirstAdvance()
-  {
-    // noop by default. Will be overridden by child-coupling-schemes, if data has to be received here. See SerialCouplingScheme.
-    return;
-  }
+  virtual void performReceiveOfFirstAdvance() = 0;
 
   /// Functions needed for advance()
 

--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -134,17 +134,45 @@ void BiCouplingScheme::exchangeInitialData()
       sendData(getM2N(), getSendData());
     }
     if (receivesInitializedData()) {
+      for (const DataMap::value_type &pair : getReceiveData()) {
+        pair.second->clearTimeStepsStorage(false);
+      }
       receiveData(getM2N(), getReceiveData());
+      for (const DataMap::value_type &pair : getReceiveData()) {
+        pair.second->moveTimeStepsStorage();
+      }
       checkDataHasBeenReceived();
+    } else {
+      initializeZeroReceiveData(getReceiveData());
     }
   } else { // second participant
     if (receivesInitializedData()) {
+      for (const DataMap::value_type &pair : getReceiveData()) {
+        pair.second->clearTimeStepsStorage(false);
+      }
       receiveData(getM2N(), getReceiveData());
+      for (const DataMap::value_type &pair : getReceiveData()) {
+        pair.second->moveTimeStepsStorage();
+      }
       checkDataHasBeenReceived();
+    } else {
+      initializeZeroReceiveData(getReceiveData());
     }
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData());
     }
+  }
+}
+
+void BiCouplingScheme::retreiveTimeStepReceiveData(double relativeDt)
+{
+  PRECICE_ASSERT(math::greaterEquals(relativeDt, time::Storage::WINDOW_START), relativeDt);
+  PRECICE_ASSERT(math::greaterEquals(time::Storage::WINDOW_END, relativeDt), relativeDt);
+  for (auto &receiveData : getReceiveData()) {
+    auto dataId    = receiveData.second->getDataID();
+    auto allData   = getAllData();
+    auto data      = allData[dataId];
+    data->values() = data->getDataAtTime(relativeDt);
   }
 }
 

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -74,6 +74,13 @@ public:
     return getSendData(dataID) != nullptr;
   }
 
+  /**
+   * @brief retreives time step data from CouplingData into mesh values
+   *
+   * @param relativeDt relative dt associated with the data.
+   */
+  void retreiveTimeStepReceiveData(double relativeDt) override final;
+
 protected:
   /// Returns all data to be sent.
   DataMap &getSendData()

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -29,13 +29,6 @@ void CompositionalCouplingScheme::initialize(
   determineActiveCouplingSchemes();
 }
 
-void CompositionalCouplingScheme::receiveResultOfFirstAdvance()
-{
-  for (const Scheme &scheme : _couplingSchemes) {
-    scheme.scheme->receiveResultOfFirstAdvance();
-  }
-}
-
 bool CompositionalCouplingScheme::sendsInitializedData() const
 {
   PRECICE_TRACE();
@@ -135,6 +128,14 @@ bool CompositionalCouplingScheme::hasDataBeenReceived() const
   }
   PRECICE_DEBUG("return {}", hasBeenReceived);
   return hasBeenReceived;
+}
+
+void CompositionalCouplingScheme::retreiveTimeStepReceiveData(double relativeDt)
+{
+  PRECICE_TRACE();
+  for (SchemesIt it = _activeSchemesBegin; it != _activeSchemesEnd; it++) {
+    it->scheme->retreiveTimeStepReceiveData(relativeDt);
+  }
 }
 
 double CompositionalCouplingScheme::getTime() const

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -81,8 +81,6 @@ public:
       double startTime,
       int    startTimeWindow) final override;
 
-  void receiveResultOfFirstAdvance() override final;
-
   /// Returns true, if any of the composed coupling schemes sendsInitializedData for this participant
   bool sendsInitializedData() const override final;
 
@@ -117,6 +115,13 @@ public:
    * @returns true, if data has been exchanged in last call of advance().
    */
   bool hasDataBeenReceived() const final override;
+
+  /**
+   * @brief retreives time step data from CouplingData into mesh values
+   *
+   * @param relativeDt relative dt associated with the data.
+   */
+  void retreiveTimeStepReceiveData(double relativeDt) final override;
 
   /**
    * @brief Returns the currently computed time of the coupling scheme.

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -132,4 +132,27 @@ void CouplingData::storeExtrapolationData()
   _extrapolation.store(values());
 }
 
+void CouplingData::clearTimeStepsStorage(bool keepZero)
+{
+  _timeStepsStorage.clear(keepZero);
+}
+
+void CouplingData::moveTimeStepsStorage()
+{
+  _timeStepsStorage.move();
+}
+
+void CouplingData::storeDataAtTime(Eigen::VectorXd data, double relativeDt)
+{
+  PRECICE_ASSERT(math::greaterEquals(relativeDt, time::Storage::WINDOW_START), relativeDt);
+  PRECICE_ASSERT(math::greaterEquals(relativeDt, _timeStepsStorage.maxStoredNormalizedDt()), relativeDt, _timeStepsStorage.maxStoredNormalizedDt());
+  PRECICE_ASSERT(math::greaterEquals(time::Storage::WINDOW_END, relativeDt), relativeDt);
+  _timeStepsStorage.setValueAtTime(relativeDt, data);
+}
+
+Eigen::VectorXd CouplingData::getDataAtTime(double relativeDt)
+{
+  return _timeStepsStorage.getValueAtTime(relativeDt);
+}
+
 } // namespace precice::cplscheme

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -5,6 +5,7 @@
 #include "cplscheme/CouplingScheme.hpp"
 #include "cplscheme/impl/Extrapolation.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "time/Storage.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice {
@@ -71,10 +72,22 @@ public:
   void initializeExtrapolation();
 
   /// move to next window and initialize data via extrapolation
-  void moveToNextWindow();
+  void moveToNextWindow(); // @todo very easy to mix up with moveTimeStepsStorage. Try to rename or merge!
 
   /// store current value in _extrapolation
   void storeExtrapolationData();
+
+  /// clears _timeStepsStorage. Called after data was written or before data is received.
+  void clearTimeStepsStorage(bool keepZero);
+
+  /// moves _timeStepsStorage. Called after converged data was received.
+  void moveTimeStepsStorage(); // @todo very easy to mix up with moveToNextWindow. Try to rename or merge!
+
+  /// stores data at key relativeDt in _timeStepsStorage for later use.
+  void storeDataAtTime(Eigen::VectorXd data, double relativeDt);
+
+  /// returns data for a given key. Assumes that this data exists under the key.
+  Eigen::VectorXd getDataAtTime(double relativeDt);
 
 private:
   /**
@@ -104,6 +117,9 @@ private:
 
   /// Extrapolation associated with this CouplingData
   cplscheme::impl::Extrapolation _extrapolation;
+
+  /// Stores time steps in the current time window
+  time::Storage _timeStepsStorage;
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -69,16 +69,6 @@ public:
       int    startTimeWindow) = 0;
 
   /**
-   * @brief Receives result of first advance, if this has to happen inside SolverInterface::initialize()
-   *
-   * This is only relevant for the second participant of the SerialCouplingScheme, because other coupling schemes only
-   * receive initial data in initialize. This part is implemented as a public function to be called from
-   * SolverInterfaceImpl. SolverInterfaceImpl has to store data received in CouplingScheme::initialize before calling
-   * CouplingScheme::receiveResultOfFirstAdvance, which will override the data in the receive buffer.
-   */
-  virtual void receiveResultOfFirstAdvance() = 0;
-
-  /**
    * @brief Returns whether this participant of the coupling scheme sends initialized data.
    *
    * @returns true, if this participant of the coupling scheme sends initialized data
@@ -119,6 +109,14 @@ public:
 
   /// @brief Returns true, if data has been exchanged in last call of advance().
   virtual bool hasDataBeenReceived() const = 0;
+
+  // @todo find a better name. This is too low level.
+  /**
+   * @brief retreives time step data from CouplingData into mesh values
+   *
+   * @param relativeDt relative dt associated with the data.
+   */
+  virtual void retreiveTimeStepReceiveData(double relativeDt) = 0;
 
   /// Returns the currently computed time of the coupling scheme.
   virtual double getTime() const = 0;

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -77,6 +77,13 @@ public:
     return std::any_of(_sendDataVector.cbegin(), _sendDataVector.cend(), [](const auto &sendExchange) { return not sendExchange.second.empty(); });
   }
 
+  /**
+   * @brief retreives time step data from CouplingData into mesh values
+   *
+   * @param relativeDt relative dt associated with the data.
+   */
+  void retreiveTimeStepReceiveData(double relativeDt) override final;
+
 private:
   /**
    * @brief A vector of m2ns. A m2n is a communication device to the other coupling participant.
@@ -99,18 +106,9 @@ private:
    * @brief BiCouplingScheme has _sendData and _receiveData
    * @returns DataMap with all data
    */
-  const DataMap getAllData() override
-  {
-    DataMap allData;
-    // @todo user C++17 std::map::merge
-    for (auto &sendData : _sendDataVector) {
-      allData.insert(sendData.second.begin(), sendData.second.end());
-    }
-    for (auto &receiveData : _receiveDataVector) {
-      allData.insert(receiveData.second.begin(), receiveData.second.end());
-    }
-    return allData;
-  }
+  const DataMap getAllData() override;
+
+  void performReceiveOfFirstAdvance() override final;
 
   /**
    * @brief Exchanges all data between the participants of the MultiCouplingScheme and applies acceleration.

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -59,6 +59,8 @@ public:
 private:
   logging::Logger _log{"cplscheme::ParallelCouplingScheme"};
 
+  void performReceiveOfFirstAdvance() override final;
+
   /**
    * @brief Exchanges all data between the participants of the ParallelCouplingScheme and applies acceleration.
    * @returns true, if iteration converged

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -128,8 +128,6 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(cplScheme->getNextTimestepMaxLength() > 0.0); // ??
     } else if (participantName == std::string("Participant1")) {
       cplScheme->initialize(0.0, 1);
-      BOOST_TEST(!cplScheme->hasDataBeenReceived());
-      cplScheme->receiveResultOfFirstAdvance();
       BOOST_TEST(cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());
@@ -159,8 +157,6 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
     } else {
       BOOST_TEST(participantName == std::string("Participant2"), participantName);
       cplScheme->initialize(0.0, 1);
-      BOOST_TEST(!cplScheme->hasDataBeenReceived());
-      cplScheme->receiveResultOfFirstAdvance();
       BOOST_TEST(cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -40,14 +40,6 @@ public:
   /**
    * @brief Not implemented.
    */
-  void receiveResultOfFirstAdvance() override final
-  {
-    PRECICE_ASSERT(false);
-  }
-
-  /**
-   * @brief Not implemented.
-   */
   bool isInitialized() const override final
   {
     PRECICE_ASSERT(false);
@@ -105,6 +97,14 @@ public:
   {
     PRECICE_ASSERT(false);
     return false;
+  }
+
+  /**
+   * @brief Not implemented.
+   */
+  void retreiveTimeStepReceiveData(double relativeDt) override final
+  {
+    PRECICE_ASSERT(false);
   }
 
   /**

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -53,8 +53,6 @@ void runSimpleExplicitCoupling(
   if (participantName == std::string("Participant0")) {
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
@@ -94,8 +92,6 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
   } else if (participantName == std::string("Participant1")) {
     cplScheme.initialize(0.0, 1);
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     double value = dataValues0(vertex.getID());
     BOOST_TEST(testing::equals(value, valueData0));
@@ -162,8 +158,6 @@ void runExplicitCouplingWithSubcycling(
     double dtDesired = cplScheme.getNextTimestepMaxLength() / 2.0;
     double dtUsed    = dtDesired;
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
     BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
@@ -212,8 +206,6 @@ void runExplicitCouplingWithSubcycling(
   } else if (participantName == nameParticipant1) {
     // Start coupling
     cplScheme.initialize(0.0, 1);
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     // Validate current coupling status
     BOOST_TEST(testing::equals(dataValues0(vertex.getID()), valueData0));
@@ -407,8 +399,6 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
     double dt = 0.3;
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
@@ -431,8 +421,6 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
     cplScheme.initialize(0.0, 1);
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
@@ -504,8 +492,6 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteInitialData()));
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(dataValues0(0), 0.0));
     BOOST_TEST(testing::equals(dataValues1(0), 1.0));
     dataValues2(0) = 2.0;
@@ -521,7 +507,6 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
     dataValues1(0) = 1.0;
     cplScheme.markActionFulfilled(constants::actionWriteInitialData());
     cplScheme.initialize(0.0, 1);
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(testing::equals(dataValues2(0), 2.0));
     cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
     cplScheme.advance();
@@ -581,8 +566,6 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
     cplScheme.markActionFulfilled(constants::actionWriteInitialData());
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(dataValues0(0), 0.0));
     BOOST_TEST(testing::equals(dataValues1(0), 1.0));
     dataValues2(0) = 2.0;
@@ -600,8 +583,6 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
     cplScheme.markActionFulfilled(constants::actionWriteInitialData());
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(dataValues2(0), 3.0));
     dataValues0(0) = 4.0;
     cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -74,7 +74,6 @@ void runCoupling(
 
   if (nameParticipant == nameParticipant0) {
     cplScheme.initialize(0.0, 1);
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -139,7 +138,6 @@ void runCoupling(
     BOOST_TEST(testing::equals(computedTimesteps, 3));
   } else if (nameParticipant == nameParticipant1) {
     cplScheme.initialize(0.0, 1);
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -239,7 +237,6 @@ void runCouplingWithSubcycling(
   if (nameParticipant == nameParticipant0) {
     iterationCount++; // different handling due to subcycling
     cplScheme.initialize(0.0, 1);
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -320,7 +317,6 @@ void runCouplingWithSubcycling(
   else if (nameParticipant == nameParticipant1) {
     iterationCount++; // different handling due to subcycling
     cplScheme.initialize(0.0, 1);
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
     BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
@@ -688,7 +684,6 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
   cplScheme.initialize(0.0, 1);
-  cplScheme.receiveResultOfFirstAdvance();
 
   Eigen::VectorXd v(1); // buffer for data
 
@@ -912,8 +907,6 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
     // first participant receives initial data = 4 (see above)
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(!cplScheme.hasDataBeenReceived());
     BOOST_TEST(mesh->data(receiveDataIndex)->values().size() == 1);
     BOOST_TEST(testing::equals(mesh->data(receiveDataIndex)->values()(0), 4.0));
     // first participant does not send any data here
@@ -922,8 +915,6 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   } else {
     // second participant result written by first participant in its first window = 1 (see below)
     cplScheme.initialize(0.0, 1);
-    BOOST_TEST(!cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(context.isNamed(second));
     BOOST_TEST(mesh->data(receiveDataIndex)->values().size() == 1);
@@ -1134,7 +1125,6 @@ BOOST_AUTO_TEST_CASE(SecondOrderWithAcceleration)
   std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
   cplScheme.initialize(0.0, 1);
-  cplScheme.receiveResultOfFirstAdvance();
 
   Eigen::VectorXd v(1); // buffer for data
 
@@ -1617,8 +1607,6 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(Fixture::isImplicitCouplingScheme(cplScheme));
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(!cplScheme.hasDataBeenReceived());
     // ensure that initial data was read
     BOOST_TEST(receiveCouplingData->getSize() == 3);
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
@@ -1659,8 +1647,6 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 3); // here, previousIteration is correctly initialized, see above
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     cplScheme.initialize(0.0, 1);
-    BOOST_TEST(!cplScheme.hasDataBeenReceived());
-    cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(receiveCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 4.0));

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -32,20 +32,14 @@ int ReadDataContext::getInterpolationOrder() const
   return _waveform->getInterpolationOrder();
 }
 
-void ReadDataContext::storeDataInWaveform()
+void ReadDataContext::storeDataInWaveform(double relativeDt)
 {
-  _waveform->store(_providedData->values()); // store mapped or received _providedData in the _waveform
+  _waveform->store(_providedData->values(), relativeDt); // store mapped or received _providedData in the _waveform
 }
 
 Eigen::VectorXd ReadDataContext::sampleWaveformAt(double normalizedDt)
 {
   return _waveform->sample(normalizedDt);
-}
-
-void ReadDataContext::initializeWaveform()
-{
-  PRECICE_ASSERT(not hasWriteMapping(), "Write mapping does not need waveforms.");
-  _waveform->initialize(_providedData->values());
 }
 
 void ReadDataContext::moveToNextWindow()

--- a/src/precice/impl/ReadDataContext.hpp
+++ b/src/precice/impl/ReadDataContext.hpp
@@ -56,19 +56,16 @@ public:
   Eigen::VectorXd sampleWaveformAt(double normalizedDt);
 
   /**
-   * @brief Initializes the _waveform as a constant function with values from _providedData.
-   */
-  void initializeWaveform();
-
-  /**
    * @brief Updates _waveform when moving to the next time window.
    */
   void moveToNextWindow();
 
   /**
-   * @brief Stores _providedData as first sample of _waveform.
+   * @brief Stores _providedData in _waveform. Uses provided relativeDt to label data.
+   *
+   * @param[in] relativeDt relativeDt in waveform the data will be associated with.
    */
-  void storeDataInWaveform();
+  void storeDataInWaveform(double relativeDt);
 
 private:
   static logging::Logger _log;

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -525,7 +525,7 @@ private:
   void mapWrittenData();
 
   /// Computes, performs, and resets all suitable read mappings.
-  void mapReadData();
+  void mapReadData(std::vector<double> receiveTimes);
 
   /**
    * @brief Performs all data actions with given timing.

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -7,6 +7,12 @@ namespace precice::time {
 
 class Storage {
 public:
+  /// Fixed time associated with beginning of window
+  static const double WINDOW_START;
+
+  /// Fixed time associated with end of window
+  static const double WINDOW_END;
+
   /**
    * @brief Stores data samples in time and provides corresponding convenience functions.
    *
@@ -40,6 +46,15 @@ public:
    * @return the maximum normalized dt from this Storage
    */
   double maxStoredNormalizedDt();
+
+  // @todo try to remove this function. In most cases we could use Eigen::VectorXd Storage::getValueAtEndOfWindow() instead (more efficient and robust).
+  /**
+   * @brief Returns the value at given time contained in this Storage.
+   *
+   * @param time a double, the value in the Storage is associated with
+   * @return Eigen::VectorXd a value in this Storage
+   */
+  Eigen::VectorXd getValueAtTime(double time);
 
   /**
    * @brief Returns the value at time following "before" contained in this Storage.

--- a/src/time/Waveform.cpp
+++ b/src/time/Waveform.cpp
@@ -34,7 +34,9 @@ void Waveform::store(const Eigen::VectorXd &values, double normalizedDt)
     bool keepZero = true;
     _storage.clear(keepZero);
   }
-  PRECICE_ASSERT(values.size() == _storage.nDofs());
+  if (_storage.nTimes() > 0) {
+    PRECICE_ASSERT(values.size() == _storage.nDofs());
+  }
   _storage.setValueAtTime(normalizedDt, values);
 }
 
@@ -61,7 +63,7 @@ Eigen::VectorXd Waveform::sample(double normalizedDt)
 {
   const int usedOrder = computeUsedOrder(_interpolationOrder, _storage.nTimes());
 
-  PRECICE_ASSERT(math::equals(this->_storage.maxStoredNormalizedDt(), 1.0), this->_storage.maxStoredNormalizedDt()); // sampling is only allowed, if a window is complete.
+  PRECICE_ASSERT(math::equals(this->_storage.maxStoredNormalizedDt(), time::Storage::WINDOW_END), this->_storage.maxStoredNormalizedDt()); // sampling is only allowed, if a window is complete.
 
   if (_interpolationOrder == 0) {
     return this->_storage.getValueAtOrAfter(normalizedDt);


### PR DESCRIPTION
## Main changes of this PR

Removes `CouplingScheme::receiveResultOfFirstAdvance` and simplifies usage of `CouplingScheme`

## Motivation and additional information

simplifies implementation in #1414 and #1462 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
