### PR TITLE
Use `substeps="false"` as default

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -110,7 +110,7 @@ void BaseCouplingScheme::sendTimes(const m2n::PtrM2N &m2n, const Eigen::VectorXd
   m2n->send(times);
 }
 
-void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange)
+void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialCommunication)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get() != nullptr);
@@ -148,7 +148,7 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
         m2n->send(serialized.gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions() * serialized.nTimeSteps());
       }
     } else {
-      if (initialDataExchange) { // send data for WINDOW_START. Will be used for WINDOW_START and WINDOW_END.
+      if (initialCommunication) { // send data for WINDOW_START. Will be used for WINDOW_START and WINDOW_END.
         PRECICE_ASSERT(math::equals(stamples.front().timestamp, time::Storage::WINDOW_START));
         PRECICE_ASSERT(math::equals(stamples.back().timestamp, time::Storage::WINDOW_START));
       } else { // send data for WINDOW_END.
@@ -186,7 +186,7 @@ Eigen::VectorXd BaseCouplingScheme::receiveTimes(const m2n::PtrM2N &m2n, int nTi
   return times;
 }
 
-void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange)
+void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialCommunication)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get());
@@ -219,7 +219,7 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
         m2n->receive(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
       }
 
-      if (initialDataExchange) { // also use receive data for WINDOW_START.
+      if (initialCommunication) { // also use receive data for WINDOW_START.
         data->setSampleAtTime(time::Storage::WINDOW_START, data->sample());
       }
       // use received data for WINDOW_END.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -110,7 +110,7 @@ void BaseCouplingScheme::sendTimes(const m2n::PtrM2N &m2n, const Eigen::VectorXd
   m2n->send(times);
 }
 
-void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData)
+void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get() != nullptr);
@@ -120,10 +120,10 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
     const auto &stamples = data->stamples();
     PRECICE_ASSERT(stamples.size() > 0);
 
-    if (data->exchangeSubsteps()) {
-      int nTimeSteps = data->timeStepsStorage().nTimes();
-      PRECICE_ASSERT(nTimeSteps > 0);
+    int nTimeSteps = data->timeStepsStorage().nTimes();
+    PRECICE_ASSERT(nTimeSteps > 0);
 
+    if (data->exchangeSubsteps()) {
       if (nTimeSteps > 1) { // otherwise PRECICE_ASSERT below is triggered during initialization
         const Eigen::VectorXd timesAscending = data->timeStepsStorage().getTimes();
         PRECICE_ASSERT(math::equals(timesAscending(0), time::Storage::WINDOW_START), timesAscending(0));                                     // assert that first element is time::Storage::WINDOW_START
@@ -148,7 +148,13 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
         m2n->send(serialized.gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions() * serialized.nTimeSteps());
       }
     } else {
-      data->sample() = stamples.back().sample;
+      if (initialDataExchange) {
+        PRECICE_ASSERT(math::equals(stamples.front().timestamp, time::Storage::WINDOW_START));
+        data->sample() = stamples.front().sample;
+      } else {
+        PRECICE_ASSERT(math::equals(stamples.back().timestamp, time::Storage::WINDOW_END));
+        data->sample() = stamples.back().sample;
+      }
 
       // Data is only received on ranks with size>0, which is checked in the derived class implementation
       m2n->send(data->values(), data->getMeshID(), data->getDimensions());
@@ -180,7 +186,7 @@ Eigen::VectorXd BaseCouplingScheme::receiveTimes(const m2n::PtrM2N &m2n, int nTi
   return times;
 }
 
-void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData)
+void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get());
@@ -212,7 +218,12 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
         PRECICE_ASSERT(data->hasGradient());
         m2n->receive(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
       }
