### PR TITLE
Fix initialization for `substeps="false"`

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -110,7 +110,7 @@ void BaseCouplingScheme::sendTimes(const m2n::PtrM2N &m2n, const Eigen::VectorXd
   m2n->send(times);
 }
 
-void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange)
+void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialCommunication)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get() != nullptr);
@@ -148,7 +148,7 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
         m2n->send(serialized.gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions() * serialized.nTimeSteps());
       }
     } else {
-      if (initialDataExchange) { // send data for WINDOW_START. Will be used for WINDOW_START and WINDOW_END.
+      if (initialCommunication) { // send data for WINDOW_START. Will be used for WINDOW_START and WINDOW_END.
         PRECICE_ASSERT(math::equals(stamples.front().timestamp, time::Storage::WINDOW_START));
         PRECICE_ASSERT(math::equals(stamples.back().timestamp, time::Storage::WINDOW_START));
       } else { // send data for WINDOW_END.
@@ -186,7 +186,7 @@ Eigen::VectorXd BaseCouplingScheme::receiveTimes(const m2n::PtrM2N &m2n, int nTi
   return times;
 }
 
-void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange)
+void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialCommunication)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get());
@@ -219,7 +219,7 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
         m2n->receive(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
       }
 
-      if (initialDataExchange) { // also use receive data for WINDOW_START.
+      if (initialCommunication) { // also use receive data for WINDOW_START.
         data->setSampleAtTime(time::Storage::WINDOW_START, data->sample());
       }
       // use received data for WINDOW_END.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -110,7 +110,7 @@ void BaseCouplingScheme::sendTimes(const m2n::PtrM2N &m2n, const Eigen::VectorXd
   m2n->send(times);
 }
 
-void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData)
+void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get() != nullptr);
@@ -120,10 +120,10 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
     const auto &stamples = data->stamples();
     PRECICE_ASSERT(stamples.size() > 0);
 
-    if (data->exchangeSubsteps()) {
-      int nTimeSteps = data->timeStepsStorage().nTimes();
-      PRECICE_ASSERT(nTimeSteps > 0);
+    int nTimeSteps = data->timeStepsStorage().nTimes();
+    PRECICE_ASSERT(nTimeSteps > 0);
 
+    if (data->exchangeSubsteps()) {
       if (nTimeSteps > 1) { // otherwise PRECICE_ASSERT below is triggered during initialization
         const Eigen::VectorXd timesAscending = data->timeStepsStorage().getTimes();
         PRECICE_ASSERT(math::equals(timesAscending(0), time::Storage::WINDOW_START), timesAscending(0));                                     // assert that first element is time::Storage::WINDOW_START
@@ -148,7 +148,13 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
         m2n->send(serialized.gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions() * serialized.nTimeSteps());
       }
     } else {
-      data->sample() = stamples.back().sample;
+      if (initialDataExchange) {
+        PRECICE_ASSERT(math::equals(stamples.front().timestamp, time::Storage::WINDOW_START));
+        data->sample() = stamples.front().sample;
+      } else {
+        PRECICE_ASSERT(math::equals(stamples.back().timestamp, time::Storage::WINDOW_END));
+        data->sample() = stamples.back().sample;
+      }
 
       // Data is only received on ranks with size>0, which is checked in the derived class implementation
       m2n->send(data->values(), data->getMeshID(), data->getDimensions());
@@ -180,7 +186,7 @@ Eigen::VectorXd BaseCouplingScheme::receiveTimes(const m2n::PtrM2N &m2n, int nTi
   return times;
 }
 
-void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData)
+void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get());
@@ -212,7 +218,12 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
         PRECICE_ASSERT(data->hasGradient());
         m2n->receive(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
       }
-      data->setSampleAtTime(time::Storage::WINDOW_END, data->sample());
+
+      if (initialDataExchange) {
+        data->setSampleAtTime(time::Storage::WINDOW_START, data->sample());
+      } else {
+        data->setSampleAtTime(time::Storage::WINDOW_END, data->sample());
+      }
     }
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -250,8 +250,9 @@ protected:
    *
    * @param m2n M2N used for communication
    * @param sendData DataMap associated with sent data
