### PR TITLE
Add get(Mesh|Data)Dimensions

### DIFF
--- a/docs/changelog/1631.md
+++ b/docs/changelog/1631.md
@@ -1,0 +1,1 @@
+- Replaced `getDimensions()` with `getMeshDimensions(meshName)` and `getDataDimensions(meshName, dataName)`.

--- a/examples/solverdummies/c/solverdummy.c
+++ b/examples/solverdummies/c/solverdummy.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     meshName      = "SolverTwo-Mesh";
   }
 
-  dimensions = precicec_getDimensions();
+  dimensions = precicec_getMeshDimensions(meshName);
   vertices   = malloc(numberOfVertices * dimensions * sizeof(double));
   readData   = malloc(numberOfVertices * dimensions * sizeof(double));
   writeData  = malloc(numberOfVertices * dimensions * sizeof(double));

--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
     meshName      = "SolverTwo-Mesh";
   }
 
-  int dimensions       = interface.getDimensions();
+  int dimensions       = interface.getMeshDimensions(meshName);
   int numberOfVertices = 3;
 
   std::vector<double> readData(numberOfVertices * dimensions);

--- a/examples/solverdummies/fortran/solverdummy.f90
+++ b/examples/solverdummies/fortran/solverdummy.f90
@@ -31,7 +31,7 @@ PROGRAM main
   CALL precicef_create(participantName, config, rank, commsize)
 
   ! Allocate dummy mesh with only one vertex
-  CALL precicef_get_dims(dimensions)
+  CALL precicef_get_mesh_dimensions(meshName, dimensions)
   ALLOCATE(vertices(numberOfVertices*dimensions))
   ALLOCATE(vertexIDs(numberOfVertices))
   ALLOCATE(readData(numberOfVertices*dimensions))

--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -80,10 +80,11 @@ PRECICE_API void precicec_finalize();
 ///@name Status Queries
 ///@{
 
-/**
- * @brief Returns the number of spatial configurations for the coupling.
- */
-PRECICE_API int precicec_getDimensions();
+/// @copydoc precice::SolverInterface::getMeshDimensions()
+PRECICE_API int precicec_getMeshDimensions(const char *meshName);
+
+/// @copydoc precice::SolverInterface::getDataDimensions()
+PRECICE_API int precicec_getDataDimensions(const char *meshName, const char *dataName);
 
 /**
  * @brief Returns true (->1), if the coupled simulation is ongoing

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -72,10 +72,16 @@ void precicec_finalize()
   impl.reset();
 }
 
-int precicec_getDimensions()
+int precicec_getMeshDimensions(const char *meshName)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  return impl->getDimensions();
+  return impl->getMeshDimensions(meshName);
+}
+
+int precicec_getDataDimensions(const char *meshName, const char *dataName)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  return impl->getDataDimensions(meshName, dataName);
 }
 
 int precicec_isCouplingOngoing()

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -72,15 +72,40 @@ PRECICE_API void precicef_finalize_();
 
 /**
  * Fortran syntax:
- * precicef_get_dims( INTEGER dimensions )
+ * precicef_get_mesh_dimensions_(
+ *   CHARACTER meshName(*),
+ *   INTEGER   dimensions)
  *
- * IN:  -
+ * IN:  mesh, meshNameLength
  * OUT: dimensions
  *
- * @copydoc precice::SolverInterface::getDimensions()
+ * @copydoc precice::SolverInterface::getMeshDimensions()
  *
  */
