### PR TITLE
Rename m2n config attributes to `acceptor` and `connector`

### DIFF
--- a/docs/changelog/1683.md
+++ b/docs/changelog/1683.md
@@ -1,0 +1,1 @@
+- Renamed the `<m2n:... />` attributes `from` and `to` to `acceptor` and `connector`.

--- a/examples/solverdummies/precice-config.xml
+++ b/examples/solverdummies/precice-config.xml
@@ -45,7 +45,7 @@
     <read-data name="Data-One" mesh="SolverTwo-Mesh" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/src/cplscheme/tests/explicit-coupling-scheme-1.xml
+++ b/src/cplscheme/tests/explicit-coupling-scheme-1.xml
@@ -8,7 +8,7 @@
     <use-data name="Data1" />
   </mesh>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
 
   <participant name="Participant0">
     <provide-mesh name="Mesh" />

--- a/src/cplscheme/tests/explicit-coupling-scheme-2.xml
+++ b/src/cplscheme/tests/explicit-coupling-scheme-2.xml
@@ -8,7 +8,7 @@
     <use-data name="Data1" />
   </mesh>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
 
   <participant name="Participant0">
     <provide-mesh name="Mesh" />

--- a/src/cplscheme/tests/multi-solver-coupling-1.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-1.xml
@@ -29,8 +29,8 @@
     <read-data name="Data1" mesh="Mesh" />
   </participant>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
-  <m2n:sockets from="Participant1" to="Participant2" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
+  <m2n:sockets acceptor="Participant1" connector="Participant2" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Participant0" second="Participant1" />

--- a/src/cplscheme/tests/multi-solver-coupling-2.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-2.xml
@@ -29,8 +29,8 @@
     <read-data name="Data1" mesh="Mesh" />
   </participant>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
-  <m2n:sockets from="Participant1" to="Participant2" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
+  <m2n:sockets acceptor="Participant1" connector="Participant2" />
 
   <coupling-scheme:serial-implicit>
     <participants first="Participant0" second="Participant1" />

--- a/src/cplscheme/tests/multi-solver-coupling-3.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-3.xml
@@ -29,8 +29,8 @@
     <read-data name="Data1" mesh="Mesh" />
   </participant>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
-  <m2n:sockets from="Participant1" to="Participant2" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
+  <m2n:sockets acceptor="Participant1" connector="Participant2" />
 
   <coupling-scheme:serial-implicit>
     <participants first="Participant0" second="Participant1" />

--- a/src/cplscheme/tests/multi-solver-coupling-4.xml
+++ b/src/cplscheme/tests/multi-solver-coupling-4.xml
@@ -29,8 +29,8 @@
     <read-data name="Data1" mesh="Mesh" />
   </participant>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
-  <m2n:sockets from="Participant1" to="Participant2" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
+  <m2n:sockets acceptor="Participant1" connector="Participant2" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Participant0" second="Participant1" />

--- a/src/cplscheme/tests/parallel-explicit-coupling-datainit.xml
+++ b/src/cplscheme/tests/parallel-explicit-coupling-datainit.xml
@@ -10,7 +10,7 @@
     <use-data name="Data2" />
   </mesh>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
 
   <participant name="Participant0">
     <provide-mesh name="Mesh" />

--- a/src/cplscheme/tests/parallel-implicit-cplscheme-relax-const-config.xml
+++ b/src/cplscheme/tests/parallel-implicit-cplscheme-relax-const-config.xml
@@ -8,7 +8,7 @@
     <use-data name="Data1" />
   </mesh>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
 
   <participant name="Participant0">
     <provide-mesh name="Mesh" />

--- a/src/cplscheme/tests/serial-explicit-coupling-datainit.xml
+++ b/src/cplscheme/tests/serial-explicit-coupling-datainit.xml
@@ -10,7 +10,7 @@
     <use-data name="Data2" />
   </mesh>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
 
   <participant name="Participant0">
     <provide-mesh name="Mesh" />

--- a/src/cplscheme/tests/serial-implicit-cplscheme-absolute-config.xml
+++ b/src/cplscheme/tests/serial-implicit-cplscheme-absolute-config.xml
@@ -8,7 +8,7 @@
     <use-data name="Data1" />
   </mesh>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
 
   <participant name="Participant0">
     <provide-mesh name="Mesh" />

--- a/src/cplscheme/tests/serial-implicit-cplscheme-relax-const-config.xml
+++ b/src/cplscheme/tests/serial-implicit-cplscheme-relax-const-config.xml
@@ -8,7 +8,7 @@
     <use-data name="Data1" />
   </mesh>
 
-  <m2n:sockets from="Participant0" to="Participant1" />
+  <m2n:sockets acceptor="Participant0" connector="Participant1" />
 
   <participant name="Participant0">
     <provide-mesh name="Mesh" />

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -107,10 +107,10 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
   attrTwoLevel.setDocumentation("Use a two-level initialization scheme. "
                                 "Recommended for large parallel runs (>5000 MPI ranks).");
 
-  auto attrFrom = XMLAttribute<std::string>("from")
+  auto attrFrom = XMLAttribute<std::string>("acceptor")
                       .setDocumentation(
                           "First participant name involved in communication. For performance reasons, we recommend to use "
-                          "the participant with less ranks at the coupling interface as \"from\" in the m2n communication.");
+                          "the participant with less ranks at the coupling interface as \"acceptor\" in the m2n communication.");
   auto attrTo = XMLAttribute<std::string>("to")
                     .setDocumentation("Second participant name involved in communication.");
 
@@ -123,33 +123,33 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
   }
 }
 
