### PR TITLE
Fix timestep vs. time step.

### DIFF
--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -61,17 +61,17 @@ PRECICE_API void precicec_createSolverInterface(
 /**
  * @brief Initiates the coupling to the coupling supervisor and initializes coupling data.
  *
- * @return Maximal length of first timestep to be computed by solver.
+ * @return Maximal size of first time step to be computed by solver.
  */
 PRECICE_API double precicec_initialize();
 
 /**
  * @brief Exchanges data between solver and coupling supervisor.
  *
- * @param[in] computedTimestepLength Length of timestep computed by solver.
- * @return Maximal length of next timestep to be computed by solver.
+ * @param[in] computedTimeStepSize Size of time step computed by solver.
+ * @return Maximal size of next time step to be computed by solver.
  */
-PRECICE_API double precicec_advance(double computedTimestepLength);
+PRECICE_API double precicec_advance(double computedTimeStepSize);
 
 /**
  * @brief Finalizes the coupling to the coupling supervisor.

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -59,10 +59,10 @@ double precicec_initialize()
   return impl->initialize();
 }
 
-double precicec_advance(double computedTimestepLength)
+double precicec_advance(double computedTimeStepSize)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  return impl->advance(computedTimestepLength);
+  return impl->advance(computedTimeStepSize);
 }
 
 void precicec_finalize()

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -39,27 +39,27 @@ PRECICE_API void precicef_create_(
 
 /**
  * Fortran syntax:
- * precicef_initialize( DOUBLE PRECISION timstepLengthLimit )
+ * precicef_initialize( DOUBLE PRECISION timeStepSizeLimit )
  *
  * IN:  -
- * OUT: timestepLengthLimit
+ * OUT: timeStepSizeLimit
  *
  * @copydoc precice::SolverInterface::initialize()
  *
  */
-PRECICE_API void precicef_initialize_(double *timestepLengthLimit);
+PRECICE_API void precicef_initialize_(double *timeStepSizeLimit);
 
 /**
  * Fortran syntax:
- * precicef_advance( DOUBLE PRECISION timstepLengthLimit )
+ * precicef_advance( DOUBLE PRECISION timeStepSizeLimit )
  *
- * IN:  timestepLengthLimit
- * OUT: timestepLengthLimit
+ * IN:  timeStepSizeLimit
+ * OUT: timeStepSizeLimit
  *
  * @copydoc precice::SolverInterface::advance()
  *
  */
-PRECICE_API void precicef_advance_(double *timestepLengthLimit);
+PRECICE_API void precicef_advance_(double *timeStepSizeLimit);
 
 /**
  * Fortran syntax:

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -54,17 +54,17 @@ void precicef_create_(
 }
 
 void precicef_initialize_(
-    double *timestepLengthLimit)
+    double *timeStepSizeLimit)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  *timestepLengthLimit = impl->initialize();
+  *timeStepSizeLimit = impl->initialize();
 }
 
 void precicef_advance_(
-    double *timestepLengthLimit)
+    double *timeStepSizeLimit)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  *timestepLengthLimit = impl->advance(*timestepLengthLimit);
+  *timeStepSizeLimit = impl->advance(*timeStepSizeLimit);
 }
 
 void precicef_finalize_()

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -34,17 +34,17 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
 {
   PRECICE_TEST(1_rank);
   //use two vectors and see if underrelaxation works
-  double           initialRelaxation        = 0.01;
-  int              maxIterationsUsed        = 50;
-  int              timestepsReused          = 6;
-  int              reusedTimestepsAtRestart = 0;
-  int              chunkSize                = 0;
-  int              filter                   = Acceleration::QR1FILTER;
-  int              restartType              = MVQNAcceleration::NO_RESTART;
-  double           singularityLimit         = 1e-10;
-  double           svdTruncationEps         = 0.0;
-  bool             enforceInitialRelaxation = false;
-  bool             alwaysBuildJacobian      = false;
+  double           initialRelaxation          = 0.01;
+  int              maxIterationsUsed          = 50;
+  int              timeWindowsReused          = 6;
+  int              reusedTimeWindowsAtRestart = 0;
+  int              chunkSize                  = 0;
+  int              filter                     = Acceleration::QR1FILTER;
+  int              restartType                = MVQNAcceleration::NO_RESTART;
+  double           singularityLimit           = 1e-10;
+  double           svdTruncationEps           = 0.0;
+  bool             enforceInitialRelaxation   = false;
+  bool             alwaysBuildJacobian        = false;
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
@@ -54,8 +54,8 @@ BOOST_AUTO_TEST_CASE(testMVQNPP)
   mesh::PtrMesh           dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
 
   MVQNAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                      timestepsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
-                      restartType, chunkSize, reusedTimestepsAtRestart, svdTruncationEps);
+                      timeWindowsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
+                      restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps);
 
   Eigen::VectorXd fcol1;
 
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
 
   double           initialRelaxation        = 0.01;
   int              maxIterationsUsed        = 50;
-  int              timestepsReused          = 6;
+  int              timeWindowsReused        = 6;
   int              filter                   = acceleration::BaseQNAcceleration::QR1FILTER;
   double           singularityLimit         = 1e-10;
   bool             enforceInitialRelaxation = false;
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                        timestepsReused, filter, singularityLimit, dataIDs, prec);
+                        timeWindowsReused, filter, singularityLimit, dataIDs, prec);
 
   mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
   mesh::PtrData forces(new mesh::Data("fvalues", -1, 1));

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -340,20 +340,20 @@ void BaseCouplingScheme::addComputedTime(
   _time += timeToAdd;
 
   // Check validness
-  bool valid = math::greaterEquals(getNextTimestepMaxLength(), 0.0, _eps);
+  bool valid = math::greaterEquals(getNextTimeStepMaxSize(), 0.0, _eps);
   PRECICE_CHECK(valid,
-                "The timestep length given to preCICE in \"advance\" {} exceeds the maximum allowed timestep length {} "
+                "The time step size given to preCICE in \"advance\" {} exceeds the maximum allowed time step size {} "
                 "in the remaining of this time window. "
-                "Did you restrict your timestep length, \"dt = min(precice_dt, dt)\"? "
+                "Did you restrict your time step size, \"dt = min(preciceDt, solverDt)\"? "
                 "For more information, consult the adapter example in the preCICE documentation.",
                 timeToAdd, _timeWindowSize - _computedTimeWindowPart + timeToAdd);
 }
 
 bool BaseCouplingScheme::willDataBeExchanged(
-    double lastSolverTimestepLength) const
+    double lastSolverTimeStepSize) const
 {
-  PRECICE_TRACE(lastSolverTimestepLength);
-  double remainder = getNextTimestepMaxLength() - lastSolverTimestepLength;
+  PRECICE_TRACE(lastSolverTimeStepSize);
+  double remainder = getNextTimeStepMaxSize() - lastSolverTimeStepSize;
   return not math::greater(remainder, 0.0, _eps);
 }
 
@@ -398,7 +398,7 @@ int BaseCouplingScheme::getTimeWindows() const
   return _timeWindows;
 }
 
-double BaseCouplingScheme::getNextTimestepMaxLength() const
+double BaseCouplingScheme::getNextTimeStepMaxSize() const
 {
   if (hasTimeWindowSize()) {
     return _timeWindowSize - _computedTimeWindowPart;
@@ -476,7 +476,7 @@ std::string BaseCouplingScheme::printBasicState(
     os << ", time-window-size: " << _timeWindowSize;
   }
   if (hasTimeWindowSize() || (_maxTime != UNDEFINED_TIME)) {
-    os << ", max-timestep-length: " << getNextTimestepMaxLength();
+    os << ", max-time-step-size: " << getNextTimeStepMaxSize();
   }
   os << ", ongoing: ";
   isCouplingOngoing() ? os << "yes" : os << "no";
@@ -676,7 +676,7 @@ void BaseCouplingScheme::advanceTXTWriters()
 
 bool BaseCouplingScheme::reachedEndOfTimeWindow()
 {
-  return math::equals(getNextTimestepMaxLength(), 0.0, _eps) || not hasTimeWindowSize();
+  return math::equals(getNextTimeStepMaxSize(), 0.0, _eps) || not hasTimeWindowSize();
 }
 
 void BaseCouplingScheme::storeIteration()

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -51,8 +51,8 @@ class CouplingData;
  * -# query actions and mark them as fulfilled
  * -# compute data to be sent (possibly taking into account received data from
  *    initialize())
- * -# advance the coupling scheme with advance(); where the maximum timestep
- *    length (= time window size) needs to be obeyed
+ * -# advance the coupling scheme with advance(); where the maximum time step
+ *    size (= time window size) needs to be obeyed
  * -# ....
  * -# when the method isCouplingOngoing() returns false, call finalize() to
  *    stop the coupling scheme
@@ -98,10 +98,10 @@ public:
    * Also returns true after the last call of advance() at the end of the
    * simulation.
    *
-   * @param lastSolverTimestepLength [IN] The length of the last timestep
+   * @param lastSolverTimeStepSize [IN] The size of the last time step
    *        computed by the solver calling willDataBeExchanged().
    */
-  bool willDataBeExchanged(double lastSolverTimestepLength) const override final;
+  bool willDataBeExchanged(double lastSolverTimeStepSize) const override final;
 
   /**
    * @brief getter for _hasDataBeenReceived
@@ -141,12 +141,12 @@ public:
   double getTimeWindowSize() const override final;
 
   /**
-   * @brief Returns the maximal length of the next timestep to be computed.
+   * @brief Returns the maximal size of the next time step to be computed.
    *
    * If no time window size is prescribed by the coupling scheme, always the
    * maximal double accuracy floating point number value is returned.
    */
-  double getNextTimestepMaxLength() const override final;
+  double getNextTimeStepMaxSize() const override final;
 
   /// Returns true, when the coupled simulation is still ongoing.
   bool isCouplingOngoing() const override final;

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -143,12 +143,12 @@ std::vector<std::string> CompositionalCouplingScheme::getCouplingPartners() cons
   return partners;
 }
 
-bool CompositionalCouplingScheme::willDataBeExchanged(double lastSolverTimestepLength) const
+bool CompositionalCouplingScheme::willDataBeExchanged(double lastSolverTimeStepSize) const
 {
-  PRECICE_TRACE(lastSolverTimestepLength);
+  PRECICE_TRACE(lastSolverTimeStepSize);
   auto schemes         = allSchemes();
   bool willBeExchanged = std::any_of(schemes.begin(), schemes.end(),
-                                     [lastSolverTimestepLength](const auto &cpl) { return cpl->willDataBeExchanged(lastSolverTimestepLength); });
+                                     [lastSolverTimeStepSize](const auto &cpl) { return cpl->willDataBeExchanged(lastSolverTimeStepSize); });
   PRECICE_DEBUG("return {}", willBeExchanged);
   return willBeExchanged;
 }
