### PR TITLE
Remove non-empty precice-run when running tests

### DIFF
--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -4,6 +4,9 @@
 // Specify the overall name of test framework
 #define BOOST_TEST_MODULE "preCICE Tests"
 
+#include <boost/filesystem/directory.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/test/tools/fpc_tolerance.hpp>
 #include <boost/test/tree/test_case_counter.hpp>
 #include <boost/test/tree/traverse.hpp>
@@ -36,6 +39,16 @@ void setupTolerance()
   boost::test_tools::fpc_tolerance<float>()  = tolerance;
 }
 
+void removeStaleRunDirectory()
+{
+  namespace bf = boost::filesystem;
+  bf::path runDir("precice-run");
+  if (bf::exists(runDir) && bf::is_directory(runDir) && !bf::is_empty(runDir)) {
+    std::cout << "Removing a non-empty precice-run directory from a previously failing test.\n";
+    bf::remove_all(runDir);
+  }
+}
+
 /// Entry point for the boost test executable
 int main(int argc, char *argv[])
 {
@@ -55,6 +68,10 @@ int main(int argc, char *argv[])
   }
 
   std::cout << "This test suite runs on rank " << rank << " of " << size << '\n';
+
+  if (rank == 0) {
+    removeStaleRunDirectory();
+  }
 
   setupTolerance();
   int       retCode  = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -4,9 +4,7 @@
 // Specify the overall name of test framework
 #define BOOST_TEST_MODULE "preCICE Tests"
 
-#include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/test/tools/fpc_tolerance.hpp>
 #include <boost/test/tree/test_case_counter.hpp>
 #include <boost/test/tree/traverse.hpp>


### PR DESCRIPTION
## Main changes of this PR

This PR adds a section to the test executable, which removes an existing non-empty `precice-run` folder.

## Motivation and additional information

Failing tests now don't leak stale connectivity files into following test runs.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
