### PR TITLE
Use APPEND in public header property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ GENERATE_EXPORT_HEADER(preciceCore
   )
 
 # Add the export header to the public headers of the preCICE lib
-set_property(TARGET precice PROPERTY PUBLIC_HEADER
+set_property(TARGET precice APPEND PROPERTY PUBLIC_HEADER
     ${CMAKE_BINARY_DIR}/src/precice/export.h)
 
 #


### PR DESCRIPTION
## Main changes of this PR

Use `APPEND` in public header property of `export.h`.

Closes #1554 

## Motivation and additional information

See #1554 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