@@ -210,14 +210,14 @@ double CompositionalCouplingScheme::getTimeWindowSize() const
   return timeWindowSize;
 }
 
-double CompositionalCouplingScheme::getNextTimestepMaxLength() const
+double CompositionalCouplingScheme::getNextTimeStepMaxSize() const
 {
   PRECICE_TRACE();
   auto   schemes   = allSchemes();
   double maxLength = std::transform_reduce(
       schemes.begin(), schemes.end(), std::numeric_limits<double>::max(),
       ::min<double>,
-      std::mem_fn(&CouplingScheme::getNextTimestepMaxLength));
+      std::mem_fn(&CouplingScheme::getNextTimeStepMaxSize));
   PRECICE_DEBUG("return {}", maxLength);
   return maxLength;
 }

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -143,8 +143,6 @@ public:
   /**
    * @brief Returns true, if time window size is given by any of the coupling schemes in this compositional coupling scheme.
    *
-   * If any of the solvers in the composition has a time step size limit, this
-   * counts as limit.
    */
   bool hasTimeWindowSize() const final override;
 
@@ -154,8 +152,6 @@ public:
    * An assertion is thrown, if no valid time window size is given. Check with
    * hasTimeWindowSize().
    *
-   * The smallest time step size limit in the coupling scheme composition has
-   * to be obeyed.
    */
   double getTimeWindowSize() const final override;
 

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -115,10 +115,10 @@ public:
    * Also returns true after the last call of advance() at the end of the
    * simulation.
    *
-   * @param lastSolverTimestepLength [IN] The length of the last timestep
+   * @param lastSolverTimeStepSize [IN] The size of the last time step
    *        computed by the solver calling willDataBeExchanged().
    */
-  bool willDataBeExchanged(double lastSolverTimestepLength) const final override;
+  bool willDataBeExchanged(double lastSolverTimeStepSize) const final override;
 
   /**
    * @brief checks all coupling schemes this coupling scheme is composed of.
@@ -141,33 +141,33 @@ public:
   int getTimeWindows() const final override;
 
   /**
-   * @brief Returns true, if timestep length by any of the coupling schemes in this compositional coupling scheme.
+   * @brief Returns true, if time window size is given by any of the coupling schemes in this compositional coupling scheme.
    *
-   * If any of the solvers in the composition has a timestep length limit, this
+   * If any of the solvers in the composition has a time step size limit, this
    * counts as limit.
    */
   bool hasTimeWindowSize() const final override;
 
   /**
-   * @brief Returns the timestep length, if one is given by the coupling scheme.
+   * @brief Returns the time window size, if one is given by the coupling scheme.
    *
-   * An assertion is thrown, if no valid timestep is given. Check with
+   * An assertion is thrown, if no valid time window size is given. Check with
    * hasTimeWindowSize().
    *
-   * The smallest timestep length limit in the coupling scheme composition has
+   * The smallest time step size limit in the coupling scheme composition has
    * to be obeyed.
    */
   double getTimeWindowSize() const final override;
 
   /**
-   * @brief Returns the maximal length of the next timestep to be computed.
+   * @brief Returns the maximal size of the next time step to be computed.
    *
-   * If no timestep length is prescribed by the coupling scheme, always the
+   * If no time step size is prescribed by the coupling scheme, always the
    * maximal double accuracy floating point number value is returned.
    *
-   * This is the minimum of all max lengths of the composed coupling schemes.
+   * This is the minimum of all max sizes of the composed coupling schemes.
    */
-  double getNextTimestepMaxLength() const final override;
+  double getNextTimeStepMaxSize() const final override;
 
   /**
    * @brief Returns true, when the coupled simulation is still ongoing.

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -165,10 +165,10 @@ public:
    * Also returns true after the last call of advance() at the end of the
    * simulation.
    *
-   * @param lastSolverTimestepLength [IN] The length of the last timestep
+   * @param lastSolverTimeStepSize [IN] The size of the last time step
    *        computed by the solver calling willDataBeExchanged().
    */
-  virtual bool willDataBeExchanged(double lastSolverTimestepLength) const = 0;
+  virtual bool willDataBeExchanged(double lastSolverTimeStepSize) const = 0;
 
   /// @brief Returns true, if data has been exchanged in last call of advance().
   virtual bool hasDataBeenReceived() const = 0;
@@ -191,12 +191,12 @@ public:
   virtual double getTimeWindowSize() const = 0;
 
   /**
-   * @brief Returns the maximal length of the next timestep to be computed.
+   * @brief Returns the maximal size of the next time step to be computed.
    *
    * If no time window size is prescribed by the coupling scheme, always the
    * maximal double accuracy floating point number value is returned.
    */
-  virtual double getNextTimestepMaxLength() const = 0;
+  virtual double getNextTimeStepMaxSize() const = 0;
 
   /// Returns true, when the coupled simulation is still ongoing.
   virtual bool isCouplingOngoing() const = 0;

--- a/src/cplscheme/cplscheme.dox
+++ b/src/cplscheme/cplscheme.dox
@@ -49,12 +49,12 @@ mesh.setVertexData ( data );
 
 // Create explicit coupling scheme object
 double maxSimulationTime = 1.0;
-int maxSimulationTimesteps = 100;
-double timesteplength = 0.01;
+int maxSimulationTimeSteps = 100;
+double timeStepSize = 0.01;
 std::string nameFirstParticipant ( nameThisSolver );
 std::string nameSecondParticipant ( nameOtherSolver );
 ExplicitCouplingScheme cplScheme (
-   maxSimulationTime, maxSimulationTimesteps, timestepLength,
+   maxSimulationTime, maxSimulationTimeSteps, timeStepSize,
    nameFirstParticipant, nameSecondParticipant );
 cplScheme.addMesh ( mesh );
 std::string nameDataCreator ( nameThisSolver );
@@ -67,7 +67,7 @@ while ( cplScheme.isCouplingOngoing() ) {
 
    // ...
 
-   cplScheme.advance ( computedTimestepLength );
+   cplScheme.advance ( computedTimeStepSize );
 
    // ...
 

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -224,9 +224,9 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int                         numberIterations = 1;
-  int                         maxTimeSteps     = 10;
-  PtrCouplingScheme           scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  int                         maxTimeWindows   = 10;
+  PtrCouplingScheme           scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -250,13 +250,13 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 1;
-  int               maxTimeSteps     = 10;
+  int               maxTimeWindows   = 10;
   PtrCouplingScheme scheme1(
-      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   PtrCouplingScheme scheme2(
-      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   PtrCouplingScheme scheme3(
-      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -282,10 +282,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 1;
-  int               maxTimeSteps     = 10;
-  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  int               maxTimeWindows   = 10;
+  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   numberIterations = 2;
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -324,10 +324,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 2;
-  int               maxTimeSteps     = 10;
-  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  int               maxTimeWindows   = 10;
+  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   numberIterations = 1;
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -358,12 +358,12 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 1;
-  int               maxTimeSteps     = 10;
+  int               maxTimeWindows   = 10;
   PtrCouplingScheme scheme1(
-      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   numberIterations = 3;
   PtrCouplingScheme scheme2(
-      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -394,10 +394,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3Explicit1)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 3;
-  int               maxTimeSteps     = 10;
-  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  int               maxTimeWindows   = 10;
+  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   numberIterations = 1;
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -102,11 +102,11 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(cplScheme->isCouplingOngoing());
       while (cplScheme->isCouplingOngoing()) {
         BOOST_REQUIRE(computedTime < 1.1);
-        BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
+        BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimeStepMaxSize()));
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
+        cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
@@ -115,7 +115,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
         } else {
           BOOST_TEST(cplScheme->isTimeWindowComplete());
-          computedTime += cplScheme->getNextTimestepMaxLength();
+          computedTime += cplScheme->getNextTimeStepMaxSize();
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
@@ -126,7 +126,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(computedTimesteps == 10);
       BOOST_TEST(cplScheme->isTimeWindowComplete());
       BOOST_TEST(not cplScheme->isCouplingOngoing());
-      BOOST_TEST(cplScheme->getNextTimestepMaxLength() > 0.0); // ??
+      BOOST_TEST(cplScheme->getNextTimeStepMaxSize() > 0.0); // ??
     } else if (participantName == std::string("Participant1")) {
       cplScheme->initialize(0.0, 1);
       BOOST_TEST(!cplScheme->hasDataBeenReceived());
@@ -136,11 +136,11 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(cplScheme->isCouplingOngoing());
       while (cplScheme->isCouplingOngoing()) {
         BOOST_REQUIRE(computedTime < 1.1);
-        BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
+        BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimeStepMaxSize()));
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
+        cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
@@ -149,7 +149,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
         } else {
           BOOST_TEST(cplScheme->isTimeWindowComplete());
-          computedTime += cplScheme->getNextTimestepMaxLength();
+          computedTime += cplScheme->getNextTimeStepMaxSize();
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
@@ -160,7 +160,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(computedTimesteps == 10);
       BOOST_TEST(cplScheme->isTimeWindowComplete());
       BOOST_TEST(not cplScheme->isCouplingOngoing());
-      BOOST_TEST(cplScheme->getNextTimestepMaxLength() > 0.0); // ??
+      BOOST_TEST(cplScheme->getNextTimeStepMaxSize() > 0.0); // ??
     } else {
       BOOST_TEST(participantName == std::string("Participant2"), participantName);
       cplScheme->initialize(0.0, 1);
@@ -171,11 +171,11 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(cplScheme->isCouplingOngoing());
       while (cplScheme->isCouplingOngoing()) {
         BOOST_REQUIRE(computedTime < 1.1);
-        BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimestepMaxLength()));
+        BOOST_TEST(testing::equals(0.1, cplScheme->getNextTimeStepMaxSize()));
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        cplScheme->addComputedTime(cplScheme->getNextTimestepMaxLength());
+        cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
@@ -184,7 +184,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
         } else {
           BOOST_TEST(cplScheme->isTimeWindowComplete());
-          computedTime += cplScheme->getNextTimestepMaxLength();
+          computedTime += cplScheme->getNextTimeStepMaxSize();
           computedTimesteps++;
         }
         BOOST_TEST(testing::equals(computedTime, cplScheme->getTime()));
@@ -196,7 +196,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(computedTimesteps == 10);
       BOOST_TEST(cplScheme->isTimeWindowComplete());
       BOOST_TEST(not cplScheme->isCouplingOngoing());
-      BOOST_TEST(cplScheme->getNextTimestepMaxLength() > 0.0); // ??
+      BOOST_TEST(cplScheme->getNextTimeStepMaxSize() > 0.0); // ??
     }
   }
 