-PRECICE_API void precicef_get_dims_(int *dimensions);
+PRECICE_API void precicef_get_mesh_dimensions_(
+    const char *meshName,
+    int *       dimensions,
+    int         meshNameLength);
+
+/**
+ * Fortran syntax:
+ * precicef_get_data_dimensions_(
+ *   CHARACTER meshName(*),
+ *   CHARACTER dataName(*),
+ *   INTEGER   dimensions)
+ *
+ * IN:  mesh, data, meshNameLength, dataNameLength
+ * OUT: dimensions
+ *
+ * @copydoc precice::SolverInterface::getDataDimensions()
+ *
+ */
+PRECICE_API void precicef_get_data_dimensions_(
+    const char *meshName,
+    const char *dataName,
+    int *       dimensions,
+    int         meshNameLength,
+    int         dataNameLength);
 
 /**
  * Fortran syntax:

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -73,11 +73,24 @@ void precicef_finalize_()
   impl.reset();
 }
 
-void precicef_get_dims_(
-    int *dimensions)
+void precicef_get_mesh_dimensions_(
+    const char *meshName,
+    int *       dimensions,
+    int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  *dimensions = impl->getDimensions();
+  *dimensions = impl->getMeshDimensions(precice::impl::strippedStringView(meshName, meshNameLength));
+}
+
+void precicef_get_data_dimensions_(
+    const char *meshName,
+    const char *dataName,
+    int *       dimensions,
+    int         meshNameLength,
+    int         dataNameLength)
+{
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  *dimensions = impl->getDataDimensions(precice::impl::strippedStringView(meshName, meshNameLength), precice::impl::strippedStringView(dataName, dataNameLength));
 }
 
 void precicef_is_coupling_ongoing_(

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -186,7 +186,7 @@ std::vector<std::string> Mesh::availableData() const
   return names;
 }
 
-const PtrData &Mesh::data(const std::string &dataName) const
+const PtrData &Mesh::data(std::string_view dataName) const
 {
   auto iter = std::find_if(_data.begin(), _data.end(), [&dataName](const auto &dptr) {
     return dptr->getName() == dataName;

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -187,7 +187,7 @@ public:
   std::vector<std::string> availableData() const;
 
   /// Returns the data with the matching name
-  const PtrData &data(const std::string &dataName) const;
+  const PtrData &data(std::string_view dataName) const;
 
   /// Returns the name of the mesh, as set in the config file.
   const std::string &getName() const;

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -57,9 +57,14 @@ void SolverInterface::finalize()
   return _impl->finalize();
 }
 
-int SolverInterface::getDimensions() const
+int SolverInterface::getMeshDimensions(::precice::string_view meshName) const
 {
-  return _impl->getDimensions();
+  return _impl->getMeshDimensions(toSV(meshName));
+}
+
+int SolverInterface::getDataDimensions(::precice::string_view meshName, ::precice::string_view dataName) const
+{
+  return _impl->getDataDimensions(toSV(meshName), toSV(dataName));
 }
 
 bool SolverInterface::isCouplingOngoing() const

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -165,14 +165,28 @@ public:
   ///@{
 
   /**
-   * @brief Returns the number of spatial dimensions configured.
+   * @brief Returns the spatial dimensionality of the given mesh.
    *
-   * @returns the configured dimension
+   * @param[in] meshName the name of the associated mesh
+   * @param[in] dataName the name of the data to check
    *
-   * Currently, two and three dimensional problems can be solved using preCICE.
-   * The dimension is specified in the XML configuration.
+   * @returns the dimensions of the given mesh
    */
