### PR TITLE
Add coverity to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Short rational why preCICE needs this change. If this is already described in an
 ## Author's checklist
 
 * [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
+* [ ] I ran coverity on this PR and took care of defecty I may have introduced. (Use workflow dispatch [here](https://github.com/precice/precice/actions/workflows/coverity-scan.yml))
 * [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
 * [ ] I added a test to cover the proposed changes in our test suite.
 * [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Short rational why preCICE needs this change. If this is already described in an
 ## Author's checklist
 
 * [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
-* [ ] I ran coverity on this PR and took care of defecty I may have introduced. (Use workflow dispatch [here](https://github.com/precice/precice/actions/workflows/coverity-scan.yml))
+* [ ] I ran coverity on this PR and took care of defects I may have introduced. (Use workflow dispatch [here](https://github.com/precice/precice/actions/workflows/coverity-scan.yml))
 * [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
 * [ ] I added a test to cover the proposed changes in our test suite.
 * [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).


### PR DESCRIPTION
## Main changes of this PR

Add a new checkbox for coverity.

## Motivation and additional information

Make coverity a hard requirement for PRs to be merged.

Todo:

- [ ] Need to be able to run coverity also on branches on forks (for devs working on their fork when contributing). Any idea how to allow this @fsimonis ? Probably this is a security policy by github.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