+   * @param initialCommunication if true and exchange of substeps is deactivated, will send data for WINDOW_START, else will send data for WINDOW_END
    */
-  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange = false);
+  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialCommunication = false);
 
   int receiveNumberOfTimeSteps(const m2n::PtrM2N &m2n);
 
@@ -262,8 +263,9 @@ protected:
    *
    * @param m2n M2N used for communication
    * @param receiveData DataMap associated with received data
+   * @param initialCommunication if true and exchange of substeps is deactivated, will store received data for WINDOW_START and WINDOW_END, else store received data only for WINDOW_END
    */
-  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange = false);
+  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialCommunication = false);
 
   /**
    * @brief Initializes storage in receiveData as zero

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -251,7 +251,7 @@ protected:
    * @param m2n M2N used for communication
    * @param sendData DataMap associated with sent data
    */
-  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData);
+  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange = false);
 
   int receiveNumberOfTimeSteps(const m2n::PtrM2N &m2n);
 
@@ -263,7 +263,7 @@ protected:
    * @param m2n M2N used for communication
    * @param receiveData DataMap associated with received data
    */
-  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData);
+  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange = false);
 
   /**
    * @brief Initializes storage in receiveData as zero

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -89,7 +89,6 @@ void MultiCouplingScheme::exchangeInitialData()
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();
     } else {
@@ -100,20 +99,17 @@ void MultiCouplingScheme::exchangeInitialData()
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
         sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
   } else {
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
         sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();
     } else {

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -83,9 +83,12 @@ void MultiCouplingScheme::exchangeInitialData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
 
+  bool initialDataExchange = true;
+
   if (_isController) {
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();
@@ -96,17 +99,20 @@ void MultiCouplingScheme::exchangeInitialData()
     }
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
   } else {
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -83,12 +83,12 @@ void MultiCouplingScheme::exchangeInitialData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
 
-  bool initialDataExchange = true;
+  bool initialCommunication = true;
 
   if (_isController) {
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialCommunication);
       }
       checkDataHasBeenReceived();
     } else {
@@ -98,18 +98,18 @@ void MultiCouplingScheme::exchangeInitialData()
     }
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialCommunication);
       }
     }
   } else {
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialCommunication);
       }
     }
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialCommunication);
       }
       checkDataHasBeenReceived();
     } else {

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -25,28 +25,28 @@ ParallelCouplingScheme::ParallelCouplingScheme(
 
 void ParallelCouplingScheme::exchangeInitialData()
 {
-  bool initialDataExchange = true;
+  bool initialCommunication = true;
 
   // F: send, receive, S: receive, send
   if (doesFirstStep()) {
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
     if (receivesInitializedData()) {
-      receiveData(getM2N(), getReceiveData(), initialDataExchange);
+      receiveData(getM2N(), getReceiveData(), initialCommunication);
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
   } else { // second participant
     if (receivesInitializedData()) {
-      receiveData(getM2N(), getReceiveData(), initialDataExchange);
+      receiveData(getM2N(), getReceiveData(), initialCommunication);
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
   }
 }

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -31,11 +31,9 @@ void ParallelCouplingScheme::exchangeInitialData()
   if (doesFirstStep()) {
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
-      sendData(getM2N(), getSendData(), initialDataExchange);
     }
     if (receivesInitializedData()) {
       receiveData(getM2N(), getReceiveData(), initialDataExchange);
-      receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
@@ -43,13 +41,11 @@ void ParallelCouplingScheme::exchangeInitialData()
   } else { // second participant
     if (receivesInitializedData()) {
       receiveData(getM2N(), getReceiveData(), initialDataExchange);
-      receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
   }

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -25,12 +25,16 @@ ParallelCouplingScheme::ParallelCouplingScheme(
 
 void ParallelCouplingScheme::exchangeInitialData()
 {
+  bool initialDataExchange = true;
+
   // F: send, receive, S: receive, send
   if (doesFirstStep()) {
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData());
+      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialDataExchange);
     }
     if (receivesInitializedData()) {
+      receiveData(getM2N(), getReceiveData(), initialDataExchange);
       receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
@@ -38,13 +42,15 @@ void ParallelCouplingScheme::exchangeInitialData()
     }
   } else { // second participant
     if (receivesInitializedData()) {
+      receiveData(getM2N(), getReceiveData(), initialDataExchange);
       receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData());
+      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialDataExchange);
     }
   }
 }

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -96,7 +96,6 @@ void SerialCouplingScheme::exchangeInitialData()
   if (doesFirstStep()) {
     if (receivesInitializedData()) {
       receiveData(getM2N(), getReceiveData(), initialDataExchange);
-      receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
@@ -107,23 +106,20 @@ void SerialCouplingScheme::exchangeInitialData()
   } else { // second participant
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
-      sendData(getM2N(), getSendData(), initialDataExchange);
     }
     PRECICE_DEBUG("Receiving data...");
+    // similar to SerialCouplingScheme::exchangeSecondData()
     if (receivesInitializedData()) {                                // should actually also check if(data->exchangeSubsteps()), but a bit difficult...
       receiveData(getM2N(), getReceiveData(), initialDataExchange); // @todo need to receive data for WINDOW_START and WINDOW_END here, if no substeps are exchanged...
     }
-    // similar to SerialCouplingScheme::exchangeSecondData()
     receiveAndSetTimeWindowSize();
-    receiveData(getM2N(), getReceiveData());
+    receiveData(getM2N(), getReceiveData()); // receive data from end of first time step of first participant
     checkDataHasBeenReceived();
   }
 }
 
 void SerialCouplingScheme::exchangeFirstData()
 {
-  bool initialDataExchange = true;
-
   if (isExplicitCouplingScheme()) {
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Sending data...");

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -107,10 +107,10 @@ void SerialCouplingScheme::exchangeInitialData()
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
-    // similar to SerialCouplingScheme::exchangeSecondData()
     if (receivesInitializedData()) {                                // this send/recv pair is only needed, if no substeps are exchanged.
       receiveData(getM2N(), getReceiveData(), initialDataExchange); // Receive data for WINDOW_START and WINDOW_END here
     }
+    // similar to SerialCouplingScheme::exchangeSecondData()
     PRECICE_DEBUG("Receiving data...");
     receiveAndSetTimeWindowSize();
     receiveData(getM2N(), getReceiveData());

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -90,25 +90,25 @@ void SerialCouplingScheme::receiveAndSetTimeWindowSize()
 
 void SerialCouplingScheme::exchangeInitialData()
 {
-  bool initialDataExchange = true;
+  bool initialCommunication = true;
 
   // F: send, receive, S: receive, send
   if (doesFirstStep()) {
     if (receivesInitializedData()) {
-      receiveData(getM2N(), getReceiveData(), initialDataExchange);
+      receiveData(getM2N(), getReceiveData(), initialCommunication);
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) { // this send/recv pair is only needed, if no substeps are exchanged.
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
   } else { // second participant
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
-    if (receivesInitializedData()) {                                // this send/recv pair is only needed, if no substeps are exchanged.
-      receiveData(getM2N(), getReceiveData(), initialDataExchange); // Receive data for WINDOW_START and WINDOW_END here
+    if (receivesInitializedData()) {                                 // this send/recv pair is only needed, if no substeps are exchanged.
+      receiveData(getM2N(), getReceiveData(), initialCommunication); // Receive data for WINDOW_START and WINDOW_END here
     }
     // similar to SerialCouplingScheme::exchangeSecondData()
     PRECICE_DEBUG("Receiving data...");

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -100,20 +100,20 @@ void SerialCouplingScheme::exchangeInitialData()
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
-    if (sendsInitializedData()) { // should actually also check if(data->exchangeSubsteps()), but a bit difficult...
+    if (sendsInitializedData()) { // this send/recv pair is only needed, if no substeps are exchanged.
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
   } else { // second participant
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
-    PRECICE_DEBUG("Receiving data...");
     // similar to SerialCouplingScheme::exchangeSecondData()
-    if (receivesInitializedData()) {                                // should actually also check if(data->exchangeSubsteps()), but a bit difficult...
-      receiveData(getM2N(), getReceiveData(), initialDataExchange); // @todo need to receive data for WINDOW_START and WINDOW_END here, if no substeps are exchanged...
+    if (receivesInitializedData()) {                                // this send/recv pair is only needed, if no substeps are exchanged.
+      receiveData(getM2N(), getReceiveData(), initialDataExchange); // Receive data for WINDOW_START and WINDOW_END here
     }
+    PRECICE_DEBUG("Receiving data...");
     receiveAndSetTimeWindowSize();
-    receiveData(getM2N(), getReceiveData()); // receive data from end of first time step of first participant
+    receiveData(getM2N(), getReceiveData());
     checkDataHasBeenReceived();
   }
 }

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
@@ -1,0 +1,144 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/Participant.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(ParallelCoupling)
+
+/**
+ * @brief Test to run a simple coupling with subcycling.
+ *
+ * Ensures that each time step provides its own data, but preCICE only exchanges data at the end of the window.
+ *
+ * Deactivates exchange of substeps. Uses first degree interpolation. Uses data initialization for both participants.
+ */
+BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  typedef double (*DataFunction)(double);
+
+  DataFunction dataOneFunction = [](double t) -> double {
+    return (double) (2 + t);
+  };
+  DataFunction dataTwoFunction = [](double t) -> double {
+    return (double) (10 + t);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "DataOne";
+    writeFunction = dataOneFunction;
+    readDataName  = "DataTwo";
+    readFunction  = dataTwoFunction;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "DataTwo";
+    writeFunction = dataTwoFunction;
+    readDataName  = "DataOne";
+    readFunction  = dataOneFunction;
+  }
+
+  double   writeData = 0;
+  double   readData  = 0;
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
+
+  int    nSubsteps       = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows        = 5; // perform 5 windows.
+  int    timestep        = 0;
+  int    timewindow      = 0;
+  double startTime       = 0;
+  double windowStartTime = 0;
+  int    windowStartStep = 0;
+  int    iterations      = 0;
+  double time            = 0;
+
+  if (precice.requiresInitialData()) {
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+  }
+
+  precice.initialize();
+  BOOST_TEST(precice.getMaxTimeStepSize() == 2.0); // use window size != 1.0 to be able to detect more possible bugs
+  double windowDt      = precice.getMaxTimeStepSize();
+  double solverDt      = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a timestep of fixed size.
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.requiresWritingCheckpoint()) {
+      windowStartTime = time;
+      windowStartStep = timestep;
+    }
+    double preciceDt = precice.getMaxTimeStepSize();
+    double currentDt = solverDt > preciceDt ? preciceDt : solverDt; // determine actual time step size; must fit into remaining time in window
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0 * currentDt, {&readData, 1});
+
+    if (iterations == 0) {                                                     // special situation: Both solvers are in their very first time windows, first iteration, first time step
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0.5 * currentDt, {&readData, 1});
+
+    if (iterations == 0) {                                                     // special situation: Both solvers are in their very first time windows, first iteration, first time step
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0.5 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 1.0 * currentDt, {&readData, 1});
+
+    if (iterations == 0) {                                                     // special situation: Both solvers are in their very first time windows, first iteration, first time step
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 1.0 * currentDt));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    BOOST_TEST(currentDt == expectedDts[timestep % nSubsteps]);
+    time += currentDt;
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+    precice.advance(currentDt);
+    timestep++;
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
+      iterations++;
+      timestep = windowStartStep;
+      time     = windowStartTime;
+    }
+    if (precice.isTimeWindowComplete()) {
+      iterations++;
+      timewindow++;
+      BOOST_TEST(iterations == 3);
+      iterations = 0;
+    }
+  }
+
+  precice.finalize();
+  BOOST_TEST(timestep == nWindows * nSubsteps);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration dimensions="3">
+  <data:scalar name="DataOne" waveform-degree="1" />
+  <data:scalar name="DataTwo" waveform-degree="1" />
+
+  <mesh name="MeshOne">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="2" />
+    <max-iterations value="3" />
+    <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="false" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="false" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
@@ -1,0 +1,144 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/Participant.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief Test to run a simple coupling with subcycling.
+ *
+ * Ensures that each time step provides its own data, but preCICE only exchanges data at the end of the window.
+ *
+ * Deactivates exchange of substeps. Uses first degree interpolation. Uses data initialization for both participants.
+ */
+BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  typedef double (*DataFunction)(double);
+
+  DataFunction dataOneFunction = [](double t) -> double {
+    return (double) (2 + t);
+  };
+  DataFunction dataTwoFunction = [](double t) -> double {
+    return (double) (10 + t);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "DataOne";
+    writeFunction = dataOneFunction;
+    readDataName  = "DataTwo";
+    readFunction  = dataTwoFunction;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "DataTwo";
+    writeFunction = dataTwoFunction;
+    readDataName  = "DataOne";
+    readFunction  = dataOneFunction;
+  }
+
+  double   writeData = 0;
+  double   readData  = 0;
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
+
+  int    nSubsteps       = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows        = 5; // perform 5 windows.
+  int    timestep        = 0;
+  int    timewindow      = 0;
+  double startTime       = 0;
+  double windowStartTime = 0;
+  int    windowStartStep = 0;
+  int    iterations      = 0;
+  double time            = 0;
+
+  if (precice.requiresInitialData()) {
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+  }
+
+  precice.initialize();
+  BOOST_TEST(precice.getMaxTimeStepSize() == 2.0); // use window size != 1.0 to be able to detect more possible bugs
+  double windowDt      = precice.getMaxTimeStepSize();
+  double solverDt      = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a timestep of fixed size.
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.requiresWritingCheckpoint()) {
+      windowStartTime = time;
+      windowStartStep = timestep;
+    }
+    double preciceDt = precice.getMaxTimeStepSize();
+    double currentDt = solverDt > preciceDt ? preciceDt : solverDt; // determine actual time step size; must fit into remaining time in window
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0 * currentDt, {&readData, 1});
+
+    if (context.isNamed("SolverOne") && iterations == 0) {                     // special situation for serial coupling: SolverOne gets the old data in its first iteration for all time windows.
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0.5 * currentDt, {&readData, 1});
+
+    if (context.isNamed("SolverOne") && iterations == 0) {                     // special situation for serial coupling: SolverOne gets the old data in its first iteration for all time windows.
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0.5 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 1.0 * currentDt, {&readData, 1});
+
+    if (context.isNamed("SolverOne") && iterations == 0) {                     // special situation for serial coupling: SolverOne gets the old data in its first iteration for all time windows.
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 1.0 * currentDt));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    BOOST_TEST(currentDt == expectedDts[timestep % nSubsteps]);
+    time += currentDt;
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+    precice.advance(currentDt);
+    timestep++;
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
+      iterations++;
+      timestep = windowStartStep;
+      time     = windowStartTime;
+    }
+    if (precice.isTimeWindowComplete()) {
+      iterations++;
+      timewindow++;
+      BOOST_TEST(iterations == 3);
+      iterations = 0;
+    }
+  }
+
+  precice.finalize();
+  BOOST_TEST(timestep == nWindows * nSubsteps);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration dimensions="3">
+  <data:scalar name="DataOne" waveform-degree="1" />
+  <data:scalar name="DataTwo" waveform-degree="1" />
+
+  <mesh name="MeshOne">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="2" />
+    <max-iterations value="3" />
+    <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="false" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="false" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -180,6 +180,7 @@ target_sources(testprecice
     tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+    tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -192,6 +193,7 @@ target_sources(testprecice
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+    tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp


### PR DESCRIPTION
## Main changes of this PR

Bugfix, if initializing data and `substeps="false"`. Ensures that data at `WINDOW_START` and `WINDOW_END` is set during initialization. Previously, only data for `WINDOW_END` was set.

## Motivation and additional information

Bug detected for partitioned heat equation with `waveform-degree="1"` and `substeps="false"`. Mentioned in #1710.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] ~~I added a changelog file with `make changelog` if there are user-observable changes since the last release.~~ Not needed. Buggy state was not released.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] ~~For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).~~ Not needed.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
