### PR TITLE
Add exceptions to precice errors

### DIFF
--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -24,6 +24,7 @@ static precice::logging::Logger _log("SolverInterfaceC");
 
 static std::string errormsg       = "preCICE has not been created properly. Be sure to call \"precicec_createSolverInterface\" or \"precicec_createSolverInterface_withCommunicator\" before any other call to preCICE.";
 static std::string errormsgCreate = "preCICE has been created already! Be sure to call either \"precicec_createSolverInterface\" or \"precicec_createSolverInterface_withCommunicator\" exactly once.";
+using Err                         = ::precice::APIError;
 
 void precicec_createSolverInterface_withCommunicator(
     const char *participantName,
@@ -35,7 +36,7 @@ void precicec_createSolverInterface_withCommunicator(
   std::string stringAccessorName(participantName);
   std::string stringConfigFileName(configFileName);
 
-  PRECICE_CHECK(impl == nullptr, errormsgCreate);
+  PRECICE_CHECK(impl == nullptr, Err, errormsgCreate);
   impl.reset(new precice::SolverInterface(stringAccessorName,
                                           stringConfigFileName,
                                           solverProcessIndex,
@@ -52,7 +53,7 @@ void precicec_createSolverInterface(
   std::string stringAccessorName(participantName);
   std::string stringConfigFileName(configFileName);
 
-  PRECICE_CHECK(impl == nullptr, errormsgCreate);
+  PRECICE_CHECK(impl == nullptr, Err, errormsgCreate);
   impl.reset(new precice::SolverInterface(stringAccessorName,
                                           stringConfigFileName,
                                           solverProcessIndex,
@@ -61,32 +62,32 @@ void precicec_createSolverInterface(
 
 double precicec_initialize()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->initialize();
 }
 
 double precicec_advance(double computedTimestepLength)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->advance(computedTimestepLength);
 }
 
 void precicec_finalize()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->finalize();
   impl.reset();
 }
 
 int precicec_getDimensions()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->getDimensions();
 }
 
 int precicec_isCouplingOngoing()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isCouplingOngoing()) {
     return 1;
   }
@@ -95,7 +96,7 @@ int precicec_isCouplingOngoing()
 
 int precicec_isTimeWindowComplete()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isTimeWindowComplete()) {
     return 1;
   }
@@ -104,25 +105,25 @@ int precicec_isTimeWindowComplete()
 
 int precicec_requiresInitialData()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->requiresInitialData() ? 1 : 0;
 }
 
 int precicec_requiresWritingCheckpoint()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->requiresWritingCheckpoint() ? 1 : 0;
 }
 
 int precicec_requiresReadingCheckpoint()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->requiresReadingCheckpoint() ? 1 : 0;
 }
 
 int precicec_hasMesh(const char *meshName)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringMeshName(meshName);
   if (impl->hasMesh(stringMeshName)) {
     return 1;
@@ -132,28 +133,28 @@ int precicec_hasMesh(const char *meshName)
 
 int precicec_getMeshID(const char *meshName)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringMeshName(meshName);
   return impl->getMeshID(stringMeshName);
 }
 
 int precicec_hasData(const char *dataName, int meshID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringDataName(dataName);
   return impl->hasData(stringDataName, meshID);
 }
 
 int precicec_getDataID(const char *dataName, int meshID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringDataName(dataName);
   return impl->getDataID(stringDataName, meshID);
 }
 
 int precicec_requiresMeshConnectivityFor(int meshID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresMeshConnectivityFor(meshID)) {
     return 1;
   }
@@ -164,7 +165,7 @@ int precicec_setMeshVertex(
     int           meshID,
     const double *position)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->setMeshVertex(meshID, position);
 }
 
@@ -174,14 +175,14 @@ void precicec_setMeshVertices(
     const double *positions,
     int *         ids)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshVertices(meshID, size, positions, ids);
 }
 
 int precicec_getMeshVertexSize(
     int meshID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->getMeshVertexSize(meshID);
 }
 
@@ -190,7 +191,7 @@ void precicec_setMeshEdge(
     int firstVertexID,
     int secondVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdge(meshID, firstVertexID, secondVertexID);
 }
 
@@ -199,7 +200,7 @@ void precicec_setMeshEdges(
     int        size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdges(meshID, size, vertices);
 }
 
@@ -209,7 +210,7 @@ void precicec_setMeshTriangle(
     int secondVertexID,
     int thirdVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangle(meshID, firstVertexID, secondVertexID, thirdVertexID);
 }
 
@@ -218,7 +219,7 @@ void precicec_setMeshTriangles(
     int        size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangles(meshID, size, vertices);
 }
 
@@ -229,7 +230,7 @@ void precicec_setMeshQuad(
     int thirdVertexID,
     int fourthVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuad(meshID, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
 }
 
@@ -238,7 +239,7 @@ void precicec_setMeshQuads(
     int        size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuads(meshID, size, vertices);
 }
 
@@ -249,7 +250,7 @@ void precicec_setMeshTetrahedron(
     int thirdVertexID,
     int fourthVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedron(meshID, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
 }
 
@@ -258,7 +259,7 @@ void precicec_setMeshTetrahedra(
     int        size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedra(meshID, size, vertices);
 }
 
@@ -268,7 +269,7 @@ void precicec_writeBlockVectorData(
     const int *   valueIndices,
     const double *values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorData(dataID, size, valueIndices, values);
 }
 
@@ -277,7 +278,7 @@ void precicec_writeVectorData(
     int           valueIndex,
     const double *dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorData(dataID, valueIndex, dataValue);
 }
 
@@ -287,7 +288,7 @@ void precicec_writeBlockScalarData(
     const int *   valueIndices,
     const double *values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarData(dataID, size, valueIndices, values);
 }
 
@@ -296,7 +297,7 @@ void precicec_writeScalarData(
     int    valueIndex,
     double dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarData(dataID, valueIndex, dataValue);
 }
 
@@ -306,7 +307,7 @@ void precicec_readBlockVectorData(
     const int *valueIndices,
     double *   values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockVectorData(dataID, size, valueIndices, values);
 }
 
@@ -315,7 +316,7 @@ void precicec_readVectorData(
     int     valueIndex,
     double *dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readVectorData(dataID, valueIndex, dataValue);
 }
 
@@ -325,7 +326,7 @@ void precicec_readBlockScalarData(
     const int *valueIndices,
     double *   values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockScalarData(dataID, size, valueIndices, values);
 }
 
@@ -334,13 +335,13 @@ void precicec_readScalarData(
     int     valueIndex,
     double *dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readScalarData(dataID, valueIndex, *dataValue);
 }
 
 int precicec_requiresGradientDataFor(int dataID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresGradientDataFor(dataID)) {
     return 1;
   }
@@ -352,7 +353,7 @@ void precicec_writeScalarGradientData(
     int           valueIndex,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarGradientData(dataID, valueIndex, gradientValues);
 }
 
@@ -362,7 +363,7 @@ void precicec_writeBlockScalarGradientData(
     const int *   valueIndices,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarGradientData(dataID, size, valueIndices, gradientValues);
 }
 
@@ -371,7 +372,7 @@ void precicec_writeVectorGradientData(
     int           valueIndex,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorGradientData(dataID, valueIndex, gradientValues);
 }
 
@@ -381,7 +382,7 @@ void precicec_writeBlockVectorGradientData(
     const int *   valueIndices,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorGradientData(dataID, size, valueIndices, gradientValues);
 }
 

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -6,6 +6,7 @@ extern "C" {
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
 #include "precice/SolverInterface.hpp"
+#include "precice/exceptions.hpp"
 #include "precice/impl/versions.hpp"
 #include "utils/assertion.hpp"
 
@@ -32,7 +33,7 @@ void precicec_createSolverInterface_withCommunicator(
     int         solverProcessIndex,
     int         solverProcessSize,
     void *      communicator)
-{
+try {
   std::string stringAccessorName(participantName);
   std::string stringConfigFileName(configFileName);
 
@@ -42,6 +43,8 @@ void precicec_createSolverInterface_withCommunicator(
                                           solverProcessIndex,
                                           solverProcessSize,
                                           communicator));
+} catch (...) {
+  std::abort();
 }
 
 void precicec_createSolverInterface(
@@ -49,7 +52,7 @@ void precicec_createSolverInterface(
     const char *configFileName,
     int         solverProcessIndex,
     int         solverProcessSize)
-{
+try {
   std::string stringAccessorName(participantName);
   std::string stringConfigFileName(configFileName);
 
@@ -58,115 +61,147 @@ void precicec_createSolverInterface(
                                           stringConfigFileName,
                                           solverProcessIndex,
                                           solverProcessSize));
+} catch (...) {
+  std::abort();
 }
 
 double precicec_initialize()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->initialize();
+} catch (...) {
+  std::abort();
 }
 
 double precicec_advance(double computedTimestepLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->advance(computedTimestepLength);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_finalize()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->finalize();
   impl.reset();
+} catch (...) {
+  std::abort();
 }
 
 int precicec_getDimensions()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->getDimensions();
+} catch (...) {
+  std::abort();
 }
 
 int precicec_isCouplingOngoing()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isCouplingOngoing()) {
     return 1;
   }
   return 0;
+} catch (...) {
+  std::abort();
 }
 
 int precicec_isTimeWindowComplete()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isTimeWindowComplete()) {
     return 1;
   }
   return 0;
+} catch (...) {
+  std::abort();
 }
 
 int precicec_requiresInitialData()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->requiresInitialData() ? 1 : 0;
+} catch (...) {
+  std::abort();
 }
 
 int precicec_requiresWritingCheckpoint()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->requiresWritingCheckpoint() ? 1 : 0;
+} catch (...) {
+  std::abort();
 }
 
 int precicec_requiresReadingCheckpoint()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->requiresReadingCheckpoint() ? 1 : 0;
+} catch (...) {
+  std::abort();
 }
 
 int precicec_hasMesh(const char *meshName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringMeshName(meshName);
   if (impl->hasMesh(stringMeshName)) {
     return 1;
   }
   return 0;
+} catch (...) {
+  std::abort();
 }
 
 int precicec_getMeshID(const char *meshName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringMeshName(meshName);
   return impl->getMeshID(stringMeshName);
+} catch (...) {
+  std::abort();
 }
 
 int precicec_hasData(const char *dataName, int meshID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringDataName(dataName);
   return impl->hasData(stringDataName, meshID);
+} catch (...) {
+  std::abort();
 }
 
 int precicec_getDataID(const char *dataName, int meshID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   std::string stringDataName(dataName);
   return impl->getDataID(stringDataName, meshID);
+} catch (...) {
+  std::abort();
 }
 
 int precicec_requiresMeshConnectivityFor(int meshID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresMeshConnectivityFor(meshID)) {
     return 1;
   }
   return 0;
