### PR TITLE
Port Mesh API to spans

### DIFF
--- a/docs/changelog/1641.md
+++ b/docs/changelog/1641.md
@@ -1,0 +1,2 @@
+- Changed API from pointers to spans. Every provided span contains an associated size, which are required to be correctly sized.
+- Added error messages for inconsistent argument sizes.

--- a/docs/documents/span.dox
+++ b/docs/documents/span.dox
@@ -1,0 +1,10 @@
+/** @class precice::span
+ *
+ * @copyright Copyright Tristan Brindle 2018.
+ *
+ * @brief A C++ 11 implementation of the non-owning C++20 std::span type.
+ *
+ * A span represents a non-owning view into a contiguous block of memory of a known size.
+ *
+ * This version contains an additional constructor for `const char *`-style C strings, allowing the span to mimic C++17 std::string_view.
+ */

--- a/examples/solverdummies/cpp/solverdummy.cpp
+++ b/examples/solverdummies/cpp/solverdummy.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
     }
   }
 
-  interface.setMeshVertices(meshName, numberOfVertices, vertices.data(), vertexIDs.data());
+  interface.setMeshVertices(meshName, vertices, vertexIDs);
 
   if (interface.requiresInitialData()) {
     std::cout << "DUMMY: Writing initial data\n";

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -154,7 +154,8 @@ int precicec_setMeshVertex(
     const double *position)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  return impl->setMeshVertex(meshName, position);
+  auto size = static_cast<long unsigned>(impl->getMeshDimensions(meshName));
+  return impl->setMeshVertex(meshName, {position, size});
 }
 
 void precicec_setMeshVertices(
@@ -164,7 +165,9 @@ void precicec_setMeshVertices(
     int *         ids)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshVertices(meshName, size, positions, ids);
+  auto idsSize = static_cast<long unsigned>(size);
+  auto posSize = static_cast<long unsigned>(impl->getMeshDimensions(meshName) * size);
+  impl->setMeshVertices(meshName, {positions, posSize}, {ids, idsSize});
 }
 
 int precicec_getMeshVertexSize(
@@ -189,7 +192,8 @@ void precicec_setMeshEdges(
     const int * vertices)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshEdges(meshName, size, vertices);
+  auto verticesSize = static_cast<long unsigned>(size) * 2;
+  impl->setMeshEdges(meshName, {vertices, verticesSize});
 }
 
 void precicec_setMeshTriangle(
@@ -208,7 +212,8 @@ void precicec_setMeshTriangles(
     const int * vertices)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshTriangles(meshName, size, vertices);
+  auto verticesSize = static_cast<long unsigned>(size) * 3;
+  impl->setMeshTriangles(meshName, {vertices, verticesSize});
 }
 
 void precicec_setMeshQuad(
@@ -228,7 +233,8 @@ void precicec_setMeshQuads(
     const int * vertices)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshQuads(meshName, size, vertices);
+  auto verticesSize = static_cast<long unsigned>(size) * 4;
+  impl->setMeshQuads(meshName, {vertices, verticesSize});
 }
 
 void precicec_setMeshTetrahedron(
@@ -248,7 +254,8 @@ void precicec_setMeshTetrahedra(
     const int * vertices)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshTetrahedra(meshName, size, vertices);
+  auto verticesSize = static_cast<long unsigned>(size) * 4;
+  impl->setMeshTetrahedra(meshName, {vertices, verticesSize});
 }
 
 void precicec_writeData(
@@ -308,7 +315,8 @@ void precicec_setMeshAccessRegion(
     const char *  meshName,
     const double *boundingBox)
 {
-  impl->setMeshAccessRegion(meshName, boundingBox);
+  auto bbSize = static_cast<long unsigned>(impl->getMeshDimensions(meshName)) * 2;
+  impl->setMeshAccessRegion(meshName, {boundingBox, bbSize});
 }
 
 void precicec_getMeshVerticesAndIDs(
@@ -317,7 +325,8 @@ void precicec_getMeshVerticesAndIDs(
     int *       ids,
     double *    coordinates)
 {
-  impl->getMeshVerticesAndIDs(meshName, size, ids, coordinates);
+  auto coordinatesSize = static_cast<long unsigned>(impl->getMeshDimensions(meshName) * size);
+  impl->getMeshVerticesAndIDs(meshName, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
 }
 
 #ifdef __GNUC__

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -191,7 +191,9 @@ void precicef_set_vertex_(
     int           meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  *vertexID = impl->setMeshVertex(precice::impl::strippedStringView(meshName, meshNameLength), position);
+  auto sv           = precice::impl::strippedStringView(meshName, meshNameLength);
+  auto positionSize = static_cast<unsigned long>(impl->getMeshDimensions(sv));
+  *vertexID         = impl->setMeshVertex(sv, {position, positionSize});
 }
 
 void precicef_get_mesh_vertex_size_(
@@ -211,7 +213,9 @@ void precicef_set_vertices_(
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshVertices(precice::impl::strippedStringView(meshName, meshNameLength), *size, positions, positionIDs);
+  auto sv           = precice::impl::strippedStringView(meshName, meshNameLength);
+  auto positionSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * *size);
+  impl->setMeshVertices(sv, {positions, positionSize}, {positionIDs, static_cast<unsigned long>(*size)});
 }
 
 void precicef_set_edge_(
@@ -231,7 +235,8 @@ void precicef_set_mesh_edges_(
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshEdges(precice::impl::strippedStringView(meshName, meshNameLength), *size, vertices);
+  auto verticesSize = static_cast<unsigned long>(*size) * 2;
+  impl->setMeshEdges(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
 }
 
 void precicef_set_triangle_(
@@ -252,7 +257,8 @@ void precicef_set_mesh_triangles_(
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshTriangles(precice::impl::strippedStringView(meshName, meshNameLength), *size, vertices);
+  auto verticesSize = static_cast<unsigned long>(*size) * 3;
+  impl->setMeshTriangles(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
 }
 
 void precicef_set_quad_(
@@ -274,7 +280,8 @@ void precicef_set_mesh_quads_(
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshQuads(precice::impl::strippedStringView(meshName, meshNameLength), *size, vertices);
+  auto verticesSize = static_cast<unsigned long>(*size) * 4;
+  impl->setMeshQuads(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
 }
 
 void precicef_set_tetrahedron(
@@ -296,7 +303,8 @@ void precicef_set_mesh_tetrahedra_(
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshTetrahedra(precice::impl::strippedStringView(meshName, meshNameLength), *size, vertices);
+  auto verticesSize = static_cast<unsigned long>(*size) * 4;
+  impl->setMeshTetrahedra(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
 }
 
 void precicef_write_data_(
@@ -408,7 +416,9 @@ void precicef_set_mesh_access_region_(
     int           meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->setMeshAccessRegion(precice::impl::strippedStringView(meshName, meshNameLength), boundingBox);
+  auto sv     = precice::impl::strippedStringView(meshName, meshNameLength);
+  auto bbSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * 2);
+  impl->setMeshAccessRegion(sv, {boundingBox, bbSize});
 }
 
 void precicef_get_mesh_vertices_and_ids_(
@@ -419,7 +429,9 @@ void precicef_get_mesh_vertices_and_ids_(
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  impl->getMeshVerticesAndIDs(precice::impl::strippedStringView(meshName, meshNameLength), size, ids, coordinates);
+  auto sv              = precice::impl::strippedStringView(meshName, meshNameLength);
+  auto coordinatesSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * size);
+  impl->getMeshVerticesAndIDs(sv, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
 }
 
 #ifdef __GNUC__

--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -126,8 +126,8 @@ bool SolverInterface::hasData(::precice::string_view meshName, ::precice::string
 // }
 
 int SolverInterface::setMeshVertex(
-    ::precice::string_view meshName,
-    const double *         position)
+    ::precice::string_view        meshName,
+    ::precice::span<const double> position)
 {
   return _impl->setMeshVertex(toSV(meshName), position);
 }
@@ -139,12 +139,11 @@ int SolverInterface::getMeshVertexSize(
 }
 
 void SolverInterface::setMeshVertices(
-    ::precice::string_view meshName,
-    int                    size,
-    const double *         positions,
-    int *                  ids)
+    ::precice::string_view        meshName,
+    ::precice::span<const double> positions,
+    ::precice::span<VertexID>     ids)
 {
-  _impl->setMeshVertices(toSV(meshName), size, positions, ids);
+  _impl->setMeshVertices(toSV(meshName), positions, ids);
 }
 
 void SolverInterface::setMeshEdge(
@@ -156,11 +155,10 @@ void SolverInterface::setMeshEdge(
 }
 
 void SolverInterface::setMeshEdges(
-    ::precice::string_view meshName,
-    int                    size,
-    const int *            vertices)
+    ::precice::string_view          meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  _impl->setMeshEdges(toSV(meshName), size, vertices);
+  _impl->setMeshEdges(toSV(meshName), vertices);
 }
 
 void SolverInterface::setMeshTriangle(
@@ -173,11 +171,10 @@ void SolverInterface::setMeshTriangle(
 }
 
 void SolverInterface::setMeshTriangles(
-    ::precice::string_view meshName,
-    int                    size,
-    const int *            vertices)
+    ::precice::string_view          meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  _impl->setMeshTriangles(toSV(meshName), size, vertices);
+  _impl->setMeshTriangles(toSV(meshName), vertices);
 }
 
 void SolverInterface::setMeshQuad(
@@ -192,11 +189,10 @@ void SolverInterface::setMeshQuad(
 }
 
 void SolverInterface::setMeshQuads(
-    ::precice::string_view meshName,
-    int                    size,
-    const int *            vertices)
+    ::precice::string_view          meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  _impl->setMeshQuads(toSV(meshName), size, vertices);
+  _impl->setMeshQuads(toSV(meshName), vertices);
 }
 
 void SolverInterface::setMeshTetrahedron(
@@ -211,11 +207,10 @@ void SolverInterface::setMeshTetrahedron(
 }
 
 void SolverInterface::setMeshTetrahedra(
-    ::precice::string_view meshName,
-    int                    size,
-    const int *            vertices)
+    ::precice::string_view          meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  _impl->setMeshTetrahedra(toSV(meshName), size, vertices);
+  _impl->setMeshTetrahedra(toSV(meshName), vertices);
 }
 
 void SolverInterface::writeData(
@@ -237,18 +232,17 @@ void SolverInterface::readData(
   _impl->readData(toSV(meshName), toSV(dataName), vertices, relativeReadTime, values);
 }
 
-void SolverInterface::setMeshAccessRegion(::precice::string_view meshName,
-                                          const double *         boundingBox) const
+void SolverInterface::setMeshAccessRegion(::precice::string_view        meshName,
+                                          ::precice::span<const double> boundingBox) const
 {
   _impl->setMeshAccessRegion(toSV(meshName), boundingBox);
 }
 
-void SolverInterface::getMeshVerticesAndIDs(::precice::string_view meshName,
-                                            const int              size,
-                                            int *                  ids,
-                                            double *               coordinates) const
+void SolverInterface::getMeshVerticesAndIDs(::precice::string_view    meshName,
+                                            ::precice::span<VertexID> ids,
+                                            ::precice::span<double>   coordinates) const
 {
-  _impl->getMeshVerticesAndIDs(toSV(meshName), size, ids, coordinates);
+  _impl->getMeshVerticesAndIDs(toSV(meshName), ids, coordinates);
 }
 
 void SolverInterface::writeGradientData(

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -594,7 +594,7 @@ public:
    * @param[in] values the values to write to preCICE.
    *
    * @pre every VertexID in vertices is a return value of setMeshVertex or setMeshVertices
-   * @pre values.size() = getDataDimensions(meshName, dataName) * vertices.size()
+   * @pre values.size() == getDataDimensions(meshName, dataName) * vertices.size()
    *
    * @see SolverInterface::setMeshVertex()
    * @see SolverInterface::setMeshVertices()
@@ -628,7 +628,7 @@ public:
    * @param[out] values the destination memory to read the data from.
    *
    * @pre every VertexID in vertices is a return value of setMeshVertex or setMeshVertices
-   * @pre values.size() = getDataDimensions(meshName, dataName) * vertices.size()
+   * @pre values.size() == getDataDimensions(meshName, dataName) * vertices.size()
    *
    * @post values contain the read data as specified in the above format.
    *

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -716,7 +716,7 @@ void SolverInterfaceImpl::setMeshEdges(
   mesh::PtrMesh &mesh = context.mesh;
   PRECICE_CHECK(vertices.size() % 2 == 0,
                 "Cannot interpret passed vertex IDs attempting to set edges of mesh \"{}\" . "
-                "You passed {} vertices, but we expected an odd number.",
+                "You passed {} vertices, but we expected an even number.",
                 meshName, vertices.size());
   {
     auto end           = vertices.end();

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -644,41 +644,43 @@ void SolverInterfaceImpl::resetMesh(
 }
 
 int SolverInterfaceImpl::setMeshVertex(
-    std::string_view meshName,
-    const double *   position)
+    std::string_view              meshName,
+    ::precice::span<const double> position)
 {
   PRECICE_TRACE(meshName);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  Eigen::VectorXd internalPosition{
-      Eigen::Map<const Eigen::VectorXd>{position, _dimensions}};
-  PRECICE_DEBUG("Position = {}", internalPosition.format(utils::eigenio::debug()));
-  int           index   = -1;
-  MeshContext & context = _accessor->usedMeshContext(meshName);
-  mesh::PtrMesh mesh(context.mesh);
-  PRECICE_DEBUG("MeshRequirement: {}", fmt::streamed(context.meshRequirement));
-  index = mesh->createVertex(internalPosition).getID();
-  mesh->allocateDataValues();
+  MeshContext &context = _accessor->usedMeshContext(meshName);
+  auto &       mesh    = *context.mesh;
+  PRECICE_CHECK(position.size() == static_cast<unsigned long>(mesh.getDimensions()),
+                "Cannot set vertex for mesh \"{}\". Expected {} position components but found {}.", meshName, mesh.getDimensions(), position.size());
+  auto index = mesh.createVertex(Eigen::Map<const Eigen::VectorXd>{position.data(), _dimensions}).getID();
+  mesh.allocateDataValues();
   return index;
 }
 
 void SolverInterfaceImpl::setMeshVertices(
-    std::string_view meshName,
-    int              size,
-    const double *   positions,
-    int *            ids)
+    std::string_view              meshName,
+    ::precice::span<const double> positions,
+    ::precice::span<VertexID>     ids)
 {
-  PRECICE_TRACE(meshName, size);
+  PRECICE_TRACE(meshName, positions.size(), ids.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext & context = _accessor->usedMeshContext(meshName);
-  mesh::PtrMesh mesh(context.mesh);
-  PRECICE_DEBUG("Set positions");
+  MeshContext &context = _accessor->usedMeshContext(meshName);
+  auto &       mesh    = *context.mesh;
+
+  const auto meshDims             = mesh.getDimensions();
+  const auto expectedPositionSize = ids.size() * meshDims;
+  PRECICE_CHECK(positions.size() == expectedPositionSize,
+                "Input sizes are inconsistent attempting to set vertices on {}D mesh \"{}\". "
+                "You passed {} vertices indices and {} position components, but we expected {} position components ({} x {}).",
+                meshDims, meshName, ids.size(), positions.size(), expectedPositionSize, ids.size(), meshDims);
+
   const Eigen::Map<const Eigen::MatrixXd> posMatrix{
-      positions, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
-  for (int i = 0; i < size; ++i) {
-    Eigen::VectorXd current(posMatrix.col(i));
-    ids[i] = mesh->createVertex(current).getID();
+      positions.data(), _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(ids.size())};
+  for (unsigned long i = 0; i < ids.size(); ++i) {
+    ids[i] = mesh.createVertex(posMatrix.col(i)).getID();
   }
-  mesh->allocateDataValues();
+  mesh.allocateDataValues();
 }
 
 void SolverInterfaceImpl::setMeshEdge(
@@ -701,11 +703,10 @@ void SolverInterfaceImpl::setMeshEdge(
 }
 
 void SolverInterfaceImpl::setMeshEdges(
-    std::string_view meshName,
-    int              size,
-    const int *      vertices)
+    std::string_view                meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  PRECICE_TRACE(meshName, size);
+  PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
@@ -713,18 +714,22 @@ void SolverInterfaceImpl::setMeshEdges(
   }
 
   mesh::PtrMesh &mesh = context.mesh;
+  PRECICE_CHECK(vertices.size() % 2 == 0,
+                "Cannot interpret passed vertex IDs attempting to set edges of mesh \"{}\" . "
+                "You passed {} vertices, but we expected an odd number.",
+                meshName, vertices.size());
   {
-    auto end           = std::next(vertices, size * 2);
-    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
+    auto end           = vertices.end();
+    auto [first, last] = utils::find_first_range(vertices.begin(), end, [&mesh](VertexID vid) {
       return !mesh->isValidVertexID(vid);
     });
     PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
-                  std::distance(vertices, first),
-                  std::distance(vertices, last));
+                  std::distance(vertices.begin(), first),
+                  std::distance(vertices.begin(), last));
   }
 
-  for (int i = 0; i < size; ++i) {
+  for (unsigned long i = 0; i < vertices.size() / 2; ++i) {
     auto aid = vertices[2 * i];
     auto bid = vertices[2 * i + 1];
     mesh->createEdge(mesh->vertices()[aid], mesh->vertices()[bid]);
@@ -769,11 +774,10 @@ void SolverInterfaceImpl::setMeshTriangle(
 }
 
 void SolverInterfaceImpl::setMeshTriangles(
-    std::string_view meshName,
-    int              size,
-    const int *      vertices)
+    std::string_view                meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  PRECICE_TRACE(meshName, size);
+  PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
@@ -781,18 +785,22 @@ void SolverInterfaceImpl::setMeshTriangles(
   }
 
   mesh::PtrMesh &mesh = context.mesh;
+  PRECICE_CHECK(vertices.size() % 3 == 0,
+                "Cannot interpret passed vertex IDs attempting to set triangles of mesh \"{}\" . "
+                "You passed {} vertices, which isn't dividable by 3.",
+                meshName, vertices.size());
   {
-    auto end           = std::next(vertices, size * 3);
-    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
+    auto end           = vertices.end();
+    auto [first, last] = utils::find_first_range(vertices.begin(), end, [&mesh](VertexID vid) {
       return !mesh->isValidVertexID(vid);
     });
     PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
-                  std::distance(vertices, first),
-                  std::distance(vertices, last));
+                  std::distance(vertices.begin(), first),
+                  std::distance(vertices.begin(), last));
   }
 
-  for (int i = 0; i < size; ++i) {
+  for (unsigned long i = 0; i < vertices.size() / 3; ++i) {
     auto aid = vertices[3 * i];
     auto bid = vertices[3 * i + 1];
     auto cid = vertices[3 * i + 2];
@@ -855,11 +863,10 @@ void SolverInterfaceImpl::setMeshQuad(
 }
 
 void SolverInterfaceImpl::setMeshQuads(
-    std::string_view meshName,
-    int              size,
-    const int *      vertices)
+    std::string_view                meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  PRECICE_TRACE(meshName, size);
+  PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
@@ -867,18 +874,22 @@ void SolverInterfaceImpl::setMeshQuads(
   }
 
   mesh::Mesh &mesh = *(context.mesh);
+  PRECICE_CHECK(vertices.size() % 4 == 0,
+                "Cannot interpret passed vertex IDs attempting to set quads of mesh \"{}\" . "
+                "You passed {} vertices, which isn't dividable by 4.",
+                meshName, vertices.size());
   {
-    auto end           = std::next(vertices, size * 4);
-    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
+    auto end           = vertices.end();
+    auto [first, last] = utils::find_first_range(vertices.begin(), end, [&mesh](VertexID vid) {
       return !mesh.isValidVertexID(vid);
     });
     PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
-                  std::distance(vertices, first),
-                  std::distance(vertices, last));
+                  std::distance(vertices.begin(), first),
+                  std::distance(vertices.begin(), last));
   }
 
-  for (int i = 0; i < size; ++i) {
+  for (unsigned long i = 0; i < vertices.size() / 4; ++i) {
     auto aid = vertices[4 * i];
     auto bid = vertices[4 * i + 1];
     auto cid = vertices[4 * i + 2];
@@ -943,11 +954,10 @@ void SolverInterfaceImpl::setMeshTetrahedron(
 }
 
 void SolverInterfaceImpl::setMeshTetrahedra(
-    std::string_view meshName,
-    int              size,
-    const int *      vertices)
+    std::string_view                meshName,
+    ::precice::span<const VertexID> vertices)
 {
-  PRECICE_TRACE(meshName, size);
+  PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
@@ -955,18 +965,22 @@ void SolverInterfaceImpl::setMeshTetrahedra(
   }
 
   mesh::PtrMesh &mesh = context.mesh;
+  PRECICE_CHECK(vertices.size() % 4 == 0,
+                "Cannot interpret passed vertex IDs attempting to set quads of mesh \"{}\" . "
+                "You passed {} vertices, which isn't dividable by 4.",
+                meshName, vertices.size());
   {
-    auto end           = std::next(vertices, size * 4);
-    auto [first, last] = utils::find_first_range(vertices, end, [&mesh](VertexID vid) {
+    auto end           = vertices.end();
+    auto [first, last] = utils::find_first_range(vertices.begin(), end, [&mesh](VertexID vid) {
       return !mesh->isValidVertexID(vid);
     });
     PRECICE_CHECK(first == end,
                   impl::errorInvalidVertexIDRange,
-                  std::distance(vertices, first),
-                  std::distance(vertices, last));
+                  std::distance(vertices.begin(), first),
+                  std::distance(vertices.begin(), last));
   }
 
-  for (int i = 0; i < size; ++i) {
+  for (unsigned long i = 0; i < vertices.size() / 4; ++i) {
     auto aid = vertices[4 * i];
     auto bid = vertices[4 * i + 1];
     auto cid = vertices[4 * i + 2];
@@ -1047,7 +1061,7 @@ void SolverInterfaceImpl::readData(
   const auto       dataDims         = context.getDataDimensions();
   const auto       expectedDataSize = vertices.size() * dataDims;
   PRECICE_CHECK(expectedDataSize == values.size(),
-                "Input sizes are inconsistent attempting to read {}D data \"{}\" from mesh \"{}\". "
+                "Input/Output sizes are inconsistent attempting to read {}D data \"{}\" from mesh \"{}\". "
                 "You passed {} vertices and {} data components, but we expected {} data components ({} x {}).",
                 dataDims, dataName, meshName,
                 vertices.size(), values.size(), expectedDataSize, dataDims, vertices.size());
@@ -1112,23 +1126,27 @@ void SolverInterfaceImpl::writeGradientData(
 }
 
 void SolverInterfaceImpl::setMeshAccessRegion(
-    const std::string_view meshName,
-    const double *         boundingBox) const
+    const std::string_view        meshName,
+    ::precice::span<const double> boundingBox) const
 {
   PRECICE_EXPERIMENTAL_API();
-  PRECICE_TRACE(meshName);
+  PRECICE_TRACE(meshName, boundingBox.size());
   PRECICE_REQUIRE_MESH_USE(meshName);
   PRECICE_CHECK(_state != State::Finalized, "setMeshAccessRegion() cannot be called after finalize().")
   PRECICE_CHECK(_state != State::Initialized, "setMeshAccessRegion() needs to be called before initialize().");
   PRECICE_CHECK(!_accessRegionDefined, "setMeshAccessRegion may only be called once.");
-  PRECICE_CHECK(boundingBox != nullptr, "setMeshAccessRegion was called with boundingBox == nullptr.");
 
   // Get the related mesh
   MeshContext & context = _accessor->meshContext(meshName);
   mesh::PtrMesh mesh(context.mesh);
-  PRECICE_DEBUG("Define bounding box");
+  int           dim = mesh->getDimensions();
+  PRECICE_CHECK(boundingBox.size() == static_cast<unsigned long>(dim) * 2,
+                "Incorrect amount of bounding box components attempting to set the bounding box of {}D mesh \"{}\" . "
+                "You passed {} limits, but we expected {} ({}x2).",
+                dim, meshName, boundingBox.size(), dim * 2, dim);
+
   // Transform bounds into a suitable format
-  int                 dim = mesh->getDimensions();
+  PRECICE_DEBUG("Define bounding box");
   std::vector<double> bounds(dim * 2);
 
   for (int d = 0; d < dim; ++d) {
@@ -1146,37 +1164,47 @@ void SolverInterfaceImpl::setMeshAccessRegion(
 }
 
 void SolverInterfaceImpl::getMeshVerticesAndIDs(
-    const std::string_view meshName,
-    const int              size,
-    int *                  ids,
-    double *               coordinates) const
+    const std::string_view    meshName,
+    ::precice::span<VertexID> ids,
+    ::precice::span<double>   coordinates) const
 {
   PRECICE_EXPERIMENTAL_API();
-  PRECICE_TRACE(meshName, size);
+  PRECICE_TRACE(meshName, ids.size(), coordinates.size());
   PRECICE_REQUIRE_MESH_USE(meshName);
-  PRECICE_DEBUG("Get {} mesh vertices with IDs", size);
+  PRECICE_DEBUG("Get {} mesh vertices with IDs", ids.size());
 
   // Check, if the requested mesh data has already been received. Otherwise, the function call doesn't make any sense
   PRECICE_CHECK((_state == State::Initialized) || _accessor->isMeshProvided(meshName), "initialize() has to be called before accessing"
                                                                                        " data of the received mesh \"{}\" on participant \"{}\".",
                 meshName, _accessor->getName());
 
-  if (size == 0)
+  if (ids.empty() && coordinates.empty()) {
     return;
-
+  }
   const MeshContext & context = _accessor->meshContext(meshName);
   const mesh::PtrMesh mesh(context.mesh);
 
-  PRECICE_CHECK(ids != nullptr, "getMeshVerticesAndIDs() was called with ids == nullptr");
-  PRECICE_CHECK(coordinates != nullptr, "getMeshVerticesAndIDs() was called with coordinates == nullptr");
-
   const auto &vertices = mesh->vertices();
-  PRECICE_CHECK(static_cast<unsigned int>(size) <= vertices.size(), "The queried size exceeds the number of available points.");
+  const auto  meshSize = vertices.size();
+  const auto  meshDims = mesh->getDimensions();
+  PRECICE_CHECK(ids.size() == meshSize,
+                "Output size is incorrect attempting to get vertex ids of {}D mesh \"{}\". "
+                "You passed {} vertices indices, but we expected {}. "
+                "Use getMeshVertexSize(\"{}\") to receive the required amount of vertices.",
+                meshDims, meshName, ids.size(), meshSize, meshName);
+  const auto expectedCoordinatesSize = static_cast<unsigned long>(meshDims * meshSize);
+  PRECICE_CHECK(coordinates.size() == expectedCoordinatesSize,
+                "Output size is incorrect attempting to get vertex coordinates of {}D mesh \"{}\". "
+                "You passed {} coordinate components, but we expected {} ({}x{}). "
+                "Use getMeshVertexSize(\"{}\") and getMeshDimensions(\"{}\") to receive the required amount components",
+                meshDims, meshName, coordinates.size(), expectedCoordinatesSize, meshSize, meshDims, meshName, meshName);
+
+  PRECICE_CHECK(ids.size() <= vertices.size(), "The queried size exceeds the number of available points.");
 
   Eigen::Map<Eigen::MatrixXd> posMatrix{
-      coordinates, _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(size)};
+      coordinates.data(), _dimensions, static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(ids.size())};
 
-  for (size_t i = 0; i < static_cast<size_t>(size); i++) {
+  for (unsigned long i = 0; i < ids.size(); i++) {
     PRECICE_ASSERT(i < vertices.size(), i, vertices.size());
     ids[i]           = vertices[i].getID();
     posMatrix.col(i) = vertices[i].getCoords();

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -154,18 +154,17 @@ public:
 
   /// @copydoc SolverInterface::setMeshVertex
   int setMeshVertex(
-      std::string_view meshName,
-      const double *   position);
+      std::string_view              meshName,
+      ::precice::span<const double> position);
 
   /// @copydoc SolverInterface::getMeshVertexSize
   int getMeshVertexSize(std::string_view meshName) const;
 
   /// @copydoc SolverInterface::setMeshVertices
   void setMeshVertices(
-      std::string_view meshName,
-      int              size,
-      const double *   positions,
-      int *            ids);
+      std::string_view              meshName,
+      ::precice::span<const double> positions,
+      ::precice::span<VertexID>     ids);
 
   /// @copydoc SolverInterface::setMeshEdge
   void setMeshEdge(
@@ -175,9 +174,8 @@ public:
 
   /// @copydoc SolverInterface::setMeshEdges
   void setMeshEdges(
-      std::string_view meshName,
-      int              size,
-      const int *      vertices);
+      std::string_view                meshName,
+      ::precice::span<const VertexID> vertices);
 
   /// @copydoc SolverInterface::setMeshTriangle
   void setMeshTriangle(
@@ -188,9 +186,8 @@ public:
 
   /// @copydoc SolverInterface::setMeshTriangles
   void setMeshTriangles(
-      std::string_view meshName,
-      int              size,
-      const int *      vertices);
+      std::string_view                meshName,
+      ::precice::span<const VertexID> vertices);
 
   /// @copydoc SolverInterface::setMeshQuad
   void setMeshQuad(
@@ -202,9 +199,8 @@ public:
 
   /// @copydoc SolverInterface::setMeshQuads
   void setMeshQuads(
-      std::string_view meshName,
-      int              size,
-      const int *      vertices);
+      std::string_view                meshName,
+      ::precice::span<const VertexID> vertices);
 
   /// @copydoc SolverInterface::setMeshTetrahedron
   void setMeshTetrahedron(
@@ -216,9 +212,8 @@ public:
 
   /// @copydoc SolverInterface::setMeshTetrahedra
   void setMeshTetrahedra(
-      std::string_view meshName,
-      int              size,
-      const int *      vertices);
+      std::string_view                meshName,
+      ::precice::span<const VertexID> vertices);
 
   ///@}
 
@@ -260,15 +255,14 @@ public:
   ///@{
 
   /// @copydoc SolverInterface::setMeshAccessRegion
-  void setMeshAccessRegion(std::string_view meshName,
-                           const double *   boundingBox) const;
+  void setMeshAccessRegion(std::string_view              meshName,
+                           ::precice::span<const double> boundingBox) const;
 
   /// @copydoc SolverInterface::getMeshVerticesAndIDs
   void getMeshVerticesAndIDs(
-      std::string_view meshName,
-      const int        size,
-      int *            ids,
-      double *         coordinates) const;
+      std::string_view          meshName,
+      ::precice::span<VertexID> ids,
+      ::precice::span<double>   coordinates) const;
 
   ///@}
 

--- a/src/precice/span.hpp
+++ b/src/precice/span.hpp
@@ -9,8 +9,10 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
 //    (See accompanying file ../../LICENSE_1_0.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef TCB_SPAN_HPP_INCLUDED
-#define TCB_SPAN_HPP_INCLUDED
+#ifndef PRECICE_SPAN_HPP_INCLUDED
+#define PRECICE_SPAN_HPP_INCLUDED
+
+#pragma once
 
 #include <array>
 #include <cstddef>
@@ -18,46 +20,42 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
 #include <cstring>
 #include <type_traits>
 
-#ifndef TCB_SPAN_NO_EXCEPTIONS
+#ifndef PRECICE_SPAN_NO_EXCEPTIONS
 // Attempt to discover whether we're being compiled with exception support
 #if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
-#define TCB_SPAN_NO_EXCEPTIONS
+#define PRECICE_SPAN_NO_EXCEPTIONS
 #endif
 #endif
 
-#ifndef TCB_SPAN_NO_EXCEPTIONS
+#ifndef PRECICE_SPAN_NO_EXCEPTIONS
 #include <cstdio>
 #include <stdexcept>
 #endif
 
 // Various feature test macros
 
-#ifndef TCB_SPAN_NAMESPACE_NAME
-#define TCB_SPAN_NAMESPACE_NAME precice
-#endif
-
 #if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#define TCB_SPAN_HAVE_CPP17
+#define PRECICE_SPAN_HAVE_CPP17
 #endif
 
 #if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
-#define TCB_SPAN_HAVE_CPP14
+#define PRECICE_SPAN_HAVE_CPP14
 #endif
 
-namespace TCB_SPAN_NAMESPACE_NAME {
+namespace precice {
 
 // Establish default contract checking behavior
-#if !defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION) &&                          \
-    !defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION) &&                      \
-    !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
-#if defined(NDEBUG) || !defined(TCB_SPAN_HAVE_CPP14)
-#define TCB_SPAN_NO_CONTRACT_CHECKING
+#if !defined(PRECICE_SPAN_THROW_ON_CONTRACT_VIOLATION) &&                          \
+    !defined(PRECICE_SPAN_TERMINATE_ON_CONTRACT_VIOLATION) &&                      \
+    !defined(PRECICE_SPAN_NO_CONTRACT_CHECKING)
+#if defined(NDEBUG) || !defined(PRECICE_SPAN_HAVE_CPP14)
+#define PRECICE_SPAN_NO_CONTRACT_CHECKING
 #else
-#define TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION
+#define PRECICE_SPAN_TERMINATE_ON_CONTRACT_VIOLATION
 #endif
 #endif
 
-#if defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION)
+#if defined(PRECICE_SPAN_THROW_ON_CONTRACT_VIOLATION)
 struct contract_violation_error : std::logic_error {
     explicit contract_violation_error(const char* msg) : std::logic_error(msg)
     {}
@@ -68,82 +66,82 @@ inline void contract_violation(const char* msg)
     throw contract_violation_error(msg);
 }
 
-#elif defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION)
+#elif defined(PRECICE_SPAN_TERMINATE_ON_CONTRACT_VIOLATION)
 [[noreturn]] inline void contract_violation(const char* /*unused*/)
 {
     std::terminate();
 }
 #endif
 
-#if !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
-#define TCB_SPAN_STRINGIFY(cond) #cond
-#define TCB_SPAN_EXPECT(cond)                                                  \
-    cond ? (void) 0 : contract_violation("Expected " TCB_SPAN_STRINGIFY(cond))
+#if !defined(PRECICE_SPAN_NO_CONTRACT_CHECKING)
+#define PRECICE_SPAN_STRINGIFY(cond) #cond
+#define PRECICE_SPAN_EXPECT(cond)                                                  \
+    cond ? (void) 0 : contract_violation("Expected " PRECICE_SPAN_STRINGIFY(cond))
 #else
-#define TCB_SPAN_EXPECT(cond)
+#define PRECICE_SPAN_EXPECT(cond)
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_inline_variables)
-#define TCB_SPAN_INLINE_VAR inline
+#if defined(PRECICE_SPAN_HAVE_CPP17) || defined(__cpp_inline_variables)
+#define PRECICE_SPAN_INLINE_VAR inline
 #else
-#define TCB_SPAN_INLINE_VAR
+#define PRECICE_SPAN_INLINE_VAR
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP14) ||                                            \
+#if defined(PRECICE_SPAN_HAVE_CPP14) ||                                            \
     (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
-#define TCB_SPAN_HAVE_CPP14_CONSTEXPR
+#define PRECICE_SPAN_HAVE_CPP14_CONSTEXPR
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR)
-#define TCB_SPAN_CONSTEXPR14 constexpr
+#if defined(PRECICE_SPAN_HAVE_CPP14_CONSTEXPR)
+#define PRECICE_SPAN_CONSTEXPR14 constexpr
 #else
-#define TCB_SPAN_CONSTEXPR14
+#define PRECICE_SPAN_CONSTEXPR14
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR) &&                                  \
+#if defined(PRECICE_SPAN_HAVE_CPP14_CONSTEXPR) &&                                  \
     (!defined(_MSC_VER) || _MSC_VER > 1900)
-#define TCB_SPAN_CONSTEXPR_ASSIGN constexpr
+#define PRECICE_SPAN_CONSTEXPR_ASSIGN constexpr
 #else
-#define TCB_SPAN_CONSTEXPR_ASSIGN
+#define PRECICE_SPAN_CONSTEXPR_ASSIGN
 #endif
 
-#if defined(TCB_SPAN_NO_CONTRACT_CHECKING)
-#define TCB_SPAN_CONSTEXPR11 constexpr
+#if defined(PRECICE_SPAN_NO_CONTRACT_CHECKING)
+#define PRECICE_SPAN_CONSTEXPR11 constexpr
 #else
-#define TCB_SPAN_CONSTEXPR11 TCB_SPAN_CONSTEXPR14
+#define PRECICE_SPAN_CONSTEXPR11 PRECICE_SPAN_CONSTEXPR14
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_deduction_guides)
-#define TCB_SPAN_HAVE_DEDUCTION_GUIDES
+#if defined(PRECICE_SPAN_HAVE_CPP17) || defined(__cpp_deduction_guides)
+#define PRECICE_SPAN_HAVE_DEDUCTION_GUIDES
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_byte)
-#define TCB_SPAN_HAVE_STD_BYTE
+#if defined(PRECICE_SPAN_HAVE_CPP17) || defined(__cpp_lib_byte)
+#define PRECICE_SPAN_HAVE_STD_BYTE
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_array_constexpr)
-#define TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
+#if defined(PRECICE_SPAN_HAVE_CPP17) || defined(__cpp_lib_array_constexpr)
+#define PRECICE_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
 #endif
 
-#if defined(TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC)
-#define TCB_SPAN_ARRAY_CONSTEXPR constexpr
+#if defined(PRECICE_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC)
+#define PRECICE_SPAN_ARRAY_CONSTEXPR constexpr
 #else
-#define TCB_SPAN_ARRAY_CONSTEXPR
+#define PRECICE_SPAN_ARRAY_CONSTEXPR
 #endif
 
-#ifdef TCB_SPAN_HAVE_STD_BYTE
+#ifdef PRECICE_SPAN_HAVE_STD_BYTE
 using byte = std::byte;
 #else
 using byte = unsigned char;
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP17)
-#define TCB_SPAN_NODISCARD [[nodiscard]]
+#if defined(PRECICE_SPAN_HAVE_CPP17)
+#define PRECICE_SPAN_NODISCARD [[nodiscard]]
 #else
-#define TCB_SPAN_NODISCARD
+#define PRECICE_SPAN_NODISCARD
 #endif
 
-TCB_SPAN_INLINE_VAR constexpr std::size_t dynamic_extent = SIZE_MAX;
+PRECICE_SPAN_INLINE_VAR constexpr std::size_t dynamic_extent = SIZE_MAX;
 
 template <typename ElementType, std::size_t Extent = dynamic_extent>
 class span;
@@ -175,7 +173,7 @@ struct span_storage<E, dynamic_extent> {
 };
 
 // Reimplementation of C++17 std::size() and std::data()
-#if defined(TCB_SPAN_HAVE_CPP17) ||                                            \
+#if defined(PRECICE_SPAN_HAVE_CPP17) ||                                            \
     defined(__cpp_lib_nonmember_container_access)
 using std::data;
 using std::size;
@@ -215,9 +213,9 @@ constexpr const E* data(std::initializer_list<E> il) noexcept
 {
     return il.begin();
 }
-#endif // TCB_SPAN_HAVE_CPP17
+#endif // PRECICE_SPAN_HAVE_CPP17
 
-#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_void_t)
+#if defined(PRECICE_SPAN_HAVE_CPP17) || defined(__cpp_lib_void_t)
 using std::void_t;
 #else
 template <typename...>
@@ -317,16 +315,16 @@ public:
     constexpr span() noexcept
     {}
 
-    TCB_SPAN_CONSTEXPR11 span(pointer ptr, size_type count)
+    PRECICE_SPAN_CONSTEXPR11 span(pointer ptr, size_type count)
         : storage_(ptr, count)
     {
-        TCB_SPAN_EXPECT(extent == dynamic_extent || count == extent);
+        PRECICE_SPAN_EXPECT(extent == dynamic_extent || count == extent);
     }
 
-    TCB_SPAN_CONSTEXPR11 span(pointer first_elem, pointer last_elem)
+    PRECICE_SPAN_CONSTEXPR11 span(pointer first_elem, pointer last_elem)
         : storage_(first_elem, last_elem - first_elem)
     {
-        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+        PRECICE_SPAN_EXPECT(extent == dynamic_extent ||
                         last_elem - first_elem ==
                             static_cast<std::ptrdiff_t>(extent));
     }
@@ -346,7 +344,7 @@ public:
                       detail::is_container_element_type_compatible<
                           std::array<T, N>&, ElementType>::value,
                   int>::type = 0>
-    TCB_SPAN_ARRAY_CONSTEXPR span(std::array<T, N>& arr) noexcept
+    PRECICE_SPAN_ARRAY_CONSTEXPR span(std::array<T, N>& arr) noexcept
         : storage_(arr.data(), N)
     {}
 
@@ -356,7 +354,7 @@ public:
                       detail::is_container_element_type_compatible<
                           const std::array<T, N>&, ElementType>::value,
                   int>::type = 0>
-    TCB_SPAN_ARRAY_CONSTEXPR span(const std::array<T, N>& arr) noexcept
+    PRECICE_SPAN_ARRAY_CONSTEXPR span(const std::array<T, N>& arr) noexcept
         : storage_(arr.data(), N)
     {}
 
@@ -397,7 +395,7 @@ public:
 
     ~span() noexcept = default;
 
-    TCB_SPAN_CONSTEXPR_ASSIGN span&
+    PRECICE_SPAN_CONSTEXPR_ASSIGN span&
     operator=(const span& other) noexcept = default;
 
     // Custom span constructor to allow string_view imitation
@@ -410,21 +408,21 @@ public:
     span(T cstring)
         : storage_(cstring, std::strlen(cstring))
     {
-        TCB_SPAN_EXPECT(extent == dynamic_extent);
+        PRECICE_SPAN_EXPECT(extent == dynamic_extent);
     }
 
     // [span.sub], span subviews
     template <std::size_t Count>
-    TCB_SPAN_CONSTEXPR11 span<element_type, Count> first() const
+    PRECICE_SPAN_CONSTEXPR11 span<element_type, Count> first() const
     {
-        TCB_SPAN_EXPECT(Count <= size());
+        PRECICE_SPAN_EXPECT(Count <= size());
         return {data(), Count};
     }
 
     template <std::size_t Count>
-    TCB_SPAN_CONSTEXPR11 span<element_type, Count> last() const
+    PRECICE_SPAN_CONSTEXPR11 span<element_type, Count> last() const
     {
-        TCB_SPAN_EXPECT(Count <= size());
+        PRECICE_SPAN_EXPECT(Count <= size());
         return {data() + (size() - Count), Count};
     }
 
@@ -436,32 +434,32 @@ public:
                                                           : dynamic_extent)>;
 
     template <std::size_t Offset, std::size_t Count = dynamic_extent>
-    TCB_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
+    PRECICE_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
     {
-        TCB_SPAN_EXPECT(Offset <= size() &&
+        PRECICE_SPAN_EXPECT(Offset <= size() &&
                         (Count == dynamic_extent || Offset + Count <= size()));
         return {data() + Offset,
                 Count != dynamic_extent ? Count : size() - Offset};
     }
 
-    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    PRECICE_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
     first(size_type count) const
     {
-        TCB_SPAN_EXPECT(count <= size());
+        PRECICE_SPAN_EXPECT(count <= size());
         return {data(), count};
     }
 
-    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    PRECICE_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
     last(size_type count) const
     {
-        TCB_SPAN_EXPECT(count <= size());
+        PRECICE_SPAN_EXPECT(count <= size());
         return {data() + (size() - count), count};
     }
 
-    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    PRECICE_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
     subspan(size_type offset, size_type count = dynamic_extent) const
     {
-        TCB_SPAN_EXPECT(offset <= size() &&
+        PRECICE_SPAN_EXPECT(offset <= size() &&
                         (count == dynamic_extent || offset + count <= size()));
         return {data() + offset,
                 count == dynamic_extent ? size() - offset : count};
@@ -475,27 +473,27 @@ public:
         return size() * sizeof(element_type);
     }
 
-    TCB_SPAN_NODISCARD constexpr bool empty() const noexcept
+    PRECICE_SPAN_NODISCARD constexpr bool empty() const noexcept
     {
         return size() == 0;
     }
 
     // [span.elem], span element access
-    TCB_SPAN_CONSTEXPR11 reference operator[](size_type idx) const
+    PRECICE_SPAN_CONSTEXPR11 reference operator[](size_type idx) const
     {
-        TCB_SPAN_EXPECT(idx < size());
+        PRECICE_SPAN_EXPECT(idx < size());
         return *(data() + idx);
     }
 
-    TCB_SPAN_CONSTEXPR11 reference front() const
+    PRECICE_SPAN_CONSTEXPR11 reference front() const
     {
-        TCB_SPAN_EXPECT(!empty());
+        PRECICE_SPAN_EXPECT(!empty());
         return *data();
     }
 
-    TCB_SPAN_CONSTEXPR11 reference back() const
+    PRECICE_SPAN_CONSTEXPR11 reference back() const
     {
-        TCB_SPAN_EXPECT(!empty());
+        PRECICE_SPAN_EXPECT(!empty());
         return *(data() + (size() - 1));
     }
 
@@ -506,12 +504,12 @@ public:
 
     constexpr iterator end() const noexcept { return data() + size(); }
 
-    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
+    PRECICE_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
     {
         return reverse_iterator(end());
     }
 
-    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
+    PRECICE_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
     {
         return reverse_iterator(begin());
     }
@@ -520,7 +518,7 @@ private:
     storage_type storage_{};
 };
 
-#ifdef TCB_SPAN_HAVE_DEDUCTION_GUIDES
+#ifdef PRECICE_SPAN_HAVE_DEDUCTION_GUIDES
 
 /* Deduction Guides */
 template <class T, size_t N>
@@ -539,7 +537,7 @@ span(Container&)->span<typename std::remove_reference<
 template <class Container>
 span(const Container&)->span<const typename Container::value_type>;
 
-#endif // TCB_HAVE_DEDUCTION_GUIDES
+#endif // PRECICE_HAVE_DEDUCTION_GUIDES
 
 template <typename ElementType, std::size_t Extent>
 constexpr span<ElementType, Extent>
@@ -555,13 +553,13 @@ constexpr span<T, N> make_span(T (&arr)[N]) noexcept
 }
 
 template <typename T, std::size_t N>
-TCB_SPAN_ARRAY_CONSTEXPR span<T, N> make_span(std::array<T, N>& arr) noexcept
+PRECICE_SPAN_ARRAY_CONSTEXPR span<T, N> make_span(std::array<T, N>& arr) noexcept
 {
     return {arr};
 }
 
 template <typename T, std::size_t N>
-TCB_SPAN_ARRAY_CONSTEXPR span<const T, N>
+PRECICE_SPAN_ARRAY_CONSTEXPR span<const T, N>
 make_span(const std::array<T, N>& arr) noexcept
 {
     return {arr};
@@ -606,22 +604,22 @@ constexpr auto get(span<E, S> s) -> decltype(s[N])
     return s[N];
 }
 
-} // namespace TCB_SPAN_NAMESPACE_NAME
+} // namespace precice
 
 namespace std {
 
 template <typename ElementType, size_t Extent>
-class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>>
+class tuple_size<precice::span<ElementType, Extent>>
     : public integral_constant<size_t, Extent> {};
 
 template <typename ElementType>
-class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<
-    ElementType, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
+class tuple_size<precice::span<
+    ElementType, precice::dynamic_extent>>; // not defined
 
 template <size_t I, typename ElementType, size_t Extent>
-class tuple_element<I, TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>> {
+class tuple_element<I, precice::span<ElementType, Extent>> {
 public:
-    static_assert(Extent != TCB_SPAN_NAMESPACE_NAME::dynamic_extent &&
+    static_assert(Extent != precice::dynamic_extent &&
                       I < Extent,
                   "");
     using type = ElementType;
@@ -629,4 +627,4 @@ public:
 
 } // end namespace std
 
-#endif // TCB_SPAN_HPP_INCLUDED
+#endif // PRECICE_SPAN_HPP_INCLUDED

--- a/src/precice/tests/ParallelTests.cpp
+++ b/src/precice/tests/ParallelTests.cpp
@@ -58,7 +58,7 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
     auto            dataBAID = "DataBA";
 
     if (context.isPrimary()) {
-      int vertex1 = cplInterface.setMeshVertex(meshName, coordOneA.data());
+      int vertex1 = cplInterface.setMeshVertex(meshName, coordOneA);
 
       cplInterface.initialize();
       double maxDt = cplInterface.getMaxTimeStepSize();
@@ -84,7 +84,7 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
       cplInterface.finalize();
 
     } else {
-      int vertex2 = cplInterface.setMeshVertex(meshName, coordOneB.data());
+      int vertex2 = cplInterface.setMeshVertex(meshName, coordOneB);
 
       cplInterface.initialize();
       double maxDt = cplInterface.getMaxTimeStepSize();
@@ -114,10 +114,10 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
     SolverInterface cplInterface("SolverB", configFile, 0, 1);
     auto            meshName1 = "MeshB1";
     auto            meshName2 = "MeshB2";
-    int             vertex1   = cplInterface.setMeshVertex(meshName1, coordOneA.data());
-    int             vertex2   = cplInterface.setMeshVertex(meshName1, coordOneB.data());
-    int             vertex3   = cplInterface.setMeshVertex(meshName2, coordOneA.data());
-    int             vertex4   = cplInterface.setMeshVertex(meshName2, coordOneB.data());
+    int             vertex1   = cplInterface.setMeshVertex(meshName1, coordOneA);
+    int             vertex2   = cplInterface.setMeshVertex(meshName1, coordOneB);
+    int             vertex3   = cplInterface.setMeshVertex(meshName2, coordOneA);
+    int             vertex4   = cplInterface.setMeshVertex(meshName2, coordOneB);
 
     auto dataABID = "DataAB"; // meshName1
     auto dataBAID = "DataBA"; // meshName1
@@ -159,8 +159,8 @@ void multiCouplingThreeSolversParallelControl(const std::string configFile, cons
   } else {
     SolverInterface cplInterface("SolverC", configFile, 0, 1);
     auto            meshName = "MeshC";
-    int             vertex1  = cplInterface.setMeshVertex(meshName, coordOneA.data());
-    int             vertex2  = cplInterface.setMeshVertex(meshName, coordOneB.data());
+    int             vertex1  = cplInterface.setMeshVertex(meshName, coordOneA);
+    int             vertex2  = cplInterface.setMeshVertex(meshName, coordOneB);
     auto            dataCBID = "DataCB";
     auto            dataBCID = "DataBC";
 

--- a/tests/parallel/CouplingOnLine.cpp
+++ b/tests/parallel/CouplingOnLine.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine)
                             xCoord, yCoord, 0.2 + offset,
                             xCoord, yCoord, 0.3 + offset,
                             xCoord, yCoord, 0.4 + offset};
-    interface.setMeshVertices(meshName, 4, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     interface.advance(1.0);
     interface.finalize();
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(CouplingOnLine)
                             xCoord, yCoord, 0.96,
                             xCoord, yCoord, 1.08,
                             xCoord, yCoord, 1.2};
-    interface.setMeshVertices(meshName, 10, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     interface.advance(1.0);
     interface.finalize();

--- a/tests/parallel/ExportTimeseries.cpp
+++ b/tests/parallel/ExportTimeseries.cpp
@@ -20,9 +20,11 @@ BOOST_AUTO_TEST_CASE(ExportTimeseries)
   BOOST_REQUIRE(interface.getMeshDimensions(meshName) == 3);
 
   if (context.isNamed("ExporterOne")) {
-    interface.setMeshVertices(meshName, 6, coords.data(), vertexIds.data());
+    interface.setMeshVertices(meshName, coords, vertexIds);
   } else {
-    interface.setMeshVertices(meshName, 3, &coords[context.rank * 9], vertexIds.data());
+    auto coordsPtr  = &coords[context.rank * 9];
+    auto coordsSize = vertexIds.size() * 3;
+    interface.setMeshVertices(meshName, {coordsPtr, coordsSize}, vertexIds);
   }
 
   double time = 0.0;

--- a/tests/parallel/GlobalRBFPartitioning.cpp
+++ b/tests/parallel/GlobalRBFPartitioning.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     double values[2];
     interface.advance(1.0);
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioning)
     auto                     meshName = "MeshTwo";
     int                      vertexIDs[6];
     double                   positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     auto   dataName  = "Data2";
     double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};

--- a/tests/parallel/GlobalRBFPartitioningPETSc.cpp
+++ b/tests/parallel/GlobalRBFPartitioningPETSc.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioningPETSc)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     double values[2];
     interface.advance(1.0);
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(GlobalRBFPartitioningPETSc)
     auto                     meshName = "MeshTwo";
     int                      vertexIDs[6];
     double                   positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     auto   dataName  = "Data2";
     double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};

--- a/tests/parallel/LocalRBFPartitioning.cpp
+++ b/tests/parallel/LocalRBFPartitioning.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     double values[2];
     interface.advance(1.0);
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioning)
     auto                     meshName = "MeshTwo";
     int                      vertexIDs[6];
     double                   positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     auto   dataName  = "Data2";
     double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};

--- a/tests/parallel/LocalRBFPartitioningPETSc.cpp
+++ b/tests/parallel/LocalRBFPartitioningPETSc.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioningPETSc)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     double values[2];
     interface.advance(1.0);
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(LocalRBFPartitioningPETSc)
     auto                     meshName = "MeshTwo";
     int                      vertexIDs[6];
     double                   positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     auto   dataName  = "Data2";
     double values[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};

--- a/tests/parallel/NearestProjectionRePartitioning.cpp
+++ b/tests/parallel/NearestProjectionRePartitioning.cpp
@@ -99,7 +99,7 @@ BOOST_DATA_TEST_CASE(NearestProjectionRePartitioning,
           0.22547, yCoord, zCoord};
       BOOST_TEST(numberOfVertices * dimensions == positions.size());
       std::vector<int> vertexIDs(numberOfVertices);
-      interface.setMeshVertices(meshName, numberOfVertices, positions.data(), vertexIDs.data());
+      interface.setMeshVertices(meshName, positions, vertexIDs);
       interface.initialize();
       BOOST_TEST(precice::testing::WhiteboxAccessor::impl(interface).mesh("Nodes").triangles().size() == 15);
       interface.advance(1.0);
@@ -152,7 +152,7 @@ BOOST_DATA_TEST_CASE(NearestProjectionRePartitioning,
         0.5, yCoord, zCoord1};
     BOOST_TEST(numberOfVertices * dimensions == positions.size());
     std::vector<int> vertexIDs(numberOfVertices);
-    interface.setMeshVertices(meshName, numberOfVertices, positions.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, positions, vertexIDs);
 
     const int numberOfCells = numberOfVertices / 2 - 1;
 
@@ -169,7 +169,7 @@ BOOST_DATA_TEST_CASE(NearestProjectionRePartitioning,
         ids.push_back(vertexIDs.at(i * 2 + 2));
         ids.push_back(vertexIDs.at(i * 2 + 3));
       }
-      interface.setMeshTriangles(meshName, numberOfCells, ids.data());
+      interface.setMeshTriangles(meshName, ids);
     } else {
       for (int i = 0; i < numberOfCells; i++) {
         // left-diag-bottom

--- a/tests/parallel/TestBoundingBoxInitialization.cpp
+++ b/tests/parallel/TestBoundingBoxInitialization.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitialization)
 
   std::vector<int> vertexIDs;
   for (int i = i1; i < i2; i++) {
-    precice::VertexID vertexID = interface.setMeshVertex(meshName, positions[i].data());
+    precice::VertexID vertexID = interface.setMeshVertex(meshName, positions[i]);
     vertexIDs.push_back(vertexID);
   }
 

--- a/tests/parallel/TestBoundingBoxInitializationTwoWay.cpp
+++ b/tests/parallel/TestBoundingBoxInitializationTwoWay.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationTwoWay)
 
   std::vector<int> vertexIDs;
   for (int i = i1; i < i2; i++) {
-    precice::VertexID vertexID = interface.setMeshVertex(meshName, positions[i].data());
+    precice::VertexID vertexID = interface.setMeshVertex(meshName, positions[i]);
     vertexIDs.push_back(vertexID);
   }
 

--- a/tests/parallel/UserDefinedMPICommunicator.cpp
+++ b/tests/parallel/UserDefinedMPICommunicator.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
   } else {
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicator)
     auto                     meshName = "MeshTwo";
     int                      vertexIDs[6];
     double                   positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
   }

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.cpp
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
   } else {
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(UserDefinedMPICommunicatorPetRBF)
     auto   meshName = "MeshTwo";
     int    vertexIDs[6];
     double positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     interface.finalize();
   }

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
@@ -30,11 +30,11 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
     std::vector<double> positions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.0}) : std::vector<double>({0.0, 4.0, 0.0, 5.0, 0.0, 6.0});
 
     std::vector<int> ownIDs(positions.size() / dim, -1);
-    interface.setMeshVertices(ownMeshName, ownIDs.size(), positions.data(), ownIDs.data());
+    interface.setMeshVertices(ownMeshName, positions, ownIDs);
 
     std::array<double, dim * 2> boundingBox = context.isPrimary() ? std::array<double, dim * 2>{0.0, 1.0, 0.0, 3.5} : std::array<double, dim * 2>{0.0, 1.0, 3.5, 5.0};
     // Define region of interest, where we could obtain direct write access
-    interface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    interface.setMeshAccessRegion(otherMeshName, boundingBox);
 
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshName, otherMeshSize, otherIDs.data(), solverTwoMesh.data());
+    interface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverTwoMesh);
     // Expected data = positions of the other participant's mesh
     const std::vector<double> expectedData = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.5}) : std::vector<double>({0.0, 3.5, 0.0, 4.0, 0.0, 5.0});
     BOOST_TEST(solverTwoMesh == expectedData);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
     std::vector<int>    ids(positions.size() / dim, -1);
 
     // Define the mesh