-m2n::PtrM2N M2NConfiguration::getM2N(const std::string &from, const std::string &to)
+m2n::PtrM2N M2NConfiguration::getM2N(const std::string &acceptor, const std::string &connector)
 {
   using std::get;
   for (M2NTuple &tuple : _m2ns) {
-    if ((get<1>(tuple) == from) && (get<2>(tuple) == to)) {
+    if ((get<1>(tuple) == acceptor) && (get<2>(tuple) == connector)) {
       return get<0>(tuple);
-    } else if ((get<2>(tuple) == from) && (get<1>(tuple) == to)) {
+    } else if ((get<2>(tuple) == acceptor) && (get<1>(tuple) == connector)) {
       return get<0>(tuple);
     }
   }
-  PRECICE_ERROR("There is no m2n communication configured between participants \"" + from + "\" and \"" + to + "\". Please add an appropriate \"<m2n />\" tag.");
+  PRECICE_ERROR("There is no m2n communication configured between participants \"" + acceptor + "\" and \"" + connector + "\". Please add an appropriate \"<m2n />\" tag.");
 }
 
-bool M2NConfiguration::isM2NConfigured(const std::string &from, const std::string &to)
+bool M2NConfiguration::isM2NConfigured(const std::string &acceptor, const std::string &connector)
 {
   return std::any_of(std::begin(_m2ns), std::end(_m2ns),
-                     [from, to](const auto &m2nTuple) {
-                       return ((std::get<1>(m2nTuple) == from) && (std::get<2>(m2nTuple) == to)) || ((std::get<1>(m2nTuple) == to) && (std::get<2>(m2nTuple) == from));
+                     [acceptor, connector](const auto &m2nTuple) {
+                       return ((std::get<1>(m2nTuple) == acceptor) && (std::get<2>(m2nTuple) == connector)) || ((std::get<1>(m2nTuple) == connector) && (std::get<2>(m2nTuple) == acceptor));
                      });
 }
 
 void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag)
 {
   if (tag.getNamespace() == TAG) {
-    std::string from = tag.getStringAttributeValue("from");
-    std::string to   = tag.getStringAttributeValue("to");
-    checkDuplicates(from, to);
+    std::string acceptor  = tag.getStringAttributeValue("acceptor");
+    std::string connector = tag.getStringAttributeValue("connector");
+    checkDuplicates(acceptor, connector);
     bool enforceGatherScatter = tag.getBooleanAttributeValue(ATTR_ENFORCE_GATHER_SCATTER);
     bool useTwoLevelInit      = tag.getBooleanAttributeValue(ATTR_USE_TWO_LEVEL_INIT);
 
@@ -214,21 +214,21 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
     PRECICE_ASSERT(distrFactory.get() != nullptr);
 
     auto m2n = std::make_shared<m2n::M2N>(com, distrFactory, false, useTwoLevelInit);
-    _m2ns.emplace_back(m2n, from, to);
+    _m2ns.emplace_back(m2n, acceptor, connector);
   }
 }
 
 void M2NConfiguration::checkDuplicates(
-    const std::string &from,
-    const std::string &to)
+    const std::string &acceptor,
+    const std::string &connector)
 {
   using std::get;
   bool alreadyAdded = false;
   for (M2NTuple &tuple : _m2ns) {
-    alreadyAdded |= (get<1>(tuple) == from) && (get<2>(tuple) == to);
-    alreadyAdded |= (get<2>(tuple) == from) && (get<1>(tuple) == to);
+    alreadyAdded |= (get<1>(tuple) == acceptor) && (get<2>(tuple) == connector);
+    alreadyAdded |= (get<2>(tuple) == acceptor) && (get<1>(tuple) == connector);
   }
-  PRECICE_CHECK(!alreadyAdded, "Multiple m2n communications between participant \"" + from + "\" and \"" + to + "\" are not allowed. Please remove redundant <m2n /> tags between them.");
+  PRECICE_CHECK(!alreadyAdded, "Multiple m2n communications between participant \"" + acceptor + "\" and \"" + connector + "\" are not allowed. Please remove redundant <m2n /> tags between them.");
 }
 
 } // namespace precice::m2n

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -111,7 +111,7 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
                       .setDocumentation(
                           "First participant name involved in communication. For performance reasons, we recommend to use "
                           "the participant with less ranks at the coupling interface as \"acceptor\" in the m2n communication.");
-  auto attrTo = XMLAttribute<std::string>("to")
+  auto attrTo = XMLAttribute<std::string>("connector")
                     .setDocumentation("Second participant name involved in communication.");
 
   for (XMLTag &tag : tags) {

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -31,8 +31,8 @@ public:
     * user names.
     */
   m2n::PtrM2N getM2N(
-      const std::string &from,
-      const std::string &to);
+      const std::string &acceptor,
+      const std::string &connector);
 
   /// Returns all configured communication objects.
   std::vector<M2NTuple> &m2ns()
@@ -40,7 +40,7 @@ public:
     return _m2ns;
   }
 
-  bool isM2NConfigured(const std::string &from, const std::string &to);
+  bool isM2NConfigured(const std::string &acceptor, const std::string &connector);
 
   virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
 
@@ -57,8 +57,8 @@ private:
   std::vector<M2NTuple> _m2ns;
 
   void checkDuplicates(
-      const std::string &from,
-      const std::string &to);
+      const std::string &acceptor,
+      const std::string &connector);
 };
 
 } // namespace m2n

--- a/src/precice/tests/config-checker.xml
+++ b/src/precice/tests/config-checker.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/CouplingOnLine.xml
+++ b/tests/parallel/CouplingOnLine.xml
@@ -26,7 +26,7 @@
     <write-data name="Pressure" mesh="FASTEST_Mesh" />
   </participant>
 
-  <m2n:sockets from="FASTEST" to="Ateles" />
+  <m2n:sockets acceptor="FASTEST" to="Ateles" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="FASTEST" second="Ateles" />

--- a/tests/parallel/CouplingOnLine.xml
+++ b/tests/parallel/CouplingOnLine.xml
@@ -26,7 +26,7 @@
     <write-data name="Pressure" mesh="FASTEST_Mesh" />
   </participant>
 
-  <m2n:sockets acceptor="FASTEST" to="Ateles" />
+  <m2n:sockets acceptor="FASTEST" connector="Ateles" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="FASTEST" second="Ateles" />

--- a/tests/parallel/ExportTimeseries.xml
+++ b/tests/parallel/ExportTimeseries.xml
@@ -34,7 +34,7 @@
     <export:csv directory="timeseries" />
   </participant>
 
-  <m2n:sockets from="ExporterOne" to="ExporterTwo" />
+  <m2n:sockets acceptor="ExporterOne" to="ExporterTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="ExporterOne" second="ExporterTwo" />

--- a/tests/parallel/ExportTimeseries.xml
+++ b/tests/parallel/ExportTimeseries.xml
@@ -34,7 +34,7 @@
     <export:csv directory="timeseries" />
   </participant>
 
-  <m2n:sockets acceptor="ExporterOne" to="ExporterTwo" />
+  <m2n:sockets acceptor="ExporterOne" connector="ExporterTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="ExporterOne" second="ExporterTwo" />

--- a/tests/parallel/GlobalRBFPartitioning.xml
+++ b/tests/parallel/GlobalRBFPartitioning.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/GlobalRBFPartitioning.xml
+++ b/tests/parallel/GlobalRBFPartitioning.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/GlobalRBFPartitioningPETSc.xml
+++ b/tests/parallel/GlobalRBFPartitioningPETSc.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/GlobalRBFPartitioningPETSc.xml
+++ b/tests/parallel/GlobalRBFPartitioningPETSc.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/LocalRBFPartitioning.xml
+++ b/tests/parallel/LocalRBFPartitioning.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/LocalRBFPartitioning.xml
+++ b/tests/parallel/LocalRBFPartitioning.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/LocalRBFPartitioningPETSc.xml
+++ b/tests/parallel/LocalRBFPartitioningPETSc.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/LocalRBFPartitioningPETSc.xml
+++ b/tests/parallel/LocalRBFPartitioningPETSc.xml
@@ -40,7 +40,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/NearestProjectionRePartitioning.xml
+++ b/tests/parallel/NearestProjectionRePartitioning.xml
@@ -29,7 +29,7 @@
     <export:vtk />
   </participant>
 
-  <m2n:sockets acceptor="FluidSolver" to="SolidSolver" />
+  <m2n:sockets acceptor="FluidSolver" connector="SolidSolver" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="FluidSolver" second="SolidSolver" />

--- a/tests/parallel/NearestProjectionRePartitioning.xml
+++ b/tests/parallel/NearestProjectionRePartitioning.xml
@@ -29,7 +29,7 @@
     <export:vtk />
   </participant>
 
