### PR TITLE
Make waveform non-experimental and first order the default

### DIFF
--- a/docs/changelog/1684.md
+++ b/docs/changelog/1684.md
@@ -1,0 +1,1 @@
+* Use `waveform-order="1"` as default. Makes time interpolation non-experimental, therefore no need to use `experimental="true"`. Note on explicit schemes: Depending on the scheme for some participants `waveform-order="1"` technically leads to a zeroth order interpolation.

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -301,31 +301,8 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
   PRECICE_TRACE(tag.getFullName());
   if (tag.getNamespace() == TAG) {
     if (_config.type == VALUE_SERIAL_EXPLICIT) {
-
-      //Check the waveform order of both participants in the explicit coupling
-      const auto first  = _config.participants[0];
-      const auto second = _config.participants[1];
-
-      auto first_participant = _participantConfig->getParticipant(first);
-      for (const auto &dataContext : first_participant->readDataContexts()) {
-        const int usedOrder = dataContext.getInterpolationOrder();
-        // The first participants waveform order has to be 1 for serial explicit coupling
-        int allowedOrder = 1;
-        if (usedOrder > allowedOrder) {
-          PRECICE_ERROR(
-              "You configured <read-data name=\"{}\" mesh=\"{}\" waveform-order=\"{}\" />, but for the serial explicit coupling scheme only a waveform-order of \"{}\" is allowed for the first participant.",
-              dataContext.getDataName(), dataContext.getMeshName(), usedOrder, allowedOrder);
-        }
-      }
-      auto second_participant = _participantConfig->getParticipant(second);
-      for (const auto &dataContext : second_participant->readDataContexts()) {
-        const int usedOrder = dataContext.getInterpolationOrder();
-        if (usedOrder < 0) {
-          PRECICE_ERROR(
-              "You configured <read-data name=\"{}\" mesh=\"{}\" waveform-order=\"{}\" />, but for the serial explicit coupling scheme the waveform-order must be non-negative for the second participant.",
-              dataContext.getDataName(), dataContext.getMeshName(), usedOrder);
-        }
-      }
+      int maxAllowedOrder = 1; // explicit coupling schemes do not allow higher-order waveform iteration
+      checkWaveformOrderReadData(maxAllowedOrder);
 
       std::string       accessor(_config.participants[0]);
       PtrCouplingScheme scheme = createSerialExplicitCouplingScheme(accessor);
@@ -337,7 +314,7 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
       //_couplingSchemes[accessor] = scheme;
       _config = Config();
     } else if (_config.type == VALUE_PARALLEL_EXPLICIT) {
-      int maxAllowedOrder = 1; // explicit coupling schemes do not allow waveform iteration
+      int maxAllowedOrder = 1; // explicit coupling schemes do not allow higher-order waveform iteration
       checkWaveformOrderReadData(maxAllowedOrder);
 
       std::string       accessor(_config.participants[0]);

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -301,9 +301,6 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
   PRECICE_TRACE(tag.getFullName());
   if (tag.getNamespace() == TAG) {
     if (_config.type == VALUE_SERIAL_EXPLICIT) {
-      int maxAllowedOrder = 1; // explicit coupling schemes do not allow higher-order waveform iteration
-      checkWaveformOrderReadData(maxAllowedOrder);
-
       std::string       accessor(_config.participants[0]);
       PtrCouplingScheme scheme = createSerialExplicitCouplingScheme(accessor);
       addCouplingScheme(scheme, accessor);
@@ -314,9 +311,6 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
       //_couplingSchemes[accessor] = scheme;
       _config = Config();
     } else if (_config.type == VALUE_PARALLEL_EXPLICIT) {
-      int maxAllowedOrder = 1; // explicit coupling schemes do not allow higher-order waveform iteration
-      checkWaveformOrderReadData(maxAllowedOrder);
-
       std::string       accessor(_config.participants[0]);
       PtrCouplingScheme scheme = createParallelExplicitCouplingScheme(accessor);
       addCouplingScheme(scheme, accessor);
@@ -1039,22 +1033,6 @@ void CouplingSchemeConfiguration::checkIfDataIsExchanged(
                 "Data \"{}\" is currently not exchanged over the respective mesh on which it is used for convergence measures and/or iteration acceleration. "
                 "Please check the <exchange ... /> and <...-convergence-measure ... /> tags in the <coupling-scheme:... /> of your precice-config.xml.",
                 dataName);
-}
-
-void CouplingSchemeConfiguration::checkWaveformOrderReadData(
-    int maxAllowedOrder) const
-{
-  for (const precice::impl::PtrParticipant &participant : _participantConfig->getParticipants()) {
-    for (const auto &dataContext : participant->readDataContexts()) {
-      const int usedOrder = dataContext.getInterpolationOrder();
-      PRECICE_ASSERT(usedOrder >= 0); // ensure that usedOrder was set
-      if (usedOrder > maxAllowedOrder) {
-        PRECICE_ERROR(
-            "You configured <read-data name=\"{}\" mesh=\"{}\" waveform-order=\"{}\" />, but for the coupling scheme you are using only a maximum waveform-order of \"{}\" is allowed.",
-            dataContext.getDataName(), dataContext.getMeshName(), usedOrder, maxAllowedOrder);
-      }
-    }
-  }
 }
 
 void CouplingSchemeConfiguration::checkSerialImplicitAccelerationData(

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -125,8 +125,6 @@ private:
   const std::string VALUE_FIXED;
   const std::string VALUE_FIRST_PARTICIPANT;
 
-  bool _experimental = false;
-
   struct ConvergenceMeasureDefintion {
     mesh::PtrData               data;
     bool                        suffices;

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -275,9 +275,6 @@ private:
   void checkIfDataIsExchanged(
       DataID dataID) const;
 
-  void checkWaveformOrderReadData(
-      int maxAllowedOrder) const;
-
   void checkSerialImplicitAccelerationData(
       DataID dataID, const std::string &first, const std::string &second) const;
 

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -78,7 +78,6 @@ void Configuration::xmlTagCallback(const xml::ConfigurationContext &context, xml
     _meshConfiguration->setDimensions(_dimensions);
     _participantConfiguration->setDimensions(_dimensions);
     _experimental = tag.getBooleanAttributeValue("experimental");
-    _couplingSchemeConfiguration->setExperimental(_experimental);
     _participantConfiguration->setExperimental(_experimental);
   } else {
     PRECICE_UNREACHABLE("Received callback from unknown tag '{}'.", tag.getName());

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -334,9 +334,6 @@ void ParticipantConfiguration::xmlTagCallback(
     mesh::PtrData data          = getData(mesh, dataName);
     int           waveformOrder = tag.getIntAttributeValue(ATTR_ORDER);
     if (waveformOrder != time::Time::DEFAULT_INTERPOLATION_ORDER) {
-      if (!_experimental) {
-        PRECICE_ERROR("You tried to configure the read data with name \"{}\" to use the waveform-order=\"{}\", which is currently still experimental. Please set experimental=\"true\", if you want to use this feature.", dataName, waveformOrder);
-      }
       if (waveformOrder < time::Time::MIN_INTERPOLATION_ORDER || waveformOrder > time::Time::MAX_INTERPOLATION_ORDER) {
         PRECICE_ERROR("You tried to configure the read data with name \"{}\" to use the waveform-order=\"{}\", but the order must be between \"{}\" and \"{}\". Please use an order in the allowed range.", dataName, waveformOrder, time::Time::MIN_INTERPOLATION_ORDER, time::Time::MAX_INTERPOLATION_ORDER);
       }

--- a/src/time/Time.cpp
+++ b/src/time/Time.cpp
@@ -2,7 +2,7 @@
 
 namespace precice::time {
 
-const int Time::DEFAULT_INTERPOLATION_ORDER = 0;
+const int Time::DEFAULT_INTERPOLATION_ORDER = 1;
 
 const int Time::MIN_INTERPOLATION_ORDER = 0;
 

--- a/tests/serial/TestReadAPI.xml
+++ b/tests/serial/TestReadAPI.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="True">
+<precice-configuration dimensions="3">
   <data:vector name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,7 +32,7 @@
       from="MeshOne"
       to="MeshTwo"
       constraint="consistent" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
     <write-data name="DataTwo" mesh="MeshTwo" />
   </participant>
 

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
@@ -16,7 +16,7 @@
     <provide-mesh name="MeshOne" />
     <receive-mesh name="MeshTwo" from="SolverTwo" safety-factor="0" direct-access="true" />
     <write-data name="Velocities" mesh="MeshTwo" />
-    <read-data name="Forces" mesh="MeshOne" waveform-order="1" />
+    <read-data name="Forces" mesh="MeshOne" />
     <mapping:nearest-neighbor
       direction="read"
       from="MeshTwo"
@@ -26,7 +26,7 @@
 
   <participant name="SolverTwo">
     <provide-mesh name="MeshTwo" />
-    <read-data name="Velocities" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="Velocities" mesh="MeshTwo" />
     <write-data name="Forces" mesh="MeshTwo" />
   </participant>
 

--- a/tests/serial/mapping-scaled-consistent/helpers.cpp
+++ b/tests/serial/mapping-scaled-consistent/helpers.cpp
@@ -48,6 +48,15 @@ void testQuadMappingScaledConsistent(const std::string configFile, const TestCon
     BOOST_REQUIRE(mesh.edges().empty());
     BOOST_REQUIRE(mesh.triangles().size() == 2);
 
+    auto   dataAID  = "DataOne";
+    int    ids[]    = {idA, idB, idC, idD};
+    double values[] = {valOneA, valOneB, valOneC, valOneD};
+
+    // Hotfix for https://github.com/precice/precice/issues/1686
+    if (participant.requiresInitialData()) {
+      participant.writeData(meshOneID, dataAID, ids, values);
+    }
+
     // Initialize, thus sending the mesh.
     participant.initialize();
     double maxDt = participant.getMaxTimeStepSize();
@@ -56,9 +65,6 @@ void testQuadMappingScaledConsistent(const std::string configFile, const TestCon
     BOOST_TEST(participant.isCouplingOngoing(), "Sending participant should have to advance once!");
 
     // Write the data to be send.
-    auto   dataAID  = "DataOne";
-    int    ids[]    = {idA, idB, idC, idD};
-    double values[] = {valOneA, valOneB, valOneC, valOneD};
     participant.writeData(meshOneID, dataAID, ids, values);
 
     // Advance, thus send the data to the receiving partner.
@@ -143,15 +149,21 @@ void testQuadMappingScaledConsistentVolumetric(const std::string configFile, con
     BOOST_REQUIRE(mesh.vertices().size() == 5);
     BOOST_REQUIRE(mesh.triangles().size() == 3);
 
+    auto   dataAID  = "DataOne";
+    int    ids[]    = {idA, idB, idC, idD, idExtra};
+    double values[] = {valOneA, valOneB, valOneC, valOneD, valOneExtra};
+
+    // Hotfix for https://github.com/precice/precice/issues/1686
+    if (participant.requiresInitialData()) {
+      participant.writeData(meshOneID, dataAID, ids, values);
+    }
+
     // Initialize, thus sending the mesh.
     participant.initialize();
     double maxDt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Sending participant should have to advance once!");
 
     // Write the data to be send.
-    auto   dataAID  = "DataOne";
-    int    ids[]    = {idA, idB, idC, idD, idExtra};
-    double values[] = {valOneA, valOneB, valOneC, valOneD, valOneExtra};
     participant.writeData(meshOneID, dataAID, ids, values);
 
     // Advance, thus send the data to the receiving partner.
@@ -244,15 +256,21 @@ void testTetraScaledConsistentVolumetric(const std::string configFile, const Tes
     BOOST_REQUIRE(mesh.vertices().size() == 5);
     BOOST_REQUIRE(mesh.tetrahedra().size() == 2);
 
+    auto   dataAID  = "DataOne";
+    int    ids[]    = {idA, idB, idC, idD, idExtra};
+    double values[] = {valOneA, valOneB, valOneC, valOneD, valOneExtra};
+
+    // Hotfix for https://github.com/precice/precice/issues/1686
+    if (participant.requiresInitialData()) {
+      participant.writeData(meshOneID, dataAID, ids, values);
+    }
+
     // Initialize, thus sending the mesh.
     participant.initialize();
     double maxDt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Sending participant should have to advance once!");
 
     // Write the data to be send.
-    auto   dataAID  = "DataOne";
-    int    ids[]    = {idA, idB, idC, idD, idExtra};
-    double values[] = {valOneA, valOneB, valOneC, valOneD, valOneExtra};
     participant.writeData(meshOneID, dataAID, ids, values);
 
     // Advance, thus send the data to the receiving partner.

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnA.xml
@@ -32,6 +32,6 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" initialize="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
@@ -32,6 +32,6 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
@@ -23,7 +23,7 @@
       from="MeshOne"
       to="MeshTwo"
       constraint="scaled-consistent-surface" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testQuadMappingScaledConsistentOnB.xml
@@ -23,7 +23,7 @@
       from="MeshOne"
       to="MeshTwo"
       constraint="scaled-consistent-surface" />
-    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnA.xml
@@ -32,6 +32,6 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" initialize="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
@@ -23,7 +23,7 @@
       from="MeshOne"
       to="MeshTwo"
       constraint="scaled-consistent-volume" />
-    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
@@ -32,6 +32,6 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
+++ b/tests/serial/mapping-scaled-consistent/testTetraOnB.xml
@@ -23,7 +23,7 @@
       from="MeshOne"
       to="MeshTwo"
       constraint="scaled-consistent-volume" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnA2D.xml
@@ -32,6 +32,6 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" initialize="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
@@ -23,7 +23,7 @@
       from="MeshOne"
       to="MeshTwo"
       constraint="scaled-consistent-volume" />
-    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
@@ -32,6 +32,6 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
+++ b/tests/serial/mapping-scaled-consistent/testVolumetricOnB2D.xml
@@ -23,7 +23,7 @@
       from="MeshOne"
       to="MeshTwo"
       constraint="scaled-consistent-volume" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="0" />
   </participant>
 
   <participant name="SolverTwo">

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="0" />
   </participant>
 
   <participant name="SolverTwo">

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="0" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithWaveform.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="0" />
   </participant>
 
   <participant name="SolverTwo">

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -23,8 +23,8 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" />
-    <read-data name="DataThree" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataThree" mesh="MeshOne" waveform-order="1" />
   </participant>
 
   <participant name="SolverTwo">
@@ -41,7 +41,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
   <participant name="SolverThree">
@@ -58,7 +58,7 @@
       to="MeshThree"
       constraint="consistent" />
     <write-data name="DataThree" mesh="MeshThree" />
-    <read-data name="DataOne" mesh="MeshThree" />
+    <read-data name="DataOne" mesh="MeshThree" waveform-order="0" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -23,8 +23,8 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
-    <read-data name="DataThree" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="0" />
+    <read-data name="DataThree" mesh="MeshOne" waveform-order="0" />
   </participant>
 
   <participant name="SolverTwo">

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
   <data:scalar name="DataThree" />
@@ -23,8 +23,8 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
-    <read-data name="DataThree" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+    <read-data name="DataThree" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -41,7 +41,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <participant name="SolverThree">
@@ -58,7 +58,7 @@
       to="MeshThree"
       constraint="consistent" />
     <write-data name="DataThree" mesh="MeshThree" />
-    <read-data name="DataOne" mesh="MeshThree" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshThree" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="0" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="0" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="0" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingZero.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="1" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="1" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets from="SolverOne" to="SolverTwo" />

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingZero.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration dimensions="3">
   <data:scalar name="DataOne" />
   <data:scalar name="DataTwo" />
 


### PR DESCRIPTION
## Main changes of this PR

* Removes requirement for setting `experimental="true"`, if waveform interpolation is used.
* Changes default waveform order to first order.

## Motivation and additional information

This is our intended default behavior for version 3.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
