### PR TITLE
Add configuration porter

### DIFF
--- a/tools/porting/README.md
+++ b/tools/porting/README.md
@@ -1,0 +1,8 @@
+# Porting Tools
+
+## Porting configuration from version 2 to version 3
+
+The tool `precice-2-to-3` ports a configuration file of precice version 2 to version 3.
+It requires python 3.6 and the python package `lxml` to be installed on the system.
+
+You may still need to adjust the resulting configuration file, thus it is highly recommended to read the porting guide.

--- a/tools/porting/precice-2-to-3
+++ b/tools/porting/precice-2-to-3
@@ -31,6 +31,7 @@ def parseXML(content):
 def parseXMLFile(filename):
     return parseXML(open(filename, "rb").read())
 
+
 def portParticipant(p):
     # use-mesh -> receive-mesh / provide-mesh
     for um in p.findall("use-mesh"):
@@ -61,8 +62,12 @@ def portParticipant(p):
     removedTimings = ["regular-prior", "regular-post", "on-exchange-prior", "on-exchange-post", "read-mapping-prior", "write-mapping-prior", "on-time-window-complete-post"]
     removedActions = ["ComputeCurvatureAction", "ScaleByDtAction"]
     for a in filter(lambda c: c.tag.startswith("action"), p.iterchildren()):
-        if a.tag.removeprefix("action:") in removedActions or a.tag.attrib["timing"] in removedTimings:
+        if a.tag.removeprefix("action:") in removedActions:
             p.remove(a)
+            print(f"Removed: {a.tag} (action unsupported)")
+        elif a.tag.removeprefix("action:") in removedActions:
+            p.remove(a)
+            print(f"Removed: {a.tag} (timing unsupported)")
     return p
 
 
@@ -70,6 +75,7 @@ def portCouplingScheme(cpl):
     # removed extrapolation order
     for extra in cpl.findall("extrapolation-order"):
         cpl.remove(extra)
+        print("Removed: extrapolation-order")
     return cpl
 
 
@@ -95,7 +101,6 @@ def portConfiguration(root):
     for cpl in root.findall("coupling-schemes"):
         cpl = portCouplingScheme(cpl)
     return root
-
 
 
 if __name__ == '__main__':

--- a/tools/porting/precice-2-to-3
+++ b/tools/porting/precice-2-to-3
@@ -3,6 +3,8 @@
 from lxml import etree
 import sys
 import argparse
+import os
+import shutil
 
 
 if sys.version_info < (3, 6):
@@ -75,6 +77,9 @@ def portConfiguration(root):
     assert root.tag == "precice-configuration"
     # remove SI
     si = root.find("solver-interface")
+    if si is None:
+        print("This configuration already seems to be a version 3 configuration file.")
+        return None
     dims = si.attrib["dimensions"]
     root.attrib.update({"dimensions": dims})
     experimental = si.attrib.get("experimental")
@@ -84,12 +89,13 @@ def portConfiguration(root):
         root.append(c)
     root.remove(si)
 
-    for p in tree.findall("participant"):
+    for p in root.findall("participant"):
         p = portParticipant(p)
 
-    for cpl in tree.findall("coupling-schemes"):
+    for cpl in root.findall("coupling-schemes"):
         cpl = portCouplingScheme(cpl)
     return root
+
 
 
 if __name__ == '__main__':
@@ -97,6 +103,16 @@ if __name__ == '__main__':
     parser.add_argument('infile',  type=str, help="The XML configuration file to update.")
     args = parser.parse_args()
 
-    tree = parseXMLFile(args.infile)
-    ported = portConfiguration(tree)
-    print(etree.tostring(ported).decode())
+    print("Parsing file")
+    root = parseXMLFile(args.infile)
+    ported = portConfiguration(root)
+    if ported is None:
+        sys.exit(1)
+
+    print("Creating backup")
+    shutil.copyfile(args.infile, args.infile+".bak")
+
+    print("Writing file")
+    tree = etree.ElementTree(ported)
+    tree.write(args.infile, pretty_print=True, xml_declaration=True, encoding="utf-8")
+    sys.exit(0)

--- a/tools/porting/precice-2-to-3
+++ b/tools/porting/precice-2-to-3
@@ -23,7 +23,11 @@ def quote(text):
     return f'"{text}"'
 
 
+PRECICE_NAMESPACES = ["basis-function", "mapping"]
+
 def parseXML(content):
+    for ns in PRECICE_NAMESPACES:
+        etree.register_namespace(ns, ns)
     p = etree.XMLParser(recover=True, remove_comments=True)
     return etree.fromstring(content, p)
 
@@ -49,23 +53,25 @@ def portParticipant(p):
             m.attrib["constraint"] = "scaled-consisitent-surface"
 
         # rbf mappings
-        if m.tag.startswith("mapping:rbf"):
-            rbf = m.tag.removeprefix("mapping:rbf-")
-            if isTrue(attrib.get("use-qr-decomposition", "false")):
-                m.tag = "mapping:rbf-global-iterative"
-            else:
-                m.tag = "mapping:rbf-global-direct"
-            rbfattribs = {k: v for k, v in m.attrib.itmes() if k in ["shape-parameter", "support-radius"]}
-            m.append(etree.Element("basis-function:"+rbf, rbfattribs))
+        if m.tag.startswith("mapping:rbf-"):
+            rbf = m.tag.split("-", 1)[1]
+            rbfAttribs = {k: v for k, v in m.attrib.items() if k in ["shape-parameter", "support-radius"]}
+            mapAttribs = {k: v for k, v in m.attrib.items() if k not in ["shape-parameter", "support-radius", "use-qr-decomposition"]}
+
+            mapping = etree.Element("{mapping}rbf", mapAttribs)
+            mapping.append(etree.Element("{basis-function}"+rbf, rbfAttribs))
+            p.remove(m)
+            p.append(mapping)
+
 
     # actions
     removedTimings = ["regular-prior", "regular-post", "on-exchange-prior", "on-exchange-post", "read-mapping-prior", "write-mapping-prior", "on-time-window-complete-post"]
     removedActions = ["ComputeCurvatureAction", "ScaleByDtAction"]
     for a in filter(lambda c: c.tag.startswith("action"), p.iterchildren()):