-      data->setSampleAtTime(time::Storage::WINDOW_END, data->sample());
+
+      if (initialDataExchange) {
+        data->setSampleAtTime(time::Storage::WINDOW_START, data->sample());
+      } else {
+        data->setSampleAtTime(time::Storage::WINDOW_END, data->sample());
+      }
     }
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -250,8 +250,9 @@ protected:
    *
    * @param m2n M2N used for communication
    * @param sendData DataMap associated with sent data
+   * @param initialCommunication if true and exchange of substeps is deactivated, will send data for WINDOW_START, else will send data for WINDOW_END
    */
-  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange = false);
+  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialCommunication = false);
 
   int receiveNumberOfTimeSteps(const m2n::PtrM2N &m2n);
 
@@ -262,8 +263,9 @@ protected:
    *
    * @param m2n M2N used for communication
    * @param receiveData DataMap associated with received data
+   * @param initialCommunication if true and exchange of substeps is deactivated, will store received data for WINDOW_START and WINDOW_END, else store received data only for WINDOW_END
    */
-  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange = false);
+  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialCommunication = false);
 
   /**
    * @brief Initializes storage in receiveData as zero

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -251,7 +251,7 @@ protected:
    * @param m2n M2N used for communication
    * @param sendData DataMap associated with sent data
    */
-  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData);
+  void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData, bool initialDataExchange = false);
 
   int receiveNumberOfTimeSteps(const m2n::PtrM2N &m2n);
 
@@ -263,7 +263,7 @@ protected:
    * @param m2n M2N used for communication
    * @param receiveData DataMap associated with received data
    */
