### PR TITLE
Fix UB in tests

### DIFF
--- a/tests/parallel/TestFinalize.cpp
+++ b/tests/parallel/TestFinalize.cpp
@@ -16,7 +16,8 @@ BOOST_AUTO_TEST_CASE(TestFinalize)
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
     auto                     meshName = "MeshOne";
     double                   xCoord   = 0.0 + context.rank;
-    interface.setMeshVertex(meshName, Eigen::Vector3d(xCoord, 0.0, 0.0).data());
+    double                   v[]      = {xCoord, 0, 0};
+    interface.setMeshVertex(meshName, v);
     interface.initialize();
     BOOST_TEST(precice::testing::WhiteboxAccessor::impl(interface).mesh("MeshOne").vertices().size() == 1);
     BOOST_TEST(precice::testing::WhiteboxAccessor::impl(interface).mesh("MeshTwo").vertices().size() == 1);
@@ -26,7 +27,8 @@ BOOST_AUTO_TEST_CASE(TestFinalize)
     precice::SolverInterface interface(context.name, context.config(), context.rank, context.size);
     auto                     meshName = "MeshTwo";
     double                   xCoord   = 0.0 + context.rank;
-    interface.setMeshVertex(meshName, Eigen::Vector3d(xCoord, 0.0, 0.0).data());
+    double                   v[]      = {xCoord, 0, 0};
+    interface.setMeshVertex(meshName, v);
     interface.initialize();
     BOOST_TEST(precice::testing::WhiteboxAccessor::impl(interface).mesh("MeshTwo").vertices().size() == 1);
     interface.finalize();

--- a/tests/serial/TestExplicitWithSolverGeometry.cpp
+++ b/tests/serial/TestExplicitWithSolverGeometry.cpp
@@ -23,13 +23,17 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithSolverGeometry)
   int    timesteps = 0;
   double time      = 0;
 
+  double v0[]   = {0, 0, 0};
+  double v100[] = {1, 0, 0};
+  double v010[] = {0, 1, 0};
+
   precice::SolverInterface couplingInterface(context.name, context.config(), 0, 1);
   if (context.isNamed("SolverOne")) {
     //was necessary to replace pre-defined geometries
     auto meshName = "MeshOne";
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
-    couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-    couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    couplingInterface.setMeshVertex(meshName, v0);
+    couplingInterface.setMeshVertex(meshName, v100);
 
     couplingInterface.initialize();
     double dt = couplingInterface.getMaxTimeStepSize();
@@ -43,9 +47,9 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithSolverGeometry)
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto meshName = "SolverGeometry";
-    int  i0       = couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-    int  i1       = couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
-    int  i2       = couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 1.0, 0.0).data());
+    int  i0       = couplingInterface.setMeshVertex(meshName, v0);
+    int  i1       = couplingInterface.setMeshVertex(meshName, v100);
+    int  i2       = couplingInterface.setMeshVertex(meshName, v010);
     couplingInterface.setMeshTriangle(meshName, i0, i1, i2);
     couplingInterface.initialize();
     double dt = couplingInterface.getMaxTimeStepSize();

