### PR TITLE
Add selective synchronization

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -83,6 +83,11 @@ BaseCouplingScheme::BaseCouplingScheme(
   }
 }
 
+std::string BaseCouplingScheme::getLocalParticipant() const
+{
+  return _localParticipant;
+}
+
 bool BaseCouplingScheme::isImplicitCouplingScheme() const
 {
   PRECICE_ASSERT(_couplingMode != Undefined);

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -99,6 +99,21 @@ bool BaseCouplingScheme::hasConverged() const
   return _hasConverged;
 }
 
+void BaseCouplingScheme::updateDynamicParticipants(const std::set<std::string> &dynamicParticipants)
+{
+  if (dynamicParticipants.count(_localParticipant) == 1) {
+    _isSynchonizationRequired = true;
+  } else {
+    auto partners = getCouplingPartners();
+    for (const auto &partner : partners) {
+      if (dynamicParticipants.count(partner) == 1) {
+        _isSynchonizationRequired = true;
+        return;
+      }
+    }
+  }
+}
+
 void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData)
 {
   PRECICE_TRACE();

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -211,12 +211,6 @@ bool BaseCouplingScheme::sendsInitializedData() const
   return _sendsInitializedData;
 }
 
-CouplingScheme::ChangedMeshes BaseCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
-{
-  PRECICE_ASSERT(changes.empty());
-  return changes;
-}
-
 void BaseCouplingScheme::firstExchange()
 {
   PRECICE_TRACE(_timeWindows, _time);
@@ -235,15 +229,9 @@ void BaseCouplingScheme::firstExchange()
   }
 }
 
-CouplingScheme::ChangedMeshes BaseCouplingScheme::secondSynchronization()
-{
-  return {};
-}
-
 void BaseCouplingScheme::secondExchange()
 {
   PRECICE_TRACE(_timeWindows, _time);
-  checkCompletenessRequiredActions();
   PRECICE_ASSERT(_isInitialized, "Before calling advance() coupling scheme has to be initialized via initialize().");
   PRECICE_ASSERT(_couplingMode != Undefined);
 

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -195,11 +195,7 @@ public:
   /// Receives result of first advance, if this has to happen inside SolverInterface::initialize(), see CouplingScheme.hpp
   void receiveResultOfFirstAdvance() override final;
 
-  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override final;
-
   void firstExchange() override final;
-
-  ChangedMeshes secondSynchronization() override final;
 
   void secondExchange() override final;
 
@@ -379,6 +375,12 @@ protected:
    */
   int getExtrapolationOrder();
 
+  /**
+   * @brief Function to check whether end of time window is reached. Does not check for convergence
+   * @returns true if end time of time window is reached.
+   */
+  bool reachedEndOfTimeWindow();
+
 private:
   /// Coupling mode used by coupling scheme.
   CouplingMode _couplingMode = Undefined;
@@ -506,8 +508,6 @@ private:
    */
   virtual void performReceiveOfFirstAdvance();
 
-  /// Functions needed for advance()
-
   /// Exchanges the first set of data
   virtual void exchangeFirstData() = 0;
 
@@ -524,12 +524,6 @@ private:
    * @brief If any required actions are open, an error message is issued.
    */
   void checkCompletenessRequiredActions();
-
-  /**
-   * @brief Function to check whether end of time window is reached. Does not check for convergence
-   * @returns true if end time of time window is reached.
-   */
-  bool reachedEndOfTimeWindow();
 
   /**
    * @brief Initialize txt writers for iterations and convergence tracking

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -75,6 +75,11 @@ public:
       int                           extrapolationOrder);
 
   /**
+   * @brief Getter for _localParticipant
+   */
+  std::string getLocalParticipant() const override final;
+
+  /**
    * @brief Getter for _sendsInitializedData
    * @returns _sendsInitializedData
    */

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -386,6 +386,14 @@ protected:
    */
   bool reachedEndOfTimeWindow();
 
+  void updateDynamicParticipants(const std::set<std::string> &dynamicParticipants) override final;
+
+protected:
+  bool isSynchronizationRequired() const
+  {
+    return _isSynchonizationRequired;
+  }
+
 private:
   /// Coupling mode used by coupling scheme.
   CouplingMode _couplingMode = Undefined;
@@ -470,6 +478,9 @@ private:
 
   /// Smallest number, taking validDigits into account: eps = std::pow(10.0, -1 * validDigits)
   const double _eps;
+
+  /// Is either the local or the remote coupling partner dynamic?
+  bool _isSynchonizationRequired = false;
 
   /**
    * @brief Holds meta information to perform a convergence measurement.

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -86,6 +86,10 @@ protected:
 
   void exchangeInitialData() override final;
 
+  CouplingScheme::ChangedMeshes receiveRemoteChanges();
+
+  void sendLocalChanges(const CouplingScheme::ChangedMeshes &changes);
+
 private:
   mutable logging::Logger _log{"cplscheme::BiCouplingScheme"};
 

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -358,4 +358,12 @@ bool CompositionalCouplingScheme::hasConverged() const
   return _implicitScheme->hasConverged();
 }
 
+void CompositionalCouplingScheme::updateDynamicParticipants(const std::set<std::string> &dynamicParticipants)
+{
+  PRECICE_TRACE();
+  for (auto scheme : schemesToRun()) {
+    scheme->updateDynamicParticipants(dynamicParticipants);
+  }
+}
+
 } // namespace precice::cplscheme

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -132,6 +132,12 @@ void CompositionalCouplingScheme::finalize()
   }
 }
 
+std::string CompositionalCouplingScheme::getLocalParticipant() const
+{
+  // Returns the local participant of the first scheme
+  return allSchemes().front()->getLocalParticipant();
+}
+
 std::vector<std::string> CompositionalCouplingScheme::getCouplingPartners() const
 {
   PRECICE_TRACE();

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -106,6 +106,8 @@ public:
   /// Finalizes the coupling and disconnects communication.
   void finalize() final override;
 
+  std::string getLocalParticipant() const final override;
+
   /// Returns list of all coupling partners
   std::vector<std::string> getCouplingPartners() const final override;
 

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -223,6 +223,9 @@ public:
   /// True if the implicit scheme has converged or no implicit scheme is defined
   bool hasConverged() const final;
 
+  /// Forwards the info to all subschemes
+  void updateDynamicParticipants(const std::set<std::string> &dynamicParticipants) final;
+
 private:
   mutable logging::Logger _log{"cplscheme::CompositionalCouplingScheme"};
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -237,6 +238,9 @@ public:
 
   /// Returns false if the scheme is implicit and hasn't converged
   virtual bool hasConverged() const = 0;
+
+  /// Informs the cplscheme which participants are considerred dynamic
+  virtual void updateDynamicParticipants(const std::set<std::string> &dynamicParticipants) = 0;
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -156,6 +156,8 @@ public:
   /// Finalizes the coupling and disconnects communication.
   virtual void finalize() = 0;
 
+  virtual std::string getLocalParticipant() const = 0;
+
   /// Returns list of all coupling partners.
   virtual std::vector<std::string> getCouplingPartners() const = 0;
 

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -107,7 +107,7 @@ void MultiCouplingScheme::exchangeInitialData()
 
 CouplingScheme::ChangedMeshes MultiCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
 {
-  if (!reachedEndOfTimeWindow()) {
+  if (!reachedEndOfTimeWindow() || !isSynchronizationRequired()) {
     return {};
   }
 

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -70,6 +70,10 @@ public:
 
   bool hasAnySendData() override final;
 
+  CouplingScheme::ChangedMeshes firstSynchronization(const CouplingScheme::ChangedMeshes &changes) final;
+
+  CouplingScheme::ChangedMeshes secondSynchronization() final;
+
 private:
   /**
    * @brief A vector of m2ns. A m2n is a communication device to the other coupling participant.
@@ -101,6 +105,10 @@ private:
 
   /// if this is the controller or not
   bool _isController;
+
+  void sendLocalChanges(const CouplingScheme::ChangedMeshes &changes);
+
+  CouplingScheme::ChangedMeshes receiveRemoteChanges();
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -25,6 +25,9 @@ ParallelCouplingScheme::ParallelCouplingScheme(
 
 CouplingScheme::ChangedMeshes ParallelCouplingScheme::firstSynchronization(const CouplingScheme::ChangedMeshes &changes)
 {
+  if (!isSynchronizationRequired()) {
+    return {};
+  }
   PRECICE_DEBUG("Exchanging mesh changes...");
   if (doesFirstStep()) { // first participant
     sendLocalChanges(changes);

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -56,11 +56,19 @@ public:
       int                           maxIterations      = UNDEFINED_MAX_ITERATIONS,
       int                           extrapolationOrder = UNDEFINED_EXTRAPOLATION_ORDER);
 
+  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) final;
+
+  ChangedMeshes secondSynchronization() final;
+
 private:
   logging::Logger _log{"cplscheme::ParallelCouplingScheme"};
 
+  /// Exchanges first set of data between the participants of the ParallelCouplingScheme
   void exchangeFirstData() override final;
 
+  /**
+   * @brief Exchanges the second set of data between the participants of the ParallelCouplingScheme and applies acceleration.
+   */
   void exchangeSecondData() override final;
 
   const DataMap getAccelerationData() override final;

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -54,6 +54,10 @@ public:
       int                           maxIterations      = UNDEFINED_MAX_ITERATIONS,
       int                           extrapolationOrder = UNDEFINED_EXTRAPOLATION_ORDER);
 
