### PR TITLE
Add missing xml error handlers

### DIFF
--- a/docs/changelog/1574.md
+++ b/docs/changelog/1574.md
@@ -1,0 +1,1 @@
+- Fixed missing error on mismatched closing xml tags

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -217,7 +217,7 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
   // We need to exit after the sink removal as the default sink exists before
   // the log configuration is parsed.
   if (auto noconfigs = std::none_of(configs.begin(), configs.end(), [](const auto &config) { return config.enabled; });
-      !enabled || noconfigs) {
+      !enabled && noconfigs) {
     auto sink = boost::make_shared<NullSink>();
     boost::log::core::get()->add_sink(sink);
     activeSinks.emplace_back(std::move(sink));

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -93,6 +93,16 @@ void OnStructuredErrorFunc(void *userData, xmlError *error)
   ConfigParser::MessageProxy(error->level, message);
 }
 
+void OnErrorFunc(void *userData, const char *error, ...)
+{
+  ConfigParser::MessageProxy(XML_ERR_ERROR, error);
+}
+
+void OnFatalErrorFunc(void *userData, const char *error, ...)
+{
+  ConfigParser::MessageProxy(XML_ERR_FATAL, error);
+}
+
 // ------------------------- ConfigParser implementation  -------------------------
 
 precice::logging::Logger ConfigParser::_log("xml::XMLParser");
@@ -146,6 +156,8 @@ int ConfigParser::readXmlFile(std::string const &filePath)
   SAXHandler.endElementNs   = OnEndElementNs;
   SAXHandler.characters     = OnCharacters;
   SAXHandler.serror         = OnStructuredErrorFunc;
+  SAXHandler.error          = OnErrorFunc;
+  SAXHandler.fatalError     = OnFatalErrorFunc;
 
   std::ifstream ifs(filePath);
   PRECICE_CHECK(ifs, "XML parser was unable to open configuration file \"{}\"", filePath);


### PR DESCRIPTION
## Main changes of this PR

This PR adds missing error handlers for libxml2.

## Motivation and additional information

Tag mismatches are correctly handled now.

```
ERROR: Opening and ending tag mismatch: configuration line 2 and figuration
```

Closes #1564

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
