### PR TITLE
Print all reasonable tag hints instead of only the first

### DIFF
--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -221,7 +221,10 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 
       auto matches = utils::computeMatches(expectedName, names);
       if (matches.front().distance < 3) {
-        PRECICE_ERROR("The configuration contains an unknown tag <{}>. Did you mean <{}>?", expectedName, matches.front().name);
+        matches.erase(std::remove_if(matches.begin(), matches.end(), [](auto &m) { return m.distance > 2; }), matches.end());
+        std::vector<std::string> stringMatches;
+        std::transform(matches.begin(), matches.end(), std::back_inserter(stringMatches), [](auto &m) { return m.name; });
+        PRECICE_ERROR("The configuration contains an unknown tag <{}>. Did you mean <{}>?", expectedName, fmt::join(stringMatches, ">,<"));
       } else {
         PRECICE_ERROR("The configuration contains an unknown tag <{}>. Expected tags are {}.", expectedName, fmt::join(names, ", "));
       }

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -204,9 +204,13 @@ void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttribute
           pos != _attributeHints.end()) {
         PRECICE_ERROR("The tag <{}> in the configuration contains the attribute \"{}\". {}", _fullName, name, pos->second);
       }
+
       auto matches = utils::computeMatches(name, _attributes);
       if (matches.front().distance < 3) {
-        PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, matches.front().name);
+        matches.erase(std::remove_if(matches.begin(), matches.end(), [](auto &m) { return m.distance > 2; }), matches.end());
+        std::vector<std::string> stringMatches;
+        std::transform(matches.begin(), matches.end(), std::back_inserter(stringMatches), [](auto &m) { return m.name; });
+        PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, fmt::join(stringMatches, ", "));
       }
       PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Expected attributes are {}.", _fullName, name, fmt::join(_attributes, ", "));
     }


### PR DESCRIPTION
## Main changes of this PR

Prints all tag hints instead of only the first.

## Motivation and additional information

Which turns something like this:

```bash
ERROR: The configuration contains an unknown tag <basis-function:compact-polynomial-c3>. Did you mean <basis-function:compact-polynomial-c0>?
```
 into 

```bash
ERROR: The configuration contains an unknown tag <basis-function:compact-polynomial-c3>. Did you mean <basis-function:compact-polynomial-c0>,<basis-function:compact-polynomial-c2>,<basis-function:compact-polynomial-c4>,<basis-function:compact-polynomial-c6>?
```

I don't like the first version, because it looks as if we only have the `c0` function, but we have more (better) ones.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