-  <m2n:sockets from="FluidSolver" to="SolidSolver" />
+  <m2n:sockets acceptor="FluidSolver" to="SolidSolver" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="FluidSolver" second="SolidSolver" />

--- a/tests/parallel/PrimaryRankSockets.xml
+++ b/tests/parallel/PrimaryRankSockets.xml
@@ -37,7 +37,7 @@
     <write-data name="MyData2" mesh="SerialMesh" />
   </participant>
 
-  <m2n:sockets acceptor="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
+  <m2n:sockets acceptor="ParallelSolver" connector="SerialSolver" enforce-gather-scatter="true" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="ParallelSolver" second="SerialSolver" />

--- a/tests/parallel/PrimaryRankSockets.xml
+++ b/tests/parallel/PrimaryRankSockets.xml
@@ -37,7 +37,7 @@
     <write-data name="MyData2" mesh="SerialMesh" />
   </participant>
 
-  <m2n:sockets from="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
+  <m2n:sockets acceptor="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="ParallelSolver" second="SerialSolver" />

--- a/tests/parallel/TestBoundingBoxInitialization.xml
+++ b/tests/parallel/TestBoundingBoxInitialization.xml
@@ -27,7 +27,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="Fluid" to="Structure" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="Fluid" connector="Structure" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/TestBoundingBoxInitialization.xml
+++ b/tests/parallel/TestBoundingBoxInitialization.xml
@@ -27,7 +27,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="Fluid" to="Structure" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="Fluid" to="Structure" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/TestBoundingBoxInitializationTwoWay.xml
+++ b/tests/parallel/TestBoundingBoxInitializationTwoWay.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="StructureMesh" />
   </participant>
 
-  <m2n:sockets from="Fluid" to="Structure" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="Fluid" to="Structure" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/TestBoundingBoxInitializationTwoWay.xml
+++ b/tests/parallel/TestBoundingBoxInitializationTwoWay.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="StructureMesh" />
   </participant>
 
-  <m2n:sockets acceptor="Fluid" to="Structure" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="Fluid" connector="Structure" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/TestFinalize.xml
+++ b/tests/parallel/TestFinalize.xml
@@ -38,7 +38,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/TestFinalize.xml
+++ b/tests/parallel/TestFinalize.xml
@@ -38,7 +38,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/UserDefinedMPICommunicator.xml
+++ b/tests/parallel/UserDefinedMPICommunicator.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/UserDefinedMPICommunicator.xml
+++ b/tests/parallel/UserDefinedMPICommunicator.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
@@ -41,7 +41,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
@@ -41,7 +41,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" use-two-level-initialization="true" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" use-two-level-initialization="true" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
@@ -38,7 +38,7 @@
     <read-data name="Forces" mesh="StructureMesh" />
   </participant>
 
-  <m2n:mpi enforce-gather-scatter="true" from="Fluid" to="Structure" />
+  <m2n:mpi enforce-gather-scatter="true" acceptor="Fluid" connector="Structure" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
@@ -38,7 +38,7 @@
     <read-data name="Forces" mesh="StructureMesh" />
   </participant>
 
-  <m2n:mpi acceptor="Fluid" to="Structure" />
+  <m2n:mpi acceptor="Fluid" connector="Structure" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
@@ -38,7 +38,7 @@
     <read-data name="Forces" mesh="StructureMesh" />
   </participant>
 
-  <m2n:mpi from="Fluid" to="Structure" />
+  <m2n:mpi acceptor="Fluid" to="Structure" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
@@ -38,7 +38,7 @@
     <read-data name="Forces" mesh="StructureMesh" />
   </participant>
 
-  <m2n:sockets from="Fluid" to="Structure" />
+  <m2n:sockets acceptor="Fluid" to="Structure" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
@@ -38,7 +38,7 @@
     <read-data name="Forces" mesh="StructureMesh" />
   </participant>
 
-  <m2n:sockets acceptor="Fluid" to="Structure" />
+  <m2n:sockets acceptor="Fluid" connector="Structure" />
 
   <coupling-scheme:serial-explicit>
     <participants first="Fluid" second="Structure" />

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyPrimaryRank.xml
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyPrimaryRank.xml
@@ -37,7 +37,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
+  <m2n:sockets acceptor="ParallelSolver" connector="SerialSolver" enforce-gather-scatter="true" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="ParallelSolver" second="SerialSolver" />

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyPrimaryRank.xml
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyPrimaryRank.xml
@@ -37,7 +37,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
+  <m2n:sockets acceptor="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="ParallelSolver" second="SerialSolver" />

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedPrimaryRank.xml
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedPrimaryRank.xml
@@ -37,7 +37,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
+  <m2n:sockets acceptor="ParallelSolver" connector="SerialSolver" enforce-gather-scatter="true" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="ParallelSolver" second="SerialSolver" />

--- a/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedPrimaryRank.xml
+++ b/tests/parallel/gather-scatter/EnforceGatherScatterEmptyReceivedPrimaryRank.xml
@@ -37,7 +37,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
+  <m2n:sockets acceptor="ParallelSolver" to="SerialSolver" enforce-gather-scatter="true" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="ParallelSolver" second="SerialSolver" />

--- a/tests/parallel/lifecycle/ConstructAndExplicitFinalize.xml
+++ b/tests/parallel/lifecycle/ConstructAndExplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/lifecycle/ConstructAndExplicitFinalize.xml
+++ b/tests/parallel/lifecycle/ConstructAndExplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/lifecycle/ConstructOnly.xml
+++ b/tests/parallel/lifecycle/ConstructOnly.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/lifecycle/ConstructOnly.xml
+++ b/tests/parallel/lifecycle/ConstructOnly.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/lifecycle/Full.xml
+++ b/tests/parallel/lifecycle/Full.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/lifecycle/Full.xml
+++ b/tests/parallel/lifecycle/Full.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/lifecycle/ImplicitFinalize.xml
+++ b/tests/parallel/lifecycle/ImplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/lifecycle/ImplicitFinalize.xml
+++ b/tests/parallel/lifecycle/ImplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
@@ -29,7 +29,7 @@
     <write-data name="Data2" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.xml
@@ -29,7 +29,7 @@
     <write-data name="Data2" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelCube1To3.xml
+++ b/tests/parallel/mapping-volume/ParallelCube1To3.xml
@@ -28,7 +28,7 @@
     <export:vtu />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelCube1To3.xml
+++ b/tests/parallel/mapping-volume/ParallelCube1To3.xml
@@ -28,7 +28,7 @@
     <export:vtu />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelCube3To1.xml
+++ b/tests/parallel/mapping-volume/ParallelCube3To1.xml
@@ -27,7 +27,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelCube3To1.xml
+++ b/tests/parallel/mapping-volume/ParallelCube3To1.xml
@@ -27,7 +27,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelCubeConservative1To3.xml
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative1To3.xml
@@ -27,7 +27,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOneCubeConservative1To3" to="SolverTwoCubeConservative1To3" />
+  <m2n:sockets acceptor="SolverOneCubeConservative1To3" to="SolverTwoCubeConservative1To3" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOneCubeConservative1To3" second="SolverTwoCubeConservative1To3" />