-    interface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());
+    interface.setMeshVertices(meshName, positions, ids);
     // Allocate data to read
     std::vector<double> readData(ids.size(), -1);
     std::vector<double> writeData;

--- a/tests/parallel/direct-mesh-access/helpers.cpp
+++ b/tests/parallel/direct-mesh-access/helpers.cpp
@@ -23,7 +23,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
 
     std::vector<double> boundingBox = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 3.5}) : boundingBoxSecondaryRank;
     // Set bounding box
-    interface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    interface.setMeshAccessRegion(otherMeshName, boundingBox);
     // Initialize the solverinterface
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
@@ -39,7 +39,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
     // Allocate memory
     std::vector<int>    ids(meshSize);
     std::vector<double> coordinates(meshSize * dim);
-    interface.getMeshVerticesAndIDs(otherMeshName, meshSize, ids.data(), coordinates.data());
+    interface.getMeshVerticesAndIDs(otherMeshName, ids, coordinates);
 
     // Check the received vertex coordinates
     std::vector<double> expectedPositions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.0}) : expectedPositionSecondaryRank;
@@ -87,7 +87,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
     const int        size = positions.size() / dim;
     std::vector<int> ids(size);
 
-    interface.setMeshVertices(meshName, size, positions.data(), ids.data());
+    interface.setMeshVertices(meshName, positions, ids);
 
     {
       // Check, if we can use the 'getMeshVerticesAndIDs' function on provided meshes as well,
@@ -96,7 +96,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
       BOOST_TEST(ownMeshSize == size);
       std::vector<int>    ownIDs(ownMeshSize);
       std::vector<double> ownCoordinates(ownMeshSize * dim);
-      interface.getMeshVerticesAndIDs(meshName, ownMeshSize, ownIDs.data(), ownCoordinates.data());
+      interface.getMeshVerticesAndIDs(meshName, ownIDs, ownCoordinates);
       BOOST_TEST(ownIDs == ids);
       BOOST_TEST(testing::equals(positions, ownCoordinates));
     }

