### PR TITLE
Introduce _allData in BaseCouplingScheme to avoid duplicates

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -284,7 +284,7 @@ void BaseCouplingScheme::secondExchange()
 void BaseCouplingScheme::storeExtrapolationData()
 {
   PRECICE_TRACE(_timeWindows);
-  for (auto &pair : getAllData()) {
+  for (auto &pair : _allData) {
     PRECICE_DEBUG("Store data: {}", pair.first);
     pair.second->storeExtrapolationData();
   }
@@ -524,7 +524,7 @@ void BaseCouplingScheme::initializeStorages()
 {
   PRECICE_TRACE();
   // Reserve storage for all data
-  for (auto &pair : getAllData()) {
+  for (auto &pair : _allData) {
     pair.second->initializeExtrapolation();
   }
   // Reserve storage for acceleration
@@ -562,9 +562,8 @@ void BaseCouplingScheme::addConvergenceMeasure(
     bool                        doesLogging)
 {
   ConvergenceMeasureContext convMeasure;
-  auto                      allData = getAllData();
-  PRECICE_ASSERT(allData.count(dataID) == 1, "Data with given data ID must exist!");
-  convMeasure.couplingData = allData.at(dataID);
+  PRECICE_ASSERT(_allData.count(dataID) == 1, "Data with given data ID must exist!");
+  convMeasure.couplingData = _allData.at(dataID);
   convMeasure.suffices     = suffices;
   convMeasure.strict       = strict;
   convMeasure.measure      = std::move(measure);
@@ -680,7 +679,7 @@ bool BaseCouplingScheme::reachedEndOfTimeWindow()
 void BaseCouplingScheme::storeIteration()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme());
-  for (const DataMap::value_type &pair : getAllData()) {
+  for (const DataMap::value_type &pair : _allData) {
     pair.second->storeIteration();
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -266,6 +266,18 @@ protected:
   void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData);
 
   /**
+   * @brief Adds CouplingData with given properties to this BaseCouplingScheme and returns a pointer to the CouplingData
+   *
+   * If CouplingData with ID of provided data already exists in coupling scheme, no duplicate is created but a pointer to the already existing CouplingData is returned.
+   *
+   * @param data data the CouplingData is associated with
+   * @param mesh mesh the CouplingData is associated with
+   * @param requiresInitialization true, if CouplingData requires initialization
+   * @return PtrCouplingData pointer to CouplingData owned by the CouplingScheme
+   */
+  PtrCouplingData addCouplingData(const mesh::PtrData &data, mesh::PtrMesh mesh, bool requiresInitialization);
+
+  /**
    * @brief Function to determine whether coupling scheme is an explicit coupling scheme
    * @returns true, if coupling scheme is explicit
    */

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -246,6 +246,9 @@ public:
   bool hasConverged() const override;
 
 protected:
+  /// All send and receive data as a map "data ID -> data"
+  DataMap _allData;
+
   /**
    * @brief Sends data sendDataIDs given in mapCouplingData with communication.
    *
@@ -261,12 +264,6 @@ protected:
    * @param receiveData DataMap associated with received data
    */
   void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData);
-
-  /**
-   * @brief interface to provide all CouplingData, depending on coupling scheme being used
-   * @return DataMap containing all CouplingData
-   */
-  virtual const DataMap getAllData() = 0;
 
   /**
    * @brief Function to determine whether coupling scheme is an explicit coupling scheme

--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -54,23 +54,11 @@ void BiCouplingScheme::addDataToSend(
     bool                 requiresInitialization)
 {
   PRECICE_TRACE();
-  // @todo factor out into BaseCouplingScheme, function should create new CouplingData in _allData, if it does not exist and return the corresponding PtrCouplingData
-  int             id = data->getID();
-  PtrCouplingData ptrCplData;
-  if (!utils::contained(id, _allData)) { // data is not used by this coupling scheme yet, create new CouplingData
-    if (isExplicitCouplingScheme()) {
-      ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), requiresInitialization);
-    } else {
-      ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), requiresInitialization, getExtrapolationOrder());
-    }
-    _allData.emplace(id, ptrCplData);
-  } else {
-    ptrCplData = _allData[id];
-  }
+  PtrCouplingData ptrCplData = addCouplingData(data, std::move(mesh), requiresInitialization);
 
-  if (!utils::contained(id, _sendData)) {
-    PRECICE_ASSERT(_sendData.count(id) == 0, "Key already exists!");
-    _sendData.emplace(id, ptrCplData);
+  if (!utils::contained(data->getID(), _sendData)) {
+    PRECICE_ASSERT(_sendData.count(data->getID()) == 0, "Key already exists!");
+    _sendData.emplace(data->getID(), ptrCplData);
   } else {
     PRECICE_ERROR("Data \"{0}\" cannot be added twice for sending. Please remove any duplicate <exchange data=\"{0}\" .../> tags", data->getName());
   }
@@ -82,23 +70,11 @@ void BiCouplingScheme::addDataToReceive(
     bool                 requiresInitialization)
 {
   PRECICE_TRACE();
-  // @todo factor out into BaseCouplingScheme, function should create new CouplingData in _allData, if it does not exist and return the corresponding PtrCouplingData
-  int             id = data->getID();
-  PtrCouplingData ptrCplData;
-  if (!utils::contained(id, _allData)) { // data is not used by this coupling scheme yet, create new CouplingData
-    if (isExplicitCouplingScheme()) {
-      ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), requiresInitialization);
-    } else {
-      ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), requiresInitialization, getExtrapolationOrder());
-    }
-    _allData.emplace(id, ptrCplData);
-  } else {
-    ptrCplData = _allData[id];
-  }
+  PtrCouplingData ptrCplData = addCouplingData(data, std::move(mesh), requiresInitialization);
 
-  if (!utils::contained(id, _receiveData)) {
-    PRECICE_ASSERT(_receiveData.count(id) == 0, "Key already exists!");
-    _receiveData.emplace(id, ptrCplData);
+  if (!utils::contained(data->getID(), _receiveData)) {
+    PRECICE_ASSERT(_receiveData.count(data->getID()) == 0, "Key already exists!");
+    _receiveData.emplace(data->getID(), ptrCplData);
   } else {
     PRECICE_ERROR("Data \"{0}\" cannot be added twice for receiving. Please remove any duplicate <exchange data=\"{0}\" ... /> tags", data->getName());
   }

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -75,12 +75,6 @@ protected:
   /// Returns all data to be received.
   DataMap &getReceiveData();
 
-  /**
-   * @brief BiCouplingScheme has _sendData and _receiveData
-   * @returns DataMap with all data
-   */
-  const DataMap getAllData() override final;
-
   /// Sets the values
   CouplingData *getSendData(DataID dataID);
 

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -149,41 +149,23 @@ void MultiCouplingScheme::exchangeSecondData()
 void MultiCouplingScheme::addDataToSend(
     const mesh::PtrData &data,
     mesh::PtrMesh        mesh,
-    bool                 initialize,
+    bool                 requiresInitialization,
     const std::string &  to)
 {
-  // @todo factor out into BaseCouplingScheme, function should create new CouplingData in _allData, if it does not exist and return the corresponding PtrCouplingData
-  int             id = data->getID();
-  PtrCouplingData ptrCplData;
-  if (!utils::contained(id, _allData)) { // data is not used by this coupling scheme yet, create new CouplingData
-    ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), initialize, getExtrapolationOrder());
-    _allData.emplace(id, ptrCplData);
-  } else { // data is already used by another exchange of this coupling scheme, use existing CouplingData
-    ptrCplData = _allData[id];
-  }
-
+  PtrCouplingData ptrCplData = addCouplingData(data, std::move(mesh), requiresInitialization);
   PRECICE_DEBUG("Configuring send data to {}", to);
-  _sendDataVector[to].emplace(id, ptrCplData);
+  _sendDataVector[to].emplace(data->getID(), ptrCplData);
 }
 
 void MultiCouplingScheme::addDataToReceive(
     const mesh::PtrData &data,
     mesh::PtrMesh        mesh,
-    bool                 initialize,
+    bool                 requiresInitialization,
     const std::string &  from)
 {
-  // @todo factor out into BaseCouplingScheme, function should create new CouplingData in _allData, if it does not exist and return the corresponding PtrCouplingData
-  int             id = data->getID();
-  PtrCouplingData ptrCplData;
-  if (!utils::contained(id, _allData)) { // data is not used by this coupling scheme yet, create new CouplingData
-    ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), initialize, getExtrapolationOrder());
-    _allData.emplace(id, ptrCplData);
-  } else { // data is already used by another exchange of this coupling scheme, use existing CouplingData
-    ptrCplData = _allData[id];
-  }
-
+  PtrCouplingData ptrCplData = addCouplingData(data, std::move(mesh), requiresInitialization);
   PRECICE_DEBUG("Configuring receive data from {}", from);
-  _receiveDataVector[from].emplace(id, ptrCplData);
+  _receiveDataVector[from].emplace(data->getID(), ptrCplData);
 }
 
 } // namespace precice::cplscheme

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -67,7 +67,7 @@ bool MultiCouplingScheme::hasAnySendData()
 const DataMap MultiCouplingScheme::getAccelerationData()
 {
   // MultiCouplingScheme applies acceleration to all CouplingData
-  return getAllData();
+  return _allData;
 }
 
 void MultiCouplingScheme::exchangeInitialData()
