### PR TITLE
Fix format exception propagation from PRECICE_TRACE and PRECICE_ASSERT

### DIFF
--- a/src/utils/ArgumentFormatter.hpp
+++ b/src/utils/ArgumentFormatter.hpp
@@ -15,6 +15,6 @@
 #define PRECICE_LOG_ARGUMENTS(...)                                                                                  \
   BOOST_PP_IF(BOOST_VMD_IS_EMPTY(__VA_ARGS__),                                                                      \
               "",                                                                                                   \
-              fmt::format(                                                                                          \
+              ::precice::utils::format_or_error(                                                                    \
                   "\n" BOOST_PP_SEQ_FOR_EACH_I(PRECICE_LOG_ARGUMENTS_FMT, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)), \
                   __VA_ARGS__))


### PR DESCRIPTION
## Main changes of this PR

The `PRECICE_TRACE` and `PRECICE_ASSERT` still leaked the format exception to the caller.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.