### PR TITLE
Add GitHub Action to detect merge commits

### DIFF
--- a/.github/workflows/detect-merge-commits.yml
+++ b/.github/workflows/detect-merge-commits.yml
@@ -17,6 +17,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run test
-        uses: NexusPHP/no-merge-commits@v1
+        uses: NexusPHP/no-merge-commits@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/detect-merge-commits.yml
+++ b/.github/workflows/detect-merge-commits.yml
@@ -1,0 +1,22 @@
+name: Detect Merge Commits
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    name: Check for merge commits
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run test
+        uses: NexusPHP/no-merge-commits@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Main changes of this PR

Adds https://github.com/marketplace/actions/no-merge-commits-action to our CI, using the default config from the documentation of the action.

## Motivation and additional information

It looks like we don't want merge commits in `develop`.

There are a few [alternatives](https://github.com/marketplace?category=&query=merge+commits+sort%3Apopularity-desc&type=actions&verification=), all equally unknown. This seemed to be the most recently updated.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* I added a test to cover the proposed changes in our test suite. -> N/A
* For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> N/A
* I sticked to C++17 features. -> N/A
* I sticked to CMake version 3.16.3. -> N/A
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
