### PR TITLE
Re-arrange delimiters in log files

### DIFF
--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -35,8 +35,8 @@ void TXTTableWriter::addData(
   if ((type == INT) || (type == DOUBLE)) {
     _outputStream << delimiter << name;
   } else {
+    _outputStream << delimiter << name << 0;
     if (type == VECTOR2D) {
-      _outputStream << delimiter << name << 0;
       for (int i = 1; i < 2; i++) {
         _outputStream << "  " << name << i;
       }

--- a/src/io/TXTTableWriter.cpp
+++ b/src/io/TXTTableWriter.cpp
@@ -30,16 +30,21 @@ void TXTTableWriter::addData(
   data.name = name;
   data.type = type;
   _data.push_back(data);
+
+  std::string delimiter = _data.empty() ? "" : "  ";
   if ((type == INT) || (type == DOUBLE)) {
-    _outputStream << name << "  ";
-  } else if (type == VECTOR2D) {
-    for (int i = 0; i < 2; i++) {
-      _outputStream << name << i << "  ";
-    }
+    _outputStream << delimiter << name;
   } else {
-    PRECICE_ASSERT(type == VECTOR3D);
-    for (int i = 0; i < 3; i++) {
-      _outputStream << name << i << "  ";
+    if (type == VECTOR2D) {
+      _outputStream << delimiter << name << 0;
+      for (int i = 1; i < 2; i++) {
+        _outputStream << "  " << name << i;
+      }
+    } else {
+      PRECICE_ASSERT(type == VECTOR3D);
+      for (int i = 1; i < 3; i++) {
+        _outputStream << "  " << name << i;
+      }
     }
   }
   // Print out everything apart from INT consistently in scientific
@@ -62,7 +67,9 @@ void TXTTableWriter::writeData(
   }
   PRECICE_ASSERT(_writeIterator->name == name, _writeIterator->name, name);
   PRECICE_ASSERT(_writeIterator->type == INT, _writeIterator->type);
-  _outputStream << std::setw(6) << value << "  ";
+
+  std::string delimiter = _writeIterator == _data.begin() ? "" : "  ";
+  _outputStream << delimiter << std::setw(6) << value;
   _writeIterator++;
   if (_writeIterator == _data.end()) {
     _outputStream.flush();
@@ -81,7 +88,9 @@ void TXTTableWriter::writeData(
   }
   PRECICE_ASSERT(_writeIterator->name == name, _writeIterator->name, name);
   PRECICE_ASSERT(_writeIterator->type == DOUBLE, _writeIterator->type);
-  _outputStream << std::setw(15) << value << "  ";
+
+  std::string delimiter = _writeIterator == _data.begin() ? "" : "  ";
+  _outputStream << delimiter << std::setw(15) << value;
   _writeIterator++;
   if (_writeIterator == _data.end()) {
     _outputStream.flush();
@@ -100,8 +109,12 @@ void TXTTableWriter::writeData(
   }
   PRECICE_ASSERT(_writeIterator->name == name, _writeIterator->name, name);
   PRECICE_ASSERT(_writeIterator->type == VECTOR2D, _writeIterator->type);
-  for (int i = 0; i < value.size(); i++) {
-    _outputStream << std::setw(15) << value[i] << "  ";
+
+  std::string delimiter = _writeIterator == _data.begin() ? "" : "  ";
+  _outputStream << delimiter << std::setw(15) << value[0];
+
+  for (int i = 1; i < value.size(); i++) {
+    _outputStream << "  " << std::setw(15) << value[i];
   }
   _writeIterator++;
   if (_writeIterator == _data.end()) {
@@ -121,8 +134,11 @@ void TXTTableWriter::writeData(
   }
   PRECICE_ASSERT(_writeIterator->name == name, _writeIterator->name, name);
   PRECICE_ASSERT(_writeIterator->type == VECTOR3D, _writeIterator->type);
-  for (int i = 0; i < value.size(); i++) {
-    _outputStream << std::setw(15) << value[i] << "  ";
+
+  std::string delimiter = _writeIterator == _data.begin() ? "" : "  ";
+  _outputStream << delimiter << std::setw(15) << value[0];
+  for (int i = 1; i < value.size(); i++) {
+    _outputStream << "  " << std::setw(15) << value[i];
   }
   _writeIterator++;
   if (_writeIterator == _data.end()) {


### PR DESCRIPTION
## Main changes of this PR

Removes the trailing whitespace in the watchpoint, convergence and iterator log files.

## Additional information

working with trailing whitespaces in hit is tedious.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