--- a/tests/parallel/distributed-communication/helpers.cpp
+++ b/tests/parallel/distributed-communication/helpers.cpp
@@ -59,7 +59,7 @@ void runTestDistributedCommunication(std::string const &config, TestContext cons
 
   std::vector<int> vertexIDs;
   for (int i = i1; i < i2; i++) {
-    VertexID vertexID = precice.setMeshVertex(meshName, positions[i].data());
+    VertexID vertexID = precice.setMeshVertex(meshName, positions[i]);
     vertexIDs.push_back(vertexID);
   }
 

--- a/tests/parallel/gather-scatter/helpers.cpp
+++ b/tests/parallel/gather-scatter/helpers.cpp
@@ -23,7 +23,7 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
     std::vector<int>          ids(size, 0);
 
     // Set mesh vertices
-    interface.setMeshVertices(meshName, size, coordinates.data(), ids.data());
+    interface.setMeshVertices(meshName, coordinates, ids);
 
     // Initialize the solverinterface
     interface.initialize();
@@ -66,7 +66,7 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
     std::vector<int>          ids(size);
 
     // Set vertices
-    interface.setMeshVertices(meshName, size, coordinates.data(), ids.data());
+    interface.setMeshVertices(meshName, coordinates, ids);
 
     // Initialize the solverinterface
     interface.initialize();

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4 + 0.05;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     BOOST_TEST(interface.requiresGradientDataFor(meshName, dataName) == false);
     Eigen::Vector2d values;
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)
     auto            meshName = "MeshTwo";
     int             vertexIDs[6];
     double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     interface.initialize();
     auto dataName = "Data2";
     BOOST_TEST(interface.requiresGradientDataFor(meshName, dataName));

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
     int    vertexIDs[2];
     double xCoord       = context.rank * 0.4 + 0.05;
     double positions[4] = {xCoord, 0.0, xCoord + 0.2, 0.0};
