### PR TITLE
Introduce Wrappers for better encapsulation of Read/WriteDataContext

### DIFF
--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -37,10 +37,22 @@ int DataContext::getDataDimensions() const
   return _providedData->getDimensions();
 }
 
+int DataContext::getSpatialDimensions() const
+{
+  PRECICE_ASSERT(_providedData);
+  return _providedData->getSpatialDimensions();
+}
+
 std::string DataContext::getMeshName() const
 {
   PRECICE_ASSERT(_mesh);
   return _mesh->getName();
+}
+
+int DataContext::getMeshVertexCount() const
+{
+  PRECICE_ASSERT(_mesh);
+  return _mesh->vertices().size();
 }
 
 MeshID DataContext::getMeshID() const
@@ -49,10 +61,10 @@ MeshID DataContext::getMeshID() const
   return _mesh->getID();
 }
 
-const mesh::Mesh &DataContext::getMesh() const
+bool DataContext::hasGradient() const
 {
-  PRECICE_ASSERT(_mesh);
-  return *_mesh;
+  PRECICE_ASSERT(_providedData);
+  return _providedData->hasGradient();
 }
 
 void DataContext::appendMapping(MappingContext mappingContext)
@@ -98,6 +110,12 @@ bool DataContext::hasReadMapping() const
 bool DataContext::hasWriteMapping() const
 {
   return std::any_of(_mappingContexts.begin(), _mappingContexts.end(), [this](auto &context) { return context.fromData == _providedData; });
+}
+
+bool DataContext::isValidVertexID(const VertexID id) const
+{
+  PRECICE_ASSERT(_mesh);
+  return _mesh->isValidVertexID(id);
 }
 
 } // namespace precice::impl

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -48,6 +48,13 @@ public:
   int getDataDimensions() const;
 
   /**
+   * @brief Get the spatial dimensions of _providedData.
+   *
+   * @return int Spatial dimensions of _providedData.
+   */
+  int getSpatialDimensions() const;
+
+  /**
    * @brief Get the name of _mesh.
    *
    * @return std::string Name of _mesh.
@@ -62,9 +69,12 @@ public:
   MeshID getMeshID() const;
 
   /**
-   * @brief Get the Mesh
+   * @brief Returns whether _providedData has gradient
+   *
+   * @return true, if it has gradient
+   * @return false, if it has gradient
    */
-  const mesh::Mesh &getMesh() const;
+  bool hasGradient() const;
 
   /**
    * @brief Perform the mapping for all mapping contexts and the corresponding data context (from and to data)
@@ -131,6 +141,16 @@ protected:
    * @return True, if DataContext has any write mapping.
    */
   bool hasWriteMapping() const;
+
+  /**
+   * @brief Get the number of vertices of mesh
+   *
+   * @return int number of vertices
+   */
+  int getMeshVertexCount() const;
+
+  /// Returns true if the given vertexID is valid
+  bool isValidVertexID(const VertexID id) const;
 
 private:
   /// Unique mesh associated with _providedData.

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -31,7 +31,7 @@ void ReadDataContext::readValues(::precice::span<const VertexID> vertices, doubl
 {
   Eigen::Map<Eigen::MatrixXd>       outputData(values.data(), getDataDimensions(), values.size());
   const Eigen::MatrixXd             sample{_waveform->sample(normalizedDt)};
-  Eigen::Map<const Eigen::MatrixXd> localData(sample.data(), getDataDimensions(), getMesh().vertices().size());
+  Eigen::Map<const Eigen::MatrixXd> localData(sample.data(), getDataDimensions(), getMeshVertexCount());
   for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
     outputData.col(i) = localData.col(vertices[i]);
   }

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -11,16 +11,10 @@ WriteDataContext::WriteDataContext(
 {
 }
 
-mesh::PtrData WriteDataContext::providedData()
-{
-  PRECICE_ASSERT(_providedData);
-  return _providedData;
-}
-
 void WriteDataContext::writeValues(::precice::span<const VertexID> vertices, ::precice::span<const double> values)
 {
   Eigen::Map<const Eigen::MatrixXd> inputData(values.data(), getDataDimensions(), vertices.size());
-  Eigen::Map<Eigen::MatrixXd>       localData(_providedData->values().data(), getDataDimensions(), getMesh().vertices().size());
+  Eigen::Map<Eigen::MatrixXd>       localData(_providedData->values().data(), getDataDimensions(), getMeshVertexCount());
 
   for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
     localData.col(vertices[i]) = inputData.col(i);
@@ -29,9 +23,9 @@ void WriteDataContext::writeValues(::precice::span<const VertexID> vertices, ::p
 
 void WriteDataContext::writeGradientValues(::precice::span<const VertexID> vertices, ::precice::span<const double> gradients)
 {
-  const auto                        gradientComponents = getMesh().getDimensions() * getDataDimensions();
+  const auto                        gradientComponents = getSpatialDimensions() * getDataDimensions();
   Eigen::Map<const Eigen::MatrixXd> inputGradients(gradients.data(), gradientComponents, vertices.size());
-  Eigen::Map<Eigen::MatrixXd>       localGradients(_providedData->gradientValues().data(), gradientComponents, getMesh().vertices().size());
+  Eigen::Map<Eigen::MatrixXd>       localGradients(_providedData->gradientValues().data(), gradientComponents, getMeshVertexCount());
 
   for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
     localGradients.col(vertices[i]) = inputGradients.col(i);

--- a/src/precice/impl/WriteDataContext.hpp
+++ b/src/precice/impl/WriteDataContext.hpp
@@ -26,13 +26,6 @@ public:
       mesh::PtrMesh mesh);
 
   /**
-   * @brief Get _providedData member.
-   *
-   * @return mesh::PtrData _providedData.
-   */
-  mesh::PtrData providedData();
-
-  /**
    * @brief Store values in _providedData.values()
    *
    * @param[in] vertices ids of data


### PR DESCRIPTION
## Main changes of this PR

Introduces wrappers in Read/WriteDataContext for better encapsulation of mesh.

## Motivation and additional information

* ~~Reduces amount of code duplication and preparatory refactoring for #1612.~~ (Code duplication was already taken care of in #1636)
* Improves encapsulation, especially allows to remove getter for `_providedData`.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] ~~I added a changelog file with `make changelog` if there are user-observable changes since the last release.~~ (not needed, because refactoring)
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