@@ -223,12 +223,10 @@ BOOST_AUTO_TEST_SUITE(DummySchemeCompositionTests)
 BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
 {
   PRECICE_TEST(1_rank, Require::Events);
-  int               numberIterations = 1;
-  int               maxTimesteps     = 10;
-  PtrCouplingScheme scheme1(
-      new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
-  PtrCouplingScheme scheme2(
-      new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  int                         numberIterations = 1;
+  int                         maxTimeSteps     = 10;
+  PtrCouplingScheme           scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -252,13 +250,13 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 1;
-  int               maxTimesteps     = 10;
+  int               maxTimeSteps     = 10;
   PtrCouplingScheme scheme1(
-      new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   PtrCouplingScheme scheme2(
-      new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   PtrCouplingScheme scheme3(
-      new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -284,10 +282,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 1;
-  int               maxTimesteps     = 10;
-  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  int               maxTimeSteps     = 10;
+  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   numberIterations = 2;
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -326,10 +324,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 2;
-  int               maxTimesteps     = 10;
-  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  int               maxTimeSteps     = 10;
+  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   numberIterations = 1;
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -360,12 +358,12 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 1;
-  int               maxTimesteps     = 10;
+  int               maxTimeSteps     = 10;
   PtrCouplingScheme scheme1(
-      new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   numberIterations = 3;
   PtrCouplingScheme scheme2(
-      new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+      new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
@@ -396,10 +394,10 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3Explicit1)
 {
   PRECICE_TEST(1_rank, Require::Events);
   int               numberIterations = 3;
-  int               maxTimesteps     = 10;
-  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  int               maxTimeSteps     = 10;
+  PtrCouplingScheme scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   numberIterations = 1;
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimesteps));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeSteps));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -9,7 +9,7 @@ DummyCouplingScheme::DummyCouplingScheme(
     int numberIterations,
     int maxTimeWindows)
     : _numberIterations(numberIterations),
-      _maxTimeSteps(maxTimeWindows)
+      _maxTimeWindows(maxTimeWindows)
 {
 }
 
@@ -53,7 +53,7 @@ void DummyCouplingScheme::secondExchange()
   _hasConverged = _iterations == _numberIterations;
 
   if (_hasConverged) {
-    if (_timeWindows == _maxTimeSteps) {
+    if (_timeWindows == _maxTimeWindows) {
       _isOngoing = false;
     }
     _timeWindows++;
@@ -77,7 +77,7 @@ void DummyCouplingScheme::finalize()
 bool DummyCouplingScheme::isCouplingOngoing() const
 {
   PRECICE_ASSERT(_isInitialized);
-  if (_timeWindows <= _maxTimeSteps)
+  if (_timeWindows <= _maxTimeWindows)
     return true;
   return false;
 }

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -7,9 +7,9 @@ namespace precice::cplscheme::tests {
 
 DummyCouplingScheme::DummyCouplingScheme(
     int numberIterations,
-    int maxTimesteps)
+    int maxTimeSteps)
     : _numberIterations(numberIterations),
-      _maxTimesteps(maxTimesteps)
+      _maxTimeSteps(maxTimeSteps)
 {
 }
 
@@ -20,7 +20,7 @@ void DummyCouplingScheme::initialize(
   PRECICE_ASSERT(not _isInitialized);
   _isInitialized = true;
   _isOngoing     = true;
-  _timesteps     = startTimesteps;
+  _timeWindows   = startTimesteps;
   _iterations    = 1;
 }
 
@@ -53,18 +53,18 @@ void DummyCouplingScheme::secondExchange()
   _hasConverged = _iterations == _numberIterations;
 
   if (_hasConverged) {
-    if (_timesteps == _maxTimesteps) {
+    if (_timeWindows == _maxTimeSteps) {
       _isOngoing = false;
     }
-    _timesteps++;
+    _timeWindows++;
     _iterations = 1;
   } else {
     _iterations++;
   }
   if (isImplicitCouplingScheme()) {
-    PRECICE_DEBUG("advanced to {}-{}/{} (ongoing {})", _timesteps, _iterations, _numberIterations, _isOngoing);
+    PRECICE_DEBUG("advanced to {}-{}/{} (ongoing {})", _timeWindows, _iterations, _numberIterations, _isOngoing);
   } else {
-    PRECICE_DEBUG("advanced to {} (ongoing {})", _timesteps, _isOngoing);
+    PRECICE_DEBUG("advanced to {} (ongoing {})", _timeWindows, _isOngoing);
   }
 }
 
@@ -77,7 +77,7 @@ void DummyCouplingScheme::finalize()
 bool DummyCouplingScheme::isCouplingOngoing() const
 {
   PRECICE_ASSERT(_isInitialized);
-  if (_timesteps <= _maxTimesteps)
+  if (_timeWindows <= _maxTimeSteps)
     return true;
   return false;
 }

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -7,9 +7,9 @@ namespace precice::cplscheme::tests {
 
 DummyCouplingScheme::DummyCouplingScheme(
     int numberIterations,
-    int maxTimeSteps)
+    int maxTimeWindows)
     : _numberIterations(numberIterations),
-      _maxTimeSteps(maxTimeSteps)
+      _maxTimeSteps(maxTimeWindows)
 {
 }
 

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -235,7 +235,7 @@ private:
   int _iterations = 0;
 
   /// @brief Maximal number of time windows to be performed.
-  int _maxTimeSteps;
+  int _maxTimeWindows;
 
   /// @brief Performed number of time windows.
   int _timeWindows = 0;

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -18,12 +18,13 @@ public:
   /**
    * @brief Constructor.
    *
-   * @param[in] numberIterations If 1, models and explicit coupling scheme,
-   *        otherwise and implicit one.
+   * @param[in] numberIterations If 1, models an explicit coupling scheme,
+   *        otherwise an implicit one.
+   * @param[in] maxTimeWindows Number of time windows this DummyCouplingScheme has to perform.
    */
   DummyCouplingScheme(
       int numberIterations,
-      int maxTimeSteps);
+      int maxTimeWindows);
 
   /**
    * @brief Destructor, empty.
@@ -227,13 +228,13 @@ public:
 private:
   mutable logging::Logger _log{"cplscheme::tests::DummyCouplingScheme"};
 
-  /// @brief Number of iterations performed per time step. 1 --> explicit.
+  /// @brief Number of iterations performed per time window. 1 --> explicit.
   int _numberIterations;
 
-  /// @brief Performed iterations in the current time step.
+  /// @brief Performed iterations in the current time window.
   int _iterations = 0;
 
-  /// @brief Maximal number of time steps to be performed.
+  /// @brief Maximal number of time windows to be performed.
   int _maxTimeSteps;
 
   /// @brief Performed number of time windows.

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -23,7 +23,7 @@ public:
    */
   DummyCouplingScheme(
       int numberIterations,
-      int maxTimesteps);
+      int maxTimeSteps);
 
   /**
    * @brief Destructor, empty.
@@ -100,7 +100,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  bool willDataBeExchanged(double lastSolverTimestepLength) const override final
+  bool willDataBeExchanged(double lastSolverTimeStepSize) const override final
   {
     PRECICE_ASSERT(false);
     return false;
@@ -129,7 +129,7 @@ public:
    */
   int getTimeWindows() const override final
   {
-    return _timesteps;
+    return _timeWindows;
     return 0;
   }
 
@@ -154,7 +154,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  double getNextTimestepMaxLength() const override final
+  double getNextTimeStepMaxSize() const override final
   {
     PRECICE_ASSERT(false);
     return 0;
@@ -227,17 +227,17 @@ public:
 private:
   mutable logging::Logger _log{"cplscheme::tests::DummyCouplingScheme"};
 
-  /// @brief Number of iterations performed per timestep. 1 --> explicit.
+  /// @brief Number of iterations performed per time step. 1 --> explicit.
   int _numberIterations;
 
-  /// @brief Performed iterations in the current timestep.
+  /// @brief Performed iterations in the current time step.
   int _iterations = 0;
 
-  /// @brief Maximal number of timesteps to be performed.
-  int _maxTimesteps;
+  /// @brief Maximal number of time steps to be performed.
+  int _maxTimeSteps;
 
-  /// @brief Performed number of timesteps.
-  int _timesteps = 0;
+  /// @brief Performed number of time windows.
+  int _timeWindows = 0;
 
   /// @brief True, if initialize has been called.
   bool _isInitialized = false;

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -315,13 +315,14 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
 
-  double      maxTime      = 1.0;
-  int         maxTimeSteps = 10;
-  double      timeStepSize = 0.1;
-  std::string nameParticipant0("Participant0");
-  std::string nameParticipant1("Participant1");
-  int         sendDataIndex    = -1;
-  int         receiveDataIndex = -1;
+  const double maxTime        = 1.0;
+  const int    maxTimeWindows = 10;
+  const double timeWindowSize = 0.1;
+  const double timeStepSize   = timeWindowSize; // solver is not subcycling
+  std::string  nameParticipant0("Participant0");
+  std::string  nameParticipant1("Participant1");
+  int          sendDataIndex    = -1;
+  int          receiveDataIndex = -1;
 
   if (context.isNamed(nameParticipant0)) {
     sendDataIndex    = 0;
@@ -331,7 +332,7 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
     receiveDataIndex = 0;
   }
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimeSteps, timeStepSize, 12, nameParticipant0,
+      maxTime, maxTimeWindows, timeWindowSize, 12, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Explicit);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -670,13 +671,14 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
 
-  double      maxTime      = 1.0;
-  int         maxTimeSteps = 10;
-  double      timeStepSize = 0.1;
-  std::string nameParticipant0("Participant0");
-  std::string nameParticipant1("Participant1");
-  int         sendDataIndex    = -1;
-  int         receiveDataIndex = -1;
+  const double maxTime        = 1.0;
+  const int    maxTimeWindows = 10;
+  const double timeWindowSize = 0.1;
+  const double timeStepSize   = timeWindowSize; // solver is not subcycling
+  std::string  nameParticipant0("Participant0");
+  std::string  nameParticipant1("Participant1");
+  int          sendDataIndex    = -1;
+  int          receiveDataIndex = -1;
   if (context.isNamed(nameParticipant0)) {
     sendDataIndex    = 0;
     receiveDataIndex = 1;
@@ -685,7 +687,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
     receiveDataIndex = 0;
   }
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimeSteps, timeStepSize, 12, nameParticipant0,
+      maxTime, maxTimeWindows, timeWindowSize, 12, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Explicit);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -61,9 +61,9 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
       dataValues0(vertex.getID()) = valueData0;
-      computedTime += cplScheme.getNextTimestepMaxLength();
+      computedTime += cplScheme.getNextTimeStepMaxSize();
       computedTimesteps++;
-      cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
+      cplScheme.addComputedTime(cplScheme.getNextTimeStepMaxSize());
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -94,7 +94,7 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
-    BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
+    BOOST_TEST(cplScheme.getNextTimeStepMaxSize() > 0.0);
   } else if (participantName == std::string("Participant1")) {
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
@@ -109,9 +109,9 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
       dataValues1.segment(vertex.getID() * 3, 3) = valueData1;
-      computedTime += cplScheme.getNextTimestepMaxLength();
+      computedTime += cplScheme.getNextTimeStepMaxSize();
       computedTimesteps++;
-      cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
+      cplScheme.addComputedTime(cplScheme.getNextTimeStepMaxSize());
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -139,7 +139,7 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
-    BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
+    BOOST_TEST(cplScheme.getNextTimeStepMaxSize() > 0.0);
   }
 }
 
@@ -165,7 +165,7 @@ void runExplicitCouplingWithSubcycling(
   BOOST_TEST(((participantName == nameParticipant0) || (participantName == nameParticipant1)));
   if (participantName == nameParticipant0) {
     cplScheme.initialize(0.0, 1);
-    double dtDesired = cplScheme.getNextTimestepMaxLength() / 2.0;
+    double dtDesired = cplScheme.getNextTimeStepMaxSize() / 2.0;
     double dtUsed    = dtDesired;
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();
@@ -185,9 +185,9 @@ void runExplicitCouplingWithSubcycling(
       cplScheme.secondExchange();
       // If the dt from preCICE is larger than the desired one, do subcycling,
       // else, use the dt from preCICE
-      dtUsed = cplScheme.getNextTimestepMaxLength() > dtDesired
+      dtUsed = cplScheme.getNextTimeStepMaxSize() > dtDesired
                    ? dtDesired
-                   : cplScheme.getNextTimestepMaxLength();
+                   : cplScheme.getNextTimeStepMaxSize();
       BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
       BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
       BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -217,7 +217,7 @@ void runExplicitCouplingWithSubcycling(
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
-    BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
+    BOOST_TEST(cplScheme.getNextTimeStepMaxSize() > 0.0);
   } else if (participantName == nameParticipant1) {
     // Start coupling
     cplScheme.initialize(0.0, 1);
@@ -233,9 +233,9 @@ void runExplicitCouplingWithSubcycling(
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
       dataValues1.segment(vertex.getID() * 3, 3) = valueData1;
-      computedTime += cplScheme.getNextTimestepMaxLength();
+      computedTime += cplScheme.getNextTimeStepMaxSize();
       computedTimesteps++;
-      cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
+      cplScheme.addComputedTime(cplScheme.getNextTimeStepMaxSize());
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -262,7 +262,7 @@ void runExplicitCouplingWithSubcycling(
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
     BOOST_TEST(cplScheme.isTimeWindowComplete());
     BOOST_TEST(not cplScheme.isCouplingOngoing());
-    BOOST_TEST(cplScheme.getNextTimestepMaxLength() > 0.0);
+    BOOST_TEST(cplScheme.getNextTimeStepMaxSize() > 0.0);
   }
 }
 
@@ -315,9 +315,9 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
 
-  double      maxTime        = 1.0;
-  int         maxTimesteps   = 10;
-  double      timestepLength = 0.1;
+  double      maxTime      = 1.0;
+  int         maxTimeSteps = 10;
+  double      timeStepSize = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   int         sendDataIndex    = -1;
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
     receiveDataIndex = 0;
   }
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimesteps, timestepLength, 12, nameParticipant0,
+      maxTime, maxTimeSteps, timeStepSize, 12, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Explicit);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -422,12 +422,12 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
     cplScheme.initialize(0.0, 1);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     cplScheme.receiveResultOfFirstAdvance();
-    BOOST_TEST(cplScheme.getNextTimestepMaxLength() == 1);
+    BOOST_TEST(cplScheme.getNextTimeStepMaxSize() == 1);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
     while (cplScheme.isCouplingOngoing()) {
-      preciceDt = cplScheme.getNextTimestepMaxLength();
+      preciceDt = cplScheme.getNextTimeStepMaxSize();
       dt        = std::min({solverDt, preciceDt});
       computedTime += dt;
       computedTimesteps++;
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
     BOOST_TEST(testing::equals(dataValues0(0), 0.0));
     BOOST_TEST(testing::equals(dataValues1(0), 1.0));
     dataValues2(0) = 2.0;
-    cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
+    cplScheme.addComputedTime(cplScheme.getNextTimeStepMaxSize());
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
     cplScheme.secondSynchronization();
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
     cplScheme.initialize(0.0, 1);
     cplScheme.receiveResultOfFirstAdvance();
     BOOST_TEST(testing::equals(dataValues2(0), 2.0));
-    cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
+    cplScheme.addComputedTime(cplScheme.getNextTimeStepMaxSize());
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
     cplScheme.secondSynchronization();
@@ -615,7 +615,7 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
     BOOST_TEST(testing::equals(dataValues0(0), 0.0));
     BOOST_TEST(testing::equals(dataValues1(0), 1.0));
     dataValues2(0) = 2.0;
-    cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
+    cplScheme.addComputedTime(cplScheme.getNextTimeStepMaxSize());
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
     cplScheme.secondSynchronization();
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(dataValues2(0), 3.0));
     dataValues0(0) = 4.0;
-    cplScheme.addComputedTime(cplScheme.getNextTimestepMaxLength());
+    cplScheme.addComputedTime(cplScheme.getNextTimeStepMaxSize());
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
     cplScheme.secondSynchronization();
@@ -670,9 +670,9 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
   mesh->allocateDataValues();
   meshConfig.addMesh(mesh);
 
-  double      maxTime        = 1.0;
-  int         maxTimesteps   = 10;
-  double      timestepLength = 0.1;
+  double      maxTime      = 1.0;
+  int         maxTimeSteps = 10;
+  double      timeStepSize = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   int         sendDataIndex    = -1;
@@ -685,7 +685,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
     receiveDataIndex = 0;
   }
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimesteps, timestepLength, 12, nameParticipant0,
+      maxTime, maxTimeSteps, timeStepSize, 12, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Explicit);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -99,9 +99,9 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create a ParallelImplicitCouplingScheme object
-  double      maxTime        = 1.0;
-  int         maxTimesteps   = 3;
-  double      timestepLength = 0.1;
+  double      maxTime      = 1.0;
+  int         maxTimeSteps = 3;
+  double      timeStepSize = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   int         sendDataIndex              = -1;
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   // Create the coupling scheme object
   ParallelCouplingScheme cplScheme(
-      maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE, BaseCouplingScheme::Implicit, 100, extrapolationOrder);
 
   using Fixture = testing::ParallelCouplingSchemeFixture;
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
       }
