### PR TITLE
Add cstring support to span

### DIFF
--- a/src/precice/tests/SpanTests.cpp
+++ b/src/precice/tests/SpanTests.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <string_view>
 
 #include "testing/Testing.hpp"
 #include "utils/span.hpp"
@@ -42,6 +43,17 @@ BOOST_AUTO_TEST_CASE(FromCString)
   const char *     s = "hello there";
   span<const char> const_span{s};
   BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
+}
+
+BOOST_AUTO_TEST_CASE(ToStringView)
+{
+  PRECICE_TEST(1_rank);
+  const char *     s = "hello there";
+  span<const char> const_span{s};
+  std::string_view sv{const_span.data(), const_span.size()};
+
+  BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
+  BOOST_TEST(s == sv);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/SpanTests.cpp
+++ b/src/precice/tests/SpanTests.cpp
@@ -36,5 +36,13 @@ BOOST_AUTO_TEST_CASE(FromString)
   BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
 }
 
+BOOST_AUTO_TEST_CASE(FromCString)
+{
+  PRECICE_TEST(1_rank);
+  const char *     s = "hello there";
+  span<const char> const_span{s};
+  BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/SpanTests.cpp
+++ b/src/precice/tests/SpanTests.cpp
@@ -1,0 +1,40 @@
+#include <string>
+
+#include "testing/Testing.hpp"
+#include "utils/span.hpp"
+
+BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(Span)
+
+using precice::span;
+
+BOOST_AUTO_TEST_CASE(FromDoubleVector)
+{
+  PRECICE_TEST(1_rank);
+  std::vector<double> v{1.0, 2.0, 3.0, 4.0};
+  span<const double>  const_span{v};
+  BOOST_TEST(v == const_span, boost::test_tools::per_element());
+  span<double> mut_span{v};
+  BOOST_TEST(v == mut_span, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(FromIntVector)
+{
+  PRECICE_TEST(1_rank);
+  std::vector<int> v{1, 2, 3, 4};
+  span<const int>  const_span{v};
+  BOOST_TEST(v == const_span, boost::test_tools::per_element());
+  span<int> mut_span{v};
+  BOOST_TEST(v == mut_span, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(FromString)
+{
+  PRECICE_TEST(1_rank);
+  std::string      s = "hello there";
+  span<const char> const_span{s};
+  BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -4,7 +4,7 @@
 
 target_sources(preciceCore
     PRIVATE
-    ${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp
+    ${CMAKE_BINARY_DIR}/src/precice/impl/versions.cpp
     ${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp
     src/acceleration/Acceleration.cpp
     src/acceleration/Acceleration.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -65,6 +65,7 @@ target_sources(testprecice
     src/partition/tests/fixtures.hpp
     src/precice/tests/DataContextTest.cpp
     src/precice/tests/ParallelTests.cpp
+    src/precice/tests/SpanTests.cpp
     src/precice/tests/ToolingTests.cpp
     src/precice/tests/VersioningTests.cpp
     src/precice/tests/WatchIntegralTest.cpp

--- a/src/utils/span.hpp
+++ b/src/utils/span.hpp
@@ -15,6 +15,7 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <type_traits>
 
 #ifndef TCB_SPAN_NO_EXCEPTIONS
@@ -398,6 +399,18 @@ public:
 
     TCB_SPAN_CONSTEXPR_ASSIGN span&
     operator=(const span& other) noexcept = default;
+
+    // Custom span constructor to allow string_view imitation
+    template <
+        std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && std::is_same<pointer, const char*>::value,
+            int>::type = 0>
+    span(pointer cstring)
+        : storage_(cstring, std::strlen(cstring))
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent);
+    }
 
     // [span.sub], span subviews
     template <std::size_t Count>


### PR DESCRIPTION
## Main changes of this PR

This PR adds tests for the span type and a conditional cstring constructor.
This makes `span<const char>` usable as a replacement for `std::string_view`.

## Motivation and additional information

Preparation for tackling #1605

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