-    interface.setMeshVertices(meshName, 2, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
     BOOST_TEST(interface.requiresGradientDataFor(meshName, dataName1) == false);
     BOOST_TEST(interface.requiresGradientDataFor(meshName, dataName2) == false);
     interface.initialize();
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
     auto            meshName = "MeshTwo";
     int             vertexIDs[6];
     double          positions[12] = {0.0, 0.0, 0.2, 0.0, 0.4, 0.0, 0.6, 0.0, 0.8, 0.0, 1.0, 0.0};
-    interface.setMeshVertices(meshName, 6, positions, vertexIDs);
+    interface.setMeshVertices(meshName, positions, vertexIDs);
 
     auto dataName1 = "Data1";
     auto dataName2 = "Data2";

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
     if (context.isPrimary()) {
       std::vector<int>    vertexIDs(2);
       std::vector<double> positions = {1.0, 1.0, 2.0, 2., 2., 3.0};
-      interface.setMeshVertices(meshName, 2, positions.data(), vertexIDs.data());
+      interface.setMeshVertices(meshName, positions, vertexIDs);
       interface.initialize();
       Eigen::Vector3d values;
       interface.advance(1.0);
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
     } else {
       std::vector<int>    vertexIDs(1);
       std::vector<double> positions = {4.0, 4.0, 4.0};
-      interface.setMeshVertices(meshName, 1, positions.data(), vertexIDs.data());
+      interface.setMeshVertices(meshName, positions, vertexIDs);
       interface.initialize();
       Eigen::Vector3d values;
       interface.advance(1.0);
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
     if (context.isPrimary()) {
       std::vector<int>    vertexIDs(4);
       std::vector<double> positions = {4.0, 4.0, 4.0, 0.0, 0.4, 0.0, 0.7, 0.7, 1.7, 0.0, 1.0, 0.0};
-      interface.setMeshVertices(meshName, 4, positions.data(), vertexIDs.data());
+      interface.setMeshVertices(meshName, positions, vertexIDs);
       interface.initialize();
       auto                dataName = "Data2";
       std::vector<double> values   = {1.0, 2.0, 3.0,
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
       // Assigned to the first rank
       std::vector<int>    vertexIDs(1);
       std::vector<double> positions = {2.1, 2.1, 3.1};
-      interface.setMeshVertices(meshName, 1, positions.data(), vertexIDs.data());
+      interface.setMeshVertices(meshName, positions, vertexIDs);
       interface.initialize();
       auto                dataName = "Data2";
       std::vector<double> values   = {2.0, 3.0, 4.0};

--- a/tests/parallel/mapping-volume/ParallelCube1To3.cpp
+++ b/tests/parallel/mapping-volume/ParallelCube1To3.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(ParallelCube1To3)
               1, 1, 1};
 
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     VertexID v000 = vertexIDs[0];
     VertexID v001 = vertexIDs[1];
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(ParallelCube1To3)
     }
 
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
     interface.initialize();
     dt = interface.getMaxTimeStepSize();
 

--- a/tests/parallel/mapping-volume/ParallelCube3To1.cpp
+++ b/tests/parallel/mapping-volume/ParallelCube3To1.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(ParallelCube3To1)
     }
 
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
     switch (context.rank) {
     case 0:
       interface.setMeshTetrahedron(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2], vertexIDs[3]);
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(ParallelCube3To1)
     }
 
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.initialize();
     dt = interface.getMaxTimeStepSize();

