### PR TITLE
Remove deprecated API function in fortran bindings

### DIFF
--- a/docs/changelog/1537.md
+++ b/docs/changelog/1537.md
@@ -1,1 +1,1 @@
-* Removed deprecated API function `precicef_ongoing_()` in fortran bindings
+- Removed deprecated API function `precicef_ongoing_()` in fortran bindings.

--- a/docs/changelog/1537.md
+++ b/docs/changelog/1537.md
@@ -1,0 +1,1 @@
+* Removed deprecated API function `precicef_ongoing_()` in fortran bindings

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -83,20 +83,6 @@ PRECICE_API void precicef_finalize_();
 PRECICE_API void precicef_get_dims_(int *dimensions);
 
 /**
- * @deprecated Forwards to precicef_is_coupling_ongoing_
- *
- * Fortran syntax:
- * precicef_ongoing( INTEGER isOngoing )
- *
- * IN:  -
- * OUT: isOngoing(1:true, 0:false)
- *
- * @copydoc precice::SolverInterface::isOngoing()
- *
- */
-[[deprecated("Use precicef_is_coupling_ongoing_() instead.")]] void precicef_ongoing_(int *isOngoing);
-
-/**
  * Fortran syntax:
  * precicef_is_coupling_ongoing( INTEGER isOngoing )
  *

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -84,12 +84,6 @@ void precicef_get_dims_(
   *dimensions = impl->getDimensions();
 }
 
-void precicef_ongoing_(
-    int *isOngoing)
-{
-  precicef_is_coupling_ongoing_(isOngoing);
-}
-
 void precicef_is_coupling_ongoing_(
     int *isOngoing)
 {


### PR DESCRIPTION
## Main changes of this PR

Remove deprecated API function `precicef_ongoing_()` in fortran bindings.

## Motivation and additional information

closes #822

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
