### PR TITLE
PUM mapping: use only a single cluster for small cases

### DIFF
--- a/docs/changelog/1736.md
+++ b/docs/changelog/1736.md
@@ -1,0 +1,1 @@
+- Changed the partition-of-unity mapping to only create a single cluster, if the desired number of vertices per cluster is smaller than the local number of vertices.

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -334,6 +334,15 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   inMesh->computeBoundingBox();
   auto localBB = inMesh->getBoundingBox();
 
+  // If we have less vertices in the whole domain than our target cluster size,
+  // we just use a single cluster. The clustering result of the algorithm further
+  // down is in this case not optimal.
+  // The single cluster has in principle a radius of inf. We use here twice the
+  // length of the longest bounding box edge length and the center of the bounding
+  // box for the center point.
+  if (inMesh->vertices().size() < verticesPerCluster)
+    return {localBB.longestEdgeLength() * 2, Vertices{mesh::Vertex({localBB.center(), 0})}};
+
   // We define a convenience alias for the localBB. In case we need to synchronize the clustering across ranks later on, we need
   // to work with the global bounding box of the whole domain.
   auto globalBB = localBB;


### PR DESCRIPTION
## Main changes of this PR

If the user-specified target number of vertices per cluster/cluster size is higher than the number of vertices in the (local) mesh, we use just a single cluster and bypass the clustering algorithm. 

## Motivation and additional information

Open for discussion. In principle, that's not what the PUM was made for and a user could just use the 'available' global RBF mappings to achieve the same effect. Now that we have the alias tag, it would be somewhat tedious to go back and forth between the alias tag and a specific kind of mapping in the precice config (more arguments, different opening/closing tags). Therefore, I would just go with the proposed changes such that the PUM does the same by default -> no config changes needed. We could revert the change at anytime, if needed.

Will add a changelog, if approved.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
