### PR TITLE
Refactor mesh vertex id checks

### DIFF
--- a/src/mesh/Utils.hpp
+++ b/src/mesh/Utils.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <mesh/Edge.hpp>
 #include <mesh/Mesh.hpp>
+#include <optional>
 #include <utility>
 
 namespace precice {
@@ -138,6 +139,16 @@ Eigen::VectorXd integrateSurface(const PtrMesh &mesh, const PtrData &data);
 
 /// Given the data and the mesh, this function returns the volume integral. Assumes no overlap exists for the mesh
 Eigen::VectorXd integrateVolume(const PtrMesh &mesh, const PtrData &data);
+
+template <typename Container>
+std::optional<std::size_t> locateInvalidVertexID(const Mesh &mesh, const Container &container)
+{
+  if (const auto invalidIter = std::find_if(container.begin(), container.end(), [&mesh](VertexID id) { return !mesh.isValidVertexID(id); });
+      invalidIter != container.end()) {
+    return {std::distance(container.begin(), invalidIter)};
+  }
+  return std::nullopt;
+}
 
 } // namespace mesh
 } // namespace precice

--- a/src/mesh/tests/UtilsTest.cpp
+++ b/src/mesh/tests/UtilsTest.cpp
@@ -1,0 +1,59 @@
+#include "mesh/Utils.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(MeshTests)
+
+BOOST_AUTO_TEST_SUITE(UtilsTests)
+
+BOOST_AUTO_TEST_CASE(LocateInvalidId)
+{
+  using namespace precice;
+  using namespace precice::mesh;
+  mesh::Mesh mesh("2D Testmesh", 2, testing::nextMeshID());
+  auto       v1 = mesh.createVertex(Eigen::Vector2d::Zero()).getID();
+  auto       v2 = mesh.createVertex(Eigen::Vector2d::Ones()).getID();
+
+  using VIDs = std::vector<VertexID>;
+
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{v1, v2, 99});
+    BOOST_TEST(index.has_value());
+    BOOST_TEST(index.value() == 2);
+  }
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{99, v1, v2});
+    BOOST_TEST(index.has_value());
+    BOOST_TEST(index.value() == 0);
+  }
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{99, v1, v2, 99});
+    BOOST_TEST(index.has_value());
+    BOOST_TEST(index.value() == 0);
+  }
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{v1, v2, 99, v1, v2});
+    BOOST_TEST(index.has_value());
+    BOOST_TEST(index.value() == 2);
+  }
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{99});
+    BOOST_TEST(index.has_value());
+    BOOST_TEST(index.value() == 0);
+  }
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{v1, v2});
+    BOOST_TEST(!index.has_value());
+  }
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{});
+    BOOST_TEST(!index.has_value());
+  }
+  {
+    auto index = locateInvalidVertexID(mesh, VIDs{99});
+    BOOST_TEST(index.has_value());
+    BOOST_TEST(index.value() == 0);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END();
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <optional>
 #include <string>
+
 #include "MappingContext.hpp"
 #include "MeshContext.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "mesh/Utils.hpp"
 
 namespace precice {
 
@@ -84,6 +87,12 @@ public:
    * @return True, if this DataContext is associated with a mapping. False, if not.
    */
   bool hasMapping() const;
+
+  template <typename Container>
+  std::optional<std::size_t> locateInvalidVertexID(const Container &c)
+  {
+    return mesh::locateInvalidVertexID(*_mesh, c);
+  }
 
 protected:
   /**

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -32,13 +32,8 @@ void ReadDataContext::readValues(::precice::span<const VertexID> vertices, doubl
   Eigen::Map<Eigen::MatrixXd>       outputData(values.data(), getDataDimensions(), values.size());
   const Eigen::MatrixXd             sample{_waveform->sample(normalizedDt)};
   Eigen::Map<const Eigen::MatrixXd> localData(sample.data(), getDataDimensions(), getMesh().vertices().size());
-  for (int i = 0; i < vertices.size(); ++i) {
-    const auto vid = vertices[i];
-    PRECICE_CHECK(getMesh().isValidVertexID(vid),
-                  "Cannot read data \"{}\" from invalid Vertex ID ({}) of mesh \"{}\". "
-                  "Please make sure you only use the results from calls to setMeshVertex/Vertices().",
-                  getDataName(), vid, getMeshName());
-    outputData.col(i) = localData.col(vid);
+  for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
+    outputData.col(i) = localData.col(vertices[i]);
   }
 }
 

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -22,12 +22,8 @@ void WriteDataContext::writeValues(::precice::span<const VertexID> vertices, ::p
   Eigen::Map<const Eigen::MatrixXd> inputData(values.data(), getDataDimensions(), vertices.size());
   Eigen::Map<Eigen::MatrixXd>       localData(_providedData->values().data(), getDataDimensions(), getMesh().vertices().size());
 
-  for (int i = 0; i < vertices.size(); ++i) {
-    const auto vid = vertices[i];
-    PRECICE_CHECK(getMesh().isValidVertexID(vid),
-                  "Cannot write data \"{}\" to invalid Vertex ID ({}) of mesh \"{}\". Please make sure you only use the results from calls to setMeshVertex/Vertices().",
-                  getDataName(), vid, getMeshName());
-    localData.col(vid) = inputData.col(i);
+  for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
+    localData.col(vertices[i]) = inputData.col(i);
   }
 }
 
@@ -37,12 +33,8 @@ void WriteDataContext::writeGradientValues(::precice::span<const VertexID> verti
   Eigen::Map<const Eigen::MatrixXd> inputGradients(gradients.data(), gradientComponents, vertices.size());
   Eigen::Map<Eigen::MatrixXd>       localGradients(_providedData->gradientValues().data(), gradientComponents, getMesh().vertices().size());
 
-  for (int i = 0; i < vertices.size(); ++i) {
-    const auto vid = vertices[i];
-    PRECICE_CHECK(getMesh().isValidVertexID(vid),
-                  "Cannot write gradient for data \"{}\" to invalid Vertex ID ({}) of mesh \"{}\". Please make sure you only use the results from calls to setMeshVertex/Vertices().",
-                  getDataName(), vid, getMeshName());
-    localGradients.col(vid) = inputGradients.col(i);
+  for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
+    localGradients.col(vertices[i]) = inputGradients.col(i);
   }
 }
 

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -59,6 +59,7 @@ target_sources(testprecice
     src/mesh/tests/MeshTest.cpp
     src/mesh/tests/TetrahedronTest.cpp
     src/mesh/tests/TriangleTest.cpp
+    src/mesh/tests/UtilsTest.cpp
     src/mesh/tests/VertexTest.cpp
     src/partition/tests/ProvidedPartitionTest.cpp
     src/partition/tests/ReceivedPartitionTest.cpp


### PR DESCRIPTION
## Main changes of this PR

Refactors mesh vertex id checks into a helper.
This simplifies the read/write data loop.


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