+  CouplingScheme::ChangedMeshes firstSynchronization(const CouplingScheme::ChangedMeshes &changes) final;
+
+  CouplingScheme::ChangedMeshes secondSynchronization() final;
+
 protected:
   /**
    * @brief Setter for _timeWindowSize
@@ -78,9 +82,13 @@ private:
 
   void performReceiveOfFirstAdvance() override final;
 
+  /// Exchanges the first set of data between the participants of the SerialCouplingSchemes
   void exchangeFirstData() override;
 
-  void exchangeSecondData() override final;
+  /**
+   * @brief Exchanges the second set of data between the participants of the SerialCouplingSchemes
+   */
+  void exchangeSecondData() override;
 
   const DataMap getAccelerationData() override final;
 };

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -91,6 +91,15 @@ public:
   /*
    * @brief Not implemented.
    */
+  virtual std::string getLocalParticipant() const
+  {
+    PRECICE_ASSERT(false);
+    return {};
+  }
+
+  /*
+   * @brief Not implemented.
+   */
   std::vector<std::string> getCouplingPartners() const override final
   {
     PRECICE_ASSERT(false);

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -26,11 +26,6 @@ public:
       int maxTimesteps);
 
   /**
-   * @brief Destructor, empty.
-   */
-  //virtual ~DummyCouplingScheme() {}
-
-  /**
    * @brief
    */
   void initialize(
@@ -69,11 +64,6 @@ public:
   void addComputedTime(double timeToAdd) override final
   { /* Do nothing */
   }
-
-  /**
-   * @brief
-   */
-  //void advance() override final;
 
   ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override;
 
@@ -241,6 +231,14 @@ public:
   }
 
   bool hasConverged() const override;