@@ -100,20 +100,6 @@ void MultiCouplingScheme::exchangeInitialData()
     }
   }
   PRECICE_DEBUG("Initial data is exchanged in MultiCouplingScheme");
-}
-
-const DataMap MultiCouplingScheme::getAllData()
-{
-  // MultiCouplingScheme has to collect all send data and receive data from _sendDataVector and _receiveDataVector
-  DataMap allData;
-  // @todo use C++17 std::map::merge
-  for (auto &sendData : _sendDataVector) {
-    allData.insert(sendData.second.begin(), sendData.second.end());
-  }
-  for (auto &receiveData : _receiveDataVector) {
-    allData.insert(receiveData.second.begin(), receiveData.second.end());
-  }
-  return allData;
 }
 
 void MultiCouplingScheme::exchangeFirstData()
@@ -166,9 +152,17 @@ void MultiCouplingScheme::addDataToSend(
     bool                 initialize,
     const std::string &  to)
 {
-  int id = data->getID();
+  // @todo factor out into BaseCouplingScheme, function should create new CouplingData in _allData, if it does not exist and return the corresponding PtrCouplingData
+  int             id = data->getID();
+  PtrCouplingData ptrCplData;
+  if (!utils::contained(id, _allData)) { // data is not used by this coupling scheme yet, create new CouplingData
+    ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), initialize, getExtrapolationOrder());
+    _allData.emplace(id, ptrCplData);
+  } else { // data is already used by another exchange of this coupling scheme, use existing CouplingData
+    ptrCplData = _allData[id];
+  }
+
   PRECICE_DEBUG("Configuring send data to {}", to);
