### PR TITLE
Rename XML tag solver-interface

### DIFF
--- a/examples/solverdummies/precice-config.xml
+++ b/examples/solverdummies/precice-config.xml
@@ -9,7 +9,7 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Data-One" />
     <data:vector name="Data-Two" />
 
@@ -57,5 +57,5 @@
       <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
       <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/src/precice/config/SolverInterfaceConfiguration.cpp
+++ b/src/precice/config/SolverInterfaceConfiguration.cpp
@@ -23,7 +23,7 @@ namespace precice::config {
 SolverInterfaceConfiguration::SolverInterfaceConfiguration(xml::XMLTag &parent)
 {
   using namespace xml;
-  XMLTag tag(*this, "solver-interface", XMLTag::OCCUR_ONCE);
+  XMLTag tag(*this, "simulation-setup", XMLTag::OCCUR_ONCE);
   tag.setDocumentation("Configuration of simulation relevant features.");
   auto attrDimensions = makeXMLAttribute("dimensions", 2)
                             .setDocumentation("Determines the spatial dimensionality of the configuration")
@@ -52,7 +52,7 @@ void SolverInterfaceConfiguration::xmlTagCallback(
     xml::XMLTag &                    tag)
 {
   PRECICE_TRACE();
-  if (tag.getName() == "solver-interface") {
+  if (tag.getName() == "simulation-setup") {
     _dimensions = tag.getIntAttributeValue("dimensions");
     _dataConfiguration->setDimensions(_dimensions);
     _meshConfiguration->setDimensions(_dimensions);
@@ -70,7 +70,7 @@ void SolverInterfaceConfiguration::xmlEndTagCallback(
     xml::XMLTag &                    tag)
 {
   PRECICE_TRACE();
-  if (tag.getName() == "solver-interface") {
+  if (tag.getName() == "simulation-setup") {
     //test if both participants do have the exchange meshes
     typedef std::map<std::string, std::vector<std::string>>::value_type neededMeshPair;
     for (const neededMeshPair &neededMeshes : _meshConfiguration->getNeededMeshes()) {

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -161,6 +161,6 @@
 
 #define PRECICE_EXPERIMENTAL_API()                                                                                                                    \
   PRECICE_CHECK(_allowsExperimental, "You called the API function \"{}\", which is part of the experimental API. "                                    \
-                                     "You may unlock the full API by specifying <solver-interface experimental=\"true\" ... > in the configuration. " \
+                                     "You may unlock the full API by specifying <simulation-setup experimental=\"true\" ... > in the configuration. " \
                                      "Please be aware that experimental features may change in any future version (even minor or bugfix).",           \
                 __func__)

--- a/src/precice/tests/config-checker.xml
+++ b/src/precice/tests/config-checker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -56,5 +56,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/CouplingOnLine.xml
+++ b/tests/parallel/CouplingOnLine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Pressure" />
 
     <mesh name="FASTEST_Mesh">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="Pressure" mesh="FASTEST_Mesh" from="FASTEST" to="Ateles" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/ExportTimeseries.xml
+++ b/tests/parallel/ExportTimeseries.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="S" />
     <data:vector name="V" />
 
@@ -44,5 +44,5 @@
       <exchange data="S" mesh="A" from="ExporterOne" to="ExporterTwo" />
       <exchange data="V" mesh="A" from="ExporterOne" to="ExporterTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/GlobalRBFPartitioning.xml
+++ b/tests/parallel/GlobalRBFPartitioning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -50,5 +50,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/GlobalRBFPartitioningPETSc.xml
+++ b/tests/parallel/GlobalRBFPartitioningPETSc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -50,5 +50,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/LocalRBFPartitioning.xml
+++ b/tests/parallel/LocalRBFPartitioning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -50,5 +50,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/LocalRBFPartitioningPETSc.xml
+++ b/tests/parallel/LocalRBFPartitioningPETSc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -50,5 +50,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/NearestProjectionRePartitioning.xml
+++ b/tests/parallel/NearestProjectionRePartitioning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Data1" />
 
     <mesh name="CellCenters">
@@ -38,5 +38,5 @@
       <time-window-size value="1.0" />
       <exchange data="Data1" mesh="Nodes" from="SolidSolver" to="FluidSolver" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/PrimaryRankSockets.xml
+++ b/tests/parallel/PrimaryRankSockets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="MyData1" />
     <data:scalar name="MyData2" />
 
@@ -47,5 +47,5 @@
       <exchange data="MyData1" mesh="SerialMesh" from="ParallelSolver" to="SerialSolver" />
       <exchange data="MyData2" mesh="SerialMesh" from="SerialSolver" to="ParallelSolver" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/TestBoundingBoxInitialization.xml
+++ b/tests/parallel/TestBoundingBoxInitialization.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -36,5 +36,5 @@
       <time-window-size value="1.0" />
       <exchange data="Forces" mesh="FluidMesh" from="Fluid" to="Structure" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/TestBoundingBoxInitializationTwoWay.xml
+++ b/tests/parallel/TestBoundingBoxInitializationTwoWay.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -46,5 +46,5 @@
       <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure" />
       <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/TestFinalize.xml
+++ b/tests/parallel/TestFinalize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Data1" />
     <data:vector name="Data2" />
 
@@ -48,5 +48,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/UserDefinedMPICommunicator.xml
+++ b/tests/parallel/UserDefinedMPICommunicator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -47,5 +47,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -51,5 +51,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
     <data:scalar name="Forces" />
 
@@ -40,5 +40,5 @@
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -48,5 +48,5 @@
       <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure" />
       <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -48,5 +48,5 @@
       <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure" />
       <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -48,5 +48,5 @@
       <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure" />
       <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyPrimaryRank.xml
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyPrimaryRank.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="MyData1" />
     <data:scalar name="MyData2" />
 
@@ -47,5 +47,5 @@
       <exchange data="MyData2" mesh="SerialMesh" from="SerialSolver" to="ParallelSolver" />
       <exchange data="MyData1" mesh="ParallelMesh" from="ParallelSolver" to="SerialSolver" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedPrimaryRank.xml
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedPrimaryRank.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="MyData1" />
     <data:scalar name="MyData2" />
 
@@ -47,5 +47,5 @@
       <exchange data="MyData2" mesh="SerialMesh" from="SerialSolver" to="ParallelSolver" />
       <exchange data="MyData1" mesh="ParallelMesh" from="ParallelSolver" to="SerialSolver" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/lifecycle/ConstructAndExplicitFinalize.xml
+++ b/tests/parallel/lifecycle/ConstructAndExplicitFinalize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/lifecycle/ConstructOnly.xml
+++ b/tests/parallel/lifecycle/ConstructOnly.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/lifecycle/Full.xml
+++ b/tests/parallel/lifecycle/Full.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/lifecycle/ImplicitFinalize.xml
+++ b/tests/parallel/lifecycle/ImplicitFinalize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="on">
+  <simulation-setup dimensions="2" experimental="on">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -46,5 +46,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="on">
+  <simulation-setup dimensions="2" experimental="on">
     <data:scalar name="Data1" />
     <data:vector name="Data2" />
 
@@ -47,5 +47,5 @@
       <exchange data="Data1" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:scalar name="Data1" />
     <data:vector name="Data2" />
 
@@ -38,5 +38,5 @@
       <time-window-size value="1.0" />
       <exchange data="Data2" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelCube1To3.xml
+++ b/tests/parallel/mapping-volume/ParallelCube1To3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -37,5 +37,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelCube3To1.xml
+++ b/tests/parallel/mapping-volume/ParallelCube3To1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -36,5 +36,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelCubeConservative1To3.xml
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative1To3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -40,5 +40,5 @@
         from="SolverOneCubeConservative1To3"
         to="SolverTwoCubeConservative1To3" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelCubeConservative3To1.xml
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative3To1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -44,5 +44,5 @@
         from="SolverOneCubeConservative3To1"
         to="SolverTwoCubeConservative3To1" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelSquare1To2.xml
+++ b/tests/parallel/mapping-volume/ParallelSquare1To2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelSquare2To1.xml
+++ b/tests/parallel/mapping-volume/ParallelSquare2To1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelSquareConservative1To2.xml
+++ b/tests/parallel/mapping-volume/ParallelSquareConservative1To2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.xml
+++ b/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -56,5 +56,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -56,5 +56,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -58,5 +58,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -58,5 +58,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -56,5 +56,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-IMVJ>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -56,5 +56,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-IMVJ>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/serial/TestQN1.xml
+++ b/tests/quasi-newton/serial/TestQN1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -55,5 +55,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/serial/TestQN2.xml
+++ b/tests/quasi-newton/serial/TestQN2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -57,5 +57,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/quasi-newton/serial/TestQN3.xml
+++ b/tests/quasi-newton/serial/TestQN3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -55,5 +55,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-IMVJ>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/AitkenAcceleration.xml
+++ b/tests/serial/AitkenAcceleration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data" />
     <data:scalar name="Data2" />
 
@@ -45,5 +45,5 @@
         <initial-relaxation value="0.1" />
       </acceleration:aitken>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/PreconditionerBug.xml
+++ b/tests/serial/PreconditionerBug.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="DataOne" />
     <data:vector name="DataTwo" />
 
@@ -48,5 +48,5 @@
         <filter type="QR2" limit="1e-3" />
       </acceleration:IQN-ILS>
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/SendMeshToMultipleParticipants.xml
+++ b/tests/serial/SendMeshToMultipleParticipants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data" />
 
     <mesh name="MeshA">
@@ -58,5 +58,5 @@
       <time-window-size value="1.0" />
       <exchange data="Data" mesh="MeshA" from="SolverOne" to="SolverThree" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/SummationActionTwoSources.xml
+++ b/tests/serial/SummationActionTwoSources.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="SourceOne" />
     <data:scalar name="SourceTwo" />
     <data:scalar name="Target" />
@@ -67,5 +67,5 @@
       <time-window-size value="1.0" />
       <exchange data="SourceTwo" mesh="MeshTarget" from="SolverSourceTwo" to="SolverTarget" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/TestExplicitWithDataMultipleReadWrite.xml
+++ b/tests/serial/TestExplicitWithDataMultipleReadWrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -41,5 +41,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/TestExplicitWithSolverGeometry.xml
+++ b/tests/serial/TestExplicitWithSolverGeometry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
     <data:vector name="Displacements" />
@@ -52,5 +52,5 @@
       <exchange data="Velocities" mesh="SolverGeometry" from="SolverTwo" to="SolverOne" />
       <exchange data="Displacements" mesh="SolverGeometry" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/TestImplicit.xml
+++ b/tests/serial/TestImplicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -43,5 +43,5 @@
       <exchange data="Forces" mesh="Square" from="SolverOne" to="SolverTwo" />
       <exchange data="Velocities" mesh="Square" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/TestReadAPI.xml
+++ b/tests/serial/TestReadAPI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="True">
+  <simulation-setup dimensions="3" experimental="True">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/action-timings/ActionTimingsExplicit.xml
+++ b/tests/serial/action-timings/ActionTimingsExplicit.xml
@@ -9,7 +9,7 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -64,5 +64,5 @@
         to="SolverOne"
         initialize="True" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/action-timings/ActionTimingsImplicit.xml
+++ b/tests/serial/action-timings/ActionTimingsImplicit.xml
@@ -9,7 +9,7 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -61,5 +61,5 @@
       <exchange data="Forces" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="Velocities" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/circular/Explicit.xml
+++ b/tests/serial/circular/Explicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface>
+  <simulation-setup>
     <data:scalar name="DAB" />
     <data:scalar name="DBC" />
     <data:scalar name="DCA" />
@@ -68,5 +68,5 @@
       <max-time-windows value="2" />
       <exchange data="DCA" mesh="MA" from="C" to="A" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/convergence-measures/testConvergenceMeasures1.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -49,5 +49,5 @@
       <absolute-convergence-measure limit="1e-1" data="Data2" mesh="MeshOne" suffices="true" />
       <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/convergence-measures/testConvergenceMeasures2.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -53,5 +53,5 @@
         mesh="MeshOne"
         suffices="true" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/convergence-measures/testConvergenceMeasures3.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Data1" />
     <data:scalar name="Data2" />
 
@@ -53,5 +53,5 @@
         mesh="MeshOne"
         suffices="true" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
     <data:scalar name="Forces" />
 
@@ -32,5 +32,5 @@
       <exchange data="Velocities" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="Forces" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
     <data:scalar name="Forces" />
 
@@ -42,5 +42,5 @@
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" initialize="true" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
     <data:scalar name="Forces" />
 
@@ -42,5 +42,5 @@
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/direct-mesh-access/Explicit.xml
+++ b/tests/serial/direct-mesh-access/Explicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
     <data:scalar name="Forces" />
 
@@ -40,5 +40,5 @@
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
       <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/direct-mesh-access/ExplicitRead.xml
+++ b/tests/serial/direct-mesh-access/ExplicitRead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Velocities" />
 
     <mesh name="MeshTwo">
@@ -25,5 +25,5 @@
       <time-window-size value="1.0" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/direct-mesh-access/Implicit.xml
+++ b/tests/serial/direct-mesh-access/Implicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2" experimental="true">
+  <simulation-setup dimensions="2" experimental="true">
     <data:scalar name="Forces" />
     <data:scalar name="Velocities" />
 
@@ -37,5 +37,5 @@
       <exchange data="Forces" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
       <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/explicit/TestExplicitMPI.xml
+++ b/tests/serial/explicit/TestExplicitMPI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -46,5 +46,5 @@
       <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo" />
       <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/explicit/TestExplicitMPISingle.xml
+++ b/tests/serial/explicit/TestExplicitMPISingle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -46,5 +46,5 @@
       <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo" />
       <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/explicit/TestExplicitSockets.xml
+++ b/tests/serial/explicit/TestExplicitSockets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -46,5 +46,5 @@
       <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo" />
       <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/initialize-data/Explicit.xml
+++ b/tests/serial/initialize-data/Explicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/initialize-data/Implicit.xml
+++ b/tests/serial/initialize-data/Implicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -53,5 +53,5 @@
         to="SolverOne"
         initialize="true" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/initialize-data/ImplicitBoth.xml
+++ b/tests/serial/initialize-data/ImplicitBoth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -53,5 +53,5 @@
         to="SolverOne"
         initialize="true" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/initialize-data/ReadMapping.xml
+++ b/tests/serial/initialize-data/ReadMapping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Data" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="Data" mesh="MeshTwo" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/initialize-data/WriteMapping.xml
+++ b/tests/serial/initialize-data/WriteMapping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Data" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="Data" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/lifecycle/ConstructAndExplicitFinalize.xml
+++ b/tests/serial/lifecycle/ConstructAndExplicitFinalize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/lifecycle/ConstructOnly.xml
+++ b/tests/serial/lifecycle/ConstructOnly.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/lifecycle/Full.xml
+++ b/tests/serial/lifecycle/Full.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/lifecycle/ImplicitFinalize.xml
+++ b/tests/serial/lifecycle/ImplicitFinalize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -47,5 +47,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:vector name="DataOne" />
     <data:vector name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:vector name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:vector name="DataOne" />
     <data:vector name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:vector name="DataA" />
     <data:scalar name="DataB" />
 
@@ -36,5 +36,5 @@
       <time-window-size value="1" />
       <exchange data="DataA" mesh="MeshA" from="A" to="B" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:scalar name="DataA" />
     <data:scalar name="DataB" />
 
@@ -36,5 +36,5 @@
       <time-window-size value="1" />
       <exchange data="DataA" mesh="MeshA" from="A" to="B" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="on">
+  <simulation-setup dimensions="3" experimental="on">
     <data:vector name="DataA" />
     <data:scalar name="DataB" />
 
@@ -36,5 +36,5 @@
       <time-window-size value="1" />
       <exchange data="DataA" mesh="MeshA" from="A" to="B" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-projection/MappingNearestProjectionEdges.xml
+++ b/tests/serial/mapping-nearest-projection/MappingNearestProjectionEdges.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesTallKite.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesTallKite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesWideKite.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesWideKite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-nearest-projection/QuadMappingNearestProjectionEdges.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingNearestProjectionEdges.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-rbf-gaussian/GaussianShapeParameter.xml
+++ b/tests/serial/mapping-rbf-gaussian/GaussianShapeParameter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -39,5 +39,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-rbf-gaussian/GaussianSupportRadius.xml
+++ b/tests/serial/mapping-rbf-gaussian/GaussianSupportRadius.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -39,5 +39,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTetraConservativeRead.xml
+++ b/tests/serial/mapping-volume/OneTetraConservativeRead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTetraConservativeWrite.xml
+++ b/tests/serial/mapping-volume/OneTetraConservativeWrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTetraRead.xml
+++ b/tests/serial/mapping-volume/OneTetraRead.xml
@@ -7,7 +7,7 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -42,5 +42,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTetraWrite.xml
+++ b/tests/serial/mapping-volume/OneTetraWrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTriangleConservativeRead.xml
+++ b/tests/serial/mapping-volume/OneTriangleConservativeRead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTriangleConservativeWrite.xml
+++ b/tests/serial/mapping-volume/OneTriangleConservativeWrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTriangleRead.xml
+++ b/tests/serial/mapping-volume/OneTriangleRead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mapping-volume/OneTriangleWrite.xml
+++ b/tests/serial/mapping-volume/OneTriangleWrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -35,5 +35,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mesh-requirements/NearestNeighborA.xml
+++ b/tests/serial/mesh-requirements/NearestNeighborA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Data" />
 
     <mesh name="MeshA">
@@ -31,5 +31,5 @@
       <time-window-size value="1" />
       <exchange data="Data" mesh="MeshA" from="A" to="B" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mesh-requirements/NearestNeighborB.xml
+++ b/tests/serial/mesh-requirements/NearestNeighborB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Data" />
 
     <mesh name="MeshA">
@@ -31,5 +31,5 @@
       <time-window-size value="1" />
       <exchange data="Data" mesh="MeshA" from="A" to="B" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mesh-requirements/NearestProjection2DA.xml
+++ b/tests/serial/mesh-requirements/NearestProjection2DA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Data" />
 
     <mesh name="MeshA">
@@ -35,5 +35,5 @@
       <time-window-size value="1" />
       <exchange data="Data" mesh="MeshA" from="A" to="B" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/mesh-requirements/NearestProjection2DB.xml
+++ b/tests/serial/mesh-requirements/NearestProjection2DB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="Data" />
 
     <mesh name="MeshA">
@@ -35,5 +35,5 @@
       <time-window-size value="1" />
       <exchange data="Data" mesh="MeshA" from="A" to="B" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multi-coupling/MultiCoupling.xml
+++ b/tests/serial/multi-coupling/MultiCoupling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Forces1" />
     <data:vector name="Forces2" />
     <data:vector name="Forces3" />
@@ -152,5 +152,5 @@
         <time-windows-reused value="8" />
       </acceleration:IQN-ILS>
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers1.xml
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataAB" />
     <data:scalar name="DataBA" />
     <data:scalar name="DataBC" />
@@ -137,5 +137,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers2.xml
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataAB" />
     <data:scalar name="DataBA" />
     <data:scalar name="DataBC" />
@@ -138,5 +138,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataAB" />
     <data:scalar name="DataBA" />
     <data:scalar name="DataBC" />
@@ -90,5 +90,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataAB" />
     <data:scalar name="DataBA" />
     <data:scalar name="DataBC" />
@@ -100,5 +100,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataAB" />
     <data:scalar name="DataBA" />
     <data:scalar name="DataBC" />
@@ -91,5 +91,5 @@
         <time-windows-reused value="0" />
       </acceleration:IQN-ILS>
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multiple-mappings/MultipleReadFromMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleReadFromMappings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Pressure" />
 
     <mesh name="MeshB">
@@ -46,5 +46,5 @@
       <time-window-size value="1.0" />
       <exchange data="Pressure" mesh="MeshB" from="B" to="A" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multiple-mappings/MultipleReadToMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleReadToMappings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DisplacementTop" />
     <data:scalar name="DisplacementBottom" />
     <data:scalar name="Pressure" />
@@ -55,5 +55,5 @@
       <exchange data="DisplacementTop" mesh="MeshATop" from="A" to="B" />
       <exchange data="DisplacementBottom" mesh="MeshABottom" from="A" to="B" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Pressure" />
 
     <mesh name="MeshB">
@@ -48,5 +48,5 @@
       <exchange data="Pressure" mesh="MeshATop" from="B" to="A" />
       <exchange data="Pressure" mesh="MeshABottom" from="B" to="A" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="Pressure" />
     <data:scalar name="Temperature" />
 
@@ -57,5 +57,5 @@
       <exchange data="Temperature" mesh="MeshATop" from="B" to="A" />
       <exchange data="Temperature" mesh="MeshABottom" from="B" to="A" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/multiple-mappings/MultipleWriteToMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteToMappings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DisplacementSum" />
     <data:scalar name="DisplacementTop" />
     <data:scalar name="DisplacementBottom" />
@@ -59,5 +59,5 @@
       <time-window-size value="1.0" />
       <exchange data="DisplacementSum" mesh="MeshB" from="A" to="B" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/three-solvers/ThreeSolversExplicitExplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversExplicitExplicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Data" />
 
     <mesh name="MeshA">
@@ -63,5 +63,5 @@
       <time-window-size value="1.0" />
       <exchange data="Data" mesh="MeshB" from="SolverOne" to="SolverThree" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Data0" />
     <data:scalar name="Data1" />
     <data:vector name="Data2" />
@@ -81,5 +81,5 @@
       <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree" />
       <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/three-solvers/ThreeSolversFirstParticipant.xml
+++ b/tests/serial/three-solvers/ThreeSolversFirstParticipant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataA" />
     <data:scalar name="DataB" />
 
@@ -65,5 +65,5 @@
       <time-window-size method="first-participant" />
       <exchange data="DataB" mesh="MeshTwoB" from="SolverTwo" to="SolverThree" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Data0" />
     <data:scalar name="Data1" />
     <data:vector name="Data2" />
@@ -81,5 +81,5 @@
       <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree" />
       <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/three-solvers/ThreeSolversParallel.xml
+++ b/tests/serial/three-solvers/ThreeSolversParallel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Data0" />
     <data:scalar name="Data1" />
     <data:vector name="Data2" />
@@ -81,5 +81,5 @@
       <exchange data="Data0" mesh="MeshB" from="SolverOne" to="SolverThree" initialize="1" />
       <exchange data="Data2" mesh="MeshB" from="SolverThree" to="SolverOne" initialize="1" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -52,5 +52,5 @@
       <time-window-size value="2.0" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
 
@@ -46,5 +46,5 @@
       <exchange data="Forces" mesh="Test-Square" from="SolverOne" to="SolverTwo" />
       <exchange data="Velocities" mesh="Test-Square" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="true" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -46,5 +46,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
     <data:scalar name="DataThree" />
@@ -78,5 +78,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverThree" />
       <exchange data="DataThree" mesh="MeshOne" from="SolverThree" to="SolverOne" />
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
     <data:scalar name="DataThree" />
@@ -78,5 +78,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverThree" initialize="on" />
       <exchange data="DataThree" mesh="MeshOne" from="SolverThree" to="SolverOne" initialize="on" />
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
     <data:scalar name="DataThree" />
@@ -78,5 +78,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverThree" initialize="on" />
       <exchange data="DataThree" mesh="MeshOne" from="SolverThree" to="SolverOne" initialize="on" />
     </coupling-scheme:multi>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="True" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="True" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3">
+  <simulation-setup dimensions="3">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="3" experimental="true">
+  <simulation-setup dimensions="3" experimental="true">
     <data:scalar name="DataOne" />
     <data:scalar name="DataTwo" />
 
@@ -48,5 +48,5 @@
       <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
     </coupling-scheme:serial-implicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.xml
+++ b/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:scalar name="DataOne" />
 
     <mesh name="MeshOne">
@@ -37,5 +37,5 @@
       <time-window-size value="1.0" />
       <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/whitebox/TestConfigurationComsol.xml
+++ b/tests/serial/whitebox/TestConfigurationComsol.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
     <data:vector name="Displacements" />
@@ -64,5 +64,5 @@
       <exchange data="Displacements" mesh="ComsolNodes" from="Comsol" to="Peano" />
       <exchange data="VelocityDeltas" mesh="ComsolNodes" from="Comsol" to="Peano" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/whitebox/TestConfigurationPeano.xml
+++ b/tests/serial/whitebox/TestConfigurationPeano.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Forces" />
     <data:vector name="Velocities" />
     <data:vector name="Displacements" />
@@ -64,5 +64,5 @@
       <exchange data="Displacements" mesh="ComsolNodes" from="Comsol" to="Peano" />
       <exchange data="VelocityDeltas" mesh="ComsolNodes" from="Comsol" to="Peano" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.xml
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <solver-interface dimensions="2">
+  <simulation-setup dimensions="2">
     <data:vector name="Velocities" />
 
     <mesh name="Test-Square-One">
@@ -38,5 +38,5 @@
       <time-window-size value="0.01" />
       <exchange data="Velocities" mesh="Test-Square-One" from="SolverOne" to="SolverTwo" />
     </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </simulation-setup>
 </precice-configuration>


### PR DESCRIPTION
## Main changes of this PR

Related to #1458. Renames the XML tag `<solver-interface>` to `<simulation-setup>` and adjusts the tests accordingly.

## Motivation and additional information

More related PRs follow, this is a separate one to facilitate reviewing (too many test configs).

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* I added a test to cover the proposed changes in our test suite. -> N/A
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