+
+  /**
+   * @brief Not implemented.
+   */
+  void updateDynamicParticipants(const std::set<std::string> &dynamicParticipants) override final
+  {
+    PRECICE_ASSERT(false);
+  }
 
 private:
   mutable logging::Logger _log{"cplscheme::tests::DummyCouplingScheme"};

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -274,9 +274,11 @@ void ParticipantConfiguration::xmlTagCallback(
     std::string name    = tag.getStringAttributeValue(ATTR_NAME);
     auto        dynamic = tag.getBooleanAttributeValue(ATTR_DYNAMIC);
 
-    PRECICE_CHECK(!dynamic || _experimental,
-                  "You tried to configure the provided mesh \"{}\" to use the option dynamic=\"true\", which is currently still experimental. Please set experimental=\"true\", if you want to use this feature.", name);
-    PRECICE_WARN("You configured the provided mesh \"{}\" to use the option dynamic=\"true\", which is currently still experimental. Use with care.", name);
+    if (dynamic) {
+      PRECICE_CHECK(_experimental,
+                    "You tried to configure the provided mesh \"{}\" to use the option dynamic=\"true\", which is currently still experimental. Please set experimental=\"true\", if you want to use this feature.", name);
+      PRECICE_WARN("You configured the provided mesh \"{}\" to use the option dynamic=\"true\", which is currently still experimental. Use with care.", name);
+    }
 
     mesh::PtrMesh mesh = _meshConfig->getMesh(name);
     PRECICE_CHECK(mesh,

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -153,6 +153,9 @@ private:
   void checkIllDefinedMappings(
       const mapping::MappingConfiguration::ConfiguredMapping &mapping,
       const impl::PtrParticipant &                            participant);
+
+  /// Updates all participants regarding dynamicity information
+  void updateParticipantDynamicity();
 };
 
 } // namespace config

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -83,6 +83,7 @@ private:
   const std::string TAG_INTRA_COMM     = "intra-comm";
 
   const std::string ATTR_NAME               = "name";
