### PR TITLE
Overhaul Eigen type compare for Boost.Test

### DIFF
--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -77,16 +77,19 @@ boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,
                                            const Eigen::MatrixBase<DerivedB> &B,
                                            double                             tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
 {
-  if (not math::equals(A, B, tolerance)) {
+  if ((A - B).array().abs().maxCoeff() > tolerance) {
     boost::test_tools::predicate_result res(false);
     Eigen::IOFormat                     format;
     if (A.cols() == 1) {
       format.rowSeparator = ", ";
       format.rowPrefix    = "  ";
+      format.precision    = Eigen::FullPrecision;
     }
     res.message() << "\n"
                   << A.format(format) << " != \n"
-                  << B.format(format);
+                  << B.format(format) << '\n'
+                  << (A - B).cwiseAbs().format(format) << " < " << tolerance << '\n'
+                  << (A - B).unaryExpr([tolerance](double e) -> bool { return std::abs(e) < tolerance; }).format(format) << " in tolerance";
     return res;
   }
   return true;


### PR DESCRIPTION
## Main changes of this PR

This PR changes the comparison for eigen types to a component-wise tolerance check and adds information:
- The absolute difference matrix |A-B|
- The tolerance used which depends on the test
- Which elements don't fullfill the tolerance

Example for Vector of 3 components:

```
1.54166666666667,   15.4166666666667,   154.166666666667 !=
1.54167,   15.4167,   154.167
3.33333333335517e-06,   3.33333333308872e-05,   0.000333333333287555 < 0.0001
1,   1,   0 in tolerance
```

## Motivation and additional information

Due to rounding in the output, it was often not clear which components were problematic, by how much they differed from the expected value, and what the used tolerance was.
This PR addresses all of this.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
