### PR TITLE
Add workflow to build precice/precice:develop

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -1,0 +1,27 @@
+name: Develop image
+# Builds the nightly precice/precice:develop image
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  dockerfile:
+    name: "Develop docker "
+    runs-on: ubuntu-latest
+    env:
+        docker_username: precice
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.docker_username }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Dockerfile
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          file: "./tools/releasing/packaging/develop/Dockerfile"
+          tags: ${{ env.docker_username }}/precice:develop

--- a/tools/releasing/packaging/develop/Dockerfile
+++ b/tools/releasing/packaging/develop/Dockerfile
@@ -1,0 +1,9 @@
+# Dockerfile to build a ubuntu image containing the installed develop
+
+FROM precice/ci-ubuntu-2204
+RUN git clone --depth=1 --branch=develop https://github.com/precice/precice.git precice-build && \
+    cd precice-build && \
+    cmake -DBUILD_TESTING=OFF . && \
+    make -j $(nproc) install && \
+    cd .. && \
+    rm -r precice-build

--- a/tools/releasing/packaging/develop/README.md
+++ b/tools/releasing/packaging/develop/README.md
@@ -1,0 +1,9 @@
+# preCICE develop Dockerfile
+
+The point of this dockerfile is to build a Ubuntu-based test distribution of the current preCICE develop.
+
+Use the following to build the image locally:
+```
+cd tools/releasing/packaging/develop/
+docker build -t precice/precice:develop .
+```


### PR DESCRIPTION
## Main changes of this PR

This PR adds a workflow which builds a nightly version of `precice/precice:develop`.
The workflow can also be triggered manually

## Motivation and additional information

We need a solution to test bindings now

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
