### PR TITLE
Move sync tag from root tag to profiling

### DIFF
--- a/docs/changelog/1743.md
+++ b/docs/changelog/1743.md
@@ -1,0 +1,1 @@
+- Moved the configuration to enable synchronization from the root tag to profiling: `<profiling synchronize="true" />`.

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -18,11 +18,7 @@
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLAttribute.hpp"
 
-namespace precice {
-
-extern bool syncMode;
-
-namespace config {
+namespace precice::config {
 
 Configuration::Configuration()
     : _tag(*this, "precice-configuration", xml::XMLTag::OCCUR_ONCE),
@@ -37,10 +33,6 @@ Configuration::Configuration()
   _tag.addNamespace("action");
   _tag.addNamespace("coupling-scheme");
   _tag.addNamespace("acceleration");
-
-  auto attrSyncMode = xml::makeXMLAttribute("sync-mode", false)
-                          .setDocumentation("sync-mode enabled additional inter- and intra-participant synchronizations");
-  _tag.addAttribute(attrSyncMode);
 
   auto attrDimensions = xml::makeXMLAttribute("dimensions", 2)
                             .setDocumentation("Determines the spatial dimensionality of the configuration")
@@ -72,8 +64,7 @@ void Configuration::xmlTagCallback(const xml::ConfigurationContext &context, xml
 {
   PRECICE_TRACE(tag.getName());
   if (tag.getName() == "precice-configuration") {
-    precice::syncMode = tag.getBooleanAttributeValue("sync-mode");
-    _dimensions       = tag.getIntAttributeValue("dimensions");
+    _dimensions = tag.getIntAttributeValue("dimensions");
     _dataConfiguration->setDimensions(_dimensions);
     _meshConfiguration->setDimensions(_dimensions);
     _participantConfiguration->setDimensions(_dimensions);
@@ -122,5 +113,4 @@ Configuration::getParticipantConfiguration() const
   return _participantConfiguration;
 }
 
-} // namespace config
-} // namespace precice
+} // namespace precice::config

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -76,9 +76,6 @@ using precice::profiling::Event;
 
 namespace precice {
 
-/// Enabled further inter- and intra-solver synchronisation
-bool syncMode = false;
-
 namespace impl {
 
 ParticipantImpl::ParticipantImpl(

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -74,9 +74,7 @@
 
 using precice::profiling::Event;
 
-namespace precice {
-
-namespace impl {
+namespace precice::impl {
 
 ParticipantImpl::ParticipantImpl(
     std::string_view      participantName,
@@ -1501,5 +1499,4 @@ const mesh::Mesh &ParticipantImpl::mesh(const std::string &meshName) const
   return *_accessor->usedMeshContext(meshName).mesh;
 }
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/profiling/config/ProfilingConfiguration.cpp
+++ b/src/profiling/config/ProfilingConfiguration.cpp
@@ -9,6 +9,8 @@
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
 
+bool precice::syncMode = false;
+
 namespace precice::profiling {
 
 namespace {
@@ -53,6 +55,11 @@ ProfilingConfiguration::ProfilingConfiguration(xml::XMLTag &parent)
                                              "Events will be written to `<directory>/precice-events/`");
   tag.addAttribute(attrDirectory);
 
+  auto attrSynchronize = xml::makeXMLAttribute("synchronize", false)
+                             .setDocumentation("Enables additional inter- and intra-participant synchronization points. "
+                                               "This avoids measuring blocking time for communication and other collective operations.");
+  tag.addAttribute(attrSynchronize);
+
   parent.addSubtag(tag);
 }
 
@@ -60,9 +67,10 @@ void ProfilingConfiguration::xmlTagCallback(
     const xml::ConfigurationContext &context,
     xml::XMLTag &                    tag)
 {
-  auto mode       = tag.getStringAttributeValue("mode");
-  auto flushEvery = tag.getIntAttributeValue("flush-every");
-  auto directory  = boost::filesystem::path(tag.getStringAttributeValue("directory"));
+  precice::syncMode = tag.getBooleanAttributeValue("synchronize");
+  auto mode         = tag.getStringAttributeValue("mode");
+  auto flushEvery   = tag.getIntAttributeValue("flush-every");
+  auto directory    = boost::filesystem::path(tag.getStringAttributeValue("directory"));
   PRECICE_CHECK(flushEvery >= 0, "You configured the profiling to flush-every=\"{}\", which is invalid. "
                                  "Please choose a number >= 0.");
 
@@ -79,7 +87,8 @@ void ProfilingConfiguration::xmlTagCallback(
 
 void applyDefaults()
 {
-  auto &er = profiling::EventRegistry::instance();
+  precice::syncMode = false;
+  auto &er          = profiling::EventRegistry::instance();
 
   er.setWriteQueueMax(DEFAULT_SYNC_EVERY);
 

--- a/src/profiling/config/ProfilingConfiguration.hpp
+++ b/src/profiling/config/ProfilingConfiguration.hpp
@@ -4,6 +4,11 @@
 #include "logging/Logger.hpp"
 #include "xml/XMLTag.hpp"
 
+namespace precice {
+/// Enabled further inter- and intra-solver synchronisation
+extern bool syncMode;
+} // namespace precice
+
 namespace precice::profiling {
 
 constexpr int         DEFAULT_SYNC_EVERY = 50;


### PR DESCRIPTION
## Main changes of this PR

This PR moves the sync attribute from the precice-configuration/root tag to the profiling tag.

## Motivation and additional information

Closes #1634

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

