### PR TITLE
Rename `gradientValues` to `gradients`

### DIFF
--- a/extras/bindings/c/include/precice/SolverInterfaceC.h
+++ b/extras/bindings/c/include/precice/SolverInterfaceC.h
@@ -360,7 +360,7 @@ PRECICE_API void precicec_writeGradientData(
     const char *  dataName,
     int           size,
     const int *   valueIndices,
-    const double *gradientValues);
+    const double *gradients);
 
 /**
  * @brief See precice::SolverInterface::setMeshAccessRegion().

--- a/extras/bindings/c/src/SolverInterfaceC.cpp
+++ b/extras/bindings/c/src/SolverInterfaceC.cpp
@@ -298,12 +298,12 @@ void precicec_writeBlockVectorGradientData(
     const char *  dataName,
     int           size,
     const int *   valueIndices,
-    const double *gradientValues)
+    const double *gradients)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto gradientComponents = impl->getDataDimensions(meshName, dataName) * impl->getMeshDimensions(meshName);
   auto gradientSize       = size * gradientComponents;
-  impl->writeGradientData(meshName, dataName, {valueIndices, static_cast<unsigned long>(size)}, {gradientValues, static_cast<unsigned long>(gradientSize)});
+  impl->writeGradientData(meshName, dataName, {valueIndices, static_cast<unsigned long>(size)}, {gradients, static_cast<unsigned long>(gradientSize)});
 }
 
 const char *precicec_getVersionInformation()

--- a/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/SolverInterfaceFortran.hpp
@@ -538,9 +538,9 @@ PRECICE_API void precicef_requires_gradient_data_for_(
  *   CHARACTER dataName(*),
  *   INTEGER size,
  *   INTEGER valueIndices,
- *   DOUBLE PRECISION gradientValues )
+ *   DOUBLE PRECISION gradients )
  *
- * IN:  mesh, data, size, valueIndices, gradientValues, meshNameLength, dataNameLength
+ * IN:  mesh, data, size, valueIndices, gradients, meshNameLength, dataNameLength
  * OUT: -
  *
  * @copydoc precice::SolverInterface::writeGradientData
@@ -550,7 +550,7 @@ PRECICE_API void precicef_write_gradient_data_(
     const char *  dataName,
     const int *   size,
     const int *   valueIndices,
-    const double *gradientValues,
+    const double *gradients,
     int           meshNameLength,
     int           dataNameLength);
 

--- a/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
+++ b/extras/bindings/fortran/src/SolverInterfaceFortran.cpp
@@ -394,7 +394,7 @@ void precicef_write_gradient_data_(
     const char *  dataName,
     const int *   size,
     const int *   valueIndices,
-    const double *gradientValues,
+    const double *gradients,
     int           meshNameLength,
     int           dataNameLength)
 {
@@ -407,7 +407,7 @@ void precicef_write_gradient_data_(
   impl->writeGradientData(strippedMeshName,
                           strippedDataName,
                           {valueIndices, static_cast<unsigned long>(*size)},
-                          {gradientValues, static_cast<unsigned long>(gradientSize)});
+                          {gradients, static_cast<unsigned long>(gradientSize)});
 }
 
 void precicef_set_mesh_access_region_(

--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -23,7 +23,7 @@ void Acceleration::applyRelaxation(double omega, const DataMap &cplData) const
     values *= omega;
     values += oldValues * (1 - omega);
     if (couplingData->hasGradient()) {
-      auto &      gradients    = couplingData->gradientValues();
+      auto &      gradients    = couplingData->gradients();
       const auto &oldGradients = couplingData->previousIterationGradients();
       gradients *= omega;
       gradients += oldGradients * (1 - omega);

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -268,17 +268,17 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradient)
   displacements->values().resize(4);
   displacements->values() << 1.0, 2.0, 3.0, 4.0;
   displacements->requireDataGradient();
-  displacements->gradientValues().resize(dim, 4);
+  displacements->gradients().resize(dim, 4);
   for (unsigned int r = 0; r < dim; ++r) {
     for (unsigned int c = 0; c < 4; ++c)
-      displacements->gradientValues()(r, c) = r + r * c;
+      displacements->gradients()(r, c) = r + r * c;
   }
   // //init forces
   forces->values().resize(4);
   forces->values() << 0.2, 0.2, 0.2, 0.2;
   forces->requireDataGradient();
-  forces->gradientValues().resize(dim, 4);
-  forces->gradientValues().setConstant(-2);
+  forces->gradients().resize(dim, 4);
+  forces->gradients().setConstant(-2);
 
   cplscheme::PtrCouplingData dpcd = std::make_shared<cplscheme::CouplingData>(displacements, dummyMesh, false);
   cplscheme::PtrCouplingData fpcd = std::make_shared<cplscheme::CouplingData>(forces, dummyMesh, false);
@@ -292,9 +292,9 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradient)
   acc.initialize(data);
 
   displacements->values() << 3.5, 2.0, 2.0, 1.0;
-  displacements->gradientValues().setConstant(2.5);
+  displacements->gradients().setConstant(2.5);
   forces->values() << 0.1, 0.1, 0.1, 0.1;
-  forces->gradientValues().setConstant(3);
+  forces->gradients().setConstant(3);
 
   acc.performAcceleration(data);
 
@@ -309,21 +309,21 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradient)
   BOOST_TEST(data.at(1)->values()(3) == 0.16);
 
   // Test gradient data
-  BOOST_TEST(data.at(0)->gradientValues()(0, 0) == 1);
-  BOOST_TEST(data.at(0)->gradientValues()(0, 1) == 1);
-  BOOST_TEST(data.at(0)->gradientValues()(0, 2) == 1);
-  BOOST_TEST(data.at(0)->gradientValues()(1, 0) == 1.6);
-  BOOST_TEST(data.at(0)->gradientValues()(1, 1) == 2.2);
-  BOOST_TEST(data.at(0)->gradientValues()(1, 2) == 2.8);
-  BOOST_TEST(data.at(1)->gradientValues()(0, 0) == 0);
-  BOOST_TEST(data.at(1)->gradientValues()(0, 1) == 0);
-  BOOST_TEST(data.at(1)->gradientValues()(0, 2) == 0);
-  BOOST_TEST(data.at(1)->gradientValues()(1, 0) == 0);
-  BOOST_TEST(data.at(1)->gradientValues()(1, 1) == 0);
-  BOOST_TEST(data.at(1)->gradientValues()(1, 2) == 0);
+  BOOST_TEST(data.at(0)->gradients()(0, 0) == 1);
+  BOOST_TEST(data.at(0)->gradients()(0, 1) == 1);
+  BOOST_TEST(data.at(0)->gradients()(0, 2) == 1);
+  BOOST_TEST(data.at(0)->gradients()(1, 0) == 1.6);
+  BOOST_TEST(data.at(0)->gradients()(1, 1) == 2.2);
+  BOOST_TEST(data.at(0)->gradients()(1, 2) == 2.8);
+  BOOST_TEST(data.at(1)->gradients()(0, 0) == 0);
+  BOOST_TEST(data.at(1)->gradients()(0, 1) == 0);
+  BOOST_TEST(data.at(1)->gradients()(0, 2) == 0);
+  BOOST_TEST(data.at(1)->gradients()(1, 0) == 0);
+  BOOST_TEST(data.at(1)->gradients()(1, 1) == 0);
+  BOOST_TEST(data.at(1)->gradients()(1, 2) == 0);
 
   data.begin()->second->values() << 10, 10, 10, 10;
-  displacements->gradientValues().setConstant(4);
+  displacements->gradients().setConstant(4);
 
   acc.performAcceleration(data);
 
@@ -337,12 +337,12 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradient)
   BOOST_TEST(data.at(1)->values()(2) == 0.184);
   BOOST_TEST(data.at(1)->values()(3) == 0.184);
 
-  BOOST_TEST(data.at(0)->gradientValues()(0, 0) == 1.6);
-  BOOST_TEST(data.at(0)->gradientValues()(0, 1) == 1.6);
-  BOOST_TEST(data.at(0)->gradientValues()(0, 2) == 1.6);
-  BOOST_TEST(data.at(0)->gradientValues()(1, 0) == 2.2);
-  BOOST_TEST(data.at(0)->gradientValues()(1, 1) == 2.8);
-  BOOST_TEST(data.at(0)->gradientValues()(1, 2) == 3.4);
+  BOOST_TEST(data.at(0)->gradients()(0, 0) == 1.6);
+  BOOST_TEST(data.at(0)->gradients()(0, 1) == 1.6);
+  BOOST_TEST(data.at(0)->gradients()(0, 2) == 1.6);
+  BOOST_TEST(data.at(0)->gradients()(1, 0) == 2.2);
+  BOOST_TEST(data.at(0)->gradients()(1, 1) == 2.8);
+  BOOST_TEST(data.at(0)->gradients()(1, 2) == 3.4);
 }
 
 #endif // not PRECICE_NO_MPI

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -105,7 +105,7 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
     m2n->send(data->values(), data->getMeshID(), data->getDimensions());
 
     if (data->hasGradient()) {
-      m2n->send(data->gradientValues(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
+      m2n->send(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
     }
   }
 }
@@ -120,7 +120,7 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
     m2n->receive(data->values(), data->getMeshID(), data->getDimensions());
 
     if (data->hasGradient()) {
-      m2n->receive(data->gradientValues(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
+      m2n->receive(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
     }
   }
 }

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -48,16 +48,16 @@ const Eigen::VectorXd &CouplingData::values() const
   return _data->values();
 }
 
-Eigen::MatrixXd &CouplingData::gradientValues()
+Eigen::MatrixXd &CouplingData::gradients()
 {
   PRECICE_ASSERT(_data != nullptr);
-  return _data->gradientValues();
+  return _data->gradients();
 }
 
-const Eigen::MatrixXd &CouplingData::gradientValues() const
+const Eigen::MatrixXd &CouplingData::gradients() const
 {
   PRECICE_ASSERT(_data != nullptr);
-  return _data->gradientValues();
+  return _data->gradients();
 }
 
 bool CouplingData::hasGradient() const
@@ -75,8 +75,8 @@ void CouplingData::storeIteration()
 {
   _previousIteration = this->values();
   if (this->hasGradient()) {
-    PRECICE_ASSERT(this->gradientValues().size() > 0);
-    _previousIterationGradients = this->gradientValues();
+    PRECICE_ASSERT(this->gradients().size() > 0);
+    _previousIterationGradients = this->gradients();
   }
 }
 

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -29,10 +29,10 @@ public:
   const Eigen::VectorXd &values() const;
 
   /// Returns a reference to the gradient data values.
-  Eigen::MatrixXd &gradientValues();
+  Eigen::MatrixXd &gradients();
 
   /// Returns a const reference to the gradient data values.
-  const Eigen::MatrixXd &gradientValues() const;
+  const Eigen::MatrixXd &gradients() const;
 
   /// Returns if the data contains gradient data
   bool hasGradient() const;

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -164,14 +164,14 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
   const int spaceDim = mesh.getDimensions();
   for (const mesh::PtrData &data : mesh.data()) {
     if (data->hasGradient()) { // Check whether this data has gradient
-      auto &gradientValues = data->gradientValues();
+      auto &gradients = data->gradients();
       if (data->getDimensions() == 1) { // Scalar data, create a vector <dataname>_gradient
         outFile << "VECTORS " << data->getName() << "_gradient"
                 << " double\n";
-        for (int i = 0; i < gradientValues.cols(); i++) { // Loop over vertices
-          int j = 0;                                      // Dimension counter
-          for (; j < gradientValues.rows(); j++) {        // Loop over space directions
-            outFile << gradientValues.coeff(j, i) << " ";
+        for (int i = 0; i < gradients.cols(); i++) { // Loop over vertices
+          int j = 0;                                 // Dimension counter
+          for (; j < gradients.rows(); j++) {        // Loop over space directions
+            outFile << gradients.coeff(j, i) << " ";
           }
           if (j < 3) { // If 2D data add additional zero as third component
             outFile << '0';
@@ -181,10 +181,10 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
       } else { // Vector data, write n vector for n dimension <dataname>_(dx/dy/dz)
         outFile << "VECTORS " << data->getName() << "_dx"
                 << " double\n";
-        for (int i = 0; i < gradientValues.cols(); i += spaceDim) { // Loop over vertices
+        for (int i = 0; i < gradients.cols(); i += spaceDim) { // Loop over vertices
           int j = 0;
-          for (; j < gradientValues.rows(); j++) { // Loop over components
-            outFile << gradientValues.coeff(j, i) << " ";
+          for (; j < gradients.rows(); j++) { // Loop over components
+            outFile << gradients.coeff(j, i) << " ";
           }
           if (j < 3) { // If 2D data add additional zero as third component
             outFile << '0';
@@ -195,10 +195,10 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
 
         outFile << "VECTORS " << data->getName() << "_dy"
                 << " double\n";
-        for (int i = 1; i < gradientValues.cols(); i += spaceDim) { // Loop over vertices
+        for (int i = 1; i < gradients.cols(); i += spaceDim) { // Loop over vertices
           int j = 0;
-          for (; j < gradientValues.rows(); j++) { // Loop over components
-            outFile << gradientValues.coeff(j, i) << " ";
+          for (; j < gradients.rows(); j++) { // Loop over components
+            outFile << gradients.coeff(j, i) << " ";
           }
           if (j < 3) { // If 2D data add additional zero as third component
             outFile << '0';
@@ -210,10 +210,10 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
         if (spaceDim == 3) { // dz is only for 3D data
           outFile << "VECTORS " << data->getName() << "_dz"
                   << " double\n";
-          for (int i = 2; i < gradientValues.cols(); i += spaceDim) { // Loop over vertices
+          for (int i = 2; i < gradients.cols(); i += spaceDim) { // Loop over vertices
             int j = 0;
-            for (; j < gradientValues.rows(); j++) { // Loop over components
-              outFile << gradientValues.coeff(j, i) << " ";
+            for (; j < gradients.rows(); j++) { // Loop over components
+              outFile << gradients.coeff(j, i) << " ";
             }
             if (j < 3) { // If 2D data add additional zero as third component
               outFile << '0';

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -156,7 +156,7 @@ void ExportXML::writeSubFile(
 
 void ExportXML::exportGradient(const mesh::PtrData data, const int spaceDim, std::ostream &outFile) const
 {
-  const auto &             gradientValues = data->gradientValues();
+  const auto &             gradients      = data->gradients();
   const int                dataDimensions = data->getDimensions();
   std::vector<std::string> suffices;
   if (dataDimensions == 1) {
@@ -172,10 +172,10 @@ void ExportXML::exportGradient(const mesh::PtrData data, const int spaceDim, std
     outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << suffix << "\" NumberOfComponents=\"" << 3;
     outFile << "\" format=\"ascii\">\n";
     outFile << "               ";
-    for (int i = counter; i < gradientValues.cols(); i += spaceDim) { // Loop over vertices
+    for (int i = counter; i < gradients.cols(); i += spaceDim) { // Loop over vertices
       int j = 0;
-      for (; j < gradientValues.rows(); j++) { // Loop over components
-        outFile << gradientValues.coeff(j, i) << " ";
+      for (; j < gradients.rows(); j++) { // Loop over components
+        outFile << gradients.coeff(j, i) << " ";
       }
       if (j < 3) { // If 2D data add additional zero as third component
         outFile << "0.0"

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -39,11 +39,11 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   valuesScalar << 1.0, 2.0;
   valuesVector << 1.0, 2.0, 3.0, 4.0;
 
-  // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradValuesScalar = dataScalar->gradientValues();
-  Eigen::MatrixXd &gradValuesVector = dataVector->gradientValues();
-  gradValuesScalar.setOnes();
-  gradValuesVector.setOnes();
+  // Create corresponding gradient data (all gradients = const = 1)
+  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
+  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
+  gradientsScalar.setOnes();
+  gradientsVector.setOnes();
   io::ExportVTK exportVTK;
   std::string   filename = "io-VTKExport-ExportDatawithGradient";
   std::string   location = "";

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -44,10 +44,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   valuesVector.setLinSpaced(1., 5.);
 
   // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradValuesScalar = dataScalar->gradientValues();
-  Eigen::MatrixXd &gradValuesVector = dataVector->gradientValues();
-  gradValuesScalar.setOnes();
-  gradValuesVector.setOnes();
+  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
+  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
+  gradientsScalar.setOnes();
+  gradientsVector.setOnes();
   io::ExportVTP exportVTP;
   std::string   filename = "io-VTPExport-ExportDatawithGradient" + std::to_string(dimensions);
   std::string   location = "";
@@ -76,10 +76,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   valuesVector.setLinSpaced(1., 5.);
 
   // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradValuesScalar = dataScalar->gradientValues();
-  Eigen::MatrixXd &gradValuesVector = dataVector->gradientValues();
-  gradValuesScalar.setOnes();
-  gradValuesVector.setOnes();
+  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
+  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
+  gradientsScalar.setOnes();
+  gradientsVector.setOnes();
   io::ExportVTP exportVTP;
   std::string   filename = "io-VTPExport-ExportDatawithGradient" + std::to_string(dimensions);
   std::string   location = "";

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -46,10 +46,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   valuesVector.setLinSpaced(1., 5.);
 
   // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradValuesScalar = dataScalar->gradientValues();
-  Eigen::MatrixXd &gradValuesVector = dataVector->gradientValues();
-  gradValuesScalar.setOnes();
-  gradValuesVector.setOnes();
+  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
+  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
+  gradientsScalar.setOnes();
+  gradientsVector.setOnes();
   io::ExportVTU exportVTU;
   std::string   filename = "io-VTUExport-ExportDatawithGradient" + std::to_string(dimensions);
   std::string   location = "";
@@ -79,10 +79,10 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   valuesVector.setLinSpaced(1., 5.);
 
   // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradValuesScalar = dataScalar->gradientValues();
-  Eigen::MatrixXd &gradValuesVector = dataVector->gradientValues();
-  gradValuesScalar.setOnes();
-  gradValuesVector.setOnes();
+  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
+  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
+  gradientsScalar.setOnes();
+  gradientsVector.setOnes();
   io::ExportVTU exportVTU;
   std::string   filename = "io-VTUExport-ExportDatawithGradient" + std::to_string(dimensions);
   std::string   location = "";

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -70,7 +70,7 @@ void NearestNeighborGradientMapping::mapConsistent(DataID inputDataID, DataID ou
   const int              valueDimensions = input()->data(inputDataID)->getDimensions(); // Data dimensions (for scalar = 1, for vectors > 1)
   const Eigen::VectorXd &inputValues     = input()->data(inputDataID)->values();
   Eigen::VectorXd &      outputValues    = output()->data(outputDataID)->values();
-  const Eigen::MatrixXd &gradientValues  = input()->data(inputDataID)->gradientValues();
+  const Eigen::MatrixXd &gradients       = input()->data(inputDataID)->gradients();
 
   //Consistent mapping
   PRECICE_DEBUG((hasConstraint(CONSISTENT) ? "Map consistent" : "Map scaled-consistent"));
@@ -84,7 +84,7 @@ void NearestNeighborGradientMapping::mapConsistent(DataID inputDataID, DataID ou
       const int mapOutputIndex = (i * valueDimensions) + dim;
       const int mapInputIndex  = inputIndex + dim;
 
-      outputValues(mapOutputIndex) = inputValues(mapInputIndex) + _offsetsMatched[i].transpose() * gradientValues.col(mapInputIndex);
+      outputValues(mapOutputIndex) = inputValues(mapInputIndex) + _offsetsMatched[i].transpose() * gradients.col(mapInputIndex);
     }
   }
 

--- a/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborGradientMappingTest.cpp
@@ -41,10 +41,10 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   inValuesVector << 1.0, 2.0, 3.0, 4.0;
 
   // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &inGradValuesScalar = inDataScalar->gradientValues();
-  Eigen::MatrixXd &inGradValuesVector = inDataVector->gradientValues();
-  inGradValuesScalar.setOnes();
-  inGradValuesVector.setOnes();
+  Eigen::MatrixXd &inGradientsScalar = inDataScalar->gradients();
+  Eigen::MatrixXd &inGradientsVector = inDataVector->gradients();
+  inGradientsScalar.setOnes();
+  inGradientsVector.setOnes();
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));
@@ -76,8 +76,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   BOOST_CHECK(equals(inValuesVector, outValuesVector));
 
   // Map data with almost coinciding vertices, with a null gradient, has to result in equal values
-  inGradValuesScalar.setZero();
-  inGradValuesVector.setZero();
+  inGradientsScalar.setZero();
+  inGradientsVector.setZero();
   outVertex0.setCoords(inVertex0.getCoords() + Eigen::Vector2d::Constant(0.1));
   outVertex1.setCoords(inVertex1.getCoords() + Eigen::Vector2d::Constant(0.1));
 
@@ -91,8 +91,8 @@ BOOST_AUTO_TEST_CASE(ConsistentNonIncremental)
   BOOST_CHECK(equals(expected, outValuesVector));
 
   // Map data with almost coinciding vertices, should be a little different with the gradient optimization
-  inGradValuesScalar.setOnes();
-  inGradValuesVector.setOnes();
+  inGradientsScalar.setOnes();
+  inGradientsVector.setOnes();
   outVertex0.setCoords(inVertex0.getCoords() + Eigen::Vector2d::Constant(0.1));
   outVertex1.setCoords(inVertex1.getCoords() + Eigen::Vector2d::Constant(0.1));
 
@@ -132,16 +132,16 @@ BOOST_AUTO_TEST_CASE(ConsistentGradientNotConstant)
   inValuesVector << 1.0, 2.0, 3.0, 4.0;
 
   // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &inGradValuesScalar = inDataScalar->gradientValues();
-  Eigen::MatrixXd &inGradValuesVector = inDataVector->gradientValues();
+  Eigen::MatrixXd &inGradientsScalar = inDataScalar->gradients();
+  Eigen::MatrixXd &inGradientsVector = inDataVector->gradients();
 
-  inGradValuesScalar.col(0) << 2.0, 3.0;
-  inGradValuesScalar.col(1) << 2.0, 3.0;
+  inGradientsScalar.col(0) << 2.0, 3.0;
+  inGradientsScalar.col(1) << 2.0, 3.0;
 
-  inGradValuesVector.col(0) << 2.0, 3.0;
-  inGradValuesVector.col(1) << 4.0, 5.0;
-  inGradValuesVector.col(2) << 2.0, 3.0;
-  inGradValuesVector.col(3) << 4.0, 5.0;
+  inGradientsVector.col(0) << 2.0, 3.0;
+  inGradientsVector.col(1) << 4.0, 5.0;
+  inGradientsVector.col(2) << 2.0, 3.0;
+  inGradientsVector.col(3) << 4.0, 5.0;
 
   // Create mesh to map to
   PtrMesh outMesh(new Mesh("OutMesh", dimensions, testing::nextMeshID()));

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -42,14 +42,14 @@ const Eigen::VectorXd &Data::values() const
   return _values;
 }
 
-Eigen::MatrixXd &Data::gradientValues()
+Eigen::MatrixXd &Data::gradients()
 {
-  return _gradientValues;
+  return _gradients;
 }
 
-const Eigen::MatrixXd &Data::gradientValues() const
+const Eigen::MatrixXd &Data::gradients() const
 {
-  return _gradientValues;
+  return _gradients;
 }
 
 const std::string &Data::getName() const
@@ -66,7 +66,7 @@ void Data::toZero()
 {
   _values.setZero();
   if (_hasGradient) {
-    _gradientValues.setZero();
+    _gradients.setZero();
   }
 }
 
@@ -107,19 +107,19 @@ void Data::allocateValues(int expectedCount)
     const SizeType spaceDimensions = _spatialDimensions;
 
     const SizeType expectedColumnSize = expectedCount * _dimensions;
-    const auto     actualColumnSize   = static_cast<SizeType>(_gradientValues.cols());
+    const auto     actualColumnSize   = static_cast<SizeType>(_gradients.cols());
 
     // Shrink Buffer
     if (expectedColumnSize < actualColumnSize) {
-      _gradientValues.resize(spaceDimensions, expectedColumnSize);
+      _gradients.resize(spaceDimensions, expectedColumnSize);
     }
 
     // Enlarge Buffer
     if (expectedColumnSize > actualColumnSize) {
       const auto columnLeftToAllocate = expectedColumnSize - actualColumnSize;
-      utils::append(_gradientValues, Eigen::MatrixXd(Eigen::MatrixXd::Zero(spaceDimensions, columnLeftToAllocate)));
+      utils::append(_gradients, Eigen::MatrixXd(Eigen::MatrixXd::Zero(spaceDimensions, columnLeftToAllocate)));
     }
-    PRECICE_DEBUG("Gradient Data {} now has {} x {} values", _name, _gradientValues.rows(), _gradientValues.cols());
+    PRECICE_DEBUG("Gradient Data {} now has {} x {} values", _name, _gradients.rows(), _gradients.cols());
   }
 }
 

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -58,10 +58,10 @@ public:
   const Eigen::VectorXd &values() const;
 
   /// Returns a reference to the gradient data values.
-  Eigen::MatrixXd &gradientValues();
+  Eigen::MatrixXd &gradients();
 
   /// Returns a const reference to the gradient data values.
-  const Eigen::MatrixXd &gradientValues() const;
+  const Eigen::MatrixXd &gradients() const;
 
   /// Returns the name of the data set, as set in the config file.
   const std::string &getName() const;
@@ -96,7 +96,7 @@ private:
 
   Eigen::VectorXd _values;
 
-  Eigen::MatrixXd _gradientValues;
+  Eigen::MatrixXd _gradients;
 
   /// Name of the data set.
   std::string _name;

--- a/src/precice/impl/SolverInterfaceImpl.cpp
+++ b/src/precice/impl/SolverInterfaceImpl.cpp
@@ -1118,7 +1118,7 @@ void SolverInterfaceImpl::writeGradientData(
 
   PRECICE_VALIDATE_DATA(gradients.data(), gradients.size());
 
-  context.writeGradientValues(vertices, gradients);
+  context.writeGradients(vertices, gradients);
 }
 
 void SolverInterfaceImpl::setMeshAccessRegion(

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -21,11 +21,11 @@ void WriteDataContext::writeValues(::precice::span<const VertexID> vertices, ::p
   }
 }
 
-void WriteDataContext::writeGradientValues(::precice::span<const VertexID> vertices, ::precice::span<const double> gradients)
+void WriteDataContext::writeGradients(::precice::span<const VertexID> vertices, ::precice::span<const double> gradients)
 {
   const auto                        gradientComponents = getSpatialDimensions() * getDataDimensions();
   Eigen::Map<const Eigen::MatrixXd> inputGradients(gradients.data(), gradientComponents, vertices.size());
-  Eigen::Map<Eigen::MatrixXd>       localGradients(_providedData->gradientValues().data(), gradientComponents, getMeshVertexCount());
+  Eigen::Map<Eigen::MatrixXd>       localGradients(_providedData->gradients().data(), gradientComponents, getMeshVertexCount());
 
   for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
     localGradients.col(vertices[i]) = inputGradients.col(i);

--- a/src/precice/impl/WriteDataContext.hpp
+++ b/src/precice/impl/WriteDataContext.hpp
@@ -34,12 +34,12 @@ public:
   void writeValues(::precice::span<const VertexID> vertices, ::precice::span<const double> values);
 
   /**
-   * @brief Store gradients in _providedData.gradientValues()
+   * @brief Store gradients in _providedData.gradients()
    *
    * @param[in] vertices ids of data
    * @param[in] gradients gradients of data
    */