-  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData);
+  void receiveData(const m2n::PtrM2N &m2n, const DataMap &receiveData, bool initialDataExchange = false);
 
   /**
    * @brief Initializes storage in receiveData as zero

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -89,7 +89,6 @@ void MultiCouplingScheme::exchangeInitialData()
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();
     } else {
@@ -100,20 +99,17 @@ void MultiCouplingScheme::exchangeInitialData()
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
         sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
   } else {
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
         sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();
     } else {

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -83,9 +83,12 @@ void MultiCouplingScheme::exchangeInitialData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
 
+  bool initialDataExchange = true;
+
   if (_isController) {
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();
@@ -96,17 +99,20 @@ void MultiCouplingScheme::exchangeInitialData()
     }
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
   } else {
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
       }
     }
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
         receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
       }
       checkDataHasBeenReceived();

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -83,12 +83,12 @@ void MultiCouplingScheme::exchangeInitialData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
 
-  bool initialDataExchange = true;
+  bool initialCommunication = true;
 
   if (_isController) {
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialCommunication);
       }
       checkDataHasBeenReceived();
     } else {
@@ -98,18 +98,18 @@ void MultiCouplingScheme::exchangeInitialData()
     }
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialCommunication);
       }
     }
   } else {
     if (sendsInitializedData()) {
       for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second, initialDataExchange);
+        sendData(_m2ns[sendExchange.first], sendExchange.second, initialCommunication);
       }
     }
     if (receivesInitializedData()) {
       for (auto &receiveExchange : _receiveDataVector) {
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialDataExchange);
+        receiveData(_m2ns[receiveExchange.first], receiveExchange.second, initialCommunication);
       }
       checkDataHasBeenReceived();
     } else {

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -25,28 +25,28 @@ ParallelCouplingScheme::ParallelCouplingScheme(
 
 void ParallelCouplingScheme::exchangeInitialData()
 {
-  bool initialDataExchange = true;
+  bool initialCommunication = true;
 
   // F: send, receive, S: receive, send
   if (doesFirstStep()) {
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
     if (receivesInitializedData()) {
-      receiveData(getM2N(), getReceiveData(), initialDataExchange);
+      receiveData(getM2N(), getReceiveData(), initialCommunication);
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
   } else { // second participant
     if (receivesInitializedData()) {
-      receiveData(getM2N(), getReceiveData(), initialDataExchange);
+      receiveData(getM2N(), getReceiveData(), initialCommunication);
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
   }
 }

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -31,11 +31,9 @@ void ParallelCouplingScheme::exchangeInitialData()
   if (doesFirstStep()) {
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
-      sendData(getM2N(), getSendData(), initialDataExchange);
     }
     if (receivesInitializedData()) {
       receiveData(getM2N(), getReceiveData(), initialDataExchange);
-      receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
@@ -43,13 +41,11 @@ void ParallelCouplingScheme::exchangeInitialData()
   } else { // second participant
     if (receivesInitializedData()) {
       receiveData(getM2N(), getReceiveData(), initialDataExchange);
-      receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
   }

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -25,12 +25,16 @@ ParallelCouplingScheme::ParallelCouplingScheme(
 
 void ParallelCouplingScheme::exchangeInitialData()
 {
+  bool initialDataExchange = true;
+
   // F: send, receive, S: receive, send
   if (doesFirstStep()) {
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData());
+      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialDataExchange);
     }
     if (receivesInitializedData()) {
+      receiveData(getM2N(), getReceiveData(), initialDataExchange);
       receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
@@ -38,13 +42,15 @@ void ParallelCouplingScheme::exchangeInitialData()
     }
   } else { // second participant
     if (receivesInitializedData()) {
+      receiveData(getM2N(), getReceiveData(), initialDataExchange);
       receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData());
+      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialDataExchange);
     }
   }
 }

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -96,7 +96,6 @@ void SerialCouplingScheme::exchangeInitialData()
   if (doesFirstStep()) {
     if (receivesInitializedData()) {
       receiveData(getM2N(), getReceiveData(), initialDataExchange);
-      receiveData(getM2N(), getReceiveData());
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
@@ -107,23 +106,20 @@ void SerialCouplingScheme::exchangeInitialData()
   } else { // second participant
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
-      sendData(getM2N(), getSendData(), initialDataExchange);
     }
     PRECICE_DEBUG("Receiving data...");
+    // similar to SerialCouplingScheme::exchangeSecondData()
     if (receivesInitializedData()) {                                // should actually also check if(data->exchangeSubsteps()), but a bit difficult...
       receiveData(getM2N(), getReceiveData(), initialDataExchange); // @todo need to receive data for WINDOW_START and WINDOW_END here, if no substeps are exchanged...
     }
-    // similar to SerialCouplingScheme::exchangeSecondData()
     receiveAndSetTimeWindowSize();
-    receiveData(getM2N(), getReceiveData());
+    receiveData(getM2N(), getReceiveData()); // receive data from end of first time step of first participant
     checkDataHasBeenReceived();
   }
 }
 
 void SerialCouplingScheme::exchangeFirstData()
 {
-  bool initialDataExchange = true;
-
   if (isExplicitCouplingScheme()) {
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Sending data...");

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -107,10 +107,10 @@ void SerialCouplingScheme::exchangeInitialData()
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
-    // similar to SerialCouplingScheme::exchangeSecondData()
     if (receivesInitializedData()) {                                // this send/recv pair is only needed, if no substeps are exchanged.
       receiveData(getM2N(), getReceiveData(), initialDataExchange); // Receive data for WINDOW_START and WINDOW_END here
     }
+    // similar to SerialCouplingScheme::exchangeSecondData()
     PRECICE_DEBUG("Receiving data...");
     receiveAndSetTimeWindowSize();
     receiveData(getM2N(), getReceiveData());

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -90,25 +90,25 @@ void SerialCouplingScheme::receiveAndSetTimeWindowSize()
 
 void SerialCouplingScheme::exchangeInitialData()
 {
-  bool initialDataExchange = true;
+  bool initialCommunication = true;
 
   // F: send, receive, S: receive, send
   if (doesFirstStep()) {
     if (receivesInitializedData()) {
-      receiveData(getM2N(), getReceiveData(), initialDataExchange);
+      receiveData(getM2N(), getReceiveData(), initialCommunication);
       checkDataHasBeenReceived();
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
     if (sendsInitializedData()) { // this send/recv pair is only needed, if no substeps are exchanged.
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
   } else { // second participant
     if (sendsInitializedData()) {
-      sendData(getM2N(), getSendData(), initialDataExchange);
+      sendData(getM2N(), getSendData(), initialCommunication);
     }
-    if (receivesInitializedData()) {                                // this send/recv pair is only needed, if no substeps are exchanged.
-      receiveData(getM2N(), getReceiveData(), initialDataExchange); // Receive data for WINDOW_START and WINDOW_END here
+    if (receivesInitializedData()) {                                 // this send/recv pair is only needed, if no substeps are exchanged.
+      receiveData(getM2N(), getReceiveData(), initialCommunication); // Receive data for WINDOW_START and WINDOW_END here
     }
     // similar to SerialCouplingScheme::exchangeSecondData()
     PRECICE_DEBUG("Receiving data...");

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -100,20 +100,20 @@ void SerialCouplingScheme::exchangeInitialData()
     } else {
       initializeWithZeroInitialData(getReceiveData());
     }
-    if (sendsInitializedData()) { // should actually also check if(data->exchangeSubsteps()), but a bit difficult...
+    if (sendsInitializedData()) { // this send/recv pair is only needed, if no substeps are exchanged.
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
   } else { // second participant
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData(), initialDataExchange);
     }
-    PRECICE_DEBUG("Receiving data...");
     // similar to SerialCouplingScheme::exchangeSecondData()
-    if (receivesInitializedData()) {                                // should actually also check if(data->exchangeSubsteps()), but a bit difficult...
-      receiveData(getM2N(), getReceiveData(), initialDataExchange); // @todo need to receive data for WINDOW_START and WINDOW_END here, if no substeps are exchanged...
+    if (receivesInitializedData()) {                                // this send/recv pair is only needed, if no substeps are exchanged.
+      receiveData(getM2N(), getReceiveData(), initialDataExchange); // Receive data for WINDOW_START and WINDOW_END here
     }
+    PRECICE_DEBUG("Receiving data...");
     receiveAndSetTimeWindowSize();
-    receiveData(getM2N(), getReceiveData()); // receive data from end of first time step of first participant
+    receiveData(getM2N(), getReceiveData());
     checkDataHasBeenReceived();
   }
 }

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -526,7 +526,7 @@ void CouplingSchemeConfiguration::addTagExchange(
   tagExchange.addAttribute(participantTo);
   auto attrInitialize = XMLAttribute<bool>(ATTR_INITIALIZE, false).setDocumentation("Should this data be initialized during initialize?");
   tagExchange.addAttribute(attrInitialize);
-  auto attrExchangeSubsteps = XMLAttribute<bool>(ATTR_EXCHANGE_SUBSTEPS, true).setDocumentation("Should this data exchange substeps?");
+  auto attrExchangeSubsteps = XMLAttribute<bool>(ATTR_EXCHANGE_SUBSTEPS, false).setDocumentation("Should this data exchange substeps?");
   tagExchange.addAttribute(attrExchangeSubsteps);
   tag.addSubtag(tagExchange);
 }

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -107,7 +107,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        mesh->data(0)->setSampleAtTime(time::Storage::WINDOW_START, time::Sample{1, mesh->data(0)->values()});
+        mesh->data(0)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{1, mesh->data(0)->values()});
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
@@ -142,7 +142,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        mesh->data(1)->setSampleAtTime(time::Storage::WINDOW_START, time::Sample{ddims, mesh->data(1)->values()});
+        mesh->data(1)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{ddims, mesh->data(1)->values()});
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
@@ -178,7 +178,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        mesh->data(2)->setSampleAtTime(time::Storage::WINDOW_START, time::Sample{ddims, mesh->data(2)->values()});
+        mesh->data(2)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{ddims, mesh->data(2)->values()});
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -439,6 +439,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
       dt        = std::min({solverDt, preciceDt});
       computedTime += dt;
       computedTimesteps++;
+      mesh->data(0)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
       cplScheme.addComputedTime(dt);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
@@ -466,6 +467,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
     while (cplScheme.isCouplingOngoing()) {
       computedTime += cplScheme.getTimeWindowSize();
       computedTimesteps++;
+      mesh->data(1)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
       cplScheme.addComputedTime(cplScheme.getTimeWindowSize());
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();

--- a/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversExplicitImplicit.xml
@@ -54,8 +54,10 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="10" />
     <time-window-size value="1.0" />
-    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo" substeps="true" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne" substeps="true" />
   </coupling-scheme:serial-explicit>
 
   <coupling-scheme:serial-implicit>
@@ -64,7 +66,9 @@
     <time-window-size value="1.0" />
     <max-iterations value="10" />
     <min-iteration-convergence-measure min-iterations="3" data="Data2" mesh="MeshA" />
-    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverThree" />
-    <exchange data="Data2" mesh="MeshA" from="SolverThree" to="SolverOne" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverThree" substeps="true" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data2" mesh="MeshA" from="SolverThree" to="SolverOne" substeps="true" />
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
+++ b/tests/serial/three-solvers/ThreeSolversImplicitExplicit.xml
@@ -56,15 +56,19 @@
     <time-window-size value="1.0" />
     <max-iterations value="10" />
     <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA" />
-    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo" substeps="true" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne" substeps="true" />
   </coupling-scheme:serial-implicit>
 
   <coupling-scheme:serial-explicit>
     <participants first="SolverOne" second="SolverThree" />
     <max-time-windows value="10" />
     <time-window-size value="1.0" />
-    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverThree" />
-    <exchange data="Data2" mesh="MeshA" from="SolverThree" to="SolverOne" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverThree" substeps="true" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data2" mesh="MeshA" from="SolverThree" to="SolverOne" substeps="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/three-solvers/ThreeSolversParallel.xml
+++ b/tests/serial/three-solvers/ThreeSolversParallel.xml
@@ -56,15 +56,31 @@
     <time-window-size value="1.0" />
     <max-iterations value="10" />
     <min-iteration-convergence-measure min-iterations="3" data="Data1" mesh="MeshA" />
-    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverTwo" substeps="true" />
+    <!-- Does not work for substeps="false" -->
+    <exchange data="Data1" mesh="MeshA" from="SolverTwo" to="SolverOne" substeps="true" />
   </coupling-scheme:parallel-implicit>
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverThree" />
     <max-time-windows value="10" />
     <time-window-size value="1.0" />
-    <exchange data="Data0" mesh="MeshA" from="SolverOne" to="SolverThree" initialize="1" />
-    <exchange data="Data2" mesh="MeshA" from="SolverThree" to="SolverOne" initialize="1" />
+    <!-- Does not work for substeps="false" -->
+    <exchange
+      data="Data0"
+      mesh="MeshA"
+      from="SolverOne"
+      to="SolverThree"
+      initialize="1"
+      substeps="true" />
+    <!-- Does not work for substeps="false" -->
+    <exchange
+      data="Data2"
+      mesh="MeshA"
+      from="SolverThree"
+      to="SolverOne"
+      initialize="1"
+      substeps="true" />
   </coupling-scheme:parallel-explicit>
 </precice-configuration>

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcycling.xml
@@ -42,13 +42,25 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="true" />
   </coupling-scheme:parallel-explicit>
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="true" />
   </coupling-scheme:parallel-explicit>
 </precice-configuration>

--- a/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
+++ b/tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
@@ -42,25 +42,13 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange
-      data="DataOne"
-      mesh="MeshOne"
-      from="SolverOne"
-      to="SolverTwo"
-      initialize="on"
-      substeps="false" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
   </coupling-scheme:parallel-explicit>
 
   <coupling-scheme:parallel-explicit>
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange
-      data="DataTwo"
-      mesh="MeshOne"
-      from="SolverTwo"
-      to="SolverOne"
-      initialize="on"
-      substeps="false" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
   </coupling-scheme:parallel-explicit>
 </precice-configuration>

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -42,7 +42,19 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
-    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="true" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="true" />
   </coupling-scheme:parallel-explicit>
 </precice-configuration>

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
@@ -42,19 +42,7 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange
-      data="DataOne"
-      mesh="MeshOne"
-      from="SolverOne"
-      to="SolverTwo"
-      initialize="on"
-      substeps="false" />
-    <exchange
-      data="DataTwo"
-      mesh="MeshOne"
-      from="SolverTwo"
-      to="SolverOne"
-      initialize="on"
-      substeps="false" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
   </coupling-scheme:parallel-explicit>
 </precice-configuration>

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.xml
@@ -42,7 +42,19 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
-    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="true" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="true" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
@@ -42,13 +42,7 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="2.0" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
-    <exchange
-      data="DataTwo"
-      mesh="MeshOne"
-      from="SolverTwo"
-      to="SolverOne"
-      initialize="on"
-      substeps="false" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
@@ -72,33 +72,9 @@
     <time-window-size value="2" />
     <max-iterations value="3" />
     <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
-    <exchange
-      data="DataOne"
-      mesh="MeshOne"
-      from="SolverOne"
-      to="SolverTwo"
-      initialize="on"
-      substeps="false" />
-    <exchange
-      data="DataTwo"
-      mesh="MeshOne"
-      from="SolverTwo"
-      to="SolverOne"
-      initialize="on"
-      substeps="false" />
-    <exchange
-      data="DataOne"
-      mesh="MeshOne"
-      from="SolverOne"
-      to="SolverThree"
-      initialize="on"
-      substeps="false" />
-    <exchange
-      data="DataThree"
-      mesh="MeshOne"
-      from="SolverThree"
-      to="SolverOne"
-      initialize="on"
-      substeps="false" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverThree" initialize="on" />
+    <exchange data="DataThree" mesh="MeshOne" from="SolverThree" to="SolverOne" initialize="on" />
   </coupling-scheme:multi>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
@@ -44,19 +44,7 @@
     <time-window-size value="2" />
     <max-iterations value="3" />
     <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
-    <exchange
-      data="DataOne"
-      mesh="MeshOne"
-      from="SolverOne"
-      to="SolverTwo"
-      initialize="on"
-      substeps="false" />
-    <exchange
-      data="DataTwo"
-      mesh="MeshOne"
-      from="SolverTwo"
-      to="SolverOne"
-      initialize="on"
-      substeps="false" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
   </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
@@ -1,0 +1,144 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/Participant.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(ParallelCoupling)
+
+/**
+ * @brief Test to run a simple coupling with subcycling.
+ *
+ * Ensures that each time step provides its own data, but preCICE only exchanges data at the end of the window.
+ *
+ * Deactivates exchange of substeps. Uses first degree interpolation. Uses data initialization for both participants.
+ */
+BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  typedef double (*DataFunction)(double);
+
+  DataFunction dataOneFunction = [](double t) -> double {
+    return (double) (2 + t);
+  };
+  DataFunction dataTwoFunction = [](double t) -> double {
+    return (double) (10 + t);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "DataOne";
+    writeFunction = dataOneFunction;
+    readDataName  = "DataTwo";
+    readFunction  = dataTwoFunction;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "DataTwo";
+    writeFunction = dataTwoFunction;
+    readDataName  = "DataOne";
+    readFunction  = dataOneFunction;
+  }
+
+  double   writeData = 0;
+  double   readData  = 0;
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
+
+  int    nSubsteps       = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows        = 5; // perform 5 windows.
+  int    timestep        = 0;
+  int    timewindow      = 0;
+  double startTime       = 0;
+  double windowStartTime = 0;
+  int    windowStartStep = 0;
+  int    iterations      = 0;
+  double time            = 0;
+
+  if (precice.requiresInitialData()) {
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+  }
+
+  precice.initialize();
+  BOOST_TEST(precice.getMaxTimeStepSize() == 2.0); // use window size != 1.0 to be able to detect more possible bugs
+  double windowDt      = precice.getMaxTimeStepSize();
+  double solverDt      = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a timestep of fixed size.
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.requiresWritingCheckpoint()) {
+      windowStartTime = time;
+      windowStartStep = timestep;
+    }
+    double preciceDt = precice.getMaxTimeStepSize();
+    double currentDt = solverDt > preciceDt ? preciceDt : solverDt; // determine actual time step size; must fit into remaining time in window
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0 * currentDt, {&readData, 1});
+
+    if (iterations == 0) {                                                     // special situation: Both solvers are in their very first time windows, first iteration, first time step
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0.5 * currentDt, {&readData, 1});
+
+    if (iterations == 0) {                                                     // special situation: Both solvers are in their very first time windows, first iteration, first time step
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0.5 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 1.0 * currentDt, {&readData, 1});
+
+    if (iterations == 0) {                                                     // special situation: Both solvers are in their very first time windows, first iteration, first time step
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 1.0 * currentDt));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    BOOST_TEST(currentDt == expectedDts[timestep % nSubsteps]);
+    time += currentDt;
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+    precice.advance(currentDt);
+    timestep++;
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
+      iterations++;
+      timestep = windowStartStep;
+      time     = windowStartTime;
+    }
+    if (precice.isTimeWindowComplete()) {
+      iterations++;
+      timewindow++;
+      BOOST_TEST(iterations == 3);
+      iterations = 0;
+    }
+  }
+
+  precice.finalize();
+  BOOST_TEST(timestep == nWindows * nSubsteps);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration dimensions="3">
+  <data:scalar name="DataOne" waveform-degree="1" />
+  <data:scalar name="DataTwo" waveform-degree="1" />
+
+  <mesh name="MeshOne">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="2" />
+    <max-iterations value="3" />
+    <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="false" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="false" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.xml
+++ b/tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.xml
@@ -44,7 +44,19 @@
     <time-window-size value="2" />
     <max-iterations value="3" />
     <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
