### PR TITLE
Add pre-commit hook for updating CMake sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,12 @@ repos:
   rev: v2.2.2
   hooks:
     - id: codespell
+- repo: local
+  hooks:
+  - id: update-cmake-sources
+    name: update CMake sources
+    entry: tools/building/updateSourceFiles.py
+    pass_filenames: false
+    require_serial: true
+    language: python
+    types_or: [c, c++]


### PR DESCRIPTION
## Main changes of this PR

This PR adds a local pre-commit hook that runs tools/building/updateSourceFiles.py on C/C++ file changes.

## Motivation and additional information

This should prevent build and installation problems via the CI

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
