### PR TITLE
Map rbf alias tag onto PUM mapping

### DIFF
--- a/docs/changelog/1616.md
+++ b/docs/changelog/1616.md
@@ -1,0 +1,1 @@
+- Changed rbf alias mapping configuration to map to `rbf-pum-direct` instead of `rbf-global-...`.

--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -121,5 +121,9 @@ void LinearCellInterpolationMapping::computeMapping()
   _hasComputedMapping = true;
 }
 
+std::string LinearCellInterpolationMapping::getName() const
+{
+  return "linear-cell interpolation";
+}
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/LinearCellInterpolationMapping.hpp
+++ b/src/mapping/LinearCellInterpolationMapping.hpp
@@ -18,6 +18,9 @@ public:
   /// Computes the projections and interpolation relations.
   void computeMapping() final override;
 
+  /// name of the lci mapping
+  std::string getName() const final override;
+
 private:
   logging::Logger _log{"mapping::LinearCellInterpolationMappingMapping"};
 };

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -127,6 +127,9 @@ public:
   /// Returns whether the mapping requires gradient data
   bool requiresGradientData() const;
 
+  /// Returns the name of the mapping method for logging purpose
+  virtual std::string getName() const = 0;
+
 protected:
   /// Returns pointer to input mesh.
   mesh::PtrMesh input() const;

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -93,8 +93,12 @@ void NearestNeighborGradientMapping::mapConsistent(DataID inputDataID, DataID ou
 
 void NearestNeighborGradientMapping::mapConservative(DataID /*inputDataID*/, DataID /*outputDataID*/)
 {
-  PRECICE_ASSERT(false, "Not implemented.")
+  PRECICE_ASSERT(false, "Not implemented.");
 }
 
+std::string NearestNeighborGradientMapping::getName() const
+{
+  return "nearest-neighbor-gradient";
+}
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/NearestNeighborGradientMapping.hpp
+++ b/src/mapping/NearestNeighborGradientMapping.hpp
@@ -22,6 +22,9 @@ public:
   /// Calculates the offsets needed for the gradient mappings after calculating the matched vertices
   void onMappingComputed(mesh::PtrMesh origins, mesh::PtrMesh searchSpace) final override;
 
+  /// name of the nng mapping
+  std::string getName() const final override;
+
 protected:
   /// @copydoc Mapping::mapConservative
   void mapConservative(DataID inputDataID, DataID outputDataID) final override;

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -82,5 +82,9 @@ void NearestNeighborMapping::mapConsistent(DataID inputDataID, DataID outputData
   PRECICE_DEBUG("Mapped values = {}", utils::previewRange(3, outputValues));
 }
 
+std::string NearestNeighborMapping::getName() const
+{
+  return "nearest-neighbor";
+}
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/NearestNeighborMapping.hpp
+++ b/src/mapping/NearestNeighborMapping.hpp
@@ -19,6 +19,9 @@ public:
    */
   NearestNeighborMapping(Constraint constraint, int dimensions);
 
+  /// name of the nn mapping
+  std::string getName() const final override;
+
 protected:
   /// @copydoc Mapping::mapConservative
   void mapConservative(DataID inputDataID, DataID outputDataID) final override;

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -107,5 +107,9 @@ void NearestProjectionMapping::computeMapping()
   _hasComputedMapping = true;
 }
 
+std::string NearestProjectionMapping::getName() const
+{
+  return "nearest-projection";
+}
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -19,6 +19,9 @@ public:
   /// Computes the projections and interpolation relations.
   void computeMapping() final override;
 
+  /// name of the np mapping
+  std::string getName() const final override;
+
 private:
   logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};
 };

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -401,5 +401,11 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::clear()
   _clusterRadius            = 0;
   this->_hasComputedMapping = false;
 }
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+std::string PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::getName() const
+{
+  return "partition of unity rbf";
+}
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -405,7 +405,7 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::clear()
 template <typename RADIAL_BASIS_FUNCTION_T>
 std::string PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::getName() const
 {
-  return "partition of unity rbf";
+  return "partition-of-unity RBF";
 }
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -195,7 +195,7 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     }
   }
   // Log the average number of resulting clusters
