### PR TITLE
Remove hasMesh and hasData.

### DIFF
--- a/docs/changelog/1741.md
+++ b/docs/changelog/1741.md
@@ -1,1 +1,1 @@
-- Remove API function `hasMesh` and `hasData`.
+- Removed API functions `hasMesh` and `hasData`.

--- a/docs/changelog/1741.md
+++ b/docs/changelog/1741.md
@@ -1,0 +1,1 @@
+- Remove API function `hasMesh` and `hasData`.

--- a/extras/bindings/c/include/precice/preciceC.h
+++ b/extras/bindings/c/include/precice/preciceC.h
@@ -119,14 +119,6 @@ PRECICE_API int precicec_requiresReadingCheckpoint();
 ///@anchor precice-mesh-access
 ///@{
 
-/**
- * @brief Checks if the mesh with given name is used by a solver.
- *
- * @param[in] meshName the name of the mesh.
- * @returns whether the mesh is used.
- */
-PRECICE_API int precicec_hasMesh(const char *meshName);
-
 /// @copydoc precice::Participant::requiresMeshConnectivityFor()
 PRECICE_API int precicec_requiresMeshConnectivityFor(const char *meshName);
 
@@ -281,11 +273,6 @@ PRECICE_API void precicec_setMeshTetrahedra(
 
 ///@name Data Access
 ///@{
-
-/**
- * @brief Returns true (!=0), if data with given name is available.
- */
-PRECICE_API int precicec_hasData(const char *meshName, const char *dataName);
 
 /**
  * @brief Writes vector data values given as block.

--- a/extras/bindings/c/src/preciceC.cpp
+++ b/extras/bindings/c/src/preciceC.cpp
@@ -125,21 +125,6 @@ int precicec_requiresReadingCheckpoint()
   return impl->requiresReadingCheckpoint() ? 1 : 0;
 }
 
-int precicec_hasMesh(const char *meshName)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  if (impl->hasMesh(meshName)) {
-    return 1;
-  }
-  return 0;
-}
-
-int precicec_hasData(const char *meshName, const char *dataName)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  return impl->hasData(meshName, dataName);
-}
-
 int precicec_requiresMeshConnectivityFor(const char *meshName)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -184,43 +184,6 @@ PRECICE_API void precicef_requires_writing_checkpoint_(
 
 /**
  * Fortran syntax:
- * precicef_has_mesh(
- *   CHARACTER meshName(*),
- *   INTEGER   hasMesh )
- *
- * IN:  meshName
- * OUT: hasMesh(1:true, 0:false)
- *
- * @copydoc precice::Participant::hasMesh()
- *
- */
-PRECICE_API void precicef_has_mesh_(
-    const char *meshName,
-    int *       hasMesh,
-    int         meshNameLengthName);
-
-/**
- * Fortran syntax:
- * precicef_has_data(
- *   CHARACTER meshName(*),
- *   CHARACTER dataName(*),
- *   INTEGER   hasData)
- *
- * IN:  mesh, data, meshNameLength, dataNameLength
- * OUT: hasData(1:true, 0:false)
- *
- * @copydoc precice::Participant::hasData()
- *
- */
-PRECICE_API void precicef_has_data_(
-    const char *meshName,
-    const char *dataName,
-    int *       hasData,
-    int         meshNameLength,
-    int         dataNameLength);
-
-/**
- * Fortran syntax:
  * precicef_precicef_requires_mesh_connectivity_for_(
  *   CHARACTER meshName(*),
  *   INTEGER   required)

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -143,34 +143,6 @@ void precicef_requires_reading_checkpoint_(
   *isRequired = impl->requiresReadingCheckpoint() ? 1 : 0;
 }
 
-void precicef_has_mesh_(
-    const char *meshName,
-    int *       hasMesh,
-    int         meshNameLength)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  if (impl->hasMesh(precice::impl::strippedStringView(meshName, meshNameLength))) {
-    *hasMesh = 1;
-  } else {
-    *hasMesh = 0;
-  }
-}
-
-void precicef_has_data_(
-    const char *meshName,
-    const char *dataName,
-    int *       hasData,
-    int         meshNameLength,
-    int         dataNameLength)
-{
-  PRECICE_CHECK(impl != nullptr, errormsg);
-  if (impl->hasData(precice::impl::strippedStringView(meshName, meshNameLength), precice::impl::strippedStringView(dataName, dataNameLength))) {
-    *hasData = 1;
-  } else {
-    *hasData = 0;
-  }
-}
-
 void precicef_requires_mesh_connectivity_for_(
     const char *meshName,
     int *       required,

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -99,11 +99,6 @@ bool Participant::requiresWritingCheckpoint()
   return _impl->requiresWritingCheckpoint();
 }
 
-bool Participant::hasMesh(::precice::string_view meshName) const
-{
-  return _impl->hasMesh(toSV(meshName));
-}
-
 bool Participant::requiresMeshConnectivityFor(::precice::string_view meshName) const
 {
   return _impl->requiresMeshConnectivityFor(toSV(meshName));
@@ -113,11 +108,6 @@ bool Participant::requiresGradientDataFor(::precice::string_view meshName,
                                           ::precice::string_view dataName) const
 {
   return _impl->requiresGradientDataFor(toSV(meshName), toSV(dataName));
-}
-
-bool Participant::hasData(::precice::string_view meshName, ::precice::string_view dataName) const
-{
-  return _impl->hasData(toSV(meshName), toSV(dataName));
 }
 
 // void Participant:: resetMesh

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -320,14 +320,6 @@ public:
   //  void resetMesh ( ::precice::string_view meshName );
 
   /**
-   * @brief Checks if the mesh with given name is used by a solver.
-   *
-   * @param[in] meshName the name of the mesh
-   * @returns whether the mesh is used.
-   */
-  bool hasMesh(::precice::string_view meshName) const;
-
-  /**
    * @brief Checks if the given mesh requires connectivity.
    *
    * preCICE may require connectivity information from the solver and
@@ -565,17 +557,6 @@ public:
 
   ///@name Data Access
   ///@{
-
-  /**
-   * @brief Checks if the data with given name is used by a solver and mesh.
-   *
-   * @param[in] meshName the name of the associated mesh
-   * @param[in] dataName the name of the data to check
-   * @returns whether the mesh contains the data.
-   */
-  bool hasData(
-      ::precice::string_view meshName,
-      ::precice::string_view dataName) const;
 
   /**
    * @brief Writes data to a mesh.

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -538,21 +538,6 @@ bool ParticipantImpl::requiresReadingCheckpoint()
   return required;
 }
 
-bool ParticipantImpl::hasMesh(std::string_view meshName) const
-{
-  PRECICE_TRACE(meshName);
-  return _accessor->hasMesh(meshName);
-}
-
-bool ParticipantImpl::hasData(
-    std::string_view meshName,
-    std::string_view dataName) const
-{
-  PRECICE_TRACE(dataName, meshName);
-  PRECICE_VALIDATE_MESH_NAME(meshName);
-  return _accessor->isDataUsed(dataName, meshName);
-}
-
 bool ParticipantImpl::requiresMeshConnectivityFor(std::string_view meshName) const
 {
   PRECICE_VALIDATE_MESH_NAME(meshName);

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -145,9 +145,6 @@ public:
   /// @copydoc Participant::resetMesh
   void resetMesh(std::string_view meshName);
 
-  /// @copydoc Participant::hasMesh
-  bool hasMesh(std::string_view meshName) const;
-
   /// @copydoc Participant::requiresMeshConnectivityFor
   bool requiresMeshConnectivityFor(std::string_view meshName) const;
 
@@ -222,11 +219,6 @@ public:
 
   ///@name Data Access
   ///@{
-
-  /// @copydoc Participant::hasData
-  bool hasData(
-      std::string_view meshName,
-      std::string_view dataName) const;
 
   /// @copydoc Participant::readData
   void readData(

--- a/tests/serial/explicit/helpers.cpp
+++ b/tests/serial/explicit/helpers.cpp
@@ -22,13 +22,11 @@ void runTestExplicit(std::string const &configurationFileName, TestContext const
   // was necessary to replace pre-defined geometries
   if (context.isNamed("SolverOne")) {
     auto meshName = "MeshOne";
-    BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
     couplingInterface.setMeshVertices(meshName, pos, vids);
   }
   if (context.isNamed("SolverTwo")) {
     auto meshName = "Test-Square";
-    BOOST_REQUIRE(couplingInterface.hasMesh(meshName));
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(meshName) == 3);
     couplingInterface.setMeshVertices(meshName, pos, vids);
   }

--- a/tests/serial/mapping-volume/OneTetraRead.cpp
+++ b/tests/serial/mapping-volume/OneTetraRead.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_SUITE(MappingVolume)
 BOOST_AUTO_TEST_CASE(OneTetraRead)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
-  testMappingVolumeOneTetra(context.config(), context);
+  testMappingVolumeOneTetra(context.config(), context, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/mapping-volume/OneTetraWrite.cpp
+++ b/tests/serial/mapping-volume/OneTetraWrite.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_SUITE(MappingVolume)
 BOOST_AUTO_TEST_CASE(OneTetraWrite)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
-  testMappingVolumeOneTetra(context.config(), context);
+  testMappingVolumeOneTetra(context.config(), context, false);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/mapping-volume/OneTriangleRead.cpp
+++ b/tests/serial/mapping-volume/OneTriangleRead.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_SUITE(MappingVolume)
 BOOST_AUTO_TEST_CASE(OneTriangleRead)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
-  testMappingVolumeOneTriangle(context.config(), context);
+  testMappingVolumeOneTriangle(context.config(), context, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/mapping-volume/OneTriangleWrite.cpp
+++ b/tests/serial/mapping-volume/OneTriangleWrite.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_SUITE(MappingVolume)
 BOOST_AUTO_TEST_CASE(OneTriangleWrite)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
-  testMappingVolumeOneTriangle(context.config(), context);
+  testMappingVolumeOneTriangle(context.config(), context, false);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -66,14 +66,6 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
     double dt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Receiving participant must advance once.");
 
-    // If "read" mapping, check received mesh
-    if (precice::testing::WhiteboxAccessor::impl(participant).hasMesh("MeshOne")) {
-      auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-      BOOST_REQUIRE(mesh.vertices().size() == 3);
-      BOOST_REQUIRE(mesh.edges().size() == 3);
-      BOOST_REQUIRE(mesh.triangles().size() == 1);
-    }
-
     participant.advance(dt);
     BOOST_TEST(!participant.isCouplingOngoing(), "Receiving participant must advance only once.");
 
@@ -227,15 +219,6 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
     participant.initialize();
     double dt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Receiving participant must advance once.");
-
-    // If "read" mapping, check received mesh, including connectivity
-    if (precice::testing::WhiteboxAccessor::impl(participant).hasMesh("MeshOne")) {
-      auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-      BOOST_CHECK(mesh.vertices().size() == 4);
-      BOOST_CHECK(mesh.edges().size() == 6);
-      BOOST_CHECK(mesh.triangles().size() == 4);
-      BOOST_CHECK(mesh.tetrahedra().size() == 1);
-    }
 
     participant.advance(dt);
     BOOST_TEST(!participant.isCouplingOngoing(), "Receiving participant must advance only once.");

--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -7,7 +7,7 @@
 #include "precice/impl/ParticipantImpl.hpp"
 #include "precice/precice.hpp"
 
-void testMappingVolumeOneTriangle(const std::string configFile, const TestContext &context)
+void testMappingVolumeOneTriangle(const std::string configFile, const TestContext &context, bool read)
 {
   using precice::testing::equals;
 
@@ -65,6 +65,14 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
     participant.initialize();
     double dt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Receiving participant must advance once.");
+
+    // If "read" mapping, check received mesh
+    if (read) {
+      auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
+      BOOST_REQUIRE(mesh.vertices().size() == 3);
+      BOOST_REQUIRE(mesh.edges().size() == 3);
+      BOOST_REQUIRE(mesh.triangles().size() == 1);
+    }
 
     participant.advance(dt);
     BOOST_TEST(!participant.isCouplingOngoing(), "Receiving participant must advance only once.");
@@ -151,7 +159,7 @@ void testMappingVolumeOneTriangleConservative(const std::string configFile, cons
   }
 }
 
-void testMappingVolumeOneTetra(const std::string configFile, const TestContext &context)
+void testMappingVolumeOneTetra(const std::string configFile, const TestContext &context, bool read)
 {
   using precice::testing::equals;
 
@@ -219,6 +227,15 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
     participant.initialize();
     double dt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Receiving participant must advance once.");
+
+    // If "read" mapping, check received mesh, including connectivity
+    if (read) {
+      auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
+      BOOST_CHECK(mesh.vertices().size() == 4);
+      BOOST_CHECK(mesh.edges().size() == 6);
+      BOOST_CHECK(mesh.triangles().size() == 4);
+      BOOST_CHECK(mesh.tetrahedra().size() == 1);
+    }
 
     participant.advance(dt);
     BOOST_TEST(!participant.isCouplingOngoing(), "Receiving participant must advance only once.");

--- a/tests/serial/mapping-volume/helpers.hpp
+++ b/tests/serial/mapping-volume/helpers.hpp
@@ -7,9 +7,9 @@
 using namespace precice;
 using precice::testing::TestContext;
 
-void testMappingVolumeOneTriangle(const std::string configFile, const TestContext &context);
+void testMappingVolumeOneTriangle(const std::string configFile, const TestContext &context, bool read);
 void testMappingVolumeOneTriangleConservative(const std::string configFile, const TestContext &context);
-void testMappingVolumeOneTetra(const std::string configFile, const TestContext &context);
+void testMappingVolumeOneTetra(const std::string configFile, const TestContext &context, bool read);
 void testMappingVolumeOneTetraConservative(const std::string configFile, const TestContext &context);
 
 #endif


### PR DESCRIPTION
## Main changes of this PR

Removes `hasMesh` and `hasData`.

## Motivation and additional information

See #1251 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
