### PR TITLE
Add attribute hints

### DIFF
--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -486,6 +486,8 @@ void CouplingSchemeConfiguration::addTransientLimitTags(
                           .setOptions({VALUE_FIXED, VALUE_FIRST_PARTICIPANT})
                           .setDocumentation("The method used to determine the time window size. Use `fixed` to fix the time window size for the participants.");
     tagTimeWindowSize.addAttribute(attrMethod);
+  } else {
+    tagTimeWindowSize.addAttributeHint(ATTR_METHOD, "This feature is only available for serial coupling schemes.");
   }
   tag.addSubtag(tagTimeWindowSize);
 }

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -52,48 +52,60 @@ XMLTag &XMLTag::addSubtag(const XMLTag &tag)
 
 XMLTag &XMLTag::addAttribute(const XMLAttribute<double> &attribute)
 {
-  PRECICE_TRACE(attribute.getName());
-  PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
-  _attributes.insert(attribute.getName());
-  _doubleAttributes.insert(std::pair<std::string, XMLAttribute<double>>(attribute.getName(), attribute));
+  const auto &name = attribute.getName();
+  PRECICE_TRACE(name);
+  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
+  _attributes.insert(name);
+  _doubleAttributes.insert(std::pair<std::string, XMLAttribute<double>>(name, attribute));
   return *this;
 }
 
 XMLTag &XMLTag::addAttribute(const XMLAttribute<int> &attribute)
 {
-  PRECICE_TRACE(attribute.getName());
-  PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
-  _attributes.insert(attribute.getName());
-  _intAttributes.insert(std::pair<std::string, XMLAttribute<int>>(attribute.getName(), attribute));
+  const auto &name = attribute.getName();
+  PRECICE_TRACE(name);
+  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
+  _attributes.insert(name);
+  _intAttributes.insert(std::pair<std::string, XMLAttribute<int>>(name, attribute));
   return *this;
 }
 
 XMLTag &XMLTag::addAttribute(const XMLAttribute<std::string> &attribute)
 {
-  PRECICE_TRACE(attribute.getName());
-  PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
-  _attributes.insert(attribute.getName());
-  _stringAttributes.insert(std::pair<std::string, XMLAttribute<std::string>>(attribute.getName(), attribute));
+  const auto &name = attribute.getName();
+  PRECICE_TRACE(name);
+  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
+  _attributes.insert(name);
+  _stringAttributes.insert(std::pair<std::string, XMLAttribute<std::string>>(name, attribute));
   return *this;
 }
 
 XMLTag &XMLTag::addAttribute(const XMLAttribute<bool> &attribute)
 {
-  PRECICE_TRACE(attribute.getName());
-  PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
-  _attributes.insert(attribute.getName());
-  _booleanAttributes.insert(std::pair<std::string, XMLAttribute<bool>>(attribute.getName(), attribute));
+  const auto &name = attribute.getName();
+  PRECICE_TRACE(name);
+  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
+  _attributes.insert(name);
+  _booleanAttributes.insert(std::pair<std::string, XMLAttribute<bool>>(name, attribute));
   return *this;
 }
 
 XMLTag &XMLTag::addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute)
 {
-  PRECICE_TRACE(attribute.getName());
-  PRECICE_ASSERT(not utils::contained(attribute.getName(), _attributes));
-  _attributes.insert(attribute.getName());
+  const auto &name = attribute.getName();
+  PRECICE_TRACE(name);
+  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
+  _attributes.insert(name);
   _eigenVectorXdAttributes.insert(
-      std::pair<std::string, XMLAttribute<Eigen::VectorXd>>(attribute.getName(), attribute));
+      std::pair<std::string, XMLAttribute<Eigen::VectorXd>>(name, attribute));
   return *this;
+}
+
+void XMLTag::addAttributeHint(std::string name, std::string message)
+{
+  PRECICE_TRACE(name);
+  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
+  _attributeHints.emplace(std::move(name), std::move(message));
 }
 
 bool XMLTag::hasAttribute(const std::string &attributeName)
@@ -187,6 +199,11 @@ void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttribute
     auto name = element.first;
 
     if (not utils::contained(name, _attributes)) {
+      // check existing hints
+      if (auto pos = _attributeHints.find(name);
+          pos != _attributeHints.end()) {
+        PRECICE_ERROR("The tag <{}> in the configuration contains the attribute \"{}\". {}", _fullName, name, pos->second);
+      }
       auto matches = utils::computeMatches(name, _attributes);
       if (matches.front().distance < 3) {
         PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, matches.front().name);

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -134,6 +134,9 @@ public:
   /// Adds a XML attribute by making a copy of the given attribute.
   XMLTag &addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute);
 
+  /// Adds a hint for missing attributes, which will be displayed allong the error message.
+  void addAttributeHint(std::string name, std::string message);
+
   bool hasAttribute(const std::string &attributeName);
 
   template <typename Container>
@@ -268,6 +271,8 @@ private:
   AttributeMap<bool> _booleanAttributes;
 
   AttributeMap<Eigen::VectorXd> _eigenVectorXdAttributes;
+
+  std::map<std::string, std::string> _attributeHints;
 
   void areAllSubtagsConfigured() const;
 


### PR DESCRIPTION
## Main changes of this PR

Based on #1573 and #1575, this PR adds attribute hints.
These hints will be displayed along the error message if an attribute is missing.

```
myXMLTag.addAttributeHint("obsolete", "Do this instead.");

<mytag obsolete="something">

ERROR: The tag <mytag> in the configuration contains the attribute "obsolete". Do this instead.
```

## Motivation and additional information

See #1569

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
