### PR TITLE
Make direct access non-experimental

### DIFF
--- a/docs/changelog/1740.md
+++ b/docs/changelog/1740.md
@@ -1,0 +1,2 @@
+- Changed direct-mesh access to be non-experimental.
+- Renamed the direct-mesh API function `getMeshVerticesAndIDs` to `getMeshVertexIDsAndCoordinates`.

--- a/extras/bindings/c/include/precice/preciceC.h
+++ b/extras/bindings/c/include/precice/preciceC.h
@@ -370,9 +370,9 @@ PRECICE_API void precicec_setMeshAccessRegion(
     const double *boundingBox);
 
 /**
- * @brief See precice::Participant::getMeshVerticesAndIDs().
+ * @brief See precice::Participant::getMeshVertexIDsAndCoordinates().
  */
-PRECICE_API void precicec_getMeshVerticesAndIDs(
+PRECICE_API void precicec_getMeshVertexIDsAndCoordinates(
     const char *meshName,
     const int   size,
     int *       ids,

--- a/extras/bindings/c/include/precice/preciceC.h
+++ b/extras/bindings/c/include/precice/preciceC.h
@@ -277,6 +277,22 @@ PRECICE_API void precicec_setMeshTetrahedra(
     int         size,
     const int * vertices);
 
+/**
+ * @brief See precice::Participant::setMeshAccessRegion().
+ */
+PRECICE_API void precicec_setMeshAccessRegion(
+    const char *  meshName,
+    const double *boundingBox);
+
+/**
+ * @brief See precice::Participant::getMeshVertexIDsAndCoordinates().
+ */
+PRECICE_API void precicec_getMeshVertexIDsAndCoordinates(
+    const char *meshName,
+    const int   size,
+    int *       ids,
+    double *    coordinates);
+
 ///@}
 
 ///@name Data Access
@@ -361,22 +377,6 @@ PRECICE_API void precicec_writeGradientData(
     int           size,
     const int *   valueIndices,
     const double *gradients);
-
-/**
- * @brief See precice::Participant::setMeshAccessRegion().
- */
-PRECICE_API void precicec_setMeshAccessRegion(
-    const char *  meshName,
-    const double *boundingBox);
-
-/**
- * @brief See precice::Participant::getMeshVertexIDsAndCoordinates().
- */
-PRECICE_API void precicec_getMeshVertexIDsAndCoordinates(
-    const char *meshName,
-    const int   size,
-    int *       ids,
-    double *    coordinates);
 
 ///@}
 

--- a/extras/bindings/c/src/preciceC.cpp
+++ b/extras/bindings/c/src/preciceC.cpp
@@ -319,14 +319,14 @@ void precicec_setMeshAccessRegion(
   impl->setMeshAccessRegion(meshName, {boundingBox, bbSize});
 }
 
-void precicec_getMeshVerticesAndIDs(
+void precicec_getMeshVertexIDsAndCoordinates(
     const char *meshName,
     const int   size,
     int *       ids,
     double *    coordinates)
 {
   auto coordinatesSize = static_cast<long unsigned>(impl->getMeshDimensions(meshName) * size);
-  impl->getMeshVerticesAndIDs(meshName, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
+  impl->getMeshVertexIDsAndCoordinates(meshName, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
 }
 
 #ifdef __GNUC__

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -581,7 +581,7 @@ PRECICE_API void precicef_set_mesh_access_region_(
  * IN:  mesh, size, meshNameLength
  * OUT: ids, coordinates
  *
- * @copydoc precice::Participant::getMeshVerticesAndIDs()
+ * @copydoc precice::Participant::getMeshVertexIDsAndCoordinates()
  */
 PRECICE_API void precicef_get_mesh_vertices_and_ids_(
     const char *meshName,

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -456,6 +456,42 @@ PRECICE_API void precicef_set_mesh_tetrahedra_(
 
 /**
  * Fortran syntax:
+ * precicef_set_mesh_access_region_(
+ *   CHARACTER        meshName(*),
+ *   DOUBLE PRECISION bounding_box(dim*2))
+ *
+ * IN:  mesh, bounding_box, meshNameLength
+ * OUT: -
+ *
+ * @copydoc precice::Participant::setMeshAccessRegion()
+ */
+PRECICE_API void precicef_set_mesh_access_region_(
+    const char *  meshName,
+    const double *boundingBox,
+    int           meshNameLength);
+
+/**
+ * Fortran syntax:
+ * precicef_get_mesh_vertex_ids_and_coordinates_(
+ *   CHARACTER        meshName(*),
+ *   INTEGER          size,
+ *   INTEGER          ids(size),
+ *   DOUBLE PRECISION coordinates(dim*size))
+ *
+ * IN:  mesh, size, meshNameLength
+ * OUT: ids, coordinates
+ *
+ * @copydoc precice::Participant::getMeshVertexIDsAndCoordinates()
+ */
+PRECICE_API void precicef_get_mesh_vertex_ids_and_coordinates_(
+    const char *meshName,
+    const int   size,
+    int *       ids,
+    double *    coordinates,
+    int         meshNameLength);
+
+/**
+ * Fortran syntax:
  * precicef_write_data(
  *   CHARACTER meshName(*),
  *   CHARACTER dataName(*),
@@ -553,42 +589,6 @@ PRECICE_API void precicef_write_gradient_data_(
     const double *gradients,
     int           meshNameLength,
     int           dataNameLength);
-
-/**
- * Fortran syntax:
- * precicef_set_mesh_access_region_(
- *   CHARACTER        meshName(*),
- *   DOUBLE PRECISION bounding_box(dim*2))
- *
- * IN:  mesh, bounding_box, meshNameLength
- * OUT: -
- *
- * @copydoc precice::Participant::setMeshAccessRegion()
- */
-PRECICE_API void precicef_set_mesh_access_region_(
-    const char *  meshName,
-    const double *boundingBox,
-    int           meshNameLength);
-
-/**
- * Fortran syntax:
- * precicef_get_mesh_vertices_and_ids_(
- *   CHARACTER        meshName(*),
- *   INTEGER          size,
- *   INTEGER          ids(size),
- *   DOUBLE PRECISION coordinates(dim*size))
- *
- * IN:  mesh, size, meshNameLength
- * OUT: ids, coordinates
- *
- * @copydoc precice::Participant::getMeshVertexIDsAndCoordinates()
- */
-PRECICE_API void precicef_get_mesh_vertices_and_ids_(
-    const char *meshName,
-    const int   size,
-    int *       ids,
-    double *    coordinates,
-    int         meshNameLength);
 
 ///@}
 

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -431,7 +431,7 @@ void precicef_get_mesh_vertices_and_ids_(
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto sv              = precice::impl::strippedStringView(meshName, meshNameLength);
   auto coordinatesSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * size);
-  impl->getMeshVerticesAndIDs(sv, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
+  impl->getMeshVertexIDsAndCoordinates(sv, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
 }
 
 #ifdef __GNUC__

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -240,11 +240,11 @@ void Participant::setMeshAccessRegion(::precice::string_view        meshName,
   _impl->setMeshAccessRegion(toSV(meshName), boundingBox);
 }
 
-void Participant::getMeshVerticesAndIDs(::precice::string_view    meshName,
-                                        ::precice::span<VertexID> ids,
-                                        ::precice::span<double>   coordinates) const
+void Participant::getMeshVertexIDsAndCoordinates(::precice::string_view    meshName,
+                                                 ::precice::span<VertexID> ids,
+                                                 ::precice::span<double>   coordinates) const
 {
-  _impl->getMeshVerticesAndIDs(toSV(meshName), ids, coordinates);
+  _impl->getMeshVertexIDsAndCoordinates(toSV(meshName), ids, coordinates);
 }
 
 void Participant::writeGradientData(

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -645,10 +645,8 @@ public:
 
   ///@}
 
-  /** @name Experimental: Direct Access
-   * These API functions are \b experimental and may change in future versions.
+  /** @name Direct Access
    */
-  ///@{
 
   /**
    * @brief setMeshAccessRegion Define a region of interest on a received mesh
@@ -738,8 +736,6 @@ public:
       ::precice::string_view    meshName,
       ::precice::span<VertexID> ids,
       ::precice::span<double>   coordinates) const;
-
-  ///@}
 
   /** @name Experimental: Gradient Data
    * These API functions are \b experimental and may change in future versions.

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -712,7 +712,7 @@ public:
       ::precice::span<const double> boundingBox) const;
 
   /**
-   * @brief getMeshVerticesAndIDs Iterates over the region of
+   * @brief getMeshVertexIDsAndCoordinates Iterates over the region of
    *        interest defined by bounding boxes and reads the corresponding
    *        coordinates omitting the mapping.
    *
@@ -734,7 +734,7 @@ public:
    * @see getMeshVertexSize() to get the amount of vertices in the mesh
    * @see getMeshDimensions() to get the spacial dimensionality of the mesh
    */
-  void getMeshVerticesAndIDs(
+  void getMeshVertexIDsAndCoordinates(
       ::precice::string_view    meshName,
       ::precice::span<VertexID> ids,
       ::precice::span<double>   coordinates) const;

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -294,13 +294,6 @@ void ParticipantConfiguration::xmlTagCallback(
                   "Please add the name of the other participant to the receive-mesh tag: <receive-mesh name=\"{}\" from=\"(other participant)\" ... />",
                   context.name, name, name)
 
-    if (allowDirectAccess) {
-      if (!_experimental) {
-        PRECICE_ERROR("You tried to configure the received mesh \"{}\" to use the option access-direct=\"true\", which is currently still experimental. Please set experimental=\"true\", if you want to use this feature.", name);
-      }
-      PRECICE_WARN("You configured the received mesh \"{}\" to use the option access-direct=\"true\", which is currently still experimental. Use with care.", name);
-    }
-
     PRECICE_CHECK(_participants.back()->getName() != from,
                   "Participant \"{}\" cannot receive mesh \"{}\" from itself. "
                   "To provide a mesh, use <provide-mesh name=\"{}\" /> instead.",

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1132,7 +1132,7 @@ void ParticipantImpl::setMeshAccessRegion(
   _accessRegionDefined = true;
 }
 
-void ParticipantImpl::getMeshVerticesAndIDs(
+void ParticipantImpl::getMeshVertexIDsAndCoordinates(
     const std::string_view    meshName,
     ::precice::span<VertexID> ids,
     ::precice::span<double>   coordinates) const

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1098,7 +1098,6 @@ void ParticipantImpl::setMeshAccessRegion(
     const std::string_view        meshName,
     ::precice::span<const double> boundingBox) const
 {
-  PRECICE_EXPERIMENTAL_API();
   PRECICE_TRACE(meshName, boundingBox.size());
   PRECICE_REQUIRE_MESH_USE(meshName);
   PRECICE_CHECK(_state != State::Finalized, "setMeshAccessRegion() cannot be called after finalize().")
@@ -1137,7 +1136,6 @@ void ParticipantImpl::getMeshVertexIDsAndCoordinates(
     ::precice::span<VertexID> ids,
     ::precice::span<double>   coordinates) const
 {
-  PRECICE_EXPERIMENTAL_API();
   PRECICE_TRACE(meshName, ids.size(), coordinates.size());
   PRECICE_REQUIRE_MESH_USE(meshName);
   PRECICE_DEBUG("Get {} mesh vertices with IDs", ids.size());

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -261,8 +261,8 @@ public:
   void setMeshAccessRegion(std::string_view              meshName,
                            ::precice::span<const double> boundingBox) const;
 
-  /// @copydoc Participant::getMeshVerticesAndIDs
-  void getMeshVerticesAndIDs(
+  /// @copydoc Participant::getMeshVertexIDsAndCoordinates
+  void getMeshVertexIDsAndCoordinates(
       std::string_view          meshName,
       ::precice::span<VertexID> ids,
       ::precice::span<double>   coordinates) const;

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -252,8 +252,7 @@ public:
 
   ///@}
 
-  /** @name Experimental Data Access
-   * These API functions are \b experimental and may change in future versions.
+  /** @name Direct Access
    */
   ///@{
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshAndMapping)
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverTwoMesh);
+    interface.getMeshVertexIDsAndCoordinates(otherMeshName, otherIDs, solverTwoMesh);
     // Expected data = positions of the other participant's mesh
     const std::vector<double> expectedData = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.5}) : std::vector<double>({0.0, 3.5, 0.0, 4.0, 0.0, 5.0});
     BOOST_TEST(solverTwoMesh == expectedData);

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
   <data:scalar name="Forces" />
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapNoWriteTwoLevelInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshOverlapTwoLevelInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/parallel/direct-mesh-access/helpers.cpp
+++ b/tests/parallel/direct-mesh-access/helpers.cpp
@@ -39,7 +39,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
     // Allocate memory
     std::vector<int>    ids(meshSize);
     std::vector<double> coordinates(meshSize * dim);
-    interface.getMeshVerticesAndIDs(otherMeshName, ids, coordinates);
+    interface.getMeshVertexIDsAndCoordinates(otherMeshName, ids, coordinates);
 
     // Check the received vertex coordinates
     std::vector<double> expectedPositions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.0}) : expectedPositionSecondaryRank;
@@ -90,13 +90,13 @@ void runTestAccessReceivedMesh(const TestContext &       context,
     interface.setMeshVertices(meshName, positions, ids);
 
     {
-      // Check, if we can use the 'getMeshVerticesAndIDs' function on provided meshes as well,
+      // Check, if we can use the 'getMeshVertexIDsAndCoordinates' function on provided meshes as well,
       // though the actual purpose is of course using it on received meshes
       const std::size_t ownMeshSize = interface.getMeshVertexSize(meshName);
       BOOST_TEST(ownMeshSize == size);
       std::vector<int>    ownIDs(ownMeshSize);
       std::vector<double> ownCoordinates(ownMeshSize * dim);
-      interface.getMeshVerticesAndIDs(meshName, ownIDs, ownCoordinates);
+      interface.getMeshVertexIDsAndCoordinates(meshName, ownIDs, ownCoordinates);
       BOOST_TEST(ownIDs == ids);
       BOOST_TEST(testing::equals(positions, ownCoordinates));
     }

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
     // Allocate a vector containing the vertices
     std::vector<double> receivedMesh(receivedMeshSize * dim);
     std::vector<int>    receiveMeshIDs(receivedMeshSize, -1);
-    interface.getMeshVerticesAndIDs(receivedMeshName, receiveMeshIDs, receivedMesh);
+    interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
 
     // Allocate data to read and write
     std::vector<double> readData(receiveMeshIDs.size(), -1);

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
   <data:scalar name="Forces" />
 

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
 
     std::vector<double> otherPositions(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshID, otherIDs, otherPositions);
+    interface.getMeshVertexIDsAndCoordinates(otherMeshID, otherIDs, otherPositions);
 
     // writeData for first window
     for (int i = 0; i < otherMeshSize; ++i) {

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
   <data:scalar name="Forces" />
 

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
 
     std::vector<double> otherPositions(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshName, otherIDs, otherPositions);
+    interface.getMeshVertexIDsAndCoordinates(otherMeshName, otherIDs, otherPositions);
 
     // Some dummy writeData
     std::vector<double> readData(ownIDs.size(), -1);

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
   <data:scalar name="Forces" />
 

--- a/tests/serial/direct-mesh-access/Explicit.cpp
+++ b/tests/serial/direct-mesh-access/Explicit.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(Explicit)
 
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(meshSize * dim);
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, ids, solverTwoMesh);
+    couplingInterface.getMeshVertexIDsAndCoordinates(otherMeshName, ids, solverTwoMesh);
     // Some dummy writeData
     std::array<double, 4> writeData({1, 2, 3, 4});
 

--- a/tests/serial/direct-mesh-access/Explicit.xml
+++ b/tests/serial/direct-mesh-access/Explicit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(ExplicitAndMapping)
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(otherMeshSize * dim);
     std::vector<int>    otherIDs(otherMeshSize, -1);
-    interface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverTwoMesh);
+    interface.getMeshVertexIDsAndCoordinates(otherMeshName, otherIDs, solverTwoMesh);
     // Some dummy writeData
     std::array<double, 5> writeData({1, 2, 3, 4, 5});
 

--- a/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
+++ b/tests/serial/direct-mesh-access/ExplicitAndMapping.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
   <data:scalar name="Forces" />
 

--- a/tests/serial/direct-mesh-access/ExplicitRead.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitRead.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(ExplicitRead)
 
     // Allocate a vector containing the vertices
     std::vector<double> solverTwoMesh(meshSize * dim);
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, ids, solverTwoMesh);
+    couplingInterface.getMeshVertexIDsAndCoordinates(otherMeshName, ids, solverTwoMesh);
 
     // Allocate data to read
     std::vector<double> readData(4, std::numeric_limits<double>::max());

--- a/tests/serial/direct-mesh-access/ExplicitRead.xml
+++ b/tests/serial/direct-mesh-access/ExplicitRead.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Velocities" />
 
   <mesh name="MeshTwo">

--- a/tests/serial/direct-mesh-access/Implicit.cpp
+++ b/tests/serial/direct-mesh-access/Implicit.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
     std::vector<double> solverTwoMesh(meshSize * dim);
     std::vector<int>    otherIDs(meshSize);
 
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverTwoMesh);
+    couplingInterface.getMeshVertexIDsAndCoordinates(otherMeshName, otherIDs, solverTwoMesh);
     // Some dummy writeData
     std::array<double, 3> writeData({1, 2, 3});
 
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(Implicit)
     std::vector<double> solverOneMesh(meshSize * dim);
     std::vector<int>    otherIDs(meshSize);
 
-    couplingInterface.getMeshVerticesAndIDs(otherMeshName, otherIDs, solverOneMesh);
+    couplingInterface.getMeshVertexIDsAndCoordinates(otherMeshName, otherIDs, solverOneMesh);
     // Some dummy writeData
     std::array<double, 4> writeData({10, 11, 12, 13});
 

--- a/tests/serial/direct-mesh-access/Implicit.xml
+++ b/tests/serial/direct-mesh-access/Implicit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2" experimental="true">
+<precice-configuration dimensions="2">
   <data:scalar name="Forces" />
   <data:scalar name="Velocities" />
 


### PR DESCRIPTION
## Main changes of this PR

Makes the direct mesh access API non-experimental and adjusts the API function layout according to #1739 

## Motivation and additional information

The current shape of this feature is ready to be released. Future extensions the capabilities (e.g. parallel capabilities) can (probably) be provided in a non-breaking way. Resolves #1739.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
