### PR TITLE
Replace `BaseCouplingScheme::_time` with `BaseCouplingScheme::_timeWindowStartTime`

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -51,7 +51,7 @@ BaseCouplingScheme::BaseCouplingScheme(
       _extrapolationOrder(extrapolationOrder),
       _eps(std::pow(10.0, -1 * validDigits))
 {
-  PRECICE_ASSERT(not((maxTime != UNDEFINED_TIME) && (maxTime < 0.0)),
+  PRECICE_ASSERT(not((maxTime != UNDEFINED_MAX_TIME) && (maxTime < 0.0)),
                  "Maximum time has to be larger than zero.");
   PRECICE_ASSERT(not((maxTimeWindows != UNDEFINED_TIME_WINDOWS) && (maxTimeWindows < 0)),
                  "Maximum number of time windows has to be larger than zero.");
@@ -167,7 +167,7 @@ void BaseCouplingScheme::initialize(double startTime, int startTimeWindow)
   PRECICE_ASSERT(not isInitialized());
   PRECICE_ASSERT(math::greaterEquals(startTime, 0.0), startTime);
   PRECICE_ASSERT(startTimeWindow >= 0, startTimeWindow);
-  _time                = startTime;
+  _timeWindowStartTime = startTime;
   _timeWindows         = startTimeWindow;
   _hasDataBeenReceived = false;
 
@@ -219,7 +219,7 @@ CouplingScheme::ChangedMeshes BaseCouplingScheme::firstSynchronization(const Cou
 
 void BaseCouplingScheme::firstExchange()
 {
-  PRECICE_TRACE(_timeWindows, _time);
+  PRECICE_TRACE(_timeWindows, getTime());
   checkCompletenessRequiredActions();
   PRECICE_ASSERT(_isInitialized, "Before calling advance() coupling scheme has to be initialized via initialize().");
   _hasDataBeenReceived  = false;
@@ -242,7 +242,7 @@ CouplingScheme::ChangedMeshes BaseCouplingScheme::secondSynchronization()
 
 void BaseCouplingScheme::secondExchange()
 {
-  PRECICE_TRACE(_timeWindows, _time);
+  PRECICE_TRACE(_timeWindows, getTime());
   checkCompletenessRequiredActions();
   PRECICE_ASSERT(_isInitialized, "Before calling advance() coupling scheme has to be initialized via initialize().");
   PRECICE_ASSERT(_couplingMode != Undefined);
@@ -262,13 +262,13 @@ void BaseCouplingScheme::secondExchange()
         // time window remainder is zero. Subtract the time window size and do another
         // coupling iteration.
         PRECICE_ASSERT(math::greater(_computedTimeWindowPart, 0.0));
-        _time = _time - _computedTimeWindowPart;
         _timeWindows -= 1;
       } else { // write output, prepare for next window
         PRECICE_DEBUG("Convergence achieved");
         advanceTXTWriters();
         PRECICE_INFO("Time window completed");
         _isTimeWindowComplete = true;
+        _timeWindowStartTime += _computedTimeWindowPart;
         if (isCouplingOngoing()) {
           PRECICE_DEBUG("Setting require create checkpoint");
           requireAction(CouplingScheme::Action::WriteCheckpoint);
@@ -284,6 +284,7 @@ void BaseCouplingScheme::secondExchange()
     } else {
       PRECICE_INFO("Time window completed");
       _isTimeWindowComplete = true;
+      _timeWindowStartTime += _computedTimeWindowPart;
     }
     if (isCouplingOngoing()) {
       PRECICE_ASSERT(_hasDataBeenReceived);
@@ -332,12 +333,11 @@ bool BaseCouplingScheme::isInitialized() const
 void BaseCouplingScheme::addComputedTime(
     double timeToAdd)
 {
-  PRECICE_TRACE(timeToAdd, _time);
+  PRECICE_TRACE(timeToAdd, getTime());
   PRECICE_ASSERT(isCouplingOngoing(), "Invalid call of addComputedTime() after simulation end.");
 
   // add time interval that has been computed in the solver to get the correct time remainder
   _computedTimeWindowPart += timeToAdd;
-  _time += timeToAdd;
 
   // Check validness
   bool valid = math::greaterEquals(getNextTimeStepMaxSize(), 0.0, _eps);
@@ -390,7 +390,7 @@ void BaseCouplingScheme::setTimeWindows(int timeWindows)
 
 double BaseCouplingScheme::getTime() const
 {
-  return _time;
+  return _timeWindowStartTime + _computedTimeWindowPart;
 }
 
 int BaseCouplingScheme::getTimeWindows() const
@@ -403,17 +403,17 @@ double BaseCouplingScheme::getNextTimeStepMaxSize() const
   if (hasTimeWindowSize()) {
     return _timeWindowSize - _computedTimeWindowPart;
   } else {
-    if (math::equals(_maxTime, UNDEFINED_TIME)) {
+    if (math::equals(_maxTime, UNDEFINED_MAX_TIME)) {
       return std::numeric_limits<double>::max();
     } else {
-      return _maxTime - _time;
+      return _maxTime - getTime();
     }
   }
 }
 
 bool BaseCouplingScheme::isCouplingOngoing() const
 {
-  bool timeLeft      = math::greater(_maxTime, _time, _eps) || math::equals(_maxTime, UNDEFINED_TIME);
+  bool timeLeft      = math::greater(_maxTime, getTime(), _eps) || math::equals(_maxTime, UNDEFINED_MAX_TIME);
   bool timestepsLeft = (_maxTimeWindows >= _timeWindows) || (_maxTimeWindows == UNDEFINED_TIME_WINDOWS);
   return timeLeft && timestepsLeft;
 }
@@ -455,7 +455,7 @@ std::string BaseCouplingScheme::printCouplingState() const
   if (_maxIterations != -1) {
     os << " of " << _maxIterations;
   }
-  os << ", " << printBasicState(_timeWindows, _time) << ", " << printActionsState();
+  os << ", " << printBasicState(_timeWindows, getTime()) << ", " << printActionsState();
   return os.str();
 }
 
@@ -469,13 +469,13 @@ std::string BaseCouplingScheme::printBasicState(
     os << " of " << _maxTimeWindows;
   }
   os << ", time: " << time;
-  if (_maxTime != UNDEFINED_TIME) {
+  if (_maxTime != UNDEFINED_MAX_TIME) {
     os << " of " << _maxTime;
   }
   if (hasTimeWindowSize()) {
     os << ", time-window-size: " << _timeWindowSize;
   }
-  if (hasTimeWindowSize() || (_maxTime != UNDEFINED_TIME)) {
+  if (hasTimeWindowSize() || (_maxTime != UNDEFINED_MAX_TIME)) {
     os << ", max-time-step-size: " << getNextTimeStepMaxSize();
   }
   os << ", ongoing: ";

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -377,11 +377,11 @@ private:
 
   mutable logging::Logger _log{"cplscheme::BaseCouplingScheme"};
 
-  /// Maximum time being computed. End of simulation is reached, if _time == _maxTime
+  /// Maximum time being computed. End of simulation is reached, if getTime() == _maxTime
   double _maxTime;
 
-  /// current time; _time <= _maxTime
-  double _time = 0;
+  /// time of beginning of the current time window
+  double _timeWindowStartTime = 0;
 
   /// Number of time windows that have to be computed. End of simulation is reached, if _timeWindows == _maxTimeWindows
   int _maxTimeWindows;

--- a/src/cplscheme/CouplingScheme.cpp
+++ b/src/cplscheme/CouplingScheme.cpp
@@ -2,7 +2,7 @@
 
 namespace precice::cplscheme {
 
-const double CouplingScheme::UNDEFINED_TIME = -1.0;
+const double CouplingScheme::UNDEFINED_MAX_TIME = -1.0;
 
 const int CouplingScheme::UNDEFINED_TIME_WINDOWS = -1;
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -41,7 +41,7 @@ namespace cplscheme {
 class CouplingScheme {
 public:
   /// Does not define a time limit for the coupled simulation.
-  static const double UNDEFINED_TIME;
+  static const double UNDEFINED_MAX_TIME;
 
   /// Does not define limit on time windows for the coupled simulation.
   static const int UNDEFINED_TIME_WINDOWS;

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -28,8 +28,8 @@ public:
   /**
  * @brief Constructor.
  *
- * @param[in] maxTime Simulation time limit, or UNDEFINED_TIME.
- * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIMEWINDOWS.
+ * @param[in] maxTime Simulation time limit, or UNDEFINED_MAX_TIME.
+ * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIME_WINDOWS.
  * @param[in] timeWindowSize Simulation time window size.
  * @param[in] validDigits valid digits for computation of the remainder of a time window
  * @param[in] localParticipant Name of participant using this coupling scheme.

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -29,8 +29,8 @@ public:
   /**
    * @brief Constructor.
    *
-   * @param[in] maxTime Simulation time limit, or UNDEFINED_TIME.
-   * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIMEWINDOWS.
+   * @param[in] maxTime Simulation time limit, or UNDEFINED_MAX_TIME.
+   * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIME_WINDOWS.
    * @param[in] timeWindowSize Simulation time window size.
    * @param[in] validDigits valid digits for computation of the remainder of a time window
    * @param[in] firstParticipant Name of participant starting simulation.

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -27,8 +27,8 @@ public:
   /**
  * @brief Constructor.
  *
- * @param[in] maxTime Simulation time limit, or UNDEFINED_TIME.
- * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIMEWINDOWS.
+ * @param[in] maxTime Simulation time limit, or UNDEFINED_MAX_TIME.
+ * @param[in] maxTimeWindows Simulation time windows limit, or UNDEFINED_TIME_WINDOWS.
  * @param[in] timeWindowSize Simulation time window size.
  * @param[in] validDigits valid digits for computation of the remainder of a time window
  * @param[in] firstParticipant Name of participant starting simulation.

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -142,7 +142,7 @@ private:
     std::vector<std::string>      participants;
     std::string                   controller;
     bool                          setController  = false;
-    double                        maxTime        = CouplingScheme::UNDEFINED_TIME;
+    double                        maxTime        = CouplingScheme::UNDEFINED_MAX_TIME;
     int                           maxTimeWindows = CouplingScheme::UNDEFINED_TIME_WINDOWS;
     double                        timeWindowSize = CouplingScheme::UNDEFINED_TIME_WINDOW_SIZE;
     int                           validDigits    = 16;

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   mesh->allocateDataValues();
   BOOST_TEST(data->values().size() == 1);
 
-  const double          maxTime        = CouplingScheme::UNDEFINED_TIME;
+  const double          maxTime        = CouplingScheme::UNDEFINED_MAX_TIME;
   const int             maxTimeWindows = 1;
   const double          timeWindowSize = 1.0;
   std::string           first          = "First";
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  const double maxTime            = CouplingScheme::UNDEFINED_TIME;
+  const double maxTime            = CouplingScheme::UNDEFINED_MAX_TIME;
   const int    maxTimeWindows     = 2;
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  const double maxTime            = CouplingScheme::UNDEFINED_TIME;
+  const double maxTime            = CouplingScheme::UNDEFINED_MAX_TIME;
   const int    maxTimeWindows     = 2;
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(FirstOrder)
   mesh->allocateDataValues();
   BOOST_TEST(data->values().size() == 1);
 
-  const double          maxTime        = CouplingScheme::UNDEFINED_TIME;
+  const double          maxTime        = CouplingScheme::UNDEFINED_MAX_TIME;
   const int             maxTimeWindows = 1;
   const double          timeWindowSize = 1.0;
   std::string           first          = "First";
@@ -579,7 +579,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithAcceleration)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  const double maxTime            = CouplingScheme::UNDEFINED_TIME;
+  const double maxTime            = CouplingScheme::UNDEFINED_MAX_TIME;
   const int    maxTimeWindows     = 2;
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;
@@ -784,7 +784,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderWithInitializationAndAcceleration)
   meshConfig.addMesh(mesh);
 
   // Create all parameters necessary to create an ImplicitCouplingScheme object
-  const double maxTime            = CouplingScheme::UNDEFINED_TIME;
+  const double maxTime            = CouplingScheme::UNDEFINED_MAX_TIME;
   const int    maxTimeWindows     = 2;
   const double timeWindowSize     = 0.1;
   const int    maxIterations      = 3;


### PR DESCRIPTION
## Main changes of this PR

* Replace _time with _timeWindowStartTime for easier tracking of time.

## Motivation and additional information

Makes tracking of time a bit simpler, because we do not need to roll back the `_time`, if an iteration did not converge, but instead we increase the `_timeWindowStartTime`, if the iteration converged. At all places, where `_time` is used, we now use `getTime()`.

Important: Similar to https://github.com/precice/precice/pull/1109 and might come with similar risks.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