-    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="true" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="true" />
   </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.xml
@@ -44,13 +44,7 @@
     <time-window-size value="2" />
     <max-iterations value="3" />
     <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
-    <exchange
-      data="DataTwo"
-      mesh="MeshOne"
-      from="SolverTwo"
-      to="SolverOne"
-      initialize="on"
-      substeps="false" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
@@ -1,0 +1,144 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/Participant.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief Test to run a simple coupling with subcycling.
+ *
+ * Ensures that each time step provides its own data, but preCICE only exchanges data at the end of the window.
+ *
+ * Deactivates exchange of substeps. Uses first degree interpolation. Uses data initialization for both participants.
+ */
+BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  typedef double (*DataFunction)(double);
+
+  DataFunction dataOneFunction = [](double t) -> double {
+    return (double) (2 + t);
+  };
+  DataFunction dataTwoFunction = [](double t) -> double {
+    return (double) (10 + t);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "DataOne";
+    writeFunction = dataOneFunction;
+    readDataName  = "DataTwo";
+    readFunction  = dataTwoFunction;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "DataTwo";
+    writeFunction = dataTwoFunction;
+    readDataName  = "DataOne";
+    readFunction  = dataOneFunction;
+  }
+
+  double   writeData = 0;
+  double   readData  = 0;
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID  = precice.setMeshVertex(meshName, v0);
+
+  int    nSubsteps       = 4; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows        = 5; // perform 5 windows.
+  int    timestep        = 0;
+  int    timewindow      = 0;
+  double startTime       = 0;
+  double windowStartTime = 0;
+  int    windowStartStep = 0;
+  int    iterations      = 0;
+  double time            = 0;
+
+  if (precice.requiresInitialData()) {
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+  }
+
+  precice.initialize();
+  BOOST_TEST(precice.getMaxTimeStepSize() == 2.0); // use window size != 1.0 to be able to detect more possible bugs
+  double windowDt      = precice.getMaxTimeStepSize();
+  double solverDt      = windowDt / (nSubsteps - 0.5);                 // Solver always tries to do a timestep of fixed size.
+  double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.requiresWritingCheckpoint()) {
+      windowStartTime = time;
+      windowStartStep = timestep;
+    }
+    double preciceDt = precice.getMaxTimeStepSize();
+    double currentDt = solverDt > preciceDt ? preciceDt : solverDt; // determine actual time step size; must fit into remaining time in window
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0 * currentDt, {&readData, 1});
+
+    if (context.isNamed("SolverOne") && iterations == 0) {                     // special situation for serial coupling: SolverOne gets the old data in its first iteration for all time windows.
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0.5 * currentDt, {&readData, 1});
+
+    if (context.isNamed("SolverOne") && iterations == 0) {                     // special situation for serial coupling: SolverOne gets the old data in its first iteration for all time windows.
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 0.5 * currentDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 1.0 * currentDt, {&readData, 1});
+
+    if (context.isNamed("SolverOne") && iterations == 0) {                     // special situation for serial coupling: SolverOne gets the old data in its first iteration for all time windows.
+      BOOST_TEST(readData == readFunction(startTime + timewindow * windowDt)); // zeroth window: Initial Data from SolverTwo; following windows: data at end of window was written by SolverTwo.
+    } else {
+      BOOST_TEST(readData == readFunction(time + 1.0 * currentDt));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    BOOST_TEST(currentDt == expectedDts[timestep % nSubsteps]);
+    time += currentDt;
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+    precice.advance(currentDt);
+    timestep++;
+    if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
+      iterations++;
+      timestep = windowStartStep;
+      time     = windowStartTime;
+    }
+    if (precice.isTimeWindowComplete()) {
+      iterations++;
+      timewindow++;
+      BOOST_TEST(iterations == 3);
+      iterations = 0;
+    }
+  }
+
+  precice.finalize();
+  BOOST_TEST(timestep == nWindows * nSubsteps);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration dimensions="3">
+  <data:scalar name="DataOne" waveform-degree="1" />
+  <data:scalar name="DataTwo" waveform-degree="1" />
+
+  <mesh name="MeshOne">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="2" />
+    <max-iterations value="3" />
+    <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="false" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="false" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.xml
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.xml
@@ -44,7 +44,19 @@
     <time-window-size value="2" />
     <max-iterations value="3" />
     <min-iteration-convergence-measure min-iterations="3" data="DataOne" mesh="MeshOne" />
-    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
-    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    <exchange
+      data="DataOne"
+      mesh="MeshOne"
+      from="SolverOne"
+      to="SolverTwo"
+      initialize="on"
+      substeps="true" />
+    <exchange
+      data="DataTwo"
+      mesh="MeshOne"
+      from="SolverTwo"
+      to="SolverOne"
+      initialize="on"
+      substeps="true" />
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -180,6 +180,7 @@ target_sources(testprecice
     tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+    tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.cpp
     tests/serial/time/implicit/parallel-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp
@@ -192,6 +193,7 @@ target_sources(testprecice
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipantFixedWindows.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+    tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubstepsUseInitFirst.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstExtrapolation.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSamplingFirstNoInit.cpp


### PR DESCRIPTION
## Main changes of this PR

Use `substeps="false"` as default.

## Motivation and additional information

Implements default value `substeps="false"` following discussion about default value in #1721.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] Merge #1719 

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
