### PR TITLE
Replace PRECICE_ROOT with CMake configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ CMakeFiles
 Makefile
 src/precice/impl/versions.hpp
 src/precice/Version.h
+src/testing/SourceLocation.hpp
 .idea
 CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 include(GenerateVersionInformation)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/DetectGitRevision.cmake)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp" @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/src/testing/SourceLocation.hpp.in" "${PROJECT_BINARY_DIR}/src/testing/SourceLocation.hpp" @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
 
 # Setup export header

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -59,7 +59,7 @@ function(add_precice_test)
     PROPERTIES
     RUN_SERIAL TRUE # Do not run this test in parallel with others
     WORKING_DIRECTORY "${PAT_WDIR}"
-    ENVIRONMENT "PRECICE_ROOT=${preCICE_SOURCE_DIR};OMPI_MCA_rmaps_base_oversubscribe=1"
+    ENVIRONMENT "OMPI_MCA_rmaps_base_oversubscribe=1"
     )
   if(PAT_TIMEOUT)
     set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PAT_TIMEOUT} )

--- a/src/testing/SourceLocation.hpp.in
+++ b/src/testing/SourceLocation.hpp.in
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace precice::testing {
+const char *SourceLocation = "@preCICE_SOURCE_DIR@";
+}

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -8,6 +8,7 @@
 
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
+#include "testing/SourceLocation.hpp"
 #include "testing/Testing.hpp"
 #include "utils/assertion.hpp"
 
@@ -16,13 +17,7 @@ namespace precice::testing {
 std::string getPathToRepository()
 {
   precice::logging::Logger _log("testing");
-  char *                   preciceRoot = std::getenv("PRECICE_ROOT");
-  PRECICE_CHECK(preciceRoot != nullptr,
-                "Environment variable PRECICE_ROOT is required to run the tests, but has not been set. Please set it to the root directory of the precice repository.");
-
-  // Cleanup the path by canonicalising it.
-  boost::filesystem::path root(preciceRoot);
-  return boost::filesystem::weakly_canonical(root).string();
+  return precice::testing::SourceLocation;
 }
 
 std::string getPathToSources()

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -118,7 +118,7 @@ typename std::enable_if<std::is_arithmetic<Scalar>::value, boost::test_tools::pr
   return true;
 }
 
-/// Returns $PRECICE_ROOT, the base path of the repo.
+/// Returns the base path of the repo.
 std::string getPathToRepository();
 
 /// Returns the base path to the sources.


### PR DESCRIPTION
## Main changes of this PR

This PR replaces the need for setting `PRECICE_ROOT` prior to running the tests with a header file configured by CMake.

## Motivation and additional information

Simplifies integration in #1502 and removes the need set `PRECICE_ROOT` when manually running the tests via mpirun.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
