### PR TITLE
Improve error message for unknown XML tags and attribues.

### DIFF
--- a/docs/changelog/1573.md
+++ b/docs/changelog/1573.md
@@ -1,0 +1,1 @@
+- Improved error messages of unknown tags and attributes in the configuration.

--- a/src/utils/String.cpp
+++ b/src/utils/String.cpp
@@ -1,4 +1,5 @@
 #include "String.hpp"
+#include <Eigen/Dense>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <memory>
 #include <vector>
@@ -72,6 +73,30 @@ std::string truncate_wstring_to_string(std::wstring wstr, char fill)
     converted[i]    = (ret == 1) ? mb.front() : fill;
   }
   return converted;
+}
+
+std::size_t editDistance(std::string_view s1, std::string_view s2)
+{
+  const std::size_t len1 = s1.size(), len2 = s2.size();
+  using Matrix = Eigen::Matrix<std::size_t, Eigen::Dynamic, Eigen::Dynamic>;
+  Matrix distances(len1 + 1, len2 + 1);
+
+  distances(0, 0) = 0;
+  for (std::size_t i = 1; i <= len1; ++i)
+    distances(i, 0) = i;
+  for (std::size_t i = 1; i <= len2; ++i)
+    distances(0, i) = i;
+
+  for (std::size_t i = 1; i <= len1; ++i) {
+    for (std::size_t j = 1; j <= len2; ++j) {
+      auto deletionCost     = distances(i - 1, j) + 1;
+      auto insertionCost    = distances(i, j - 1) + 1;
+      auto substitutionCost = distances(i - 1, j - 1) + (s1[i - 1] == s2[j - 1] ? 0 : 1);
+      distances(i, j)       = std::min({deletionCost, insertionCost, substitutionCost});
+    }
+  }
+
+  return distances(len1, len2);
 }
 
 } // namespace precice::utils

--- a/src/utils/String.hpp
+++ b/src/utils/String.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace precice {
 namespace utils {
@@ -72,6 +74,35 @@ std::string truncate_wstring_to_string(std::wstring wstr, char fill = '#');
   oss << message;                        \
   return oss.str();                      \
 }()
+
+std::size_t editDistance(std::string_view s1, std::string_view s2);
+
+struct StringMatch {
+  std::string name;
+  std::size_t distance;
+
+  bool operator<(const StringMatch &other) const
+  {
+    if (distance == other.distance) {
+      return name < other.name;
+    } else {
+      return distance < other.distance;
+    }
+  }
+};
+
+template <class Container>
+std::vector<StringMatch> computeMatches(std::string_view given, const Container &expected)
+{
+  std::vector<StringMatch> entries;
+  for (const auto &candidate : expected) {
+    entries.push_back(StringMatch{
+        candidate,
+        utils::editDistance(given, candidate)});
+  }
+  std::sort(entries.begin(), entries.end());
+  return entries;
+}
 
 } // namespace utils
 } // namespace precice

--- a/src/utils/tests/StringTest.cpp
+++ b/src/utils/tests/StringTest.cpp
@@ -1,3 +1,4 @@
+#include <boost/test/tools/interface.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <string>
 #include "math/constants.hpp"
@@ -91,6 +92,36 @@ BOOST_AUTO_TEST_CASE(StringMaker)
   auto str2    = sm.str();
   BOOST_TEST(str2.size() == 2);
   BOOST_TEST(str2 == "12");
+}
+
+BOOST_AUTO_TEST_CASE(EditDistance)
+{
+  PRECICE_TEST(1_rank);
+  using precice::utils::editDistance;
+  BOOST_TEST(editDistance("left", "theft") == 2);
+  BOOST_TEST(editDistance("aaa", "aa") == 1);
+  BOOST_TEST(editDistance("aAa", "aaa") == 1);
+  BOOST_TEST(editDistance("same", "same") == 0);
+}
+
+BOOST_AUTO_TEST_CASE(ComputeMatches)
+{
+  PRECICE_TEST(1_rank);
+  std::set names{"left", "right", "up", "down"};
+  auto     matches = utils::computeMatches("lewp", names);
+  BOOST_TEST_REQUIRE(matches.size() == 4);
+
+  BOOST_TEST(matches[0].name == "left");
+  BOOST_TEST(matches[0].distance == 2);
+
+  BOOST_TEST(matches[1].name == "down");
+  BOOST_TEST(matches[1].distance == 3);
+
+  BOOST_TEST(matches[2].name == "up");
+  BOOST_TEST(matches[2].distance == 3);
+
+  BOOST_TEST(matches[3].name == "right");
+  BOOST_TEST(matches[3].distance == 5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -129,7 +129,7 @@ int XMLTag::getIntAttributeValue(const std::string &name, std::optional<int> def
   return default_value.value();
 }
 
-const std::string &XMLTag::getStringAttributeValue(const std::string &name, std::optional<std::string> default_value) const
+std::string XMLTag::getStringAttributeValue(const std::string &name, std::optional<std::string> default_value) const
 {
   std::map<std::string, XMLAttribute<std::string>>::const_iterator iter;
   iter = _stringAttributes.find(name);

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -187,7 +187,11 @@ void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttribute
     auto name = element.first;
 
     if (not utils::contained(name, _attributes)) {
-      PRECICE_ERROR("Tag <{}> contains an unknown attribute named \"{}\".", _name, name);
+      auto matches = utils::computeMatches(name, _attributes);
+      if (matches.front().distance < 3) {
+        PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, matches.front().name);
+      }
+      PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Expected attributes are {}.", _fullName, name, fmt::join(_attributes, ", "));
     }
   }
 

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -173,7 +173,7 @@ public:
 
   int getIntAttributeValue(const std::string &name, std::optional<int> default_value = std::nullopt) const;
 
-  const std::string &getStringAttributeValue(const std::string &name, std::optional<std::string> default_value = std::nullopt) const;
+  std::string getStringAttributeValue(const std::string &name, std::optional<std::string> default_value = std::nullopt) const;
 
   bool getBooleanAttributeValue(const std::string &name, std::optional<bool> default_value = std::nullopt) const;
 


### PR DESCRIPTION
## Main changes of this PR

This PR changes error messages for unknown xml tags and attributes.

Instead of complaining about the unknow tag, it computes the edit distance to expected values.
If the candidate with the lowest edit distance is lower than 3, then the we propose it as a fix.
Otherwise we list all expected values.

## Motivation and additional information

This catches many typos and gives helpful options.

Closes #1566

### Typo
```
ERROR: The configuration contains an unknown tag <mapping:nearest-neighbour>. Did you mean <mapping:nearest-neighbor>?
```

```
ERROR: The configuration contains an unknown tag <provoke-mesh>. Did you mean <provide-mesh>?
```

### Correct prefix

```
ERROR: The configuration contains an unknown tag <mapping:nearest-nachbar>. Expected tags are mapping:linear-cell-interpolation, mapping:nearest-neighbor, mapping:nearest-neighbor-gradient, mapping:nearest-projection, mapping:rbf, mapping:rbf-global-direct, mapping:rbf-global-iterative.
```

### No clue

```
ERROR: The configuration contains an unknown tag <things-that-like-to-couple>. Expected tags are exchange, max-time, max-time-windows, participants, time-window-size.
```

```
ERROR: The tag <mapping:nearest-neighbor> in the configuration contains an unknown attribute "destination". Expected attributes are constraint, direction, from, to.
```

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.
