### PR TITLE
Fix incorrect write gradient data C API

### DIFF
--- a/extras/bindings/c/src/ParticipantC.cpp
+++ b/extras/bindings/c/src/ParticipantC.cpp
@@ -293,7 +293,7 @@ int precicec_requiresGradientDataFor(const char *meshName,
   return 0;
 }
 
-void precicec_writeBlockVectorGradientData(
+void precicec_writeGradientData(
     const char *  meshName,
     const char *  dataName,
     int           size,


### PR DESCRIPTION
## Main changes of this PR

The name in the cpp file was wrong.
If we had tests for the C API, then this would have resulted in link errors.

## Motivation and additional information

Have working bindings

Thanks to @erikscheurer for noticing this!

Fixup for #1636 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* :sob: I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.