--- a/tests/serial/explicit/helpers.cpp
+++ b/tests/serial/explicit/helpers.cpp
@@ -16,20 +16,21 @@ void runTestExplicit(std::string const &configurationFileName, TestContext const
 
   SolverInterface couplingInterface(context.name, configurationFileName, 0, 1);
 
+  double pos[] = {0, 0, 0, 1, 1, 1};
+  int    vids[2];
+
   // was necessary to replace pre-defined geometries
   if (context.isNamed("SolverOne")) {
     auto meshName = "MeshOne";
     BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
-    couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-    couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    couplingInterface.setMeshVertices(meshName, 2, pos, vids);
   }
   if (context.isNamed("SolverTwo")) {
     auto meshName = "Test-Square";
     BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
-    couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-    couplingInterface.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    couplingInterface.setMeshVertices(meshName, 2, pos, vids);
   }
 
   couplingInterface.initialize();

--- a/tests/serial/initialize-data/Explicit.cpp
+++ b/tests/serial/initialize-data/Explicit.cpp
@@ -25,8 +25,9 @@ BOOST_AUTO_TEST_CASE(Explicit)
 
   SolverInterface cplInterface(context.name, context.config(), 0, 1);
   if (context.isNamed("SolverOne")) {
-    auto meshName = "MeshOne";
-    cplInterface.setMeshVertex(meshName, Vector3d(1.0, 2.0, 3.0).data());
+    auto   meshName = "MeshOne";
+    double v[]      = {1.0, 2.0, 3.0};
+    cplInterface.setMeshVertex(meshName, v);
     auto   dataAID    = "DataOne";
     auto   dataBID    = "DataTwo";
     double valueDataB = 0.0;

--- a/tests/serial/three-solvers/ThreeSolversFirstParticipant.cpp
+++ b/tests/serial/three-solvers/ThreeSolversFirstParticipant.cpp
@@ -18,10 +18,12 @@ BOOST_AUTO_TEST_CASE(ThreeSolversFirstParticipant)
 
   precice::SolverInterface precice(context.name, config, 0, 1);
 
+  double v0[] = {0, 0};
+
   if (context.isNamed("SolverOne")) {
 
     auto meshName = "MeshOne";
-    precice.setMeshVertex(meshName, Eigen::Vector2d(0, 0).data());
+    precice.setMeshVertex(meshName, v0);
 
     precice.initialize();
 
@@ -35,9 +37,9 @@ BOOST_AUTO_TEST_CASE(ThreeSolversFirstParticipant)
   } else if (context.isNamed("SolverTwo")) {
 
     auto meshAID = "MeshTwoA";
-    precice.setMeshVertex(meshAID, Eigen::Vector2d(0, 0).data());
+    precice.setMeshVertex(meshAID, v0);
     auto meshBID = "MeshTwoB";
-    precice.setMeshVertex(meshBID, Eigen::Vector2d(0, 0).data());
+    precice.setMeshVertex(meshBID, v0);
 
     precice.initialize();
     double dt = precice.getMaxTimeStepSize();
@@ -56,7 +58,7 @@ BOOST_AUTO_TEST_CASE(ThreeSolversFirstParticipant)
     BOOST_TEST(context.isNamed("SolverThree"));
 
     auto meshName = "MeshThree";
-    precice.setMeshVertex(meshName, Eigen::Vector2d(0, 0).data());
+    precice.setMeshVertex(meshName, v0);
 
     precice.initialize();
     double dt = precice.getMaxTimeStepSize();

--- a/tests/serial/three-solvers/helpers.cpp
+++ b/tests/serial/three-solvers/helpers.cpp
@@ -16,13 +16,16 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
 
   int callsOfAdvance = 0;
 
+  double v0[] = {0, 0};
+  double v1[] = {1, 1};
+
   if (context.isNamed("SolverOne")) {
     precice::SolverInterface precice(context.name, config, 0, 1);
 
     auto meshAID = "MeshA";
     auto meshBID = "MeshB";
-    precice.setMeshVertex(meshAID, Eigen::Vector2d(0, 0).data());
-    precice.setMeshVertex(meshBID, Eigen::Vector2d(1, 1).data());
+    precice.setMeshVertex(meshAID, v0);
+    precice.setMeshVertex(meshBID, v1);
 
     if (precice.requiresInitialData()) {
     }
@@ -44,7 +47,7 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
     SolverInterface precice(context.name, config, 0, 1);
 
     auto meshName = "MeshC";
-    precice.setMeshVertex(meshName, Eigen::Vector2d(0, 0).data());
+    precice.setMeshVertex(meshName, v0);
 
     if (precice.requiresInitialData()) {
     }
@@ -67,7 +70,7 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
     SolverInterface precice(context.name, config, 0, 1);
 
     auto meshName = "MeshD";
-    precice.setMeshVertex(meshName, Eigen::Vector2d(0, 0).data());
+    precice.setMeshVertex(meshName, v0);
 
     if (precice.requiresInitialData()) {
     }

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
@@ -51,9 +51,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
     readFunction  = dataOneFunction;
   }
 
-  double writeData, readData;
-
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   writeData, readData;
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps  = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows   = 5; // perform 5 windows.

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
 
   double writeData, readData;
 
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps  = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows   = 5; // perform 5 windows.

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
@@ -21,11 +21,14 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
+  double v0[] = {0, 0, 0};
+  double v1[] = {1, 0, 0};
+
   SolverInterface precice(context.name, context.config(), 0, 1);
   if (context.isNamed("SolverOne")) {
     auto meshName = "MeshOne";
-    precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-    precice.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    precice.setMeshVertex(meshName, v0);
+    precice.setMeshVertex(meshName, v1);
     precice.initialize();
     double maxDt     = precice.getMaxTimeStepSize();
     int    timestep  = 0;
@@ -42,8 +45,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto meshName = "Test-Square";
-    precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
-    precice.setMeshVertex(meshName, Eigen::Vector3d(1.0, 0.0, 0.0).data());
+    precice.setMeshVertex(meshName, v0);
+    precice.setMeshVertex(meshName, v1);
     precice.initialize();
     double maxDt     = precice.getMaxTimeStepSize();
     int    timestep  = 0;

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
@@ -45,7 +45,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipant)
     readDataName  = "DataOne";
   }
 
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
   precice.initialize();
   double dt = precice.getMaxTimeStepSize();
 

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
@@ -44,7 +44,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipantInitData)
     readDataName  = "DataOne";
   }
 
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
   precice.requiresInitialData(); // TODO fix
   precice.initialize();
   double dt = precice.getMaxTimeStepSize();

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   }
 
   double   writeData, readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps  = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows   = 5; // perform 5 windows.

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.cpp
@@ -52,7 +52,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveform)
   }
 
   double   writeData, readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps  = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows   = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
