### PR TITLE
Update eigen version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if(TPL_ENABLE_EIGEN3)
   # Use EIGEN3_ROOT to set the directory
   xsdk_tpl_require(EIGEN3 EIGEN3_INCLUDE_DIR)
 endif()
-find_package(Eigen3 3.2 REQUIRED)
+find_package(Eigen3 3.3.7 REQUIRED)
 message(STATUS "Found Eigen ${EIGEN3_VERSION}")
 precice_validate_eigen()
 


### PR DESCRIPTION
## Main changes of this PR
Updates the eigen version requirement to match our documentation. I tried to test that it actually fails with older versions. That's, unfortunately, not too easy as older versions do not rely on CMake.
