### PR TITLE
Bump version on develop to 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.16.3)
-project(preCICE VERSION 2.5.0 LANGUAGES CXX)
+project(preCICE VERSION 3.0.0 LANGUAGES CXX)
 set(preCICE_SOVERSION ${preCICE_VERSION_MAJOR})
 
 #

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -87,6 +87,11 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${preCICE_SOURCE_DIR}/tools/releasing/pa
 set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS TRUE)
 set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS_POLICY "=")
 
+# Handling version conflicts
+set(CPACK_DEBIAN_PACKAGE_PROVIDES precice)
+set(CPACK_DEBIAN_PACKAGE_CONFLICTS "precice, libprecice2")
+set(CPACK_DEBIAN_PACKAGE_REPLACES precice)
+
 # Install doc files
 install(FILES tools/releasing/packaging/debian/copyright
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/${CPACK_PACKAGE_NAME}


### PR DESCRIPTION
## Main changes of this PR

This PR bumps the version on develop to 3.0.0.

It also adds a manual conflict with libprecice2 and declares it to provide the `preCICE` virtual package. This should cover future major versions.


## Motivation and additional information

This should simplify porting dependants of the preCICE core.

Generated Debian packages and pkg-config should work too.
Note that this will change the major version, which is part of the Debian package name. So this one directly conflicts with the old one.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.