-      cplScheme.addComputedTime(timestepLength);
+      cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
-      cplScheme.addComputedTime(timestepLength);
+      cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   BOOST_TEST(data->values().size() == 1);
 
   const double          maxTime      = CouplingScheme::UNDEFINED_TIME;
-  const int             maxTimesteps = 1;
+  const int             maxTimeSteps = 1;
   const double          dt           = 1.0;
   std::string           first        = "First";
   std::string           second       = "Second";
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   const int             extrapolationOrder = 1;
 
   // Test first order extrapolation
-  ParallelCouplingScheme scheme(maxTime, maxTimesteps, dt, 16, first, second,
+  ParallelCouplingScheme scheme(maxTime, maxTimeSteps, dt, 16, first, second,
                                 accessor, globalCom, constants::FIXED_TIME_WINDOW_SIZE,
                                 BaseCouplingScheme::Implicit, maxIterations, extrapolationOrder);
 
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timestepLength     = timeWindowSize;
+  const double timeStepSize       = timeWindowSize;
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
       v << 2.0;
     }
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
 
     v << 3.0;
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timestepLength     = timeWindowSize;
+  const double timeStepSize       = timeWindowSize;
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;
@@ -685,7 +685,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
       v << 2.0;
     }
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
@@ -740,7 +740,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
 
     v << 3.0;
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -99,15 +99,16 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create a ParallelImplicitCouplingScheme object
-  double      maxTime      = 1.0;
-  int         maxTimeSteps = 3;
-  double      timeStepSize = 0.1;
-  std::string nameParticipant0("Participant0");
-  std::string nameParticipant1("Participant1");
-  int         sendDataIndex              = -1;
-  int         receiveDataIndex           = -1;
-  bool        dataRequiresInitialization = false;
-  int         extrapolationOrder         = 0;
+  double       maxTime        = 1.0;
+  int          maxTimeWindows = 3;
+  const double timeWindowSize = 0.1;
+  const double timeStepSize   = timeWindowSize; // solver is not subcycling
+  std::string  nameParticipant0("Participant0");
+  std::string  nameParticipant1("Participant1");
+  int          sendDataIndex              = -1;
+  int          receiveDataIndex           = -1;
+  bool         dataRequiresInitialization = false;
+  int          extrapolationOrder         = 0;
   if (context.isNamed(nameParticipant0)) {
     sendDataIndex              = dataID0;
     receiveDataIndex           = dataID1;
@@ -120,7 +121,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   // Create the coupling scheme object
   ParallelCouplingScheme cplScheme(
-      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeWindows, timeWindowSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE, BaseCouplingScheme::Implicit, 100, extrapolationOrder);
 
   using Fixture = testing::ParallelCouplingSchemeFixture;
@@ -223,19 +224,19 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   mesh->allocateDataValues();
   BOOST_TEST(data->values().size() == 1);
 
-  const double          maxTime      = CouplingScheme::UNDEFINED_TIME;
-  const int             maxTimeSteps = 1;
-  const double          dt           = 1.0;
-  std::string           first        = "First";
-  std::string           second       = "Second";
-  std::string           accessor     = second;
+  const double          maxTime        = CouplingScheme::UNDEFINED_TIME;
+  const int             maxTimeWindows = 1;
+  const double          timeWindowSize = 1.0;
+  std::string           first          = "First";
+  std::string           second         = "Second";
+  std::string           accessor       = second;
   com::PtrCommunication com(new com::MPIDirectCommunication());
   m2n::PtrM2N           globalCom(new m2n::M2N(com, m2n::DistributedComFactory::SharedPointer()));
   const int             maxIterations      = 1;
   const int             extrapolationOrder = 1;
 
   // Test first order extrapolation
-  ParallelCouplingScheme scheme(maxTime, maxTimeSteps, dt, 16, first, second,
+  ParallelCouplingScheme scheme(maxTime, maxTimeWindows, timeWindowSize, 16, first, second,
                                 accessor, globalCom, constants::FIXED_TIME_WINDOW_SIZE,
                                 BaseCouplingScheme::Implicit, maxIterations, extrapolationOrder);
 
@@ -339,7 +340,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timeStepSize       = timeWindowSize;
+  const double timeStepSize       = timeWindowSize; // solver is not subcycling
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;
@@ -559,7 +560,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timeStepSize       = timeWindowSize;
+  const double timeStepSize       = timeWindowSize; // solver is not subcycling
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -87,9 +87,9 @@ void runCoupling(
 
     while (cplScheme.isCouplingOngoing()) {
       dataValues0(index) += stepsizeData0;
-      // The max timestep length is required to be obeyed.
-      double maxLengthTimestep = cplScheme.getNextTimestepMaxLength();
-      cplScheme.addComputedTime(maxLengthTimestep);
+      // The max time step size is required to be obeyed.
+      double maxTimeStepSize = cplScheme.getNextTimeStepMaxSize();
+      cplScheme.addComputedTime(maxTimeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -100,7 +100,7 @@ void runCoupling(
       // timestep.
       if (cplScheme.isTimeWindowComplete()) {
         // Advance participant time and timestep
-        computedTime += maxLengthTimestep;
+        computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
         BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
@@ -158,9 +158,9 @@ void runCoupling(
       currentData = dataValues1.segment(index * 3, 3);
       currentData += stepsizeData1;
       dataValues1.segment(index * 3, 3) = currentData;
-      // The max timestep length is required to be obeyed.
-      double maxLengthTimestep = cplScheme.getNextTimestepMaxLength();
-      cplScheme.addComputedTime(maxLengthTimestep);
+      // The max time step size is required to be obeyed.
+      double maxTimeStepSize = cplScheme.getNextTimeStepMaxSize();
+      cplScheme.addComputedTime(maxTimeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -171,7 +171,7 @@ void runCoupling(
       // timestep.
       if (cplScheme.isTimeWindowComplete()) {
         // Advance participant time and timestep
-        computedTime += maxLengthTimestep;
+        computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
         BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
@@ -256,13 +256,13 @@ void runCouplingWithSubcycling(
     cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
     BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
 
-    double maxTimestepLength      = cplScheme.getNextTimestepMaxLength();
-    double computedTimestepLength = maxTimestepLength / 2.0;
-    int    subcyclingStep         = 0;
+    double maxTimeStepSize      = cplScheme.getNextTimeStepMaxSize();
+    double computedTimeStepSize = maxTimeStepSize / 2.0;
+    int    subcyclingStep       = 0;
 
     // Main coupling loop
     while (cplScheme.isCouplingOngoing()) {
-      cplScheme.addComputedTime(computedTimestepLength);
+      cplScheme.addComputedTime(computedTimeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -272,7 +272,7 @@ void runCouplingWithSubcycling(
       // timestep.
       if (cplScheme.isTimeWindowComplete()) {
         // Advance participant time and timestep
-        computedTime += maxTimestepLength;
+        computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
         BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
@@ -293,13 +293,13 @@ void runCouplingWithSubcycling(
           BOOST_TEST(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
-        // interface values in next timestep.
+        // interface values in next time step.
         stepsizeData0 = initialStepsizeData0;
         BOOST_TEST(testing::equals(subcyclingStep, 1));
         subcyclingStep = 0;
       } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
-        // If length of global timestep is reached
+        // If end of time window is reached
         if (cplScheme.hasDataBeenReceived()) {
           BOOST_TEST(iterationCount <= *iterValidIterations);
           BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -340,28 +340,28 @@ void runCouplingWithSubcycling(
     cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
     BOOST_TEST(cplScheme.isActionFulfilled(CouplingScheme::Action::WriteCheckpoint));
 
-    double maxTimestepLength       = cplScheme.getNextTimestepMaxLength();
-    double preferredTimestepLength = maxTimestepLength / 2.5;
-    double computedTimestepLength  = preferredTimestepLength;
-    int    subcyclingStep          = 0;
+    double maxTimeStepSize       = cplScheme.getNextTimeStepMaxSize();
+    double preferredTimeStepSize = maxTimeStepSize / 2.5;
+    double computedTimeStepSize  = preferredTimeStepSize;
+    int    subcyclingStep        = 0;
 
     // Main coupling loop
     while (cplScheme.isCouplingOngoing()) {
-      cplScheme.addComputedTime(computedTimestepLength);
+      cplScheme.addComputedTime(computedTimeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
       cplScheme.secondExchange();
-      computedTimestepLength =
-          cplScheme.getNextTimestepMaxLength() < preferredTimestepLength
-              ? cplScheme.getNextTimestepMaxLength()
-              : preferredTimestepLength;
-      // A coupling timestep is complete, when the coupling iterations are
+      computedTimeStepSize =
+          cplScheme.getNextTimeStepMaxSize() < preferredTimeStepSize
+              ? cplScheme.getNextTimeStepMaxSize()
+              : preferredTimeStepSize;
+      // A coupling time step is complete, when the coupling iterations are
       // globally converged and if subcycling steps have filled one global
-      // timestep.
+      // time step.
       if (cplScheme.isTimeWindowComplete()) {
-        // Advance participant time and timestep
-        computedTime += maxTimestepLength;
+        // Advance participant time and time step
+        computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
         BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
@@ -382,13 +382,13 @@ void runCouplingWithSubcycling(
           BOOST_TEST(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
-        // interface values in next timestep.
+        // interface values in next time step.
         stepsizeData1 = initialStepsizeData1;
         BOOST_TEST(testing::equals(subcyclingStep, 2));
         subcyclingStep = 0;
       } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
-        // If length of global timestep is reached
+        // If end of time window is reached
         if (cplScheme.hasDataBeenReceived()) {
           BOOST_TEST(iterationCount <= *iterValidIterations);
           BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   BOOST_TEST(data->values().size() == 1);
 
   const double          maxTime      = CouplingScheme::UNDEFINED_TIME;
-  const int             maxTimesteps = 1;
+  const int             maxTimeSteps = 1;
   const double          dt           = 1.0;
   std::string           first        = "First";
   std::string           second       = "Second";
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   const int             extrapolationOrder = 1;
 
   // Test first order extrapolation
-  SerialCouplingScheme scheme(maxTime, maxTimesteps, dt, 16, first, second,
+  SerialCouplingScheme scheme(maxTime, maxTimeSteps, dt, 16, first, second,
                               accessor, globalCom, constants::FIXED_TIME_WINDOW_SIZE,
                               BaseCouplingScheme::Implicit, maxIterations, extrapolationOrder);
 
@@ -584,7 +584,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timestepLength     = timeWindowSize;
+  const double timeStepSize       = timeWindowSize;
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;
@@ -669,7 +669,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
       v << 2.0;
     }
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
@@ -716,7 +716,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
 
     v << 3.0;
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timestepLength     = timeWindowSize;
+  const double timeStepSize       = timeWindowSize;
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;
@@ -911,7 +911,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
       v << 2.0;
     }
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
@@ -958,7 +958,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
 
     v << 3.0;
     mesh->data(sendDataIndex)->values() = v;
-    cplScheme.addComputedTime(timestepLength);
+    cplScheme.addComputedTime(timeStepSize);
 
     cplScheme.firstSynchronization({});
     cplScheme.firstExchange();
@@ -1018,9 +1018,9 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double      maxTime        = 1.0;
-  int         maxTimesteps   = 3;
-  double      timestepLength = 0.1;
+  double      maxTime      = 1.0;
+  int         maxTimeSteps = 3;
+  double      timeStepSize = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   int         sendDataIndex        = -1;
@@ -1039,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimesteps, timestepLength, 16, nameParticipant0,
+      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -1124,9 +1124,9 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double      maxTime        = 1.0;
-  int         maxTimesteps   = 3;
-  double      timestepLength = 0.1;
+  double      maxTime      = 1.0;
+  int         maxTimeSteps = 3;
+  double      timeStepSize = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   int         sendDataIndex        = -1;
@@ -1145,7 +1145,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -1187,9 +1187,9 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double           maxTime        = 1.0;
-  int              maxTimesteps   = 3;
-  double           timestepLength = 0.1;
+  double           maxTime      = 1.0;
+  int              maxTimeSteps = 3;
+  double           timeStepSize = 0.1;
   std::string      nameParticipant0("Participant0");
   std::string      nameParticipant1("Participant1");
   int              sendDataIndex        = -1;
@@ -1211,7 +1211,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -1253,9 +1253,9 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double      maxTime        = 1.0;
-  int         maxTimesteps   = 3;
-  double      timestepLength = 0.1;
+  double      maxTime      = 1.0;
+  int         maxTimeSteps = 3;
+  double      timeStepSize = 0.1;
   std::string nameParticipant0("Participant0");
   std::string nameParticipant1("Participant1");
   int         sendDataIndex              = -1;
@@ -1276,7 +1276,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimesteps, timestepLength, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   using Fixture = testing::SerialCouplingSchemeFixture;
@@ -1330,7 +1330,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
       }
-      cplScheme.addComputedTime(timestepLength);
+      cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -1368,7 +1368,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
-      cplScheme.addComputedTime(timestepLength);
+      cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -468,19 +468,19 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   mesh->allocateDataValues();
   BOOST_TEST(data->values().size() == 1);
 
-  const double          maxTime      = CouplingScheme::UNDEFINED_TIME;
-  const int             maxTimeSteps = 1;
-  const double          dt           = 1.0;
-  std::string           first        = "First";
-  std::string           second       = "Second";
-  std::string           accessor     = second;
+  const double          maxTime        = CouplingScheme::UNDEFINED_TIME;
+  const int             maxTimeWindows = 1;
+  const double          timeWindowSize = 1.0;
+  std::string           first          = "First";
+  std::string           second         = "Second";
+  std::string           accessor       = second;
   com::PtrCommunication com(new com::MPIDirectCommunication());
   m2n::PtrM2N           globalCom(new m2n::M2N(com, m2n::DistributedComFactory::SharedPointer()));
   const int             maxIterations      = 1;
   const int             extrapolationOrder = 1;
 
   // Test first order extrapolation
-  SerialCouplingScheme scheme(maxTime, maxTimeSteps, dt, 16, first, second,
+  SerialCouplingScheme scheme(maxTime, maxTimeWindows, timeWindowSize, 16, first, second,
                               accessor, globalCom, constants::FIXED_TIME_WINDOW_SIZE,
                               BaseCouplingScheme::Implicit, maxIterations, extrapolationOrder);
 
@@ -584,7 +584,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timeStepSize       = timeWindowSize;
+  const double timeStepSize       = timeWindowSize; // solver is not subcycling
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
   const int    extrapolationOrder = 1;
-  const double timeStepSize       = timeWindowSize;
+  const double timeStepSize       = timeWindowSize; // solver is not subcycling
   std::string  first("Participant0");
   std::string  second("Participant1");
   int          sendDataIndex        = -1;
@@ -1018,15 +1018,15 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double      maxTime      = 1.0;
-  int         maxTimeSteps = 3;
-  double      timeStepSize = 0.1;
-  std::string nameParticipant0("Participant0");
-  std::string nameParticipant1("Participant1");
-  int         sendDataIndex        = -1;
-  int         receiveDataIndex     = -1;
-  int         convergenceDataIndex = -1;
-  int         extrapolationOrder   = 0;
+  const double maxTime        = 1.0;
+  const int    maxTimeWindows = 3;
+  const double timeWindowSize = 0.1;
+  std::string  nameParticipant0("Participant0");
+  std::string  nameParticipant1("Participant1");
+  int          sendDataIndex        = -1;
+  int          receiveDataIndex     = -1;
+  int          convergenceDataIndex = -1;
+  int          extrapolationOrder   = 0;
   if (context.isNamed(nameParticipant0)) {
     sendDataIndex        = 0;
     receiveDataIndex     = 1;
@@ -1039,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0,
+      maxTime, maxTimeWindows, timeWindowSize, 16, nameParticipant0,
       nameParticipant1, context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -1124,15 +1124,15 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double      maxTime      = 1.0;
-  int         maxTimeSteps = 3;
-  double      timeStepSize = 0.1;
-  std::string nameParticipant0("Participant0");
-  std::string nameParticipant1("Participant1");
-  int         sendDataIndex        = -1;
-  int         receiveDataIndex     = -1;
-  int         convergenceDataIndex = -1;
-  int         extrapolationOrder   = 0;
+  const double maxTime        = 1.0;
+  const int    maxTimeWindows = 3;
+  const double timeWindowSize = 0.1;
+  std::string  nameParticipant0("Participant0");
+  std::string  nameParticipant1("Participant1");
+  int          sendDataIndex        = -1;
+  int          receiveDataIndex     = -1;
+  int          convergenceDataIndex = -1;
+  int          extrapolationOrder   = 0;
   if (context.isNamed(nameParticipant0)) {
     sendDataIndex        = 0;
     receiveDataIndex     = 1;
@@ -1145,7 +1145,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronized)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeWindows, timeWindowSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -1187,9 +1187,9 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double           maxTime      = 1.0;
-  int              maxTimeSteps = 3;
-  double           timeStepSize = 0.1;
+  double           maxTime        = 1.0;
+  int              maxTimeWindows = 3;
+  double           timeWindowSize = 0.1;
   std::string      nameParticipant0("Participant0");
   std::string      nameParticipant1("Participant1");
   int              sendDataIndex        = -1;
@@ -1211,7 +1211,7 @@ BOOST_AUTO_TEST_CASE(testMinIterConvergenceMeasureSynchronizedWithSubcycling)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeWindows, timeWindowSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   cplScheme.addDataToSend(mesh->data(sendDataIndex), mesh, false);
@@ -1253,16 +1253,17 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  double      maxTime      = 1.0;
-  int         maxTimeSteps = 3;
-  double      timeStepSize = 0.1;
-  std::string nameParticipant0("Participant0");
-  std::string nameParticipant1("Participant1");
-  int         sendDataIndex              = -1;
-  int         receiveDataIndex           = -1;
-  bool        dataRequiresInitialization = false;
-  int         convergenceDataIndex       = -1;
-  int         extrapolationOrder         = 0;
+  const double maxTime        = 1.0;
+  const int    maxTimeWindows = 3;
+  const double timeWindowSize = 0.1;
+  const double timeStepSize   = timeWindowSize; // solver is not subcycling
+  std::string  nameParticipant0("Participant0");
+  std::string  nameParticipant1("Participant1");
+  int          sendDataIndex              = -1;
+  int          receiveDataIndex           = -1;
+  bool         dataRequiresInitialization = false;
+  int          convergenceDataIndex       = -1;
+  int          extrapolationOrder         = 0;
   if (context.isNamed(nameParticipant0)) {
     sendDataIndex        = dataID0;
     receiveDataIndex     = dataID1;
@@ -1276,7 +1277,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   // Create the coupling scheme object
   cplscheme::SerialCouplingScheme cplScheme(
-      maxTime, maxTimeSteps, timeStepSize, 16, nameParticipant0, nameParticipant1,
+      maxTime, maxTimeWindows, timeWindowSize, 16, nameParticipant0, nameParticipant1,
       context.name, m2n, constants::FIXED_TIME_WINDOW_SIZE,
       BaseCouplingScheme::Implicit, 100, extrapolationOrder);
   using Fixture = testing::SerialCouplingSchemeFixture;

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -32,9 +32,9 @@ double SolverInterface::initialize()
 }
 
 double SolverInterface::advance(
-    double computedTimestepLength)
+    double computedTimeStepSize)
 {
-  return _impl->advance(computedTimestepLength);
+  return _impl->advance(computedTimeStepSize);
 }
 
 void SolverInterface::finalize()

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -89,7 +89,7 @@ public:
    * - Sets up a connection to the other participants of the coupled simulation.
    * - Creates all meshes, solver meshes need to be submitted before.
    * - Receives first coupling data. The starting values for coupling data are zero by default.
-   * - Determines length of the first timestep to be computed.
+   * - Determines size of the first time step to be computed.
    *
    * @pre initialize() has not yet been called.
    *
@@ -97,12 +97,12 @@ public:
    * @post Meshes are exchanged between coupling partners and the parallel partitions are created.
    * @post Initial coupling data was exchanged.
    *
-   * @return Maximum length of first timestep to be computed by the solver.
+   * @return Maximum size of first time step to be computed by the solver.
    */
   double initialize();
 
   /**
-   * @brief Advances preCICE after the solver has computed one timestep.
+   * @brief Advances preCICE after the solver has computed one time step.
    *
    * - Sends and resets coupling data written by solver to coupling partners.
    * - Receives coupling data read by solver.
@@ -111,24 +111,24 @@ public:
    * - Exchanges and computes information regarding the state of the coupled
    *   simulation.
    *
-   * @param[in] computedTimestepLength Length of timestep used by the solver.
+   * @param[in] computedTimeStepSize Size of time step used by the solver.
    *
    * @pre initialize() has been called successfully.
-   * @pre The solver has computed one timestep.
+   * @pre The solver has computed one time step.
    * @pre The solver has written all coupling data.
    * @pre isCouplngOngoing() returns true.
    * @pre finalize() has not yet been called.
    *
    * @post Coupling data values specified in the configuration are exchanged.
-   * @post Coupling scheme state (computed time, computed timesteps, ...) is updated.
+   * @post Coupling scheme state (computed time, computed time steps, ...) is updated.
    * @post The coupling state is logged.
    * @post Configured data mapping schemes are applied.
    * @post [Second Participant] Configured acceleration schemes are applied.
    * @post Meshes with data are exported to files if configured.
    *
-   * @return Maximum length of next timestep to be computed by solver.
+   * @return Maximum size of next time step to be computed by solver.
    */
-  double advance(double computedTimestepLength);
+  double advance(double computedTimeStepSize);
 
   /**
    * @brief Finalizes preCICE.
@@ -667,7 +667,7 @@ public:
    *
    * The data is read at relativeReadTime, which indicates the point in time measured from the beginning of the current time step.
    * relativeReadTime = 0 corresponds to data at the beginning of the time step. Assuming that the user will call advance(dt) at the
-   * end of the time step, dt indicates the length of the current time step. Then relativeReadTime = dt corresponds to the data at
+   * end of the time step, dt indicates the size of the current time step. Then relativeReadTime = dt corresponds to the data at
    * the end of the time step.
    *
    * @param[in] meshName the name of mesh that hold the data.
@@ -704,7 +704,7 @@ public:
    *
    * The data is read at relativeReadTime, which indicates the point in time measured from the beginning of the current time step.
    * relativeReadTime = 0 corresponds to data at the beginning of the time step. Assuming that the user will call advance(dt) at the
-   * end of the time step, dt indicates the length of the current time step. Then relativeReadTime = dt corresponds to the data at
+   * end of the time step, dt indicates the size of the current time step. Then relativeReadTime = dt corresponds to the data at
    * the end of the time step.
    *
    * @param[in] meshName the name of mesh that hold the data.
@@ -736,7 +736,7 @@ public:
    *
    * The data is read at relativeReadTime, which indicates the point in time measured from the beginning of the current time step.
    * relativeReadTime = 0 corresponds to data at the beginning of the time step. Assuming that the user will call advance(dt) at the
-   * end of the time step, dt indicates the length of the current time step. Then relativeReadTime = dt corresponds to the data at
+   * end of the time step, dt indicates the size of the current time step. Then relativeReadTime = dt corresponds to the data at
    * the end of the time step.
    *
    * @param[in] meshName the name of mesh that hold the data.
@@ -769,7 +769,7 @@ public:
    *
    * The data is read at relativeReadTime, which indicates the point in time measured from the beginning of the current time step.
    * relativeReadTime = 0 corresponds to data at the beginning of the time step. Assuming that the user will call advance(dt) at the
-   * end of the time step, dt indicates the length of the current time step. Then relativeReadTime = dt corresponds to the data at
+   * end of the time step, dt indicates the size of the current time step. Then relativeReadTime = dt corresponds to the data at
    * the end of the time step.
    *
    * @param[in] meshName the name of mesh that hold the data.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -351,7 +351,7 @@ double SolverInterfaceImpl::initialize()
   }
 
   PRECICE_DEBUG("Initialize coupling schemes");
-  // result of _couplingScheme->getNextTimestepMaxLength() can change when calling _couplingScheme->initialize(...) and first participant method is used for setting the time window size.
+  // result of _couplingScheme->getNextTimeStepMaxSize() can change when calling _couplingScheme->initialize(...) and first participant method is used for setting the time window size.
   _couplingScheme->initialize(time, timeWindow);
 
   if (_couplingScheme->hasDataBeenReceived()) {
@@ -387,15 +387,15 @@ double SolverInterfaceImpl::initialize()
   PRECICE_INFO(_couplingScheme->printCouplingState());
 
   // determine dt at the very end of the method to get the final value, even if first participant method is used (see above).
-  double dt = _couplingScheme->getNextTimestepMaxLength();
+  double dt = _couplingScheme->getNextTimeStepMaxSize();
   return dt;
 }
 
 double SolverInterfaceImpl::advance(
-    double computedTimestepLength)
+    double computedTimeStepSize)
 {
 
-  PRECICE_TRACE(computedTimestepLength);
+  PRECICE_TRACE(computedTimeStepSize);
 
   // Events for the solver time, stopped when we enter, restarted when we leave advance
   auto &solverEvent = EventRegistry::instance().getStoredEvent("solver.advance");
@@ -411,19 +411,19 @@ double SolverInterfaceImpl::advance(
   PRECICE_CHECK(_state == State::Initialized, "initialize() has to be called before advance().")
   PRECICE_ASSERT(_couplingScheme->isInitialized());
   PRECICE_CHECK(isCouplingOngoing(), "advance() cannot be called when isCouplingOngoing() returns false.");
-  PRECICE_CHECK(!math::equals(computedTimestepLength, 0.0), "advance() cannot be called with a timestep size of 0.");
-  PRECICE_CHECK(computedTimestepLength > 0.0, "advance() cannot be called with a negative timestep size {}.", computedTimestepLength);
+  PRECICE_CHECK(!math::equals(computedTimeStepSize, 0.0), "advance() cannot be called with a time step size of 0.");
+  PRECICE_CHECK(computedTimeStepSize > 0.0, "advance() cannot be called with a negative time step size {}.", computedTimeStepSize);
   _numberAdvanceCalls++;
 
 #ifndef NDEBUG
-  PRECICE_DEBUG("Synchronize timestep length");
+  PRECICE_DEBUG("Synchronize time step size");
   if (utils::IntraComm::isParallel()) {
-    syncTimestep(computedTimestepLength);
+    syncTimestep(computedTimeStepSize);
   }
 #endif
 
   // Update the coupling scheme time state. Necessary to get correct remainder.
-  _couplingScheme->addComputedTime(computedTimestepLength);
+  _couplingScheme->addComputedTime(computedTimeStepSize);
   // Current time
   double time = _couplingScheme->getTime();
 
@@ -458,7 +458,7 @@ double SolverInterfaceImpl::advance(
 
   _meshLock.lockAll();
   solverEvent.start(precice::syncMode);
-  return _couplingScheme->getNextTimestepMaxLength();
+  return _couplingScheme->getNextTimeStepMaxSize();
 }
 
 void SolverInterfaceImpl::finalize()
@@ -1324,15 +1324,15 @@ void SolverInterfaceImpl::readBlockVectorData(
 {
   PRECICE_TRACE(meshName, dataName, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockVectorData(...) cannot be called after finalize().");
-  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimestepMaxLength(), "readBlockVectorData(...) cannot sample data outside of current time window.");
+  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimeStepMaxSize(), "readBlockVectorData(...) cannot sample data outside of current time window.");
   PRECICE_CHECK(relativeReadTime >= 0, "readBlockVectorData(...) cannot sample data before the current time.");
   double normalizedReadTime;
   if (_couplingScheme->hasTimeWindowSize()) {
-    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimestepMaxLength();
+    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimeStepMaxSize();
     double readTime      = timeStepStart + relativeReadTime;
     normalizedReadTime   = readTime / _couplingScheme->getTimeWindowSize(); //@todo might be moved into coupling scheme
   } else {                                                                  // if this participant defines time window size through participant-first method
-    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimestepMaxLength(), "Waveform relaxation is not allowed for solver that sets the time step size");
+    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimeStepMaxSize(), "Waveform relaxation is not allowed for solver that sets the time step size");
     normalizedReadTime = 1; // by default read at end of window.
   }
   PRECICE_REQUIRE_DATA_READ(meshName, dataName);
@@ -1370,15 +1370,15 @@ void SolverInterfaceImpl::readVectorData(
 {
   PRECICE_TRACE(meshName, dataName, valueIndex);
   PRECICE_CHECK(_state != State::Finalized, "readVectorData(...) cannot be called after finalize().");
-  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimestepMaxLength(), "readVectorData(...) cannot sample data outside of current time window.");
+  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimeStepMaxSize(), "readVectorData(...) cannot sample data outside of current time window.");
   PRECICE_CHECK(relativeReadTime >= 0, "readVectorData(...) cannot sample data before the current time.");
   double normalizedReadTime;
   if (_couplingScheme->hasTimeWindowSize()) {
-    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimestepMaxLength();
+    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimeStepMaxSize();
     double readTime      = timeStepStart + relativeReadTime;
     normalizedReadTime   = readTime / _couplingScheme->getTimeWindowSize(); //@todo might be moved into coupling scheme
   } else {                                                                  // if this participant defines time window size through participant-first method
-    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimestepMaxLength(), "Waveform relaxation is not allowed for solver that sets the time step size");
+    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimeStepMaxSize(), "Waveform relaxation is not allowed for solver that sets the time step size");
     normalizedReadTime = 1; // by default read at end of window.
   }
   PRECICE_REQUIRE_DATA_READ(meshName, dataName);
@@ -1413,15 +1413,15 @@ void SolverInterfaceImpl::readBlockScalarData(
 {
   PRECICE_TRACE(meshName, dataName, size);
   PRECICE_CHECK(_state != State::Finalized, "readBlockScalarData(...) cannot be called after finalize().");
-  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimestepMaxLength(), "readBlockScalarData(...) cannot sample data outside of current time window.");
+  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimeStepMaxSize(), "readBlockScalarData(...) cannot sample data outside of current time window.");
   PRECICE_CHECK(relativeReadTime >= 0, "readBlockScalarData(...) cannot sample data before the current time.");
   double normalizedReadTime;
   if (_couplingScheme->hasTimeWindowSize()) {
-    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimestepMaxLength();
+    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimeStepMaxSize();
     double readTime      = timeStepStart + relativeReadTime;
     normalizedReadTime   = readTime / _couplingScheme->getTimeWindowSize(); //@todo might be moved into coupling scheme
   } else {                                                                  // if this participant defines time window size through participant-first method
-    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimestepMaxLength(), "Waveform relaxation is not allowed for solver that sets the time step size");
+    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimeStepMaxSize(), "Waveform relaxation is not allowed for solver that sets the time step size");
     normalizedReadTime = 1; // by default read at end of window.
   }
   PRECICE_REQUIRE_DATA_READ(meshName, dataName);
@@ -1456,15 +1456,15 @@ void SolverInterfaceImpl::readScalarData(
 {
   PRECICE_TRACE(meshName, dataName, valueIndex, value);
   PRECICE_CHECK(_state != State::Finalized, "readScalarData(...) cannot be called after finalize().");
-  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimestepMaxLength(), "readScalarData(...) cannot sample data outside of current time window.");
+  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimeStepMaxSize(), "readScalarData(...) cannot sample data outside of current time window.");
   PRECICE_CHECK(relativeReadTime >= 0, "readScalarData(...) cannot sample data before the current time.");
   double normalizedReadTime;
   if (_couplingScheme->hasTimeWindowSize()) {
-    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimestepMaxLength();
+    double timeStepStart = _couplingScheme->getTimeWindowSize() - _couplingScheme->getNextTimeStepMaxSize();
     double readTime      = timeStepStart + relativeReadTime;
     normalizedReadTime   = readTime / _couplingScheme->getTimeWindowSize(); //@todo might be moved into coupling scheme
   } else {                                                                  // if this participant defines time window size through participant-first method
-    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimestepMaxLength(), "Waveform relaxation is not allowed for solver that sets the time step size");
+    PRECICE_CHECK(relativeReadTime == _couplingScheme->getNextTimeStepMaxSize(), "Waveform relaxation is not allowed for solver that sets the time step size");
     normalizedReadTime = 1; // by default read at end of window.
   }
   PRECICE_REQUIRE_DATA_READ(meshName, dataName);
@@ -1808,19 +1808,19 @@ void SolverInterfaceImpl::initializeIntraCommunication()
       _accessorProcessRank, _accessorCommunicatorSize);
 }
 
-void SolverInterfaceImpl::syncTimestep(double computedTimestepLength)
+void SolverInterfaceImpl::syncTimestep(double computedTimeStepSize)
 {
   PRECICE_ASSERT(utils::IntraComm::isParallel());
   if (utils::IntraComm::isSecondary()) {
-    utils::IntraComm::getCommunication()->send(computedTimestepLength, 0);
+    utils::IntraComm::getCommunication()->send(computedTimeStepSize, 0);
   } else {
     PRECICE_ASSERT(utils::IntraComm::isPrimary());
     for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
       double dt;
       utils::IntraComm::getCommunication()->receive(dt, secondaryRank);
-      PRECICE_CHECK(math::equals(dt, computedTimestepLength),
-                    "Found ambiguous values for the timestep length passed to preCICE in \"advance\". On rank {}, the value is {}, while on rank 0, the value is {}.",
-                    secondaryRank, dt, computedTimestepLength);
+      PRECICE_CHECK(math::equals(dt, computedTimeStepSize),
+                    "Found ambiguous values for the time step size passed to preCICE in \"advance\". On rank {}, the value is {}, while on rank 0, the value is {}.",
+                    secondaryRank, dt, computedTimeStepSize);
     }
   }
 }

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -94,7 +94,7 @@ public:
   double initialize();
 
   /// @copydoc SolverInterface::advance
-  double advance(double computedTimestepLength);
+  double advance(double computedTimeStepSize);
 
   /// @copydoc SolverInterface::finalize
   void finalize();
@@ -490,8 +490,8 @@ private:
   /// Advances the coupling schemes
   void advanceCouplingScheme();
 
-  /// Syncs the timestep between all ranks (all timesteps should be the same!)
-  void syncTimestep(double computedTimestepLength);
+  /// Syncs the time step between all ranks (all time steps should be the same!)
+  void syncTimestep(double computedTimeStepSize);
 
   /// Which channels to close in closeCommunicationChannels()
   enum class CloseChannels : bool {

--- a/src/precice/precice.dox
+++ b/src/precice/precice.dox
@@ -40,7 +40,7 @@ while ( interface.isCouplingOngoing() ){
 
    // ...
 
-   if ( interface.isWriteDataRequired(computedTimestepLength) ) {
+   if ( interface.isWriteDataRequired(computedTimeStepSize) ) {
       // ...
       interface.writeVectorData ( forceDataID, solverNodeCoords, forceValue );
       // ...
@@ -48,10 +48,10 @@ while ( interface.isCouplingOngoing() ){
 
    // When all data values are written, the simulation can be advanced.
    // preCICE automatically exchanges data between coupled solvers and
-   // computes the current state of the simulation. It uses the timestep length
-   // of the solver timestep for that, and returns an upper limit for the next
-   // timestep of the solver.
-   dtLimit = interface.advance ( computedTimestepLength );
+   // computes the current state of the simulation. It uses the time step size
+   // of the solver time step for that, and returns an upper limit for the next
+   // time step of the solver.
+   dtLimit = interface.advance ( computedTimeStepSize );
 }
 
 // A call to finalize cleans up data structures and disconnects coupled solvers

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
@@ -70,8 +70,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(maxDt == 2.0); // use window size != 1.0 to be able to detect more possible bugs
   double windowDt      = maxDt;
   double dt            = windowDt / (nSubsteps - 0.5);                 // Solver tries to do a timestep of size 4/7
-  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
-  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual timestep length; must fit into remaining time in window
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses time step size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual time step size; must fit into remaining time in window
 
   while (precice.isCouplingOngoing()) {
     double readTime = timewindow * windowDt; // both solvers lag one window behind for parallel-explicit coupling.

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -69,9 +69,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   double maxDt = precice.initialize();
   BOOST_TEST(maxDt == 2.0); // use window size != 1.0 to be able to detect more possible bugs
   double windowDt      = maxDt;
-  double dt            = windowDt / (nSubsteps - 0.5);                 // Solver tries to do a timestep of size 4/7
-  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
-  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual timestep length; must fit into remaining time in window
+  double dt            = windowDt / (nSubsteps - 0.5);                 // Solver tries to do a time step of size 4/7
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses time step size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual time step size; must fit into remaining time in window
 
   while (precice.isCouplingOngoing()) {
     double readTime = timewindow * windowDt; // both solvers lag one window behind for parallel-explicit coupling.

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
@@ -28,8 +28,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
     precice.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     double maxDt     = precice.initialize();
     int    timestep  = 0;
-    double dt        = maxDt / 2.0; // Timestep length desired by solver
-    double currentDt = dt;          // Timestep length used by solver
+    double dt        = maxDt / 2.0; // Time step size desired by solver
+    double currentDt = dt;          // Time step size used by solver
     while (precice.isCouplingOngoing()) {
       maxDt     = precice.advance(currentDt);
       currentDt = dt > maxDt ? maxDt : dt;
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
     precice.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
     double maxDt     = precice.initialize();
     int    timestep  = 0;
-    double dt        = maxDt / 3.0; // Timestep length desired by solver
-    double currentDt = dt;          // Timestep length used by solver
+    double dt        = maxDt / 3.0; // Time step size desired by solver
+    double currentDt = dt;          // Time step size used by solver
     while (precice.isCouplingOngoing()) {
       maxDt     = precice.advance(currentDt);
       currentDt = dt > maxDt ? maxDt : dt;

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -69,9 +69,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   double maxDt = precice.initialize();
   BOOST_TEST(maxDt == 2.0); // use window size != 1.0 to be able to detect more possible bugs
   double windowDt      = maxDt;
-  double dt            = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a timestep of fixed size.
-  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
-  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual timestep length; must fit into remaining time in window
+  double dt            = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a time step of fixed size.
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses time step size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual time step size; must fit into remaining time in window
 
   while (precice.isCouplingOngoing()) {
     double readTime;

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveform)
   BOOST_TEST(maxDt == 2.0); // use window size != 1.0 to be able to detect more possible bugs
   double windowDt  = maxDt;
   double dt        = windowDt / (nSubsteps - 0.5); // Solver always tries to do a timestep of fixed size.
-  double currentDt = dt > maxDt ? maxDt : dt;      // determine actual timestep length; must fit into remaining time in window
+  double currentDt = dt > maxDt ? maxDt : dt;      // determine actual time step size; must fit into remaining time in window
   double timeCheckpoint;
 
   while (precice.isCouplingOngoing()) {

--- a/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
@@ -45,8 +45,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
 
   double maxDt     = precice.initialize();
   double windowDt  = maxDt;
-  double dt        = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 2 steps with size 1/2
-  double currentDt = dt;                   // Timestep length used by solver
+  double dt        = windowDt / nSubsteps; // time step size desired by solver. E.g. 2 steps with size 1/2
+  double currentDt = dt;                   // time step size used by solver
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -84,8 +84,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
 
   double maxDt     = precice.initialize();
   double windowDt  = maxDt;
-  double dt        = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 2 steps with size 1/2
-  double currentDt = dt;                   // Timestep length used by solver
+  double dt        = windowDt / nSubsteps; // time step size desired by solver. E.g. 2 steps with size 1/2
+  double currentDt = dt;                   // time step size used by solver
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -82,8 +82,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
 
   double maxDt        = precice.initialize();
   double windowDt     = maxDt;
-  double dt           = maxDt; // Timestep length desired by solver
-  double currentDt    = dt;    // Timestep length used by solver
+  double dt           = maxDt; // time step size desired by solver
+  double currentDt    = dt;    // time step size used by solver
   double sampleDts[4] = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
   double readTime; // time where we are reading
   double sampleDt; // dt relative to timestep start, where we are sampling

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -73,8 +73,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(maxDt == 2.0); // use window size != 1.0 to be able to detect more possible bugs
   double windowDt      = maxDt;
   double dt            = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a timestep of fixed size.
-  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
-  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual timestep length; must fit into remaining time in window
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses time step size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual time step size; must fit into remaining time in window
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -69,8 +69,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
 
   double maxDt        = precice.initialize();
   double windowDt     = maxDt;
-  double dt           = maxDt; // Timestep length desired by solver
-  double currentDt    = dt;    // Timestep length used by solver
+  double dt           = maxDt; // time step size desired by solver
+  double currentDt    = dt;    // time step size used by solver
   double sampleDts[4] = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
   double readTime; // time where we are reading
   double sampleDt; // dt relative to timestep start, where we are sampling

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -63,8 +63,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
   double time            = 0;
   double maxDt           = precice.initialize();
   double windowDt        = maxDt;
-  double dt              = maxDt; // Timestep length desired by solver
-  double currentDt       = dt;    // Timestep length used by solver
+  double dt              = maxDt; // time step size desired by solver
+  double currentDt       = dt;    // time step size used by solver
   double sampleDts[4]    = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
   int    nSamples        = 4;
   int    iterations      = 0;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
@@ -65,8 +65,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
   }
 
   double maxDt     = precice.initialize();
-  double dt        = maxDt; // Timestep length desired by solver
-  double currentDt = dt;    // Timestep length used by solver
+  double dt        = maxDt; // time step size desired by solver
+  double currentDt = dt;    // time step size used by solver
   double timeCheckpoint;
   double sampleDts[4] = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
   double readDts[4]   = {0.0, currentDt, currentDt, currentDt};

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
@@ -69,9 +69,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
 
   double maxDt    = precice.initialize();
   double windowDt = maxDt;
-  double dt       = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
+  double dt       = windowDt / nSubsteps; // time step size desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt = dt;                  // time step size used by solver
   double timeCheckpoint;
   int    iterations;
 

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
@@ -67,9 +67,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
 
   double maxDt    = precice.initialize();
   double windowDt = maxDt;
-  double dt       = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
+  double dt       = windowDt / nSubsteps; // time step size desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt = dt;                  // time step size used by solver
   double timeCheckpoint;
   int    iterations;
 

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
@@ -67,9 +67,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
   double maxDt    = precice.initialize();
   double windowDt = maxDt;
   int    timestepCheckpoint;
-  double dt = windowDt / nSubsteps;       // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
+  double dt = windowDt / nSubsteps;       // time step size desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt = dt;                  // time step size used by solver
   double timeCheckpoint;
   int    iterations;
 

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   BOOST_TEST(maxDt == 2.0); // use window size != 1.0 to be able to detect more possible bugs
   double windowDt      = maxDt;
   double dt            = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a timestep of fixed size.
-  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
-  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual timestep length; must fit into remaining time in window
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses time step size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+  double currentDt     = dt > maxDt ? maxDt : dt;                      // determine actual time step size; must fit into remaining time in window
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
 
   double maxDt        = precice.initialize();
   double windowDt     = maxDt;
-  double dt           = maxDt; // Timestep length desired by solver
-  double currentDt    = dt;    // Timestep length used by solver
+  double dt           = maxDt; // time step size desired by solver
+  double currentDt    = dt;    // time step size used by solver
   double sampleDts[4] = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
 
   while (precice.isCouplingOngoing()) {

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -62,8 +62,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
   int    timewindow      = 0;
   double windowStartTime = 0;
   int    windowStartStep = 0;
-  double dt              = maxDt; // Timestep length desired by solver
-  double currentDt       = dt;    // Timestep length used by solver
+  double dt              = maxDt; // time step size desired by solver
+  double currentDt       = dt;    // time step size used by solver
   double time            = timestep * dt;
   double sampleDts[4]    = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
   int    nSamples        = 4;

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
   }
 
   double maxDt        = precice.initialize();
-  double dt           = maxDt; // Timestep length desired by solver
-  double currentDt    = dt;    // Timestep length used by solver
+  double dt           = maxDt; // time step size desired by solver
+  double currentDt    = dt;    // time step size used by solver
   double sampleDts[4] = {0.0, dt / 4.0, dt / 2.0, 3.0 * dt / 4.0};
   double readDts[4]   = {0.0, currentDt, currentDt, currentDt};
 

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
@@ -72,9 +72,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
 
   double maxDt    = precice.initialize();
   double windowDt = maxDt;
-  double dt       = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
+  double dt       = windowDt / nSubsteps; // time step size desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt = dt;                  // time step size used by solver
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
@@ -70,9 +70,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
 
   double maxDt    = precice.initialize();
   double windowDt = maxDt;
-  double dt       = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
+  double dt       = windowDt / nSubsteps; // time step size desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt = dt;                  // time step size used by solver
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
@@ -70,9 +70,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
 
   double maxDt    = precice.initialize();
   double windowDt = maxDt;
-  double dt       = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
+  double dt       = windowDt / nSubsteps; // time step size desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt = dt;                  // time step size used by solver
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {


### PR DESCRIPTION
## Main changes of this PR

* Replace "timestep" with "timeStep" in code
* Replace "timestep" with "time step" in documentation
* Replace "timestep length" with "time step size" in documentation
* Replace "timestepLength" with "timeStepSize" in code

## Motivation and additional information

Make code and documentation more consistent. Especially w.r.t #1623 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release. (not necessary)
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
