### PR TITLE
Fix bug that prevents requiring checkpoint in last window

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -348,16 +348,18 @@ void BaseCouplingScheme::secondExchange()
         // coupling iteration.
         PRECICE_ASSERT(math::greater(_computedTimeWindowPart, 0.0));
         _timeWindows -= 1;
-      } else { // write output, prepare for next window
+        _computedTimeWindowPart = 0.0; // reset window
+      } else {                         // write output, prepare for next window
         PRECICE_DEBUG("Convergence achieved");
         advanceTXTWriters();
         PRECICE_INFO("Time window completed");
+        _isTimeWindowComplete = true;
+        _timeWindowStartTime += _computedTimeWindowPart;
+        _computedTimeWindowPart = 0.0; // reset window
         if (isCouplingOngoing()) {
           PRECICE_DEBUG("Setting require create checkpoint");
           requireAction(CouplingScheme::Action::WriteCheckpoint);
         }
-        _isTimeWindowComplete = true;
-        _timeWindowStartTime += _computedTimeWindowPart;
       }
       //update iterations
       _totalIterations++;
@@ -370,11 +372,11 @@ void BaseCouplingScheme::secondExchange()
       PRECICE_INFO("Time window completed");
       _isTimeWindowComplete = true;
       _timeWindowStartTime += _computedTimeWindowPart;
+      _computedTimeWindowPart = 0.0; // reset window
     }
     if (isCouplingOngoing()) {
       PRECICE_ASSERT(_hasDataBeenReceived);
     }
-    _computedTimeWindowPart = 0.0; // reset window
   }
 }
 

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -352,12 +352,12 @@ void BaseCouplingScheme::secondExchange()
         PRECICE_DEBUG("Convergence achieved");
         advanceTXTWriters();
         PRECICE_INFO("Time window completed");
-        _isTimeWindowComplete = true;
-        _timeWindowStartTime += _computedTimeWindowPart;
         if (isCouplingOngoing()) {
           PRECICE_DEBUG("Setting require create checkpoint");
           requireAction(CouplingScheme::Action::WriteCheckpoint);
         }
+        _isTimeWindowComplete = true;
+        _timeWindowStartTime += _computedTimeWindowPart;
       }
       //update iterations
       _totalIterations++;