--- a/tests/parallel/mapping-volume/ParallelCubeConservative1To3.xml
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative1To3.xml
@@ -27,7 +27,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOneCubeConservative1To3" to="SolverTwoCubeConservative1To3" />
+  <m2n:sockets acceptor="SolverOneCubeConservative1To3" connector="SolverTwoCubeConservative1To3" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOneCubeConservative1To3" second="SolverTwoCubeConservative1To3" />

--- a/tests/parallel/mapping-volume/ParallelCubeConservative3To1.xml
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative3To1.xml
@@ -31,7 +31,7 @@
     <export:vtu />
   </participant>
 
-  <m2n:sockets from="SolverOneCubeConservative3To1" to="SolverTwoCubeConservative3To1" />
+  <m2n:sockets acceptor="SolverOneCubeConservative3To1" to="SolverTwoCubeConservative3To1" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOneCubeConservative3To1" second="SolverTwoCubeConservative3To1" />

--- a/tests/parallel/mapping-volume/ParallelCubeConservative3To1.xml
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative3To1.xml
@@ -31,7 +31,7 @@
     <export:vtu />
   </participant>
 
-  <m2n:sockets acceptor="SolverOneCubeConservative3To1" to="SolverTwoCubeConservative3To1" />
+  <m2n:sockets acceptor="SolverOneCubeConservative3To1" connector="SolverTwoCubeConservative3To1" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOneCubeConservative3To1" second="SolverTwoCubeConservative3To1" />

--- a/tests/parallel/mapping-volume/ParallelSquare1To2.xml
+++ b/tests/parallel/mapping-volume/ParallelSquare1To2.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelSquare1To2.xml
+++ b/tests/parallel/mapping-volume/ParallelSquare1To2.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelSquare2To1.xml
+++ b/tests/parallel/mapping-volume/ParallelSquare2To1.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelSquare2To1.xml
+++ b/tests/parallel/mapping-volume/ParallelSquare2To1.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelSquareConservative1To2.xml
+++ b/tests/parallel/mapping-volume/ParallelSquareConservative1To2.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelSquareConservative1To2.xml
+++ b/tests/parallel/mapping-volume/ParallelSquareConservative1To2.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.xml
+++ b/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.xml
+++ b/tests/parallel/mapping-volume/ParallelTriangleConservative2To1.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
@@ -37,7 +37,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN1.xml
+++ b/tests/quasi-newton/serial/TestQN1.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN1.xml
+++ b/tests/quasi-newton/serial/TestQN1.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN2.xml
+++ b/tests/quasi-newton/serial/TestQN2.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN2.xml
+++ b/tests/quasi-newton/serial/TestQN2.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN3.xml
+++ b/tests/quasi-newton/serial/TestQN3.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN3.xml
+++ b/tests/quasi-newton/serial/TestQN3.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/AitkenAcceleration.xml
+++ b/tests/serial/AitkenAcceleration.xml
@@ -32,7 +32,7 @@
     <write-data name="Data2" mesh="B-Mesh" />
   </participant>
 
-  <m2n:sockets from="B" to="A" />
+  <m2n:sockets acceptor="B" to="A" />
 
   <coupling-scheme:serial-implicit>
     <participants first="B" second="A" />

--- a/tests/serial/AitkenAcceleration.xml
+++ b/tests/serial/AitkenAcceleration.xml
@@ -32,7 +32,7 @@
     <write-data name="Data2" mesh="B-Mesh" />
   </participant>
 
-  <m2n:sockets acceptor="B" to="A" />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:serial-implicit>
     <participants first="B" second="A" />

--- a/tests/serial/PreconditionerBug.xml
+++ b/tests/serial/PreconditionerBug.xml
@@ -36,7 +36,7 @@
     <write-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/PreconditionerBug.xml
+++ b/tests/serial/PreconditionerBug.xml
@@ -36,7 +36,7 @@
     <write-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/SendMeshToMultipleParticipants.xml
+++ b/tests/serial/SendMeshToMultipleParticipants.xml
@@ -33,8 +33,8 @@
     <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/SendMeshToMultipleParticipants.xml
+++ b/tests/serial/SendMeshToMultipleParticipants.xml
@@ -33,8 +33,8 @@
     <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="conservative" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/SummationActionTwoSources.xml
+++ b/tests/serial/SummationActionTwoSources.xml
@@ -50,8 +50,8 @@
     <write-data name="SourceTwo" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverSourceOne" to="SolverTarget" />
-  <m2n:sockets acceptor="SolverSourceTwo" to="SolverTarget" />
+  <m2n:sockets acceptor="SolverSourceOne" connector="SolverTarget" />
+  <m2n:sockets acceptor="SolverSourceTwo" connector="SolverTarget" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverSourceOne" second="SolverTarget" />

--- a/tests/serial/SummationActionTwoSources.xml
+++ b/tests/serial/SummationActionTwoSources.xml
@@ -50,8 +50,8 @@
     <write-data name="SourceTwo" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverSourceOne" to="SolverTarget" />
-  <m2n:sockets from="SolverSourceTwo" to="SolverTarget" />
+  <m2n:sockets acceptor="SolverSourceOne" to="SolverTarget" />
+  <m2n:sockets acceptor="SolverSourceTwo" to="SolverTarget" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverSourceOne" second="SolverTarget" />

--- a/tests/serial/TestExplicitWithDataMultipleReadWrite.xml
+++ b/tests/serial/TestExplicitWithDataMultipleReadWrite.xml
@@ -31,7 +31,7 @@
     <write-data name="DataTwo" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/TestExplicitWithDataMultipleReadWrite.xml
+++ b/tests/serial/TestExplicitWithDataMultipleReadWrite.xml
@@ -31,7 +31,7 @@
     <write-data name="DataTwo" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/TestExplicitWithSolverGeometry.xml
+++ b/tests/serial/TestExplicitWithSolverGeometry.xml
@@ -4,7 +4,7 @@
   <data:vector name="Velocities" />
   <data:vector name="Displacements" />
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <mesh name="MeshOne">
     <use-data name="Forces" />

--- a/tests/serial/TestExplicitWithSolverGeometry.xml
+++ b/tests/serial/TestExplicitWithSolverGeometry.xml
@@ -4,7 +4,7 @@
   <data:vector name="Velocities" />
   <data:vector name="Displacements" />
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <mesh name="MeshOne">
     <use-data name="Forces" />

--- a/tests/serial/TestImplicit.xml
+++ b/tests/serial/TestImplicit.xml
@@ -3,7 +3,7 @@
   <data:vector name="Forces" />
   <data:vector name="Velocities" />
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <mesh name="Square">
     <use-data name="Forces" />

--- a/tests/serial/TestImplicit.xml
+++ b/tests/serial/TestImplicit.xml
@@ -3,7 +3,7 @@
   <data:vector name="Forces" />
   <data:vector name="Velocities" />
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <mesh name="Square">
     <use-data name="Forces" />