-  int getDimensions() const;
+  int getMeshDimensions(::precice::string_view meshName) const;
+
+  /**
+   * @brief Returns the spatial dimensionality of the given data on the given mesh.
+   *
+   * Note that vectorial data dimensionality directly depends on the spacial dimensionality of the mesh.
+   *
+   * @param[in] meshName the name of the associated mesh
+   * @param[in] dataName the name of the data to get the dimensions for
+   *
+   * @returns the dimensions of the given Data
+   *
+   * @see getMeshDimensions
+   */
+  int getDataDimensions(::precice::string_view meshName, ::precice::string_view dataName) const;
 
   /**
    * @brief Checks if the coupled simulation is still ongoing.

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -509,10 +509,19 @@ void SolverInterfaceImpl::finalize()
   _state = State::Finalized;
 }
 
-int SolverInterfaceImpl::getDimensions() const
+int SolverInterfaceImpl::getMeshDimensions(std::string_view meshName) const
 {
-  PRECICE_TRACE(_dimensions);
-  return _dimensions;
+  PRECICE_TRACE(meshName);
+  PRECICE_VALIDATE_MESH_NAME(meshName);
+  return _accessor->usedMeshContext(meshName).mesh->getDimensions();
+}
+
+int SolverInterfaceImpl::getDataDimensions(std::string_view meshName, std::string_view dataName) const
+{
+  PRECICE_TRACE(meshName, dataName);
+  PRECICE_VALIDATE_MESH_NAME(meshName);
+  PRECICE_VALIDATE_DATA_NAME(meshName, dataName);
+  return _accessor->usedMeshContext(meshName).mesh->data(dataName)->getDimensions();
 }
 
 bool SolverInterfaceImpl::isCouplingOngoing() const

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -104,8 +104,11 @@ public:
   ///@name Status Queries
   ///@{
 
-  /// @copydoc SolverInterface::getDimensions
-  int getDimensions() const;
+  /// @copydoc SolverInterface::getMeshDimensions
+  int getMeshDimensions(std::string_view meshName) const;
+
+  /// @copydoc SolverInterface::getDataDimensions
+  int getDataDimensions(std::string_view meshName, std::string_view dataName) const;
 
   /// @copydoc SolverInterface::isCouplingOngoing
   bool isCouplingOngoing() const;

--- a/tests/parallel/ExportTimeseries.cpp
+++ b/tests/parallel/ExportTimeseries.cpp
@@ -12,12 +12,12 @@ BOOST_AUTO_TEST_CASE(ExportTimeseries)
   PRECICE_TEST("ExporterOne"_on(1_rank), "ExporterTwo"_on(2_ranks));
 
   precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-  BOOST_REQUIRE(interface.getDimensions() == 3);
 
   std::vector<precice::VertexID> vertexIds(6 / context.size, -1);
   double                         y = context.size;
   std::vector<double>            coords{0, y, 0, 1, y, 0, 2, y, 0, 3, y, 0, 4, y, 0, 5, y, 0};
   auto                           meshName = context.isNamed("ExporterOne") ? "A" : "B";
+  BOOST_REQUIRE(interface.getMeshDimensions(meshName) == 3);
 
   if (context.isNamed("ExporterOne")) {
     interface.setMeshVertices(meshName, 6, coords.data(), vertexIds.data());

--- a/tests/parallel/NearestProjectionRePartitioning.cpp
+++ b/tests/parallel/NearestProjectionRePartitioning.cpp
@@ -25,8 +25,8 @@ BOOST_DATA_TEST_CASE(NearestProjectionRePartitioning,
       interface.finalize();
     } else {
       auto      meshName   = "CellCenters";
-      const int dimensions = 3;
-      BOOST_TEST(interface.getDimensions() == dimensions);
+      const int dimensions = interface.getMeshDimensions(meshName);
+      BOOST_REQUIRE(dimensions == 3);
 
       const int                 numberOfVertices = 65;
       const double              yCoord           = 0.0;
@@ -109,8 +109,8 @@ BOOST_DATA_TEST_CASE(NearestProjectionRePartitioning,
     BOOST_TEST(context.isNamed("SolidSolver"));
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
     auto                     meshName   = "Nodes";
-    const int                dimensions = 3;
-    BOOST_TEST(interface.getDimensions() == dimensions);
+    const int                dimensions = interface.getMeshDimensions(meshName);
+    BOOST_REQUIRE(dimensions == 3);
     const int                 numberOfVertices = 34;
     const double              yCoord           = 0.0;
     const double              zCoord1          = 0.0;

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
@@ -19,12 +19,13 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
   if (context.isNamed("SolverOne")) {
     // Set up Solverinterface
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
-    constexpr int dim           = 2;
-    auto          ownMeshName   = "MeshOne";
-    auto          otherMeshName = "MeshTwo";
-    auto          readDataName  = "Forces";
-    auto          writeDataName = "Velocities";
+    constexpr int            dim           = 2;
+    auto                     ownMeshName   = "MeshOne";
+    auto                     otherMeshName = "MeshTwo";
+    auto                     readDataName  = "Forces";
+    auto                     writeDataName = "Velocities";
+    BOOST_TEST(interface.getMeshDimensions(ownMeshName) == 2);
+    BOOST_TEST(interface.getMeshDimensions(otherMeshName) == 2);
 
     std::vector<double> positions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.0}) : std::vector<double>({0.0, 4.0, 0.0, 5.0, 0.0, 6.0});
 
@@ -73,16 +74,16 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
     }
 
   } else {
-    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    const int                dim = interface.getDimensions();
-    BOOST_TEST(context.isNamed("SolverTwo"));
-    std::vector<double> positions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0}) : std::vector<double>({0.0, 3.5, 0.0, 4.0, 0.0, 5.0});
-    std::vector<int>    ids(positions.size() / dim, -1);
-
     // Query IDs
     auto meshName      = "MeshTwo";
     auto writeDataName = "Forces";
     auto readDataName  = "Velocities";
+
+    precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
+    const int                dim = interface.getMeshDimensions(meshName);
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    std::vector<double> positions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0}) : std::vector<double>({0.0, 3.5, 0.0, 4.0, 0.0, 5.0});
+    std::vector<int>    ids(positions.size() / dim, -1);
 
     // Define the mesh
     interface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());

--- a/tests/parallel/direct-mesh-access/helpers.cpp
+++ b/tests/parallel/direct-mesh-access/helpers.cpp
@@ -19,7 +19,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
     auto                     otherMeshName = "MeshTwo";
     auto                     dataName      = "Velocities";
-    const int                dim           = interface.getDimensions();
+    const int                dim           = interface.getMeshDimensions(otherMeshName);
 
     std::vector<double> boundingBox = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 3.5}) : boundingBoxSecondaryRank;
     // Set bounding box
@@ -73,12 +73,12 @@ void runTestAccessReceivedMesh(const TestContext &       context,
     // Defines the mesh and reads data
     BOOST_REQUIRE(context.isNamed("SolverTwo"));
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
 
     // Get IDs
     auto      meshName = "MeshTwo";
     auto      dataName = "Velocities";
-    const int dim      = interface.getDimensions();
+    const int dim      = interface.getMeshDimensions(meshName);
+    BOOST_TEST(dim == 2);
     // Define the interface
     std::vector<double> positions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0}) : std::vector<double>({0.0, 3.0, 0.0, 4.0, 0.0, 5.0});
 

--- a/tests/parallel/gather-scatter/helpers.cpp
+++ b/tests/parallel/gather-scatter/helpers.cpp
@@ -14,7 +14,7 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
     auto                     meshName      = "ParallelMesh";
     auto                     writeDataName = "MyData1";
     auto                     readDataName  = "MyData2";
-    const int                dim           = interface.getDimensions();
+    const int                dim           = interface.getMeshDimensions(meshName);
     BOOST_TEST(dim == 2);
 
     // Set coordinates, primary according to input argument
@@ -59,8 +59,8 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
     auto      meshName      = "SerialMesh";
     auto      writeDataName = "MyData2";
     auto      readDataName  = "MyData1";
-    const int dim           = interface.getDimensions();
-    BOOST_TEST(interface.getDimensions() == 2);
+    const int dim           = interface.getMeshDimensions(meshName);
+    BOOST_TEST(interface.getMeshDimensions(meshName) == 2);
 
     // Define the interface
     const std::vector<double> coordinates{0.0, 0.5, 0.0, 3.5, 0.0, 5.0};

--- a/tests/serial/TestExplicitWithSolverGeometry.cpp
+++ b/tests/serial/TestExplicitWithSolverGeometry.cpp
@@ -24,10 +24,10 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithSolverGeometry)
   double time      = 0;
 
   precice::SolverInterface couplingInterface(context.name, context.config(), 0, 1);
-  BOOST_TEST(couplingInterface.getDimensions() == 3);
   if (context.isNamed("SolverOne")) {
     //was necessary to replace pre-defined geometries
     auto meshName = "MeshOne";
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
     couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
 

--- a/tests/serial/TestReadAPI.cpp
+++ b/tests/serial/TestReadAPI.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/tools/old/interface.hpp>
 #ifndef PRECICE_NO_MPI
 
 #include "testing/Testing.hpp"

--- a/tests/serial/action-timings/ActionTimingsExplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsExplicit.cpp
@@ -19,7 +19,6 @@ BOOST_AUTO_TEST_CASE(ActionTimingsExplicit)
   using namespace precice;
   SolverInterface interface(context.name, context.config(), 0, 1);
 
-  int         dimensions = interface.getDimensions();
   std::string meshName;
   std::string writeDataName;
   std::string readDataName;
@@ -37,6 +36,7 @@ BOOST_AUTO_TEST_CASE(ActionTimingsExplicit)
     readDataName  = "Forces";
     writeValue    = 2;
   }
+  int                 dimensions = interface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
   int                 vertexID = interface.setMeshVertex(meshName, vertex.data());
 

--- a/tests/serial/action-timings/ActionTimingsImplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsImplicit.cpp
@@ -21,7 +21,6 @@ BOOST_AUTO_TEST_CASE(ActionTimingsImplicit)
 
   SolverInterface interface(context.name, context.config(), context.rank, context.size);
 
-  int         dimensions = interface.getDimensions();
   std::string meshName;
   std::string writeDataName;
   std::string readDataName;
@@ -39,6 +38,7 @@ BOOST_AUTO_TEST_CASE(ActionTimingsImplicit)
     readDataName  = "Forces";
     writeValue    = 2;
   }
+  int                 dimensions = interface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
   int                 vertexID = interface.setMeshVertex(meshName, vertex.data());
 

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
@@ -17,11 +17,11 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
   if (context.isNamed("SolverOne")) {
     // Set up Solverinterface
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
-    constexpr int dim              = 2;
-    const auto    providedMeshName = "MeshOne";
-    const auto    readDataName     = "Forces";
-    const auto    writeDataName    = "Velocities";
+    constexpr int            dim              = 2;
+    const auto               providedMeshName = "MeshOne";
+    const auto               readDataName     = "Forces";
+    const auto               writeDataName    = "Velocities";
+    BOOST_TEST(interface.getMeshDimensions(providedMeshName) == 2);
 
     std::vector<double> positions = std::vector<double>({0.5, 0.25});
     const int           meshSize  = positions.size() / dim;
@@ -63,11 +63,11 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
-    constexpr int dim              = 2;
-    const auto    receivedMeshName = "MeshOne";
-    const auto    writeDataName    = "Forces";
-    const auto    readDataName     = "Velocities";
+    constexpr int            dim              = 2;
+    const auto               receivedMeshName = "MeshOne";
+    const auto               writeDataName    = "Forces";
+    const auto               readDataName     = "Velocities";
+    BOOST_TEST(interface.getMeshDimensions(receivedMeshName) == 2);
 
     std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0};
     // Define region of interest, where we could obtain direct write access

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
@@ -16,12 +16,13 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
   if (context.isNamed("SolverOne")) {
     // Set up Solverinterface
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
-    constexpr int dim         = 2;
-    const auto    ownMeshID   = "MeshOne";
-    const auto    otherMeshID = "MeshTwo";
-    const auto    readDataID  = "Forces";
-    const auto    writeDataID = "Velocities";
+    constexpr int            dim         = 2;
+    const auto               ownMeshID   = "MeshOne";
+    const auto               otherMeshID = "MeshTwo";
+    const auto               readDataID  = "Forces";
+    const auto               writeDataID = "Velocities";
+    BOOST_REQUIRE(interface.getMeshDimensions(ownMeshID) == 2);
+    BOOST_REQUIRE(interface.getMeshDimensions(otherMeshID) == 2);
 
     std::vector<double> ownPositions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ownIDs(ownPositions.size() / dim, -1);
@@ -99,11 +100,11 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
-    constexpr int dim           = 2;
-    const auto    meshName      = "MeshTwo";
-    const auto    writeDataName = "Forces";
-    const auto    readDataName  = "Velocities";
+    constexpr int            dim           = 2;
+    const auto               meshName      = "MeshTwo";
+    const auto               writeDataName = "Forces";
+    const auto               readDataName  = "Velocities";
+    BOOST_REQUIRE(interface.getMeshDimensions(meshName) == 2);
 
     std::vector<double> positions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ids(positions.size() / dim, -1);

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
@@ -16,12 +16,13 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
   if (context.isNamed("SolverOne")) {
     // Set up Solverinterface
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
-    constexpr int dim           = 2;
-    const auto    ownMeshName   = "MeshOne";
-    const auto    otherMeshName = "MeshTwo";
-    const auto    readDataName  = "Forces";
-    const auto    writeDataName = "Velocities";
+    constexpr int            dim           = 2;
+    const auto               ownMeshName   = "MeshOne";
+    const auto               otherMeshName = "MeshTwo";
+    const auto               readDataName  = "Forces";
+    const auto               writeDataName = "Velocities";
+    BOOST_REQUIRE(interface.getMeshDimensions(ownMeshName) == 2);
+    BOOST_REQUIRE(interface.getMeshDimensions(otherMeshName) == 2);
 
     std::vector<double> ownPositions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ownIDs(ownPositions.size() / dim, -1);
@@ -95,11 +96,11 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
-    BOOST_TEST(interface.getDimensions() == 2);
-    constexpr int dim         = 2;
-    const auto    meshID      = "MeshTwo";
-    const auto    writeDataID = "Forces";
-    const auto    readDataID  = "Velocities";
+    constexpr int            dim         = 2;
+    const auto               meshID      = "MeshTwo";
+    const auto               writeDataID = "Forces";
+    const auto               readDataID  = "Velocities";
+    BOOST_REQUIRE(interface.getMeshDimensions(meshID) == 2);
 
     std::vector<double> positions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ids(positions.size() / dim, -1);

--- a/tests/serial/direct-mesh-access/Explicit.cpp
+++ b/tests/serial/direct-mesh-access/Explicit.cpp
@@ -19,7 +19,6 @@ BOOST_AUTO_TEST_CASE(Explicit)
 
   // Set up Solverinterface
   precice::SolverInterface couplingInterface(context.name, context.config(), 0, 1);
-  BOOST_TEST(couplingInterface.getDimensions() == 2);
 
   std::vector<double> positions = {0.0, 0.0, 0.0, 0.05, 0.1, 0.1, 0.1, 0.0};
   std::vector<int>    ids(4, -1);
@@ -29,7 +28,8 @@ BOOST_AUTO_TEST_CASE(Explicit)
 
   if (context.isNamed("SolverOne")) {
     auto otherMeshName = "MeshTwo";
-    auto dataName      = "Velocities";
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(otherMeshName) == 2);
+    auto dataName = "Velocities";
 
     // Define region of interest, where we could obtain direct write access
     couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox.data());
@@ -64,6 +64,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
     // Query IDs
     auto meshName = "MeshTwo";
     auto dataName = "Velocities";
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 2);
 
     // Define the mesh
     couplingInterface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
@@ -21,14 +21,15 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
 
   // Set up Solverinterface
   precice::SolverInterface interface(context.name, context.config(), 0, 1);
-  BOOST_TEST(interface.getDimensions() == 2);
-  constexpr int dim = 2;
+  constexpr int            dim = 2;
 
   if (context.isNamed("SolverOne")) {
     auto ownMeshName   = "MeshOne";
     auto otherMeshName = "MeshTwo";
     auto readDataName  = "Forces";
     auto writeDataName = "Velocities";
+    BOOST_REQUIRE(interface.getMeshDimensions(ownMeshName) == 2);
+    BOOST_REQUIRE(interface.getMeshDimensions(otherMeshName) == 2);
 
     std::vector<double> positions = {0.2, 0.2, 0.1, 0.6, 0.1, 0.0, 0.1, 0.0};
     std::vector<int>    ownIDs(4, -1);
@@ -77,6 +78,8 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
     auto meshName      = "MeshTwo";
     auto writeDataName = "Forces";
     auto readDataName  = "Velocities";
+
+    BOOST_REQUIRE(interface.getMeshDimensions(meshName) == 2);
 
     // Define the mesh
     interface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());

--- a/tests/serial/direct-mesh-access/ExplicitRead.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitRead.cpp
@@ -19,7 +19,6 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
 
   // Set up Solverinterface
   precice::SolverInterface couplingInterface(context.name, context.config(), 0, 1);
-  BOOST_TEST(couplingInterface.getDimensions() == 2);
 
   std::vector<double> positions = {0.0, 0.0, 0.0, 0.05, 0.1, 0.1, 0.1, 0.0};
   std::vector<int>    ids(4, -1);
@@ -30,6 +29,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
   if (context.isNamed("SolverOne")) {
     auto otherMeshName = "MeshTwo";
     auto dataName      = "Velocities";
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(otherMeshName) == 2);
 
     // Define region of interest, where we could obtain direct write access
     couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox.data());
@@ -69,6 +69,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
     // Query IDs
     auto meshName = "MeshTwo";
     auto dataName = "Velocities";
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName));
 
     // Define the mesh
     couplingInterface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());

--- a/tests/serial/direct-mesh-access/Implicit.cpp
+++ b/tests/serial/direct-mesh-access/Implicit.cpp
@@ -18,8 +18,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
 
   // Set up Solverinterface
   precice::SolverInterface couplingInterface(context.name, context.config(), 0, 1);
-  BOOST_TEST(couplingInterface.getDimensions() == 2);
-  constexpr int dim = 2;
+  constexpr int            dim = 2;
 
   if (context.isNamed("SolverOne")) {
     std::vector<double>         positions   = {0.1, 0.1, 0.2, 0.05, 0.1, 0.0, 0.3, 0.9};
@@ -30,6 +29,8 @@ BOOST_AUTO_TEST_CASE(Implicit)
     auto otherMeshName = "MeshTwo";
     auto ownDataName   = "Forces";
     auto otherDataName = "Velocities";
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(ownMeshName) == 2);
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(otherMeshName) == 2);
 
     // Define the own mesh
     couplingInterface.setMeshVertices(ownMeshName, ownIDs.size(), positions.data(), ownIDs.data());
@@ -87,6 +88,9 @@ BOOST_AUTO_TEST_CASE(Implicit)
     auto otherMeshName = "MeshOne";
     auto ownDataName   = "Velocities";
     auto otherDataName = "Forces";
+
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(otherMeshName) == 2);
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(ownMeshName) == 2);
 
     // Define the mesh
     couplingInterface.setMeshVertices(ownMeshName, ownIDs.size(), positions.data(), ownIDs.data());

--- a/tests/serial/explicit/helpers.cpp
+++ b/tests/serial/explicit/helpers.cpp
@@ -1,3 +1,4 @@
+#include <boost/test/unit_test_log.hpp>
 #ifndef PRECICE_NO_MPI
 
 #include "helpers.hpp"
@@ -15,19 +16,22 @@ void runTestExplicit(std::string const &configurationFileName, TestContext const
 
   SolverInterface couplingInterface(context.name, configurationFileName, 0, 1);
 
-  //was necessary to replace pre-defined geometries
-  if (context.isNamed("SolverOne") && couplingInterface.hasMesh("MeshOne")) {
+  // was necessary to replace pre-defined geometries
+  if (context.isNamed("SolverOne")) {
     auto meshName = "MeshOne";
+    BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
     couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
   }
-  if (context.isNamed("SolverTwo") && couplingInterface.hasMesh("Test-Square")) {
+  if (context.isNamed("SolverTwo")) {
     auto meshName = "Test-Square";
+    BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
+    BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
     couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
     couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
   }
 
-  BOOST_TEST(couplingInterface.getDimensions() == 3);
   couplingInterface.initialize();
   double dt = couplingInterface.getMaxTimeStepSize();
   while (couplingInterface.isCouplingOngoing()) {

--- a/tests/serial/initialize-data/Explicit.cpp
+++ b/tests/serial/initialize-data/Explicit.cpp
@@ -1,4 +1,3 @@
-#include <boost/test/tools/old/interface.hpp>
 #ifndef PRECICE_NO_MPI
 
 #include "testing/Testing.hpp"

--- a/tests/serial/initialize-data/Implicit.cpp
+++ b/tests/serial/initialize-data/Implicit.cpp
@@ -20,7 +20,6 @@ BOOST_AUTO_TEST_CASE(Implicit)
 
   SolverInterface couplingInterface(context.name, context.config(), 0, 1);
 
-  int         dimensions = couplingInterface.getDimensions();
   std::string meshName;
   std::string writeDataName;
   std::string readDataName;
@@ -40,6 +39,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
     writeValue        = 2;
     expectedReadValue = 1;
   }
+  int                 dimensions = couplingInterface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
   int                 vertexID = couplingInterface.setMeshVertex(meshName, vertex.data());
   double              dt       = 0;

--- a/tests/serial/initialize-data/ImplicitBoth.cpp
+++ b/tests/serial/initialize-data/ImplicitBoth.cpp
@@ -21,7 +21,6 @@ BOOST_AUTO_TEST_CASE(ImplicitBoth)
 
   SolverInterface couplingInterface(context.name, context.config(), 0, 1);
 
-  int         dimensions = couplingInterface.getDimensions();
   std::string meshName;
   std::string writeDataName;
   std::string readDataName;
@@ -41,6 +40,7 @@ BOOST_AUTO_TEST_CASE(ImplicitBoth)
     writeValue        = 2;
     expectedReadValue = 1;
   }
+  int                 dimensions = couplingInterface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
   int                 vertexID = couplingInterface.setMeshVertex(meshName, vertex.data());
 

--- a/tests/serial/multi-coupling/MultiCoupling.cpp
+++ b/tests/serial/multi-coupling/MultiCoupling.cpp
@@ -40,9 +40,7 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
       context.isNamed("SOLIDZ2") ||
       context.isNamed("SOLIDZ3")) {
     precice::SolverInterface precice(context.name, context.config(), 0, 1);
-    BOOST_TEST(precice.getDimensions() == 2);
-
-    std::string meshName, dataWriteID, dataReadID;
+    std::string              meshName, dataWriteID, dataReadID;
     if (context.isNamed("SOLIDZ1")) {
       meshName    = "SOLIDZ_Mesh1";
       dataWriteID = "Displacements1";
@@ -56,6 +54,7 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
       dataWriteID = "Displacements3";
       dataReadID  = "Forces3";
     }
+    BOOST_REQUIRE(precice.getMeshDimensions(meshName) == 2);
 
     std::vector<int> vertexIDs;
     int              vertexID = -1;
@@ -94,13 +93,15 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
   } else {
     BOOST_TEST(context.isNamed("NASTIN"));
     precice::SolverInterface precice("NASTIN", context.config(), 0, 1);
-    BOOST_TEST(precice.getDimensions() == 2);
-    auto meshName1    = "NASTIN_Mesh1";
-    auto meshName2    = "NASTIN_Mesh2";
-    auto meshName3    = "NASTIN_Mesh3";
-    auto dataWriteID1 = "Forces1";
-    auto dataWriteID2 = "Forces2";
-    auto dataWriteID3 = "Forces3";
+    auto                     meshName1    = "NASTIN_Mesh1";
+    auto                     meshName2    = "NASTIN_Mesh2";
+    auto                     meshName3    = "NASTIN_Mesh3";
+    auto                     dataWriteID1 = "Forces1";
+    auto                     dataWriteID2 = "Forces2";
+    auto                     dataWriteID3 = "Forces3";
+    BOOST_TEST(precice.getMeshDimensions(meshName1) == 2);
+    BOOST_TEST(precice.getMeshDimensions(meshName2) == 2);
+    BOOST_TEST(precice.getMeshDimensions(meshName3) == 2);
 
     std::vector<int> vertexIDs1;
     int              vertexID = -1;

--- a/tests/serial/whitebox/TestConfigurationComsol.cpp
+++ b/tests/serial/whitebox/TestConfigurationComsol.cpp
@@ -19,7 +19,6 @@ BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
   // Test configuration for accessor "Comsol"
   SolverInterface interfaceComsol("Comsol", context.config(), 0, 1);
   BOOST_TEST(testing::WhiteboxAccessor::impl(interfaceComsol)._participants.size() == 2);
-  BOOST_TEST(interfaceComsol.getDimensions() == 2);
 
   impl::PtrParticipant comsol = testing::WhiteboxAccessor::impl(interfaceComsol)._participants.at(1);
   BOOST_TEST(comsol);
@@ -31,6 +30,8 @@ BOOST_AUTO_TEST_CASE(TestConfigurationComsol)
   BOOST_TEST(meshContexts.count("ComsolNodes") > 0);
   BOOST_TEST(meshContexts.at("ComsolNodes")->mesh->getName() == std::string("ComsolNodes"));
   BOOST_TEST(comsol->_usedMeshContexts.size() == 1);
+
+  BOOST_TEST(interfaceComsol.getMeshDimensions("ComsolNodes") == 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/whitebox/TestConfigurationPeano.cpp
+++ b/tests/serial/whitebox/TestConfigurationPeano.cpp
@@ -20,7 +20,6 @@ BOOST_AUTO_TEST_CASE(TestConfigurationPeano)
   SolverInterface interfacePeano("Peano", context.config(), 0, 1);
 
   BOOST_TEST(testing::WhiteboxAccessor::impl(interfacePeano)._participants.size() == 2);
-  BOOST_TEST(interfacePeano.getDimensions() == 2);
 
   impl::PtrParticipant peano = testing::WhiteboxAccessor::impl(interfacePeano)._participants.at(0);
   BOOST_TEST(peano);
@@ -32,6 +31,8 @@ BOOST_AUTO_TEST_CASE(TestConfigurationPeano)
 
   BOOST_TEST(meshContexts.count("PeanoNodes") > 0);
   BOOST_TEST(meshContexts.count("ComsolNodes") > 0);
+  BOOST_TEST(interfacePeano.getMeshDimensions("PeanoNodes") == 2);
+  BOOST_TEST(interfacePeano.getMeshDimensions("ComsolNodes") == 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Whitebox

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
@@ -23,13 +23,13 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
   SolverInterface cplInterface(context.name, context.config(), 0, 1);
-  BOOST_TEST(cplInterface.getDimensions() == 2);
 
   std::vector<double> positions = {0.0, 0.0, 0.0, 0.1, 0.1, 0.1, 0.1, 0.0};
   std::vector<int>    ids       = {0, 0, 0, 0};
 
   if (context.isNamed("SolverOne")) {
     auto meshName = "Test-Square-One";
+    BOOST_REQUIRE(cplInterface.getMeshDimensions(meshName));
     cplInterface.setMeshVertices(meshName, 4, positions.data(), ids.data());
     for (int i = 0; i < 4; i++)
       cplInterface.setMeshEdge(meshName, ids.at(i), ids.at((i + 1) % 4));
@@ -50,6 +50,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto meshName = "Test-Square-Two";
+    BOOST_REQUIRE(cplInterface.getMeshDimensions(meshName));
     cplInterface.setMeshVertices(meshName, 4, positions.data(), ids.data());
     for (int i = 0; i < 4; i++)
       cplInterface.setMeshEdge(meshName, ids.at(i), ids.at((i + 1) % 4));


### PR DESCRIPTION
## Main changes of this PR

This PR replaces the `getDimensions()` API with `getMeshDimensions(meshName)` and `getDataDimensions(meshName, DataName)`.

## Motivation and additional information

Requires #1626

Related to #1466 and #1559


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