--- a/tests/parallel/mapping-volume/ParallelCubeConservative1To3.cpp
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative1To3.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ParallelCubeConservative1To3)
               0.3, 0.7, 0.9};
 
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.initialize();
     dt = interface.getMaxTimeStepSize();
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(ParallelCubeConservative1To3)
     }
 
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
     switch (context.rank) {
     case 0:
       interface.setMeshTetrahedron(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2], vertexIDs[3]);

--- a/tests/parallel/mapping-volume/ParallelCubeConservative3To1.cpp
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative3To1.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(ParallelCubeConservative3To1)
       break;
     }
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.initialize();
     dt = interface.getMaxTimeStepSize();
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(ParallelCubeConservative3To1)
               0, 1, 1};
 
     vertexIDs.resize(coords.size() / 3);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     VertexID v000 = vertexIDs[0];
 

--- a/tests/parallel/mapping-volume/ParallelSquare1To2.cpp
+++ b/tests/parallel/mapping-volume/ParallelSquare1To2.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(ParallelSquare1To2)
               1.0, 1.0,
               0.0, 1.0};
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     // Square ABCD in counter-clockwise order. A is the origin, B on the right
     interface.setMeshTriangle(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2]);
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(ParallelSquare1To2)
     }
 
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.initialize();
     dt = interface.getMaxTimeStepSize();

--- a/tests/parallel/mapping-volume/ParallelSquare2To1.cpp
+++ b/tests/parallel/mapping-volume/ParallelSquare2To1.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(ParallelSquare2To1)
     }
 
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, 3, coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
     interface.setMeshTriangle(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2]);
 
     interface.initialize();
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(ParallelSquare2To1)
               1. / 2, 5. / 6};
 
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.initialize();
     dt = interface.getMaxTimeStepSize();

--- a/tests/parallel/mapping-volume/ParallelSquareConservative1To2.cpp
+++ b/tests/parallel/mapping-volume/ParallelSquareConservative1To2.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(ParallelSquareConservative1To2)
     coords = {0.3, 0.5,
               0.9, 0.2};
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.initialize();
     dt = interface.getMaxTimeStepSize();
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(ParallelSquareConservative1To2)
     }
 
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
     interface.setMeshTriangle(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2]);
 
     interface.initialize();

--- a/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.cpp
+++ b/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(ParallelTriangleConservative2To1)
       coords = {0.7, 0.2};
     }
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.initialize();
     dt = interface.getMaxTimeStepSize();
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(ParallelTriangleConservative2To1)
     std::vector<double> coords = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0}; // Lower-left triangle making half the unit square
 
     vertexIDs.resize(coords.size() / 2);
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
     interface.setMeshTriangle(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2]);
 
     interface.initialize();

--- a/tests/quasi-newton/helpers.cpp
+++ b/tests/quasi-newton/helpers.cpp
@@ -31,16 +31,16 @@ void runTestQN(std::string const &config, TestContext const &context)
 
   if (context.isNamed("SolverOne")) {
     if (context.isPrimary()) {
-      interface.setMeshVertices(meshName, 4, positions0, vertexIDs);
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
     } else {
-      interface.setMeshVertices(meshName, 4, positions1, vertexIDs);
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
     }
   } else {
     BOOST_REQUIRE(context.isNamed("SolverTwo"));
     if (context.isPrimary()) {
-      interface.setMeshVertices(meshName, 4, positions0, vertexIDs);
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
     } else {
-      interface.setMeshVertices(meshName, 4, positions1, vertexIDs);
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
     }
   }
 
@@ -126,13 +126,13 @@ void runTestQNEmptyPartition(std::string const &config, TestContext const &conte
   if (context.isNamed("SolverOne")) {
     // All mesh is on primary rank
     if (context.isPrimary()) {
-      interface.setMeshVertices(meshName, 4, positions0, vertexIDs);
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
     }
   } else {
     BOOST_REQUIRE(context.isNamed("SolverTwo"));
     // All mesh is on secondary rank
     if (not context.isPrimary()) {
-      interface.setMeshVertices(meshName, 4, positions0, vertexIDs);
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
     }
   }
 

--- a/tests/serial/AitkenAcceleration.cpp
+++ b/tests/serial/AitkenAcceleration.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
 
   if (context.isNamed("A")) {
     auto meshName = "A-Mesh";
-    int  vertexID = interface.setMeshVertex(meshName, vertex.data());
+    int  vertexID = interface.setMeshVertex(meshName, vertex);
     auto dataName = "Data";
 
     interface.initialize();
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(AitkenAcceleration)
   } else {
     BOOST_TEST(context.isNamed("B"));
     auto meshName = "B-Mesh";
-    int  vertexID = interface.setMeshVertex(meshName, vertex.data());
+    int  vertexID = interface.setMeshVertex(meshName, vertex);
     auto dataName = "Data";
 
     interface.initialize();

--- a/tests/serial/PreconditionerBug.cpp
+++ b/tests/serial/PreconditionerBug.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(PreconditionerBug)
 
   Vector2d vertex{0.0, 0.0};
 
-  precice::VertexID vertexID = interface.setMeshVertex(meshName, vertex.data());
+  precice::VertexID vertexID = interface.setMeshVertex(meshName, vertex);
 
   interface.initialize();
   int numberOfAdvanceCalls = 0;

--- a/tests/serial/SendMeshToMultipleParticipants.cpp
+++ b/tests/serial/SendMeshToMultipleParticipants.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(SendMeshToMultipleParticipants)
 
   precice::SolverInterface interface(context.name, context.config(), 0, 1);
 
-  const precice::VertexID vertexID = interface.setMeshVertex(meshName, vertex.data());
+  const precice::VertexID vertexID = interface.setMeshVertex(meshName, vertex);
   auto                    dataName = "Data";
   interface.initialize();
   double maxDt = interface.getMaxTimeStepSize();

--- a/tests/serial/SummationActionTwoSources.cpp
+++ b/tests/serial/SummationActionTwoSources.cpp
@@ -31,10 +31,10 @@ BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
 
     auto meshName = "MeshTarget";
 
-    int idA = interface.setMeshVertex(meshName, coordA.data());
-    int idB = interface.setMeshVertex(meshName, coordB.data());
-    int idC = interface.setMeshVertex(meshName, coordC.data());
-    int idD = interface.setMeshVertex(meshName, coordD.data());
+    int idA = interface.setMeshVertex(meshName, coordA);
+    int idB = interface.setMeshVertex(meshName, coordB);
+    int idC = interface.setMeshVertex(meshName, coordC);
+    int idD = interface.setMeshVertex(meshName, coordD);
 
     // Initialize, the mesh
     interface.initialize();
@@ -73,10 +73,10 @@ BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
 
     auto meshName = "MeshOne";
 
-    int idA = interface.setMeshVertex(meshName, coordA.data());
-    int idB = interface.setMeshVertex(meshName, coordB.data());
-    int idC = interface.setMeshVertex(meshName, coordC.data());
-    int idD = interface.setMeshVertex(meshName, coordD.data());
+    int idA = interface.setMeshVertex(meshName, coordA);
+    int idB = interface.setMeshVertex(meshName, coordB);
+    int idC = interface.setMeshVertex(meshName, coordC);
+    int idD = interface.setMeshVertex(meshName, coordD);
 
     // Initialize, the mesh
     interface.initialize();
@@ -112,10 +112,10 @@ BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
 
     auto meshName = "MeshTwo";
 
-    int idA = interface.setMeshVertex(meshName, coordA.data());
-    int idB = interface.setMeshVertex(meshName, coordB.data());
-    int idC = interface.setMeshVertex(meshName, coordC.data());
-    int idD = interface.setMeshVertex(meshName, coordD.data());
+    int idA = interface.setMeshVertex(meshName, coordA);
+    int idB = interface.setMeshVertex(meshName, coordB);
+    int idC = interface.setMeshVertex(meshName, coordC);
+    int idD = interface.setMeshVertex(meshName, coordD);
 
     // Initialize, the mesh
     interface.initialize();

--- a/tests/serial/TestExplicitWithDataMultipleReadWrite.cpp
+++ b/tests/serial/TestExplicitWithDataMultipleReadWrite.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataMultipleReadWrite)
     Eigen::VectorXd readDataA(size * 3);
     Eigen::VectorXd readDataB(size);
     Eigen::VectorXd readPositions(size * 3);
-    vertexIDs[0] = cplInterface.setMeshVertex(meshName, readPositions.data());
+    vertexIDs[0] = cplInterface.setMeshVertex(meshName, readPositions);
 
     auto dataAID = "DataOne";
     auto dataBID = "DataTwo";
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataMultipleReadWrite)
     Eigen::VectorXd writeDataA(size * 3);
     Eigen::VectorXd writeDataB(size);
     Eigen::VectorXd writePositions(size * 3);
-    vertexIDs[0] = cplInterface.setMeshVertex(meshName, writePositions.data());
+    vertexIDs[0] = cplInterface.setMeshVertex(meshName, writePositions);
 
     BOOST_REQUIRE(cplInterface.requiresInitialData());
 

--- a/tests/serial/TestReadAPI.cpp
+++ b/tests/serial/TestReadAPI.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(TestReadAPI)
     Eigen::VectorXd writeDataA(size * 3);
     Eigen::VectorXd readDataB(size);
     Eigen::VectorXd readPositions(size * 3);
-    vertexIDs[0] = cplInterface.setMeshVertex(meshName, readPositions.data());
+    vertexIDs[0] = cplInterface.setMeshVertex(meshName, readPositions);
 
     auto dataAID = "DataOne";
     auto dataBID = "DataTwo";
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(TestReadAPI)
     Eigen::VectorXd readDataA(size * 3);
     Eigen::VectorXd writeDataB(size);
     Eigen::VectorXd writePositions(size * 3);
-    vertexIDs[0] = cplInterface.setMeshVertex(meshName, writePositions.data());
+    vertexIDs[0] = cplInterface.setMeshVertex(meshName, writePositions);
 
     auto dataAID = "DataOne";
     auto dataBID = "DataTwo";

--- a/tests/serial/action-timings/ActionTimingsExplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsExplicit.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(ActionTimingsExplicit)
   }
   int                 dimensions = interface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
-  int                 vertexID = interface.setMeshVertex(meshName, vertex.data());
+  int                 vertexID = interface.setMeshVertex(meshName, vertex);
 
   double dt = -1;
   BOOST_TEST(action::RecorderAction::records.empty());

--- a/tests/serial/action-timings/ActionTimingsImplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsImplicit.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(ActionTimingsImplicit)
   }
   int                 dimensions = interface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
-  int                 vertexID = interface.setMeshVertex(meshName, vertex.data());
+  int                 vertexID = interface.setMeshVertex(meshName, vertex);
 
   double dt = -1;
   BOOST_TEST(action::RecorderAction::records.empty());

--- a/tests/serial/circular/helper.hpp
+++ b/tests/serial/circular/helper.hpp
@@ -21,7 +21,7 @@ inline void cyclicExplicit(TestContext &context)
   const std::vector<double> coords{1, 0, 2, 0};
 
   std::vector<int> ids(2);
-  interface.setMeshVertices(meshName, 2, coords.data(), ids.data());
+  interface.setMeshVertices(meshName, coords, ids);
 
   std::vector<double> data{0, 0};
 

--- a/tests/serial/convergence-measures/helpers.cpp
+++ b/tests/serial/convergence-measures/helpers.cpp
@@ -17,7 +17,7 @@ void testConvergenceMeasures(const std::string configFile, TestContext const &co
 
   std::vector<double> writeValues = {1.0, 1.01, 2.0, 2.5, 2.8, 2.81};
 
-  VertexID vertexID = interface.setMeshVertex(meshName, vertex.data());
+  VertexID vertexID = interface.setMeshVertex(meshName, vertex);
 
   interface.initialize();
   int numberOfAdvanceCalls = 0;

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
     std::vector<double> positions = std::vector<double>({0.5, 0.25});
     const int           meshSize  = positions.size() / dim;
     std::vector<int>    ids(meshSize, -1);
-    interface.setMeshVertices(providedMeshName, ids.size(), positions.data(), ids.data());
+    interface.setMeshVertices(providedMeshName, positions, ids);
 
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
 
     std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0};
     // Define region of interest, where we could obtain direct write access
-    interface.setMeshAccessRegion(receivedMeshName, boundingBox.data());
+    interface.setMeshAccessRegion(receivedMeshName, boundingBox);
 
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
     // Allocate a vector containing the vertices
     std::vector<double> receivedMesh(receivedMeshSize * dim);
     std::vector<int>    receiveMeshIDs(receivedMeshSize, -1);
