### PR TITLE
Simplify SolverInterfaceImpl constructor

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -1,6 +1,8 @@
-#include "precice/SolverInterface.hpp"
+#include <optional>
 #include <string_view>
+
 #include "cplscheme/Constants.hpp"
+#include "precice/SolverInterface.hpp"
 #include "precice/impl/SolverInterfaceImpl.hpp"
 #include "precice/impl/versions.hpp"
 
@@ -25,7 +27,7 @@ SolverInterface::SolverInterface(
     ::precice::string_view configurationFileName,
     int                    solverProcessIndex,
     int                    solverProcessSize)
-    : _impl(new impl::SolverInterfaceImpl(toSV(participantName), toSV(configurationFileName), solverProcessIndex, solverProcessSize))
+    : _impl(new impl::SolverInterfaceImpl(toSV(participantName), toSV(configurationFileName), solverProcessIndex, solverProcessSize, std::nullopt))
 {
 }
 
@@ -35,7 +37,7 @@ SolverInterface::SolverInterface(
     int                    solverProcessIndex,
     int                    solverProcessSize,
     void *                 communicator)
-    : _impl(new impl::SolverInterfaceImpl(toSV(participantName), toSV(configurationFileName), solverProcessIndex, solverProcessSize, communicator))
+    : _impl(new impl::SolverInterfaceImpl(toSV(participantName), toSV(configurationFileName), solverProcessIndex, solverProcessSize, {communicator}))
 {
 }
 

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -53,28 +53,26 @@ public:
   ///@{
 
   /**
-   * @copydoc SolverInterface::SolverInterface(std::string_view, std::string_view, int, int)
-   */
-  SolverInterfaceImpl(
-      std::string_view participantName,
-      std::string_view configurationFileName,
-      int              solverProcessIndex,
-      int              solverProcessSize);
-
-  /**
-   * @copybrief SolverInterface::SolverInterface(std::string_view, std::string_view, int, int, void*)
+   * @brief Generic constructor for SolverInterfaceImpl.
    *
    * Use the parameter communicator to specify a custom global MPI communicator.
-   * Pass a null pointer to signal preCICE to use MPI_COMM_WORLD.
+   * Pass std::nullopt to signal preCICE to use MPI_COMM_WORLD.
    *
-   * @copydetails SolverInterface::SolverInterface(std::string_view, std::string_view, int, int, void*)
+   * @param[in] participantName Name of the participant using the interface. Has to
+   *        match the name given for a participant in the xml configuration file.
+   * @param[in] configurationFileName Name (with path) of the xml configuration file.
+   * @param[in] solverProcessIndex If the solver code runs with several processes,
+   *        each process using preCICE has to specify its index, which has to start
+   *        from 0 and end with solverProcessSize - 1.
+   * @param[in] solverProcessSize The number of solver processes using preCICE.
+   * @param[in] communicator An optional pointer to an MPI_Comm to use as communicator.
    */
   SolverInterfaceImpl(
-      std::string_view participantName,
-      std::string_view configurationFileName,
-      int              solverProcessIndex,
-      int              solverProcessSize,
-      void *           communicator);
+      std::string_view      participantName,
+      std::string_view      configurationFileName,
+      int                   solverProcessIndex,
+      int                   solverProcessSize,
+      std::optional<void *> communicator);
 
   /**
    * @brief Destructor
@@ -291,30 +289,6 @@ public:
   SolverInterfaceImpl &operator=(SolverInterfaceImpl &&) = delete;
 
 private:
-  /**
-   * @brief Generic constructor for SolverInterfaceImpl.
-   *
-   * Use the parameter communicator to specify a custom global MPI communicator.
-   * Pass a null pointer to signal preCICE to use MPI_COMM_WORLD.
-   *
-   * @param[in] participantName Name of the participant using the interface. Has to
-   *        match the name given for a participant in the xml configuration file.
-   * @param[in] configurationFileName Name (with path) of the xml configuration file.
-   * @param[in] solverProcessIndex If the solver code runs with several processes,
-   *        each process using preCICE has to specify its index, which has to start
-   *        from 0 and end with solverProcessSize - 1.
-   * @param[in] solverProcessSize The number of solver processes using preCICE.
-   * @param[in] communicator A pointer to an MPI_Comm to use as communicator.
-   * @param[in] allowNullptr    Accept nullptr for communicator.
-   */
-  SolverInterfaceImpl(
-      std::string_view participantName,
-      std::string_view configurationFileName,
-      int              solverProcessIndex,
-      int              solverProcessSize,
-      void *           communicator,
-      bool             allowNullptr);
-
   mutable logging::Logger _log{"impl::SolverInterfaceImpl"};
 
   std::string _accessorName;


### PR DESCRIPTION
## Main changes of this PR

This PR simplifies the SolverInterfaceImpl constructor by representing the MPI communication pointer as an `std::optional`. 
If the user passes a pointer, we expect it to be non-NULL.
No argument means to use `MPI_COMM_WORLD`

## Motivation and additional information

Less is more

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
