### PR TITLE
Remove getMeshIDs

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -84,11 +84,6 @@ int SolverInterface::getMeshID(
   return _impl->getMeshID(meshName);
 }
 
-std::set<int> SolverInterface::getMeshIDs() const
-{
-  return _impl->getMeshIDs();
-}
-
 bool SolverInterface::requiresMeshConnectivityFor(int meshID) const
 {
   return _impl->requiresMeshConnectivityFor(meshID);

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -311,16 +311,6 @@ public:
   int getMeshID(const std::string &meshName) const;
 
   /**
-   * @brief Returns a id-set of all used meshes by this participant.
-   *
-   * @deprecated Unclear use case and difficult to port to other languages.
-   *             Prefer calling getMeshID for specific mesh names.
-   *
-   * @returns the set of ids.
-   */
-  [[deprecated("Use getMeshID() for specific mesh names instead.")]] std::set<int> getMeshIDs() const;
-
-  /**
    * @brief Checks if the given mesh requires connectivity.
    *
    * preCICE may require connectivity information from the solver and

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -589,16 +589,6 @@ int SolverInterfaceImpl::getMeshID(
   return _accessor->getUsedMeshID(meshName);
 }
 
-std::set<int> SolverInterfaceImpl::getMeshIDs() const
-{
-  PRECICE_TRACE();
-  std::set<int> ids;
-  for (const impl::MeshContext *context : _accessor->usedMeshContexts()) {
-    ids.insert(context->mesh->getID());
-  }
-  return ids;
-}
-
 bool SolverInterfaceImpl::hasData(
     const std::string &dataName, MeshID meshID) const
 {

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -141,9 +141,6 @@ public:
   /// @copydoc SolverInterface::hasMesh
   int getMeshID(const std::string &meshName) const;
 
-  /// @copydoc SolverInterface::getMeshIDs
-  std::set<int> getMeshIDs() const;
-
   /// @copydoc SolverInterface::requiresMeshConnectivityFor
   bool requiresMeshConnectivityFor(int meshID) const;
 


### PR DESCRIPTION
## Main changes of this PR

This PR removes the deprecated API method `getMeshIDs()`.

## Motivation and additional information

Unclear use-case and will be obsolete with #1461 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist
