### PR TITLE
Add test for time adaptivity and waveform iteration

### DIFF
--- a/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.cpp
@@ -1,0 +1,128 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(ParallelCoupling)
+
+/**
+ * @brief Test to run a simple coupling where the number of time steps changes with the waveform iteration.
+ *
+ * Provides a dt argument to the read function. A first order waveform is used.
+ */
+BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithDifferentNumberOfDts)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  typedef double (*DataFunction)(double);
+
+  // The functions that are exchanged in iteration 1 and 2 respectively.
+  DataFunction funcIterOne = [](double t) -> double {
+    return (double) (1 + 2 * t) * (2 + 3 * t) * (3 + 4 * t);
+  };
+  DataFunction funcIterTwo = [](double t) -> double {
+    return (double) (6 + 5 * t) * (1 + 6 * t) * (1 + 6 * t);
+  };
+
+  BOOST_TEST(funcIterOne(0) == funcIterTwo(0)); // because the data at WINDOW_START does not change over iterations.
+
+  int         nTimeSteps;
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "DataOne";
+    readDataName  = "DataTwo";
+    nTimeSteps    = 6;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "DataTwo";
+    readDataName  = "DataOne";
+    nTimeSteps    = 4;
+  }
+
+  double   writeData = 0;
+  double   readData  = 0;
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
+  double   time      = 0;
+
+  if (precice.requiresInitialData()) {
+    writeData = funcIterOne(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+  }
+
+  precice.initialize();
+  double maxDt     = precice.getMaxTimeStepSize();
+  double windowDt  = maxDt;
+  double dt        = windowDt / nTimeSteps;
+  double currentDt = dt > maxDt ? maxDt : dt;
+
+  double windowStartTime = 0;
+  int    iterations      = 0;
+
+  while (precice.isCouplingOngoing()) {
+
+    if (precice.requiresWritingCheckpoint()) {
+      windowStartTime = time;
+      iterations      = 0;
+    }
+
+    if (context.isNamed("SolverOne")) {
+      nTimeSteps = 6 + iterations; // increase the number of time steps by one for each iteration
+    } else {
+      BOOST_TEST(context.isNamed("SolverTwo"));
+      nTimeSteps = 4 + iterations; // increase the number of time steps by one for each iteration
+    }
+
+    dt        = windowDt / nTimeSteps;
+    maxDt     = precice.getMaxTimeStepSize();
+    currentDt = dt > maxDt ? maxDt : dt;
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, currentDt, {&readData, 1});
+
+    if (iterations == 0) { // in the first iteration of each window, we only have one sample of data. Therefore constant interpolation
+      BOOST_TEST(readData == funcIterOne(windowStartTime));
+    } else if (iterations == 1) { // Check that we receive the first function in the second iteration
+      BOOST_TEST(readData == funcIterOne(time + currentDt));
+    } else { // Check that we receive the second function in the third iteration
+      BOOST_TEST(readData == funcIterTwo(time + currentDt));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the two functions.
+    time += currentDt;
+    if (iterations == 0) { // Sends the first function in the first iteration
+      writeData = funcIterOne(time);
+    } else { //Otherwise send the second function
+      writeData = funcIterTwo(time);
+    }
+
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+    precice.advance(currentDt);
+
+    if (precice.requiresReadingCheckpoint()) {
+      time = windowStartTime;
+      iterations++;
+    }
+  }
+
+  precice.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // ParallelCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.xml
+++ b/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration dimensions="3" experimental="true">
-  <data:scalar name="DataOne" />
-  <data:scalar name="DataTwo" />
+  <data:scalar name="DataOne" waveform-degree="3" />
+  <data:scalar name="DataTwo" waveform-degree="3" />
 
   <mesh name="MeshOne">
     <use-data name="DataOne" />
@@ -16,7 +16,7 @@
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
     <write-data name="DataOne" mesh="MeshOne" />
-    <read-data name="DataTwo" mesh="MeshOne" waveform-order="3" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -33,7 +33,7 @@
       to="MeshTwo"
       constraint="consistent" />
     <write-data name="DataTwo" mesh="MeshTwo" />
-    <read-data name="DataOne" mesh="MeshTwo" waveform-order="3" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />

--- a/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.xml
+++ b/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="3" experimental="true">
+<precice-configuration experimental="true">
   <data:scalar name="DataOne" waveform-degree="3" />
   <data:scalar name="DataTwo" waveform-degree="3" />
 
-  <mesh name="MeshOne">
+  <mesh name="MeshOne" dimensions="3">
     <use-data name="DataOne" />
     <use-data name="DataTwo" />
   </mesh>
 
-  <mesh name="MeshTwo">
+  <mesh name="MeshTwo" dimensions="3">
     <use-data name="DataOne" />
     <use-data name="DataTwo" />
   </mesh>

--- a/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.xml
+++ b/tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration dimensions="3" experimental="true">
+  <data:scalar name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" waveform-order="3" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" waveform-order="3" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -188,6 +188,7 @@ target_sources(testprecice
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.cpp
+    tests/serial/time/implicit/parallel-coupling/WaveformSubcyclingWithDifferentNumberOfDts.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantChangingDt.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.cpp


### PR DESCRIPTION
## Main changes of this PR
Mentioned in issue https://github.com/precice/precice/issues/1596. This should extend the test coverage to include time adaptive sub solvers.

Adds the following tests
Write and read data with non constant time steps
Write and read data with changing number of time steps

## Motivation and additional information
Reopens  #1681, which I accidentally closed and could not reopen.

Mentioned in issue https://github.com/precice/precice/issues/1596. This is in preparation for the full waveform iterations.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