@@ -37,7 +37,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
     nSubsteps = 3;
   }
 
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int totalSolves             = 0;
   int totalCompletedTimesteps = 0;

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -66,7 +66,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int    nWindows        = 5; // perform 5 windows.
   int    timestep        = 0;

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -64,7 +64,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int    nWindows        = 5; // perform 5 windows.
   int    timestep        = 0;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -52,7 +52,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   }
 
   double   writeData, readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps       = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows        = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -51,7 +51,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
   }
 
   double   writeData, readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nWindows        = 5; // perform 5 windows.
   int    timestep        = 0;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
 
   double   writeData;
   double   readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nWindows        = 5; // perform 5 windows.
   int    timestep        = 0;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
   }
 
   double   writeData, readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nWindows   = 5; // perform 5 windows.
   int    timewindow = 0;

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
@@ -54,7 +54,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   double   writeData, readData;
   VertexID vertexID;
 
-  vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double v0[] = {0, 0, 0};
+  vertexID    = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows  = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
@@ -52,7 +52,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
   }
 
   double   writeData, readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows  = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
@@ -52,7 +52,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
   }
 
   double   writeData, readData;
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows  = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
@@ -47,7 +47,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipant)
     readDataName  = "DataOne";
   }
 
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
   precice.initialize();
   double dt = precice.getMaxTimeStepSize();
 

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.cpp
@@ -62,7 +62,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipantChangingDt)
   double writeData = 0;
   double readData  = 0;
 
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
   if (precice.requiresInitialData()) {
     precice.writeScalarData(meshName, writeDataName, vertexID, writeFunction(0));
   }

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.cpp
@@ -47,7 +47,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipantFixedWindows)
     readDataName  = "DataOne";
   }
 
-  VertexID vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
   precice.initialize();
   double dt = precice.getMaxTimeStepSize();
 

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps       = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows        = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -52,7 +52,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int    nWindows        = 5; // perform 5 windows.
   int    timestep        = 0;

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirstNoInit)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int nWindows = 5; // perform 5 windows.
   precice.initialize();

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.cpp
@@ -54,7 +54,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingZero)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int    nWindows             = 5; // perform 5 windows.
   int    timewindow           = 0;

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
@@ -55,7 +55,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   double   readData  = 0;
   VertexID vertexID;
 
-  vertexID = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double v0[] = {0, 0, 0};
+  vertexID    = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps          = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows           = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps          = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows           = 5; // perform 5 windows.

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingZero)
 
   double   writeData = 0;
   double   readData  = 0;
-  VertexID vertexID  = precice.setMeshVertex(meshName, Eigen::Vector3d(0.0, 0.0, 0.0).data());
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps          = 4; // perform subcycling on solvers. 4 steps happen in each window.
   int    nWindows           = 5; // perform 5 windows.


### PR DESCRIPTION
## Main changes of this PR

This PR fixes undefined behaviour in tests due to using `.data()` on temporary Eigen vectors.


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