-  PRECICE_INFO("Partition of unity data mapping between mesh \"{}\" and mesh \"{}\": mesh \"{}\" on rank {} was decomposed into {} clusters.", this->input()->getName(), this->output()->getName(), inMesh->getName(), utils::IntraComm::getRank(), _clusters.size());
+  PRECICE_DEBUG("Partition of unity data mapping between mesh \"{}\" and mesh \"{}\": mesh \"{}\" on rank {} was decomposed into {} clusters.", this->input()->getName(), this->output()->getName(), inMesh->getName(), utils::IntraComm::getRank(), _clusters.size());
 
   if (_clusters.size() > 0) {
     PRECICE_DEBUG("Average number of vertices per cluster {}", std::accumulate(_clusters.begin(), _clusters.end(), static_cast<unsigned int>(0), [](auto &acc, auto &val) { return acc += val.getNumberOfInputVertices(); }) / _clusters.size());

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -62,16 +62,19 @@ public:
    * In debug mode, the function also exports the partition centers as a separate mesh for visualization
    * purpose.
    */
-  virtual void computeMapping() override;
+  void computeMapping() final override;
 
   /// Clears a computed mapping by deleting the content of the \p _clusters vector.
-  virtual void clear() override;
+  void clear() final override;
 
   /// tag the vertices required for the mapping
-  virtual void tagMeshFirstRound() override;
+  void tagMeshFirstRound() final override;
 
   /// nothing to do here
-  virtual void tagMeshSecondRound() override;
+  void tagMeshSecondRound() final override;
+
+  /// name of the pum mapping
+  std::string getName() const final override;
 
 private:
   /// logger, as usual

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -78,6 +78,9 @@ public:
   /// Removes a computed mapping.
   void clear() final override;
 
+  /// name of the rbf mapping
+  std::string getName() const final override;
+
   friend struct MappingTests::PetRadialBasisFunctionMapping::Serial::SolutionCaching;
 
 private:
@@ -582,6 +585,12 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::clear()
 
   previousSolution.clear();
   this->_hasComputedMapping = false;
+}
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+std::string PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::getName() const
+{
+  return "rbf global iterative";
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -590,7 +590,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::clear()
 template <typename RADIAL_BASIS_FUNCTION_T>
 std::string PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::getName() const
 {
-  return "rbf global iterative";
+  return "global-iterative RBF";
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -53,6 +53,9 @@ public:
   /// Removes a computed mapping.
   void clear() final override;
 
+  /// name of the rbf mapping
+  std::string getName() const final override;
+
 private:
   precice::logging::Logger _log{"mapping::RadialBasisFctMapping"};
 
@@ -158,6 +161,12 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::clear()
   PRECICE_TRACE();
   _rbfSolver.clear();
   this->_hasComputedMapping = false;
+}
+
+template <typename RADIAL_BASIS_FUNCTION_T>
+std::string RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::getName() const
+{
+  return "rbf global direct";
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -166,7 +166,7 @@ void RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::clear()
 template <typename RADIAL_BASIS_FUNCTION_T>
 std::string RadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::getName() const
 {
-  return "rbf global direct";
+  return "global-direct RBF";
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -327,7 +327,7 @@ void MappingConfiguration::xmlTagCallback(
 
     ConfiguredMapping configuredMapping = createMapping(dir, type, fromMesh, toMesh);
 
-    _rbfConfig = configureRBFMapping(type, context, strPolynomial, strPrealloc, xDead, yDead, zDead, solverRtol, verticesPerCluster, relativeOverlap, projectToInput);
+    _rbfConfig = configureRBFMapping(type, strPolynomial, strPrealloc, xDead, yDead, zDead, solverRtol, verticesPerCluster, relativeOverlap, projectToInput);
 
     checkDuplicates(configuredMapping);
     _mappings.push_back(configuredMapping);
@@ -381,10 +381,9 @@ void MappingConfiguration::xmlTagCallback(
   }
 }
 
-MappingConfiguration::RBFConfiguration MappingConfiguration::configureRBFMapping(const std::string &              type,
-                                                                                 const xml::ConfigurationContext &context,
-                                                                                 const std::string &              polynomial,
-                                                                                 const std::string &              preallocation,
+MappingConfiguration::RBFConfiguration MappingConfiguration::configureRBFMapping(const std::string &type,
+                                                                                 const std::string &polynomial,
+                                                                                 const std::string &preallocation,
                                                                                  bool xDead, bool yDead, bool zDead,
                                                                                  double solverRtol,
                                                                                  double verticesPerCluster,

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -489,7 +489,8 @@ MappingConfiguration::ConfiguredMapping MappingConfiguration::createMapping(
   } else {
     // We need knowledge about the basis function in order to instantiate the rbf related mapping
     PRECICE_ASSERT(requiresBasisFunction(type));
-    configuredMapping.mapping = nullptr;
+    configuredMapping.mapping                = nullptr;
+    configuredMapping.configuredWithAliasTag = type == TYPE_RBF_ALIAS;
   }
 
   configuredMapping.requiresBasisFunction = requiresBasisFunction(type);

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -401,20 +401,12 @@ MappingConfiguration::RBFConfiguration MappingConfiguration::configureRBFMapping
   else if (type == TYPE_RBF_PUM_DIRECT)
     rbfConfig.solver = RBFConfiguration::SystemSolver::PUMDirect;
   else {
-    // Rather simple auto-selection (for now)
-    // The default is the Eigen backend, as it is always available. Only in certain situations, we will decide for the PETSc backend
-    rbfConfig.solver = RBFConfiguration::SystemSolver::GlobalDirect;
+    // Rather simple auto-selection (for now), consisting of the PUM Eigen backend
+    rbfConfig.solver = RBFConfiguration::SystemSolver::PUMDirect;
 
-#ifndef PRECICE_NO_PETSC
-    // Running in serial, the Eigen backend will most likely be the fastest and most accurate variant
-    // We decide for the PETSc variant only if we have a lot of interface vertices and a lot of ranks
     // A more sophisticated criterion here could take the globalNumberOfVertices into account
     // (the mesh pointer is stored in the configuredMapping anyway), but this quantity is not yet computed
     // during the configuration time.
-    if (context.size > 16) {
-      rbfConfig.solver = RBFConfiguration::SystemSolver::GlobalIterative;
-    }
-#endif
   }
 
   if (polynomial == POLYNOMIAL_SEPARATE)

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -335,7 +335,9 @@ void MappingConfiguration::xmlTagCallback(
 
     PRECICE_ASSERT(!_mappings.empty());
     // We can only set one subtag
-    PRECICE_CHECK(_mappings.back().mapping == nullptr, "More than one basis-function was defined for the.");
+    PRECICE_CHECK(_mappings.back().mapping == nullptr, "More than one basis-function was defined for the mapping "
+                                                       "from mesh \"{}\" to mesh \"{}\".",
+                  _mappings.back().fromMesh->getName(), _mappings.back().toMesh->getName());
 
     std::string basisFctName   = tag.getName();
     double      supportRadius  = tag.getDoubleAttributeValue(ATTR_SUPPORT_RADIUS, 0.);

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -32,6 +32,8 @@ public:
     Direction direction;
     /// true for RBF mapping
     bool requiresBasisFunction;
+    /// used the automatic rbf alias tag in order to set the mapping
+    bool configuredWithAliasTag = false;
   };
 
   MappingConfiguration(

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -200,10 +200,9 @@ private:
  * the other mapping types. The information is then used later when instantiating
  * the RBF mappings in \ref xmlTagCallback().
  */
-  RBFConfiguration configureRBFMapping(const std::string &              type,
-                                       const xml::ConfigurationContext &context,
-                                       const std::string &              polynomial,
-                                       const std::string &              preallocation,
+  RBFConfiguration configureRBFMapping(const std::string &type,
+                                       const std::string &polynomial,
+                                       const std::string &preallocation,
                                        bool xDead, bool yDead, bool zDead,
                                        double solverRtol,
                                        double verticesPerCluster,

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -341,7 +341,7 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   // Step 2: Now we pick random samples from the input mesh and ask the index tree for the k-nearest neighbors
   // in order to estimate the point density and determine a proper cluster radius (see also the function documentation)
   double clusterRadius = estimateClusterRadius(verticesPerCluster, inMesh, localBB);
-  PRECICE_DEBUG("VertexCluster Radius: {}", clusterRadius);
+  PRECICE_DEBUG("Vertex cluster radius: {}", clusterRadius);
 
   // maximum distance between cluster centers lying diagonal to each other. The maximum distance takes the overlap condition into
   // account: if the distance between the centers is sqrt(2) * radius, we violate the overlap condition between diagonal clusters

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -341,7 +341,7 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   // Step 2: Now we pick random samples from the input mesh and ask the index tree for the k-nearest neighbors
   // in order to estimate the point density and determine a proper cluster radius (see also the function documentation)
   double clusterRadius = estimateClusterRadius(verticesPerCluster, inMesh, localBB);
-  PRECICE_INFO("VertexCluster Radius: {}", clusterRadius);
+  PRECICE_DEBUG("VertexCluster Radius: {}", clusterRadius);
 
   // maximum distance between cluster centers lying diagonal to each other. The maximum distance takes the overlap condition into
   // account: if the distance between the centers is sqrt(2) * radius, we violate the overlap condition between diagonal clusters

--- a/src/mapping/tests/MappingConfigurationTest.cpp
+++ b/src/mapping/tests/MappingConfigurationTest.cpp
@@ -201,16 +201,16 @@ BOOST_AUTO_TEST_CASE(RBFAliasConfiguration)
   BOOST_TEST(mappingConfig.mappings().at(0).requiresBasisFunction == true);
   {
     // last configured RBF
-    bool solverSelection = mappingConfig.rbfConfig().solver == MappingConfiguration::RBFConfiguration::SystemSolver::GlobalDirect;
+    bool solverSelection = mappingConfig.rbfConfig().solver == MappingConfiguration::RBFConfiguration::SystemSolver::PUMDirect;
     BOOST_TEST(solverSelection);
     bool poly = mappingConfig.rbfConfig().polynomial == Polynomial::SEPARATE;
     BOOST_TEST(poly);
     BOOST_TEST(mappingConfig.rbfConfig().deadAxis[0] == false);
     BOOST_TEST(mappingConfig.rbfConfig().deadAxis[1] == false);
     BOOST_TEST(mappingConfig.rbfConfig().deadAxis[2] == false);
-    BOOST_TEST(mappingConfig.rbfConfig().solverRtol == 1e-9);
-    bool prealloc = mappingConfig.rbfConfig().preallocation == Preallocation::TREE;
-    BOOST_TEST(prealloc);
+    BOOST_TEST(mappingConfig.rbfConfig().verticesPerCluster == 100);
+    BOOST_TEST(mappingConfig.rbfConfig().relativeOverlap == 0.3);
+    BOOST_TEST(mappingConfig.rbfConfig().projectToInput == true);
   }
 }
 

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -498,7 +498,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
     mapping::PtrMapping &map = mappingContext.mapping;
     PRECICE_ASSERT(map.get() == nullptr);
-    map = confMapping.mapping;
+    map                                   = confMapping.mapping;
+    mappingContext.configuredWithAliasTag = confMapping.configuredWithAliasTag;
 
     const mesh::PtrMesh &input  = fromMeshContext.mesh;
     const mesh::PtrMesh &output = toMeshContext.mesh;

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -23,6 +23,9 @@ struct MappingContext {
   /// data which is mapped to mesh
   mesh::PtrData toData = nullptr;
 
+  /// used the automatic rbf alias tag in order to set the mapping
+  bool configuredWithAliasTag = false;
+
   /// Enables gradient data in the corresponding 'from' data class
   void requireGradientData(const std::string &dataName)
   {

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1822,6 +1822,10 @@ void SolverInterfaceImpl::computeMappings(std::vector<MappingContext> &contexts,
   using namespace mapping;
   for (impl::MappingContext &context : contexts) {
     if (not context.mapping->hasComputedMapping()) {
+      if (context.configuredWithAliasTag) {
+        PRECICE_INFO("Automatic RBF mapping alias from mesh \"{}\" to mesh \"{}\" in \"{}\" direction resolves to \"{}\" .",
+                     context.mapping->getInputMesh()->getName(), context.mapping->getOutputMesh()->getName(), mappingType, context.mapping->getName());
+      }
       PRECICE_INFO("Computing \"{}\" mapping from mesh \"{}\" to mesh \"{}\" in \"{}\" direction.",
                    context.mapping->getName(), context.mapping->getInputMesh()->getName(), context.mapping->getOutputMesh()->getName(), mappingType);
       context.mapping->computeMapping();

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1822,8 +1822,8 @@ void SolverInterfaceImpl::computeMappings(std::vector<MappingContext> &contexts,
   using namespace mapping;
   for (impl::MappingContext &context : contexts) {
     if (not context.mapping->hasComputedMapping()) {
-      PRECICE_INFO("Compute \"{}\" mapping from mesh \"{}\" to mesh \"{}\".",
-                   mappingType, context.mapping->getInputMesh()->getName(), context.mapping->getOutputMesh()->getName());
+      PRECICE_INFO("Computing \"{}\" mapping from mesh \"{}\" to mesh \"{}\" in \"{}\" direction.",
+                   context.mapping->getName(), context.mapping->getInputMesh()->getName(), context.mapping->getOutputMesh()->getName(), mappingType);
       context.mapping->computeMapping();
     }
   }


### PR DESCRIPTION
## Main changes of this PR

Let's the `<mapping:rbf ..>` tag resolve to `<mapping:rbf-pum-direct >`.

## Motivation and additional information

See #1608. I ran our perpendicular-flap tutorial and as pointed out in #1608, there are cases, where the global rbf would be faster. However, the overall mapping runtime for these examples was of $\mathcal{O}(1\cdot 10^{-2})$ seconds and negligible compared to the global runtime (<1%).
 
I also cleaned up a few logging information and added the mapping name in the info log, as users often times post the log without the config. Advantage for the users: they can see what happens due to the autoconfig. 
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

Closes #1608 .

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
