### PR TITLE
Add integration tests for direct mesh access

### DIFF
--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
@@ -1,0 +1,121 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+#include <vector>
+
+// Test case for a direct mesh access by SolverTwo to a mesh defined
+// by SolverOne. Both solvers read and write data to/from MeshOne.
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+BOOST_AUTO_TEST_CASE(UseWaveform)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  if (context.isNamed("SolverOne")) {
+    // Set up Solverinterface
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    BOOST_TEST(interface.getDimensions() == 2);
+    constexpr int dim            = 2;
+    const int     providedMeshID = interface.getMeshID("MeshOne");
+    const int     readDataID     = interface.getDataID("Forces", providedMeshID);
+    const int     writeDataID    = interface.getDataID("Velocities", providedMeshID);
+
+    std::vector<double> positions = std::vector<double>({0.5, 0.25});
+    const int           meshSize  = positions.size() / dim;
+    std::vector<int>    ids(meshSize, 0);
+    interface.setMeshVertices(providedMeshID, ids.size(), positions.data(), ids.data());
+
+    double dt = interface.initialize();
+
+    // Some dummy writeData
+    std::vector<double> readData(ids.size(), 0);
+    std::vector<double> writeData;
+    for (int i = 0; i < meshSize; ++i)
+      writeData.emplace_back(i + 5);
+
+    int iterations = 0;
+    while (interface.isCouplingOngoing()) {
+      if (interface.requiresWritingCheckpoint()) {
+        // do nothing
+      }
+
+      interface.readBlockScalarData(readDataID, ids.size(), ids.data(), readData.data());
+
+      std::vector<double> expectedData = std::vector<double>({50});
+      if (iterations == 0) {
+        expectedData[0] = 0; // initial data
+      }
+
+      BOOST_TEST(precice::testing::equals(expectedData, readData));
+      interface.writeBlockScalarData(writeDataID, providedMeshID, ids.data(), writeData.data());
+      dt = interface.advance(dt);
+      iterations++;
+      if (interface.requiresReadingCheckpoint()) {
+        // do nothing
+      }
+    }
+
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    BOOST_TEST(interface.getDimensions() == 2);
+    constexpr int dim            = 2;
+    const int     receivedMeshID = interface.getMeshID("MeshOne");
+    const int     writeDataID    = interface.getDataID("Forces", receivedMeshID);
+    const int     readDataID     = interface.getDataID("Velocities", receivedMeshID);
+
+    std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0};
+    // Define region of interest, where we could obtain direct write access
+    interface.setMeshAccessRegion(receivedMeshID, boundingBox.data());
+
+    double dt = interface.initialize();
+    // Get the size of the filtered mesh within the bounding box
+    // (provided by the coupling participant)
+    const int receivedMeshSize = interface.getMeshVertexSize(receivedMeshID);
+    BOOST_TEST(receivedMeshSize == 1);
+
+    // Allocate a vector containing the vertices
+    std::vector<double> receivedMesh(receivedMeshSize * dim);
+    std::vector<int>    receiveMeshIDs(receivedMeshSize, 0);
+    interface.getMeshVerticesAndIDs(receivedMeshID, receivedMeshSize, receiveMeshIDs.data(), receivedMesh.data());
+
+    // Allocate data to read and write
+    std::vector<double> readData(receiveMeshIDs.size(), 0);
+    std::vector<double> writeData;
+    for (unsigned int i = 0; i < receivedMeshSize; ++i)
+      writeData.emplace_back(i + 50);
+    // Expected data = positions of the other participant's mesh
+    const std::vector<double> expectedData = std::vector<double>({0.5, 0.25});
+    BOOST_TEST(receivedMesh == expectedData);
+    int iterations = 0;
+    while (interface.isCouplingOngoing()) {
+      if (interface.requiresWritingCheckpoint()) {
+        // do nothing
+      }
+
+      interface.readBlockScalarData(readDataID, receiveMeshIDs.size(), receiveMeshIDs.data(), readData.data());
+
+      std::vector<double> expectedData = std::vector<double>({6});
+      if (iterations == 0) {
+        expectedData[0] = 0; // initial data
+      }
+
+      BOOST_TEST(precice::testing::equals(expectedData, readData));
+      interface.writeBlockScalarData(writeDataID, receiveMeshIDs.size(), receiveMeshIDs.data(), writeData.data());
+      dt = interface.advance(dt);
+      iterations++;
+      if (interface.requiresReadingCheckpoint()) {
+        // do nothing
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
@@ -10,7 +10,7 @@
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Serial)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
-BOOST_AUTO_TEST_CASE(UseWaveform)
+BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2" experimental="true">
+    <data:scalar name="Velocities" />
+    <data:scalar name="Forces" />
+
+    <mesh name="MeshOne">
+      <use-data name="Forces" />
+      <use-data name="Velocities" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <provide-mesh name="MeshOne" />
+      <write-data name="Velocities" mesh="MeshOne" />
+      <read-data name="Forces" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0" direct-access="true" />
+      <read-data name="Velocities" mesh="MeshOne" />
+      <write-data name="Forces" mesh="MeshOne" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:parallel-implicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="2" />
+      <max-iterations value="3" />
+      <min-iteration-convergence-measure min-iterations="3" data="Velocities" mesh="MeshOne" />
+      <time-window-size value="1.0" />
+      <exchange data="Velocities" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="Forces" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    </coupling-scheme:parallel-implicit>
+  </solver-interface>
+</precice-configuration>

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
@@ -1,0 +1,185 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+#include <vector>
+
+// Test case for a direct mesh access while also using data initialization to test the integration of the two features.
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  if (context.isNamed("SolverOne")) {
+    // Set up Solverinterface
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    BOOST_TEST(interface.getDimensions() == 2);
+    constexpr int dim         = 2;
+    const int     ownMeshID   = interface.getMeshID("MeshOne");
+    const int     otherMeshID = interface.getMeshID("MeshTwo");
+    const int     readDataID  = interface.getDataID("Forces", ownMeshID);
+    const int     writeDataID = interface.getDataID("Velocities", otherMeshID);
+
+    std::vector<double> ownPositions = std::vector<double>({0.5, 0.25});
+    std::vector<int>    ownIDs(ownPositions.size() / dim, 0);
+    interface.setMeshVertices(ownMeshID, ownIDs.size(), ownPositions.data(), ownIDs.data());
+
+    std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0};
+    // Define region of interest, where we could obtain direct write access
+    interface.setMeshAccessRegion(otherMeshID, boundingBox.data());
+
+    std::vector<double> readData(ownIDs.size(), 0);
+    std::vector<double> writeData;
+
+    // writeData for initialization
+    // for (int i = 0; i < otherMeshSize; ++i) {  // @todo otherMeshSize not available yet. See https://github.com/precice/precice/issues/1583.
+    for (int i = 0; i < 1; ++i) {
+      writeData.emplace_back(2);
+    }
+
+    if (interface.requiresInitialData()) {
+      // @todo not possible to write data to mesh here, because we can only access mesh after calling initialize due to direct access. See https://github.com/precice/precice/issues/1583.
+      // interface.writeBlockScalarData(writeDataID, otherIDs.size(), otherIDs.data(), writeData.data());
+    }
+
+    double dt = interface.initialize();
+    // Get the size of the filtered mesh within the bounding box
+    // (provided by the coupling participant)
+    const int otherMeshSize = interface.getMeshVertexSize(otherMeshID);
+    BOOST_TEST(otherMeshSize == 1);
+
+    std::vector<double> otherPositions(otherMeshSize * dim);
+    std::vector<int>    otherIDs(otherMeshSize, 0);
+
+    // writeData for first window
+    for (int i = 0; i < otherMeshSize; ++i) {
+      writeData[i] = 5;
+    }
+
+    int iterations = 0;
+    int timeWindow = 0;
+
+    while (interface.isCouplingOngoing()) {
+      if (interface.requiresWritingCheckpoint()) {
+        // do nothing
+      }
+
+      interface.readBlockScalarData(readDataID, ownIDs.size(), ownIDs.data(), readData.data());
+
+      std::vector<double> expectedData = std::vector<double>({-1});
+
+      if (timeWindow == 0) {
+        if (iterations == 0) {
+          expectedData[0] = 20; // initial data
+        } else {
+          expectedData[0] = 50;
+        }
+      } else if (timeWindow == 1) {
+        if (iterations == 0) {
+          expectedData[0] = 50; // constant initial guess
+        } else {
+          expectedData[0] = 60;
+        }
+      }
+
+      BOOST_TEST(precice::testing::equals(expectedData, readData));
+      interface.writeBlockScalarData(writeDataID, otherIDs.size(), otherIDs.data(), writeData.data());
+      dt = interface.advance(dt);
+      iterations++;
+      if (interface.requiresReadingCheckpoint()) {
+        // do nothing
+      }
+      if (interface.isTimeWindowComplete()) {
+        timeWindow++;
+        iterations = 0;
+        for (int i = 0; i < otherMeshSize; ++i) {
+          writeData[i] = writeData[i] + 2;
+        }
+      }
+    }
+
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    BOOST_TEST(interface.getDimensions() == 2);
+    constexpr int dim         = 2;
+    const int     meshID      = interface.getMeshID("MeshTwo");
+    const int     writeDataID = interface.getDataID("Forces", meshID);
+    const int     readDataID  = interface.getDataID("Velocities", meshID);
+
+    std::vector<double> positions = std::vector<double>({0.5, 0.25});
+    std::vector<int>    ids(positions.size() / dim, 0);
+    interface.setMeshVertices(meshID, ids.size(), positions.data(), ids.data());
+
+    std::vector<double> readData(ids.size(), 0);
+    std::vector<double> writeData;
+
+    // writeData for initialization
+    for (int i = 0; i < ids.size(); ++i) {
+      writeData.emplace_back(20);
+    }
+
+    if (interface.requiresInitialData()) {
+      interface.writeBlockScalarData(writeDataID, ids.size(), ids.data(), writeData.data());
+    }
+
+    double dt = interface.initialize();
+
+    // writeData for first window
+    for (unsigned int i = 0; i < ids.size(); ++i) {
+      writeData[i] = 50;
+    }
+
+    int iterations = 0;
+    int timeWindow = 0;
+
+    while (interface.isCouplingOngoing()) {
+      if (interface.requiresWritingCheckpoint()) {
+        // do nothing
+      }
+
+      interface.readBlockScalarData(readDataID, ids.size(), ids.data(), readData.data());
+
+      std::vector<double> expectedData = std::vector<double>({-1});
+
+      if (timeWindow == 0) {
+        if (iterations == 0) {
+          // expectedData[0] = 2; // initial data, @todo Currently not possible to provide initial data != 0 via direct access. See https://github.com/precice/precice/issues/1583
+          expectedData[0] = 0; // initial data
+        } else {
+          expectedData[0] = 5;
+        }
+      } else if (timeWindow == 1) {
+        if (iterations == 0) {
+          expectedData[0] = 5; // initial guess
+        } else {
+          expectedData[0] = 7;
+        }
+      }
+
+      BOOST_TEST(precice::testing::equals(expectedData, readData));
+      interface.writeBlockScalarData(writeDataID, ids.size(), ids.data(), writeData.data());
+      dt = interface.advance(dt);
+      iterations++;
+      if (interface.requiresReadingCheckpoint()) {
+        // do nothing
+      }
+      if (interface.isTimeWindowComplete()) {
+        timeWindow++;
+        iterations = 0;
+        for (int i = 0; i < ids.size(); ++i) {
+          writeData[i] = writeData[i] + 10;
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2" experimental="true">
+    <data:scalar name="Velocities" />
+    <data:scalar name="Forces" />
+
+    <mesh name="MeshOne">
+      <use-data name="Forces" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="Forces" />
+      <use-data name="Velocities" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <provide-mesh name="MeshOne" />
+      <receive-mesh name="MeshTwo" from="SolverTwo" safety-factor="0" direct-access="true" />
+      <write-data name="Velocities" mesh="MeshTwo" />
+      <read-data name="Forces" mesh="MeshOne" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="consistent" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <provide-mesh name="MeshTwo" />
+      <read-data name="Velocities" mesh="MeshTwo" />
+      <write-data name="Forces" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:parallel-implicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="2" />
+      <max-iterations value="3" />
+      <min-iteration-convergence-measure min-iterations="3" data="Velocities" mesh="MeshTwo" />
+      <time-window-size value="1.0" />
+      <exchange
+        data="Velocities"
+        mesh="MeshTwo"
+        from="SolverOne"
+        to="SolverTwo"
+        initialize="true" />
+      <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" initialize="true" />
+    </coupling-scheme:parallel-implicit>
+  </solver-interface>
+</precice-configuration>

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
@@ -1,0 +1,160 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+#include <vector>
+
+// Test case for a direct mesh access while also using waveform relaxation to test the integration of the two features.
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  if (context.isNamed("SolverOne")) {
+    // Set up Solverinterface
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    BOOST_TEST(interface.getDimensions() == 2);
+    constexpr int dim         = 2;
+    const int     ownMeshID   = interface.getMeshID("MeshOne");
+    const int     otherMeshID = interface.getMeshID("MeshTwo");
+    const int     readDataID  = interface.getDataID("Forces", ownMeshID);
+    const int     writeDataID = interface.getDataID("Velocities", otherMeshID);
+
+    std::vector<double> ownPositions = std::vector<double>({0.5, 0.25});
+    std::vector<int>    ownIDs(ownPositions.size() / dim, 0);
+    interface.setMeshVertices(ownMeshID, ownIDs.size(), ownPositions.data(), ownIDs.data());
+
+    std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0};
+    // Define region of interest, where we could obtain direct write access
+    interface.setMeshAccessRegion(otherMeshID, boundingBox.data());
+
+    double dt = interface.initialize();
+    // Get the size of the filtered mesh within the bounding box
+    // (provided by the coupling participant)
+    const int otherMeshSize = interface.getMeshVertexSize(otherMeshID);
+    BOOST_TEST(otherMeshSize == 1);
+
+    std::vector<double> otherPositions(otherMeshSize * dim);
+    std::vector<int>    otherIDs(otherMeshSize, 0);
+
+    // Some dummy writeData
+    std::vector<double> readData(ownIDs.size(), 0);
+    std::vector<double> writeData;
+    for (int i = 0; i < otherMeshSize; ++i)
+      writeData.emplace_back(5);
+
+    int iterations = 0;
+    int timeWindow = 0;
+
+    while (interface.isCouplingOngoing()) {
+      if (interface.requiresWritingCheckpoint()) {
+        // do nothing
+      }
+
+      interface.readBlockScalarData(readDataID, ownIDs.size(), ownIDs.data(), 0.5, readData.data());
+
+      std::vector<double> expectedData = std::vector<double>({-1});
+
+      if (timeWindow == 0) {
+        if (iterations == 0) {
+          expectedData[0] = 0; // initial data
+        } else {
+          expectedData[0] = 25;
+        }
+      } else if (timeWindow == 1) {
+        if (iterations == 0) {
+          expectedData[0] = 50; // constant initial guess
+        } else {
+          expectedData[0] = 55;
+        }
+      }
+
+      BOOST_TEST(precice::testing::equals(expectedData, readData));
+      interface.writeBlockScalarData(writeDataID, otherIDs.size(), otherIDs.data(), writeData.data());
+      dt = interface.advance(dt);
+      iterations++;
+      if (interface.requiresReadingCheckpoint()) {
+        // do nothing
+      }
+      if (interface.isTimeWindowComplete()) {
+        timeWindow++;
+        iterations = 0;
+        for (int i = 0; i < otherMeshSize; ++i) {
+          writeData[i] = writeData[i] + 2;
+        }
+      }
+    }
+
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    BOOST_TEST(interface.getDimensions() == 2);
+    constexpr int dim         = 2;
+    const int     meshID      = interface.getMeshID("MeshTwo");
+    const int     writeDataID = interface.getDataID("Forces", meshID);
+    const int     readDataID  = interface.getDataID("Velocities", meshID);
+
+    std::vector<double> positions = std::vector<double>({0.5, 0.25});
+    std::vector<int>    ids(positions.size() / dim, 0);
+    interface.setMeshVertices(meshID, ids.size(), positions.data(), ids.data());
+
+    double dt = interface.initialize();
+
+    // Allocate data to read and write
+    std::vector<double> readData(ids.size(), 0);
+    std::vector<double> writeData;
+    for (unsigned int i = 0; i < ids.size(); ++i)
+      writeData.emplace_back(50);
+
+    int iterations = 0;
+    int timeWindow = 0;
+
+    while (interface.isCouplingOngoing()) {
+      if (interface.requiresWritingCheckpoint()) {
+        // do nothing
+      }
+
+      interface.readBlockScalarData(readDataID, ids.size(), ids.data(), 0.5, readData.data());
+
+      std::vector<double> expectedData = std::vector<double>({-1});
+
+      if (timeWindow == 0) {
+        if (iterations == 0) {
+          expectedData[0] = 0; // initial data
+        } else {
+          expectedData[0] = 2.5;
+        }
+      } else if (timeWindow == 1) {
+        if (iterations == 0) {
+          expectedData[0] = 5; // constant initial guess
+        } else {
+          expectedData[0] = 6;
+        }
+      }
+
+      BOOST_TEST(precice::testing::equals(expectedData, readData));
+      interface.writeBlockScalarData(writeDataID, ids.size(), ids.data(), writeData.data());
+      dt = interface.advance(dt);
+      iterations++;
+      if (interface.requiresReadingCheckpoint()) {
+        // do nothing
+      }
+      if (interface.isTimeWindowComplete()) {
+        timeWindow++;
+        iterations = 0;
+        for (int i = 0; i < ids.size(); ++i) {
+          writeData[i] = writeData[i] + 10;
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
@@ -43,8 +43,9 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
     // Some dummy writeData
     std::vector<double> readData(ownIDs.size(), 0);
     std::vector<double> writeData;
-    for (int i = 0; i < otherMeshSize; ++i)
+    for (int i = 0; i < otherMeshSize; ++i) {
       writeData.emplace_back(5);
+    }
 
     int iterations = 0;
     int timeWindow = 0;
@@ -106,8 +107,9 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
     // Allocate data to read and write
     std::vector<double> readData(ids.size(), 0);
     std::vector<double> writeData;
-    for (unsigned int i = 0; i < ids.size(); ++i)
+    for (unsigned int i = 0; i < ids.size(); ++i) {
       writeData.emplace_back(50);
+    }
 
     int iterations = 0;
     int timeWindow = 0;

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2" experimental="true">
+    <data:scalar name="Velocities" />
+    <data:scalar name="Forces" />
+
+    <mesh name="MeshOne">
+      <use-data name="Forces" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="Forces" />
+      <use-data name="Velocities" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <provide-mesh name="MeshOne" />
+      <receive-mesh name="MeshTwo" from="SolverTwo" safety-factor="0" direct-access="true" />
+      <write-data name="Velocities" mesh="MeshTwo" />
+      <read-data name="Forces" mesh="MeshOne" waveform-order="1" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="MeshTwo"
+        to="MeshOne"
+        constraint="consistent" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <provide-mesh name="MeshTwo" />
+      <read-data name="Velocities" mesh="MeshTwo" waveform-order="1" />
+      <write-data name="Forces" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:parallel-implicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="2" />
+      <max-iterations value="3" />
+      <min-iteration-convergence-measure min-iterations="3" data="Velocities" mesh="MeshTwo" />
+      <time-window-size value="1.0" />
+      <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+      <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
+    </coupling-scheme:parallel-implicit>
+  </solver-interface>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -84,6 +84,7 @@ target_sources(testprecice
     tests/serial/convergence-measures/testConvergenceMeasures2.cpp
     tests/serial/convergence-measures/testConvergenceMeasures3.cpp
     tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+    tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
     tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
     tests/serial/explicit/TestExplicitMPI.cpp
     tests/serial/explicit/TestExplicitMPISingle.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -84,6 +84,7 @@ target_sources(testprecice
     tests/serial/convergence-measures/testConvergenceMeasures2.cpp
     tests/serial/convergence-measures/testConvergenceMeasures3.cpp
     tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+    tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
     tests/serial/explicit/TestExplicitMPI.cpp
     tests/serial/explicit/TestExplicitMPISingle.cpp
     tests/serial/explicit/TestExplicitSockets.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -83,6 +83,7 @@ target_sources(testprecice
     tests/serial/convergence-measures/testConvergenceMeasures1.cpp
     tests/serial/convergence-measures/testConvergenceMeasures2.cpp
     tests/serial/convergence-measures/testConvergenceMeasures3.cpp
+    tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
     tests/serial/explicit/TestExplicitMPI.cpp
     tests/serial/explicit/TestExplicitMPISingle.cpp
     tests/serial/explicit/TestExplicitSockets.cpp


### PR DESCRIPTION
## Main changes of this PR

I'm adding some more integration tests for direct access and features related to waveform relaxation and data initialization. See also #1583 and #1582 

## Motivation and additional information

Both features are experimental and not used very often. So I think it is a good idea to test how they interact.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] ~~I added a changelog file with `make changelog` if there are user-observable changes since the last release.~~ not needed
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