+} catch (...) {
+  std::abort();
 }
 
 int precicec_setMeshVertex(
     int           meshID,
     const double *position)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->setMeshVertex(meshID, position);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshVertices(
@@ -174,34 +209,42 @@ void precicec_setMeshVertices(
     int           size,
     const double *positions,
     int *         ids)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshVertices(meshID, size, positions, ids);
+} catch (...) {
+  std::abort();
 }
 
 int precicec_getMeshVertexSize(
     int meshID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   return impl->getMeshVertexSize(meshID);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshEdge(
     int meshID,
     int firstVertexID,
     int secondVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdge(meshID, firstVertexID, secondVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshEdges(
     int        meshID,
     int        size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdges(meshID, size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshTriangle(
@@ -209,18 +252,22 @@ void precicec_setMeshTriangle(
     int firstVertexID,
     int secondVertexID,
     int thirdVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangle(meshID, firstVertexID, secondVertexID, thirdVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshTriangles(
     int        meshID,
     int        size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangles(meshID, size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshQuad(
@@ -229,18 +276,22 @@ void precicec_setMeshQuad(
     int secondVertexID,
     int thirdVertexID,
     int fourthVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuad(meshID, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshQuads(
     int        meshID,
     int        size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuads(meshID, size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshTetrahedron(
@@ -249,18 +300,22 @@ void precicec_setMeshTetrahedron(
     int secondVertexID,
     int thirdVertexID,
     int fourthVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedron(meshID, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshTetrahedra(
     int        meshID,
     int        size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedra(meshID, size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeBlockVectorData(
@@ -268,18 +323,22 @@ void precicec_writeBlockVectorData(
     int           size,
     const int *   valueIndices,
     const double *values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorData(dataID, size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeVectorData(
     int           dataID,
     int           valueIndex,
     const double *dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorData(dataID, valueIndex, dataValue);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeBlockScalarData(
@@ -287,18 +346,22 @@ void precicec_writeBlockScalarData(
     int           size,
     const int *   valueIndices,
     const double *values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarData(dataID, size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeScalarData(
     int    dataID,
     int    valueIndex,
     double dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarData(dataID, valueIndex, dataValue);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_readBlockVectorData(
@@ -306,18 +369,22 @@ void precicec_readBlockVectorData(
     int        size,
     const int *valueIndices,
     double *   values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockVectorData(dataID, size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_readVectorData(
     int     dataID,
     int     valueIndex,
     double *dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readVectorData(dataID, valueIndex, dataValue);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_readBlockScalarData(
@@ -325,36 +392,44 @@ void precicec_readBlockScalarData(
     int        size,
     const int *valueIndices,
     double *   values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockScalarData(dataID, size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_readScalarData(
     int     dataID,
     int     valueIndex,
     double *dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readScalarData(dataID, valueIndex, *dataValue);
+} catch (...) {
+  std::abort();
 }
 
 int precicec_requiresGradientDataFor(int dataID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresGradientDataFor(dataID)) {
     return 1;
   }
   return 0;
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeScalarGradientData(
     int           dataID,
     int           valueIndex,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarGradientData(dataID, valueIndex, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeBlockScalarGradientData(
@@ -362,18 +437,22 @@ void precicec_writeBlockScalarGradientData(
     int           size,
     const int *   valueIndices,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarGradientData(dataID, size, valueIndices, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeVectorGradientData(
     int           dataID,
     int           valueIndex,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorGradientData(dataID, valueIndex, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_writeBlockVectorGradientData(
@@ -381,21 +460,27 @@ void precicec_writeBlockVectorGradientData(
     int           size,
     const int *   valueIndices,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorGradientData(dataID, size, valueIndices, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 const char *precicec_getVersionInformation()
-{
+try {
   return precice::versionInformation;
+} catch (...) {
+  std::abort();
 }
 
 void precicec_setMeshAccessRegion(
     const int     meshID,
     const double *boundingBox)
-{
+try {
   impl->setMeshAccessRegion(meshID, boundingBox);
+} catch (...) {
+  std::abort();
 }
 
 void precicec_getMeshVerticesAndIDs(
@@ -403,8 +488,10 @@ void precicec_getMeshVerticesAndIDs(
     const int size,
     int *     ids,
     double *  coordinates)
-{
+try {
   impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
+} catch (...) {
+  std::abort();
 }
 
 #ifdef __GNUC__

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -42,7 +42,7 @@ void precicef_create_(
     const int * solverProcessSize,
     int         lengthAccessorName,
     int         lengthConfigFileName)
-{
+try {
   // cout << "lengthAccessorName: " << lengthAccessorName << '\n';
   // cout << "lengthConfigFileName: " << lengthConfigFileName << '\n';
   // cout << "solverProcessIndex: " << *solverProcessIndex << '\n';
@@ -56,84 +56,104 @@ void precicef_create_(
   impl.reset(new precice::SolverInterface(stringAccessorName,
                                           stringConfigFileName,
                                           *solverProcessIndex, *solverProcessSize));
+} catch (...) {
+  std::abort();
 }
 
 void precicef_initialize_(
     double *timestepLengthLimit)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *timestepLengthLimit = impl->initialize();
+} catch (...) {
+  std::abort();
 }
 
 void precicef_advance_(
     double *timestepLengthLimit)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *timestepLengthLimit = impl->advance(*timestepLengthLimit);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_finalize_()
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->finalize();
   impl.reset();
+} catch (...) {
+  std::abort();
 }
 
 void precicef_get_dims_(
     int *dimensions)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *dimensions = impl->getDimensions();
+} catch (...) {
+  std::abort();
 }
 
 void precicef_is_coupling_ongoing_(
     int *isOngoing)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isCouplingOngoing()) {
     *isOngoing = 1;
   } else {
     *isOngoing = 0;
   }
+} catch (...) {
+  std::abort();
 }
 
 void precicef_is_time_window_complete_(
     int *isComplete)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isTimeWindowComplete()) {
     *isComplete = 1;
   } else {
     *isComplete = 0;
   }
+} catch (...) {
+  std::abort();
 }
 
 void precicef_requires_initial_data_(
     int *isRequired)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *isRequired = impl->requiresInitialData() ? 1 : 0;
+} catch (...) {
+  std::abort();
 }
 
 void precicef_requires_writing_checkpoint_(
     int *isRequired)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *isRequired = impl->requiresWritingCheckpoint() ? 1 : 0;
+} catch (...) {
+  std::abort();
 }
 
 void precicef_requires_reading_checkpoint_(
     int *isRequired)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *isRequired = impl->requiresReadingCheckpoint() ? 1 : 0;
+} catch (...) {
+  std::abort();
 }
 
 void precicef_has_mesh_(
     const char *meshName,
     int *       hasMesh,
     int         lengthMeshName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
   string stringMeshName(meshName, strippedLength);
@@ -142,17 +162,21 @@ void precicef_has_mesh_(
   } else {
     *hasMesh = 0;
   }
+} catch (...) {
+  std::abort();
 }
 
 void precicef_get_mesh_id_(
     const char *meshName,
     int *       meshID,
     int         lengthMeshName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
   string stringMeshName(meshName, strippedLength);
   *meshID = impl->getMeshID(stringMeshName);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_has_data_(
@@ -160,7 +184,7 @@ void precicef_has_data_(
     const int * meshID,
     int *       hasData,
     int         lengthDataName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
   string stringDataName(dataName, strippedLength);
@@ -169,6 +193,8 @@ void precicef_has_data_(
   } else {
     *hasData = 0;
   }
+} catch (...) {
+  std::abort();
 }
 
 void precicef_get_data_id_(
@@ -176,40 +202,48 @@ void precicef_get_data_id_(
     const int * meshID,
     int *       dataID,
     int         lengthDataName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
   string stringDataName(dataName, strippedLength);
   *dataID = impl->getDataID(stringDataName, *meshID);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_requires_mesh_connectivity_for_(
     const int *meshID,
     int *      required)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresMeshConnectivityFor(*meshID)) {
     *required = 1;
   } else {
     *required = 0;
   }
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_vertex_(
     const int *   meshID,
     const double *position,
     int *         vertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *vertexID = impl->setMeshVertex(*meshID, position);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_get_mesh_vertex_size_(
     const int *meshID,
     int *      meshSize)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *meshSize = impl->getMeshVertexSize(*meshID);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_vertices_(
@@ -217,27 +251,33 @@ void precicef_set_vertices_(
     const int *size,
     double *   positions,
     int *      positionIDs)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshVertices(*meshID, *size, positions, positionIDs);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_edge_(
     const int *meshID,
     const int *firstVertexID,
     const int *secondVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdge(*meshID, *firstVertexID, *secondVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_mesh_edges_(
     const int *meshID,
     const int *size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdges(*meshID, *size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_triangle_(
@@ -245,18 +285,22 @@ void precicef_set_triangle_(
     const int *firstVertexID,
     const int *secondVertexID,
     const int *thirdVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangle(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_mesh_triangles_(
     const int *meshID,
     const int *size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangles(*meshID, *size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_quad_(
@@ -265,18 +309,22 @@ void precicef_set_quad_(
     const int *secondVertexID,
     const int *thirdVertexID,
     const int *fourthVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuad(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID, *fourthVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_mesh_quads_(
     const int *meshID,
     const int *size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuads(*meshID, *size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_tetrahedron(
@@ -285,18 +333,22 @@ void precicef_set_tetrahedron(
     const int *secondVertexID,
     const int *thirdVertexID,
     const int *fourthVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedron(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID, *fourthVertexID);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_mesh_tetrahedra_(
     const int *meshID,
     const int *size,
     const int *vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedra(*meshID, *size, vertices);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_bvdata_(
@@ -304,18 +356,22 @@ void precicef_write_bvdata_(
     const int *size,
     int *      valueIndices,
     double *   values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorData(*dataID, *size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_vdata_(
     const int *   dataID,
     const int *   valueIndex,
     const double *dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorData(*dataID, *valueIndex, dataValue);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_bsdata_(
@@ -323,18 +379,22 @@ void precicef_write_bsdata_(
     const int *size,
     int *      valueIndices,
     double *   values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarData(*dataID, *size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_sdata_(
     const int *   dataID,
     const int *   valueIndex,
     const double *dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarData(*dataID, *valueIndex, *dataValue);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_read_bvdata_(
@@ -342,18 +402,22 @@ void precicef_read_bvdata_(
     const int *size,
     int *      valueIndices,
     double *   values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockVectorData(*dataID, *size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_read_vdata_(
     const int *dataID,
     const int *valueIndex,
     double *   dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readVectorData(*dataID, *valueIndex, dataValue);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_read_bsdata_(
@@ -361,48 +425,58 @@ void precicef_read_bsdata_(
     const int *size,
     int *      valueIndices,
     double *   values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockScalarData(*dataID, *size, valueIndices, values);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_read_sdata_(
     const int *dataID,
     const int *valueIndex,
     double *   dataValue)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readScalarData(*dataID, *valueIndex, *dataValue);
+} catch (...) {
+  std::abort();
 }
 
 int precice::impl::strippedLength(
     const char *string,
     int         length)
-{
+try {
   int i = length - 1;
   while (((string[i] == ' ') || (string[i] == 0)) && (i >= 0)) {
     i--;
   }
   return i + 1;
+} catch (...) {
+  std::abort();
 }
 
 void precicef_get_version_information_(
     char *versionInfo,
     int   lengthVersionInfo)
-{
+try {
   const std::string &versionInformation = precice::versionInformation;
   PRECICE_ASSERT(versionInformation.size() < (size_t) lengthVersionInfo, versionInformation.size(), lengthVersionInfo);
   for (size_t i = 0; i < versionInformation.size(); i++) {
     versionInfo[i] = versionInformation[i];
   }
+} catch (...) {
+  std::abort();
 }
 
 void precicef_set_mesh_access_region_(
     const int     meshID,
     const double *boundingBox)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshAccessRegion(meshID, boundingBox);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_get_mesh_vertices_and_IDs_(
@@ -410,28 +484,34 @@ void precicef_get_mesh_vertices_and_IDs_(
     const int size,
     int *     ids,
     double *  coordinates)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_requires_gradient_data_for_(const int *dataID, int *required)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresGradientDataFor(*dataID)) {
     *required = 1;
   } else {
     *required = 0;
   }
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_sgradient_data_(
     const int *   dataID,
     const int *   valueIndex,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarGradientData(*dataID, *valueIndex, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_bsgradient_data_(
@@ -439,18 +519,22 @@ void precicef_write_bsgradient_data_(
     const int *   size,
     const int *   valueIndices,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarGradientData(*dataID, *size, valueIndices, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_vgradient_data_(
     const int *   dataID,
     const int *   valueIndex,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorGradientData(*dataID, *valueIndex, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 void precicef_write_bvgradient_data_(
@@ -458,9 +542,11 @@ void precicef_write_bvgradient_data_(
     const int *   size,
     const int *   valueIndices,
     const double *gradientValues)
-{
+try {
   PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorGradientData(*dataID, *size, valueIndices, gradientValues);
+} catch (...) {
+  std::abort();
 }
 
 #ifdef __GNUC__

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -6,6 +6,7 @@
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
 #include "precice/SolverInterface.hpp"
+#include "precice/exceptions.hpp"
 #include "precice/impl/versions.hpp"
 #include "utils/assertion.hpp"
 
@@ -25,6 +26,7 @@ static std::unique_ptr<precice::SolverInterface> impl = nullptr;
 static precice::logging::Logger _log("SolverInterfaceFortran");
 
 static std::string errormsg = "preCICE has not been created properly. Be sure to call \"precicef_create\" before any other call to preCICE.";
+using Err                   = ::precice::APIError;
 
 namespace precice::impl {
 /**
@@ -59,20 +61,20 @@ void precicef_create_(
 void precicef_initialize_(
     double *timestepLengthLimit)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *timestepLengthLimit = impl->initialize();
 }
 
 void precicef_advance_(
     double *timestepLengthLimit)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *timestepLengthLimit = impl->advance(*timestepLengthLimit);
 }
 
 void precicef_finalize_()
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->finalize();
   impl.reset();
 }
@@ -80,14 +82,14 @@ void precicef_finalize_()
 void precicef_get_dims_(
     int *dimensions)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *dimensions = impl->getDimensions();
 }
 
 void precicef_is_coupling_ongoing_(
     int *isOngoing)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isCouplingOngoing()) {
     *isOngoing = 1;
   } else {
@@ -98,7 +100,7 @@ void precicef_is_coupling_ongoing_(
 void precicef_is_time_window_complete_(
     int *isComplete)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->isTimeWindowComplete()) {
     *isComplete = 1;
   } else {
@@ -109,21 +111,21 @@ void precicef_is_time_window_complete_(
 void precicef_requires_initial_data_(
     int *isRequired)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *isRequired = impl->requiresInitialData() ? 1 : 0;
 }
 
 void precicef_requires_writing_checkpoint_(
     int *isRequired)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *isRequired = impl->requiresWritingCheckpoint() ? 1 : 0;
 }
 
 void precicef_requires_reading_checkpoint_(
     int *isRequired)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *isRequired = impl->requiresReadingCheckpoint() ? 1 : 0;
 }
 
@@ -132,7 +134,7 @@ void precicef_has_mesh_(
     int *       hasMesh,
     int         lengthMeshName)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
   string stringMeshName(meshName, strippedLength);
   if (impl->hasMesh(meshName)) {
@@ -147,7 +149,7 @@ void precicef_get_mesh_id_(
     int *       meshID,
     int         lengthMeshName)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(meshName, lengthMeshName);
   string stringMeshName(meshName, strippedLength);
   *meshID = impl->getMeshID(stringMeshName);
@@ -159,7 +161,7 @@ void precicef_has_data_(
     int *       hasData,
     int         lengthDataName)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
   string stringDataName(dataName, strippedLength);
   if (impl->hasData(stringDataName, *meshID)) {
@@ -175,7 +177,7 @@ void precicef_get_data_id_(
     int *       dataID,
     int         lengthDataName)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   int    strippedLength = precice::impl::strippedLength(dataName, lengthDataName);
   string stringDataName(dataName, strippedLength);
   *dataID = impl->getDataID(stringDataName, *meshID);
@@ -185,7 +187,7 @@ void precicef_requires_mesh_connectivity_for_(
     const int *meshID,
     int *      required)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresMeshConnectivityFor(*meshID)) {
     *required = 1;
   } else {
@@ -198,7 +200,7 @@ void precicef_set_vertex_(
     const double *position,
     int *         vertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *vertexID = impl->setMeshVertex(*meshID, position);
 }
 
@@ -206,7 +208,7 @@ void precicef_get_mesh_vertex_size_(
     const int *meshID,
     int *      meshSize)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   *meshSize = impl->getMeshVertexSize(*meshID);
 }
 
@@ -216,7 +218,7 @@ void precicef_set_vertices_(
     double *   positions,
     int *      positionIDs)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshVertices(*meshID, *size, positions, positionIDs);
 }
 
@@ -225,7 +227,7 @@ void precicef_set_edge_(
     const int *firstVertexID,
     const int *secondVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdge(*meshID, *firstVertexID, *secondVertexID);
 }
 
@@ -234,7 +236,7 @@ void precicef_set_mesh_edges_(
     const int *size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshEdges(*meshID, *size, vertices);
 }
 
@@ -244,7 +246,7 @@ void precicef_set_triangle_(
     const int *secondVertexID,
     const int *thirdVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangle(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID);
 }
 
@@ -253,7 +255,7 @@ void precicef_set_mesh_triangles_(
     const int *size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTriangles(*meshID, *size, vertices);
 }
 
@@ -264,7 +266,7 @@ void precicef_set_quad_(
     const int *thirdVertexID,
     const int *fourthVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuad(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID, *fourthVertexID);
 }
 
@@ -273,7 +275,7 @@ void precicef_set_mesh_quads_(
     const int *size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshQuads(*meshID, *size, vertices);
 }
 
@@ -284,7 +286,7 @@ void precicef_set_tetrahedron(
     const int *thirdVertexID,
     const int *fourthVertexID)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedron(*meshID, *firstVertexID, *secondVertexID, *thirdVertexID, *fourthVertexID);
 }
 
@@ -293,7 +295,7 @@ void precicef_set_mesh_tetrahedra_(
     const int *size,
     const int *vertices)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshTetrahedra(*meshID, *size, vertices);
 }
 
@@ -303,7 +305,7 @@ void precicef_write_bvdata_(
     int *      valueIndices,
     double *   values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorData(*dataID, *size, valueIndices, values);
 }
 
@@ -312,7 +314,7 @@ void precicef_write_vdata_(
     const int *   valueIndex,
     const double *dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorData(*dataID, *valueIndex, dataValue);
 }
 
@@ -322,7 +324,7 @@ void precicef_write_bsdata_(
     int *      valueIndices,
     double *   values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarData(*dataID, *size, valueIndices, values);
 }
 
@@ -331,7 +333,7 @@ void precicef_write_sdata_(
     const int *   valueIndex,
     const double *dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarData(*dataID, *valueIndex, *dataValue);
 }
 
@@ -341,7 +343,7 @@ void precicef_read_bvdata_(
     int *      valueIndices,
     double *   values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockVectorData(*dataID, *size, valueIndices, values);
 }
 
@@ -350,7 +352,7 @@ void precicef_read_vdata_(
     const int *valueIndex,
     double *   dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readVectorData(*dataID, *valueIndex, dataValue);
 }
 
@@ -360,7 +362,7 @@ void precicef_read_bsdata_(
     int *      valueIndices,
     double *   values)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readBlockScalarData(*dataID, *size, valueIndices, values);
 }
 
@@ -369,7 +371,7 @@ void precicef_read_sdata_(
     const int *valueIndex,
     double *   dataValue)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->readScalarData(*dataID, *valueIndex, *dataValue);
 }
 
@@ -399,7 +401,7 @@ void precicef_set_mesh_access_region_(
     const int     meshID,
     const double *boundingBox)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->setMeshAccessRegion(meshID, boundingBox);
 }
 
@@ -409,13 +411,13 @@ void precicef_get_mesh_vertices_and_IDs_(
     int *     ids,
     double *  coordinates)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->getMeshVerticesAndIDs(meshID, size, ids, coordinates);
 }
 
 void precicef_requires_gradient_data_for_(const int *dataID, int *required)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   if (impl->requiresGradientDataFor(*dataID)) {
     *required = 1;
   } else {
@@ -428,7 +430,7 @@ void precicef_write_sgradient_data_(
     const int *   valueIndex,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeScalarGradientData(*dataID, *valueIndex, gradientValues);
 }
 
@@ -438,7 +440,7 @@ void precicef_write_bsgradient_data_(
     const int *   valueIndices,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockScalarGradientData(*dataID, *size, valueIndices, gradientValues);
 }
 
@@ -447,7 +449,7 @@ void precicef_write_vgradient_data_(
     const int *   valueIndex,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeVectorGradientData(*dataID, *valueIndex, gradientValues);
 }
 
@@ -457,7 +459,7 @@ void precicef_write_bvgradient_data_(
     const int *   valueIndices,
     const double *gradientValues)
 {
-  PRECICE_CHECK(impl != nullptr, errormsg);
+  PRECICE_CHECK(impl != nullptr, Err, errormsg);
   impl->writeBlockVectorGradientData(*dataID, *size, valueIndices, gradientValues);
 }
 

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -25,6 +25,7 @@ AitkenAcceleration::AitkenAcceleration(double           initialRelaxation,
       _aitkenFactor(initialRelaxation)
 {
   PRECICE_CHECK((_initialRelaxation > 0.0) && (_initialRelaxation <= 1.0),
+                ::precice::AccelerationError,
                 "Initial relaxation factor for Aitken acceleration has to "
                 "be larger than zero and smaller or equal to one. "
                 "Current initial relaxation is: {}",

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -52,16 +52,19 @@ BaseQNAcceleration::BaseQNAcceleration(
       _infostringstream(std::ostringstream::ate)
 {
   PRECICE_CHECK((_initialRelaxation > 0.0) && (_initialRelaxation <= 1.0),
+                ::precice::AccelerationError,
                 "Initial relaxation factor for QN acceleration has to "
                 "be larger than zero and smaller or equal than one. "
                 "Current initial relaxation is {}",
                 _initialRelaxation);
   PRECICE_CHECK(_maxIterationsUsed > 0,
+                ::precice::AccelerationError,
                 "Maximum number of iterations used in the quasi-Newton acceleration "
                 "scheme has to be larger than zero. "
                 "Current maximum reused iterations is {}",
                 _maxIterationsUsed);
   PRECICE_CHECK(_timeWindowsReused >= 0,
+                ::precice::AccelerationError,
                 "Number of previous time windows to be reused for "
                 "quasi-Newton acceleration has to be larger than or equal to zero. "
                 "Current number of time windows reused is {}",
@@ -217,6 +220,7 @@ void BaseQNAcceleration::updateDifferenceMatrices(
       }
 
       PRECICE_CHECK(not math::equals(residualMagnitude, 0.0),
+                    ::precice::AccelerationError,
                     "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residuals "
                     "in two consecutive iterations are identical. If a relative convergence limit was selected, "
                     "consider increasing the convergence threshold.");
@@ -392,7 +396,8 @@ void BaseQNAcceleration::performAcceleration(
     }
 
     if (std::isnan(utils::IntraComm::l2norm(xUpdate))) {
-      PRECICE_ERROR("The quasi-Newton update contains NaN values. This means that the quasi-Newton acceleration failed to converge. "
+      PRECICE_ERROR(::precice::AccelerationError,
+                    "The quasi-Newton update contains NaN values. This means that the quasi-Newton acceleration failed to converge. "
                     "When writing your own adapter this could indicate that you give wrong information to preCICE, such as identical "
                     "data in succeeding iterations. Or you do not properly save and reload checkpoints. "
                     "If you give the correct data this could also mean that the coupled problem is too hard to solve. Try to use a QR "

--- a/src/acceleration/BroydenAcceleration.cpp
+++ b/src/acceleration/BroydenAcceleration.cpp
@@ -76,7 +76,8 @@ void BroydenAcceleration::computeQNUpdate(const DataMap &cplData, Eigen::VectorX
 
   PRECICE_DEBUG("currentColumns={}", _currentColumns);
   if (_currentColumns > 1) {
-    PRECICE_ERROR("Truncated IMVJ is no longer supported. Please use IMVJ with restart mode instead.");
+    PRECICE_ERROR(::precice::AccelerationError,
+                  "Truncated IMVJ is no longer supported. Please use IMVJ with restart mode instead.");
     PRECICE_DEBUG("compute update with QR-dec");
     //computeNewtonFactorsQRDecomposition(cplData, xUpdate);
   } else {

--- a/src/acceleration/ConstantRelaxationAcceleration.cpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.cpp
@@ -19,6 +19,7 @@ ConstantRelaxationAcceleration::ConstantRelaxationAcceleration(
       _dataIDs(std::move(dataIDs))
 {
   PRECICE_CHECK((relaxation > 0.0) && (relaxation <= 1.0),
+                ::precice::AccelerationError,
                 "Relaxation factor for constant relaxation acceleration has to be larger than zero and smaller or equal to one. "
                 "Current relaxation factor is: {}",
                 relaxation);

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -156,7 +156,8 @@ void AccelerationConfiguration::xmlTagCallback(
     std::string meshName = callingTag.getStringAttributeValue(ATTR_MESH);
     auto        success  = _uniqueDataAndMeshNames.emplace(dataName, meshName);
     if (not success.second) {
-      PRECICE_ERROR("You have provided a subtag <data name=\"{}\" mesh=\"{}\"/> more than once in your <acceleration:.../>. "
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "You have provided a subtag <data name=\"{}\" mesh=\"{}\"/> more than once in your <acceleration:.../>. "
                     "Please remove the duplicated entry.",
                     dataName, meshName);
     }
@@ -167,6 +168,7 @@ void AccelerationConfiguration::xmlTagCallback(
     }
 
     PRECICE_CHECK(_meshConfig->hasMeshName(_meshName) && _meshConfig->getMesh(_meshName)->hasDataName(dataName),
+                  ::precice::ConfigurationError,
                   "Data with name \"{0}\" associated to mesh \"{1}\" not found on configuration of acceleration. "
                   "Add \"{0}\" to the \"<mesh name={1}>\" tag, or change the data name in the acceleration scheme.",
                   dataName, _meshName);
@@ -206,7 +208,8 @@ void AccelerationConfiguration::xmlTagCallback(
   } else if (callingTag.getName() == TAG_IMVJRESTART) {
 
     if (_config.alwaysBuildJacobian)
-      PRECICE_ERROR("IMVJ cannot be in restart mode while parameter always-build-jacobian is set to true. "
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "IMVJ cannot be in restart mode while parameter always-build-jacobian is set to true. "
                     "Please remove 'always-build-jacobian' from the configuration file or do not run in restart mode.");
 
 #ifndef PRECICE_NO_MPI
@@ -229,7 +232,8 @@ void AccelerationConfiguration::xmlTagCallback(
       PRECICE_ASSERT(false);
     }
 #else
-    PRECICE_ERROR("Acceleration IQN-IMVJ only works if preCICE is compiled with MPI");
+    PRECICE_ERROR(::precice::ConfigurationError,
+                  "Acceleration IQN-IMVJ only works if preCICE is compiled with MPI");
 #endif
   }
 }
@@ -306,7 +310,8 @@ void AccelerationConfiguration::xmlEndTagCallback(
               _config.imvjRSLS_reusedTimeWindows,
               _config.imvjRSSVD_truncationEps));
 #else
-      PRECICE_ERROR("Acceleration IQN-IMVJ only works if preCICE is compiled with MPI");
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "Acceleration IQN-IMVJ only works if preCICE is compiled with MPI");
 #endif
     } else if (callingTag.getName() == VALUE_BROYDEN) {
       _acceleration = PtrAcceleration(
@@ -545,7 +550,8 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     tagData.addAttribute(attrMesh);
     tag.addSubtag(tagData);
   } else {
-    PRECICE_ERROR("Acceleration of type \"{}\" is unknown. Please choose a valid acceleration scheme or check the spelling in the configuration file.", tag.getName());
+    PRECICE_ERROR(::precice::ConfigurationError,
+                  "Acceleration of type \"{}\" is unknown. Please choose a valid acceleration scheme or check the spelling in the configuration file.", tag.getName());
   }
 }
 } // namespace precice::acceleration

--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -34,6 +34,7 @@ void ScaleByAreaAction::performAction(double time)
 
   if (meshDimensions == 2) {
     PRECICE_CHECK(getMesh()->edges().size() != 0,
+                  ::precice::ActionError,
                   "The multiply/divide-by-area actions require meshes with connectivity information. In 2D, please ensure that the mesh {} contains edges.", getMesh()->getName());
     for (mesh::Edge &edge : getMesh()->edges()) {
       areas[edge.vertex(0).getID()] += edge.getEnclosingRadius();
@@ -41,6 +42,7 @@ void ScaleByAreaAction::performAction(double time)
     }
   } else {
     PRECICE_CHECK(getMesh()->triangles().size() != 0,
+                  ::precice::ActionError,
                   "The multiply/divide-by-area actions require meshes with connectivity information. In 3D, please ensure that the mesh {} contains triangles.", getMesh()->getName());
     for (mesh::Triangle &face : getMesh()->triangles()) {
       areas[face.vertex(0).getID()] += face.getArea() / 3.0;

--- a/src/action/SummationAction.cpp
+++ b/src/action/SummationAction.cpp
@@ -23,7 +23,8 @@ SummationAction::SummationAction(
   }
 
   for (const auto &source : _sourceDataVector) {
-    PRECICE_CHECK(source->getDimensions() == _targetData->getDimensions(), "Source and target data dimensions (scalar or vector) of summation action need to be identical.");
+    PRECICE_CHECK(source->getDimensions() == _targetData->getDimensions(),
+                  ::precice::ActionError, "Source and target data dimensions (scalar or vector) of summation action need to be identical.");
   }
 }
 

--- a/src/action/config/ActionConfiguration.cpp
+++ b/src/action/config/ActionConfiguration.cpp
@@ -178,7 +178,8 @@ void ActionConfiguration::xmlEndTagCallback(
 
 int ActionConfiguration::getUsedMeshID() const
 {
-  PRECICE_CHECK(_meshConfig->hasMeshName(_configuredAction.mesh), "No mesh name \"{}\" found. Please check that the correct mesh name is used.", _configuredAction.mesh);
+  PRECICE_CHECK(_meshConfig->hasMeshName(_configuredAction.mesh),
+                ::precice::ConfigurationError, "No mesh name \"{}\" found. Please check that the correct mesh name is used.", _configuredAction.mesh);
   return _meshConfig->getMesh(_configuredAction.mesh)->getID();
 }
 
@@ -193,22 +194,26 @@ void ActionConfiguration::createAction()
   std::vector<int> sourceDataIDs;
   int              targetDataID = -1;
   PRECICE_CHECK(_meshConfig->hasMeshName(_configuredAction.mesh),
+                ::precice::ConfigurationError,
                 "Data action uses mesh \"{}\" which is not configured. Please ensure that the correct mesh name is given in <action:python mesh=\"...\">", _configuredAction.mesh);
   mesh::PtrMesh mesh = _meshConfig->getMesh(_configuredAction.mesh);
 
   if (!_configuredAction.targetData.empty()) {
     PRECICE_CHECK(mesh->hasDataName(_configuredAction.targetData),
+                  ::precice::ConfigurationError,
                   "Data action uses target data \"{}\" which is not configured. Please ensure that the target data name is used by the mesh with name \"{}\".", _configuredAction.targetData, _configuredAction.mesh);
     targetDataID = mesh->data(_configuredAction.targetData)->getID();
     PRECICE_ASSERT(targetDataID != -1);
   }
 
   for (const std::string &dataName : _configuredAction.sourceDataVector) {
-    PRECICE_CHECK(mesh->hasDataName(dataName), "Data action uses source data \"{}\" which is not configured. Please ensure that the target data name is used by the mesh with name \"{}\".", dataName, _configuredAction.mesh);
+    PRECICE_CHECK(mesh->hasDataName(dataName),
+                  ::precice::ConfigurationError, "Data action uses source data \"{}\" which is not configured. Please ensure that the target data name is used by the mesh with name \"{}\".", dataName, _configuredAction.mesh);
     sourceDataIDs.push_back(mesh->data(dataName)->getID());
   }
 
   PRECICE_CHECK((_configuredAction.sourceDataVector.empty() || not sourceDataIDs.empty()),
+                ::precice::ConfigurationError,
                 "Data action uses source data \"{}\" which is not configured. Please ensure that the source data name is used by the mesh with name \"{}\".", _configuredAction.sourceDataVector.back(), _configuredAction.mesh);
 
   action::PtrAction action;
@@ -273,7 +278,8 @@ action::Action::Timing ActionConfiguration::getTiming() const
   } else if (_configuredAction.timing == READ_MAPPING_POST) {
     timing = action::Action::READ_MAPPING_POST;
   } else {
-    PRECICE_ERROR("Unknown action timing \"{}\". "
+    PRECICE_ERROR(::precice::ConfigurationError,
+                  "Unknown action timing \"{}\". "
                   "Valid action timings are regular-prior, regular-post, on-exchange-prior, on-exchange-post, on-time-window-complete-post",
                   _configuredAction.timing);
   }

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -70,11 +70,13 @@ std::string ConnectionInfoReader::read() const
 
   std::ifstream ifs(path);
   PRECICE_CHECK(ifs,
+                ::precice::CommunicationError,
                 "Unable to establish connection as the connection file \"{}\" couldn't be opened.",
                 path);
   std::string addressData;
   std::getline(ifs, addressData);
   PRECICE_CHECK(!addressData.empty(),
+                ::precice::CommunicationError,
                 "Unable to establish connection as the connection file \"{}\" is empty. "
                 "Please report this bug to the preCICE developers.",
                 path);
@@ -115,20 +117,24 @@ void ConnectionInfoWriter::write(std::string const &info) const
     auto message = "Unable to establish connection as a {}connection file already exists at \"{}\". "
                    "This is likely a leftover of a previous crash or stop during communication build-up. "
                    "Please remove the \"precice-run\" directory and restart the simulation.";
-    PRECICE_CHECK(!bfs::exists(path), message, "", path);
-    PRECICE_CHECK(!bfs::exists(tmp), message, "temporary ")
+    PRECICE_CHECK(!bfs::exists(path),
+                  ::precice::CommunicationError, message, "", path);
+    PRECICE_CHECK(!bfs::exists(tmp),
+                  ::precice::CommunicationError, message, "temporary ")
   }
 
   PRECICE_DEBUG("Writing temporary connection file \"{}\"", tmp.generic_string());
   bfs::create_directories(tmp.parent_path());
   {
     std::ofstream ofs(tmp.string());
-    PRECICE_CHECK(ofs, "Unable to establish connection as the temporary connection file \"{}\" couldn't be opened.", tmp.generic_string());
+    PRECICE_CHECK(ofs,
+                  ::precice::CommunicationError, "Unable to establish connection as the temporary connection file \"{}\" couldn't be opened.", tmp.generic_string());
     fmt::print(ofs,
                "{}\nAcceptor: {}, Requester: {}, Tag: {}, Rank: {}",
                info, acceptorName, requesterName, tag, rank);
   }
   PRECICE_CHECK(bfs::exists(tmp),
+                ::precice::CommunicationError,
                 "Unable to establish connection as the temporary connection file \"{}\" was written, but doesn't exist on disk. "
                 "Please report this bug to the preCICE developers.",
                 tmp.generic_string());
@@ -141,6 +147,7 @@ void ConnectionInfoWriter::write(std::string const &info) const
                  tmp.generic_string());
   }
   PRECICE_CHECK(bfs::exists(path),
+                ::precice::CommunicationError,
                 "Unable to establish connection as the connection file \"{}\" doesn't exist on disk. "
                 "Please report this bug to the preCICE developers.",
                 path);

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -53,7 +53,8 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
   utils::StringMaker<MPI_MAX_PORT_NAME> sm;
   res = MPI_Open_port(MPI_INFO_NULL, sm.data());
-  PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Open_port failed with message: {}", res.message());
   _portName = sm.str();
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
@@ -66,7 +67,8 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
     // Connection
     MPI_Comm communicator;
     res = MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
-    PRECICE_CHECK(res, "MPI_Comm_accept failed with message: {}", res.message());
+    PRECICE_CHECK(res,
+                  ::precice::CommunicationError, "MPI_Comm_accept failed with message: {}", res.message());
     PRECICE_DEBUG("Accepted connection at {} for peer {}", _portName, peerCurrent);
 
     // Which rank is requesting a connection?
@@ -95,7 +97,8 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
   } while (++peerCurrent < peerCount);
 
   res = MPI_Close_port(const_cast<char *>(_portName.c_str()));
-  PRECICE_CHECK(res, "MPI_Close_port failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Close_port failed with message: {}", res.message());
   _portName.clear();
   PRECICE_DEBUG("Closed Port");
 
@@ -117,7 +120,8 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
 
   utils::StringMaker<MPI_MAX_PORT_NAME> sm;
   res = MPI_Open_port(MPI_INFO_NULL, sm.data());
-  PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Open_port failed with message: {}", res.message());
   _portName = sm.str();
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
@@ -127,7 +131,8 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
   for (int connection = 0; connection < requesterCommunicatorSize; ++connection) {
     MPI_Comm communicator;
     res = MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
-    PRECICE_CHECK(res, "MPI_Comm_accept failed with message: {}", res.message());
+    PRECICE_CHECK(res,
+                  ::precice::CommunicationError, "MPI_Comm_accept failed with message: {}", res.message());
     PRECICE_DEBUG("Accepted connection at {}", _portName);
 
     // Receive the rank of requester
@@ -141,7 +146,8 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
   }
 
   res = MPI_Close_port(const_cast<char *>(_portName.c_str()));
-  PRECICE_CHECK(res, "MPI_Close_port failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Close_port failed with message: {}", res.message());
   _portName.clear();
   PRECICE_DEBUG("Closed Port");
 
@@ -165,7 +171,8 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
 
   MPI_Comm  communicator;
   MPIResult res = MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
-  PRECICE_CHECK(res, "MPI_Comm_connect failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Comm_connect failed with message: {}", res.message());
   PRECICE_DEBUG("Requested connection to {}", _portName);
 
   _isConnected = true;
@@ -205,7 +212,8 @@ void MPIPortsCommunication::requestConnectionAsClient(std::string const &  accep
 
     MPI_Comm  communicator;
     MPIResult res = MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
-    PRECICE_CHECK(res, "MPI_Comm_connect failed with message: {}", res.message());
+    PRECICE_CHECK(res,
+                  ::precice::CommunicationError, "MPI_Comm_connect failed with message: {}", res.message());
     PRECICE_DEBUG("Requested connection to {}", _portName);
 
     // Rank 0 is always the peer, because we connected on COMM_SELF

--- a/src/com/MPISinglePortsCommunication.cpp
+++ b/src/com/MPISinglePortsCommunication.cpp
@@ -63,7 +63,8 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
 
   utils::StringMaker<MPI_MAX_PORT_NAME> sm;
   res = MPI_Open_port(MPI_INFO_NULL, sm.data());
-  PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Open_port failed with message: {}", res.message());
 
   _portName = sm.str();
 
@@ -76,7 +77,8 @@ void MPISinglePortsCommunication::acceptConnection(std::string const &acceptorNa
     // Connection
     MPI_Comm communicator;
     res = MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
-    PRECICE_CHECK(res, "MPI_Comm_accept failed with message: {}", res.message());
+    PRECICE_CHECK(res,
+                  ::precice::CommunicationError, "MPI_Comm_accept failed with message: {}", res.message());
     PRECICE_DEBUG("Accepted connection at {} for peer {}", _portName, peerCurrent);
 
     // Exchange information to which rank I am connected and which communicator size on the other side
@@ -127,21 +129,24 @@ void MPISinglePortsCommunication::acceptConnectionAsServer(std::string const &ac
 
     utils::StringMaker<MPI_MAX_PORT_NAME> sm;
     res = MPI_Open_port(MPI_INFO_NULL, sm.data());
-    PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
+    PRECICE_CHECK(res,
+                  ::precice::CommunicationError, "MPI_Open_port failed with message: {}", res.message());
     _portName = sm.str();
 
     conInfo.write(_portName);
     PRECICE_DEBUG("Accept connection at {}", _portName);
 
     res = MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, utils::Parallel::current()->comm, &_global);
-    PRECICE_CHECK(res, "MPI_Comm_accept failed with message: {}", res.message());
+    PRECICE_CHECK(res,
+                  ::precice::CommunicationError, "MPI_Comm_accept failed with message: {}", res.message());
     PRECICE_DEBUG("Accepted connection at {}", _portName);
 
   } else { // Secondary ranks call simply call accept
 
     // The port is only used on the root rank
     res = MPI_Comm_accept(nullptr, MPI_INFO_NULL, 0, utils::Parallel::current()->comm, &_global);
-    PRECICE_CHECK(res, "MPI_Comm_accept failed with message: {}", res.message());
+    PRECICE_CHECK(res,
+                  ::precice::CommunicationError, "MPI_Comm_accept failed with message: {}", res.message());
     PRECICE_DEBUG("Accepted connection");
   }
 
@@ -164,7 +169,8 @@ void MPISinglePortsCommunication::requestConnection(std::string const &acceptorN
 
   MPI_Comm  communicator;
   MPIResult res = MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
-  PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Open_port failed with message: {}", res.message());
   PRECICE_DEBUG("Requested connection to {}", _portName);
 
   // Send the rank of this requester
@@ -199,7 +205,8 @@ void MPISinglePortsCommunication::requestConnectionAsClient(std::string const & 
 
   MPIResult res = MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0,
                                    utils::Parallel::current()->comm, &_global);
-  PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
+  PRECICE_CHECK(res,
+                ::precice::CommunicationError, "MPI_Open_port failed with message: {}", res.message());
   PRECICE_DEBUG("Requested connection to {}", _portName);
 
   _isConnected = true;

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -67,7 +67,8 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
 
   try {
     std::string ipAddress = getIpAddress();
-    PRECICE_CHECK(not ipAddress.empty(), "Network \"{}\" not found for socket connection!", _networkName);
+    PRECICE_CHECK(not ipAddress.empty(),
+                  ::precice::CommunicationError, "Network \"{}\" not found for socket connection!", _networkName);
 
     using asio::ip::tcp;
 
@@ -124,7 +125,8 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
 
     acceptor.close();
   } catch (std::exception &e) {
-    PRECICE_ERROR("Accepting a socket connection at {} failed with the system error: {}", address, e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Accepting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
   // NOTE:
@@ -188,7 +190,8 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
 
     acceptor.close();
   } catch (std::exception &e) {
-    PRECICE_ERROR("Accepting a socket connection at {} failed with the system error: {}", address, e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Accepting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
   // NOTE: Keep IO service running so that it fires asynchronous handlers from another thread.
@@ -247,7 +250,8 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
     send(requesterCommunicatorSize, 0);
 
   } catch (std::exception &e) {
-    PRECICE_ERROR("Requesting a socket connection at {} failed with the system error: {}", address, e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Requesting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
   // NOTE: Keep IO service running so that it fires asynchronous handlers from another thread.
@@ -304,7 +308,8 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
       send(requesterRank, acceptorRank); // send my rank
 
     } catch (std::exception &e) {
-      PRECICE_ERROR("Requesting a socket connection at {} failed with the system error: {}", address, e.what());
+      PRECICE_ERROR(::precice::CommunicationError,
+                    "Requesting a socket connection at {} failed with the system error: {}", address, e.what());
     }
   }
   // NOTE: Keep IO service running so that it fires asynchronous handlers from another thread.
@@ -353,7 +358,8 @@ void SocketCommunication::send(std::string const &itemToSend, Rank rankReceiver)
     asio::write(*_sockets[rankReceiver], asio::buffer(&size, sizeof(size_t)));
     asio::write(*_sockets[rankReceiver], asio::buffer(itemToSend.c_str(), size));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -369,7 +375,8 @@ void SocketCommunication::send(precice::span<const int> itemsToSend, Rank rankRe
   try {
     asio::write(*_sockets[rankReceiver], asio::buffer(itemsToSend.data(), itemsToSend.size() * sizeof(int)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -430,7 +437,8 @@ void SocketCommunication::send(precice::span<const double> itemsToSend, Rank ran
   try {
     asio::write(*_sockets[rankReceiver], asio::buffer(itemsToSend.data(), itemsToSend.size() * sizeof(double)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -465,7 +473,8 @@ void SocketCommunication::send(double itemToSend, Rank rankReceiver)
   try {
     asio::write(*_sockets[rankReceiver], asio::buffer(&itemToSend, sizeof(double)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -486,7 +495,8 @@ void SocketCommunication::send(int itemToSend, Rank rankReceiver)
   try {
     asio::write(*_sockets[rankReceiver], asio::buffer(&itemToSend, sizeof(int)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -507,7 +517,8 @@ void SocketCommunication::send(bool itemToSend, Rank rankReceiver)
   try {
     asio::write(*_sockets[rankReceiver], asio::buffer(&itemToSend, sizeof(bool)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Sending data to another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -547,7 +558,8 @@ void SocketCommunication::receive(std::string &itemToReceive, Rank rankSender)
     asio::read(*_sockets[rankSender], asio::buffer(msg.data(), size));
     itemToReceive = msg.data();
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -563,7 +575,8 @@ void SocketCommunication::receive(precice::span<int> itemsToReceive, Rank rankSe
   try {
     asio::read(*_sockets[rankSender], asio::buffer(itemsToReceive.data(), itemsToReceive.size() * sizeof(int)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -579,7 +592,8 @@ void SocketCommunication::receive(precice::span<double> itemsToReceive, Rank ran
   try {
     asio::read(*_sockets[rankSender], asio::buffer(itemsToReceive.data(), itemsToReceive.size() * sizeof(double)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -602,7 +616,8 @@ PtrRequest SocketCommunication::aReceive(precice::span<double> itemsToReceive,
                        std::static_pointer_cast<SocketRequest>(request)->complete();
                      });
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 
   return request;
@@ -620,7 +635,8 @@ void SocketCommunication::receive(double &itemToReceive, Rank rankSender)
   try {
     asio::read(*_sockets[rankSender], asio::buffer(&itemToReceive, sizeof(double)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -641,7 +657,8 @@ void SocketCommunication::receive(int &itemToReceive, Rank rankSender)
   try {
     asio::read(*_sockets[rankSender], asio::buffer(&itemToReceive, sizeof(int)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -664,7 +681,8 @@ PtrRequest SocketCommunication::aReceive(int &itemToReceive, Rank rankSender)
                        std::static_pointer_cast<SocketRequest>(request)->complete();
                      });
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 
   return request;
@@ -682,7 +700,8 @@ void SocketCommunication::receive(bool &itemToReceive, Rank rankSender)
   try {
     asio::read(*_sockets[rankSender], asio::buffer(&itemToReceive, sizeof(bool)));
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 }
 
@@ -704,7 +723,8 @@ PtrRequest SocketCommunication::aReceive(bool &itemToReceive, Rank rankSender)
                        std::static_pointer_cast<SocketRequest>(request)->complete();
                      });
   } catch (std::exception &e) {
-    PRECICE_ERROR("Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  "Receiving data from another participant (using sockets) failed with a system error: {}. This often means that the other participant exited with an error (look there).", e.what());
   }
 
   return request;
@@ -783,11 +803,13 @@ std::string SocketCommunication::getIpAddress()
       err << interface.name << ' ';
     }
     err << " Please check \"network\" attributes in your configuration file.";
-    PRECICE_ERROR(err.str());
+    PRECICE_ERROR(::precice::CommunicationError,
+                  err.str());
   }
 
   // Unconnected interfaces don't have an IP address.
-  PRECICE_CHECK(not pos->address.empty(), "The interface \"{}\" does not have an IP address. Please select another interface.", _networkName);
+  PRECICE_CHECK(not pos->address.empty(),
+                ::precice::CommunicationError, "The interface \"{}\" does not have an IP address. Please select another interface.", _networkName);
 
   PRECICE_DEBUG("Detected network IP address of interface \"{}\": {}.", _networkName, pos->address);
   return pos->address;

--- a/src/com/config/CommunicationConfiguration.cpp
+++ b/src/com/config/CommunicationConfiguration.cpp
@@ -19,6 +19,7 @@ PtrCommunication CommunicationConfiguration::createCommunication(
     int         port    = tag.getIntAttributeValue("port");
 
     PRECICE_CHECK(utils::isValidPort(port),
+                  ::precice::ConfigurationError,
                   "A sockets communication was configured with an invalid port \"{}\". "
                   "Please check the \"ports=\" attributes of your socket connections.",
                   port);
@@ -28,14 +29,16 @@ PtrCommunication CommunicationConfiguration::createCommunication(
   } else if (tag.getName() == "mpi") {
     std::string dir = tag.getStringAttributeValue("exchange-directory");
 #ifdef PRECICE_NO_MPI
-    PRECICE_ERROR("Communication type \"mpi\" can only be used if preCICE was compiled with MPI support enabled. "
+    PRECICE_ERROR(::precice::ConfigurationError,
+                  "Communication type \"mpi\" can only be used if preCICE was compiled with MPI support enabled. "
                   "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
     com = std::make_shared<com::MPIPortsCommunication>(dir);
 #endif
   } else if (tag.getName() == "mpi-single") {
 #ifdef PRECICE_NO_MPI
-    PRECICE_ERROR("Communication type \"mpi-single\" can only be used if preCICE was compiled with MPI support enabled. "
+    PRECICE_ERROR(::precice::ConfigurationError,
+                  "Communication type \"mpi-single\" can only be used if preCICE was compiled with MPI support enabled. "
                   "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
     com = std::make_shared<com::MPIDirectCommunication>();

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -79,6 +79,7 @@ BaseCouplingScheme::BaseCouplingScheme(
   } else {
     PRECICE_ASSERT(isImplicitCouplingScheme());
     PRECICE_CHECK((_extrapolationOrder == 0) || (_extrapolationOrder == 1),
+                  ::precice::CouplingSchemeError,
                   "Extrapolation order has to be 0 or 1.");
   }
 }
@@ -174,6 +175,7 @@ void BaseCouplingScheme::initialize(double startTime, int startTimeWindow)
   if (isImplicitCouplingScheme()) {
     if (not doesFirstStep()) {
       PRECICE_CHECK(not _convergenceMeasures.empty(),
+                    ::precice::CouplingSchemeError,
                     "At least one convergence measure has to be defined for "
                     "an implicit coupling scheme.");
       // reserve memory and initialize data with zero
@@ -342,6 +344,7 @@ void BaseCouplingScheme::addComputedTime(
   // Check validness
   bool valid = math::greaterEquals(getNextTimestepMaxLength(), 0.0, _eps);
   PRECICE_CHECK(valid,
+                ::precice::CouplingSchemeError,
                 "The timestep length given to preCICE in \"advance\" {} exceeds the maximum allowed timestep length {} "
                 "in the remaining of this time window. "
                 "Did you restrict your timestep length, \"dt = min(precice_dt, dt)\"? "
@@ -515,7 +518,8 @@ void BaseCouplingScheme::checkCompletenessRequiredActions()
       }
       stream << toString(action);
     }
-    PRECICE_ERROR("The required actions {} are not fulfilled. "
+    PRECICE_ERROR(::precice::CouplingSchemeError,
+                  "The required actions {} are not fulfilled. "
                   "Did you forget to call \"requiresReadingCheckpoint()\" or \"requiresWritingCheckpoint()\"?",
                   stream.str());
   }
@@ -601,6 +605,7 @@ bool BaseCouplingScheme::measureConvergence()
       if (convMeasure.strict) {
         oneStrict = true;
         PRECICE_CHECK(_iterations < _maxIterations,
+                      ::precice::CouplingSchemeError,
                       "The strict convergence measure for data \"" + convMeasure.couplingData->getDataName() +
                           "\" did not converge within the maximum allowed iterations, which terminates the simulation. "
                           "To avoid this forced termination do not mark the convergence measure as strict.")

--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -43,7 +43,8 @@ BiCouplingScheme::BiCouplingScheme(
   } else if (localParticipant == _secondParticipant) {
     setDoesFirstStep(false);
   } else {
-    PRECICE_ERROR("Name of local participant \"{}\" does not match any participant specified for the coupling scheme.",
+    PRECICE_ERROR(::precice::CouplingSchemeError,
+                  "Name of local participant \"{}\" does not match any participant specified for the coupling scheme.",
                   localParticipant);
   }
 }
@@ -60,7 +61,8 @@ void BiCouplingScheme::addDataToSend(
     PRECICE_ASSERT(_sendData.count(data->getID()) == 0, "Key already exists!");
     _sendData.emplace(data->getID(), ptrCplData);
   } else {
-    PRECICE_ERROR("Data \"{0}\" cannot be added twice for sending. Please remove any duplicate <exchange data=\"{0}\" .../> tags", data->getName());
+    PRECICE_ERROR(::precice::CouplingSchemeError,
+                  "Data \"{0}\" cannot be added twice for sending. Please remove any duplicate <exchange data=\"{0}\" .../> tags", data->getName());
   }
 }
 
@@ -76,7 +78,8 @@ void BiCouplingScheme::addDataToReceive(
     PRECICE_ASSERT(_receiveData.count(data->getID()) == 0, "Key already exists!");
     _receiveData.emplace(data->getID(), ptrCplData);
   } else {
-    PRECICE_ERROR("Data \"{0}\" cannot be added twice for receiving. Please remove any duplicate <exchange data=\"{0}\" ... /> tags", data->getName());
+    PRECICE_ERROR(::precice::CouplingSchemeError,
+                  "Data \"{0}\" cannot be added twice for receiving. Please remove any duplicate <exchange data=\"{0}\" ... /> tags", data->getName());
   }
 }
 

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -33,7 +33,7 @@ void ExportVTK::doExport(
   outfile = outfile / fs::path(name + ".vtk");
   std::ofstream outstream(outfile.string(), std::ios::trunc);
   PRECICE_CHECK(outstream,
-                ::precice::IOError, "VTK export failed to open destination file \"{}\"", outfile.generic_string());
+                ::precice::ExportError, "VTK export failed to open destination file \"{}\"", outfile.generic_string());
 
   initializeWriting(outstream);
   writeHeader(outstream);

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -32,7 +32,8 @@ void ExportVTK::doExport(
     fs::create_directories(outfile);
   outfile = outfile / fs::path(name + ".vtk");
   std::ofstream outstream(outfile.string(), std::ios::trunc);
-  PRECICE_CHECK(outstream, "VTK export failed to open destination file \"{}\"", outfile.generic_string());
+  PRECICE_CHECK(outstream,
+                ::precice::IOError, "VTK export failed to open destination file \"{}\"", outfile.generic_string());
 
   initializeWriting(outstream);
   writeHeader(outstream);

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -76,7 +76,7 @@ void ExportXML::writeParallelFile(
   std::ofstream outParallelFile(outfile.string(), std::ios::trunc);
 
   PRECICE_CHECK(outParallelFile,
-                ::precice::IOError, "{} export failed to open primary file \"{}\"", getVTKFormat(), outfile.generic_string());
+                ::precice::ExportError, "{} export failed to open primary file \"{}\"", getVTKFormat(), outfile.generic_string());
 
   const auto formatType = getVTKFormat();
   outParallelFile << "<?xml version=\"1.0\"?>\n";
@@ -132,7 +132,7 @@ void ExportXML::writeSubFile(
   std::ofstream outSubFile(outfile.string(), std::ios::trunc);
 
   PRECICE_CHECK(outSubFile,
-                ::precice::IOError, "{} export failed to open secondary file \"{}\"", getVTKFormat(), outfile.generic_string());
+                ::precice::ExportError, "{} export failed to open secondary file \"{}\"", getVTKFormat(), outfile.generic_string());
 
   const auto formatType = getVTKFormat();
   outSubFile << "<?xml version=\"1.0\"?>\n";

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -75,7 +75,8 @@ void ExportXML::writeParallelFile(
   outfile = outfile / fs::path(name + getParallelExtension());
   std::ofstream outParallelFile(outfile.string(), std::ios::trunc);
 
-  PRECICE_CHECK(outParallelFile, "{} export failed to open primary file \"{}\"", getVTKFormat(), outfile.generic_string());
+  PRECICE_CHECK(outParallelFile,
+                ::precice::IOError, "{} export failed to open primary file \"{}\"", getVTKFormat(), outfile.generic_string());
 
   const auto formatType = getVTKFormat();
   outParallelFile << "<?xml version=\"1.0\"?>\n";
@@ -130,7 +131,8 @@ void ExportXML::writeSubFile(
   outfile /= fs::path(name + getPieceSuffix() + getPieceExtension());
   std::ofstream outSubFile(outfile.string(), std::ios::trunc);
 
-  PRECICE_CHECK(outSubFile, "{} export failed to open secondary file \"{}\"", getVTKFormat(), outfile.generic_string());
+  PRECICE_CHECK(outSubFile,
+                ::precice::IOError, "{} export failed to open secondary file \"{}\"", getVTKFormat(), outfile.generic_string());
 
   const auto formatType = getVTKFormat();
   outSubFile << "<?xml version=\"1.0\"?>\n";

--- a/src/io/TXTReader.cpp
+++ b/src/io/TXTReader.cpp
@@ -9,7 +9,7 @@ TXTReader::TXTReader(
 {
   _file.open(filename);
   PRECICE_CHECK(_file,
-                ::precice::IOError, "TXT reader failed to open file \"{}\"", filename);
+                ::precice::ExportError, "TXT reader failed to open file \"{}\"", filename);
   _file.setf(std::ios::showpoint);
   _file.setf(std::ios::fixed);
   //_file << std::setprecision(16);

--- a/src/io/TXTReader.cpp
+++ b/src/io/TXTReader.cpp
@@ -8,7 +8,8 @@ TXTReader::TXTReader(
     : _file()
 {
   _file.open(filename);
-  PRECICE_CHECK(_file, "TXT reader failed to open file \"{}\"", filename);
+  PRECICE_CHECK(_file,
+                ::precice::IOError, "TXT reader failed to open file \"{}\"", filename);
   _file.setf(std::ios::showpoint);
   _file.setf(std::ios::fixed);
   //_file << std::setprecision(16);

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -14,7 +14,8 @@ TXTTableWriter::TXTTableWriter(
       _outputStream()
 {
   _outputStream.open(filename);
-  PRECICE_CHECK(_outputStream, "TXT table writer failed to open file \"{}\"", filename);
+  PRECICE_CHECK(_outputStream,
+                ::precice::IOError, "TXT table writer failed to open file \"{}\"", filename);
 
   _outputStream.setf(std::ios::showpoint);
   _outputStream.setf(std::ios::fixed);

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -15,7 +15,7 @@ TXTTableWriter::TXTTableWriter(
 {
   _outputStream.open(filename);
   PRECICE_CHECK(_outputStream,
-                ::precice::IOError, "TXT table writer failed to open file \"{}\"", filename);
+                ::precice::ExportError, "TXT table writer failed to open file \"{}\"", filename);
 
   _outputStream.setf(std::ios::showpoint);
   _outputStream.setf(std::ios::fixed);

--- a/src/io/TXTWriter.cpp
+++ b/src/io/TXTWriter.cpp
@@ -9,7 +9,8 @@ TXTWriter::TXTWriter(
     : _file()
 {
   _file.open(filename);
-  PRECICE_CHECK(_file, "TXT writer failed to open file \"{}\"", filename);
+  PRECICE_CHECK(_file,
+                ::precice::IOError, "TXT writer failed to open file \"{}\"", filename);
 
   _file.setf(std::ios::showpoint);
   _file.setf(std::ios::fixed);

--- a/src/io/TXTWriter.cpp
+++ b/src/io/TXTWriter.cpp
@@ -10,7 +10,7 @@ TXTWriter::TXTWriter(
 {
   _file.open(filename);
   PRECICE_CHECK(_file,
-                ::precice::IOError, "TXT writer failed to open file \"{}\"", filename);
+                ::precice::ExportError, "TXT writer failed to open file \"{}\"", filename);
 
   _file.setf(std::ios::showpoint);
   _file.setf(std::ios::fixed);

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -13,12 +13,8 @@
 
 #define PRECICE_INFO(...) _log.info(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
 
-#define PRECICE_ERROR(...)                                                   \
-  do {                                                                       \
-    auto preciceErrorMessage = precice::utils::format_or_error(__VA_ARGS__); \
-    _log.error(PRECICE_LOG_LOCATION, preciceErrorMessage);                   \
-    throw precice::Error{preciceErrorMessage};                               \
-  } while (false)
+#define PRECICE_ERROR(...) \
+  _log.error<::precice::Error>(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
 
 #define PRECICE_CHECK(check, ...) \
   if (!(check)) {                 \

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "precice/exceptions.hpp"
 #include "utils/fmt.hpp"
 
 #define PRECICE_LOG_LOCATION     \

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -13,8 +13,8 @@
 
 #define PRECICE_INFO(...) _log.info(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
 
-#define PRECICE_ERROR(...) \
-  _log.error<::precice::Error>(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
+#define PRECICE_ERROR(kind, ...) \
+  _log.error<kind>(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
 
 #define PRECICE_CHECK(check, ...) \
   if (!(check)) {                 \

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -12,10 +12,11 @@
 
 #define PRECICE_INFO(...) _log.info(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
 
-#define PRECICE_ERROR(...)                                                          \
-  do {                                                                              \
-    _log.error(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__)); \
-    std::exit(-1);                                                                  \
+#define PRECICE_ERROR(...)                                                   \
+  do {                                                                       \
+    auto preciceErrorMessage = precice::utils::format_or_error(__VA_ARGS__); \
+    _log.error(PRECICE_LOG_LOCATION, preciceErrorMessage);                   \
+    throw precice::Error{preciceErrorMessage};                               \
   } while (false)
 
 #define PRECICE_CHECK(check, ...) \

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <precice/exceptions.hpp>
 #include <string>
 
 namespace precice::logging {
@@ -33,6 +34,8 @@ public:
   template <typename Exception>
   void error(LogLocation loc, const std::string &mess)
   {
+    static_assert(std::is_base_of_v<::precice::Error, Exception>,
+                  "The given exception must be derived from ::precice::Error");
     error(std::move(loc), mess);
     throw Exception{mess};
   }

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -29,6 +29,14 @@ public:
 
   ///@name Logging operations
   ///@{
+  /// Logs an error and throws an exception
+  template <typename Exception>
+  void error(LogLocation loc, const std::string &mess)
+  {
+    error(std::move(loc), mess);
+    throw Exception{mess};
+  }
+
   void error(LogLocation loc, const std::string &mess) noexcept;
   void warning(LogLocation loc, const std::string &mess) noexcept;
   void info(LogLocation loc, const std::string &mess) noexcept;

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -133,7 +133,8 @@ m2n::PtrM2N M2NConfiguration::getM2N(const std::string &from, const std::string 
       return get<0>(tuple);
     }
   }
-  PRECICE_ERROR("There is no m2n communication configured between participants \"" + from + "\" and \"" + to + "\". Please add an appropriate \"<m2n />\" tag.");
+  PRECICE_ERROR(::precice::ConfigurationError,
+                "There is no m2n communication configured between participants \"" + from + "\" and \"" + to + "\". Please add an appropriate \"<m2n />\" tag.");
 }
 
 bool M2NConfiguration::isM2NConfigured(const std::string &from, const std::string &to)
@@ -168,6 +169,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
       int         port    = tag.getIntAttributeValue("port");
 
       PRECICE_CHECK(not utils::isTruncated<unsigned short>(port),
+                    ::precice::ConfigurationError,
                     "The value given for the \"port\" attribute is not a 16-bit unsigned integer: {}", port);
 
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
@@ -176,7 +178,8 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
     } else if (tagName == "mpi-multiple-ports") {
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
-      PRECICE_ERROR("Communication type \"mpi-multiple-ports\" can only be used if preCICE was compiled with MPI support enabled. "
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "Communication type \"mpi-multiple-ports\" can only be used if preCICE was compiled with MPI support enabled. "
                     "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
 #ifdef OMPI_MAJOR_VERSION
@@ -191,7 +194,8 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
       }
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
-      PRECICE_ERROR("Communication type \"{}\" can only be used if preCICE was compiled with MPI support enabled. "
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "Communication type \"{}\" can only be used if preCICE was compiled with MPI support enabled. "
                     "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".",
                     tagName);
 #else
@@ -228,7 +232,8 @@ void M2NConfiguration::checkDuplicates(
     alreadyAdded |= (get<1>(tuple) == from) && (get<2>(tuple) == to);
     alreadyAdded |= (get<2>(tuple) == from) && (get<1>(tuple) == to);
   }
-  PRECICE_CHECK(!alreadyAdded, "Multiple m2n communications between participant \"" + from + "\" and \"" + to + "\" are not allowed. Please remove redundant <m2n /> tags between them.");
+  PRECICE_CHECK(!alreadyAdded,
+                ::precice::ConfigurationError, "Multiple m2n communications between participant \"" + from + "\" and \"" + to + "\" are not allowed. Please remove redundant <m2n /> tags between them.");
 }
 
 } // namespace precice::m2n

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -135,6 +135,7 @@ m2n::PtrM2N M2NConfiguration::getM2N(const std::string &from, const std::string 
   }
   PRECICE_ERROR(::precice::ConfigurationError,
                 "There is no m2n communication configured between participants \"" + from + "\" and \"" + to + "\". Please add an appropriate \"<m2n />\" tag.");
+  PRECICE_UNREACHABLE("Internal error");
 }
 
 bool M2NConfiguration::isM2NConfigured(const std::string &from, const std::string &to)

--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -27,7 +27,8 @@ LinearCellInterpolationMapping::LinearCellInterpolationMapping(
     setOutputRequirement(Mapping::MeshRequirement::FULL);
   }
 
-  PRECICE_CHECK(constraint != SCALED_CONSISTENT_SURFACE, "Volume mapping doesn't support scaled-consistent-surface mappings. Use \"scaled-consistent-volume\" instead.");
+  PRECICE_CHECK(constraint != SCALED_CONSISTENT_SURFACE,
+                ::precice::MappingError, "Volume mapping doesn't support scaled-consistent-surface mappings. Use \"scaled-consistent-volume\" instead.");
 }
 
 void LinearCellInterpolationMapping::computeMapping()

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -130,16 +130,19 @@ void Mapping::scaleConsistentMapping(int inputDataID, int outputDataID, Mapping:
   for (mesh::PtrMesh mesh : {input(), output()}) {
     if (not mesh->vertices().empty()) {
 
-      PRECICE_CHECK(!(requiresEdges && mesh->edges().empty()), "Edges connectivity information is missing for the mesh \"{}\". "
-                                                               "Scaled consistent mapping requires connectivity information.",
+      PRECICE_CHECK(!(requiresEdges && mesh->edges().empty()),
+                    ::precice::MappingError, "Edges connectivity information is missing for the mesh \"{}\". "
+                                             "Scaled consistent mapping requires connectivity information.",
                     mesh->getName());
 
-      PRECICE_CHECK(!(requiresTriangles && mesh->triangles().empty()), "Triangles connectivity information is missing for the mesh \"{}\". "
-                                                                       "Scaled consistent mapping requires connectivity information.",
+      PRECICE_CHECK(!(requiresTriangles && mesh->triangles().empty()),
+                    ::precice::MappingError, "Triangles connectivity information is missing for the mesh \"{}\". "
+                                             "Scaled consistent mapping requires connectivity information.",
                     mesh->getName());
 
-      PRECICE_CHECK(!(requiresTetra && mesh->tetrahedra().empty()), "Tetrahedra connectivity information is missing for the mesh \"{}\". "
-                                                                    "Scaled consistent mapping requires connectivity information.",
+      PRECICE_CHECK(!(requiresTetra && mesh->tetrahedra().empty()),
+                    ::precice::MappingError, "Tetrahedra connectivity information is missing for the mesh \"{}\". "
+                                             "Scaled consistent mapping requires connectivity information.",
                     mesh->getName());
     }
   }

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -41,7 +41,8 @@ NearestProjectionMapping::NearestProjectionMapping(
     setOutputRequirement(Mapping::MeshRequirement::FULL);
   }
 
-  PRECICE_CHECK(constraint != SCALED_CONSISTENT_VOLUME, "Nearest-projection can't be used with volume version of the scaled-consistent mapping. Use scaled-consistent instead.");
+  PRECICE_CHECK(constraint != SCALED_CONSISTENT_VOLUME,
+                ::precice::MappingError, "Nearest-projection can't be used with volume version of the scaled-consistent mapping. Use scaled-consistent instead.");
 }
 
 void NearestProjectionMapping::computeMapping()

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -639,7 +639,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inp
         break;
       case (petsc::KSPSolver::SolverResult::Diverged):
         KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
-        PRECICE_ERROR("The polynomial QR system of the RBF mapping from mesh {} to mesh {} has diverged. "
+        PRECICE_ERROR(::precice::MappingError,
+                      "The polynomial QR system of the RBF mapping from mesh {} to mesh {} has diverged. "
                       "This means most probably that the mapping problem is not well-posed. "
                       "Please check if your coupling meshes are correct. "
                       "Maybe you need to fix axis-aligned mapping setups by marking perpendicular axes as dead? {}",
@@ -677,7 +678,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(DataID inp
       break;
     case (petsc::KSPSolver::SolverResult::Diverged):
       KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
-      PRECICE_ERROR("The linear system of the RBF mapping from mesh {} to mesh {} has diverged. "
+      PRECICE_ERROR(::precice::MappingError,
+                    "The linear system of the RBF mapping from mesh {} to mesh {} has diverged. "
                     "This means most probably that the mapping problem is not well-posed. "
                     "Please check if your coupling meshes are correct. "
                     "Maybe you need to fix axis-aligned mapping setups by marking perpendicular axes as dead? {}",
@@ -784,7 +786,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID i
         break;
       case (petsc::KSPSolver::SolverResult::Diverged):
         KSPView(_QRsolver, PETSC_VIEWER_STDOUT_WORLD);
-        PRECICE_ERROR("The polynomial linear system of the RBF mapping from mesh {} to mesh {} "
+        PRECICE_ERROR(::precice::MappingError,
+                      "The polynomial linear system of the RBF mapping from mesh {} to mesh {} "
                       "has diverged. This means most probably that the mapping problem is not well-posed. "
                       "Please check if your coupling meshes are correct. "
                       "Maybe you need to fix axis-aligned mapping setups by marking perpendicular axes as dead? {}",
@@ -815,7 +818,8 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(DataID i
         break;
       case (petsc::KSPSolver::SolverResult::Diverged):
         KSPView(_solver, PETSC_VIEWER_STDOUT_WORLD);
-        PRECICE_ERROR("The linear system of the RBF mapping from mesh {} to mesh {} "
+        PRECICE_ERROR(::precice::MappingError,
+                      "The linear system of the RBF mapping from mesh {} to mesh {} "
                       "has diverged. This means most probably that the mapping problem is not well-posed. "
                       "Please check if your coupling meshes are correct. "
                       "Maybe you need to fix axis-aligned mapping setups by marking perpendicular axes as dead? {}",

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -106,7 +106,9 @@ void RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::setDeadAxis(std::array<
   if (getDimensions() == 2 && deadAxis[2]) {
     PRECICE_WARN("Setting the z-axis to dead on a 2-dimensional problem has no effect. Please remove the respective mapping's \"z-dead\" attribute.");
   }
-  PRECICE_CHECK(std::any_of(_deadAxis.begin(), _deadAxis.end(), [](const auto &ax) { return ax == false; }), "You cannot set all axes to dead for an RBF mapping. Please remove one of the respective mapping's \"x-dead\", \"y-dead\", or \"z-dead\" attributes.");
+  PRECICE_CHECK(std::any_of(_deadAxis.begin(), _deadAxis.end(), [](const auto &ax) { return ax == false; }),
+                ::precice::MappingError,
+                "You cannot set all axes to dead for an RBF mapping. Please remove one of the respective mapping's \"x-dead\", \"y-dead\", or \"z-dead\" attributes.");
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -79,7 +79,9 @@ RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctMapping(
     : RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>(constraint, dimensions, function, deadAxis),
       _polynomial(polynomial)
 {
-  PRECICE_CHECK(!(RADIAL_BASIS_FUNCTION_T::isStrictlyPositiveDefinite() && polynomial == Polynomial::ON), "The integrated polynomial (polynomial=\"on\") is not supported for the selected radial-basis function. Please select another radial-basis function or change the polynomial configuration.");
+  PRECICE_CHECK(!(RADIAL_BASIS_FUNCTION_T::isStrictlyPositiveDefinite() && polynomial == Polynomial::ON),
+                ::precice::MappingError,
+                "The integrated polynomial (polynomial=\"on\") is not supported for the selected radial-basis function. Please select another radial-basis function or change the polynomial configuration.");
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -202,6 +202,7 @@ RadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctSolver(RADIAL_BASIS
   }
 
   PRECICE_CHECK(decompositionSuccessful,
+                ::precice::MappingError,
                 "The interpolation matrix of the RBF mapping from mesh \"{}\" to mesh \"{}\" is not invertable. "
                 "This means that the mapping problem is not well-posed. "
                 "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -302,7 +302,8 @@ void MappingConfiguration::xmlTagCallback(
 
     PRECICE_ASSERT(!_mappings.empty());
     // We can only set one subtag
-    PRECICE_CHECK(_mappings.back().mapping == nullptr, "More than one basis-function was defined for the.");
+    PRECICE_CHECK(_mappings.back().mapping == nullptr,
+                  ::precice::ConfigurationError, "More than one basis-function was defined for the.");
 
     std::string basisFctName   = tag.getName();
     double      supportRadius  = tag.getDoubleAttributeValue(ATTR_SUPPORT_RADIUS, 0.);
@@ -316,7 +317,8 @@ void MappingConfiguration::xmlTagCallback(
     if (basisFunction == BasisFunction::Gaussian) {
       const bool exactlyOneSet = (std::isfinite(supportRadius) && !std::isfinite(shapeParameter)) ||
                                  (std::isfinite(shapeParameter) && !std::isfinite(supportRadius));
-      PRECICE_CHECK(exactlyOneSet, "The specified parameters for the Gaussian RBF mapping are invalid. Please specify either a \"shape-parameter\" or a \"support-radius\".");
+      PRECICE_CHECK(exactlyOneSet,
+                    ::precice::ConfigurationError, "The specified parameters for the Gaussian RBF mapping are invalid. Please specify either a \"shape-parameter\" or a \"support-radius\".");
 
       if (std::isfinite(supportRadius) && !std::isfinite(shapeParameter)) {
         shapeParameter = std::sqrt(-std::log(Gaussian::cutoffThreshold)) / supportRadius;
@@ -338,7 +340,8 @@ void MappingConfiguration::xmlTagCallback(
 
       mapping.mapping = getRBFMapping<RBFBackend::PETSc>(basisFunction, constraintValue, mapping.fromMesh->getDimensions(), supportRadius, shapeParameter, _rbfConfig.deadAxis, _rbfConfig.solverRtol, _rbfConfig.polynomial, _rbfConfig.preallocation);
 #else
-      PRECICE_CHECK(false, "The global-iterative RBF solver requires a preCICE build with PETSc enabled.");
+      PRECICE_CHECK(false,
+                    ::precice::ConfigurationError, "The global-iterative RBF solver requires a preCICE build with PETSc enabled.");
 #endif
     } else {
       PRECICE_UNREACHABLE("Unknown RBF solver.");
@@ -416,10 +419,12 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
   mesh::PtrMesh     fromMesh(_meshConfig->getMesh(fromMeshName));
   mesh::PtrMesh     toMesh(_meshConfig->getMesh(toMeshName));
   PRECICE_CHECK(fromMesh.get() != nullptr,
+                ::precice::ConfigurationError,
                 "Mesh \"{0}\" was not found while creating a mapping. "
                 "Please correct the from=\"{0}\" attribute.",
                 fromMeshName);
   PRECICE_CHECK(toMesh.get() != nullptr,
+                ::precice::ConfigurationError,
                 "Mesh \"{0}\" was not found while creating a mapping. "
                 "Please correct the to=\"{0}\" attribute.",
                 toMeshName);
@@ -445,6 +450,7 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
 
     // NNG is not applicable with the conservative constraint
     PRECICE_CHECK(constraintValue != Mapping::CONSERVATIVE,
+                  ::precice::ConfigurationError,
                   "Nearest-neighbor-gradient mapping is not implemented using a \"conservative\" constraint. "
                   "Please select constraint=\" consistent\" or a different mapping method.");
 
@@ -467,6 +473,7 @@ void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
     bool sameFromMesh = mapping.fromMesh->getName() == configuredMapping.fromMesh->getName();
     bool sameMapping  = sameToMesh && sameFromMesh;
     PRECICE_CHECK(!sameMapping,
+                  ::precice::ConfigurationError,
                   "There cannot be two mappings from mesh \"{}\" to mesh \"{}\". "
                   "Please remove one of the duplicated meshes. ",
                   mapping.fromMesh->getName(), mapping.toMesh->getName());
@@ -476,7 +483,8 @@ void MappingConfiguration::checkDuplicates(const ConfiguredMapping &mapping)
 void MappingConfiguration::xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag)
 {
   if (requiresBasisFunction(tag.getName())) {
-    PRECICE_CHECK(_mappings.back().mapping != nullptr, "No basis-function was defined for the \"{}\" mapping from mesh \"{}\" to mesh \"{}\".", tag.getName(), _mappings.back().fromMesh->getName(), _mappings.back().toMesh->getName());
+    PRECICE_CHECK(_mappings.back().mapping != nullptr,
+                  ::precice::ConfigurationError, "No basis-function was defined for the \"{}\" mapping from mesh \"{}\" to mesh \"{}\".", tag.getName(), _mappings.back().fromMesh->getName(), _mappings.back().toMesh->getName());
   }
   PRECICE_ASSERT(_mappings.back().mapping != nullptr);
 }

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -93,6 +93,7 @@ public:
       : _cPow2(std::pow(c, 2))
   {
     PRECICE_CHECK(math::greater(c, 0.0),
+                  ::precice::MappingError,
                   "Shape parameter for radial-basis-function inverse multiquadric has to be larger than zero. Please update the \"shape-parameter\" attribute.");
   }
 
@@ -139,8 +140,10 @@ public:
         _supportRadius(supportRadius)
   {
     PRECICE_CHECK(math::greater(_shape, 0.0),
+                  ::precice::MappingError,
                   "Shape parameter for radial-basis-function gaussian has to be larger than zero. Please update the \"shape-parameter\" attribute.");
     PRECICE_CHECK(math::greater(_supportRadius, 0.0),
+                  ::precice::MappingError,
                   "Support radius for radial-basis-function gaussian has to be larger than zero. Please update the \"support-radius\" attribute.");
 
     if (supportRadius < std::numeric_limits<double>::infinity()) {
@@ -194,6 +197,7 @@ public:
   explicit CompactThinPlateSplinesC2(double supportRadius)
   {
     PRECICE_CHECK(math::greater(supportRadius, 0.0),
+                  ::precice::MappingError,
                   "Support radius for radial-basis-function compact thin-plate-splines c2 has to be larger than zero. Please update the \"support-radius\" attribute.");
     _r_inv = 1. / supportRadius;
   }
@@ -234,7 +238,9 @@ public:
   {
     logging::Logger _log{"mapping::CompactPolynomialC0"};
     PRECICE_CHECK(math::greater(supportRadius, 0.0),
+                  ::precice::MappingError,
                   "Support radius for radial-basis-function compact polynomial c0 has to be larger than zero. Please update the \"support-radius\" attribute.");
+
     _r_inv = 1. / supportRadius;
   }
 
@@ -272,6 +278,7 @@ public:
   {
     logging::Logger _log{"mapping::CompactPolynomialC2"};
     PRECICE_CHECK(math::greater(supportRadius, 0.0),
+                  ::precice::MappingError,
                   "Support radius for radial-basis-function compact polynomial c2 has to be larger than zero. Please update the \"support-radius\" attribute.");
 
     _r_inv = 1. / supportRadius;
@@ -311,6 +318,7 @@ public:
   {
     logging::Logger _log{"mapping::CompactPolynomialC4"};
     PRECICE_CHECK(math::greater(supportRadius, 0.0),
+                  ::precice::MappingError,
                   "Support radius for radial-basis-function compact polynomial c4 has to be larger than zero. Please update the \"support-radius\" attribute.");
 
     _r_inv = 1. / supportRadius;
@@ -350,6 +358,7 @@ public:
   {
     logging::Logger _log{"mapping::CompactPolynomialC6"};
     PRECICE_CHECK(math::greater(supportRadius, 0.0),
+                  ::precice::MappingError,
                   "Support radius for radial-basis-function compact polynomial c6 has to be larger than zero. Please update the \"support-radius\" attribute.");
 
     _r_inv = 1. / supportRadius;

--- a/src/math/geometry.cpp
+++ b/src/math/geometry.cpp
@@ -159,6 +159,7 @@ ConvexityResult isConvexQuad(std::array<Eigen::VectorXd, 4> coords)
   Eigen::Vector3d normalVector = e_1.cross(e_2);
 
   PRECICE_CHECK(math::equals(normalVector.dot(coords[3] - coordOrigin), 0.0),
+                ::precice::APIError,
                 "Non-planar quads are not supported. The vertex coordinates are: {}.", coords);
 
   //Transform Coordinates - coord[0] is the origin

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -138,6 +138,7 @@ PtrData &Mesh::createData(
   PRECICE_TRACE(name, dimension);
   for (const PtrData &data : _data) {
     PRECICE_CHECK(data->getName() != name,
+                  ::precice::MeshError,
                   "Data \"{}\" cannot be created twice for mesh \"{}\". "
                   "Please rename or remove one of the use-data tags with name \"{}\".",
                   name, _name, name);

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -137,11 +137,7 @@ PtrData &Mesh::createData(
 {
   PRECICE_TRACE(name, dimension);
   for (const PtrData &data : _data) {
-    PRECICE_CHECK(data->getName() != name,
-                  ::precice::MeshError,
-                  "Data \"{}\" cannot be created twice for mesh \"{}\". "
-                  "Please rename or remove one of the use-data tags with name \"{}\".",
-                  name, _name, name);
+    PRECICE_ASSERT(data->getName() != name, "Duplicate data names");
   }
   //#rows = dimensions of current mesh #columns = dimensions of corresponding data set
   PtrData data(new Data(name, id, dimension, _dimensions));

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -77,6 +77,7 @@ void DataConfiguration::addData(
   // Check if data with same name has been added already
   for (auto &elem : _data) {
     PRECICE_CHECK(elem.name != name,
+                  ::precice::ConfigurationError,
                   "Data \"{0}\" has already been defined. Please rename or remove one of the data tags with name=\"{0}\".",
                   name);
   }

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -81,7 +81,8 @@ void MeshConfiguration::xmlTagCallback(
       }
     }
     if (not found) {
-      PRECICE_ERROR("Data with name \"{}\" used by mesh \"{}\" is not defined. "
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "Data with name \"{}\" used by mesh \"{}\" is not defined. "
                     "Please define a data tag with name=\"{}\".",
                     name, _meshes.back()->getName(), name);
     }
@@ -110,7 +111,9 @@ void MeshConfiguration::addMesh(
         break;
       }
     }
-    PRECICE_CHECK(found, "Data {0} is not defined. Please define a data tag with name=\"{0}\".", dataNewMesh->getName());
+    PRECICE_CHECK(found,
+                  ::precice::ConfigurationError,
+                  "Data {0} is not defined. Please define a data tag with name=\"{0}\".", dataNewMesh->getName());
   }
   _meshes.push_back(mesh);
 }

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -53,10 +53,12 @@ void ProvidedPartition::communicate()
   for (auto &m2n : _m2ns) {
     if (m2n->usesTwoLevelInitialization()) {
 
-      PRECICE_CHECK(not twoLevelInitAlreadyUsed, "Two-level initialization does not yet support multiple receivers of a provided mesh. "
-                                                 "Please either switch two-level initialization off in your m2n definition, or "
-                                                 "adapt your mesh setup such that each provided mesh is only received by maximum one "
-                                                 "participant.");
+      PRECICE_CHECK(not twoLevelInitAlreadyUsed,
+                    ::precice::PartitionError,
+                    "Two-level initialization does not yet support multiple receivers of a provided mesh. "
+                    "Please either switch two-level initialization off in your m2n definition, or "
+                    "adapt your mesh setup such that each provided mesh is only received by maximum one "
+                    "participant.");
       twoLevelInitAlreadyUsed = true;
 
       Event e("partition.broadcastMeshPartitions." + _mesh->getName(), precice::syncMode);
@@ -109,6 +111,7 @@ void ProvidedPartition::communicate()
 
       if (not utils::IntraComm::isSecondary()) {
         PRECICE_CHECK(globalMesh.vertices().size() > 0,
+                      ::precice::PartitionError,
                       "The provided mesh \"{}\" is empty. Please set the mesh using setMeshXXX() prior to calling initialize().",
                       globalMesh.getName());
         com::sendMesh(*m2n->getPrimaryRankCommunication(), 0, globalMesh);

--- a/src/precice/config/SolverInterfaceConfiguration.cpp
+++ b/src/precice/config/SolverInterfaceConfiguration.cpp
@@ -79,6 +79,7 @@ void SolverInterfaceConfiguration::xmlEndTagCallback(
         if (participant->getName() == neededMeshes.first) {
           for (const std::string &neededMesh : neededMeshes.second) {
             PRECICE_CHECK(participant->isMeshUsed(neededMesh),
+                          ::precice::ConfigurationError,
                           "Participant \"{}\" needs to use the mesh \"{}\" to be able to use it in the coupling scheme. "
                           "Please either add a provide-mesh or a receive-mesh tag in this participant's configuration, or use a different mesh in the coupling scheme.",
                           neededMeshes.first, neededMesh);

--- a/src/precice/exceptions.hpp
+++ b/src/precice/exceptions.hpp
@@ -10,4 +10,46 @@ public:
       : std::runtime_error(what_arg){};
 };
 
+class ActionError : public precice::Error {
+public:
+  ActionError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class AccelerationError : public precice::Error {
+public:
+  AccelerationError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class CouplingSchemeError : public precice::Error {
+public:
+  CouplingSchemeError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class ExportError : public precice::Error {
+public:
+  ExportError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class MappingError : public precice::Error {
+public:
+  MappingError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class InterfaceError : public precice::Error {
+public:
+  InterfaceError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class ConfigurationError : public precice::Error {
+public:
+  ConfigurationError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
 } // namespace precice

--- a/src/precice/exceptions.hpp
+++ b/src/precice/exceptions.hpp
@@ -34,27 +34,15 @@ public:
       : precice::Error(what_arg){};
 };
 
-class IOError : public precice::Error {
+class ExportError : public precice::Error {
 public:
-  IOError(const std::string &what_arg)
+  ExportError(const std::string &what_arg)
       : precice::Error(what_arg){};
 };
 
 class MappingError : public precice::Error {
 public:
   MappingError(const std::string &what_arg)
-      : precice::Error(what_arg){};
-};
-
-class MeshError : public precice::Error {
-public:
-  MeshError(const std::string &what_arg)
-      : precice::Error(what_arg){};
-};
-
-class M2NError : public precice::Error {
-public:
-  M2NError(const std::string &what_arg)
       : precice::Error(what_arg){};
 };
 

--- a/src/precice/exceptions.hpp
+++ b/src/precice/exceptions.hpp
@@ -28,9 +28,15 @@ public:
       : precice::Error(what_arg){};
 };
 
-class ExportError : public precice::Error {
+class CommunicationError : public precice::Error {
 public:
-  ExportError(const std::string &what_arg)
+  CommunicationError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class IOError : public precice::Error {
+public:
+  IOError(const std::string &what_arg)
       : precice::Error(what_arg){};
 };
 
@@ -40,15 +46,33 @@ public:
       : precice::Error(what_arg){};
 };
 
-class InterfaceError : public precice::Error {
+class MeshError : public precice::Error {
 public:
-  InterfaceError(const std::string &what_arg)
+  MeshError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class M2NError : public precice::Error {
+public:
+  M2NError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class APIError : public precice::Error {
+public:
+  APIError(const std::string &what_arg)
       : precice::Error(what_arg){};
 };
 
 class ConfigurationError : public precice::Error {
 public:
   ConfigurationError(const std::string &what_arg)
+      : precice::Error(what_arg){};
+};
+
+class PartitionError : public precice::Error {
+public:
+  PartitionError(const std::string &what_arg)
       : precice::Error(what_arg){};
 };
 

--- a/src/precice/exceptions.hpp
+++ b/src/precice/exceptions.hpp
@@ -5,6 +5,7 @@
 namespace precice {
 
 class Error : public std::runtime_error {
+public:
   Error(const std::string &what_arg)
       : std::runtime_error(what_arg){};
 };

--- a/src/precice/exceptions.hpp
+++ b/src/precice/exceptions.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace precice {
+
+class Error : public std::runtime_error {
+  Error(const std::string &what_arg)
+      : std::runtime_error(what_arg){};
+};
+
+} // namespace precice

--- a/src/precice/impl/Participant.cpp
+++ b/src/precice/impl/Participant.cpp
@@ -135,14 +135,16 @@ void Participant::addWriteMappingContext(
 const ReadDataContext &Participant::readDataContext(DataID dataID) const
 {
   auto it = _readDataContexts.find(dataID);
-  PRECICE_CHECK(it != _readDataContexts.end(), "DataID does not exist.")
+  PRECICE_CHECK(it != _readDataContexts.end(),
+                ::precice::APIError, "DataID does not exist.")
   return it->second;
 }
 
 ReadDataContext &Participant::readDataContext(DataID dataID)
 {
   auto it = _readDataContexts.find(dataID);
-  PRECICE_CHECK(it != _readDataContexts.end(), "DataID does not exist.")
+  PRECICE_CHECK(it != _readDataContexts.end(),
+                ::precice::APIError, "DataID does not exist.")
   return it->second;
 }
 
@@ -157,14 +159,16 @@ ReadDataContext &Participant::readDataContext(const std::string &dataName)
 const WriteDataContext &Participant::writeDataContext(DataID dataID) const
 {
   auto it = _writeDataContexts.find(dataID);
-  PRECICE_CHECK(it != _writeDataContexts.end(), "DataID \"{}\" does not exist in write direction.", dataID)
+  PRECICE_CHECK(it != _writeDataContexts.end(),
+                ::precice::APIError, "DataID \"{}\" does not exist in write direction.", dataID)
   return it->second;
 }
 
 WriteDataContext &Participant::writeDataContext(DataID dataID)
 {
   auto it = _writeDataContexts.find(dataID);
-  PRECICE_CHECK(it != _writeDataContexts.end(), "DataID \"{}\" does not exist in write direction.", dataID)
+  PRECICE_CHECK(it != _writeDataContexts.end(),
+                ::precice::APIError, "DataID \"{}\" does not exist in write direction.", dataID)
   return it->second;
 }
 
@@ -492,6 +496,7 @@ void Participant::checkDuplicatedUse(const mesh::PtrMesh &mesh)
 {
   PRECICE_ASSERT((int) _meshContexts.size() > mesh->getID());
   PRECICE_CHECK(_meshContexts[mesh->getID()] == nullptr,
+                ::precice::APIError,
                 "Mesh \"{} cannot be used twice by participant {}. "
                 "Please remove one of the provide/receive-mesh nodes with name=\"{}\"./>",
                 mesh->getName(), _name, mesh->getName());
@@ -500,6 +505,7 @@ void Participant::checkDuplicatedUse(const mesh::PtrMesh &mesh)
 void Participant::checkDuplicatedData(const mesh::PtrData &data, const std::string &meshName)
 {
   PRECICE_CHECK(!isDataWrite(data->getID()) && !isDataRead(data->getID()),
+                ::precice::APIError,
                 "Participant \"{}\" can read/write data \"{}\" from/to mesh \"{}\" only once. "
                 "Please remove any duplicate instances of write-data/read-data nodes.",
                 _name, meshName, data->getName());

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -16,7 +16,7 @@
  */
 #include "utils/stacktrace.hpp"
 #define PRECICE_VALIDATE_MESH_ID_IMPL(id)                          \
-  PRECICE_CHECK(_accessor->hasMesh(id),                            \
+  PRECICE_CHECK(_accessor->hasMesh(id), ::precice::APIError,       \
                 "The given Mesh ID \"{}\" is unknown to preCICE.", \
                 id);
 
@@ -26,7 +26,7 @@
  */
 #define PRECICE_REQUIRE_MESH_USE_IMPL(id)                                                                      \
   PRECICE_VALIDATE_MESH_ID_IMPL(id)                                                                            \
-  PRECICE_CHECK(_accessor->isMeshUsed(id),                                                                     \
+  PRECICE_CHECK(_accessor->isMeshUsed(id), ::precice::APIError,                                                \
                 "This participant does not use the mesh \"{0}\", but attempted to access it. "                 \
                 "Please define a <provide-mesh name=\"{0}\" /> or <receive-mesh name=\"{0}\" from=\"...\" /> " \
                 "tag in the configuration of participant \" {1}.",                                             \
@@ -38,7 +38,7 @@
  */
 #define PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id)                                                  \
   PRECICE_REQUIRE_MESH_USE_IMPL(id)                                                            \
-  PRECICE_CHECK(_accessor->isMeshProvided(id),                                                 \
+  PRECICE_CHECK(_accessor->isMeshProvided(id), ::precice::APIError,                            \
                 "This participant does not provide Mesh \"{0}\", but attempted to modify it. " \
                 "Please add a provide-mesh tag as follows <provide-mesh name=\"{0}\" />.",     \
                 _accessor->getMeshName(id));
@@ -49,7 +49,7 @@
  */
 #define PRECICE_REQUIRE_MESH_MODIFY_IMPL(id)                                          \
   PRECICE_REQUIRE_MESH_PROVIDE_IMPL(id)                                               \
-  PRECICE_CHECK(!_meshLock.check(id),                                                 \
+  PRECICE_CHECK(!_meshLock.check(id), ::precice::APIError,                            \
                 "This participant attempted to modify the Mesh \"{}\" while locked. " \
                 "Mesh modification is only allowed before calling initialize().",     \
                 _accessor->getMeshName(id));
@@ -98,8 +98,8 @@
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_VALIDATE_DATA_ID_IMPL(id) \
-  PRECICE_CHECK(_accessor->hasData(id),   \
+#define PRECICE_VALIDATE_DATA_ID_IMPL(id)                    \
+  PRECICE_CHECK(_accessor->hasData(id), ::precice::APIError, \
                 "The given Data ID \"{}\" is unknown to preCICE.", id);
 
 /** Implementation of PRECICE_REQUIRE_DATA_READ()
@@ -108,7 +108,7 @@
  */
 #define PRECICE_REQUIRE_DATA_READ_IMPL(id)                                                                                     \
   PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                            \
-  PRECICE_CHECK((_accessor->isDataRead(id)),                                                                                   \
+  PRECICE_CHECK((_accessor->isDataRead(id)), ::precice::APIError,                                                              \
                 "This participant does not use Data \"{0}\", but attempted to read it. "                                       \
                 "Please extend the configuration of participant \"{1}\" by defining <read-data mesh=\"{2}\" name=\"{0}\" />.", \
                 _accessor->getDataName(id), _accessorName, _accessor->getMeshNameFromData(id));
@@ -119,7 +119,7 @@
  */
 #define PRECICE_REQUIRE_DATA_WRITE_IMPL(id)                                                                                     \
   PRECICE_VALIDATE_DATA_ID_IMPL(id)                                                                                             \
-  PRECICE_CHECK((_accessor->isDataWrite(id)),                                                                                   \
+  PRECICE_CHECK((_accessor->isDataWrite(id)), ::precice::APIError,                                                              \
                 "This participant does not use Data \"{0}\", but attempted to write it. "                                       \
                 "Please extend the configuration of participant \"{1}\" by defining <write-data mesh=\"{2}\" name=\"{0}\" />.", \
                 _accessor->getDataName(id), _accessorName, _accessor->getMeshNameFromData(id));
@@ -161,13 +161,15 @@
   }
 #else // NDEBUG
 
-#define PRECICE_VALIDATE_DATA(data, size) \
-  PRECICE_CHECK(std::all_of(data, data + size, [](double val) { return std::isfinite(val); }), "One of the given data values is either plus or minus infinity or NaN.");
+#define PRECICE_VALIDATE_DATA(data, size)                                                      \
+  PRECICE_CHECK(std::all_of(data, data + size, [](double val) { return std::isfinite(val); }), \
+                ::precice::APIError, "One of the given data values is either plus or minus infinity or NaN.");
 
 #endif
 
-#define PRECICE_EXPERIMENTAL_API()                                                                                                                    \
-  PRECICE_CHECK(_allowsExperimental, "You called the API function \"{}\", which is part of the experimental API. "                                    \
-                                     "You may unlock the full API by specifying <solver-interface experimental=\"true\" ... > in the configuration. " \
-                                     "Please be aware that experimental features may change in any future version (even minor or bugfix).",           \
+#define PRECICE_EXPERIMENTAL_API()                                                                                               \
+  PRECICE_CHECK(_allowsExperimental, ::precice::APIError,                                                                        \
+                "You called the API function \"{}\", which is part of the experimental API. "                                    \
+                "You may unlock the full API by specifying <solver-interface experimental=\"true\" ... > in the configuration. " \
+                "Please be aware that experimental features may change in any future version (even minor or bugfix).",           \
                 __func__)

--- a/src/precice/tests/TestSolverInterface.cpp
+++ b/src/precice/tests/TestSolverInterface.cpp
@@ -1,0 +1,43 @@
+#include "precice/SolverInterface.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+using namespace precice;
+using precice::testing::TestContext;
+
+BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(ExceptionTests)
+
+BOOST_AUTO_TEST_CASE(ConfigurationFileNotFound)
+{
+  //BOOST_REQUIRE_THROW does not work here. Expanding it manually.
+  bool allFine = false;
+  try {
+    SolverInterface s("a", "b", 0, 1);
+  } catch (std::exception) { // this should be a preCICE exception type!
+    allFine = true;
+  }
+  BOOST_TEST(allFine);
+}
+
+BOOST_AUTO_TEST_CASE(WrongParticipant)
+{
+  //BOOST_REQUIRE_THROW does not work here. Expanding it manually.
+  bool allFine = false;
+  try {
+    precice::SolverInterface s("a", testing::getPathToSources() + "/precice/tests/aitken-acceleration.xml", 0, 1);
+  } catch (std::exception) { // this should be a preCICE exception type!
+    allFine = true;
+  }
+  BOOST_TEST(allFine);
+}
+
+BOOST_AUTO_TEST_CASE(FinalizeTwice)
+{
+  precice::SolverInterface s("A", testing::getPathToSources() + "/precice/tests/aitken-acceleration.xml", 0, 1);
+  s.finalize();
+  BOOST_REQUIRE_THROW(s.finalize(), std::exception); // this should be a preCICE exception type!
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/TestSolverInterface.cpp
+++ b/src/precice/tests/TestSolverInterface.cpp
@@ -11,27 +11,15 @@ BOOST_AUTO_TEST_SUITE(ExceptionTests)
 BOOST_AUTO_TEST_CASE(ConfigurationFileNotFound)
 {
   PRECICE_TEST(1_rank);
-  //BOOST_REQUIRE_THROW does not work here. Expanding it manually.
-  bool allFine = false;
-  try {
-    SolverInterface s("a", "b", 0, 1);
-  } catch (::precice::Error) { // this should be a preCICE exception type!
-    allFine = true;
-  }
-  BOOST_TEST(allFine);
+
+  BOOST_REQUIRE_THROW(SolverInterface s("a", "b", 0, 1), ::precice::Error);
 }
 
 BOOST_AUTO_TEST_CASE(WrongParticipant)
 {
   PRECICE_TEST(1_rank);
-  //BOOST_REQUIRE_THROW does not work here. Expanding it manually.
-  bool allFine = false;
-  try {
-    precice::SolverInterface s("a", testing::getPathToSources() + "/precice/tests/config-checker.xml", 0, 1);
-  } catch (::precice::Error) { // this should be a preCICE exception type!
-    allFine = true;
-  }
-  BOOST_TEST(allFine);
+
+  BOOST_REQUIRE_THROW(precice::SolverInterface s("a", testing::getPathToSources() + "/precice/tests/config-checker.xml", 0, 1), ::precice::Error);
 }
 
 BOOST_AUTO_TEST_CASE(FinalizeTwice)

--- a/src/precice/tests/TestSolverInterface.cpp
+++ b/src/precice/tests/TestSolverInterface.cpp
@@ -10,11 +10,12 @@ BOOST_AUTO_TEST_SUITE(ExceptionTests)
 
 BOOST_AUTO_TEST_CASE(ConfigurationFileNotFound)
 {
+  PRECICE_TEST(1_rank);
   //BOOST_REQUIRE_THROW does not work here. Expanding it manually.
   bool allFine = false;
   try {
     SolverInterface s("a", "b", 0, 1);
-  } catch (std::exception) { // this should be a preCICE exception type!
+  } catch (::precice::Error) { // this should be a preCICE exception type!
     allFine = true;
   }
   BOOST_TEST(allFine);
@@ -22,11 +23,12 @@ BOOST_AUTO_TEST_CASE(ConfigurationFileNotFound)
 
 BOOST_AUTO_TEST_CASE(WrongParticipant)
 {
+  PRECICE_TEST(1_rank);
   //BOOST_REQUIRE_THROW does not work here. Expanding it manually.
   bool allFine = false;
   try {
-    precice::SolverInterface s("a", testing::getPathToSources() + "/precice/tests/aitken-acceleration.xml", 0, 1);
-  } catch (std::exception) { // this should be a preCICE exception type!
+    precice::SolverInterface s("a", testing::getPathToSources() + "/precice/tests/config-checker.xml", 0, 1);
+  } catch (::precice::Error) { // this should be a preCICE exception type!
     allFine = true;
   }
   BOOST_TEST(allFine);
@@ -34,9 +36,10 @@ BOOST_AUTO_TEST_CASE(WrongParticipant)
 
 BOOST_AUTO_TEST_CASE(FinalizeTwice)
 {
-  precice::SolverInterface s("A", testing::getPathToSources() + "/precice/tests/aitken-acceleration.xml", 0, 1);
+  PRECICE_TEST(1_rank);
+  precice::SolverInterface s("SolverOne", testing::getPathToSources() + "/precice/tests/config-checker.xml", 0, 1);
   s.finalize();
-  BOOST_REQUIRE_THROW(s.finalize(), std::exception); // this should be a preCICE exception type!
+  BOOST_REQUIRE_THROW(s.finalize(), ::precice::Error); // this should be a preCICE exception type!
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -245,6 +245,7 @@ target_sources(preciceCore
     src/precice/config/SharedPointer.hpp
     src/precice/config/SolverInterfaceConfiguration.cpp
     src/precice/config/SolverInterfaceConfiguration.hpp
+    src/precice/exceptions.hpp
     src/precice/impl/CommonErrorMessages.hpp
     src/precice/impl/DataContext.cpp
     src/precice/impl/DataContext.hpp
@@ -335,5 +336,6 @@ set_property(TARGET precice PROPERTY PUBLIC_HEADER
     ${CMAKE_BINARY_DIR}/src/precice/Version.h
     src/precice/SolverInterface.hpp
     src/precice/Tooling.hpp
+    src/precice/exceptions.hpp
     src/precice/types.hpp
     )

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -8,6 +8,7 @@
 
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
+#include "precice/exceptions.hpp"
 #include "testing/Testing.hpp"
 #include "utils/assertion.hpp"
 
@@ -18,6 +19,7 @@ std::string getPathToRepository()
   precice::logging::Logger _log("testing");
   char *                   preciceRoot = std::getenv("PRECICE_ROOT");
   PRECICE_CHECK(preciceRoot != nullptr,
+                ::precice::APIError,
                 "Environment variable PRECICE_ROOT is required to run the tests, but has not been set. Please set it to the root directory of the precice repository.");
 
   // Cleanup the path by canonicalising it.

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -63,6 +63,7 @@ target_sources(testprecice
     src/partition/tests/fixtures.hpp
     src/precice/tests/DataContextTest.cpp
     src/precice/tests/ParallelTests.cpp
+    src/precice/tests/TestSolverInterface.cpp
     src/precice/tests/ToolingTests.cpp
     src/precice/tests/VersioningTests.cpp
     src/precice/tests/WatchIntegralTest.cpp

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -125,7 +125,8 @@ ConfigParser::ConfigParser(const std::string &filePath, const ConfigurationConte
   try {
     connectTags(context, DefTags, SubTags);
   } catch (const std::exception &e) {
-    PRECICE_ERROR("An unexpected exception occurred during configuration: {}.", e.what());
+    PRECICE_ERROR(::precice::ConfigurationError,
+                  "An unexpected exception occurred during configuration: {}.", e.what());
   }
 }
 
@@ -139,7 +140,8 @@ void ConfigParser::MessageProxy(int level, const std::string &mess)
   switch (level) {
   case (XML_ERR_FATAL):
   case (XML_ERR_ERROR):
-    PRECICE_ERROR(mess);
+    PRECICE_ERROR(::precice::ConfigurationError,
+                  mess);
     break;
   case (XML_ERR_WARNING):
     PRECICE_WARN(mess);
@@ -164,7 +166,8 @@ int ConfigParser::readXmlFile(std::string const &filePath)
   SAXHandler.fatalError     = OnFatalErrorFunc;
 
   std::ifstream ifs(filePath);
-  PRECICE_CHECK(ifs, "XML parser was unable to open configuration file \"{}\"", filePath);
+  PRECICE_CHECK(ifs,
+                ::precice::ConfigurationError, "XML parser was unable to open configuration file \"{}\"", filePath);
 
   std::string content{std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>()};
 
@@ -221,9 +224,11 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 
       auto matches = utils::computeMatches(expectedName, names);
       if (matches.front().distance < 3) {
-        PRECICE_ERROR("The configuration contains an unknown tag <{}>. Did you mean <{}>?", expectedName, matches.front().name);
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      "The configuration contains an unknown tag <{}>. Did you mean <{}>?", expectedName, matches.front().name);
       } else {
-        PRECICE_ERROR("The configuration contains an unknown tag <{}>. Expected tags are {}.", expectedName, fmt::join(names, ", "));
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      "The configuration contains an unknown tag <{}>. Expected tags are {}.", expectedName, fmt::join(names, ", "));
       }
     }
 
@@ -232,7 +237,8 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 
     if ((pDefSubTag->_occurrence == XMLTag::OCCUR_ONCE) || (pDefSubTag->_occurrence == XMLTag::OCCUR_NOT_OR_ONCE)) {
       if (usedTags.count(pDefSubTag->_fullName)) {
-        PRECICE_ERROR("Tag <{}> is not allowed to occur multiple times.", pDefSubTag->_fullName);
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      "Tag <{}> is not allowed to occur multiple times.", pDefSubTag->_fullName);
       }
       usedTags.emplace(pDefSubTag->_fullName);
     }

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -160,14 +160,16 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(const std::map<std::string, std::strin
   const auto position = aAttributes.find(getName());
   if (position == aAttributes.end()) {
     if (not _hasDefaultValue) {
-      PRECICE_ERROR("Attribute \"{}\" is required, but was not defined.", _name);
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "Attribute \"{}\" is required, but was not defined.", _name);
     }
     set(_value, _defaultValue);
   } else {
     try {
       readValueSpecific(position->second, _value);
     } catch (const std::exception &e) {
-      PRECICE_ERROR(e.what());
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    e.what());
     }
     if (_hasValidation) {
       if (std::find(_options.begin(), _options.end(), _value) == _options.end()) {
@@ -183,7 +185,8 @@ void XMLAttribute<ATTRIBUTE_T>::readValue(const std::map<std::string, std::strin
           stream << " or value must be \"" << *first << '"';
         }
 
-        PRECICE_ERROR(stream.str());
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      stream.str());
       }
     }
   }

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -177,6 +177,7 @@ Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name, 
   PRECICE_ASSERT(iter != _eigenVectorXdAttributes.end());
   const auto size = iter->second.getValue().size();
   PRECICE_CHECK(size == dimensions,
+                ::precice::ConfigurationError,
                 "Vector attribute \"{}\" of tag <{}> is {}D, "
                 "which does not match the dimension of the {}D solver-interface.",
                 name, getFullName(), size, dimensions);
@@ -202,13 +203,16 @@ void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttribute
       // check existing hints
       if (auto pos = _attributeHints.find(name);
           pos != _attributeHints.end()) {
-        PRECICE_ERROR("The tag <{}> in the configuration contains the attribute \"{}\". {}", _fullName, name, pos->second);
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      "The tag <{}> in the configuration contains the attribute \"{}\". {}", _fullName, name, pos->second);
       }
       auto matches = utils::computeMatches(name, _attributes);
       if (matches.front().distance < 3) {
-        PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, matches.front().name);
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      "The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, matches.front().name);
       }
-      PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Expected attributes are {}.", _fullName, name, fmt::join(_attributes, ", "));
+      PRECICE_ERROR(::precice::ConfigurationError,
+                    "The tag <{}> in the configuration contains an unknown attribute \"{}\". Expected attributes are {}.", _fullName, name, fmt::join(_attributes, ", "));
     }
   }
 
@@ -328,9 +332,11 @@ void XMLTag::areAllSubtagsConfigured() const
     if ((not configured) && (occurOnce || occurOnceOrMore)) {
 
       if (tag->getNamespace().empty()) {
-        PRECICE_ERROR("Tag <{}> was not found but is required to occur at least once.", tag->getName());
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      "Tag <{}> was not found but is required to occur at least once.", tag->getName());
       } else {
-        PRECICE_ERROR("Tag <{}:... > was not found but is required to occur at least once.", tag->getNamespace());
+        PRECICE_ERROR(::precice::ConfigurationError,
+                      "Tag <{}:... > was not found but is required to occur at least once.", tag->getNamespace());
       }
     }
   }


### PR DESCRIPTION
## Main changes of this PR

This PR 
* adds an exception hierarchy.
* extends `PRECICE_ERROR(precice::APIError, "Oh no!")` to take an exception type first.
* migrates all error calls to exceptions
* catches exceptions and aborts in the C and Fortran bindings

## Motivation and additional information

This allows us to test failing cases.

Closes #280
Closes #1189

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
