### PR TITLE
Remove method attribute for parallel cplschemes

### DIFF
--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -205,7 +205,8 @@ void CouplingSchemeConfiguration::xmlTagCallback(
     _config.timeWindowSize = tag.getDoubleAttributeValue(ATTR_VALUE);
     _config.validDigits    = tag.getIntAttributeValue(ATTR_VALID_DIGITS);
     PRECICE_CHECK((_config.validDigits >= 1) && (_config.validDigits < 17), "Valid digits of time window size has to be between 1 and 16.");
-    _config.dtMethod = getTimesteppingMethod(tag.getStringAttributeValue(ATTR_METHOD));
+    // Attribute does not exist for parallel coupling schemes as it is always fixed.
+    _config.dtMethod = getTimesteppingMethod(tag.getStringAttributeValue(ATTR_METHOD, VALUE_FIXED));
     if (_config.dtMethod == constants::TimesteppingMethod::FIXED_TIME_WINDOW_SIZE) {
       PRECICE_CHECK(_config.timeWindowSize > 0,
                     "Time window size has to be larger than zero. "
@@ -402,8 +403,7 @@ void CouplingSchemeConfiguration::addCouplingScheme(
 
 void CouplingSchemeConfiguration::addTypespecifcSubtags(
     const std::string &type,
-    //const std::string& name,
-    xml::XMLTag &tag)
+    xml::XMLTag &      tag)
 {
   PRECICE_TRACE(type);
   addTransientLimitTags(type, tag);
@@ -480,17 +480,13 @@ void CouplingSchemeConfiguration::addTransientLimitTags(
   XMLAttribute<int> attrValidDigits(ATTR_VALID_DIGITS, 10);
   attrValidDigits.setDocumentation(R"(Precision to use when checking for end of time windows used this many digits. \\(\phi = 10^{-validDigits}\\))");
   tagTimeWindowSize.addAttribute(attrValidDigits);
-  std::vector<std::string> allowedMethods;
   if (type == VALUE_SERIAL_EXPLICIT || type == VALUE_SERIAL_IMPLICIT) {
     // method="first-participant" is only allowed for serial coupling schemes
-    allowedMethods = {VALUE_FIXED, VALUE_FIRST_PARTICIPANT};
-  } else {
-    allowedMethods = {VALUE_FIXED};
+    auto attrMethod = makeXMLAttribute(ATTR_METHOD, VALUE_FIXED)
+                          .setOptions({VALUE_FIXED, VALUE_FIRST_PARTICIPANT})
+                          .setDocumentation("The method used to determine the time window size. Use `fixed` to fix the time window size for the participants.");
+    tagTimeWindowSize.addAttribute(attrMethod);
   }
-  auto attrMethod = makeXMLAttribute(ATTR_METHOD, VALUE_FIXED)
-                        .setOptions(allowedMethods)
-                        .setDocumentation("The method used to determine the time window size. Use `fixed` to fix the time window size for the participants.");
-  tagTimeWindowSize.addAttribute(attrMethod);
   tag.addSubtag(tagTimeWindowSize);
 }
 

--- a/src/cplscheme/tests/parallel-explicit-coupling-datainit.xml
+++ b/src/cplscheme/tests/parallel-explicit-coupling-datainit.xml
@@ -31,7 +31,7 @@
   <coupling-scheme:parallel-explicit>
     <participants first="Participant0" second="Participant1" />
 
-    <time-window-size value="0.1" method="fixed" />
+    <time-window-size value="0.1" />
 
     <max-time-windows value="1" />
 


### PR DESCRIPTION
## Main changes of this PR

This PR removes the `method="fixed"` attribute for parallel coupling schemes, as they are always `fixed`.

## Motivation and additional information

Closes #1569

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