-    interface.getMeshVerticesAndIDs(receivedMeshName, receivedMeshSize, receiveMeshIDs.data(), receivedMesh.data());
+    interface.getMeshVerticesAndIDs(receivedMeshName, receiveMeshIDs, receivedMesh);
 
     // Allocate data to read and write
     std::vector<double> readData(receiveMeshIDs.size(), -1);

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
@@ -26,11 +26,11 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
 
     std::vector<double> ownPositions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ownIDs(ownPositions.size() / dim, -1);
-    interface.setMeshVertices(ownMeshID, ownIDs.size(), ownPositions.data(), ownIDs.data());
+    interface.setMeshVertices(ownMeshID, ownPositions, ownIDs);
 
     std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0};
     // Define region of interest, where we could obtain direct write access
-    interface.setMeshAccessRegion(otherMeshID, boundingBox.data());
+    interface.setMeshAccessRegion(otherMeshID, boundingBox);
 
     std::vector<double> readData(ownIDs.size(), -1);
     int                 otherMeshSize = 1; // @todo hard-coded, because we cannot read this from preCICE before interface.initialize(). See https://github.com/precice/precice/issues/1583.
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
 
     std::vector<double> otherPositions(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshID, otherMeshSize, otherIDs.data(), otherPositions.data());
+    interface.getMeshVerticesAndIDs(otherMeshID, otherIDs, otherPositions);
 
     // writeData for first window
     for (int i = 0; i < otherMeshSize; ++i) {
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
 
     std::vector<double> positions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ids(positions.size() / dim, -1);
-    interface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());
+    interface.setMeshVertices(meshName, positions, ids);
 
     std::vector<double> readData(ids.size(), -1);
     std::vector<double> writeData;

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
@@ -26,11 +26,11 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
 
     std::vector<double> ownPositions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ownIDs(ownPositions.size() / dim, -1);
-    interface.setMeshVertices(ownMeshName, ownIDs.size(), ownPositions.data(), ownIDs.data());
+    interface.setMeshVertices(ownMeshName, ownPositions, ownIDs);
 
     std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0};
     // Define region of interest, where we could obtain direct write access
-    interface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    interface.setMeshAccessRegion(otherMeshName, boundingBox);
 
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
 
     std::vector<double> otherPositions(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshName, otherMeshSize, otherIDs.data(), otherPositions.data());
+    interface.getMeshVerticesAndIDs(otherMeshName, otherIDs, otherPositions);
 
     // Some dummy writeData
     std::vector<double> readData(ownIDs.size(), -1);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
 
     std::vector<double> positions = std::vector<double>({0.5, 0.25});
     std::vector<int>    ids(positions.size() / dim, -1);
-    interface.setMeshVertices(meshID, ids.size(), positions.data(), ids.data());
+    interface.setMeshVertices(meshID, positions, ids);
 
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();

--- a/tests/serial/direct-mesh-access/Explicit.cpp
+++ b/tests/serial/direct-mesh-access/Explicit.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
     auto dataName = "Velocities";
 
     // Define region of interest, where we could obtain direct write access
-    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox);
 
     couplingInterface.initialize();
     double dt = couplingInterface.getMaxTimeStepSize();
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
 
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(meshSize * dim);
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, meshSize, ids.data(), solverTwoMesh.data());
+    couplingInterface.getMeshVerticesAndIDs(otherMeshName, ids, solverTwoMesh);
     // Some dummy writeData
     std::array<double, 4> writeData({1, 2, 3, 4});
 
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 2);
 
     // Define the mesh
-    couplingInterface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());
+    couplingInterface.setMeshVertices(meshName, positions, ids);
     // Allocate data to read
     std::vector<double> readData(4, std::numeric_limits<double>::max());
 

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
@@ -33,11 +33,11 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
 
     std::vector<double> positions = {0.2, 0.2, 0.1, 0.6, 0.1, 0.0, 0.1, 0.0};
     std::vector<int>    ownIDs(4, -1);
-    interface.setMeshVertices(ownMeshName, ownIDs.size(), positions.data(), ownIDs.data());
+    interface.setMeshVertices(ownMeshName, positions, ownIDs);
 
     std::array<double, dim * 2> boundingBox = {0.0, 1.0, 0.0, 1.0};
     // Define region of interest, where we could obtain direct write access
-    interface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    interface.setMeshAccessRegion(otherMeshName, boundingBox);
 
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshName, otherMeshSize, otherIDs.data(), solverTwoMesh.data());
+    interface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverTwoMesh);
     // Some dummy writeData
     std::array<double, 5> writeData({1, 2, 3, 4, 5});
 
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
     BOOST_REQUIRE(interface.getMeshDimensions(meshName) == 2);
 
     // Define the mesh
-    interface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());
+    interface.setMeshVertices(meshName, positions, ids);
     // Allocate data to read
     std::vector<double> readData(ids.size(), -10);
     std::vector<double> writeData;

--- a/tests/serial/direct-mesh-access/ExplicitRead.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitRead.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(otherMeshName) == 2);
 
     // Define region of interest, where we could obtain direct write access
-    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox);
 
     couplingInterface.initialize();
     double dt = couplingInterface.getMaxTimeStepSize();
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
 
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(meshSize * dim);
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, meshSize, ids.data(), solverTwoMesh.data());
+    couplingInterface.getMeshVerticesAndIDs(otherMeshName, ids, solverTwoMesh);
 
     // Allocate data to read
     std::vector<double> readData(4, std::numeric_limits<double>::max());
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName));
 
     // Define the mesh
-    couplingInterface.setMeshVertices(meshName, ids.size(), positions.data(), ids.data());
+    couplingInterface.setMeshVertices(meshName, positions, ids);
     // Some dummy readData
     std::array<double, 4> writeData({1, 2, 3, 4});
 

--- a/tests/serial/direct-mesh-access/Implicit.cpp
+++ b/tests/serial/direct-mesh-access/Implicit.cpp
@@ -33,11 +33,11 @@ BOOST_AUTO_TEST_CASE(Implicit)
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(otherMeshName) == 2);
 
     // Define the own mesh
-    couplingInterface.setMeshVertices(ownMeshName, ownIDs.size(), positions.data(), ownIDs.data());
+    couplingInterface.setMeshVertices(ownMeshName, positions, ownIDs);
     // TODO: Implement something in order to derive the bounding box from the mesh
 
     // Define region of interest, where we could obtain direct write access
-    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox);
 
     couplingInterface.initialize();
     double dt = couplingInterface.getMaxTimeStepSize();
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
     std::vector<double> solverTwoMesh(meshSize * dim);
     std::vector<int>    otherIDs(meshSize);
 
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, meshSize, otherIDs.data(), solverTwoMesh.data());
+    couplingInterface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverTwoMesh);
     // Some dummy writeData
     std::array<double, 3> writeData({1, 2, 3});
 
@@ -91,9 +91,9 @@ BOOST_AUTO_TEST_CASE(Implicit)
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(ownMeshName) == 2);
 
     // Define the mesh
-    couplingInterface.setMeshVertices(ownMeshName, ownIDs.size(), positions.data(), ownIDs.data());
+    couplingInterface.setMeshVertices(ownMeshName, positions, ownIDs);
     // Define region of interest, where we could obtain direct write access
-    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox.data());
+    couplingInterface.setMeshAccessRegion(otherMeshName, boundingBox);
     // Initialize
     couplingInterface.initialize();
     double dt = couplingInterface.getMaxTimeStepSize();
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
     std::vector<double> solverOneMesh(meshSize * dim);
     std::vector<int>    otherIDs(meshSize);
 
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, meshSize, otherIDs.data(), solverOneMesh.data());
+    couplingInterface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverOneMesh);
     // Some dummy writeData
     std::array<double, 4> writeData({10, 11, 12, 13});
 

--- a/tests/serial/explicit/helpers.cpp
+++ b/tests/serial/explicit/helpers.cpp
@@ -24,13 +24,13 @@ void runTestExplicit(std::string const &configurationFileName, TestContext const
     auto meshName = "MeshOne";
     BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
-    couplingInterface.setMeshVertices(meshName, 2, pos, vids);
+    couplingInterface.setMeshVertices(meshName, pos, vids);
   }
   if (context.isNamed("SolverTwo")) {
     auto meshName = "Test-Square";
     BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
-    couplingInterface.setMeshVertices(meshName, 2, pos, vids);
+    couplingInterface.setMeshVertices(meshName, pos, vids);
   }
 
   couplingInterface.initialize();

--- a/tests/serial/initialize-data/Explicit.cpp
+++ b/tests/serial/initialize-data/Explicit.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto     meshName = "MeshTwo";
     Vector3d pos      = Vector3d::Zero();
-    auto     vid      = cplInterface.setMeshVertex(meshName, pos.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, pos);
 
     BOOST_REQUIRE(cplInterface.requiresInitialData());
     auto   dataAID      = "DataOne";

--- a/tests/serial/initialize-data/Implicit.cpp
+++ b/tests/serial/initialize-data/Implicit.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
   }
   int                 dimensions = couplingInterface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
-  int                 vertexID = couplingInterface.setMeshVertex(meshName, vertex.data());
+  int                 vertexID = couplingInterface.setMeshVertex(meshName, vertex);
   double              dt       = 0;
   std::vector<double> writeData(dimensions, writeValue);
   std::vector<double> readData(dimensions, -1);

--- a/tests/serial/initialize-data/ImplicitBoth.cpp
+++ b/tests/serial/initialize-data/ImplicitBoth.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ImplicitBoth)
   }
   int                 dimensions = couplingInterface.getMeshDimensions(meshName);
   std::vector<double> vertex(dimensions, 0);
-  int                 vertexID = couplingInterface.setMeshVertex(meshName, vertex.data());
+  int                 vertexID = couplingInterface.setMeshVertex(meshName, vertex);
 
   double              dt = 0;
   std::vector<double> writeData(dimensions, writeValue);

--- a/tests/serial/initialize-data/helpers.cpp
+++ b/tests/serial/initialize-data/helpers.cpp
@@ -16,7 +16,7 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
   if (context.isNamed("SolverOne")) {
     auto     meshName   = "MeshOne";
     Vector3d pos        = Vector3d::Zero();
-    auto     vid        = cplInterface.setMeshVertex(meshName, pos.data());
+    auto     vid        = cplInterface.setMeshVertex(meshName, pos);
     auto     dataName   = "Data";
     double   valueDataB = 0.0;
     cplInterface.initialize();
@@ -28,7 +28,7 @@ void testDataInitialization(precice::testing::TestContext context, std::string c
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto     meshName = "MeshTwo";
     Vector3d pos      = Vector3d::Zero();
-    auto     vid      = cplInterface.setMeshVertex(meshName, pos.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, pos);
 
     //tell preCICE that data has been written
     BOOST_REQUIRE(cplInterface.requiresInitialData());

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)
   if (context.isNamed("SolverOne")) {
     auto     meshName = "MeshOne";
     Vector3d vec1     = Vector3d::Constant(0.1);
-    auto     vid      = cplInterface.setMeshVertex(meshName, vec1.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, vec1);
     auto     dataAID  = "DataOne";
     auto     dataBID  = "DataTwo";
 
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadScalar)
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto     meshName = "MeshTwo";
     Vector3d vec2     = Vector3d::Constant(0.0);
-    auto     vid      = cplInterface.setMeshVertex(meshName, vec2.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, vec2);
 
     auto dataAID = "DataOne";
     auto dataBID = "DataTwo";

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadVector)
   if (context.isNamed("SolverOne")) {
     auto     meshName = "MeshOne";
     Vector3d posOne   = Vector3d::Constant(0.0);
-    auto     vid      = cplInterface.setMeshVertex(meshName, posOne.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, posOne);
     auto     dataAID  = "DataOne";
     auto     dataBID  = "DataTwo";
 
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalReadVector)
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto     meshName = "MeshTwo";
     Vector3d pos      = Vector3d::Constant(1.0);
-    auto     vid      = cplInterface.setMeshVertex(meshName, pos.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, pos);
 
     auto dataAID = "DataOne";
     auto dataBID = "DataTwo";

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteScalar)
   if (context.isNamed("SolverOne")) {
     auto     meshName = "MeshOne";
     Vector3d vec1     = Vector3d::Constant(0.1);
-    auto     vid      = cplInterface.setMeshVertex(meshName, vec1.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, vec1);
     auto     dataAID  = "DataOne";
     auto     dataBID  = "DataTwo";
 
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteScalar)
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto     meshName = "MeshTwo";
     Vector3d vec2     = Vector3d::Constant(0.0);