--- a/tests/serial/TestReadAPI.xml
+++ b/tests/serial/TestReadAPI.xml
@@ -36,7 +36,7 @@
     <write-data name="DataTwo" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/TestReadAPI.xml
+++ b/tests/serial/TestReadAPI.xml
@@ -36,7 +36,7 @@
     <write-data name="DataTwo" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/action-timings/ActionTimingsExplicit.xml
+++ b/tests/serial/action-timings/ActionTimingsExplicit.xml
@@ -49,7 +49,7 @@
     <action:recorder timing="read-mapping-post" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/action-timings/ActionTimingsExplicit.xml
+++ b/tests/serial/action-timings/ActionTimingsExplicit.xml
@@ -49,7 +49,7 @@
     <action:recorder timing="read-mapping-post" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/action-timings/ActionTimingsImplicit.xml
+++ b/tests/serial/action-timings/ActionTimingsImplicit.xml
@@ -49,7 +49,7 @@
     <action:recorder timing="read-mapping-post" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/action-timings/ActionTimingsImplicit.xml
+++ b/tests/serial/action-timings/ActionTimingsImplicit.xml
@@ -49,7 +49,7 @@
     <action:recorder timing="read-mapping-post" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/circular/Explicit.xml
+++ b/tests/serial/circular/Explicit.xml
@@ -43,9 +43,9 @@
     <mapping:nearest-neighbor direction="write" from="MC" to="MA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="A" to="B" />
-  <m2n:sockets from="B" to="C" />
-  <m2n:sockets from="C" to="A" />
+  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="B" to="C" />
+  <m2n:sockets acceptor="C" to="A" />
 
   <coupling-scheme:serial-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/circular/Explicit.xml
+++ b/tests/serial/circular/Explicit.xml
@@ -43,9 +43,9 @@
     <mapping:nearest-neighbor direction="write" from="MC" to="MA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="A" to="B" />
-  <m2n:sockets acceptor="B" to="C" />
-  <m2n:sockets acceptor="C" to="A" />
+  <m2n:sockets acceptor="A" connector="B" />
+  <m2n:sockets acceptor="B" connector="C" />
+  <m2n:sockets acceptor="C" connector="A" />
 
   <coupling-scheme:serial-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/convergence-measures/testConvergenceMeasures1.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures1.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/convergence-measures/testConvergenceMeasures1.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures1.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/convergence-measures/testConvergenceMeasures2.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures2.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/convergence-measures/testConvergenceMeasures2.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures2.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/convergence-measures/testConvergenceMeasures3.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures3.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/convergence-measures/testConvergenceMeasures3.xml
+++ b/tests/serial/convergence-measures/testConvergenceMeasures3.xml
@@ -36,7 +36,7 @@
     <read-data name="Data1" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
@@ -20,7 +20,7 @@
     <write-data name="Forces" mesh="MeshOne" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
@@ -20,7 +20,7 @@
     <write-data name="Forces" mesh="MeshOne" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/Explicit.xml
+++ b/tests/serial/direct-mesh-access/Explicit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/Explicit.xml
+++ b/tests/serial/direct-mesh-access/Explicit.xml
@@ -16,7 +16,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
@@ -30,7 +30,7 @@
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/ExplicitRead.xml
+++ b/tests/serial/direct-mesh-access/ExplicitRead.xml
@@ -16,7 +16,7 @@
     <write-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/ExplicitRead.xml
+++ b/tests/serial/direct-mesh-access/ExplicitRead.xml
@@ -16,7 +16,7 @@
     <write-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/Implicit.xml
+++ b/tests/serial/direct-mesh-access/Implicit.xml
@@ -25,7 +25,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/direct-mesh-access/Implicit.xml
+++ b/tests/serial/direct-mesh-access/Implicit.xml
@@ -25,7 +25,7 @@
     <read-data name="Velocities" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/explicit/TestExplicitMPI.xml
+++ b/tests/serial/explicit/TestExplicitMPI.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="Test-Square" />
   </participant>
 
-  <m2n:mpi-multiple-ports from="SolverOne" to="SolverTwo" />
+  <m2n:mpi-multiple-ports acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/explicit/TestExplicitMPISingle.xml
+++ b/tests/serial/explicit/TestExplicitMPISingle.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="Test-Square" />
   </participant>
 
-  <m2n:mpi acceptor="SolverOne" to="SolverTwo" />
+  <m2n:mpi acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/explicit/TestExplicitMPISingle.xml
+++ b/tests/serial/explicit/TestExplicitMPISingle.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="Test-Square" />
   </participant>
 
-  <m2n:mpi from="SolverOne" to="SolverTwo" />
+  <m2n:mpi acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/explicit/TestExplicitSockets.xml
+++ b/tests/serial/explicit/TestExplicitSockets.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="Test-Square" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/explicit/TestExplicitSockets.xml
+++ b/tests/serial/explicit/TestExplicitSockets.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="Test-Square" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/Explicit.xml
+++ b/tests/serial/initialize-data/Explicit.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/Explicit.xml
+++ b/tests/serial/initialize-data/Explicit.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/Implicit.xml
+++ b/tests/serial/initialize-data/Implicit.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/Implicit.xml
+++ b/tests/serial/initialize-data/Implicit.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/ImplicitBoth.xml
+++ b/tests/serial/initialize-data/ImplicitBoth.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/ImplicitBoth.xml
+++ b/tests/serial/initialize-data/ImplicitBoth.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/ReadMapping.xml
+++ b/tests/serial/initialize-data/ReadMapping.xml
@@ -26,7 +26,7 @@
     <write-data name="Data" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/ReadMapping.xml
+++ b/tests/serial/initialize-data/ReadMapping.xml
@@ -26,7 +26,7 @@
     <write-data name="Data" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/WriteMapping.xml
+++ b/tests/serial/initialize-data/WriteMapping.xml
@@ -26,7 +26,7 @@
     <write-data name="Data" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/initialize-data/WriteMapping.xml
+++ b/tests/serial/initialize-data/WriteMapping.xml
@@ -26,7 +26,7 @@
     <write-data name="Data" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/ConstructAndExplicitFinalize.xml
+++ b/tests/serial/lifecycle/ConstructAndExplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/ConstructAndExplicitFinalize.xml
+++ b/tests/serial/lifecycle/ConstructAndExplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/ConstructOnly.xml
+++ b/tests/serial/lifecycle/ConstructOnly.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/ConstructOnly.xml
+++ b/tests/serial/lifecycle/ConstructOnly.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/Full.xml
+++ b/tests/serial/lifecycle/Full.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/Full.xml
+++ b/tests/serial/lifecycle/Full.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/ImplicitFinalize.xml
+++ b/tests/serial/lifecycle/ImplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/lifecycle/ImplicitFinalize.xml
+++ b/tests/serial/lifecycle/ImplicitFinalize.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
@@ -37,7 +37,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
@@ -37,7 +37,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteVector.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
@@ -11,7 +11,7 @@
     <use-data name="DataA" />
   </mesh>
 
-  <m2n:sockets from="A" to="B" />
+  <m2n:sockets acceptor="A" to="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadBlockVector.xml
@@ -11,7 +11,7 @@
     <use-data name="DataA" />
   </mesh>
 
