### PR TITLE
Fix PETSc mappings crashing when checking the config

### DIFF
--- a/docs/changelog/1578.md
+++ b/docs/changelog/1578.md
@@ -1,0 +1,1 @@
+- Fixed a crash when using `precice-tools check` to check configurations that use PETSc-based RBF mappings.

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -47,12 +47,14 @@ void checkConfiguration(const std::string &filename, const std::string &particip
   fmt::print("Checking {} for syntax and basic setup issues...\n", filename);
   config::Configuration config;
   logging::setMPIRank(0);
+  utils::Parallel::initializeMPI(nullptr, nullptr);
   xml::ConfigurationContext context{
       participant,
       0,
       size};
   xml::configure(config.getXMLTag(), context, filename);
   fmt::print(fmt::emphasis::bold | fg(fmt::color::green), "No major issues detected\n", filename);
+  utils::Parallel::finalizeMPI();
 }
 
 } // namespace tooling

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <mpi.h>
 #include <numeric>
 #include <ostream>
 #include <utility>
@@ -185,6 +186,17 @@ void Parallel::pushState(CommStatePtr newState)
 //   return nullptr;
 // #endif
 // }
+
+bool Parallel::isMPIInitialized()
+{
+#ifndef PRECICE_NO_MPI
+  int isMPIInitialized{-1};
+  MPI_Initialized(&isMPIInitialized);
+  return isMPIInitialized != 0;
+#else
+  return false;
+#endif // not PRECICE_NO_MPI
+}
 
 void Parallel::initializeManagedMPI(
     int *   argc,

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <map>
 #include <memory>
-#include <mpi.h>
 #include <numeric>
 #include <ostream>
 #include <utility>

--- a/src/utils/Parallel.hpp
+++ b/src/utils/Parallel.hpp
@@ -130,6 +130,9 @@ public:
   /// @name Initialization and Finalization
   /// @{
 
+  /// Return true if MPI is initialized
+  static bool isMPIInitialized();
+
   /**
    * @brief Initializes the MPI environment and manages it.
    *


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a crash when checking configurations that require PETSc mappings.


## Motivation and additional information

The constructor request the MPI ranks, which leads to a crash.

Closes #1562

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.