-  void writeGradientValues(::precice::span<const VertexID> vertices, ::precice::span<const double> gradients);
+  void writeGradients(::precice::span<const VertexID> vertices, ::precice::span<const double> gradients);
 
   /**
    * @brief Adds a MappingContext and the MeshContext required by the write mapping to the corresponding WriteDataContext data structures.

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
@@ -75,8 +75,8 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelScalar)
 
     if (interface.requiresGradientDataFor(meshName, dataName)) {
 
-      double gradientValues[12] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-      interface.writeGradientData(meshName, dataName, vertexIDs, gradientValues);
+      double gradients[12] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+      interface.writeGradientData(meshName, dataName, vertexIDs, gradients);
     }
     interface.advance(1.0);
     interface.finalize();

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
@@ -91,8 +91,8 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelVector)
     BOOST_TEST(interface.requiresGradientDataFor(meshName, dataName2) == true);
 
     if (interface.requiresGradientDataFor(meshName, dataName2)) {
-      std::vector<double> gradientValues(24, 1.0);
-      interface.writeGradientData(meshName, dataName2, vertexIDs, gradientValues);
+      std::vector<double> gradients(24, 1.0);
+      interface.writeGradientData(meshName, dataName2, vertexIDs, gradients);
     }
     interface.advance(1.0);
     interface.finalize();

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp
@@ -85,11 +85,11 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
       BOOST_TEST(interface.requiresGradientDataFor(meshName, dataName) == true);
 
       if (interface.requiresGradientDataFor(meshName, dataName)) {
-        std::vector<double> gradientValues;
+        std::vector<double> gradients;
         for (unsigned int i = 0; i < 36; ++i) {
-          gradientValues.emplace_back(i);
+          gradients.emplace_back(i);
         }
-        interface.writeGradientData(meshName, dataName, vertexIDs, gradientValues);
+        interface.writeGradientData(meshName, dataName, vertexIDs, gradients);
       }
     } else {
       // Assigned to the first rank
@@ -105,11 +105,11 @@ BOOST_AUTO_TEST_CASE(GradientTestParallelWriteVector)
       BOOST_TEST(interface.requiresGradientDataFor(meshName, dataName) == true);
 
       if (interface.requiresGradientDataFor(meshName, dataName)) {
-        std::vector<double> gradientValues;
+        std::vector<double> gradients;
         for (int i = 0; i < 9; ++i) {
-          gradientValues.emplace_back(-i);
+          gradients.emplace_back(-i);
         }
-        interface.writeGradientData(meshName, dataName, {&vertexIDs[0], 1}, gradientValues);
+        interface.writeGradientData(meshName, dataName, {&vertexIDs[0], 1}, gradients);
       }
     }
     interface.advance(1.0);

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.cpp
@@ -66,8 +66,8 @@ BOOST_AUTO_TEST_CASE(GradientTestUnidirectionalReadScalar)
     BOOST_TEST(cplInterface.requiresGradientDataFor(meshName, dataName) == true);
 
     if (cplInterface.requiresGradientDataFor(meshName, dataName)) {
-      double gradientValues[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
-      cplInterface.writeGradientData(meshName, dataName, indices, gradientValues);
+      double gradients[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+      cplInterface.writeGradientData(meshName, dataName, indices, gradients);
     }
 
     // Participant must make move after writing

--- a/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
+++ b/tests/serial/mapping-nearest-neighbor-gradient/helpers.cpp
@@ -35,10 +35,10 @@ void testVectorGradientFunctions(const TestContext &context)
 
     if (interface.requiresGradientDataFor(meshName, dataName)) {
 
-      std::vector<double> gradientValues({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
-                                          10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0});
+      std::vector<double> gradients({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                                     10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0});
 
-      interface.writeGradientData(meshName, dataName, indices, gradientValues);
+      interface.writeGradientData(meshName, dataName, indices, gradients);
     }
 
     // Participant must make move after writing


### PR DESCRIPTION
## Main changes of this PR

**internally** rename `gradientValues` to `gradients`

## Motivation and additional information

Because it is shorter. See also #1612 and the new data structures `Sample` and `Stample`.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] ~~I added a changelog file with `make changelog` if there are user-observable changes since the last release.~~ (not observable for the user)
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