-  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="A" connector="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
@@ -11,7 +11,7 @@
     <use-data name="DataA" />
   </mesh>
 
-  <m2n:sockets from="A" to="B" />
+  <m2n:sockets acceptor="A" to="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadScalar.xml
@@ -11,7 +11,7 @@
     <use-data name="DataA" />
   </mesh>
 
-  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="A" connector="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
@@ -11,7 +11,7 @@
     <use-data name="DataA" />
   </mesh>
 
-  <m2n:sockets from="A" to="B" />
+  <m2n:sockets acceptor="A" to="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestUnidirectionalReadVector.xml
@@ -11,7 +11,7 @@
     <use-data name="DataA" />
   </mesh>
 
-  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="A" connector="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mapping-nearest-projection/MappingNearestProjectionEdges.xml
+++ b/tests/serial/mapping-nearest-projection/MappingNearestProjectionEdges.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-projection/MappingNearestProjectionEdges.xml
+++ b/tests/serial/mapping-nearest-projection/MappingNearestProjectionEdges.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesTallKite.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesTallKite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesTallKite.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesTallKite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesWideKite.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesWideKite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesWideKite.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingDiagonalNearestProjectionEdgesWideKite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-projection/QuadMappingNearestProjectionEdges.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingNearestProjectionEdges.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-nearest-projection/QuadMappingNearestProjectionEdges.xml
+++ b/tests/serial/mapping-nearest-projection/QuadMappingNearestProjectionEdges.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-rbf-gaussian/GaussianShapeParameter.xml
+++ b/tests/serial/mapping-rbf-gaussian/GaussianShapeParameter.xml
@@ -30,7 +30,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-rbf-gaussian/GaussianShapeParameter.xml
+++ b/tests/serial/mapping-rbf-gaussian/GaussianShapeParameter.xml
@@ -30,7 +30,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-rbf-gaussian/GaussianSupportRadius.xml
+++ b/tests/serial/mapping-rbf-gaussian/GaussianSupportRadius.xml
@@ -30,7 +30,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-rbf-gaussian/GaussianSupportRadius.xml
+++ b/tests/serial/mapping-rbf-gaussian/GaussianSupportRadius.xml
@@ -30,7 +30,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
@@ -26,7 +26,7 @@
       constraint="scaled-consistent-surface" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
@@ -26,7 +26,7 @@
       constraint="scaled-consistent-surface" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
@@ -26,7 +26,7 @@
       constraint="scaled-consistent-volume" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
@@ -26,7 +26,7 @@
       constraint="scaled-consistent-volume" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
@@ -26,7 +26,7 @@
       constraint="scaled-consistent-volume" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
@@ -26,7 +26,7 @@
       constraint="scaled-consistent-volume" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraConservativeRead.xml
+++ b/tests/serial/mapping-volume/OneTetraConservativeRead.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraConservativeRead.xml
+++ b/tests/serial/mapping-volume/OneTetraConservativeRead.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraConservativeWrite.xml
+++ b/tests/serial/mapping-volume/OneTetraConservativeWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraConservativeWrite.xml
+++ b/tests/serial/mapping-volume/OneTetraConservativeWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraRead.xml
+++ b/tests/serial/mapping-volume/OneTetraRead.xml
@@ -33,7 +33,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraRead.xml
+++ b/tests/serial/mapping-volume/OneTetraRead.xml
@@ -33,7 +33,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraWrite.xml
+++ b/tests/serial/mapping-volume/OneTetraWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTetraWrite.xml
+++ b/tests/serial/mapping-volume/OneTetraWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleConservativeRead.xml
+++ b/tests/serial/mapping-volume/OneTriangleConservativeRead.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleConservativeRead.xml
+++ b/tests/serial/mapping-volume/OneTriangleConservativeRead.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleConservativeWrite.xml
+++ b/tests/serial/mapping-volume/OneTriangleConservativeWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleConservativeWrite.xml
+++ b/tests/serial/mapping-volume/OneTriangleConservativeWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleRead.xml
+++ b/tests/serial/mapping-volume/OneTriangleRead.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleRead.xml
+++ b/tests/serial/mapping-volume/OneTriangleRead.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleWrite.xml
+++ b/tests/serial/mapping-volume/OneTriangleWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mapping-volume/OneTriangleWrite.xml
+++ b/tests/serial/mapping-volume/OneTriangleWrite.xml
@@ -26,7 +26,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/mesh-requirements/NearestNeighborA.xml
+++ b/tests/serial/mesh-requirements/NearestNeighborA.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets from="A" to="B" />
+  <m2n:sockets acceptor="A" to="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mesh-requirements/NearestNeighborA.xml
+++ b/tests/serial/mesh-requirements/NearestNeighborA.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="A" connector="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mesh-requirements/NearestNeighborB.xml
+++ b/tests/serial/mesh-requirements/NearestNeighborB.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets from="A" to="B" />
+  <m2n:sockets acceptor="A" to="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mesh-requirements/NearestNeighborB.xml
+++ b/tests/serial/mesh-requirements/NearestNeighborB.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="A" connector="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mesh-requirements/NearestProjection2DA.xml
+++ b/tests/serial/mesh-requirements/NearestProjection2DA.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets from="A" to="B" />
+  <m2n:sockets acceptor="A" to="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mesh-requirements/NearestProjection2DA.xml
+++ b/tests/serial/mesh-requirements/NearestProjection2DA.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="A" connector="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mesh-requirements/NearestProjection2DB.xml
+++ b/tests/serial/mesh-requirements/NearestProjection2DB.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets from="A" to="B" />
+  <m2n:sockets acceptor="A" to="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/mesh-requirements/NearestProjection2DB.xml
+++ b/tests/serial/mesh-requirements/NearestProjection2DB.xml
@@ -10,7 +10,7 @@
     <use-data name="Data" />
   </mesh>
 
-  <m2n:sockets acceptor="A" to="B" />
+  <m2n:sockets acceptor="A" connector="B" />
 
   <participant name="A">
     <provide-mesh name="MeshA" />

--- a/tests/serial/multi-coupling/MultiCoupling.xml
+++ b/tests/serial/multi-coupling/MultiCoupling.xml
@@ -109,9 +109,9 @@
     <read-data name="Forces3" mesh="SOLIDZ_Mesh3" />
   </participant>
 
-  <m2n:sockets from="NASTIN" to="SOLIDZ1" />
-  <m2n:sockets from="NASTIN" to="SOLIDZ2" />
-  <m2n:sockets from="NASTIN" to="SOLIDZ3" />
+  <m2n:sockets acceptor="NASTIN" to="SOLIDZ1" />
+  <m2n:sockets acceptor="NASTIN" to="SOLIDZ2" />
+  <m2n:sockets acceptor="NASTIN" to="SOLIDZ3" />
 
   <coupling-scheme:multi>
     <participant name="SOLIDZ1" />

--- a/tests/serial/multi-coupling/MultiCoupling.xml
+++ b/tests/serial/multi-coupling/MultiCoupling.xml
@@ -109,9 +109,9 @@
     <read-data name="Forces3" mesh="SOLIDZ_Mesh3" />
   </participant>
 
