### PR TITLE
Some coverity fixes

### DIFF
--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -6,6 +6,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <chrono>
 #include <fstream>
+#include <stdexcept>
 #include <thread>
 
 #include "com/ConnectionInfoPublisher.hpp"
@@ -17,15 +18,27 @@ namespace bfs = boost::filesystem;
 
 namespace precice::com {
 
-std::string impl::hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &tag, Rank rank)
-{
-  constexpr int                  firstLevelLen = 2;
+namespace {
+
+std::string preciceFancyHash(const std::string &s)
+try {
   boost::uuids::string_generator ns_gen;
   auto                           ns = ns_gen("af7ce8f2-a9ee-46cb-38ee-71c318aa3580"); // md5 hash of precice.org as namespace
 
   boost::uuids::name_generator gen{ns};
-  std::string const            s    = acceptorName + tag + requesterName + std::to_string(rank);
-  std::string                  hash = boost::uuids::to_string(gen(s));
+  return boost::uuids::to_string(gen(s));
+
+} catch (const std::runtime_error &e) {
+  PRECICE_UNREACHABLE("preCICE hashing failed", e.what());
+  return "";
+}
+} // namespace
+
+std::string impl::hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &tag, Rank rank)
+{
+  constexpr int     firstLevelLen = 2;
+  std::string const s             = acceptorName + tag + requesterName + std::to_string(rank);
+  std::string       hash          = preciceFancyHash(s);
   hash.erase(std::remove(hash.begin(), hash.end(), '-'), hash.end());
 
   auto p = bfs::path(hash.substr(0, firstLevelLen)) / hash.substr(firstLevelLen);

--- a/src/com/SerializedStamples.hpp
+++ b/src/com/SerializedStamples.hpp
@@ -126,7 +126,7 @@ private:
   Eigen::VectorXd _gradients;
 
   /// number of timesteps stored in SerializedStamples
-  int _timeSteps;
+  int _timeSteps = 0;
 };
 
 } // namespace serialize

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -638,7 +638,7 @@ void CouplingSchemeConfiguration::addTagAcceleration(
     xml::XMLTag &tag)
 {
   PRECICE_TRACE(tag.getFullName());
-  if (_accelerationConfig.get() == nullptr) {
+  if (!_accelerationConfig) {
     _accelerationConfig = std::make_shared<acceleration::AccelerationConfiguration>(
         _meshConfig);
   }

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -31,11 +31,11 @@ public:
    * @param[in] xDead, yDead, zDead Deactivates mapping along an axis
    */
   RadialBasisFctBaseMapping(
-      Constraint              constraint,
-      int                     dimensions,
-      RADIAL_BASIS_FUNCTION_T function,
-      std::array<bool, 3>     deadAxis,
-      InitialGuessRequirement mappingType);
+      Constraint                     constraint,
+      int                            dimensions,
+      const RADIAL_BASIS_FUNCTION_T &function,
+      std::array<bool, 3>            deadAxis,
+      InitialGuessRequirement        mappingType);
 
   virtual ~RadialBasisFctBaseMapping() = default;
 
@@ -78,11 +78,11 @@ private:
 
 template <typename RADIAL_BASIS_FUNCTION_T>
 RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctBaseMapping(
-    Constraint              constraint,
-    int                     dimensions,
-    RADIAL_BASIS_FUNCTION_T function,
-    std::array<bool, 3>     deadAxis,
-    InitialGuessRequirement mappingType)
+    Constraint                     constraint,
+    int                            dimensions,
+    const RADIAL_BASIS_FUNCTION_T &function,
+    std::array<bool, 3>            deadAxis,
+    InitialGuessRequirement        mappingType)
     : Mapping(constraint, dimensions, false, mappingType),
       _basisFunction(function)
 {

--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -7,6 +7,7 @@
 #include <iomanip>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <ratio>
 #include <string>
 #include <sys/types.h>
@@ -62,7 +63,7 @@ void EventRegistry::initialize(std::string applicationName, int rank, int size)
 
   _writeQueue.clear();
   _firstwrite = true;
-  _globalId   = -1;
+  _globalId   = std::nullopt;
 
   _initialized = true;
   _finalized   = false;
@@ -121,7 +122,7 @@ void EventRegistry::startBackend()
   _output.open(filename);
   PRECICE_CHECK(_output, "Unable to open the events-file: \"{}\"", filename);
   _globalId = nameToID("_GLOBAL");
-  _writeQueue.emplace_back(StartEntry{_globalId, _initClock});
+  _writeQueue.emplace_back(StartEntry{_globalId.value(), _initClock});
 
   // write header
   fmt::print(_output,
@@ -152,7 +153,7 @@ void EventRegistry::stopBackend()
   }
   // create end of global event
   auto now = Event::Clock::now();
-  put(StopEntry{_globalId, now});
+  put(StopEntry{_globalId.value(), now});
   // flush the queue
   flush();
   _output << "]}";

--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -236,6 +236,7 @@ void EventRegistry::flush()
   auto first = _writeQueue.begin();
   // Don't prefix the first write with a comma
   if (_firstwrite) {
+    PRECICE_ASSERT(!_writeQueue.empty() && !_writeQueue.front().valueless_by_exception());
     std::visit(EventWriter{_output, _initClock, ""}, _writeQueue.front());
     ++first;
     _firstwrite = false;

--- a/src/profiling/EventUtils.hpp
+++ b/src/profiling/EventUtils.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <fstream>
 #include <iosfwd>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -141,16 +142,16 @@ private:
   Mode _mode = Mode::Fundamental;
 
   /// The rank/number of parallel instance of the current program
-  int _rank;
+  int _rank = 0;
 
   /// The amount of parallel instances of the current program
-  int _size;
+  int _size = 1;
 
   /// Indicator for the first record to be written
-  bool _firstwrite;
+  bool _firstwrite = true;
 
   /// The id of the global event
-  int _globalId;
+  std::optional<int> _globalId;
 
   /// Private, empty constructor for singleton pattern
   EventRegistry() = default;

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -36,7 +36,8 @@ TestContext::~TestContext() noexcept
   if (!invalid && _petsc) {
     precice::utils::Petsc::finalize();
   }
-  if (!invalid && _events) {
+  if (!invalid) {
+    // Always clean up tests.
     precice::profiling::EventRegistry::instance().finalize();
   }
   if (!invalid && _initIntraComm) {
@@ -204,14 +205,19 @@ void TestContext::initializeIntraComm()
 
 void TestContext::initializeEvents()
 {
-  if (!invalid && _events) {
-    auto &er = precice::profiling::EventRegistry::instance();
-    er.initialize(name, rank, size);
+  if (invalid) {
+    return;
+  }
+  // Always initialize the events
+  auto &er = precice::profiling::EventRegistry::instance();
+  er.initialize(name, rank, size);
+  if (_events) { // Enable them if they are requested
     er.setMode(precice::profiling::Mode::All);
     er.setDirectory("./precice-events");
-    er.initialize(name, rank, size);
-    er.startBackend();
+  } else {
+    er.setMode(precice::profiling::Mode::Off);
   }
+  er.startBackend();
 }
 
 void TestContext::initializePetsc()

--- a/src/time/Sample.hpp
+++ b/src/time/Sample.hpp
@@ -21,11 +21,11 @@ struct Sample {
 
   /// Constructs a Sample of given data dimensionality and data values
   Sample(int dims, Eigen::VectorXd inValues)
-      : dataDims(dims), values(inValues) {}
+      : dataDims(dims), values(std::move(inValues)) {}
 
   /// Constructs a Sample of given data dimensionality, data values, and data gradients
   Sample(int dims, Eigen::VectorXd inValues, Eigen::MatrixXd inGradients)
-      : dataDims(dims), values(inValues), gradients(inGradients) {}
+      : dataDims(dims), values(std::move(inValues)), gradients(std::move(inGradients)) {}
 
   Sample(const Sample &) = default;
   Sample(Sample &&)      = default;

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -73,8 +73,8 @@ void Storage::move()
   auto sampleAtBeginning = getSampleAtEnd();
   auto sampleAtEnd       = computeExtrapolation();
   _stampleStorage.clear();
-  _stampleStorage.emplace_back(time::Stample{WINDOW_START, sampleAtBeginning});
-  _stampleStorage.emplace_back(time::Stample{WINDOW_END, sampleAtEnd});
+  _stampleStorage.emplace_back(time::Stample{WINDOW_START, std::move(sampleAtBeginning)});
+  _stampleStorage.emplace_back(time::Stample{WINDOW_END, std::move(sampleAtEnd)});
 }
 
 void Storage::trim()

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -55,17 +55,18 @@ static constexpr char const *ASSERT_FMT =
  * @param[in] check the expression which needs to evaluate to true for the assertion to pass
  * @param[in] args the expression which evaluates to the formatted arguments
  */
-#define PRECICE_ASSERT_IMPL(check, args)                                 \
-  if (!(check)) {                                                        \
-    std::cerr << fmt::format(precice::utils::ASSERT_FMT,                 \
-                             BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, \
-                             BOOST_PP_STRINGIZE(check),                  \
-                             precice::utils::Parallel::getProcessRank(), \
-                             args,                                       \
-                             getStacktrace())                            \
-              << std::flush;                                             \
-    std::cout.flush();                                                   \
-    PRECICE_ASSERT_WRAPPER();                                            \
+#define PRECICE_ASSERT_IMPL(check, args)                         \
+  if (!(check)) {                                                \
+    std::cerr << precice::utils::format_or_error(                \
+                     precice::utils::ASSERT_FMT,                 \
+                     BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, \
+                     BOOST_PP_STRINGIZE(check),                  \
+                     precice::utils::Parallel::getProcessRank(), \
+                     args,                                       \
+                     getStacktrace())                            \
+              << std::flush;                                     \
+    std::cout.flush();                                           \
+    PRECICE_ASSERT_WRAPPER();                                    \
   }
 
 #define PRECICE_ASSERT_IMPL_N(check, ...) \

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -325,8 +325,9 @@ void XMLTag::areAllSubtagsConfigured() const
     bool occurOnceOrMore = tag->getOccurrence() == OCCUR_ONCE_OR_MORE;
 
     if (not ns.empty()) {
-      PRECICE_ASSERT(utils::contained(ns, _configuredNamespaces));
-      configured |= _configuredNamespaces.find(ns)->second;
+      auto nsIter = _configuredNamespaces.find(ns);
+      PRECICE_ASSERT(nsIter != _configuredNamespaces.end());
+      configured |= nsIter->second;
     }
 
     if ((not configured) && (occurOnce || occurOnceOrMore)) {


### PR DESCRIPTION
## Main changes of this PR

This PR fixes some coverity warnings:

- Fix uninitialized member
- Ensure we are not running into valueless variants
- Avoid fmt exceptions in PRECICE_ASSERT
- Fix EventRegistry init
- Clarify code
- Clarify namespace in XML check
- Catch errors in the connection info hasher
- Use perfect forwarding for func arg
- Use copy and move in sample
- Move the samples in storage move

## Motivation and additional information


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
