### PR TITLE
Exclude boundary vertices from index queries

### DIFF
--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -230,7 +230,7 @@ std::vector<VertexID> Index::getVerticesInsideBox(const mesh::Vertex &centerVert
 
   const auto &          rtree = _pimpl->getVertexRTree(*_mesh);
   std::vector<VertexID> matches;
-  rtree->query(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertices()[i]) <= radius; }),
+  rtree->query(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertices()[i]) < radius; }),
                std::back_inserter(matches));
   return matches;
 }

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -81,7 +81,7 @@ public:
   /// Get n number of closest triangles to the given vertex
   std::vector<TriangleMatch> getClosestTriangles(const Eigen::VectorXd &sourceCoord, int n);
 
-  /// Return all the vertices inside the box formed by vertex and radius
+  /// Return all the vertices inside the box formed by vertex and radius (boundary exclusive)
   std::vector<VertexID> getVerticesInsideBox(const mesh::Vertex &centerVertex, double radius);
 
   /// Return all the vertices inside a bounding box


### PR DESCRIPTION
## Main changes of this PR

Excludes boundary vertices from index query in `getVerticesInsideBox`.

## Motivation and additional information

The applied change affects other RBF mappings as well. Since the basis-function implementation returns anyway zero when using the support radius as argument, it makes sense to not collect the vertices with a distance of `radius` in the first place. 

Fixes #1733 
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

