### PR TITLE
Change CPL actions to enum struct

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -151,7 +151,7 @@ void BaseCouplingScheme::initialize(double startTime, int startTimeWindow)
       // reserve memory and initialize data with zero
       initializeStorages();
     }
-    requireAction(constants::actionWriteIterationCheckpoint());
+    requireAction(CouplingScheme::Action::WriteCheckpoint);
     initializeTXTWriters();
   }
 
@@ -229,7 +229,7 @@ void BaseCouplingScheme::secondExchange()
     if (isImplicitCouplingScheme()) { // check convergence
       if (not hasConverged()) {       // repeat window
         PRECICE_DEBUG("No convergence achieved");
-        requireAction(constants::actionReadIterationCheckpoint());
+        requireAction(CouplingScheme::Action::ReadCheckpoint);
         // The computed time window part equals the time window size, since the
         // time window remainder is zero. Subtract the time window size and do another
         // coupling iteration.
@@ -243,7 +243,7 @@ void BaseCouplingScheme::secondExchange()
         _isTimeWindowComplete = true;
         if (isCouplingOngoing()) {
           PRECICE_DEBUG("Setting require create checkpoint");
-          requireAction(constants::actionWriteIterationCheckpoint());
+          requireAction(CouplingScheme::Action::WriteCheckpoint);
         }
       }
       //update iterations
@@ -379,28 +379,28 @@ bool BaseCouplingScheme::isTimeWindowComplete() const
 }
 
 bool BaseCouplingScheme::isActionRequired(
-    const std::string &actionName) const
+    Action action) const
 {
-  return _requiredActions.count(actionName) == 1;
+  return _requiredActions.count(action) == 1;
 }
 
 bool BaseCouplingScheme::isActionFulfilled(
-    const std::string &actionName) const
+    Action action) const
 {
-  return _fulfilledActions.count(actionName) == 1;
+  return _fulfilledActions.count(action) == 1;
 }
 
 void BaseCouplingScheme::markActionFulfilled(
-    const std::string &actionName)
+    Action action)
 {
-  PRECICE_ASSERT(isActionRequired(actionName));
-  _fulfilledActions.insert(actionName);
+  PRECICE_ASSERT(isActionRequired(action));
+  _fulfilledActions.insert(action);
 }
 
 void BaseCouplingScheme::requireAction(
-    const std::string &actionName)
+    Action action)
 {
-  _requiredActions.insert(actionName);
+  _requiredActions.insert(action);
 }
 
 std::string BaseCouplingScheme::printCouplingState() const