--- a/tests/serial/ImplicitCheckpointing.cpp
+++ b/tests/serial/ImplicitCheckpointing.cpp
@@ -1,0 +1,92 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_CASE(ImplicitCheckpointing)
+{
+  /// Test simple implicit coupling with checkpointing. Checks correct tracking of time, see https://github.com/precice/precice/pull/1704.
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  double state              = 0.0;
+  double checkpoint         = 0.0;
+  int    iterationCount     = 0;
+  double initialStateChange = 5.0;
+  double stateChange        = initialStateChange;
+  int    computedTimesteps  = 0;
+
+  precice::Participant interface(context.name, context.config(), context.rank, context.size);
+
+  if (context.isNamed("SolverOne")) {
+    auto   meshName = "Square";
+    double pos[3];
+    // Set mesh positions
+    pos[0] = 0.0;
+    pos[1] = 0.0;
+    pos[2] = 0.0;
+    interface.setMeshVertex(meshName, pos);
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    auto   meshName = "SquareTwo";
+    double pos[3];
+    // Set mesh positions
+    pos[0] = 0.0;
+    pos[1] = 0.0;
+    pos[2] = 0.0;
+    interface.setMeshVertex(meshName, pos);
+  }
+
+  interface.initialize();
+  double maxDt = interface.getMaxTimeStepSize();
+
+  BOOST_TEST(interface.isCouplingOngoing());
+  BOOST_TEST(interface.requiresWritingCheckpoint());
+  BOOST_TEST(not interface.requiresReadingCheckpoint());
+
+  interface.advance(maxDt); // finish first iteration of first window
+
+  BOOST_TEST(interface.isCouplingOngoing());
+  BOOST_TEST(not interface.requiresWritingCheckpoint());
+  BOOST_TEST(interface.requiresReadingCheckpoint());
+
+  interface.advance(maxDt); // finish second iteration of first window
+
+  BOOST_TEST(interface.isCouplingOngoing());
+  BOOST_TEST(not interface.requiresWritingCheckpoint());
+  BOOST_TEST(interface.requiresReadingCheckpoint());
+
+  interface.advance(maxDt); // finish third and last iteration of first window
+
+  BOOST_TEST(interface.isCouplingOngoing());
+  BOOST_TEST(interface.requiresWritingCheckpoint());
+  BOOST_TEST(not interface.requiresReadingCheckpoint());
+
+  interface.advance(maxDt); // finish first iteration of second window
+
+  BOOST_TEST(interface.isCouplingOngoing());
+  BOOST_TEST(not interface.requiresWritingCheckpoint());
+  BOOST_TEST(interface.requiresReadingCheckpoint());
+
+  interface.advance(maxDt); // finish second iteration of second window
+
+  BOOST_TEST(interface.isCouplingOngoing());
+  BOOST_TEST(not interface.requiresWritingCheckpoint());
+  BOOST_TEST(interface.requiresReadingCheckpoint());
+
+  interface.advance(maxDt); // finish third and last iteration of second window
+
+  BOOST_TEST(not interface.isCouplingOngoing());
+  BOOST_TEST(not interface.requiresWritingCheckpoint());
+  BOOST_TEST(not interface.requiresReadingCheckpoint());
+
+  interface.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/ImplicitCheckpointing.xml
+++ b/tests/serial/ImplicitCheckpointing.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration dimensions="3">
+  <data:vector name="Forces" />
+  <data:vector name="Velocities" />
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <mesh name="Square">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <mesh name="SquareTwo">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="Square" />
+    <write-data name="Forces" mesh="Square" />
+    <read-data name="Velocities" mesh="Square" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="Square" from="SolverOne" />
+    <provide-mesh name="SquareTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SquareTwo"
+      to="Square"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Square"
+      to="SquareTwo"
+      constraint="consistent" />
+    <write-data name="Velocities" mesh="SquareTwo" />
+    <read-data name="Forces" mesh="SquareTwo" />
+  </participant>
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <min-iteration-convergence-measure min-iterations="3" data="Velocities" mesh="Square" />
+    <exchange data="Forces" mesh="Square" from="SolverOne" to="SolverTwo" />
+    <exchange data="Velocities" mesh="Square" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -63,6 +63,7 @@ target_sources(testprecice
     tests/quasi-newton/serial/TestQN2.cpp
     tests/quasi-newton/serial/TestQN3.cpp
     tests/serial/AitkenAcceleration.cpp
+    tests/serial/ImplicitCheckpointing.cpp
     tests/serial/PreconditionerBug.cpp
     tests/serial/SendMeshToMultipleParticipants.cpp
     tests/serial/SummationActionTwoSources.cpp


### PR DESCRIPTION
## Main changes of this PR

Make sure that `isCouplingOngoing()` does not accidentally evaluate `false` due to wrong update of internal time.

## Motivation and additional information

Fix bug. Found it while debugging case from https://github.com/precice/precice/issues/1680.

Original implementation has a bug with checkpointing: When entering the last window, `isCouplingOngoing()` evaluates `false`, if we increase the `_timeWindowStartTime` before checking `isCouplingOngoing()`. This will avoid writing a checkpoint for the beginning of the last window, meaning we jump back to the second to last window when reading the checkpoint.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] ~~I added a changelog file with `make changelog` if there are user-observable changes since the last release.~~ (not needed, bug does not exist in version 2.5)
* [x] I added a test to avoid reintroducing the bug.
* [x] I sticked to C++17 features.
* [X] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