-  <m2n:sockets acceptor="NASTIN" to="SOLIDZ1" />
-  <m2n:sockets acceptor="NASTIN" to="SOLIDZ2" />
-  <m2n:sockets acceptor="NASTIN" to="SOLIDZ3" />
+  <m2n:sockets acceptor="NASTIN" connector="SOLIDZ1" />
+  <m2n:sockets acceptor="NASTIN" connector="SOLIDZ2" />
+  <m2n:sockets acceptor="NASTIN" connector="SOLIDZ3" />
 
   <coupling-scheme:multi>
     <participant name="SOLIDZ1" />

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers1.xml
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers1.xml
@@ -86,11 +86,11 @@
     <mapping:nearest-neighbor direction="read" from="MeshC2" to="MeshD" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverA" to="SolverB" />
-  <m2n:sockets acceptor="SolverB" to="SolverC" />
-  <m2n:sockets acceptor="SolverC" to="SolverD" />
-  <m2n:sockets acceptor="SolverC" to="SolverA" />
-  <m2n:sockets acceptor="SolverD" to="SolverA" />
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
+  <m2n:sockets acceptor="SolverC" connector="SolverD" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverD" connector="SolverA" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers1.xml
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers1.xml
@@ -86,11 +86,11 @@
     <mapping:nearest-neighbor direction="read" from="MeshC2" to="MeshD" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverA" to="SolverB" />
-  <m2n:sockets from="SolverB" to="SolverC" />
-  <m2n:sockets from="SolverC" to="SolverD" />
-  <m2n:sockets from="SolverC" to="SolverA" />
-  <m2n:sockets from="SolverD" to="SolverA" />
+  <m2n:sockets acceptor="SolverA" to="SolverB" />
+  <m2n:sockets acceptor="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverC" to="SolverD" />
+  <m2n:sockets acceptor="SolverC" to="SolverA" />
+  <m2n:sockets acceptor="SolverD" to="SolverA" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers2.xml
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers2.xml
@@ -86,11 +86,11 @@
     <mapping:nearest-neighbor direction="read" from="MeshC2" to="MeshD" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverA" to="SolverB" />
-  <m2n:sockets acceptor="SolverB" to="SolverC" />
-  <m2n:sockets acceptor="SolverC" to="SolverD" />
-  <m2n:sockets acceptor="SolverC" to="SolverA" />
-  <m2n:sockets acceptor="SolverD" to="SolverA" />
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
+  <m2n:sockets acceptor="SolverC" connector="SolverD" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverD" connector="SolverA" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingFourSolvers2.xml
+++ b/tests/serial/multi-coupling/MultiCouplingFourSolvers2.xml
@@ -86,11 +86,11 @@
     <mapping:nearest-neighbor direction="read" from="MeshC2" to="MeshD" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverA" to="SolverB" />
-  <m2n:sockets from="SolverB" to="SolverC" />
-  <m2n:sockets from="SolverC" to="SolverD" />
-  <m2n:sockets from="SolverC" to="SolverA" />
-  <m2n:sockets from="SolverD" to="SolverA" />
+  <m2n:sockets acceptor="SolverA" to="SolverB" />
+  <m2n:sockets acceptor="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverC" to="SolverD" />
+  <m2n:sockets acceptor="SolverC" to="SolverA" />
+  <m2n:sockets acceptor="SolverD" to="SolverA" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.xml
@@ -55,9 +55,9 @@
     <read-data name="DataBC" mesh="MeshC" />
   </participant>
 
-  <m2n:sockets from="SolverA" to="SolverB" />
-  <m2n:sockets from="SolverC" to="SolverA" />
-  <m2n:sockets from="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverA" to="SolverB" />
+  <m2n:sockets acceptor="SolverC" to="SolverA" />
+  <m2n:sockets acceptor="SolverB" to="SolverC" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers1.xml
@@ -55,9 +55,9 @@
     <read-data name="DataBC" mesh="MeshC" />
   </participant>
 
-  <m2n:sockets acceptor="SolverA" to="SolverB" />
-  <m2n:sockets acceptor="SolverC" to="SolverA" />
-  <m2n:sockets acceptor="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.xml
@@ -57,9 +57,9 @@
     <mapping:nearest-neighbor direction="read" from="MeshB2" to="MeshC" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverA" to="SolverB" />
-  <m2n:sockets from="SolverC" to="SolverA" />
-  <m2n:sockets from="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverA" to="SolverB" />
+  <m2n:sockets acceptor="SolverC" to="SolverA" />
+  <m2n:sockets acceptor="SolverB" to="SolverC" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers2.xml
@@ -57,9 +57,9 @@
     <mapping:nearest-neighbor direction="read" from="MeshB2" to="MeshC" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverA" to="SolverB" />
-  <m2n:sockets acceptor="SolverC" to="SolverA" />
-  <m2n:sockets acceptor="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.xml
@@ -57,9 +57,9 @@
     <mapping:nearest-neighbor direction="read" from="MeshB2" to="MeshC" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverA" to="SolverB" />
-  <m2n:sockets from="SolverC" to="SolverA" />
-  <m2n:sockets from="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverA" to="SolverB" />
+  <m2n:sockets acceptor="SolverC" to="SolverA" />
+  <m2n:sockets acceptor="SolverB" to="SolverC" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers3.xml
@@ -57,9 +57,9 @@
     <mapping:nearest-neighbor direction="read" from="MeshB2" to="MeshC" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverA" to="SolverB" />
-  <m2n:sockets acceptor="SolverC" to="SolverA" />
-  <m2n:sockets acceptor="SolverB" to="SolverC" />
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
 
   <coupling-scheme:multi>
     <participant name="SolverA" control="yes" />

--- a/tests/serial/multiple-mappings/MultipleReadFromMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleReadFromMappings.xml
@@ -33,7 +33,7 @@
     <write-data name="Pressure" mesh="MeshB" />
   </participant>
 
-  <m2n:sockets acceptor="B" to="A" />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleReadFromMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleReadFromMappings.xml
@@ -33,7 +33,7 @@
     <write-data name="Pressure" mesh="MeshB" />
   </participant>
 
-  <m2n:sockets from="B" to="A" />
+  <m2n:sockets acceptor="B" to="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleReadToMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleReadToMappings.xml
@@ -41,7 +41,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="B" to="A" />
+  <m2n:sockets acceptor="B" to="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleReadToMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleReadToMappings.xml
@@ -41,7 +41,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" to="A" />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappings.xml
@@ -38,7 +38,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" to="A" />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappings.xml
@@ -38,7 +38,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="B" to="A" />
+  <m2n:sockets acceptor="B" to="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.xml
@@ -45,7 +45,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="B" to="A" />
+  <m2n:sockets acceptor="B" to="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteFromMappingsAndData.xml
@@ -45,7 +45,7 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" to="A" />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleWriteToMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteToMappings.xml
@@ -50,7 +50,7 @@
     <read-data name="DisplacementSum" mesh="MeshB" />
   </participant>
 
