### PR TITLE
Fix directories when used as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,7 +391,7 @@ GENERATE_EXPORT_HEADER(preciceCore
 
 # Add the export header to the public headers of the preCICE lib
 set_property(TARGET precice APPEND PROPERTY PUBLIC_HEADER
-    ${CMAKE_BINARY_DIR}/src/precice/export.h)
+    ${PROJECT_BINARY_DIR}/src/precice/export.h)
 
 #
 # Configuration of Target precice-tools

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -382,17 +382,17 @@ if(PRECICE_BUILD_TOOLS)
 
   add_tools_test(
     NAME check.file
-    COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml
+    COMMAND precice-tools check ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml
     )
 
   add_tools_test(
     NAME check.file+name
-    COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo
+    COMMAND precice-tools check ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo
     )
 
   add_tools_test(
     NAME check.file+name+size
-    COMMAND precice-tools check ${CMAKE_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
+    COMMAND precice-tools check ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
     )
 endif()
 

--- a/cmake/PrintHelper.cmake
+++ b/cmake/PrintHelper.cmake
@@ -58,8 +58,8 @@ function(print_configuration)
     "CMAKE_CXX_FLAGS;CXX compiler flags"
     "CMAKE_LINKER;CXX linker"
     "CMAKE_INSTALL_PREFIX;Install prefix"
-    "CMAKE_SOURCE_DIR;Source directory"
-    "CMAKE_BINARY_DIR;Binary directory"
+    "PROJECT_SOURCE_DIR;Source directory"
+    "PROJECT_BINARY_DIR;Binary directory"
     )
   if(PRINT_CONFIG_ADDITIONAL)
     print_variables(VARS ${PRINT_CONFIG_ADDITIONAL})

--- a/cmake/cmake_refresh_git_revision.cmake
+++ b/cmake/cmake_refresh_git_revision.cmake
@@ -32,7 +32,7 @@ set(preCICE_REVISION "no-info [git failed to run]")
 
 if(("${PRECICE_REVISION_RET}" EQUAL "0") AND ("${PRECICE_REPO_RET}" EQUAL "0"))
   file(TO_CMAKE_PATH "${PRECICE_REPO_OUT}" _detected_path)
-  if("${CMAKE_SOURCE_DIR}" STREQUAL "${_detected_path}")
+  if("${PROJECT_SOURCE_DIR}" STREQUAL "${_detected_path}")
     set(preCICE_REVISION "${PRECICE_REVISION_OUT}")
     message(STATUS "Revision status: ${preCICE_REVISION}")
   else()

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -4,12 +4,12 @@
 #
 
 
-if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
-  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt
+if(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @PROJECT_BINARY_DIR@/install_manifest.txt
   It seems as the project has not been installed yet.")
-endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
 
-file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+file(READ "@PROJECT_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")

--- a/docs/changelog/1615.md
+++ b/docs/changelog/1615.md
@@ -1,0 +1,1 @@
+- Added support to include preCICE as CMake subproject.

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -4,8 +4,8 @@
 
 target_sources(preciceCore
     PRIVATE
-    ${CMAKE_BINARY_DIR}/src/precice/impl/versions.cpp
-    ${CMAKE_BINARY_DIR}/src/precice/impl/versions.hpp
+    ${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp
+    ${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp
     src/acceleration/Acceleration.cpp
     src/acceleration/Acceleration.hpp
     src/acceleration/AitkenAcceleration.cpp
@@ -335,7 +335,7 @@ target_sources(preciceCore
 #
 
 set_property(TARGET precice PROPERTY PUBLIC_HEADER
-    ${CMAKE_BINARY_DIR}/src/precice/Version.h
+    ${PROJECT_BINARY_DIR}/src/precice/Version.h
     src/precice/SolverInterface.hpp
     src/precice/Tooling.hpp
     src/precice/types.hpp

--- a/tools/building/updateSourceFiles.py
+++ b/tools/building/updateSourceFiles.py
@@ -11,10 +11,10 @@ import pathlib
 IGNORE_PATTERNS = ["drivers"]
 
 """ Configured files, which should be ignored by git, yet installed by CMake"""
-CONFIGURED_PUBLIC = ["${CMAKE_BINARY_DIR}/src/precice/Version.h"]
+CONFIGURED_PUBLIC = ["${PROJECT_BINARY_DIR}/src/precice/Version.h"]
 
 """ Configured files, which should be ignored by git """
-CONFIGURED_SOURCES = ["${CMAKE_BINARY_DIR}/src/precice/impl/versions.hpp", "${CMAKE_BINARY_DIR}/src/precice/impl/versions.cpp"]
+CONFIGURED_SOURCES = ["${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp", "${CMAKE_BINARY_DIR}/src/precice/impl/versions.cpp"]
 
 
 def get_gitfiles():


### PR DESCRIPTION
## Main changes of this PR

This PR changes the CMAKE_SOURCE/BINARY_DIR to PROJECT_SOURCE/BINARY_DIR, which allows the project to compile correctly when used as a CMake subproject.


## Motivation and additional information

Closes #1613

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