-  PtrCouplingData ptrCplData(new CouplingData(data, std::move(mesh), initialize, getExtrapolationOrder()));
   _sendDataVector[to].emplace(id, ptrCplData);
 }
 
@@ -178,9 +172,17 @@ void MultiCouplingScheme::addDataToReceive(
     bool                 initialize,
     const std::string &  from)
 {
-  int id = data->getID();
+  // @todo factor out into BaseCouplingScheme, function should create new CouplingData in _allData, if it does not exist and return the corresponding PtrCouplingData
+  int             id = data->getID();
+  PtrCouplingData ptrCplData;
+  if (!utils::contained(id, _allData)) { // data is not used by this coupling scheme yet, create new CouplingData
+    ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), initialize, getExtrapolationOrder());
+    _allData.emplace(id, ptrCplData);
+  } else { // data is already used by another exchange of this coupling scheme, use existing CouplingData
+    ptrCplData = _allData[id];
+  }
+
   PRECICE_DEBUG("Configuring receive data from {}", from);
-  PtrCouplingData ptrCplData(new CouplingData(data, std::move(mesh), initialize, getExtrapolationOrder()));
   _receiveDataVector[from].emplace(id, ptrCplData);
 }
 

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -88,8 +88,6 @@ private:
 
   logging::Logger _log{"cplscheme::MultiCouplingScheme"};
 
-  const DataMap getAllData() override final;
-
   void exchangeFirstData() override final;
 
   void exchangeSecondData() override final;

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -54,14 +54,14 @@ public:
   void addDataToSend(
       const mesh::PtrData &data,
       mesh::PtrMesh        mesh,
-      bool                 initialize,
+      bool                 requiresInitialization,
       const std::string &  to);
 
   /// Adds data to be received on data exchange.
   void addDataToReceive(
       const mesh::PtrData &data,
       mesh::PtrMesh        mesh,
-      bool                 initialize,
+      bool                 requiresInitialization,
       const std::string &  from);
 
   void determineInitialDataExchange() override;

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -59,7 +59,7 @@ const DataMap ParallelCouplingScheme::getAccelerationData()
 {
   // ParallelCouplingScheme applies acceleration to all CouplingData
   PRECICE_ASSERT(!doesFirstStep(), "Only the second participant should do the acceleration.");
-  return getAllData();
+  return _allData;
 }
 
 } // namespace precice::cplscheme


### PR DESCRIPTION
* `_allData` is used to collect all `CouplingData` of a `CouplingScheme`
* Avoids duplicates, especially for `MultiCouplingSchemes`
* In cases where a single `CouplingData` is used at multiple places (e.g. in a `MultiCouplingScheme` where the same data is sent and/or received to different participants), multiple pointers will exist.

## Main changes of this PR

* add `_allData` to collect all `CouplingData`
* use `PtrCouplingData` to allow to point from different places to the same data

## Motivation and additional information

In #1523 maintaining `CouplingData` becomes more involved. I observed that the old approach for storing `CouplingData` in a `CouplingScheme` created duplicates under certain conditions.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release. (no user obervable changes)
* [x] I added a test to cover the proposed changes in our test suite. (no new feature, not visible before #1523)
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). (not breaking)
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
