### PR TITLE
Disable copy-constructor for ReadDataContext and WriteDataContext.

### DIFF
--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -314,8 +314,8 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
         const auto second = _config.participants[1];
 
         auto first_participant = _participantConfig->getParticipant(first);
-        for (auto &dataContext : first_participant->readDataContexts()) {
-          int usedOrder = dataContext.getInterpolationOrder();
+        for (const auto &dataContext : first_participant->readDataContexts()) {
+          const int usedOrder = dataContext.getInterpolationOrder();
           // The first participants waveform order has to be 0 for serial explicit coupling
           int allowedOrder = 0;
           if (usedOrder != allowedOrder) {
@@ -325,8 +325,8 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
           }
         }
         auto second_participant = _participantConfig->getParticipant(second);
-        for (auto &dataContext : second_participant->readDataContexts()) {
-          int usedOrder = dataContext.getInterpolationOrder();
+        for (const auto &dataContext : second_participant->readDataContexts()) {
+          const int usedOrder = dataContext.getInterpolationOrder();
           if (usedOrder < 0) {
             PRECICE_ERROR(
                 "You configured <read-data name=\"{}\" mesh=\"{}\" waveform-order=\"{}\" />, but for the serial explicit coupling scheme the waveform-order must be non-negative for the second participant.",
@@ -1077,8 +1077,8 @@ void CouplingSchemeConfiguration::checkWaveformOrderReadData(
     int maxAllowedOrder) const
 {
   for (const precice::impl::PtrParticipant &participant : _participantConfig->getParticipants()) {
-    for (auto &dataContext : participant->readDataContexts()) {
-      int usedOrder = dataContext.getInterpolationOrder();
+    for (const auto &dataContext : participant->readDataContexts()) {
+      const int usedOrder = dataContext.getInterpolationOrder();
       PRECICE_ASSERT(usedOrder >= 0); // ensure that usedOrder was set
       if (usedOrder > maxAllowedOrder) {
         PRECICE_ERROR(

--- a/src/precice/impl/Participant.hpp
+++ b/src/precice/impl/Participant.hpp
@@ -184,7 +184,7 @@ public:
   int maxReadWaveformOrder() const
   {
     int maxOrder = -1;
-    for (auto &context : _readDataContexts | boost::adaptors::map_values) {
+    for (const auto &context : _readDataContexts | boost::adaptors::map_values) {
       maxOrder = std::max(maxOrder, context.getInterpolationOrder());
     }
     return maxOrder;

--- a/src/precice/impl/ReadDataContext.hpp
+++ b/src/precice/impl/ReadDataContext.hpp
@@ -70,6 +70,16 @@ public:
    */
   void storeDataInWaveform();
 
+  /// Disable copy construction
+  ReadDataContext(const ReadDataContext &copy) = delete;
+
+  /// Disable assignment construction
+  ReadDataContext &operator=(const ReadDataContext &assign) = delete;
+
+  /// Move constructor, use the implicitly declared.
+  ReadDataContext(ReadDataContext &&) = default;
+  ReadDataContext &operator=(ReadDataContext &&) = default;
+
 private:
   static logging::Logger _log;
 

--- a/src/precice/impl/WriteDataContext.hpp
+++ b/src/precice/impl/WriteDataContext.hpp
@@ -42,6 +42,16 @@ public:
    */
   void appendMappingConfiguration(MappingContext &mappingContext, const MeshContext &meshContext) override;
 
+  /// Disable copy construction
+  WriteDataContext(const WriteDataContext &copy) = delete;
+
+  /// Disable assignment construction
+  WriteDataContext &operator=(const WriteDataContext &assign) = delete;
+
+  /// Move constructor, use the implicitly declared.
+  WriteDataContext(WriteDataContext &&) = default;
+  WriteDataContext &operator=(WriteDataContext &&) = default;
+
 private:
   static logging::Logger _log;
 };


### PR DESCRIPTION
## Main changes of this PR

Disables copy-constructor for `ReadDataContext` and `WriteDataContext`.

## Motivation and additional information

Helps to avoid accidentally copying a `DataContext` in a loop.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