-    auto     vid      = cplInterface.setMeshVertex(meshName, vec2.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, vec2);
 
     auto dataAID = "DataOne";
     auto dataBID = "DataTwo";

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
   if (context.isNamed("SolverOne")) {
     auto     meshName = "MeshOne";
     Vector3d posOne   = Vector3d::Constant(0.0);
-    auto     vid      = cplInterface.setMeshVertex(meshName, posOne.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, posOne);
     auto     dataAID  = "DataOne";
     auto     dataBID  = "DataTwo";
     BOOST_TEST(cplInterface.requiresGradientDataFor(meshName, dataAID) == false);
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(GradientTestBidirectionalWriteVector)
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto     meshName = "MeshTwo";
     Vector3d pos      = Vector3d::Constant(1.0);
-    auto     vid      = cplInterface.setMeshVertex(meshName, pos.data());
+    auto     vid      = cplInterface.setMeshVertex(meshName, pos);
 
     auto dataAID = "DataOne";
     auto dataBID = "DataTwo";

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
@@ -51,8 +51,8 @@ BOOST_AUTO_TEST_CASE(GradientTestUnidirectionalReadScalar)
 
     Vector3d posOne = Vector3d::Constant(0.0);
     Vector3d posTwo = Vector3d::Constant(1.0);
-    cplInterface.setMeshVertex(meshName, posOne.data());
-    cplInterface.setMeshVertex(meshName, posTwo.data());
+    cplInterface.setMeshVertex(meshName, posOne);
+    cplInterface.setMeshVertex(meshName, posTwo);
 
     // Initialize, thus sending the mesh.
     cplInterface.initialize();
@@ -84,8 +84,8 @@ BOOST_AUTO_TEST_CASE(GradientTestUnidirectionalReadScalar)
 
     Vector3d posOne = Vector3d::Constant(0.1);
     Vector3d posTwo = Vector3d::Constant(1.1);
-    cplInterface.setMeshVertex(meshName, posOne.data());
-    cplInterface.setMeshVertex(meshName, posTwo.data());
+    cplInterface.setMeshVertex(meshName, posOne);
+    cplInterface.setMeshVertex(meshName, posTwo);
 
     cplInterface.initialize();
     double maxDt = cplInterface.getMaxTimeStepSize();

--- a/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
@@ -19,8 +19,8 @@ void testVectorGradientFunctions(const TestContext &context)
 
     Vector3d posOne = Vector3d::Constant(0.0);
     Vector3d posTwo = Vector3d::Constant(1.0);
-    interface.setMeshVertex(meshName, posOne.data());
-    interface.setMeshVertex(meshName, posTwo.data());
+    interface.setMeshVertex(meshName, posOne);
+    interface.setMeshVertex(meshName, posTwo);
 
     // Initialize, thus sending the mesh.
     interface.initialize();
@@ -54,8 +54,8 @@ void testVectorGradientFunctions(const TestContext &context)
 
     Vector3d posOne = Vector3d::Constant(0.1);
     Vector3d posTwo = Vector3d::Constant(1.1);
-    interface.setMeshVertex(meshName, posOne.data());
-    interface.setMeshVertex(meshName, posTwo.data());
+    interface.setMeshVertex(meshName, posOne);
+    interface.setMeshVertex(meshName, posTwo);
 
     interface.initialize();
     double maxDt = interface.getMaxTimeStepSize();

--- a/tests/serial/mapping-nearest-projection/helpers.cpp
+++ b/tests/serial/mapping-nearest-projection/helpers.cpp
@@ -39,15 +39,15 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFuncti
     auto meshName = "MeshOne";
 
     // Setup mesh one.
-    int idA = interface.setMeshVertex(meshName, coordOneA.data());
-    int idB = interface.setMeshVertex(meshName, coordOneB.data());
-    int idC = interface.setMeshVertex(meshName, coordOneC.data());
-    int idD = interface.setMeshVertex(meshName, coordOneD.data());
+    int idA = interface.setMeshVertex(meshName, coordOneA);
+    int idB = interface.setMeshVertex(meshName, coordOneB);
+    int idC = interface.setMeshVertex(meshName, coordOneC);
+    int idD = interface.setMeshVertex(meshName, coordOneD);
 
     if (defineEdgesExplicitly) {
       if (useBulkFunctions) {
         std::vector ids{idA, idB, idB, idC, idC, idD, idD, idA, idC, idA};
-        interface.setMeshEdges(meshName, 5, ids.data());
+        interface.setMeshEdges(meshName, ids);
       } else {
         interface.setMeshEdge(meshName, idA, idB);
         interface.setMeshEdge(meshName, idB, idC);
@@ -59,7 +59,7 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFuncti
 
     if (useBulkFunctions) {
       std::vector ids{idA, idB, idC, idC, idD, idA};
-      interface.setMeshTriangles(meshName, 2, ids.data());
+      interface.setMeshTriangles(meshName, ids);
     } else {
       interface.setMeshTriangle(meshName, idA, idB, idC);
       interface.setMeshTriangle(meshName, idC, idD, idA);
@@ -89,9 +89,9 @@ void testMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFuncti
     auto meshName = "MeshTwo";
 
     // Setup receiving mesh.
-    int idA = interface.setMeshVertex(meshName, coordTwoA.data());
-    int idB = interface.setMeshVertex(meshName, coordTwoB.data());
-    int idC = interface.setMeshVertex(meshName, coordTwoC.data());
+    int idA = interface.setMeshVertex(meshName, coordTwoA);
+    int idB = interface.setMeshVertex(meshName, coordTwoB);
+    int idC = interface.setMeshVertex(meshName, coordTwoC);
 
     // Initialize, thus receive the data and map.
     interface.initialize();
@@ -149,15 +149,15 @@ void testQuadMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFu
     auto meshName = "MeshOne";
 
     // Setup mesh one.
-    int idA = interface.setMeshVertex(meshName, coordOneA.data());
-    int idB = interface.setMeshVertex(meshName, coordOneB.data());
-    int idC = interface.setMeshVertex(meshName, coordOneC.data());
-    int idD = interface.setMeshVertex(meshName, coordOneD.data());
+    int idA = interface.setMeshVertex(meshName, coordOneA);
+    int idB = interface.setMeshVertex(meshName, coordOneB);
+    int idC = interface.setMeshVertex(meshName, coordOneC);
+    int idD = interface.setMeshVertex(meshName, coordOneD);
 
     if (defineEdgesExplicitly) {
       if (useBulkFunctions) {
         std::vector ids{idA, idB, idB, idC, idC, idD, idD, idA};
-        interface.setMeshEdges(meshName, 4, ids.data());
+        interface.setMeshEdges(meshName, ids);
       } else {
         interface.setMeshEdge(meshName, idA, idB);
         interface.setMeshEdge(meshName, idB, idC);
@@ -168,7 +168,7 @@ void testQuadMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFu
 
     if (useBulkFunctions) {
       std::vector ids{idA, idB, idC, idD};
-      interface.setMeshQuads(meshName, 1, ids.data());
+      interface.setMeshQuads(meshName, ids);
     } else {
       interface.setMeshQuad(meshName, idA, idB, idC, idD);
     }
@@ -207,9 +207,9 @@ void testQuadMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFu
     auto meshName = "MeshTwo";
 
     // Setup receiving mesh.
-    int idA = interface.setMeshVertex(meshName, coordTwoA.data());
-    int idB = interface.setMeshVertex(meshName, coordTwoB.data());
-    int idC = interface.setMeshVertex(meshName, coordTwoC.data());
+    int idA = interface.setMeshVertex(meshName, coordTwoA);
+    int idB = interface.setMeshVertex(meshName, coordTwoB);
+    int idC = interface.setMeshVertex(meshName, coordTwoC);
 
     // Initialize, thus receive the data and map.
     interface.initialize();
@@ -251,15 +251,15 @@ void testQuadMappingNearestProjectionTallKite(bool defineEdgesExplicitly, bool u
     auto meshName = "MeshOne";
 
     // Setup mesh one.
-    int idA = interface.setMeshVertex(meshName, coordOneA.data());
-    int idB = interface.setMeshVertex(meshName, coordOneB.data());
-    int idC = interface.setMeshVertex(meshName, coordOneC.data());
-    int idD = interface.setMeshVertex(meshName, coordOneD.data());
+    int idA = interface.setMeshVertex(meshName, coordOneA);
+    int idB = interface.setMeshVertex(meshName, coordOneB);
+    int idC = interface.setMeshVertex(meshName, coordOneC);
+    int idD = interface.setMeshVertex(meshName, coordOneD);
 
     if (defineEdgesExplicitly) {
       if (useBulkFunctions) {
         std::vector ids{idA, idB, idB, idC, idC, idD, idD, idA};
-        interface.setMeshEdges(meshName, 4, ids.data());
+        interface.setMeshEdges(meshName, ids);
       } else {
         interface.setMeshEdge(meshName, idA, idB);
         interface.setMeshEdge(meshName, idB, idC);
@@ -270,7 +270,7 @@ void testQuadMappingNearestProjectionTallKite(bool defineEdgesExplicitly, bool u
 
     if (useBulkFunctions) {
       std::vector ids{idA, idB, idC, idD};
-      interface.setMeshQuads(meshName, 1, ids.data());
+      interface.setMeshQuads(meshName, ids);
     } else {
       interface.setMeshQuad(meshName, idA, idB, idC, idD);
     }
@@ -310,15 +310,15 @@ void testQuadMappingNearestProjectionWideKite(bool defineEdgesExplicitly, bool u
     auto meshName = "MeshOne";
 
     // Setup mesh one.
-    int idA = interface.setMeshVertex(meshName, coordOneA.data());
-    int idB = interface.setMeshVertex(meshName, coordOneB.data());
-    int idC = interface.setMeshVertex(meshName, coordOneC.data());
-    int idD = interface.setMeshVertex(meshName, coordOneD.data());
+    int idA = interface.setMeshVertex(meshName, coordOneA);
+    int idB = interface.setMeshVertex(meshName, coordOneB);
+    int idC = interface.setMeshVertex(meshName, coordOneC);
+    int idD = interface.setMeshVertex(meshName, coordOneD);
 
     if (defineEdgesExplicitly) {
       if (useBulkFunctions) {
         std::vector ids{idA, idB, idB, idC, idC, idD, idD, idA};
-        interface.setMeshEdges(meshName, 4, ids.data());
+        interface.setMeshEdges(meshName, ids);
       } else {
         interface.setMeshEdge(meshName, idA, idB);
         interface.setMeshEdge(meshName, idB, idC);
@@ -329,7 +329,7 @@ void testQuadMappingNearestProjectionWideKite(bool defineEdgesExplicitly, bool u
 
     if (useBulkFunctions) {
       std::vector ids{idA, idB, idD, idC};
-      interface.setMeshQuads(meshName, 1, ids.data());
+      interface.setMeshQuads(meshName, ids);
     } else {
       interface.setMeshQuad(meshName, idA, idB, idD, idC);
     }

--- a/tests/serial/mapping-rbf-gaussian/helpers.cpp
+++ b/tests/serial/mapping-rbf-gaussian/helpers.cpp
@@ -47,18 +47,18 @@ void testRBFMapping(const std::string configFile, const TestContext &context)
 
     // Setup mesh one.
     std::vector<int> ids;
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneA.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneB.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneC.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneD.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneE.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneF.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneG.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneH.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneI.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneJ.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneK.data()));
-    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneL.data()));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneA));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneB));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneC));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneD));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneE));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneF));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneG));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneH));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneI));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneJ));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneK));
+    ids.emplace_back(interface.setMeshVertex(meshOneID, coordOneL));
 
     // Initialize, thus sending the mesh.
     interface.initialize();
@@ -81,9 +81,9 @@ void testRBFMapping(const std::string configFile, const TestContext &context)
     auto meshTwoID = "MeshTwo";
 
     // Setup receiving mesh.
-    int idA = interface.setMeshVertex(meshTwoID, coordTwoA.data());
-    int idB = interface.setMeshVertex(meshTwoID, coordTwoB.data());
-    int idC = interface.setMeshVertex(meshTwoID, coordTwoC.data());
+    int idA = interface.setMeshVertex(meshTwoID, coordTwoA);
+    int idB = interface.setMeshVertex(meshTwoID, coordTwoB);
+    int idC = interface.setMeshVertex(meshTwoID, coordTwoC);
 
     // Initialize, thus receive the data and map.
     interface.initialize();

