### PR TITLE
Add error for initializing directly-accessed data

### DIFF
--- a/docs/changelog/1592.md
+++ b/docs/changelog/1592.md
@@ -1,0 +1,1 @@
+- Added error message when attempting to initialize data on a directly-accessed mesh, which is not available before initialization.

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -974,6 +974,12 @@ void CouplingSchemeConfiguration::addDataToBeExchanged(
                   to, dataName, meshName, from, to);
 
     const bool requiresInitialization = exchange.requiresInitialization;
+    PRECICE_CHECK(
+        !(requiresInitialization && _participantConfig->getParticipant(from)->isDirectAccessAllowed(exchange.mesh->getID())),
+        "Participant \"{}\" cannot initialize data of the directly-accessed mesh \"{}\" from the participant\"{}\". "
+        "Either disable the initialization in the <exchange /> tag or use a locally provided mesh instead.",
+        from, meshName, to);
+
     if (from == accessor) {
       scheme.addDataToSend(exchange.data, exchange.mesh, requiresInitialization);
     } else if (to == accessor) {

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
@@ -35,15 +35,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
     int                 otherMeshSize = 1; // @todo hard-coded, because we cannot read this from preCICE before interface.initialize(). See https://github.com/precice/precice/issues/1583.
     std::vector<double> writeData(otherMeshSize, -1);
 
-    // writeData for initialization
-    // for (int i = 0; i < otherMeshSize; ++i) {  // @todo otherMeshSize not available yet. See https://github.com/precice/precice/issues/1583.
-    //   writeData[i] = 2;
-    // }
-
-    if (interface.requiresInitialData()) {
-      // @todo not possible to write data to mesh here, because we can only access mesh after calling initialize due to direct access. See https://github.com/precice/precice/issues/1583.
-      // interface.writeBlockScalarData(writeDataID, otherIDs.size(), otherIDs.data(), writeData.data());
-    }
+    BOOST_TEST(!interface.requiresInitialData());
 
     double dt = interface.initialize();
     // Get the size of the filtered mesh within the bounding box

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
@@ -39,12 +39,7 @@
       <max-iterations value="3" />
       <min-iteration-convergence-measure min-iterations="3" data="Velocities" mesh="MeshTwo" />
       <time-window-size value="1.0" />
-      <exchange
-        data="Velocities"
-        mesh="MeshTwo"
-        from="SolverOne"
-        to="SolverTwo"
-        initialize="true" />
+      <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" initialize="true" />
     </coupling-scheme:parallel-implicit>
   </solver-interface>


### PR DESCRIPTION
## Main changes of this PR

This PR adds an error message for attempting to initialize data on a directly-accessed mesh.

The test `Integration/Serial/DirectMeshAccess/DirectAccessWithDataInitialization` would now fail with

```
ERROR: Participant "SolverOne" cannot initialize data of the directly-accessed mesh "MeshTwo" from the participant"SolverTwo". Either disable the initialization in the <exchange /> tag or use a locally provided mesh instead.
```

## Motivation and additional information

See #1583

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
