### PR TITLE
More coverity fixes

### DIFF
--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -119,7 +119,7 @@ void runCoupling(
         iterationCount = 0;
         iterValidIterations++;
         if (iterValidIterations == validIterations.end()) {
-          BOOST_TEST(not cplScheme.isCouplingOngoing());
+          BOOST_REQUIRE(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
         // interface values in next timestep.
@@ -191,7 +191,7 @@ void runCoupling(
         iterationCount = 0;
         iterValidIterations++;
         if (iterValidIterations == validIterations.end()) {
-          BOOST_TEST(not cplScheme.isCouplingOngoing());
+          BOOST_REQUIRE(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
         // interface values in next timestep.
@@ -297,7 +297,7 @@ void runCouplingWithSubcycling(
         iterationCount = 1;
         iterValidIterations++;
         if (iterValidIterations == validIterations.end()) {
-          BOOST_TEST(not cplScheme.isCouplingOngoing());
+          BOOST_REQUIRE(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
         // interface values in next time step.
@@ -391,7 +391,7 @@ void runCouplingWithSubcycling(
         iterationCount = 1;
         iterValidIterations++;
         if (iterValidIterations == validIterations.end()) {
-          BOOST_TEST(not cplScheme.isCouplingOngoing());
+          BOOST_REQUIRE(not cplScheme.isCouplingOngoing());
         }
         // Reset data values, to simulate same convergence behavior of
         // interface values in next time step.

--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <tuple>
 #include <utility>
+#include <variant>
 
 #include "logging/LogMacros.hpp"
 #include "profiling/Event.hpp"
@@ -228,7 +229,7 @@ struct EventWriter {
 } // namespace
 
 void EventRegistry::flush()
-{
+try {
   if (_mode == Mode::Off || _writeQueue.empty()) {
     return;
   }
@@ -248,6 +249,8 @@ void EventRegistry::flush()
 
   _output.flush();
   _writeQueue.clear();
+} catch (const std::bad_variant_access &e) {
+  PRECICE_UNREACHABLE(e.what());
 }
 
 int EventRegistry::nameToID(const std::string &name)

--- a/tests/serial/TestImplicit.cpp
+++ b/tests/serial/TestImplicit.cpp
@@ -1,3 +1,4 @@
+#include <boost/test/tools/interface.hpp>
 #ifndef PRECICE_NO_MPI
 
 #include "testing/Testing.hpp"
@@ -53,6 +54,7 @@ BOOST_AUTO_TEST_CASE(TestImplicit)
         state = checkpoint;
       }
       iterationCount++;
+      BOOST_TEST_REQUIRE(iterationCount > 0);
       stateChange = initialStateChange / (double) iterationCount;
       state += stateChange;
       interface.advance(maxDt);
@@ -83,6 +85,7 @@ BOOST_AUTO_TEST_CASE(TestImplicit)
         state = checkpoint;
         iterationCount++;
       }
+      BOOST_TEST_REQUIRE(iterationCount > 0);
       stateChange = initialStateChange / (double) iterationCount;
       state += stateChange;
       interface.advance(maxDt);

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
@@ -75,14 +75,14 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingDifferentDts)
   }
 
   precice.initialize();
-  double maxDt    = precice.getMaxTimeStepSize();
-  double windowDt = maxDt;
-  int    timestepCheckpoint;
-  double dt = windowDt / nSubsteps;       // Timestep length desired by solver. E.g. 4 steps  with size 1/4, 3 steps with size 1/3
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 steps with size 5/16 and 1 steps with size 1/16; 2 steps with size 4/9 and 1 step with size 1/9
-  double currentDt = dt;                  // Timestep length used by solver
-  double timeCheckpoint;
-  int    iterations;
+  double maxDt              = precice.getMaxTimeStepSize();
+  double windowDt           = maxDt;
+  int    timestepCheckpoint = 0;
+  double dt                 = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4, 3 steps with size 1/3
+  dt += windowDt / nSubsteps / nSubsteps;           // increase timestep such that we get a non-matching subcycling. E.g. 3 steps with size 5/16 and 1 steps with size 1/16; 2 steps with size 4/9 and 1 step with size 1/9
+  double currentDt      = dt;                       // Timestep length used by solver
+  double timeCheckpoint = 0.0;
+  int    iterations     = 0;
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
@@ -57,11 +57,11 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   double v0[] = {0, 0, 0};
   vertexID    = precice.setMeshVertex(meshName, v0);
 
-  int    nSubsteps = 4; // perform subcycling on solvers. 4 steps happen in each window.
-  int    nWindows  = 5; // perform 5 windows.
-  int    timestep  = 0;
-  int    timestepCheckpoint;
-  double time = 0;
+  int    nSubsteps          = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows           = 5; // perform 5 windows.
+  int    timestep           = 0;
+  int    timestepCheckpoint = 0;
+  double time               = 0;
 
   if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingFirst)
   dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
   double currentDt = dt;                  // time step size used by solver
   double timeCheckpoint{0.0};
-  int    iterations;
+  int    iterations = 0;
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
@@ -55,11 +55,11 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
   double   v0[]     = {0, 0, 0};
   VertexID vertexID = precice.setMeshVertex(meshName, v0);
 
-  int    nSubsteps = 4; // perform subcycling on solvers. 4 steps happen in each window.
-  int    nWindows  = 5; // perform 5 windows.
-  int    timestep  = 0;
-  int    timestepCheckpoint;
-  double time = 0;
+  int    nSubsteps          = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows           = 5; // perform 5 windows.
+  int    timestep           = 0;
+  int    timestepCheckpoint = 0;
+  double time               = 0;
 
   if (precice.requiresInitialData()) {
     writeData = writeFunction(time);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingMixed)
   dt += windowDt / nSubsteps / nSubsteps; // increase time step size such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
   double currentDt = dt;                  // time step size used by solver
   double timeCheckpoint{0.0};
-  int    iterations;
+  int    iterations = 0;
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.cpp
@@ -69,14 +69,14 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingThird)
   }
 
   precice.initialize();
-  double maxDt    = precice.getMaxTimeStepSize();
-  double windowDt = maxDt;
-  int    timestepCheckpoint;
-  double dt = windowDt / nSubsteps;       // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
-  double timeCheckpoint;
-  int    iterations;
+  double maxDt              = precice.getMaxTimeStepSize();
+  double windowDt           = maxDt;
+  int    timestepCheckpoint = 0;
+  double dt                 = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps;           // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt      = dt;                       // Timestep length used by solver
+  double timeCheckpoint = 0.0;
+  int    iterations     = 0;
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.cpp
@@ -69,14 +69,14 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingThird)
   }
 
   precice.initialize();
-  double maxDt    = precice.getMaxTimeStepSize();
-  double windowDt = maxDt;
-  int    timestepCheckpoint;
-  double dt = windowDt / nSubsteps;       // Timestep length desired by solver. E.g. 4 steps  with size 1/4
-  dt += windowDt / nSubsteps / nSubsteps; // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
-  double currentDt = dt;                  // Timestep length used by solver
-  double timeCheckpoint;
-  int    iterations;
+  double maxDt              = precice.getMaxTimeStepSize();
+  double windowDt           = maxDt;
+  int    timestepCheckpoint = 0;
+  double dt                 = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 4 steps  with size 1/4
+  dt += windowDt / nSubsteps / nSubsteps;           // increase timestep such that we get a non-matching subcycling. E.g. 3 step with size 5/16 and 1 step with size 1/16.
+  double currentDt      = dt;                       // Timestep length used by solver
+  double timeCheckpoint = 0.0;
+  int    iterations     = 0;
 
   while (precice.isCouplingOngoing()) {
     if (precice.requiresWritingCheckpoint()) {


### PR DESCRIPTION
## Main changes of this PR

This PR fixes warnings mainly in tests:
- Initialize variables
- Prevent div by 0
- Avoid invalid iter deref
- Catch bad variant access


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