+  const std::string ATTR_DYNAMIC            = "dynamic";
   const std::string ATTR_SOURCE_DATA        = "source-data";
   const std::string ATTR_TARGET_DATA        = "target-data";
   const std::string ATTR_TIMING             = "timing";

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -38,8 +38,14 @@ struct MeshContext {
   /// True, if accessor does create the mesh.
   bool provideMesh = false;
 
-  /// True, if the mesh is dynamic and may be changed locally or remotely
-  bool dynamic = false;
+  enum struct Dynamicity {
+    No,
+    Yes,
+    Transitively
+  };
+
+  /// Whether the mesh is static, dynamically provided or transitively dynamic via mappings or exchanges.
+  Dynamicity dynamic = Dynamicity::No;
 
   /// type of geometric filter
   partition::ReceivedPartition::GeometricFilter geoFilter = partition::ReceivedPartition::GeometricFilter::UNDEFINED;

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -38,7 +38,7 @@ struct MeshContext {
   /// True, if accessor does create the mesh.
   bool provideMesh = false;
 
-  /// True, if the mesh is dynamic and can be changed
+  /// True, if the mesh is dynamic and may be changed locally or remotely
   bool dynamic = false;
 
   /// type of geometric filter

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -38,10 +38,11 @@ struct MeshContext {
   /// True, if accessor does create the mesh.
   bool provideMesh = false;
 
+  /// The kind of dynamicity of this mesh
   enum struct Dynamicity {
-    No,
-    Yes,
-    Transitively
+    No,          ///< static mesh, mappings will stay untouched too
+    Yes,         ///< dynamic mesh, which is provided or received
+    Transitively ///< static mesh, but has a mapping to a dynamic mesh
   };
 
   /// Whether the mesh is static, dynamically provided, dynamically received or transitively dynamic via mappings.

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -38,6 +38,9 @@ struct MeshContext {
   /// True, if accessor does create the mesh.
   bool provideMesh = false;
 
+  /// True, if the mesh is dynamic and can be changed
+  bool dynamic = false;
+
   /// type of geometric filter
   partition::ReceivedPartition::GeometricFilter geoFilter = partition::ReceivedPartition::GeometricFilter::UNDEFINED;
 

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -44,7 +44,7 @@ struct MeshContext {
     Transitively
   };
 
-  /// Whether the mesh is static, dynamically provided or transitively dynamic via mappings or exchanges.
+  /// Whether the mesh is static, dynamically provided, dynamically received or transitively dynamic via mappings.
   Dynamicity dynamic = Dynamicity::No;
 
   /// type of geometric filter

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -65,7 +65,7 @@ void Participant::addWatchIntegral(
   _watchIntegrals.push_back(watchIntegral);
 }
 
-void Participant::provideMesh(const mesh::PtrMesh &mesh)
+void Participant::provideMesh(const mesh::PtrMesh &mesh, bool dynamic)
 {
   PRECICE_TRACE(_name, mesh->getName(), mesh->getID());
   checkDuplicatedUse(mesh);
@@ -74,6 +74,7 @@ void Participant::provideMesh(const mesh::PtrMesh &mesh)
   auto context                 = new MeshContext();
   context->mesh                = mesh;
   context->provideMesh         = true;
+  context->dynamic             = dynamic;
   _meshContexts[mesh->getID()] = context;
   _usedMeshContexts.push_back(context);
 }

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -105,6 +105,11 @@ void Participant::receiveMesh(const mesh::PtrMesh &                         mesh
   _usedMeshContexts.push_back(context);
 }
 
+void Participant::registerDynamicParticipant(const std::string &name)
+{
+  _dynamicParticipants.emplace(name);
+}
+
 void Participant::addWriteData(
     const mesh::PtrData &data,
     const mesh::PtrMesh &mesh)
@@ -415,18 +420,7 @@ bool Participant::isDynamic() const
 
 std::set<std::string> Participant::dynamicParticipants() const
 {
-  std::set<std::string> names;
-  if (isDynamic()) {
-    names.insert(getName());
-  }
-  for (const MeshContext *meshContext : usedMeshContexts()) {
-    if (meshContext->provideMesh || meshContext->dynamic == MeshContext::Dynamicity::No) {
-      continue;
-    }
-    names.insert(meshContext->receiveMeshFrom);
-  }
-  PRECICE_WARN("Dynamic Participants are {}", names);
-  return names;
+  return _dynamicParticipants;
 }
 
 std::vector<PtrWatchPoint> &Participant::watchPoints()

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -118,6 +118,7 @@ public:
                    partition::ReceivedPartition::GeometricFilter geoFilter,
                    const bool                                    allowDirectAccess);
 
+  /// Registers a given Participant as dynamic.
   void registerDynamicParticipant(const std::string &name);
   /// @}
 

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -117,6 +117,8 @@ public:
                    double                                        safetyFactor,
                    partition::ReceivedPartition::GeometricFilter geoFilter,
                    const bool                                    allowDirectAccess);
+
+  void registerDynamicParticipant(const std::string &name);
   /// @}
 
   /// @name Data queries
@@ -371,6 +373,8 @@ private:
   bool _useIntraComm = false;
 
   std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
+
+  std::set<std::string> _dynamicParticipants;
 
   template <typename ELEMENT_T>
   bool isDataValid(

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -109,7 +109,7 @@ public:
   void addExportContext(const io::ExportContext &context);
 
   /// Adds a mesh to be provided by the participant.
-  void provideMesh(const mesh::PtrMesh &mesh);
+  void provideMesh(const mesh::PtrMesh &mesh, bool dynamic = false);
 
   /// Adds a mesh to be received by the participant.
   void receiveMesh(const mesh::PtrMesh &                         mesh,

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -330,6 +330,12 @@ public:
 
   /// Returns all \ref ExportContext for exporting meshes and data.
   const std::vector<io::ExportContext> &exportContexts() const;
+
+  /// Is this participant dynamic?
+  bool isDynamic() const;
+
+  /// Returns the names of all dynamic participants including the local.
+  std::set<std::string> dynamicParticipants() const;
   /// @}
 
 private:

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -244,6 +244,7 @@ void SolverInterfaceImpl::configure(
   cplscheme::PtrCouplingSchemeConfiguration cplSchemeConfig =
       config.getCouplingSchemeConfiguration();
   _couplingScheme = cplSchemeConfig->getCouplingScheme(_accessorName);
+  _couplingScheme->updateDynamicParticipants(_accessor->dynamicParticipants());
 
   // Register all MeshIds to the lock, but unlock them straight away as
   // writing is allowed after configuration.

--- a/src/precice/tests/MeshContextTests.cpp
+++ b/src/precice/tests/MeshContextTests.cpp
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(DynamicMesh)
       if (pname == "B") {
         if (meshName == "Dynamic") {
           BOOST_TEST(!context->provideMesh);
-          BOOST_TEST((context->dynamic == Dynamicity::Transitively));
+          BOOST_TEST((context->dynamic == Dynamicity::Yes));
         }
         if (meshName == "Static") {
           BOOST_TEST(context->provideMesh);

--- a/src/precice/tests/MeshContextTests.cpp
+++ b/src/precice/tests/MeshContextTests.cpp
@@ -4,6 +4,7 @@
 #include <precice/config/Configuration.hpp>
 #include <precice/config/ParticipantConfiguration.hpp>
 #include <xml/ConfigParser.hpp>
+#include "precice/impl/MeshContext.hpp"
 
 using namespace precice;
 using namespace precice::impl;
@@ -33,20 +34,21 @@ BOOST_AUTO_TEST_CASE(StaticMesh)
     for (const auto &context : contexts) {
       auto meshName = context->mesh->getName();
       BOOST_REQUIRE(meshName == "MeshA" || meshName == "MeshB");
+      using Dynamicity = precice::impl::MeshContext::Dynamicity;
       if (pname == "A") {
         if (meshName == "MeshA") {
           BOOST_TEST(context->provideMesh);
-          BOOST_TEST(!context->dynamic);
+          BOOST_TEST((context->dynamic == Dynamicity::No));
         }
       }
       if (pname == "B") {
         if (meshName == "MeshA") {
           BOOST_TEST(!context->provideMesh);
-          BOOST_TEST(!context->dynamic);
+          BOOST_TEST((context->dynamic == Dynamicity::No));
         }
         if (meshName == "MeshB") {
           BOOST_TEST(context->provideMesh);
-          BOOST_TEST(!context->dynamic);
+          BOOST_TEST((context->dynamic == Dynamicity::No));
         }
       }
     }
@@ -74,20 +76,75 @@ BOOST_AUTO_TEST_CASE(DynamicMesh)
     for (const auto &context : contexts) {
       auto meshName = context->mesh->getName();
       BOOST_REQUIRE(meshName == "Dynamic" || meshName == "Static");
+      using Dynamicity = precice::impl::MeshContext::Dynamicity;
       if (pname == "A") {
         if (meshName == "Dynamic") {
           BOOST_TEST(context->provideMesh);
-          BOOST_TEST(context->dynamic);
+          BOOST_TEST((context->dynamic == Dynamicity::Yes));
         }
       }
       if (pname == "B") {
         if (meshName == "Dynamic") {
           BOOST_TEST(!context->provideMesh);
-          BOOST_TEST(context->dynamic);
+          BOOST_TEST((context->dynamic == Dynamicity::Transitively));
         }
         if (meshName == "Static") {
           BOOST_TEST(context->provideMesh);
-          BOOST_TEST(!context->dynamic);
+          BOOST_TEST((context->dynamic == Dynamicity::Transitively));
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Partial)
+{
+  PRECICE_TEST(1_rank);
+
+  config::Configuration     config;
+  xml::ConfigurationContext cont{"A", 0, 1};
+  xml::configure(config.getXMLTag(),
+                 cont,
+                 context.prefix("meshcontext-partial.xml"));
+  auto participants = config.getSolverInterfaceConfiguration().getParticipantConfiguration()->getParticipants();
+
+  BOOST_REQUIRE(participants.size() == 2);
+
+  for (const auto &participant : participants) {
+    auto pname = participant->getName();
+    BOOST_REQUIRE(pname == "A" || pname == "B");
+    const auto &contexts = participant->usedMeshContexts();
+
+    for (const auto &context : contexts) {
+      auto meshName = context->mesh->getName();
+      BOOST_REQUIRE(meshName == "MeshA" || meshName == "MeshB" || meshName == "MeshC" || meshName == "MeshD");
+      using Dynamicity = precice::impl::MeshContext::Dynamicity;
+      if (pname == "A") {
+        if (meshName == "A") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST((context->dynamic == Dynamicity::Transitively));
+        }
+        if (meshName == "C") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST((context->dynamic == Dynamicity::No));
+        }
+      }
+      if (pname == "B") {
+        if (meshName == "A") {
+          BOOST_TEST(!context->provideMesh);
+          BOOST_TEST((context->dynamic == Dynamicity::Transitively));
+        }
+        if (meshName == "B") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST((context->dynamic == Dynamicity::Yes));
+        }
+        if (meshName == "C") {
+          BOOST_TEST(!context->provideMesh);
+          BOOST_TEST((context->dynamic == Dynamicity::No));
+        }
+        if (meshName == "D") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST((context->dynamic == Dynamicity::No));
         }
       }
     }

--- a/src/precice/tests/MeshContextTests.cpp
+++ b/src/precice/tests/MeshContextTests.cpp
@@ -1,0 +1,99 @@
+#include <boost/test/tools/old/interface.hpp>
+#include <testing/Testing.hpp>
+
+#include <precice/config/Configuration.hpp>
+#include <precice/config/ParticipantConfiguration.hpp>
+#include <xml/ConfigParser.hpp>
+
+using namespace precice;
+using namespace precice::impl;
+
+BOOST_AUTO_TEST_SUITE(PreciceTests)
+
+BOOST_AUTO_TEST_SUITE(MeshContextTests)
+
+BOOST_AUTO_TEST_CASE(StaticMesh)
+{
+  PRECICE_TEST(1_rank);
+
+  config::Configuration     config;
+  xml::ConfigurationContext cont{"A", 0, 1};
+  xml::configure(config.getXMLTag(),
+                 cont,
+                 context.prefix("meshcontext-static.xml"));
+  auto participants = config.getSolverInterfaceConfiguration().getParticipantConfiguration()->getParticipants();
+
+  BOOST_REQUIRE(participants.size() == 2);
+
+  for (const auto &participant : participants) {
+    auto pname = participant->getName();
+    BOOST_REQUIRE(pname == "A" || pname == "B");
+    const auto &contexts = participant->usedMeshContexts();
+
+    for (const auto &context : contexts) {
+      auto meshName = context->mesh->getName();
+      BOOST_REQUIRE(meshName == "MeshA" || meshName == "MeshB");
+      if (pname == "A") {
+        if (meshName == "MeshA") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST(!context->dynamic);
+        }
+      }
+      if (pname == "B") {
+        if (meshName == "MeshA") {
+          BOOST_TEST(!context->provideMesh);
+          BOOST_TEST(!context->dynamic);
+        }
+        if (meshName == "MeshB") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST(!context->dynamic);
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(DynamicMesh)
+{
+  PRECICE_TEST(1_rank);
+
+  config::Configuration     config;
+  xml::ConfigurationContext cont{"A", 0, 1};
+  xml::configure(config.getXMLTag(),
+                 cont,
+                 context.prefix("meshcontext-dynamic.xml"));
+  auto participants = config.getSolverInterfaceConfiguration().getParticipantConfiguration()->getParticipants();
+
+  BOOST_REQUIRE(participants.size() == 2);
+
+  for (const auto &participant : participants) {
+    auto pname = participant->getName();
+    BOOST_REQUIRE(pname == "A" || pname == "B");
+    const auto &contexts = participant->usedMeshContexts();
+
+    for (const auto &context : contexts) {
+      auto meshName = context->mesh->getName();
+      BOOST_REQUIRE(meshName == "Dynamic" || meshName == "Static");
+      if (pname == "A") {
+        if (meshName == "Dynamic") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST(context->dynamic);
+        }
+      }
+      if (pname == "B") {
+        if (meshName == "Dynamic") {
+          BOOST_TEST(!context->provideMesh);
+          BOOST_TEST(context->dynamic);
+        }
+        if (meshName == "Static") {
+          BOOST_TEST(context->provideMesh);
+          BOOST_TEST(!context->dynamic);
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/meshcontext-dynamic.xml
+++ b/src/precice/tests/meshcontext-dynamic.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2" experimental="true">
+    <data:scalar name="Data1" />
+    <data:scalar name="Data2" />
+
+    <mesh name="Dynamic">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <mesh name="Static">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <participant name="A">
+      <provide-mesh name="Dynamic" dynamic="true" />
+      <write-data name="Data1" mesh="Dynamic" />
+      <read-data name="Data2" mesh="Dynamic" />
+    </participant>
+
+    <participant name="B">
+      <receive-mesh name="Dynamic" from="A" />
+      <provide-mesh name="Static" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="Dynamic"
+        to="Static"
+        constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="Static"
+        to="Dynamic"
+        constraint="conservative" />
+      <write-data name="Data2" mesh="Static" />
+      <read-data name="Data1" mesh="Static" />
+    </participant>
+
+    <m2n:sockets from="A" to="B" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="A" second="B" />
+      <max-time-windows value="1" />
+      <time-window-size value="1.0" />
+      <exchange data="Data1" mesh="Dynamic" from="A" to="B" />
+      <exchange data="Data2" mesh="Dynamic" from="B" to="A" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/precice/tests/meshcontext-partial.xml
+++ b/src/precice/tests/meshcontext-partial.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2" experimental="true">
+    <data:scalar name="Data1" />
+    <data:scalar name="Data2" />
+    <data:scalar name="Data3" />
+    <data:scalar name="Data4" />
+
+    <mesh name="MeshA">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <mesh name="MeshB">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <mesh name="MeshC">
+      <use-data name="Data3" />
+      <use-data name="Data4" />
+    </mesh>
+
+    <mesh name="MeshD">
+      <use-data name="Data3" />
+      <use-data name="Data4" />
+    </mesh>
+
+    <participant name="A">
+      <provide-mesh name="MeshA" />
+      <provide-mesh name="MeshC" />
+      <write-data name="Data1" mesh="MeshA" />
+      <read-data name="Data2" mesh="MeshA" />
+      <write-data name="Data3" mesh="MeshC" />
+      <read-data name="Data4" mesh="MeshC" />
+    </participant>
+
+    <participant name="B">
+      <receive-mesh name="MeshA" from="A" />
+      <receive-mesh name="MeshC" from="A" />
+      <provide-mesh name="MeshB" dynamic="true" />
+      <provide-mesh name="MeshD" />
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB" constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshB"
+        to="MeshA"
+        constraint="conservative" />
+      <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshD" constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshD"
+        to="MeshC"
+        constraint="conservative" />
+      <write-data name="Data2" mesh="MeshB" />
+      <read-data name="Data1" mesh="MeshB" />
+      <write-data name="Data4" mesh="MeshD" />
+      <read-data name="Data3" mesh="MeshD" />
+    </participant>
+
+    <m2n:sockets from="A" to="B" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="A" second="B" />
+      <max-time-windows value="1" />
+      <time-window-size value="1.0" />
+      <exchange data="Data1" mesh="MeshA" from="A" to="B" />
+      <exchange data="Data2" mesh="MeshA" from="B" to="A" />
+      <exchange data="Data3" mesh="MeshC" from="A" to="B" />
+      <exchange data="Data4" mesh="MeshC" from="B" to="A" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/precice/tests/meshcontext-static.xml
+++ b/src/precice/tests/meshcontext-static.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2">
+    <data:scalar name="Data1" />
+    <data:scalar name="Data2" />
+
+    <mesh name="MeshA">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <mesh name="MeshB">
+      <use-data name="Data1" />
+      <use-data name="Data2" />
+    </mesh>
+
+    <participant name="A">
+      <provide-mesh name="MeshA" />
+      <write-data name="Data1" mesh="MeshA" />
+      <read-data name="Data2" mesh="MeshA" />
+    </participant>
+
+    <participant name="B">
+      <receive-mesh name="MeshA" from="A" />
+      <provide-mesh name="MeshB" />
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB" constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshB"
+        to="MeshA"
+        constraint="conservative" />
+      <write-data name="Data2" mesh="MeshB" />
+      <read-data name="Data1" mesh="MeshB" />
+    </participant>
+
+    <m2n:sockets from="A" to="B" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="A" second="B" />
+      <max-time-windows value="1" />
+      <time-window-size value="1.0" />
+      <exchange data="Data1" mesh="MeshA" from="A" to="B" />
+      <exchange data="Data2" mesh="MeshA" from="B" to="A" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -62,6 +62,7 @@ target_sources(testprecice
     src/partition/tests/ReceivedPartitionTest.cpp
     src/partition/tests/fixtures.hpp
     src/precice/tests/DataContextTest.cpp
+    src/precice/tests/MeshContextTests.cpp
     src/precice/tests/ParallelTests.cpp
     src/precice/tests/ToolingTests.cpp
     src/precice/tests/VersioningTests.cpp

--- a/tests/dynamic/selective-sync/MultiCouplingDynamicController.cpp
+++ b/tests/dynamic/selective-sync/MultiCouplingDynamicController.cpp
@@ -1,0 +1,20 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../../serial/multi-coupling/helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Dynamic)
+BOOST_AUTO_TEST_SUITE(SelectiveSync)
+BOOST_AUTO_TEST_CASE(MultiCouplingDynamicController)
+{
+  PRECICE_TEST("SolverA"_on(1_rank), "SolverB"_on(1_rank), "SolverC"_on(1_rank));
+  const std::string configFile = context.config();
+  multiCouplingThreeSolvers(configFile, context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/dynamic/selective-sync/MultiCouplingDynamicController.xml
+++ b/tests/dynamic/selective-sync/MultiCouplingDynamicController.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2" experimental="true">
+    <data:scalar name="DataAB" />
+    <data:scalar name="DataBA" />
+    <data:scalar name="DataBC" />
+    <data:scalar name="DataCB" />
+
+    <mesh name="MeshA">
+      <use-data name="DataAB" />
+      <use-data name="DataBA" />
+      <use-data name="DataCB" />
+      <use-data name="DataBC" />
+    </mesh>
+
+    <mesh name="MeshB1">
+      <use-data name="DataAB" />
+      <use-data name="DataBA" />
+    </mesh>
+
+    <mesh name="MeshB2">
+      <use-data name="DataBC" />
+      <use-data name="DataCB" />
+    </mesh>
+
+    <mesh name="MeshC">
+      <use-data name="DataBC" />
+      <use-data name="DataCB" />
+    </mesh>
+
+    <participant name="SolverA">
+      <provide-mesh name="MeshA" dynamic="true" />
+      <receive-mesh name="MeshC" from="SolverC" />
+      <write-data name="DataAB" mesh="MeshA" />
+      <read-data name="DataBA" mesh="MeshA" />
+    </participant>
+
+    <participant name="SolverB">
+      <receive-mesh name="MeshA" from="SolverA" />
+      <receive-mesh name="MeshC" from="SolverC" />
+      <provide-mesh name="MeshB1" />
+      <provide-mesh name="MeshB2" />
+      <write-data name="DataBA" mesh="MeshB1" />
+      <write-data name="DataBC" mesh="MeshB2" />
+      <read-data name="DataAB" mesh="MeshB1" />
+      <read-data name="DataCB" mesh="MeshB2" />
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB1" constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshB1"
+        to="MeshA"
+        constraint="consistent" />
+      <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshB2" constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshB2"
+        to="MeshC"
+        constraint="consistent" />
+    </participant>
+
+    <participant name="SolverC">
+      <provide-mesh name="MeshC" />
+      <write-data name="DataCB" mesh="MeshC" />
+      <read-data name="DataBC" mesh="MeshC" />
+    </participant>
+
+    <m2n:sockets from="SolverA" to="SolverB" />
+    <m2n:sockets from="SolverC" to="SolverA" />
+    <m2n:sockets from="SolverB" to="SolverC" />
+
+    <coupling-scheme:multi>
+      <participant name="SolverA" control="yes" />
+      <participant name="SolverB" />
+      <participant name="SolverC" />
+      <max-time-windows value="10" />
+      <time-window-size value="1.0" />
+      <max-iterations value="2" />
+      <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" />
+      <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" />
+      <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverB" />
+      <exchange data="DataBC" mesh="MeshC" from="SolverB" to="SolverC" />
+      <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" />
+      <relative-convergence-measure data="DataCB" mesh="MeshC" limit="1e-4" />
+      <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
+      <acceleration:IQN-ILS>
+        <data name="DataAB" mesh="MeshA" />
+        <filter type="QR2" limit="1e-1" />
+        <initial-relaxation value="1.0" />
+        <max-used-iterations value="10" />
+        <time-windows-reused value="0" />
+      </acceleration:IQN-ILS>
+    </coupling-scheme:multi>
+  </solver-interface>
+</precice-configuration>

--- a/tests/dynamic/selective-sync/MultiCouplingDynamicParticipant.cpp
+++ b/tests/dynamic/selective-sync/MultiCouplingDynamicParticipant.cpp
@@ -1,0 +1,20 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../../serial/multi-coupling/helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Dynamic)
+BOOST_AUTO_TEST_SUITE(SelectiveSync)
+BOOST_AUTO_TEST_CASE(MultiCouplingDynamicParticipant)
+{
+  PRECICE_TEST("SolverA"_on(1_rank), "SolverB"_on(1_rank), "SolverC"_on(1_rank));
+  const std::string configFile = context.config();
+  multiCouplingThreeSolvers(configFile, context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/dynamic/selective-sync/MultiCouplingDynamicParticipant.xml
+++ b/tests/dynamic/selective-sync/MultiCouplingDynamicParticipant.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="2" experimental="true">
+    <data:scalar name="DataAB" />
+    <data:scalar name="DataBA" />
+    <data:scalar name="DataBC" />
+    <data:scalar name="DataCB" />
+
+    <mesh name="MeshA">
+      <use-data name="DataAB" />
+      <use-data name="DataBA" />
+      <use-data name="DataCB" />
+      <use-data name="DataBC" />
+    </mesh>
+
+    <mesh name="MeshB1">
+      <use-data name="DataAB" />
+      <use-data name="DataBA" />
+    </mesh>
+
+    <mesh name="MeshB2">
+      <use-data name="DataBC" />
+      <use-data name="DataCB" />
+    </mesh>
+
+    <mesh name="MeshC">
+      <use-data name="DataBC" />
+      <use-data name="DataCB" />
+    </mesh>
+
+    <participant name="SolverA">
+      <provide-mesh name="MeshA" />
+      <receive-mesh name="MeshC" from="SolverC" />
+      <write-data name="DataAB" mesh="MeshA" />
+      <read-data name="DataBA" mesh="MeshA" />
+    </participant>
+
+    <participant name="SolverB">
+      <receive-mesh name="MeshA" from="SolverA" />
+      <receive-mesh name="MeshC" from="SolverC" />
+      <provide-mesh name="MeshB1" dynamic="true" />
+      <provide-mesh name="MeshB2" />
+      <write-data name="DataBA" mesh="MeshB1" />
+      <write-data name="DataBC" mesh="MeshB2" />
+      <read-data name="DataAB" mesh="MeshB1" />
+      <read-data name="DataCB" mesh="MeshB2" />
+      <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB1" constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshB1"
+        to="MeshA"
+        constraint="consistent" />
+      <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshB2" constraint="consistent" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshB2"
+        to="MeshC"
+        constraint="consistent" />
+    </participant>
+
+    <participant name="SolverC">
+      <provide-mesh name="MeshC" />
+      <write-data name="DataCB" mesh="MeshC" />
+      <read-data name="DataBC" mesh="MeshC" />
+    </participant>
+
+    <m2n:sockets from="SolverA" to="SolverB" />
+    <m2n:sockets from="SolverC" to="SolverA" />
+    <m2n:sockets from="SolverB" to="SolverC" />
+
+    <coupling-scheme:multi>
+      <participant name="SolverA" control="yes" />
+      <participant name="SolverB" />
+      <participant name="SolverC" />
+      <max-time-windows value="10" />
+      <time-window-size value="1.0" />
+      <max-iterations value="2" />
+      <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" />
+      <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" />
+      <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverB" />
+      <exchange data="DataBC" mesh="MeshC" from="SolverB" to="SolverC" />
+      <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" />
+      <relative-convergence-measure data="DataCB" mesh="MeshC" limit="1e-4" />
+      <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
+      <acceleration:IQN-ILS>
+        <data name="DataAB" mesh="MeshA" />
+        <filter type="QR2" limit="1e-1" />
+        <initial-relaxation value="1.0" />
+        <max-used-iterations value="10" />
+        <time-windows-reused value="0" />
+      </acceleration:IQN-ILS>
+    </coupling-scheme:multi>
+  </solver-interface>
+</precice-configuration>

--- a/tests/dynamic/selective-sync/ParallelExplicit.cpp
+++ b/tests/dynamic/selective-sync/ParallelExplicit.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../../serial/explicit/helpers.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Dynamic)
+BOOST_AUTO_TEST_SUITE(SelectiveSync)
+BOOST_AUTO_TEST_CASE(ParallelExplicit)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  runTestExplicit(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Dynamic
+BOOST_AUTO_TEST_SUITE_END() // SelectiveSync
+
+#endif // PRECICE_NO_MPI

--- a/tests/dynamic/selective-sync/ParallelExplicit.xml
+++ b/tests/dynamic/selective-sync/ParallelExplicit.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3" experimental="true">
+    <data:vector name="Forces" />
+    <data:vector name="Velocities" />
+
+    <mesh name="Test-Square">
+      <use-data name="Forces" />
+      <use-data name="Velocities" />
+    </mesh>
+
+    <mesh name="MeshOne">
+      <use-data name="Forces" />
+      <use-data name="Velocities" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <receive-mesh name="Test-Square" from="SolverTwo" />
+      <provide-mesh name="MeshOne" dynamic="true" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshOne"
+        to="Test-Square"
+        constraint="conservative" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="Test-Square"
+        to="MeshOne"
+        constraint="consistent" />
+      <write-data name="Forces" mesh="MeshOne" />
+      <read-data name="Velocities" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <provide-mesh name="Test-Square" />
+      <write-data name="Velocities" mesh="Test-Square" />
+      <read-data name="Forces" mesh="Test-Square" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:parallel-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="10" />
+      <time-window-size value="1.0" />
+      <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo" />
+      <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne" />
+    </coupling-scheme:parallel-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/tests/dynamic/selective-sync/SerialExplicit.cpp
+++ b/tests/dynamic/selective-sync/SerialExplicit.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../../serial/explicit/helpers.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/SolverInterface.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Dynamic)
+BOOST_AUTO_TEST_SUITE(SelectiveSync)
+BOOST_AUTO_TEST_CASE(SerialExplicit)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  runTestExplicit(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Dynamic
+BOOST_AUTO_TEST_SUITE_END() // SelectiveSync
+
+#endif // PRECICE_NO_MPI

--- a/tests/dynamic/selective-sync/SerialExplicit.xml
+++ b/tests/dynamic/selective-sync/SerialExplicit.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <solver-interface dimensions="3" experimental="true">
+    <data:vector name="Forces" />
+    <data:vector name="Velocities" />
+
+    <mesh name="Test-Square">
+      <use-data name="Forces" />
+      <use-data name="Velocities" />
+    </mesh>
+
+    <mesh name="MeshOne">
+      <use-data name="Forces" />
+      <use-data name="Velocities" />
+    </mesh>
+
+    <participant name="SolverOne">
+      <receive-mesh name="Test-Square" from="SolverTwo" />
+      <provide-mesh name="MeshOne" dynamic="true" />
+      <mapping:nearest-neighbor
+        direction="write"
+        from="MeshOne"
+        to="Test-Square"
+        constraint="conservative" />
+      <mapping:nearest-neighbor
+        direction="read"
+        from="Test-Square"
+        to="MeshOne"
+        constraint="consistent" />
+      <write-data name="Forces" mesh="MeshOne" />
+      <read-data name="Velocities" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <provide-mesh name="Test-Square" />
+      <write-data name="Velocities" mesh="Test-Square" />
+      <read-data name="Forces" mesh="Test-Square" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="10" />
+      <time-window-size value="1.0" />
+      <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo" />
+      <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne" />
+    </coupling-scheme:serial-explicit>
+  </solver-interface>
+</precice-configuration>

--- a/tests/serial/initialize-data/helpers.cpp
+++ b/tests/serial/initialize-data/helpers.cpp
@@ -19,9 +19,12 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
     cplInterface.setMeshVertex(meshOneID, pos.data());
     int    dataID     = cplInterface.getDataID("Data", meshOneID);
     double valueDataB = 0.0;
-    cplInterface.initialize();
+    double dt         = cplInterface.initialize();
     cplInterface.readScalarData(dataID, 0, valueDataB);
     BOOST_TEST(2.0 == valueDataB);
+    while (cplInterface.isCouplingOngoing()) {
+      dt = cplInterface.advance(dt);
+    }
     cplInterface.finalize();
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
@@ -34,7 +37,10 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
 
     int dataID = cplInterface.getDataID("Data", meshTwoID);
     cplInterface.writeScalarData(dataID, 0, 2.0);
-    cplInterface.initialize();
+    double dt = cplInterface.initialize();
+    while (cplInterface.isCouplingOngoing()) {
+      dt = cplInterface.advance(dt);
+    }
     cplInterface.finalize();
   }
 }

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3,6 +3,8 @@
 #
 target_sources(testprecice
     PRIVATE
+    tests/dynamic/selective-sync/ParallelExplicit.cpp
+    tests/dynamic/selective-sync/SerialExplicit.cpp
     tests/parallel/CouplingOnLine.cpp
     tests/parallel/ExportTimeseries.cpp
     tests/parallel/GlobalRBFPartitioning.cpp
@@ -191,4 +193,4 @@ target_sources(testprecice
     )
 
 # Contains the list of integration test suites
-set(PRECICE_TEST_SUITES Parallel QuasiNewton Serial)
+set(PRECICE_TEST_SUITES Dynamic Parallel QuasiNewton Serial)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3,6 +3,8 @@
 #
 target_sources(testprecice
     PRIVATE
+    tests/dynamic/selective-sync/MultiCouplingDynamicController.cpp
+    tests/dynamic/selective-sync/MultiCouplingDynamicParticipant.cpp
     tests/dynamic/selective-sync/ParallelExplicit.cpp
     tests/dynamic/selective-sync/SerialExplicit.cpp
     tests/parallel/CouplingOnLine.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds
* the `dynamic` attribute to `provide-mesh`, which allows to flag meshes as dynamic
* logic for propagating this information to other participants
* Coupling scheme self-awareness (what's my name)
* Coupling scheme synchronization (which meshes have changed locally/remotely)
* logic to determine if a coupling scheme needs to synchronize based on the above

## Motivation and additional information

This handles only the synchronization. The information of which meshes change is not yet used.
This allows to further implement reinitalisation.

Closes #1293

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Do you understand the code changes? 
