### PR TITLE
Fix events tests for Python 3.10

### DIFF
--- a/tools/profiling/precice-events
+++ b/tools/profiling/precice-events
@@ -628,7 +628,7 @@ def mergeCommand(files, outfile, align):
 
     print(f"Writing to {outfile}")
     with open(outfile, 'w', newline='') as file:
-        json.dump(merged, file, separators=(",", ":"))
+        json.dump(merged, file)
 
     return 0
 


### PR DESCRIPTION
## Main changes of this PR

Adjusts the arguments of the `json.dump()` function in the `tools/profiling/precice-events` for compatibility.

## Motivation and additional information

Solution proposed by @fsimonis.

This is currently not caught in our CI, but the tests do fail on my system with Python 3.10.6 (Ubuntu 22.04).

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> solves issue that only appeared on develop, does not apply
* [ ] I added a test to cover the proposed changes in our test suite. -> Not sure if I should, as this would mean testing an additional system. Larger change.
* For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> N/A
* I sticked to C++17 features. -> N/A
* I sticked to CMake version 3.16.3. -> N/A
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* ~~Does the changelog entry make sense? Is it formatted correctly?~~
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