@@ -443,8 +443,8 @@ std::string BaseCouplingScheme::printBasicState(
 std::string BaseCouplingScheme::printActionsState() const
 {
   std::ostringstream os;
-  for (const std::string &actionName : _requiredActions) {
-    os << actionName << ' ';
+  for (auto action : _requiredActions) {
+    os << toString(action) << ' ';
   }
   return os.str();
 }
@@ -452,17 +452,17 @@ std::string BaseCouplingScheme::printActionsState() const
 void BaseCouplingScheme::checkCompletenessRequiredActions()
 {
   PRECICE_TRACE();
-  std::vector<std::string> missing;
+  std::vector<Action> missing;
   std::set_difference(_requiredActions.begin(), _requiredActions.end(),
                       _fulfilledActions.begin(), _fulfilledActions.end(),
                       std::back_inserter(missing));
   if (not missing.empty()) {
     std::ostringstream stream;
-    for (const std::string &action : missing) {
+    for (auto action : missing) {
       if (not stream.str().empty()) {
         stream << ", ";
       }
-      stream << action;
+      stream << toString(action);
     }
     PRECICE_ERROR("The required actions {} are not fulfilled. "
                   "Did you forget to call \"requiresReadingCheckpoint()\" or \"requiresWritingCheckpoint()\"?",
@@ -628,7 +628,7 @@ void BaseCouplingScheme::determineInitialSend(BaseCouplingScheme::DataMap &sendD
 {
   if (anyDataRequiresInitialization(sendData)) {
     _sendsInitializedData = true;
-    requireAction(constants::actionWriteInitialData());
+    requireAction(CouplingScheme::Action::InitializeData);
   }
 }
 

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -166,16 +166,16 @@ public:
   bool isTimeWindowComplete() const override final;
 
   /// Returns true, if the given action has to be performed by the accessor.
-  bool isActionRequired(const std::string &actionName) const override final;
+  bool isActionRequired(Action action) const override final;
 
   /// Returns true, if the given action has to be performed by the accessor.
-  bool isActionFulfilled(const std::string &actionName) const override final;
+  bool isActionFulfilled(Action action) const override final;
 
   /// Tells the coupling scheme that the accessor has performed the given action.
-  void markActionFulfilled(const std::string &actionName) override final;
+  void markActionFulfilled(Action action) override final;
 
   /// Sets an action required to be performed by the accessor.
-  void requireAction(const std::string &actionName) override final;
+  void requireAction(Action action) override final;
 
   /**
    * @brief Returns coupling state information.
@@ -452,9 +452,9 @@ private:
   /// True, if coupling has been initialized.
   bool _isInitialized = false;
 
-  std::set<std::string> _requiredActions;
+  std::set<Action> _requiredActions;
 
-  std::set<std::string> _fulfilledActions;
+  std::set<Action> _fulfilledActions;
 
   /// True if implicit scheme converged
   bool _hasConverged = false;

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -253,12 +253,12 @@ bool CompositionalCouplingScheme::isTimeWindowComplete() const
 }
 
 bool CompositionalCouplingScheme::isActionRequired(
-    const std::string &actionName) const
+    Action action) const
 {
-  PRECICE_TRACE(actionName);
+  PRECICE_TRACE();
   bool isRequired = false;
   for (auto scheme : allSchemes()) {
-    if (scheme->isActionRequired(actionName)) {
+    if (scheme->isActionRequired(action)) {
       isRequired = true;
       break;
     }
@@ -268,12 +268,12 @@ bool CompositionalCouplingScheme::isActionRequired(
 }
 
 bool CompositionalCouplingScheme::isActionFulfilled(
-    const std::string &actionName) const
+    Action action) const
 {
-  PRECICE_TRACE(actionName);
+  PRECICE_TRACE();
   bool isFulfilled = false;
   for (auto scheme : allSchemes()) {
-    if (scheme->isActionFulfilled(actionName)) {
+    if (scheme->isActionFulfilled(action)) {
       isFulfilled = true;
       break;
     }
@@ -283,22 +283,22 @@ bool CompositionalCouplingScheme::isActionFulfilled(
 }
 
 void CompositionalCouplingScheme::markActionFulfilled(
-    const std::string &actionName)
+    Action action)
 {
-  PRECICE_TRACE(actionName);
+  PRECICE_TRACE();
   for (auto scheme : allSchemes()) {
-    if (scheme->isActionRequired(actionName)) {
-      scheme->markActionFulfilled(actionName);
+    if (scheme->isActionRequired(action)) {
+      scheme->markActionFulfilled(action);
     }
   }
 }
 
 void CompositionalCouplingScheme::requireAction(
-    const std::string &actionName)
+    Action action)
 {
-  PRECICE_TRACE(actionName);
+  PRECICE_TRACE();
   for (auto scheme : schemesToRun()) {
-    scheme->requireAction(actionName);
+    scheme->requireAction(action);
   }
 }
 

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -201,16 +201,16 @@ public:
    *
    * True, if any of the composed coupling schemes requires the action.
    */
-  bool isActionRequired(const std::string &actionName) const final override;
+  bool isActionRequired(Action action) const final override;
 
   /// Returns true, if the given action has been performed by the accessor.
-  bool isActionFulfilled(const std::string &actionName) const final override;
+  bool isActionFulfilled(Action action) const final override;
 
   /// Tells the coupling scheme that the accessor has performed the given action.
-  void markActionFulfilled(const std::string &actionName) final override;
+  void markActionFulfilled(Action action) final override;
 
   /// Sets an action required to be performed by the accessor.
-  void requireAction(const std::string &actionName) final override;
+  void requireAction(Action action) final override;
 
   /// Returns a string representation of the current coupling state.
   std::string printCouplingState() const final override;

--- a/src/cplscheme/Constants.cpp
+++ b/src/cplscheme/Constants.cpp
@@ -2,22 +2,4 @@
 
 namespace precice::cplscheme::constants {
 
-const std::string &actionWriteIterationCheckpoint()
-{
-  static std::string actionWriteIterationCheckpoint("write-iteration-checkpoint");
-  return actionWriteIterationCheckpoint;
-}
-
-const std::string &actionReadIterationCheckpoint()
-{
-  static std::string actionReadIterationCheckpoint("read-iteration-checkpoint");
-  return actionReadIterationCheckpoint;
-}
-
-const std::string &actionWriteInitialData()
-{
-  static std::string actionWriteInitialData("write-initial-data");
-  return actionWriteInitialData;
-}
-
 } // namespace precice::cplscheme::constants

--- a/src/cplscheme/Constants.hpp
+++ b/src/cplscheme/Constants.hpp
@@ -6,12 +6,6 @@ namespace precice {
 namespace cplscheme {
 namespace constants {
 
-const std::string &actionWriteIterationCheckpoint();
-
-const std::string &actionReadIterationCheckpoint();
-
-const std::string &actionWriteInitialData();
-
 enum TimesteppingMethod {
   FIXED_TIME_WINDOW_SIZE,
   FIRST_PARTICIPANT_SETS_TIME_WINDOW_SIZE

--- a/src/cplscheme/CouplingScheme.cpp
+++ b/src/cplscheme/CouplingScheme.cpp
@@ -12,4 +12,14 @@ const int CouplingScheme::UNDEFINED_EXTRAPOLATION_ORDER = -1;
 
 const int CouplingScheme::UNDEFINED_MAX_ITERATIONS = -1;
 
+std::string CouplingScheme::toString(Action action)
+{
+  static const std::map<CouplingScheme::Action, const char *> actionNames{
+      {CouplingScheme::Action::WriteCheckpoint, "write-iteration-checkpoint"},
+      {CouplingScheme::Action::ReadCheckpoint, "read-iteration-checkpoint"},
+      {CouplingScheme::Action::InitializeData, "write-initial-data"}};
+
+  return actionNames.at(action);
+}
+
 } // namespace precice::cplscheme

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -55,6 +55,15 @@ public:
   /// To be used, when the number of max iterations is not defined (for explicit coupling).
   static const int UNDEFINED_MAX_ITERATIONS;
 
+  /// Actions that are required by CouplingSchemes
+  enum struct Action {
+    InitializeData, ///< Is the initialization of coupling data required?
+    ReadCheckpoint, ///< Is the participant required to read a previously written checkpoint?
+    WriteCheckpoint ///< Is the participant required to write a checkpoint?
+  };
+
+  static std::string toString(Action action);
+
   CouplingScheme &operator=(CouplingScheme &&) = delete;
 
   virtual ~CouplingScheme() {}
@@ -207,16 +216,16 @@ public:
   virtual bool isTimeWindowComplete() const = 0;
 
   /// Returns true, if the given action has to be performed by the accessor.
-  virtual bool isActionRequired(const std::string &actionName) const = 0;
+  virtual bool isActionRequired(Action action) const = 0;
 
   /// Returns true, if the given action has already been performed by the accessor.
-  virtual bool isActionFulfilled(const std::string &actionName) const = 0;
+  virtual bool isActionFulfilled(Action action) const = 0;
 
   /// Tells the coupling scheme that the accessor has performed the given action.
-  virtual void markActionFulfilled(const std::string &actionName) = 0;
+  virtual void markActionFulfilled(Action action) = 0;
 
   /// Sets an action required to be performed by the accessor.
-  virtual void requireAction(const std::string &actionName) = 0;
+  virtual void requireAction(Action action) = 0;
 
   /// Returns a string representation of the current coupling state.
   virtual std::string printCouplingState() const = 0;

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -92,9 +92,6 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
     BOOST_TEST(mesh->data().size() == 3);
     BOOST_TEST(mesh->vertices().size() > 0);
 
-    std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-    std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-
     double computedTime      = 0.0;
     int    computedTimesteps = 0;
 
@@ -106,16 +103,16 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       while (cplScheme->isCouplingOngoing()) {
         BOOST_REQUIRE(computedTime < 1.1);
         BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
-        if (cplScheme->isActionRequired(writeIterationCheckpoint)) {
-          cplScheme->markActionFulfilled(writeIterationCheckpoint);
+        if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
+          cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
         cplScheme->secondExchange();
-        if (cplScheme->isActionRequired(readIterationCheckpoint)) {
-          cplScheme->markActionFulfilled(readIterationCheckpoint);
+        if (cplScheme->isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+          cplScheme->markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
         } else {
           BOOST_TEST(cplScheme->isTimeWindowComplete());
           computedTime += cplScheme->getNextTimestepMaxLength();
@@ -140,16 +137,16 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       while (cplScheme->isCouplingOngoing()) {
         BOOST_REQUIRE(computedTime < 1.1);
         BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
-        if (cplScheme->isActionRequired(writeIterationCheckpoint)) {
-          cplScheme->markActionFulfilled(writeIterationCheckpoint);
+        if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
+          cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
         cplScheme->secondExchange();
-        if (cplScheme->isActionRequired(readIterationCheckpoint)) {
-          cplScheme->markActionFulfilled(readIterationCheckpoint);
+        if (cplScheme->isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+          cplScheme->markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
         } else {
           BOOST_TEST(cplScheme->isTimeWindowComplete());
           computedTime += cplScheme->getNextTimestepMaxLength();
@@ -175,16 +172,16 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       while (cplScheme->isCouplingOngoing()) {
         BOOST_REQUIRE(computedTime < 1.1);
         BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
-        if (cplScheme->isActionRequired(writeIterationCheckpoint)) {
-          cplScheme->markActionFulfilled(writeIterationCheckpoint);
+        if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
+          cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
         cplScheme->secondExchange();
-        if (cplScheme->isActionRequired(readIterationCheckpoint)) {
-          cplScheme->markActionFulfilled(readIterationCheckpoint);
+        if (cplScheme->isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+          cplScheme->markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
         } else {
           BOOST_TEST(cplScheme->isTimeWindowComplete());
           computedTime += cplScheme->getNextTimestepMaxLength();
@@ -226,9 +223,6 @@ BOOST_AUTO_TEST_SUITE(DummySchemeCompositionTests)
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
 {
   PRECICE_TEST(1_rank, Require::Events);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   int               numberIterations = 1;
   int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(
@@ -257,9 +251,6 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
 {
   PRECICE_TEST(1_rank, Require::Events);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   int               numberIterations = 1;
   int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(
@@ -292,9 +283,6 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
 {
   PRECICE_TEST(1_rank, Require::Events);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   int               numberIterations = 1;
   int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
@@ -319,10 +307,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
       BOOST_TEST_MESSAGE("Expl " << scheme1->getTimeWindows());
       BOOST_TEST_MESSAGE("Impl " << scheme2->getTimeWindows());
       if (advances % 2 == 0) {
-        BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
+        BOOST_TEST(scheme2->isActionRequired(CouplingScheme::Action::WriteCheckpoint));
         BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 2);
       } else {
-        BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
+        BOOST_TEST(scheme2->isActionRequired(CouplingScheme::Action::ReadCheckpoint));
         BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances + 1) / 2);
       }
     }
@@ -337,9 +325,6 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
 {
   PRECICE_TEST(1_rank, Require::Events);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   int               numberIterations = 2;
   int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
@@ -357,10 +342,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
     composition.secondExchange();
     advances++;
     if (advances % 2 == 0) {
-      BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
+      BOOST_TEST(scheme1->isActionRequired(CouplingScheme::Action::WriteCheckpoint));
       BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 2);
     } else {
-      BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(scheme1->isActionRequired(CouplingScheme::Action::ReadCheckpoint));
       BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - 1) / 2);
     }
   }
@@ -374,9 +359,6 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
 {
   PRECICE_TEST(1_rank, Require::Events);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   int               numberIterations = 1;
   int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(
@@ -396,10 +378,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
     composition.secondExchange();
     advances++;
     if (advances % 3 == 0) {
-      BOOST_TEST(scheme2->isActionRequired(writeIterationCheckpoint));
+      BOOST_TEST(scheme2->isActionRequired(CouplingScheme::Action::WriteCheckpoint));
       BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 3);
     } else {
-      BOOST_TEST(scheme2->isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(scheme2->isActionRequired(CouplingScheme::Action::ReadCheckpoint));
       BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances + (3 - advances % 3)) / 3);
     }
   }
@@ -413,9 +395,6 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3Explicit1)
 {
   PRECICE_TEST(1_rank, Require::Events);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   int               numberIterations = 3;
   int               maxTimesteps     = 10;
   PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
@@ -433,10 +412,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3Explicit1)
     composition.secondExchange();
     advances++;
     if (advances % 3 == 0) {
-      BOOST_TEST(scheme1->isActionRequired(writeIterationCheckpoint));
+      BOOST_TEST(scheme1->isActionRequired(CouplingScheme::Action::WriteCheckpoint));
       BOOST_TEST(scheme1->getTimeWindows() - 1 == advances / 3);
     } else {
-      BOOST_TEST(scheme1->isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(scheme1->isActionRequired(CouplingScheme::Action::ReadCheckpoint));
       BOOST_TEST(scheme1->getTimeWindows() - 1 == (advances - (advances % 3)) / 3);
     }
   }

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -83,19 +83,19 @@ bool DummyCouplingScheme::isCouplingOngoing() const
 }
 
 bool DummyCouplingScheme::isActionRequired(
-    const std::string &actionName) const
+    Action action) const
 {
   if (!isImplicitCouplingScheme()) {
     PRECICE_DEBUG("return false (explicit)");
     return false;
   }
-  if (actionName == constants::actionWriteIterationCheckpoint()) {
+  if (action == CouplingScheme::Action::WriteCheckpoint) {
     if (_iterations == 1) {
       PRECICE_DEBUG("return true");
       return true;
     }
   }
-  if (actionName == constants::actionReadIterationCheckpoint()) {
+  if (action == CouplingScheme::Action::ReadCheckpoint) {
     if (_iterations != 1) {
       PRECICE_DEBUG("return true");
       return true;

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -186,9 +186,9 @@ public:
   /**
    * @brief Not implemented.
    */
-  bool isActionRequired(const std::string &actionName) const override final;
+  bool isActionRequired(Action action) const override final;
 
-  bool isActionFulfilled(const std::string &actionName) const override final
+  bool isActionFulfilled(Action action) const override final
   {
     return true;
   }
@@ -196,7 +196,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  void markActionFulfilled(const std::string &actionName) override final
+  void markActionFulfilled(Action action) override final
   {
     PRECICE_ASSERT(false);
   }
@@ -213,7 +213,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  void requireAction(const std::string &actionName) override final
+  void requireAction(Action action) override final
   {
     PRECICE_ASSERT(false);
   }

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -55,8 +55,8 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
@@ -71,8 +71,8 @@ void runSimpleExplicitCoupling(
       BOOST_TEST(cplScheme.isTimeWindowComplete());
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
       BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
-      BOOST_TEST(not cplScheme.isActionRequired("WriteIterationCheckpoint"));
-      BOOST_TEST(not cplScheme.isActionRequired("ReadIterationCheckpoint"));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
       BOOST_TEST(cplScheme.isTimeWindowComplete());
       if (cplScheme.isCouplingOngoing()) {
         // No receive takes place for the participant that has started the
@@ -90,8 +90,8 @@ void runSimpleExplicitCoupling(
     // Validate results
     BOOST_TEST(testing::equals(computedTime, 1.0));
     BOOST_TEST(computedTimesteps == 10);
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
@@ -103,8 +103,8 @@ void runSimpleExplicitCoupling(
     double value = dataValues0(vertex.getID());
     BOOST_TEST(testing::equals(value, valueData0));
     valueData0 += 1.0;
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
@@ -118,8 +118,8 @@ void runSimpleExplicitCoupling(
       cplScheme.secondExchange();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
       BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
-      BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-      BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
       BOOST_TEST(cplScheme.isTimeWindowComplete());
       if (cplScheme.isCouplingOngoing()) {
         // The participant not starting the coupled simulation does neither
@@ -135,8 +135,8 @@ void runSimpleExplicitCoupling(
     // Validate results
     BOOST_TEST(testing::equals(computedTime, 1.0));
     BOOST_TEST(computedTimesteps == 10);
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
@@ -170,8 +170,8 @@ void runExplicitCouplingWithSubcycling(
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
@@ -189,8 +189,8 @@ void runExplicitCouplingWithSubcycling(
                    ? dtDesired
                    : cplScheme.getNextTimestepMaxLength();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-      BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-      BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
       if (computedTimesteps % 2 == 0) {
         // Data exchange takes only place at every second local timestep,
         // since a subcycling of 2 is used.
@@ -213,8 +213,8 @@ void runExplicitCouplingWithSubcycling(
     cplScheme.finalize();
     BOOST_TEST(testing::equals(computedTime, 1.0));
     BOOST_TEST(computedTimesteps == 20);
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
@@ -227,8 +227,8 @@ void runExplicitCouplingWithSubcycling(
     // Validate current coupling status
     BOOST_TEST(testing::equals(dataValues0(vertex.getID()), valueData0));
     valueData0 += 1.0;
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-    BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
@@ -242,8 +242,8 @@ void runExplicitCouplingWithSubcycling(
       cplScheme.secondExchange();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
       BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
-      BOOST_TEST(not cplScheme.isActionRequired("constants::actionWriteIterationCheckpoint()"));
-      BOOST_TEST(not cplScheme.isActionRequired("constants::actionReadIterationCheckpoint()"));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
       BOOST_TEST(cplScheme.isTimeWindowComplete());
       if (cplScheme.isCouplingOngoing()) {
         // The participant not starting the coupled simulation does neither
@@ -258,8 +258,8 @@ void runExplicitCouplingWithSubcycling(
     cplScheme.finalize();
     BOOST_TEST(testing::equals(computedTime, 1.0));
     BOOST_TEST(computedTimesteps == 10);
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
     BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
 
   if (context.isNamed(nameParticipant0)) {
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();
@@ -538,9 +538,9 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     dataValues1(0) = 1.0;
-    cplScheme.markActionFulfilled(constants::actionWriteInitialData());
+    cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     cplScheme.initialize(0.0, 1);
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(testing::equals(dataValues2(0), 2.0));
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
 
   connect(nameParticipant0, nameParticipant1, context.name, m2n);
   CouplingScheme &cplScheme = *cplSchemeConfig.getCouplingScheme(context.name);
-  BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+  BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
 
   BOOST_TEST(meshConfig->meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig->meshes().at(0);
@@ -600,9 +600,9 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
 
   if (context.isNamed(nameParticipant0)) {
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     dataValues2(0) = 3.0;
-    cplScheme.markActionFulfilled(constants::actionWriteInitialData());
+    cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();
@@ -622,9 +622,9 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     dataValues1(0) = 1.0;
-    cplScheme.markActionFulfilled(constants::actionWriteInitialData());
+    cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -137,9 +137,6 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   cplScheme.addConvergenceMeasure(dataID1, false, false, minIterationConvMeasure1, true);
   cplScheme.addConvergenceMeasure(dataID0, false, false, minIterationConvMeasure2, true);
 
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   if (context.isNamed(nameParticipant0)) {
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(0.0, 0.0, 0.0)));
     BOOST_TEST(receiveCouplingData->values().size() == 3);
@@ -148,9 +145,9 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(sendCouplingData->values().size() == 1);
     BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(Fixture::isImplicitCouplingScheme(cplScheme));
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     sendCouplingData->values() = Eigen::VectorXd::Constant(1, 4.0);
-    cplScheme.markActionFulfilled(constants::actionWriteInitialData());
+    cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     cplScheme.initialize(0.0, 0);
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
@@ -159,11 +156,11 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration()(0), 4.0));
     while (cplScheme.isCouplingOngoing()) {
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(writeIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
-      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(readIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.firstSynchronization({});
@@ -174,11 +171,11 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     }
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     Eigen::VectorXd v(3);
     v << 1.0, 2.0, 3.0;
     sendCouplingData->values() = v;
-    cplScheme.markActionFulfilled(constants::actionWriteInitialData());
+    cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 0.0));
     BOOST_TEST(receiveCouplingData->values().size() == 1);
     BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1);
@@ -194,8 +191,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     while (cplScheme.isCouplingOngoing()) {
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(writeIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.firstSynchronization({});
@@ -203,8 +200,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       cplScheme.secondSynchronization();
       cplScheme.secondExchange();
       BOOST_TEST(cplScheme.hasDataBeenReceived());
-      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(readIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
       }
     }
   }

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -76,14 +76,14 @@ void runCoupling(
     cplScheme.initialize(0.0, 1);
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
 
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
-    cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+    cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+    BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
 
     while (cplScheme.isCouplingOngoing()) {
       dataValues0(index) += stepsizeData0;
@@ -108,12 +108,12 @@ void runCoupling(
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
         if (cplScheme.isCouplingOngoing()) {
-          BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+          BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
         } else {
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
         }
         iterationCount = 0;
         iterValidIterations++;
@@ -126,9 +126,9 @@ void runCoupling(
       } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
         BOOST_TEST(iterationCount < *iterValidIterations);
-        BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
-        cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-        BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
+        BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
+        BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::ReadCheckpoint));
         // The written data value is decreased in a regular manner, in order
         // to achieve a predictable convergence.
         stepsizeData0 -= 1.0;
@@ -144,14 +144,14 @@ void runCoupling(
     cplScheme.initialize(0.0, 1);
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.hasDataBeenReceived());
 
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
-    cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+    cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+    BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
 
     while (cplScheme.isCouplingOngoing()) {
       Eigen::VectorXd currentData(3);
@@ -179,12 +179,12 @@ void runCoupling(
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
         if (cplScheme.isCouplingOngoing()) {
-          BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+          BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
         } else {
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
         }
         iterationCount = 0;
         iterValidIterations++;
@@ -197,11 +197,11 @@ void runCoupling(
       } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
         BOOST_TEST(iterationCount < *iterValidIterations);
-        BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+        BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
         // The load checkpoint action requires to fallback to the cplScheme of the
         // first implicit iteration of the current timestep/time.
-        cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-        BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
+        BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::ReadCheckpoint));
         // The written data value is decreased in a regular manner, in order
         // to achieve a predictable convergence.
         //stepsizeData1 -= 1.0;
@@ -247,14 +247,14 @@ void runCouplingWithSubcycling(
     cplScheme.initialize(0.0, 1);
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
 
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
-    cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+    cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+    BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
 
     double maxTimestepLength      = cplScheme.getNextTimestepMaxLength();
     double computedTimestepLength = maxTimestepLength / 2.0;
@@ -280,12 +280,12 @@ void runCouplingWithSubcycling(
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
         if (cplScheme.isCouplingOngoing()) {
-          BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+          BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
         } else {
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
         }
         iterationCount = 1;
         iterValidIterations++;
@@ -302,10 +302,10 @@ void runCouplingWithSubcycling(
         // If length of global timestep is reached
         if (cplScheme.hasDataBeenReceived()) {
           BOOST_TEST(iterationCount <= *iterValidIterations);
-          BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
+          BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::ReadCheckpoint));
           // The written data value is decreased in a regular manner, in order
           // to achieve a predictable convergence.
           stepsizeData0 -= 1.0;
@@ -313,8 +313,8 @@ void runCouplingWithSubcycling(
           iterationCount++;   // Implicit coupling iterations
         } else {              // If subcycling
           BOOST_TEST(iterationCount <= *iterValidIterations);
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
           BOOST_TEST(subcyclingStep < 2);
           subcyclingStep++;
         }
@@ -331,14 +331,14 @@ void runCouplingWithSubcycling(
     cplScheme.initialize(0.0, 1);
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.hasDataBeenReceived());
 
     // Tells coupling scheme, that a checkpoint has been created.
     // All required actions have to be performed before calling advance().
-    cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-    BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+    cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+    BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
 
     double maxTimestepLength       = cplScheme.getNextTimestepMaxLength();
     double preferredTimestepLength = maxTimestepLength / 2.5;
@@ -369,12 +369,12 @@ void runCouplingWithSubcycling(
         // change of data written
         BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
         if (cplScheme.isCouplingOngoing()) {
-          BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.markActionFulfilled(constants::actionWriteIterationCheckpoint());
-          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+          BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
         } else {
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
         }
         iterationCount = 1;
         iterValidIterations++;
@@ -391,10 +391,10 @@ void runCouplingWithSubcycling(
         // If length of global timestep is reached
         if (cplScheme.hasDataBeenReceived()) {
           BOOST_TEST(iterationCount <= *iterValidIterations);
-          BOOST_TEST(cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
-          cplScheme.markActionFulfilled(constants::actionReadIterationCheckpoint());
-          BOOST_TEST(cplScheme.isActionFulfilled(constants::actionReadIterationCheckpoint()));
+          BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+          cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
+          BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::ReadCheckpoint));
           // The written data value is decreased in a regular manner, in order
           // to achieve a predictable convergence.
           stepsizeData1.array() -= 1.0;
@@ -402,8 +402,8 @@ void runCouplingWithSubcycling(
           iterationCount++;   // Implicit coupling iterations
         } else {              // If subcycling
           BOOST_TEST(iterationCount <= *iterValidIterations);
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionReadIterationCheckpoint()));
-          BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteIterationCheckpoint()));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+          BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
           BOOST_TEST(subcyclingStep < 3);
           subcyclingStep++;
         }
@@ -696,8 +696,6 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplScheme.addConvergenceMeasure(convergenceDataIndex, false, false, minIterationConvMeasure1, true);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
   cplScheme.initialize(0.0, 1);
   cplScheme.receiveResultOfFirstAdvance();
@@ -729,13 +727,13 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
     }
 
     if (i == 0) {
-      BOOST_TEST(cplScheme.isActionRequired(writeIterationCheckpoint));
-      cplScheme.markActionFulfilled(writeIterationCheckpoint);
-      BOOST_TEST(not cplScheme.isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     } else {
-      BOOST_TEST(not cplScheme.isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(cplScheme.isActionRequired(readIterationCheckpoint));
-      cplScheme.markActionFulfilled(readIterationCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
     }
 
     // write data to mesh
@@ -781,13 +779,13 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
     }
 
     if (i == 0) {
-      BOOST_TEST(cplScheme.isActionRequired(writeIterationCheckpoint));
-      cplScheme.markActionFulfilled(writeIterationCheckpoint);
-      BOOST_TEST(not cplScheme.isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     } else {
-      BOOST_TEST(not cplScheme.isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(cplScheme.isActionRequired(readIterationCheckpoint));
-      cplScheme.markActionFulfilled(readIterationCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
     }
 
     v << 3.0;
@@ -903,8 +901,6 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplScheme.addConvergenceMeasure(convergenceDataIndex, false, false, minIterationConvMeasure1, true);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
   Eigen::VectorXd v(1); // buffer for data
 
@@ -915,13 +911,13 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   BOOST_TEST(testing::equals(mesh->data(sendDataIndex)->values()(0), 0.0));
 
   if (context.isNamed(first)) {
-    BOOST_TEST(not cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
   } else {
     BOOST_TEST(context.isNamed(second));
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     v << 4.0;
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.markActionFulfilled(constants::actionWriteInitialData());
+    cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     BOOST_TEST(mesh->data(sendDataIndex)->values().size() == 1);
     BOOST_TEST(testing::equals(mesh->data(sendDataIndex)->values()(0), 4.0));
   }
@@ -973,13 +969,13 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
     }
 
     if (i == 0) {
-      BOOST_TEST(cplScheme.isActionRequired(writeIterationCheckpoint));
-      cplScheme.markActionFulfilled(writeIterationCheckpoint);
-      BOOST_TEST(not cplScheme.isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     } else {
-      BOOST_TEST(not cplScheme.isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(cplScheme.isActionRequired(readIterationCheckpoint));
-      cplScheme.markActionFulfilled(readIterationCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
     }
 
     // write data to mesh
@@ -1025,13 +1021,13 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
     }
 
     if (i == 0) {
-      BOOST_TEST(cplScheme.isActionRequired(writeIterationCheckpoint));
-      cplScheme.markActionFulfilled(writeIterationCheckpoint);
-      BOOST_TEST(not cplScheme.isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     } else {
-      BOOST_TEST(not cplScheme.isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(cplScheme.isActionRequired(readIterationCheckpoint));
-      cplScheme.markActionFulfilled(readIterationCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
     }
 
     v << 3.0;
@@ -1154,8 +1150,6 @@ BOOST_AUTO_TEST_CASE(SecondOrderWithAcceleration)
   cplscheme::impl::PtrConvergenceMeasure minIterationConvMeasure1(
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplScheme.addConvergenceMeasure(convergenceDataIndex, false, false, minIterationConvMeasure1, true);
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
 
   cplScheme.initialize(0.0, 1);
   cplScheme.receiveResultOfFirstAdvance();
@@ -1187,13 +1181,13 @@ BOOST_AUTO_TEST_CASE(SecondOrderWithAcceleration)
     }
 
     if (i == 0) {
-      BOOST_TEST(cplScheme.isActionRequired(writeIterationCheckpoint));
-      cplScheme.markActionFulfilled(writeIterationCheckpoint);
-      BOOST_TEST(not cplScheme.isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     } else {
-      BOOST_TEST(not cplScheme.isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(cplScheme.isActionRequired(readIterationCheckpoint));
-      cplScheme.markActionFulfilled(readIterationCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
     }
 
     // write data to mesh
@@ -1239,13 +1233,13 @@ BOOST_AUTO_TEST_CASE(SecondOrderWithAcceleration)
     }
 
     if (i == 0) {
-      BOOST_TEST(cplScheme.isActionRequired(writeIterationCheckpoint));
-      cplScheme.markActionFulfilled(writeIterationCheckpoint);
-      BOOST_TEST(not cplScheme.isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     } else {
-      BOOST_TEST(not cplScheme.isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(cplScheme.isActionRequired(readIterationCheckpoint));
-      cplScheme.markActionFulfilled(readIterationCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
     }
 
     v << 3.0;
@@ -1286,13 +1280,13 @@ BOOST_AUTO_TEST_CASE(SecondOrderWithAcceleration)
     }
 
     if (i == 0) {
-      BOOST_TEST(cplScheme.isActionRequired(writeIterationCheckpoint));
-      cplScheme.markActionFulfilled(writeIterationCheckpoint);
-      BOOST_TEST(not cplScheme.isActionRequired(readIterationCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     } else {
-      BOOST_TEST(not cplScheme.isActionRequired(writeIterationCheckpoint));
-      BOOST_TEST(cplScheme.isActionRequired(readIterationCheckpoint));
-      cplScheme.markActionFulfilled(readIterationCheckpoint);
+      BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
+      BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
+      cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
     }
 
     v << 5.0;
@@ -1632,9 +1626,6 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       new cplscheme::impl::MinIterationConvergenceMeasure(minIterations));
   cplScheme.addConvergenceMeasure(convergenceDataIndex, false, false, minIterationConvMeasure1, true);
 
-  std::string writeIterationCheckpoint(constants::actionWriteIterationCheckpoint());
-  std::string readIterationCheckpoint(constants::actionReadIterationCheckpoint());
-
   if (context.isNamed(nameParticipant0)) {
     // ensure that read data is uninitialized
     BOOST_TEST(receiveCouplingData->getSize() == 3);
@@ -1666,11 +1657,11 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     // set write data
     sendCouplingData->values() = Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0);
     while (cplScheme.isCouplingOngoing()) {
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(writeIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
-      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(readIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.firstSynchronization({});
@@ -1681,11 +1672,11 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     }
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
-    BOOST_TEST(cplScheme.isActionRequired(constants::actionWriteInitialData()));
+    BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     Eigen::VectorXd v(3);
     v << 1.0, 2.0, 3.0;
     sendCouplingData->values() = v;
-    cplScheme.markActionFulfilled(constants::actionWriteInitialData());
+    cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     BOOST_TEST(receiveCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 0.0));
     BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1);
@@ -1707,8 +1698,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     while (cplScheme.isCouplingOngoing()) {
-      if (cplScheme.isActionRequired(writeIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(writeIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
       cplScheme.addComputedTime(timestepLength);
       cplScheme.firstSynchronization({});
@@ -1718,8 +1709,8 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isCouplingOngoing()) {
         BOOST_TEST(cplScheme.hasDataBeenReceived());
       }
-      if (cplScheme.isActionRequired(readIterationCheckpoint)) {
-        cplScheme.markActionFulfilled(readIterationCheckpoint);
+      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
       }
     }
   }

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -268,7 +268,7 @@ double SolverInterfaceImpl::initialize()
   PRECICE_CHECK(_state != State::Initialized, "initialize() may only be called once.");
   PRECICE_ASSERT(not _couplingScheme->isInitialized());
 
-  bool failedToInitialize = _couplingScheme->isActionRequired(cplscheme::constants::actionWriteInitialData()) && not _couplingScheme->isActionFulfilled(cplscheme::constants::actionWriteInitialData());
+  bool failedToInitialize = _couplingScheme->isActionRequired(cplscheme::CouplingScheme::Action::InitializeData) && not _couplingScheme->isActionFulfilled(cplscheme::CouplingScheme::Action::InitializeData);
   PRECICE_CHECK(not failedToInitialize,
                 "Initial data has to be written to preCICE before calling initialize(). "
                 "After defining your mesh, call requiresInitialData() to check if the participant is required to write initial data using an appropriate write...Data() function.");
@@ -529,9 +529,9 @@ bool SolverInterfaceImpl::requiresInitialData()
 {
   PRECICE_TRACE();
   PRECICE_CHECK(_state == State::Constructed, "requiresInitialData() has to be called before initialize().");
-  bool required = _couplingScheme->isActionRequired(cplscheme::constants::actionWriteInitialData());
+  bool required = _couplingScheme->isActionRequired(cplscheme::CouplingScheme::Action::InitializeData);
   if (required) {
-    _couplingScheme->markActionFulfilled(cplscheme::constants::actionWriteInitialData());
+    _couplingScheme->markActionFulfilled(cplscheme::CouplingScheme::Action::InitializeData);
   }
   return required;
 }
@@ -540,9 +540,9 @@ bool SolverInterfaceImpl::requiresWritingCheckpoint()
 {
   PRECICE_TRACE();
   PRECICE_CHECK(_state == State::Initialized, "initialize() has to be called before requiresWritingCheckpoint().");
-  bool required = _couplingScheme->isActionRequired(cplscheme::constants::actionWriteIterationCheckpoint());
+  bool required = _couplingScheme->isActionRequired(cplscheme::CouplingScheme::Action::WriteCheckpoint);
   if (required) {
-    _couplingScheme->markActionFulfilled(cplscheme::constants::actionWriteIterationCheckpoint());
+    _couplingScheme->markActionFulfilled(cplscheme::CouplingScheme::Action::WriteCheckpoint);
   }
   return required;
 }
@@ -551,9 +551,9 @@ bool SolverInterfaceImpl::requiresReadingCheckpoint()
 {
   PRECICE_TRACE();
   PRECICE_CHECK(_state == State::Initialized, "initialize() has to be called before requiresReadingCheckpoint().");
-  bool required = _couplingScheme->isActionRequired(cplscheme::constants::actionReadIterationCheckpoint());
+  bool required = _couplingScheme->isActionRequired(cplscheme::CouplingScheme::Action::ReadCheckpoint);
   if (required) {
-    _couplingScheme->markActionFulfilled(cplscheme::constants::actionReadIterationCheckpoint());
+    _couplingScheme->markActionFulfilled(cplscheme::CouplingScheme::Action::ReadCheckpoint);
   }
   return required;
 }


### PR DESCRIPTION
## Main changes of this PR

This PR 
- Replaces action names with an enum
- Ports dummy cplscheme and tests

## Motivation and additional information

Passing around strings is inefficient and error-prone.
This also doesn't have any API relevance since #1487.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
