### PR TITLE
Fix DivByZero for scaled constraints

### DIFF
--- a/docs/changelog/1697.md
+++ b/docs/changelog/1697.md
@@ -1,0 +1,2 @@
+- Fixed scaled-consistent mapping constraints with an output integral of zero to dividing by zero.
+- Added warnings for scaled-consistent mappings unable to uphold their conservation constraint.

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -229,7 +229,7 @@ void Mapping::scaleConsistentMapping(const Eigen::VectorXd &input, Eigen::Vector
   // To fulfill the constraint, we would need to scale the output data in such a way, that the integral sum of the input is preserved.
   // That's not possible using a constant scaling factor as the output sum will always be zero. Here, we return 1 and emit a warning afterwards.
   const Eigen::VectorXd scalingFactor = integralInput.binaryExpr(integralOutput, [](double lhs, double rhs) { return (rhs == 0.0) ? 1.0 : (lhs / rhs); });
-   PRECICE_DEBUG("Scaling factor in scaled-consistent mapping: {}", scalingFactor);
+  PRECICE_DEBUG("Scaling factor in scaled-consistent mapping: {}", scalingFactor);
 
   // check whether the constraint is fulfilled
   for (Eigen::Index i = 0; i < scalingFactor.size(); ++i) {

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -225,7 +225,7 @@ void Mapping::scaleConsistentMapping(const Eigen::VectorXd &input, Eigen::Vector
   Eigen::Map<Eigen::MatrixXd> outputValuesMatrix(output.data(), valueDimensions, output.size() / valueDimensions);
 
   // Scale in each direction
-  Eigen::VectorXd scalingFactor = integralInput.array() / integralOutput.array();
+  const Eigen::VectorXd scalingFactor = integralInput.binaryExpr(integralOutput, [](double lhs, double rhs) { return (rhs == 0.0) ? 0.0 : (lhs / rhs); });
   PRECICE_DEBUG("Scaling factor in scaled-consistent mapping: {}", scalingFactor);
   outputValuesMatrix.array().colwise() *= scalingFactor.array();
 } // namespace mapping

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentZeroDataComponent)
   mapping.computeMapping();
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  Eigen::VectorXd inValues{{1, 0, 0.5, 0, 1.5, 0, 1, 0}};
+  Eigen::VectorXd inValues{1, 0, 0.5, 0, 1.5, 0, 1, 0};
   time::Sample    inSample(2, inValues);
   Eigen::VectorXd outValues = Eigen::VectorXd::Zero(6);
   mapping.map(inSample, outValues);
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentZeroIntegralComponent)
   mapping.computeMapping();
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  Eigen::VectorXd inValues{{2, 1, 3, 1, 1, -1, 2, -1}};
+  Eigen::VectorXd inValues{2, 1, 3, 1, 1, -1, 2, -1};
   time::Sample    inSample(2, inValues);
   Eigen::VectorXd outValues = Eigen::VectorXd::Zero(6);
   mapping.map(inSample, outValues);

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -351,7 +351,8 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentZeroDataComponent)
   mapping.computeMapping();
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  Eigen::VectorXd inValues{1, 0, 0.5, 0, 1.5, 0, 1, 0};
+  Eigen::VectorXd inValues;
+  inValues << 1, 0, 0.5, 0, 1.5, 0, 1, 0;
   time::Sample    inSample(2, inValues);
   Eigen::VectorXd outValues = Eigen::VectorXd::Zero(6);
   mapping.map(inSample, outValues);
@@ -389,7 +390,8 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentZeroIntegralComponent)
   mapping.computeMapping();
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  Eigen::VectorXd inValues{2, 1, 3, 1, 1, -1, 2, -1};
+  Eigen::VectorXd inValues;
+  inValues << 2, 1, 3, 1, 1, -1, 2, -1;
   time::Sample    inSample(2, inValues);
   Eigen::VectorXd outValues = Eigen::VectorXd::Zero(6);
   mapping.map(inSample, outValues);

--- a/src/mapping/tests/NearestNeighborMappingTest.cpp
+++ b/src/mapping/tests/NearestNeighborMappingTest.cpp
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentZeroDataComponent)
   mapping.computeMapping();
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  Eigen::VectorXd inValues;
+  Eigen::VectorXd inValues(8);
   inValues << 1, 0, 0.5, 0, 1.5, 0, 1, 0;
   time::Sample    inSample(2, inValues);
   Eigen::VectorXd outValues = Eigen::VectorXd::Zero(6);
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentZeroIntegralComponent)
   mapping.computeMapping();
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
-  Eigen::VectorXd inValues;
+  Eigen::VectorXd inValues(8);
   inValues << 2, 1, 3, 1, 1, -1, 2, -1;
   time::Sample    inSample(2, inValues);
   Eigen::VectorXd outValues = Eigen::VectorXd::Zero(6);


### PR DESCRIPTION
## Main changes of this PR

This PR reproduces a test which fails due to div by zero and then fixes the issue.

## Motivation and additional information

Closes #1686

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
