### PR TITLE
Fixed typo in GenerateVersionInformation.cmake

### DIFF
--- a/cmake/GenerateVersionInformation.cmake
+++ b/cmake/GenerateVersionInformation.cmake
@@ -45,7 +45,7 @@ endif()
 
 # Add linker flags
 if(BUILD_SHARED_LIBS)
-  precice_vi_add_value(LDFAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+  precice_vi_add_value(LDFLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
 else()
-  precice_vi_add_value(LDFAGS "${CMAKE_STATIC_LINKER_FLAGS}")
+  precice_vi_add_value(LDFLAGS "${CMAKE_STATIC_LINKER_FLAGS}")
 endif()


### PR DESCRIPTION
## Main changes of this PR
Just a really small typo fix in _cmake/GenerateVersionInformation.cmake_.

## Motivation and additional information

Removing typos can prevent future bugs.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
