### PR TITLE
Change `IDs` in Fortran bindings to `ids`

### DIFF
--- a/docs/changelog/1624.md
+++ b/docs/changelog/1624.md
@@ -1,0 +1,1 @@
+- Fixed the Fortran API to use lowercase `id` in functions setting mesh vertices.

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -734,7 +734,7 @@ PRECICE_API void precicef_set_mesh_access_region_(
 
 /**
  * Fortran syntax:
- * precicef_get_mesh_vertices_and_IDs_(
+ * precicef_get_mesh_vertices_and_ids_(
  *   CHARACTER        meshName(*),
  *   INTEGER          size,
  *   INTEGER          ids(size),
@@ -745,7 +745,7 @@ PRECICE_API void precicef_set_mesh_access_region_(
  *
  * @copydoc precice::SolverInterface::getMeshVerticesAndIDs()
  */
-PRECICE_API void precicef_get_mesh_vertices_and_IDs_(
+PRECICE_API void precicef_get_mesh_vertices_and_ids_(
     const char *meshName,
     const int   size,
     int *       ids,

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -480,7 +480,7 @@ void precicef_set_mesh_access_region_(
   impl->setMeshAccessRegion(precice::impl::strippedStringView(meshName, meshNameLength), boundingBox);
 }
 
-void precicef_get_mesh_vertices_and_IDs_(
+void precicef_get_mesh_vertices_and_ids_(
     const char *meshName,
     const int   size,
     int *       ids,


### PR DESCRIPTION
## Main changes of this PR


## Motivation and additional information

...as that's what we used before (when we had our other ID functions) and that's what our users are used to. See https://precice.discourse.group/t/an-error-occurs-when-i-want-to-access-the-mesh-information-directly/1386/3

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