-        if a.tag.removeprefix("action:") in removedActions:
+        if a.tag.split(":")[1] in removedActions:
             p.remove(a)
             print(f"Removed: {a.tag} (action unsupported)")
-        elif a.tag.removeprefix("action:") in removedActions:
+        elif a.attrib["timing"] in removedTimings:
             p.remove(a)
             print(f"Removed: {a.tag} (timing unsupported)")
     return p
@@ -77,7 +83,6 @@ def portCouplingScheme(cpl):
         cpl.remove(extra)
         print("Removed: extrapolation-order")
     return cpl
-
 
 def portConfiguration(root):
     assert root.tag == "precice-configuration"
@@ -100,6 +105,7 @@ def portConfiguration(root):
 
     for cpl in root.findall("coupling-schemes"):
         cpl = portCouplingScheme(cpl)
+
     return root
 
 

--- a/tools/porting/precice-2-to-3
+++ b/tools/porting/precice-2-to-3
@@ -1,0 +1,102 @@
+#! /usr/bin/env python
+
+from lxml import etree
+import sys
+import argparse
+
+
+if sys.version_info < (3, 6):
+    raise RuntimeError(
+        "This program requires python 3.6 or later but you attempted to run it"
+        " with python {}.{}".format(
+            sys.version_info.major. sys.version_info.minor
+        ))
+
+
+def isTrue(text):
+    return text.lower() in ["yes", "1", "true", "on"]
+
+
+def quote(text):
+    return f'"{text}"'
+
+
+def parseXML(content):
+    p = etree.XMLParser(recover=True, remove_comments=True)
+    return etree.fromstring(content, p)
+
+
+def parseXMLFile(filename):
+    return parseXML(open(filename, "rb").read())
+
+def portParticipant(p):
+    # use-mesh -> receive-mesh / provide-mesh
+    for um in p.findall("use-mesh"):
+        if isTrue(um.attrib.get("provide", "false")):
+            um.tag = "provide-mesh"
+            um.attrib.pop("provide", None)
+        else:
+            um.tag = "receive-mesh"
+            um.attrib.pop("provide", None)
+
+    # mappings
+    for m in filter(lambda c: c.tag.startswith("mapping"), p.iterchildren()):
+        # scaled-consisitent constraint
+        if m.attrib["constraint"] == "scaled-consisitent":
+            m.attrib["constraint"] = "scaled-consisitent-surface"
+
+        # rbf mappings
+        if m.tag.startswith("mapping:rbf"):
+            rbf = m.tag.removeprefix("mapping:rbf-")
+            if isTrue(attrib.get("use-qr-decomposition", "false")):
+                m.tag = "mapping:rbf-global-iterative"
+            else:
+                m.tag = "mapping:rbf-global-direct"
+            rbfattribs = {k: v for k, v in m.attrib.itmes() if k in ["shape-parameter", "support-radius"]}
+            m.append(etree.Element("basis-function:"+rbf, rbfattribs))
+
+    # actions
+    removedTimings = ["regular-prior", "regular-post", "on-exchange-prior", "on-exchange-post", "read-mapping-prior", "write-mapping-prior", "on-time-window-complete-post"]
+    removedActions = ["ComputeCurvatureAction", "ScaleByDtAction"]
+    for a in filter(lambda c: c.tag.startswith("action"), p.iterchildren()):
+        if a.tag.removeprefix("action:") in removedActions or a.tag.attrib["timing"] in removedTimings:
+            p.remove(a)
+    return p
+
+
+def portCouplingScheme(cpl):
+    # removed extrapolation order
+    for extra in cpl.findall("extrapolation-order"):
+        cpl.remove(extra)
+    return cpl
+
+
+def portConfiguration(root):
+    assert root.tag == "precice-configuration"
+    # remove SI
+    si = root.find("solver-interface")
+    dims = si.attrib["dimensions"]
+    root.attrib.update({"dimensions": dims})
+    experimental = si.attrib.get("experimental")
+    if experimental:
+        root.attrib.update({"experimental": experimental})
+    for c in si.iterchildren():
+        root.append(c)
+    root.remove(si)
+
+    for p in tree.findall("participant"):
+        p = portParticipant(p)
+
+    for cpl in tree.findall("coupling-schemes"):
+        cpl = portCouplingScheme(cpl)
+    return root
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('infile',  type=str, help="The XML configuration file to update.")
+    args = parser.parse_args()
+
+    tree = parseXMLFile(args.infile)
+    ported = portConfiguration(tree)
+    print(etree.tostring(ported).decode())


### PR DESCRIPTION
## Main changes of this PR

This PR adds a simple configuration porter that applies a range of transformations on the xml file and outputs the result.

The script backups the old configuration and overwrites the old one.

## Motivation and additional information

Reduce unnecessary work for users.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
