### PR TITLE
Remove `getMeshVertexIDsFromPositions` and `getMeshVertices`

### DIFF
--- a/docs/changelog/1556.md
+++ b/docs/changelog/1556.md
@@ -1,0 +1,1 @@
+- Removed `getMeshVertexIDsFromPositions` and `getMeshVertices`.

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -169,38 +169,6 @@ PRECICE_API void precicec_setMeshVertices(
     int *         ids);
 
 /**
- * @brief Get vertex positions for multiple vertex ids from a given mesh
- *
- * @param[in] meshID the id of the mesh to read the vertices from.
- * @param[in] size Number of vertices to lookup
- * @param[in] ids The ids of the vertices to lookup
- * @param[out] positions a pointer to memory to write the coordinates to
- *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
- *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
- */
-PRECICE_API void precicec_getMeshVertices(
-    int        meshID,
-    int        size,
-    const int *ids,
-    double *   positions);
-
-/**
- * @brief Gets mesh vertex IDs from positions.
- *
- * @param[in] meshID ID of the mesh to retrieve positions from
- * @param[in] size Number of vertices to lookup.
- * @param[in] positions Positions to find ids for.
- *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
- *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
- * @param[out] ids IDs corresponding to positions.
- */
-PRECICE_API void precicec_getMeshVertexIDsFromPositions(
-    int           meshID,
-    int           size,
-    const double *positions,
-    int *         ids);
-
-/**
  * @brief Sets mesh edge from vertex IDs, returns edge ID.
  *
  * @param[in] meshID ID of the mesh to add the edge to

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -168,16 +168,6 @@ int precicec_setMeshVertex(
   return impl->setMeshVertex(meshID, position);
 }
 
-void precicec_getMeshVertices(
-    int        meshID,
-    int        size,
-    const int *ids,
-    double *   positions)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->getMeshVertices(meshID, size, ids, positions);
-}
-
 void precicec_setMeshVertices(
     int           meshID,
     int           size,
@@ -193,16 +183,6 @@ int precicec_getMeshVertexSize(
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
   return impl->getMeshVertexSize(meshID);
-}
-
-void precicec_getMeshVertexIDsFromPositions(
-    int           meshID,
-    int           size,
-    const double *positions,
-    int *         ids)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
 }
 
 void precicec_setMeshEdge(

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -295,46 +295,6 @@ PRECICE_API void precicef_set_vertices_(
 
 /**
  * Fortran syntax:
- * precicef_get_vertices(
- *   INTEGER          meshID,
- *   INTEGER          size,
- *   INTEGER          ids(size)
- *   DOUBLE PRECISION positions(dim*size))
- *
- * IN:  meshID, size, ids
- * OUT: positions
- *
- * @copydoc precice::SolverInterface::getMeshVertices()
- *
- */
-PRECICE_API void precicef_get_vertices_(
-    const int *meshID,
-    const int *size,
-    int *      ids,
-    double *   positions);
-
-/**
- * Fortran syntax:
- * precicef_get_vertices(
- *   INTEGER          meshID,
- *   INTEGER          size,
- *   DOUBLE PRECISION positions(dim*size),
- *   INTEGER          ids(size))
- *
- * IN:  meshID, size, positions
- * OUT: ids
- *
- * @copydoc precice::SolverInterface::getMeshVertexIDsFromPositions()
- *
- */
-PRECICE_API void precicef_get_vertex_ids_from_positions_(
-    const int *meshID,
-    const int *size,
-    double *   positions,
-    int *      ids);
-
-/**
- * Fortran syntax:
  * precicef_set_edge(
  *   INTEGER meshID,
  *   INTEGER firstVertexID,

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -220,26 +220,6 @@ void precicef_set_vertices_(
   impl->setMeshVertices(*meshID, *size, positions, positionIDs);
 }
 
-void precicef_get_vertices_(
-    const int *meshID,
-    const int *size,
-    int *      ids,
-    double *   positions)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->getMeshVertices(*meshID, *size, ids, positions);
-}
-
-void precicef_get_vertex_ids_from_positions_(
-    const int *meshID,
-    const int *size,
-    double *   positions,
-    int *      ids)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->getMeshVertexIDsFromPositions(*meshID, *size, positions, ids);
-}
-
 void precicef_set_edge_(
     const int *meshID,
     const int *firstVertexID,

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -140,24 +140,6 @@ void SolverInterface::setMeshVertices(
   _impl->setMeshVertices(meshID, size, positions, ids);
 }
 
-void SolverInterface::getMeshVertices(
-    int        meshID,
-    int        size,
-    const int *ids,
-    double *   positions) const
-{
-  _impl->getMeshVertices(meshID, size, ids, positions);
-}
-
-void SolverInterface::getMeshVertexIDsFromPositions(
-    int           meshID,
-    int           size,
-    const double *positions,
-    int *         ids) const
-{
-  _impl->getMeshVertexIDsFromPositions(meshID, size, positions, ids);
-}
-
 void SolverInterface::setMeshEdge(
     int meshID,
     int firstVertexID,

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -385,48 +385,6 @@ public:
       int *         ids);
 
   /**
-   * @brief Get vertex positions for multiple vertex ids from a given mesh
-   *
-   * @param[in] meshID the id of the mesh to read the vertices from.
-   * @param[in] size Number of vertices to lookup
-   * @param[in] ids The ids of the vertices to lookup
-   * @param[out] positions a pointer to memory to write the coordinates to
-   *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
-   *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
-   *
-   * @pre count of available elements at positions matches the configured dimension * size
-   * @pre count of available elements at ids matches size
-   *
-   * @see getDimensions()
-   */
-  void getMeshVertices(
-      int        meshID,
-      int        size,
-      const int *ids,
-      double *   positions) const;
-
-  /**
-   * @brief Gets mesh vertex IDs from positions.
-   *
-   * @param[in] meshID ID of the mesh to retrieve positions from
-   * @param[in] size Number of vertices to lookup.
-   * @param[in] positions Positions to find ids for.
-   *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
-   *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
-   * @param[out] ids IDs corresponding to positions.
-   *
-   * @pre count of available elements at positions matches the configured dimension * size
-   * @pre count of available elements at ids matches size
-   *
-   * @note prefer to reuse the IDs returned from calls to setMeshVertex() and setMeshVertices().
-   */
-  void getMeshVertexIDsFromPositions(
-      int           meshID,
-      int           size,
-      const double *positions,
-      int *         ids) const;
-
-  /**
    * @brief Sets a mesh edge from vertex IDs
    *
    * Ignored if preCICE doesn't require connectivity for the mesh.

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -165,20 +165,6 @@ public:
       const double *positions,
       int *         ids);
 
-  /// @copydoc SolverInterface::getMeshVertices
-  void getMeshVertices(
-      int        meshID,
-      size_t     size,
-      const int *ids,
-      double *   positions) const;
-
-  /// @copydoc SolverInterface::getMeshVertexIDsFromPositions
-  void getMeshVertexIDsFromPositions(
-      int           meshID,
-      size_t        size,
-      const double *positions,
-      int *         ids) const;
-
   /// @copydoc SolverInterface::setMeshEdge
   void setMeshEdge(
       MeshID meshID,


### PR DESCRIPTION
## Main changes of this PR

Remove `getMeshVertices`, `getMeshVertexIDsFromPositions` and all associated functions (i.e., bindings).

## Motivation and additional information

closes #1248

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
