### PR TITLE
Follow-up renaming of SolverInterface in comments

### DIFF
--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -52,7 +52,7 @@ ParticipantConfiguration::ParticipantConfiguration(
   auto attrName = XMLAttribute<std::string>(ATTR_NAME)
                       .setDocumentation(
                           "Name of the participant. Has to match the name given on construction "
-                          "of the precice::SolverInterface object used by the participant.");
+                          "of the precice::Participant object used by the participant.");
   tag.addAttribute(attrName);
 
   XMLTag tagWriteData(*this, TAG_WRITE, XMLTag::OCCUR_ARBITRARY);

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -93,8 +93,8 @@ ParticipantImpl::ParticipantImpl(
 {
 
   PRECICE_CHECK(!communicator || communicator.value() != nullptr,
-                "Passing \"nullptr\" as \"communicator\" to SolverInterface constructor is not allowed. "
-                "Please use the SolverInterface constructor without the \"communicator\" argument, if you don't want to pass an MPI communicator.");
+                "Passing \"nullptr\" as \"communicator\" to Participant constructor is not allowed. "
+                "Please use the Participant constructor without the \"communicator\" argument, if you don't want to pass an MPI communicator.");
   PRECICE_CHECK(!_accessorName.empty(),
                 "This participant's name is an empty string. "
                 "When constructing a preCICE interface you need to pass the name of the "

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -51,7 +51,7 @@ class Mesh;
 
 namespace impl {
 
-/// Implementation of SolverInterface. See also pimpl ideom (https://en.cppreference.com/w/cpp/language/pimpl).
+/// Implementation of Participant. See also pimpl ideom (https://en.cppreference.com/w/cpp/language/pimpl).
 class ParticipantImpl {
 public:
   ///@name Construction and Configuration
@@ -93,13 +93,13 @@ public:
   /// @name Steering Methods
   ///@{
 
-  /// @copydoc SolverInterface::initialize
+  /// @copydoc Participant::initialize
   void initialize();
 
-  /// @copydoc SolverInterface::advance
+  /// @copydoc Participant::advance
   void advance(double computedTimeStepSize);
 
-  /// @copydoc SolverInterface::finalize
+  /// @copydoc Participant::finalize
   void finalize();
 
   ///@}
@@ -107,19 +107,19 @@ public:
   ///@name Status Queries
   ///@{
 
-  /// @copydoc SolverInterface::getMeshDimensions
+  /// @copydoc Participant::getMeshDimensions
   int getMeshDimensions(std::string_view meshName) const;
 
-  /// @copydoc SolverInterface::getDataDimensions
+  /// @copydoc Participant::getDataDimensions
   int getDataDimensions(std::string_view meshName, std::string_view dataName) const;
 
-  /// @copydoc SolverInterface::isCouplingOngoing
+  /// @copydoc Participant::isCouplingOngoing
   bool isCouplingOngoing() const;
 
-  /// @copydoc SolverInterface::isTimeWindowComplete
+  /// @copydoc Participant::isTimeWindowComplete
   bool isTimeWindowComplete() const;
 
-  /// @copydoc SolverInterface::getMaxTimeStepSize
+  /// @copydoc Participant::getMaxTimeStepSize
   double getMaxTimeStepSize() const;
 
   ///@}
@@ -127,13 +127,13 @@ public:
   ///@name Requirements
   ///@{
 
-  /// @copydoc SolverInterface::requiresInitialData
+  /// @copydoc Participant::requiresInitialData
   bool requiresInitialData();
 
-  /// @copydoc SolverInterface::requiresReadingCheckpoint
+  /// @copydoc Participant::requiresReadingCheckpoint
   bool requiresReadingCheckpoint();
 
-  /// @copydoc SolverInterface::requiresWritingCheckpoint
+  /// @copydoc Participant::requiresWritingCheckpoint
   bool requiresWritingCheckpoint();
 
   ///@}
@@ -142,57 +142,57 @@ public:
   ///@anchor precice-mesh-access
   ///@{
 
-  /// @copydoc SolverInterface::resetMesh
+  /// @copydoc Participant::resetMesh
   void resetMesh(std::string_view meshName);
 
-  /// @copydoc SolverInterface::hasMesh
+  /// @copydoc Participant::hasMesh
   bool hasMesh(std::string_view meshName) const;
 
-  /// @copydoc SolverInterface::requiresMeshConnectivityFor
+  /// @copydoc Participant::requiresMeshConnectivityFor
   bool requiresMeshConnectivityFor(std::string_view meshName) const;
 
-  /// @copydoc SolverInterface::requiresGradientDataFor
+  /// @copydoc Participant::requiresGradientDataFor
   bool requiresGradientDataFor(std::string_view meshName,
                                std::string_view dataName) const;
 
-  /// @copydoc SolverInterface::setMeshVertex
+  /// @copydoc Participant::setMeshVertex
   int setMeshVertex(
       std::string_view              meshName,
       ::precice::span<const double> position);
 
-  /// @copydoc SolverInterface::getMeshVertexSize
+  /// @copydoc Participant::getMeshVertexSize
   int getMeshVertexSize(std::string_view meshName) const;
 
-  /// @copydoc SolverInterface::setMeshVertices
+  /// @copydoc Participant::setMeshVertices
   void setMeshVertices(
       std::string_view              meshName,
       ::precice::span<const double> positions,
       ::precice::span<VertexID>     ids);
 
-  /// @copydoc SolverInterface::setMeshEdge
+  /// @copydoc Participant::setMeshEdge
   void setMeshEdge(
       std::string_view meshName,
       int              firstVertexID,
       int              secondVertexID);
 
-  /// @copydoc SolverInterface::setMeshEdges
+  /// @copydoc Participant::setMeshEdges
   void setMeshEdges(
       std::string_view                meshName,
       ::precice::span<const VertexID> vertices);
 
-  /// @copydoc SolverInterface::setMeshTriangle
+  /// @copydoc Participant::setMeshTriangle
   void setMeshTriangle(
       std::string_view meshName,
       int              firstVertexID,
       int              secondVertexID,
       int              thirdVertexID);
 
-  /// @copydoc SolverInterface::setMeshTriangles
+  /// @copydoc Participant::setMeshTriangles
   void setMeshTriangles(
       std::string_view                meshName,
       ::precice::span<const VertexID> vertices);
 
-  /// @copydoc SolverInterface::setMeshQuad
+  /// @copydoc Participant::setMeshQuad
   void setMeshQuad(
       std::string_view meshName,
       int              firstVertexID,
@@ -200,12 +200,12 @@ public:
       int              thirdVertexID,
       int              fourthVertexID);
 
-  /// @copydoc SolverInterface::setMeshQuads
+  /// @copydoc Participant::setMeshQuads
   void setMeshQuads(
       std::string_view                meshName,
       ::precice::span<const VertexID> vertices);
 
-  /// @copydoc SolverInterface::setMeshTetrahedron
+  /// @copydoc Participant::setMeshTetrahedron
   void setMeshTetrahedron(
       std::string_view meshName,
       int              firstVertexID,
@@ -213,7 +213,7 @@ public:
       int              thirdVertexID,
       int              fourthVertexID);
 
-  /// @copydoc SolverInterface::setMeshTetrahedra
+  /// @copydoc Participant::setMeshTetrahedra
   void setMeshTetrahedra(
       std::string_view                meshName,
       ::precice::span<const VertexID> vertices);
@@ -223,12 +223,12 @@ public:
   ///@name Data Access
   ///@{
 
-  /// @copydoc SolverInterface::hasData
+  /// @copydoc Participant::hasData
   bool hasData(
       std::string_view meshName,
       std::string_view dataName) const;
 
-  /// @copydoc SolverInterface::readData
+  /// @copydoc Participant::readData
   void readData(
       std::string_view                meshName,
       std::string_view                dataName,
@@ -236,14 +236,14 @@ public:
       double                          relativeReadTime,
       ::precice::span<double>         values) const;
 
-  /// @copydoc SolverInterface::writeData
+  /// @copydoc Participant::writeData
   void writeData(
       std::string_view                meshName,
       std::string_view                dataName,
       ::precice::span<const VertexID> vertices,
       ::precice::span<const double>   values);
 
-  /// @copydoc SolverInterface::writeGradientData
+  /// @copydoc Participant::writeGradientData
   void writeGradientData(
       std::string_view                meshName,
       std::string_view                dataName,
@@ -257,11 +257,11 @@ public:
    */
   ///@{
 
-  /// @copydoc SolverInterface::setMeshAccessRegion
+  /// @copydoc Participant::setMeshAccessRegion
   void setMeshAccessRegion(std::string_view              meshName,
                            ::precice::span<const double> boundingBox) const;
 
-  /// @copydoc SolverInterface::getMeshVerticesAndIDs
+  /// @copydoc Participant::getMeshVerticesAndIDs
   void getMeshVerticesAndIDs(
       std::string_view          meshName,
       ::precice::span<VertexID> ids,
@@ -313,11 +313,11 @@ private:
 
   cplscheme::PtrCouplingScheme _couplingScheme;
 
-  /// Represents the various states a SolverInterface can be in.
+  /// Represents the various states a Participant can be in.
   enum struct State {
-    Constructed, // Initial state of SolverInterface
-    Initialized, // SolverInterface.initialize() triggers transition from State::Constructed to State::Initialized; mandatory
-    Finalized    // SolverInterface.finalize() triggers transition form State::Initialized to State::Finalized; mandatory
+    Constructed, // Initial state of Participant
+    Initialized, // Participant.initialize() triggers transition from State::Constructed to State::Initialized; mandatory
+    Finalized    // Participant.finalize() triggers transition form State::Initialized to State::Finalized; mandatory
   };
 
   /// Are experimental API calls allowed?
@@ -326,7 +326,7 @@ private:
   /// setMeshAccessRegion may only be called once
   mutable bool _accessRegionDefined = false;
 
-  /// The current State of the solverinterface
+  /// The current State of the Participant
   State _state{State::Constructed};
 
   /// Counts calls to advance for plotting.

--- a/src/testing/tests/ExampleTests.cpp
+++ b/src/testing/tests/ExampleTests.cpp
@@ -146,25 +146,24 @@ BOOST_AUTO_TEST_CASE(TwoProcTestsWithPETSc)
  * For integration tests (tests that directly use the preCICE API), often, you need two participants
  * where each participant uses it own communicator, i.e. each participant should not see that he is
  * part of a test.
- * In this case, you can simply create the participants and create a solverinterface.
+ * In this case, you can simply create the participants and create a Participant object.
  * The context-object is of type TestContext and provides access to the name of the current context and the rank and size of its communicator.
  */
 BOOST_AUTO_TEST_CASE(IntegrationTestsWithTwoParticipants)
 {
-  // As we will use the solverinterface, we do require anything else here.
   PRECICE_TEST("Solid"_on(2_ranks), "Fluid"_on(2_ranks));
 
   if (context.isNamed("Solid")) {
     // This is the participant Solid
     BOOST_TEST(context.hasSize(2));
 
-    // You can now create a solverinterface for your first participant
+    // You can now create a Participant object for your first participant
     // You can use context.name, context.rank, context.size
   } else {
-    // This is the participant Solid
+    // This is the participant Fluid
     BOOST_TEST(context.hasSize(2));
 
-    // You can now create a solverinterface for your second participant
+    // You can now create a Participant object for your second participant
     // You can use context.name, context.rank, context.size
   }
 }

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
 
   if (context.isNamed("SolverOne")) {
-    // Set up Solverinterface
+    // Set up Participant
     precice::Participant interface(context.name, context.config(), context.rank, context.size);
     constexpr int        dim           = 2;
     auto                 ownMeshName   = "MeshOne";

--- a/tests/parallel/direct-mesh-access/helpers.cpp
+++ b/tests/parallel/direct-mesh-access/helpers.cpp
@@ -24,7 +24,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
     std::vector<double> boundingBox = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 3.5}) : boundingBoxSecondaryRank;
     // Set bounding box
     interface.setMeshAccessRegion(otherMeshName, boundingBox);
-    // Initialize the solverinterface
+    // Initialize the Participant
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
 
@@ -101,7 +101,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
       BOOST_TEST(testing::equals(positions, ownCoordinates));
     }
 
-    // Initialize the solverinterface
+    // Initialize the Participant
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
 

--- a/tests/parallel/gather-scatter/helpers.cpp
+++ b/tests/parallel/gather-scatter/helpers.cpp
@@ -25,7 +25,7 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
     // Set mesh vertices
     interface.setMeshVertices(meshName, coordinates, ids);
 
-    // Initialize the solverinterface
+    // Initialize the Participant
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
 
@@ -38,7 +38,7 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
     // Allocate memory for readData
     std::vector<double> readData(size);
     while (interface.isCouplingOngoing()) {
-      // Write data, advance the solverinterface and readData
+      // Write data, advance the Participant and readData
       interface.writeData(meshName, writeDataName, ids, writeData);
 
       interface.advance(dt);
@@ -68,7 +68,7 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
     // Set vertices
     interface.setMeshVertices(meshName, coordinates, ids);
 
-    // Initialize the solverinterface
+    // Initialize the Participant
     interface.initialize();
     double dt = interface.getMaxTimeStepSize();
 
@@ -78,7 +78,7 @@ void runTestEnforceGatherScatter(std::vector<double> primaryPartition, const Tes
 
     // Start the time loop
     while (interface.isCouplingOngoing()) {
-      // Write data, advance solverinterface and read data
+      // Write data, advance Participant and read data
       interface.writeData(meshName, writeDataName, ids, writeData);
       interface.advance(dt);
       double dt = interface.getMaxTimeStepSize();

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
   if (context.isNamed("SolverOne")) {
-    // Set up Solverinterface
+    // Set up Participant
     precice::Participant interface(context.name, context.config(), context.rank, context.size);
     constexpr int        dim              = 2;
     const auto           providedMeshName = "MeshOne";

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
   if (context.isNamed("SolverOne")) {
-    // Set up Solverinterface
+    // Set up Participant
     precice::Participant interface(context.name, context.config(), context.rank, context.size);
     constexpr int        dim         = 2;
     const auto           ownMeshID   = "MeshOne";

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
   if (context.isNamed("SolverOne")) {
-    // Set up Solverinterface
+    // Set up Participant
     precice::Participant interface(context.name, context.config(), context.rank, context.size);
     constexpr int        dim           = 2;
     const auto           ownMeshName   = "MeshOne";

--- a/tests/serial/direct-mesh-access/Explicit.cpp
+++ b/tests/serial/direct-mesh-access/Explicit.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
-  // Set up Solverinterface
+  // Set up Participant
   precice::Participant couplingInterface(context.name, context.config(), 0, 1);
 
   std::vector<double> positions = {0.0, 0.0, 0.0, 0.05, 0.1, 0.1, 0.1, 0.0};

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
-  // Set up Solverinterface
+  // Set up Participant
   precice::Participant interface(context.name, context.config(), 0, 1);
   constexpr int        dim = 2;
 

--- a/tests/serial/direct-mesh-access/ExplicitRead.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitRead.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
-  // Set up Solverinterface
+  // Set up Participant
   precice::Participant couplingInterface(context.name, context.config(), 0, 1);
 
   std::vector<double> positions = {0.0, 0.0, 0.0, 0.05, 0.1, 0.1, 0.1, 0.0};

--- a/tests/serial/direct-mesh-access/Implicit.cpp
+++ b/tests/serial/direct-mesh-access/Implicit.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
 
-  // Set up Solverinterface
+  // Set up Participant
   precice::Participant couplingInterface(context.name, context.config(), 0, 1);
   constexpr int        dim = 2;
 


### PR DESCRIPTION
## Main changes of this PR

Following @kanishkbh's comment on https://github.com/precice/precice/pull/1643, this fixes a few missing renamings of `SolverInterface` in comments and error messages.

## Motivation and additional information

Something still missing (but which gets a bit more complicated and is not really necessary) is renaming the `interface`, `cplinterface`, and similar objects mainly in tests to `participant`. The complication stems from the multiple uses of the term "interface" (e.g., in the communication tests).

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> N/A, covered by #1643
* I added a test to cover the proposed changes in our test suite. -> N/A
* For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> N/A
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