--- a/tests/serial/mapping-scaled-consistent/helpers.cpp
+++ b/tests/serial/mapping-scaled-consistent/helpers.cpp
@@ -36,10 +36,10 @@ void testQuadMappingScaledConsistent(const std::string configFile, const TestCon
     auto meshOneID = "MeshOne";
 
     // Setup mesh one.
-    int idA = interface.setMeshVertex(meshOneID, coordOneA.data());
-    int idB = interface.setMeshVertex(meshOneID, coordOneB.data());
-    int idC = interface.setMeshVertex(meshOneID, coordOneC.data());
-    int idD = interface.setMeshVertex(meshOneID, coordOneD.data());
+    int idA = interface.setMeshVertex(meshOneID, coordOneA);
+    int idB = interface.setMeshVertex(meshOneID, coordOneB);
+    int idC = interface.setMeshVertex(meshOneID, coordOneC);
+    int idD = interface.setMeshVertex(meshOneID, coordOneD);
 
     interface.setMeshQuad(meshOneID, idA, idB, idC, idD);
 
@@ -72,9 +72,9 @@ void testQuadMappingScaledConsistent(const std::string configFile, const TestCon
     auto meshTwoID = "MeshTwo";
 
     // Setup receiving mesh.
-    int idA = interface.setMeshVertex(meshTwoID, coordTwoA.data());
-    int idB = interface.setMeshVertex(meshTwoID, coordTwoB.data());
-    int idC = interface.setMeshVertex(meshTwoID, coordTwoC.data());
+    int idA = interface.setMeshVertex(meshTwoID, coordTwoA);
+    int idB = interface.setMeshVertex(meshTwoID, coordTwoB);
+    int idC = interface.setMeshVertex(meshTwoID, coordTwoC);
 
     interface.setMeshTriangle(meshTwoID, idA, idB, idC);
 
@@ -129,11 +129,11 @@ void testQuadMappingScaledConsistentVolumetric(const std::string configFile, con
     auto meshOneID = "MeshOne";
 
     // Setup mesh one.
-    int idA     = interface.setMeshVertex(meshOneID, coordOneA.data());
-    int idB     = interface.setMeshVertex(meshOneID, coordOneB.data());
-    int idC     = interface.setMeshVertex(meshOneID, coordOneC.data());
-    int idD     = interface.setMeshVertex(meshOneID, coordOneD.data());
-    int idExtra = interface.setMeshVertex(meshOneID, coordOneExtra.data());
+    int idA     = interface.setMeshVertex(meshOneID, coordOneA);
+    int idB     = interface.setMeshVertex(meshOneID, coordOneB);
+    int idC     = interface.setMeshVertex(meshOneID, coordOneC);
+    int idD     = interface.setMeshVertex(meshOneID, coordOneD);
+    int idExtra = interface.setMeshVertex(meshOneID, coordOneExtra);
 
     interface.setMeshTriangle(meshOneID, idA, idB, idExtra);
     interface.setMeshTriangle(meshOneID, idA, idD, idExtra);
@@ -165,10 +165,10 @@ void testQuadMappingScaledConsistentVolumetric(const std::string configFile, con
     auto meshTwoID = "MeshTwo";
 
     // Setup receiving mesh.
-    int idA = interface.setMeshVertex(meshTwoID, coordTwoA.data());
-    int idB = interface.setMeshVertex(meshTwoID, coordTwoB.data());
-    int idC = interface.setMeshVertex(meshTwoID, coordTwoC.data());
-    int idD = interface.setMeshVertex(meshTwoID, coordTwoD.data());
+    int idA = interface.setMeshVertex(meshTwoID, coordTwoA);
+    int idB = interface.setMeshVertex(meshTwoID, coordTwoB);
+    int idC = interface.setMeshVertex(meshTwoID, coordTwoC);
+    int idD = interface.setMeshVertex(meshTwoID, coordTwoD);
 
     interface.setMeshEdge(meshTwoID, idA, idB);
     interface.setMeshEdge(meshTwoID, idB, idC);
@@ -231,11 +231,11 @@ void testTetraScaledConsistentVolumetric(const std::string configFile, const Tes
     auto meshOneID = "MeshOne";
 
     // Setup mesh one.
-    int idA     = interface.setMeshVertex(meshOneID, coordOneA.data());
-    int idB     = interface.setMeshVertex(meshOneID, coordOneB.data());
-    int idC     = interface.setMeshVertex(meshOneID, coordOneC.data());
-    int idD     = interface.setMeshVertex(meshOneID, coordOneD.data());
-    int idExtra = interface.setMeshVertex(meshOneID, coordOneExtra.data());
+    int idA     = interface.setMeshVertex(meshOneID, coordOneA);
+    int idB     = interface.setMeshVertex(meshOneID, coordOneB);
+    int idC     = interface.setMeshVertex(meshOneID, coordOneC);
+    int idD     = interface.setMeshVertex(meshOneID, coordOneD);
+    int idExtra = interface.setMeshVertex(meshOneID, coordOneExtra);
 
     interface.setMeshTetrahedron(meshOneID, idA, idB, idD, idExtra);
     interface.setMeshTetrahedron(meshOneID, idC, idB, idD, idExtra);
@@ -266,10 +266,10 @@ void testTetraScaledConsistentVolumetric(const std::string configFile, const Tes
     auto meshTwoID = "MeshTwo";
 
     // Setup receiving mesh.
-    int idA = interface.setMeshVertex(meshTwoID, coordTwoA.data());
-    int idB = interface.setMeshVertex(meshTwoID, coordTwoB.data());
-    int idC = interface.setMeshVertex(meshTwoID, coordTwoC.data());
-    int idD = interface.setMeshVertex(meshTwoID, coordTwoD.data());
+    int idA = interface.setMeshVertex(meshTwoID, coordTwoA);
+    int idB = interface.setMeshVertex(meshTwoID, coordTwoB);
+    int idC = interface.setMeshVertex(meshTwoID, coordTwoC);
+    int idD = interface.setMeshVertex(meshTwoID, coordTwoD);
 
     interface.setMeshTetrahedron(meshTwoID, idA, idB, idC, idD);
 

--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -22,7 +22,7 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
     std::vector<double> coords{0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
     vertexIDs.resize(coords.size() / 2);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     BOOST_TEST(vertexIDs[0] != -1, "Vertex A is invalid");
     BOOST_TEST(vertexIDs[1] != -1, "Vertex B is invalid");
@@ -59,7 +59,7 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
     std::vector<double> coords{1. / 3., 1. / 3.};
     vertexIDs.resize(coords.size() / 2);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     // Initialize, read data, advance and finalize. Check expected mapping
     interface.initialize();
@@ -107,7 +107,7 @@ void testMappingVolumeOneTriangleConservative(const std::string configFile, cons
     std::vector<double> coords{0.3, 0.2};
     vertexIDs.resize(coords.size() / 2);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     BOOST_TEST(vertexIDs[0] != -1, "Vertex A is invalid");
     BOOST_CHECK(interface.getMeshVertexSize(meshName) == 1);
@@ -131,7 +131,7 @@ void testMappingVolumeOneTriangleConservative(const std::string configFile, cons
     std::vector<double> coords{0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
     vertexIDs.resize(coords.size() / 2);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.setMeshTriangle(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2]);
 
@@ -177,7 +177,7 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
                                0.0, 0.0, 1.0};
     vertexIDs.resize(coords.size() / 3);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     BOOST_TEST(vertexIDs[0] != -1, "Vertex A is invalid");
     BOOST_TEST(vertexIDs[1] != -1, "Vertex B is invalid");
@@ -221,7 +221,7 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
     std::vector<double> coords{0.25, 0.25, 0.25};
     vertexIDs.resize(coords.size() / 2);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     // Initialize, read data, advance and finalize. Check expected mapping
     interface.initialize();
@@ -271,7 +271,7 @@ void testMappingVolumeOneTetraConservative(const std::string configFile, const T
     std::vector<double> coords{0.1, 0.2, 0.3};
     vertexIDs.resize(coords.size() / 3);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     BOOST_TEST(vertexIDs[0] != -1, "Vertex A is invalid");
     BOOST_CHECK(interface.getMeshVertexSize(meshName) == 1);
@@ -298,7 +298,7 @@ void testMappingVolumeOneTetraConservative(const std::string configFile, const T
                                0.0, 0.0, 1.0};
     vertexIDs.resize(coords.size() / 3);
 
-    interface.setMeshVertices(meshName, vertexIDs.size(), coords.data(), vertexIDs.data());
+    interface.setMeshVertices(meshName, coords, vertexIDs);
 
     interface.setMeshTetrahedron(meshName, vertexIDs[0], vertexIDs[1], vertexIDs[2], vertexIDs[3]);
 

--- a/tests/serial/multi-coupling/MultiCoupling.cpp
+++ b/tests/serial/multi-coupling/MultiCoupling.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
     std::vector<int> vertexIDs;
     int              vertexID = -1;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshName, positions.at(i).data());
+      vertexID = precice.setMeshVertex(meshName, positions.at(i));
       vertexIDs.push_back(vertexID);
     }
 
@@ -99,17 +99,17 @@ BOOST_AUTO_TEST_CASE(MultiCoupling)
     std::vector<int> vertexIDs1;
     int              vertexID = -1;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshName1, positions.at(i).data());
+      vertexID = precice.setMeshVertex(meshName1, positions.at(i));
       vertexIDs1.push_back(vertexID);
     }
     std::vector<int> vertexIDs2;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshName2, positions.at(i).data());
+      vertexID = precice.setMeshVertex(meshName2, positions.at(i));
       vertexIDs2.push_back(vertexID);
     }
     std::vector<int> vertexIDs3;
     for (size_t i = 0; i < 4; i++) {
-      vertexID = precice.setMeshVertex(meshName3, positions.at(i).data());
+      vertexID = precice.setMeshVertex(meshName3, positions.at(i));
       vertexIDs3.push_back(vertexID);
     }
 

--- a/tests/serial/multi-coupling/helpers.cpp
+++ b/tests/serial/multi-coupling/helpers.cpp
@@ -19,7 +19,7 @@ void multiCouplingThreeSolvers(const std::string configFile, const TestContext &
   if (context.isNamed("SolverA")) {
     SolverInterface cplInterface("SolverA", configFile, 0, 1);
     auto            meshName = "MeshA";
-    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA.data());
+    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA);
     auto            dataABID = "DataAB";
     auto            dataBAID = "DataBA";
 
@@ -48,8 +48,8 @@ void multiCouplingThreeSolvers(const std::string configFile, const TestContext &
     SolverInterface cplInterface("SolverB", configFile, 0, 1);
     auto            meshName1 = "MeshB1";
     auto            meshName2 = "MeshB2";
-    int             vertexID1 = cplInterface.setMeshVertex(meshName1, coordOneA.data());
-    int             vertexID2 = cplInterface.setMeshVertex(meshName2, coordOneA.data());
+    int             vertexID1 = cplInterface.setMeshVertex(meshName1, coordOneA);
+    int             vertexID2 = cplInterface.setMeshVertex(meshName2, coordOneA);
     auto            dataABID  = "DataAB";
     auto            dataBAID  = "DataBA";
     auto            dataCBID  = "DataCB";
@@ -83,7 +83,7 @@ void multiCouplingThreeSolvers(const std::string configFile, const TestContext &
   } else {
     SolverInterface cplInterface("SolverC", configFile, 0, 1);
     auto            meshName = "MeshC";
-    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA.data());
+    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA);
     auto            dataCBID = "DataCB";
     auto            dataBCID = "DataBC";
 
@@ -119,7 +119,7 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
   if (context.isNamed("SolverA")) {
     SolverInterface cplInterface("SolverA", configFile, 0, 1);
     auto            meshName = "MeshA";
-    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA.data());
+    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA);
     auto            dataABID = "DataAB";
     auto            dataBAID = "DataBA";
 
@@ -146,8 +146,8 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
     SolverInterface cplInterface("SolverB", configFile, 0, 1);
     auto            meshName1 = "MeshB1";
     auto            meshName2 = "MeshB2";
-    int             vertexID1 = cplInterface.setMeshVertex(meshName1, coordOneA.data());
-    int             vertexID2 = cplInterface.setMeshVertex(meshName2, coordOneA.data());
+    int             vertexID1 = cplInterface.setMeshVertex(meshName1, coordOneA);
+    int             vertexID2 = cplInterface.setMeshVertex(meshName2, coordOneA);
     auto            dataABID  = "DataAB";
     auto            dataBAID  = "DataBA";
     auto            dataCBID  = "DataCB";
@@ -179,8 +179,8 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
     SolverInterface cplInterface("SolverC", configFile, 0, 1);
     auto            meshName1 = "MeshC1";
     auto            meshName2 = "MeshC2";
-    int             vertexID1 = cplInterface.setMeshVertex(meshName1, coordOneA.data());
-    int             vertexID2 = cplInterface.setMeshVertex(meshName2, coordOneA.data());
+    int             vertexID1 = cplInterface.setMeshVertex(meshName1, coordOneA);
+    int             vertexID2 = cplInterface.setMeshVertex(meshName2, coordOneA);
     auto            dataBCID  = "DataBC";
     auto            dataCBID  = "DataCB";
     auto            dataCDID  = "DataCD";
@@ -210,7 +210,7 @@ void multiCouplingFourSolvers(const std::string configFile, const TestContext &c
   } else {
     SolverInterface cplInterface("SolverD", configFile, 0, 1);
     auto            meshName = "MeshD";
-    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA.data());
+    int             vertexID = cplInterface.setMeshVertex(meshName, coordOneA);
     auto            dataCDID = "DataCD";
     auto            dataDCID = "DataDC";
 

--- a/tests/serial/multiple-mappings/MultipleReadFromMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleReadFromMappings.cpp
@@ -20,8 +20,8 @@ BOOST_AUTO_TEST_CASE(MultipleReadFromMappings)
   if (context.isNamed("A")) {
     auto meshNameTop    = "MeshATop";
     auto meshNameBottom = "MeshABottom";
-    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex.data());
-    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex.data());
+    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex);
+    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex);
     auto dataNameTop    = "Pressure";
     auto dataNameBottom = "Pressure";
 
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(MultipleReadFromMappings)
   } else {
     BOOST_TEST(context.isNamed("B"));
     auto meshName = "MeshB";
-    int  vertexID = interface.setMeshVertex(meshName, vertex.data());
+    int  vertexID = interface.setMeshVertex(meshName, vertex);
     auto dataName = "Pressure";
 
     interface.initialize();

--- a/tests/serial/multiple-mappings/MultipleReadToMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleReadToMappings.cpp
@@ -20,8 +20,8 @@ BOOST_AUTO_TEST_CASE(MultipleReadToMappings)
   if (context.isNamed("A")) {
     auto meshNameTop    = "MeshATop";
     auto meshNameBottom = "MeshABottom";
-    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex.data());
-    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex.data());
+    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex);
+    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex);
     auto dataNameTop    = "DisplacementTop";
     auto dataNameBottom = "DisplacementBottom";
 
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(MultipleReadToMappings)
   } else {
     BOOST_TEST(context.isNamed("B"));
     auto meshName = "MeshB";
-    int  vertexID = interface.setMeshVertex(meshName, vertex.data());
+    int  vertexID = interface.setMeshVertex(meshName, vertex);
     auto bottomID = "DisplacementBottom";
     auto topID    = "DisplacementTop";
 

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappings.cpp
@@ -22,8 +22,8 @@ BOOST_AUTO_TEST_CASE(MultipleWriteFromMappings)
   if (context.isNamed("A")) {
     auto meshNameTop    = "MeshATop";
     auto meshNameBottom = "MeshABottom";
-    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex1.data());
-    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex3.data());
+    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex1);
+    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex3);
     auto dataNameTop    = "Pressure";
     auto dataNameBottom = "Pressure";
 
@@ -43,9 +43,9 @@ BOOST_AUTO_TEST_CASE(MultipleWriteFromMappings)
   } else {
     BOOST_TEST(context.isNamed("B"));
     auto meshName  = "MeshB";
-    int  vertexID1 = interface.setMeshVertex(meshName, vertex1.data());
-    int  vertexID2 = interface.setMeshVertex(meshName, vertex2.data());
-    int  vertexID3 = interface.setMeshVertex(meshName, vertex3.data());
+    int  vertexID1 = interface.setMeshVertex(meshName, vertex1);
+    int  vertexID2 = interface.setMeshVertex(meshName, vertex2);
+    int  vertexID3 = interface.setMeshVertex(meshName, vertex3);
     auto dataName  = "Pressure";
 
     interface.initialize();

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.cpp
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.cpp
@@ -22,8 +22,8 @@ BOOST_AUTO_TEST_CASE(MultipleWriteFromMappingsAndData)
   if (context.isNamed("A")) {
     auto meshNameTop     = "MeshATop";
     auto meshNameBottom  = "MeshABottom";
-    int  vertexIDTop     = interface.setMeshVertex(meshNameTop, vertex1.data());
-    int  vertexIDBottom  = interface.setMeshVertex(meshNameBottom, vertex3.data());
+    int  vertexIDTop     = interface.setMeshVertex(meshNameTop, vertex1);
+    int  vertexIDBottom  = interface.setMeshVertex(meshNameBottom, vertex3);
     auto dataNameTopP    = "Pressure";
     auto dataNameBottomP = "Pressure";
     auto dataNameTopT    = "Temperature";
@@ -51,9 +51,9 @@ BOOST_AUTO_TEST_CASE(MultipleWriteFromMappingsAndData)
   } else {
     BOOST_TEST(context.isNamed("B"));
     auto meshName  = "MeshB";
-    int  vertexID1 = interface.setMeshVertex(meshName, vertex1.data());
-    int  vertexID2 = interface.setMeshVertex(meshName, vertex2.data());
-    int  vertexID3 = interface.setMeshVertex(meshName, vertex3.data());
+    int  vertexID1 = interface.setMeshVertex(meshName, vertex1);
+    int  vertexID2 = interface.setMeshVertex(meshName, vertex2);
+    int  vertexID3 = interface.setMeshVertex(meshName, vertex3);
     auto dataNameP = "Pressure";
     auto dataNameT = "Temperature";
 

--- a/tests/serial/multiple-mappings/MultipleWriteToMappings.cpp
+++ b/tests/serial/multiple-mappings/MultipleWriteToMappings.cpp
@@ -20,8 +20,8 @@ BOOST_AUTO_TEST_CASE(MultipleWriteToMappings)
   if (context.isNamed("A")) {
     auto meshNameTop    = "MeshATop";
     auto meshNameBottom = "MeshABottom";
-    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex.data());
-    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex.data());
+    int  vertexIDTop    = interface.setMeshVertex(meshNameTop, vertex);
+    int  vertexIDBottom = interface.setMeshVertex(meshNameBottom, vertex);
     auto dataNameTop    = "DisplacementTop";
     auto dataNameBottom = "DisplacementBottom";
 
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(MultipleWriteToMappings)
   } else {
     BOOST_TEST(context.isNamed("B"));
     auto meshName = "MeshB";
-    int  vertexID = interface.setMeshVertex(meshName, vertex.data());
+    int  vertexID = interface.setMeshVertex(meshName, vertex);
     auto dataName = "DisplacementSum";
 
     interface.initialize();

--- a/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.cpp
+++ b/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.cpp
@@ -25,9 +25,9 @@ BOOST_AUTO_TEST_CASE(WatchIntegralScaleAndNoScale)
 
     auto meshName = "MeshOne";
 
-    int idA = interface.setMeshVertex(meshName, coordA.data());
-    int idB = interface.setMeshVertex(meshName, coordB.data());
-    int idC = interface.setMeshVertex(meshName, coordC.data());
+    int idA = interface.setMeshVertex(meshName, coordA);
+    int idB = interface.setMeshVertex(meshName, coordB);
+    int idC = interface.setMeshVertex(meshName, coordC);
 
     interface.setMeshEdge(meshName, idA, idB);
     interface.setMeshEdge(meshName, idB, idC);
@@ -68,9 +68,9 @@ BOOST_AUTO_TEST_CASE(WatchIntegralScaleAndNoScale)
 
     auto meshTwoID = "MeshTwo";
 
-    int idA = interface.setMeshVertex(meshTwoID, coordA.data());
-    int idB = interface.setMeshVertex(meshTwoID, coordB.data());
-    int idC = interface.setMeshVertex(meshTwoID, coordC.data());
+    int idA = interface.setMeshVertex(meshTwoID, coordA);
+    int idB = interface.setMeshVertex(meshTwoID, coordB);
+    int idC = interface.setMeshVertex(meshTwoID, coordC);
 
     interface.setMeshEdge(meshTwoID, idA, idB);
     interface.setMeshEdge(meshTwoID, idB, idC);

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
   if (context.isNamed("SolverOne")) {
     auto meshName = "Test-Square-One";
     BOOST_REQUIRE(cplInterface.getMeshDimensions(meshName));
-    cplInterface.setMeshVertices(meshName, 4, positions.data(), ids.data());
+    cplInterface.setMeshVertices(meshName, positions, ids);
     for (int i = 0; i < 4; i++)
       cplInterface.setMeshEdge(meshName, ids.at(i), ids.at((i + 1) % 4));
 
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
     BOOST_TEST(context.isNamed("SolverTwo"));
     auto meshName = "Test-Square-Two";
     BOOST_REQUIRE(cplInterface.getMeshDimensions(meshName));
-    cplInterface.setMeshVertices(meshName, 4, positions.data(), ids.data());
+    cplInterface.setMeshVertices(meshName, positions, ids);
     for (int i = 0; i < 4; i++)
       cplInterface.setMeshEdge(meshName, ids.at(i), ids.at((i + 1) % 4));
 


### PR DESCRIPTION
## Main changes of this PR

This PR ports the mesh API of preCICE to using spans.

C and Fortran assume correctly sized memory sections.

## Motivation and additional information

Better error messages based on stricter rules and fewer arguments for C++ users of the interface.

## Author's checklist

* [ ] I updated the doxygen documentation
* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?