-  <m2n:sockets from="B" to="A" />
+  <m2n:sockets acceptor="B" to="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/multiple-mappings/MultipleWriteToMappings.xml
+++ b/tests/serial/multiple-mappings/MultipleWriteToMappings.xml
@@ -50,7 +50,7 @@
     <read-data name="DisplacementSum" mesh="MeshB" />
   </participant>
 
-  <m2n:sockets acceptor="B" to="A" />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/serial/three-solvers/ThreeSolversExplicitExplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversExplicitExplicit.xml
@@ -33,8 +33,8 @@
     <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshD" constraint="conservative" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversExplicitExplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversExplicitExplicit.xml
@@ -33,8 +33,8 @@
     <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshD" constraint="conservative" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
@@ -47,8 +47,8 @@
     <mapping:nearest-neighbor direction="write" from="MeshD" to="MeshA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
@@ -47,8 +47,8 @@
     <mapping:nearest-neighbor direction="write" from="MeshD" to="MeshA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversFirstParticipant.xml
+++ b/tests/serial/three-solvers/ThreeSolversFirstParticipant.xml
@@ -48,8 +48,8 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverTwo" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverTwo" to="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversFirstParticipant.xml
+++ b/tests/serial/three-solvers/ThreeSolversFirstParticipant.xml
@@ -48,8 +48,8 @@
       constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverTwo" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverTwo" connector="SolverThree" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
@@ -47,8 +47,8 @@
     <mapping:nearest-neighbor direction="write" from="MeshD" to="MeshA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
@@ -47,8 +47,8 @@
     <mapping:nearest-neighbor direction="write" from="MeshD" to="MeshA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversParallel.xml
+++ b/tests/serial/three-solvers/ThreeSolversParallel.xml
@@ -47,8 +47,8 @@
     <mapping:nearest-neighbor direction="write" from="MeshD" to="MeshA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/three-solvers/ThreeSolversParallel.xml
+++ b/tests/serial/three-solvers/ThreeSolversParallel.xml
@@ -47,8 +47,8 @@
     <mapping:nearest-neighbor direction="write" from="MeshD" to="MeshA" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="Test-Square" />
   </participant>
 
-  <m2n:mpi acceptor="SolverOne" to="SolverTwo" />
+  <m2n:mpi acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="Forces" mesh="Test-Square" />
   </participant>
 
-  <m2n:mpi from="SolverOne" to="SolverTwo" />
+  <m2n:mpi acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.xml
@@ -61,8 +61,8 @@
     <read-data name="DataOne" mesh="MeshThree" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:multi>
     <participant name="SolverOne" control="yes" />

--- a/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.xml
@@ -61,8 +61,8 @@
     <read-data name="DataOne" mesh="MeshThree" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:multi>
     <participant name="SolverOne" control="yes" />

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -61,8 +61,8 @@
     <read-data name="DataOne" mesh="MeshThree" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:multi>
     <participant name="SolverOne" control="yes" />

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -61,8 +61,8 @@
     <read-data name="DataOne" mesh="MeshThree" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:multi>
     <participant name="SolverOne" control="yes" />

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -61,8 +61,8 @@
     <read-data name="DataOne" mesh="MeshThree" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
-  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverThree" />
 
   <coupling-scheme:multi>
     <participant name="SolverOne" control="yes" />

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -61,8 +61,8 @@
     <read-data name="DataOne" mesh="MeshThree" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
-  <m2n:sockets from="SolverOne" to="SolverThree" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverThree" />
 
   <coupling-scheme:multi>
     <participant name="SolverOne" control="yes" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -36,7 +36,7 @@
     <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.xml
+++ b/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.xml
@@ -28,7 +28,7 @@
     <watch-integral name="WatchIntegralNoScale" mesh="MeshTwo" scale-with-connectivity="no" />
   </participant>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.xml
+++ b/tests/serial/watch-integral/WatchIntegralScaleAndNoScale.xml
@@ -28,7 +28,7 @@
     <watch-integral name="WatchIntegralNoScale" mesh="MeshTwo" scale-with-connectivity="no" />
   </participant>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverTwo" />

--- a/tests/serial/whitebox/TestConfigurationComsol.xml
+++ b/tests/serial/whitebox/TestConfigurationComsol.xml
@@ -19,7 +19,7 @@
     <use-data name="VelocityDeltas" />
   </mesh>
 
-  <m2n:sockets from="Comsol" to="Peano" />
+  <m2n:sockets acceptor="Comsol" to="Peano" />
 
   <participant name="Peano">
     <provide-mesh name="PeanoNodes" />

--- a/tests/serial/whitebox/TestConfigurationComsol.xml
+++ b/tests/serial/whitebox/TestConfigurationComsol.xml
@@ -19,7 +19,7 @@
     <use-data name="VelocityDeltas" />
   </mesh>
 
-  <m2n:sockets acceptor="Comsol" to="Peano" />
+  <m2n:sockets acceptor="Comsol" connector="Peano" />
 
   <participant name="Peano">
     <provide-mesh name="PeanoNodes" />

--- a/tests/serial/whitebox/TestConfigurationPeano.xml
+++ b/tests/serial/whitebox/TestConfigurationPeano.xml
@@ -19,7 +19,7 @@
     <use-data name="VelocityDeltas" />
   </mesh>
 
-  <m2n:sockets from="Comsol" to="Peano" />
+  <m2n:sockets acceptor="Comsol" to="Peano" />
 
   <participant name="Peano">
     <provide-mesh name="PeanoNodes" />

--- a/tests/serial/whitebox/TestConfigurationPeano.xml
+++ b/tests/serial/whitebox/TestConfigurationPeano.xml
@@ -19,7 +19,7 @@
     <use-data name="VelocityDeltas" />
   </mesh>
 
-  <m2n:sockets acceptor="Comsol" to="Peano" />
+  <m2n:sockets acceptor="Comsol" connector="Peano" />
 
   <participant name="Peano">
     <provide-mesh name="PeanoNodes" />

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.xml
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.xml
@@ -10,7 +10,7 @@
     <use-data name="Velocities" />
   </mesh>
 
-  <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
 
   <participant name="SolverOne">
     <provide-mesh name="Test-Square-One" />

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.xml
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.xml
@@ -10,7 +10,7 @@
     <use-data name="Velocities" />
   </mesh>
 
-  <m2n:sockets acceptor="SolverOne" to="SolverTwo" />
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <participant name="SolverOne">
     <provide-mesh name="Test-Square-One" />


### PR DESCRIPTION
## Main changes of this PR

Renames the `m2n` configuration attributes to `from` -> `acceptor` and `to` -> `connector`

## Motivation and additional information

Closes #1460 

Most changes are provided by awesome `sed`

```bash
find -name '*.xml' | xargs grep -l 'm2n' | xargs -i@ sed -i '/m2n/,/>/{s/to=/connector=/}' @
find -name '*.xml' | xargs grep -l 'm2n' | xargs -i@ sed -i '/m2n/,/>/{s/from=/acceptor=/}' @
```

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* <del> N/AI added a test to cover the proposed changes in our test suite. </del>
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> https://github.com/precice/precice.github.io/pull/278
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
