### PR TITLE
Remove preallocation from PETSc RBF mapping

### DIFF
--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -126,28 +126,8 @@ private:
   /// Prints an INFO about the current mapping
   void printMappingInfo(int dim) const;
 
-  /// Toggles use of preallocation for matrix C and A
-  const Preallocation _preallocation;
-
   /// The CommState used to communicate
   utils::Parallel::CommStatePtr _commState;
-
-  void estimatePreallocationMatrixC(int rows, int cols, mesh::PtrMesh mesh);
-
-  void estimatePreallocationMatrixA(int rows, int cols, mesh::PtrMesh mesh);
-
-  /// Preallocate matrix C by only deriving the preallocation pattern
-  /*
-   * This actually involves computing the coefficients. They are not saved and thus need to be computed
-   * twice. Therefore, this is not really efficient.
-   */
-  void computePreallocationMatrixC(const mesh::PtrMesh inMesh);
-
-  void computePreallocationMatrixA(const mesh::PtrMesh inMesh, const mesh::PtrMesh outMesh);
-
-  VertexData savedPreallocationMatrixC(const mesh::PtrMesh inMesh);
-
-  VertexData savedPreallocationMatrixA(const mesh::PtrMesh inMesh, const mesh::PtrMesh outMesh);
 
   /// Preallocate matrix C and saves the coefficients using a boost::geometry spatial tree for neighbor search
   VertexData bgPreallocationMatrixC(const mesh::PtrMesh inMesh);
@@ -191,7 +171,6 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping(
       _AOmapping(nullptr),
       _solverRtol(solverRtol),
       _polynomial(polynomial),
-      _preallocation(Preallocation::TREE),
       _commState(utils::Parallel::current())
 {
   polyparams      = (_polynomial == Polynomial::ON) ? this->getPolynomialParameters() : 0;
@@ -300,20 +279,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   // preallocate the matrix. In the second phase we actually fill the matrix.
 
   // Stores col -> value for each row;
-  VertexData vertexData;
-
-  if (_preallocation == Preallocation::SAVE) {
-    vertexData = savedPreallocationMatrixC(inMesh);
-  }
-  if (_preallocation == Preallocation::COMPUTE) {
-    computePreallocationMatrixC(inMesh);
-  }
-  if (_preallocation == Preallocation::ESTIMATE) {
-    estimatePreallocationMatrixC(n, n, inMesh);
-  }
-  if (_preallocation == Preallocation::TREE) {
-    vertexData = bgPreallocationMatrixC(inMesh);
-  }
+  VertexData vertexData = bgPreallocationMatrixC(inMesh);
 
   // -- BEGIN FILL LOOP FOR MATRIX C --
   PRECICE_DEBUG("Begin filling matrix C");
@@ -356,30 +322,13 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     }
 
     // -- SETS THE COEFFICIENTS --
-    if (_preallocation == Preallocation::SAVE or _preallocation == Preallocation::TREE) {
+    {
       auto const &rowVertices = vertexData[preallocRow];
       for (const auto &vertex : rowVertices) {
         rowVals[colNum]  = this->_basisFunction.evaluate(vertex.second);
         colIdx[colNum++] = vertex.first;
       }
       ++preallocRow;
-    } else {
-      for (const mesh::Vertex &vj : inMesh->vertices()) {
-        int const col = vj.getGlobalIndex() + polyparams;
-        if (row > col)
-          continue; // matrix is symmetric
-        distance = inVertex.getCoords() - vj.getCoords();
-        for (int d = 0; d < dimensions; d++) {
-          if (this->_deadAxis[d]) {
-            distance[d] = 0;
-          }
-        }
-        double const norm = distance.norm();
-        if (this->_basisFunction.getSupportRadius() > norm) {
-          rowVals[colNum]  = this->_basisFunction.evaluate(norm);
-          colIdx[colNum++] = col; // column of entry is the globalIndex
-        }
-      }
     }
     ierr = AOApplicationToPetsc(_AOmapping, colNum, colIdx.data());
     CHKERRV(ierr);
@@ -405,18 +354,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   ierr = MatAssemblyBegin(_matrixQ, MAT_FINAL_ASSEMBLY);
   CHKERRV(ierr);
 
-  if (_preallocation == Preallocation::SAVE) {
-    vertexData = savedPreallocationMatrixA(inMesh, outMesh);
-  }
-  if (_preallocation == Preallocation::COMPUTE) {
-    computePreallocationMatrixA(inMesh, outMesh);
-  }
-  if (_preallocation == Preallocation::ESTIMATE) {
-    estimatePreallocationMatrixA(outputSize, n, inMesh);
-  }
-  if (_preallocation == Preallocation::TREE) {
-    vertexData = bgPreallocationMatrixA(inMesh, outMesh);
-  }
+  vertexData = bgPreallocationMatrixA(inMesh, outMesh);
 
   // holds the columns indices of the entries
   colIdx.resize(std::max(_matrixA.getSize().second, _matrixV.getSize().second));
@@ -451,24 +389,11 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     // -- SETS THE COEFFICIENTS --
     PetscInt colNum = 0;
 
-    if (_preallocation == Preallocation::SAVE or _preallocation == Preallocation::TREE) {
+    {
       auto const &rowVertices = vertexData[row - ownerRangeABegin];
       for (const auto &vertex : rowVertices) {
         rowVals[colNum]  = this->_basisFunction.evaluate(vertex.second);
         colIdx[colNum++] = vertex.first;
-      }
-    } else {
-      for (const mesh::Vertex &inVertex : inMesh->vertices()) {
-        distance = oVertex.getCoords() - inVertex.getCoords();
-        for (int d = 0; d < dimensions; d++) {
-          if (this->_deadAxis[d])
-            distance[d] = 0;
-        }
-        double const norm = distance.norm();
-        if (this->_basisFunction.getSupportRadius() > norm) {
-          rowVals[colNum]  = this->_basisFunction.evaluate(norm);
-          colIdx[colNum++] = inVertex.getGlobalIndex() + polyparams;
-        }
       }
     }
     ierr = AOApplicationToPetsc(_AOmapping, colNum, colIdx.data());
@@ -902,402 +827,6 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::printMappingInfo(int dim
 
   PRECICE_INFO("Mapping {} for dimension {} with polynomial set to {}",
                constraintName, dim, polynomialName);
-}
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::estimatePreallocationMatrixC(
-    int rows, int cols, mesh::PtrMesh mesh)
-{
-  std::ignore = rows;
-  std::ignore = cols;
-
-  // auto rank = _commState->rank();
-  auto size          = _commState->size();
-  auto supportRadius = this->_basisFunction.getSupportRadius();
-
-  auto bbox     = mesh->getBoundingBox();
-  auto meshSize = mesh->vertices().size();
-
-  double meshArea = bbox.getArea(this->_deadAxis);
-  // PRECICE_WARN(bbox);
-
-  // supportVolume = math::PI * 4.0/3.0 * std::pow(supportRadius, 3);
-  double supportVolume = 0;
-  if (this->getDimensions() == 2)
-    supportVolume = 2 * supportRadius;
-  else if (this->getDimensions() == 3)
-    supportVolume = math::PI * std::pow(supportRadius, 2);
-
-  PRECICE_WARN("supportVolume = {}", supportVolume);
-  PRECICE_WARN("meshArea = {}", meshArea);
-  PRECICE_WARN("meshSize = {}", meshSize);
-
-  int nnzPerRow = meshSize / meshArea * supportVolume;
-  PRECICE_WARN("nnzPerRow = {}", nnzPerRow);
-  // int nnz = nnzPerRow * rows;
-
-  if (_commState->size() == 1) {
-    MatSeqSBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), nnzPerRow / 2, nullptr);
-  } else {
-    MatMPISBAIJSetPreallocation(_matrixC, _matrixC.blockSize(),
-                                nnzPerRow / (size * 2), nullptr, nnzPerRow / (size * 2), nullptr);
-  }
-  MatSetOption(_matrixC, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
-}
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::estimatePreallocationMatrixA(
-    int rows, int cols, mesh::PtrMesh mesh)
-{
-  std::ignore = rows;
-  std::ignore = cols;
-
-  // auto rank = _commState->rank();
-  auto size          = _commState->size();
-  auto supportRadius = this->_basisFunction.getSupportRadius();
-
-  auto bbox     = mesh->getBoundingBox();
-  auto meshSize = mesh->vertices().size();
-
-  double meshArea = bbox.getArea(this->_deadAxis);
-  // PRECICE_WARN(bbox);
-
-  // supportVolume = math::PI * 4.0/3.0 * std::pow(supportRadius, 3);
-  double supportVolume = 0;
-  if (this->getDimensions() == 2)
-    supportVolume = 2 * supportRadius;
-  else if (this->getDimensions() == 3)
-    supportVolume = math::PI * std::pow(supportRadius, 2);
-
-  PRECICE_WARN("supportVolume = {}", supportVolume);
-  PRECICE_WARN("meshArea = {}", meshArea);
-  PRECICE_WARN("meshSize = {}", meshSize);
-
-  int nnzPerRow = meshSize / meshArea * supportVolume;
-  PRECICE_WARN("nnzPerRow = {}", nnzPerRow);
-  // int nnz = nnzPerRow * rows;
-
-  if (_commState->size() == 1) {
-    MatSeqSBAIJSetPreallocation(_matrixA, _matrixA.blockSize(), nnzPerRow, nullptr);
-  } else {
-    MatMPISBAIJSetPreallocation(_matrixA, _matrixA.blockSize(),
-                                nnzPerRow / size, nullptr, nnzPerRow / size, nullptr);
-  }
-  MatSetOption(_matrixA, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
-}
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computePreallocationMatrixC(const mesh::PtrMesh inMesh)
-{
-  precice::profiling::Event ePreallocC("map.pet.preallocC.From" + this->input()->getName() + "To" + this->output()->getName(), profiling::Synchronize);
-
-  PetscInt n, ierr;
-
-  const int       dimensions = this->input()->getDimensions();
-  Eigen::VectorXd distance(dimensions);
-
-  std::tie(n, std::ignore) = _matrixC.getLocalSize();
-  std::vector<PetscInt> d_nnz(n), o_nnz(n);
-  PetscInt              colOwnerRangeCBegin, colOwnerRangeCEnd;
-  std::tie(colOwnerRangeCBegin, colOwnerRangeCEnd) = _matrixC.ownerRangeColumn();
-
-  size_t local_row = 0;
-  // -- PREALLOCATES THE POLYNOMIAL PART OF THE MATRIX --
-  if (_polynomial == Polynomial::ON) {
-    for (local_row = 0; local_row < localPolyparams; local_row++) {
-      d_nnz[local_row] = colOwnerRangeCEnd - colOwnerRangeCBegin;
-      o_nnz[local_row] = _matrixC.getSize().first - d_nnz[local_row];
-    }
-  }
-
-  for (const mesh::Vertex &inVertex : inMesh->vertices()) {
-    if (not inVertex.isOwner())
-      continue;
-
-    PetscInt  col        = polyparams - 1;
-    const int global_row = local_row + _matrixC.ownerRange().first;
-    d_nnz[local_row]     = 0;
-    o_nnz[local_row]     = 0;
-
-    // -- PREALLOCATES THE COEFFICIENTS --
-    for (mesh::Vertex &vj : inMesh->vertices()) {
-      col++;
-
-      // the actual col where the vertex end up
-      PetscInt mappedCol = vj.getGlobalIndex() + polyparams;
-      ierr               = AOApplicationToPetsc(_AOmapping, 1, &mappedCol);
-      CHKERRV(ierr); // likely not efficient in the inner loop
-
-      if (global_row > mappedCol) // Skip, since we are below the diagonal
-        continue;
-
-      distance = inVertex.getCoords() - vj.getCoords();
-      for (int d = 0; d < dimensions; d++) {
-        if (this->_deadAxis[d]) {
-          distance[d] = 0;
-        }
-      }
-
-      if (this->_basisFunction.getSupportRadius() > distance.norm() or col == global_row) {
-        if (mappedCol >= colOwnerRangeCBegin and mappedCol < colOwnerRangeCEnd)
-          d_nnz[local_row]++;
-        else
-          o_nnz[local_row]++;
-      }
-    }
-    local_row++;
-  }
-
-  if (_commState->size() == 1) {
-    // std::cout << "Computed Preallocation C Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
-    ierr = MatSeqSBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data());
-    CHKERRV(ierr);
-  } else {
-    // std::cout << "Computed Preallocation C MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    // << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
-    ierr = MatMPISBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data(), 0, o_nnz.data());
-    CHKERRV(ierr);
-  }
-  MatSetOption(_matrixC, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-
-  ePreallocC.stop();
-}
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computePreallocationMatrixA(
-    const mesh::PtrMesh inMesh, const mesh::PtrMesh outMesh)
-{
-  precice::profiling::Event ePreallocA("map.pet.preallocA.From" + this->input()->getName() + "To" + this->output()->getName(), profiling::Synchronize);
-
-  PetscInt ownerRangeABegin, ownerRangeAEnd, colOwnerRangeABegin, colOwnerRangeAEnd;
-  PetscInt outputSize, ierr;
-
-  std::tie(outputSize, std::ignore) = _matrixA.getLocalSize();
-
-  std::vector<PetscInt> d_nnz(outputSize), o_nnz(outputSize);
-
-  std::tie(ownerRangeABegin, ownerRangeAEnd)       = _matrixA.ownerRange();
-  std::tie(colOwnerRangeABegin, colOwnerRangeAEnd) = _matrixA.ownerRangeColumn();
-
-  const int       dimensions = this->input()->getDimensions();
-  Eigen::VectorXd distance(dimensions);
-
-  for (int localRow = 0; localRow < ownerRangeAEnd - ownerRangeABegin; localRow++) {
-    d_nnz[localRow]             = 0;
-    o_nnz[localRow]             = 0;
-    PetscInt            col     = 0;
-    const mesh::Vertex &oVertex = outMesh->vertices()[localRow];
-
-    // -- PREALLOCATE THE POLYNOM PART OF THE MATRIX --
-    // col does not need mapping here, because the first polyparams col are always identity mapped
-    if (_polynomial == Polynomial::ON) {
-      if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-        d_nnz[localRow]++;
-      else
-        o_nnz[localRow]++;
-      col++;
-
-      for (int dim = 0; dim < dimensions; dim++) {
-        if (not this->_deadAxis[dim]) {
-          if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-            d_nnz[localRow]++;
-          else
-            o_nnz[localRow]++;
-          col++;
-        }
-      }
-    }
-
-    // -- PREALLOCATE THE COEFFICIENTS --
-    for (const mesh::Vertex &inVertex : inMesh->vertices()) {
-      distance = oVertex.getCoords() - inVertex.getCoords();
-      for (int d = 0; d < dimensions; d++) {
-        if (this->_deadAxis[d])
-          distance[d] = 0;
-      }
-
-      if (this->_basisFunction.getSupportRadius() > distance.norm()) {
-        col = inVertex.getGlobalIndex() + polyparams;
-        AOApplicationToPetsc(_AOmapping, 1, &col);
-        if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-          d_nnz[localRow]++;
-        else
-          o_nnz[localRow]++;
-      }
-    }
-  }
-  if (_commState->size() == 1) {
-    // std::cout << "Preallocation A Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
-    ierr = MatSeqAIJSetPreallocation(_matrixA, 0, d_nnz.data());
-    CHKERRV(ierr);
-  } else {
-    // std::cout << "Preallocation A MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    // << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
-    ierr = MatMPIAIJSetPreallocation(_matrixA, 0, d_nnz.data(), 0, o_nnz.data());
-    CHKERRV(ierr);
-  }
-  MatSetOption(_matrixA, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-
-  ePreallocA.stop();
-}
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-typename PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::VertexData
-PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::savedPreallocationMatrixC(mesh::PtrMesh const inMesh)
-{
-  precice::profiling::Event ePreallocC("map.pet.preallocC.From" + this->input()->getName() + "To" + this->output()->getName(), profiling::Synchronize);
-
-  PetscInt n;
-
-  const int       dimensions = this->input()->getDimensions();
-  Eigen::VectorXd distance(dimensions);
-
-  std::tie(n, std::ignore) = _matrixC.getLocalSize();
-  std::vector<PetscInt> d_nnz(n), o_nnz(n);
-  PetscInt              colOwnerRangeCBegin, colOwnerRangeCEnd;
-  std::tie(colOwnerRangeCBegin, colOwnerRangeCEnd) = _matrixC.ownerRangeColumn();
-
-  VertexData vertexData(n - localPolyparams);
-
-  size_t local_row = 0;
-  // -- PREALLOCATES THE POLYNOMIAL PART OF THE MATRIX --
-  if (_polynomial == Polynomial::ON) {
-    for (local_row = 0; local_row < localPolyparams; local_row++) {
-      d_nnz[local_row] = colOwnerRangeCEnd - colOwnerRangeCBegin;
-      o_nnz[local_row] = _matrixC.getSize().first - d_nnz[local_row];
-    }
-  }
-
-  for (const mesh::Vertex &inVertex : inMesh->vertices()) {
-    if (not inVertex.isOwner())
-      continue;
-
-    PetscInt  col        = polyparams - 1;
-    const int global_row = local_row + _matrixC.ownerRange().first;
-    d_nnz[local_row]     = 0;
-    o_nnz[local_row]     = 0;
-
-    // -- PREALLOCATES THE COEFFICIENTS --
-    for (mesh::Vertex &vj : inMesh->vertices()) {
-      col++;
-
-      PetscInt mappedCol = vj.getGlobalIndex() + polyparams;
-      AOApplicationToPetsc(_AOmapping, 1, &mappedCol); // likely not efficient in the inner loop
-
-      if (global_row > mappedCol) // Skip, since we are below the diagonal
-        continue;
-
-      distance = inVertex.getCoords() - vj.getCoords();
-      for (int d = 0; d < dimensions; d++)
-        if (this->_deadAxis[d])
-          distance[d] = 0;
-
-      double const norm = distance.norm();
-      if (this->_basisFunction.getSupportRadius() > norm or col == global_row) {
-        vertexData[local_row - localPolyparams].emplace_back(vj.getGlobalIndex() + polyparams, norm);
-        if (mappedCol >= colOwnerRangeCBegin and mappedCol < colOwnerRangeCEnd)
-          d_nnz[local_row]++;
-        else
-          o_nnz[local_row]++;
-      }
-    }
-    local_row++;
-  }
-
-  if (_commState->size() == 1) {
-    // std::cout << "Computed Preallocation C Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
-    MatSeqSBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data());
-  } else {
-    // std::cout << "Computed Preallocation C MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    //           << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
-    MatMPISBAIJSetPreallocation(_matrixC, _matrixC.blockSize(), 0, d_nnz.data(), 0, o_nnz.data());
-  }
-  MatSetOption(_matrixC, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-
-  ePreallocC.stop();
-
-  return vertexData;
-}
-
-template <typename RADIAL_BASIS_FUNCTION_T>
-typename PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::VertexData
-PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::savedPreallocationMatrixA(mesh::PtrMesh const inMesh, mesh::PtrMesh const outMesh)
-{
-  PRECICE_INFO("Using saved preallocation");
-  precice::profiling::Event ePreallocA("map.pet.preallocA.From" + this->input()->getName() + "To" + this->output()->getName(), profiling::Synchronize);
-
-  PetscInt ownerRangeABegin, ownerRangeAEnd, colOwnerRangeABegin, colOwnerRangeAEnd;
-  PetscInt outputSize;
-
-  std::tie(outputSize, std::ignore)                = _matrixA.getLocalSize(); // n hier nehmen
-  std::tie(ownerRangeABegin, ownerRangeAEnd)       = _matrixA.ownerRange();
-  std::tie(colOwnerRangeABegin, colOwnerRangeAEnd) = _matrixA.ownerRangeColumn();
-  const int dimensions                             = this->input()->getDimensions();
-
-  std::vector<PetscInt> d_nnz(outputSize), o_nnz(outputSize);
-  Eigen::VectorXd       distance(dimensions);
-
-  // Contains localRow<localCols<colPosition, distance>>>
-  VertexData vertexData(outputSize);
-
-  for (int localRow = 0; localRow < ownerRangeAEnd - ownerRangeABegin; localRow++) {
-    d_nnz[localRow]             = 0;
-    o_nnz[localRow]             = 0;
-    PetscInt            col     = 0;
-    const mesh::Vertex &oVertex = outMesh->vertices()[localRow];
-
-    // -- PREALLOCATE THE POLYNOM PART OF THE MATRIX --
-    // col does not need mapping here, because the first polyparams col are always identity mapped
-    if (_polynomial == Polynomial::ON) {
-      if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-        d_nnz[localRow]++;
-      else
-        o_nnz[localRow]++;
-      col++;
-
-      for (int dim = 0; dim < dimensions; dim++) {
-        if (not this->_deadAxis[dim]) {
-          if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-            d_nnz[localRow]++;
-          else
-            o_nnz[localRow]++;
-          col++;
-        }
-      }
-    }
-
-    // -- PREALLOCATE THE COEFFICIENTS --
-    for (const mesh::Vertex &inVertex : inMesh->vertices()) {
-      distance = oVertex.getCoords() - inVertex.getCoords();
-      for (int d = 0; d < dimensions; d++)
-        if (this->_deadAxis[d])
-          distance[d] = 0;
-
-      double const norm = distance.norm();
-      if (this->_basisFunction.getSupportRadius() > norm) {
-        col = inVertex.getGlobalIndex() + polyparams;
-        vertexData[localRow].emplace_back(col, norm);
-
-        AOApplicationToPetsc(_AOmapping, 1, &col);
-        if (col >= colOwnerRangeABegin and col < colOwnerRangeAEnd)
-          d_nnz[localRow]++;
-        else
-          o_nnz[localRow]++;
-      }
-    }
-  }
-  if (_commState->size() == 1) {
-    // std::cout << "Preallocation A Seq diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0) << '\n';
-    MatSeqAIJSetPreallocation(_matrixA, 0, d_nnz.data());
-  } else {
-    // std::cout << "Preallocation A MPI diagonal = " << std::accumulate(d_nnz.begin(), d_nnz.end(), 0)
-    //           << ", off-diagonal = " << std::accumulate(o_nnz.begin(), o_nnz.end(), 0) << '\n';
-    MatMPIAIJSetPreallocation(_matrixA, 0, d_nnz.data(), 0, o_nnz.data());
-  }
-  MatSetOption(_matrixA, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-
-  ePreallocA.stop();
-  return vertexData;
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -47,7 +47,6 @@ public:
    * @param[in] xDead, yDead, zDead Deactivates mapping along an axis
    * @param[in] solverRtol Relative tolerance for the linear solver.
    * @param[in] polynomial Type of polynomial augmentation
-   * @param[in] preallocation Sets kind of preallocation of matrices.
    *
    * For description on convergence testing and meaning of solverRtol see http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPConvergedDefault.html#KSPConvergedDefault
    */
@@ -56,9 +55,8 @@ public:
       int                            dimensions,
       const RADIAL_BASIS_FUNCTION_T &function,
       std::array<bool, 3>            deadAxis,
-      double                         solverRtol    = 1e-9,
-      Polynomial                     polynomial    = Polynomial::SEPARATE,
-      Preallocation                  preallocation = Preallocation::TREE);
+      double                         solverRtol = 1e-9,
+      Polynomial                     polynomial = Polynomial::SEPARATE);
 
   /// Deletes the PETSc objects and the _deadAxis array
   ~PetRadialBasisFctMapping() override;
@@ -182,8 +180,7 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping(
     const RADIAL_BASIS_FUNCTION_T &function,
     std::array<bool, 3>            deadAxis,
     double                         solverRtol,
-    Polynomial                     polynomial,
-    Preallocation                  preallocation)
+    Polynomial                     polynomial)
     : RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>(constraint, dimensions, function, deadAxis, Mapping::InitialGuessRequirement::Required),
       _matrixC("C"),
       _matrixQ("Q"),
@@ -194,7 +191,7 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::PetRadialBasisFctMapping(
       _AOmapping(nullptr),
       _solverRtol(solverRtol),
       _polynomial(polynomial),
-      _preallocation(preallocation),
+      _preallocation(Preallocation::TREE),
       _commState(utils::Parallel::current())
 {
   polyparams      = (_polynomial == Polynomial::ON) ? this->getPolynomialParameters() : 0;

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -74,7 +74,6 @@ public:
     std::array<bool, 3> deadAxis{};
     Polynomial          polynomial{};
     double              solverRtol{};
-    Preallocation       preallocation{};
     int                 verticesPerCluster{};
     double              relativeOverlap{};
     bool                projectToInput{};
@@ -134,13 +133,6 @@ private:
   // For iterative RBFs
   const std::string ATTR_SOLVER_RTOL = "solver-rtol";
   // const std::string ATTR_MAX_ITERATIONS="";
-
-  const std::string ATTR_PREALLOCATION     = "preallocation";
-  const std::string PREALLOCATION_ESTIMATE = "estimate";
-  const std::string PREALLOCATION_COMPUTE  = "compute";
-  const std::string PREALLOCATION_SAVE     = "save";
-  const std::string PREALLOCATION_TREE     = "tree";
-  const std::string PREALLOCATION_OFF      = "off";
 
   // For the future
   // const std::string ATTR_PARALLELISM           = "parallelism";
@@ -204,7 +196,6 @@ private:
  */
   RBFConfiguration configureRBFMapping(const std::string &type,
                                        const std::string &polynomial,
-                                       const std::string &preallocation,
                                        bool xDead, bool yDead, bool zDead,
                                        double solverRtol,
                                        double verticesPerCluster,

--- a/src/mapping/config/MappingConfigurationTypes.hpp
+++ b/src/mapping/config/MappingConfigurationTypes.hpp
@@ -14,14 +14,6 @@ enum class Polynomial {
   SEPARATE
 };
 
-enum class Preallocation {
-  OFF,
-  COMPUTE,
-  ESTIMATE,
-  SAVE,
-  TREE
-};
-
 enum class BasisFunction {
   WendlandC0,
   WendlandC2,

--- a/src/mapping/tests/MappingConfigurationTest.cpp
+++ b/src/mapping/tests/MappingConfigurationTest.cpp
@@ -81,8 +81,6 @@ BOOST_AUTO_TEST_CASE(RBFDirectConfiguration)
     BOOST_TEST(mappingConfig.rbfConfig().deadAxis[1] == false);
     BOOST_TEST(mappingConfig.rbfConfig().deadAxis[2] == true);
     BOOST_TEST(mappingConfig.rbfConfig().solverRtol == 1e-9);
-    bool prealloc = mappingConfig.rbfConfig().preallocation == Preallocation::TREE;
-    BOOST_TEST(prealloc);
   }
 }
 
@@ -123,8 +121,6 @@ BOOST_AUTO_TEST_CASE(RBFPUMConfiguration)
     BOOST_TEST(mappingConfig.rbfConfig().verticesPerCluster == 10);
     BOOST_TEST(mappingConfig.rbfConfig().relativeOverlap == 0.4);
     BOOST_TEST(mappingConfig.rbfConfig().projectToInput == true);
-    bool prealloc = mappingConfig.rbfConfig().preallocation == Preallocation::TREE;
-    BOOST_TEST(prealloc);
   }
 }
 
@@ -164,8 +160,6 @@ BOOST_AUTO_TEST_CASE(RBFIterativeConfiguration)
     BOOST_TEST(mappingConfig.rbfConfig().deadAxis[1] == false);
     BOOST_TEST(mappingConfig.rbfConfig().deadAxis[2] == true);
     BOOST_TEST(mappingConfig.rbfConfig().solverRtol == 1e-6);
-    bool prealloc = mappingConfig.rbfConfig().preallocation == Preallocation::SAVE;
-    BOOST_TEST(prealloc);
   }
 }
 #endif

--- a/src/mapping/tests/mapping-rbf-iterative-config.xml
+++ b/src/mapping/tests/mapping-rbf-iterative-config.xml
@@ -102,7 +102,6 @@
     x-dead="true"
     y-dead="false"
     z-dead="true"
-    preallocation="save"
     solver-rtol="1e-6">
     <basis-function:gaussian shape-parameter="0.3" />
   </mapping:rbf-global-iterative>


### PR DESCRIPTION
## Main changes of this PR

Removes all but the `preallocation="tree"` from the PETSc RBF mapping.

## Motivation and additional information

One of the conclusions of [Florian's thesis](https://elib.uni-stuttgart.de/bitstream/11682/10598/3/Lindner%20-%20Data%20Transfer%20in%20Partitioned%20Multi-Physics%20Simulations.pdf) [Fig 3.6] was that the boost geometry index tree-based preallocation is by far superior compared to all other methods. In addition, all other methods are not tested anywhere in the testsuite and there are apparently corner-cases, where the other (untested) preallocation methods fail for no obvious reason. In order to support this feature properly, one would have to properly test the full configuration matrix of (`polynomial` x `preallocation` x `compact/global RBF`, maybe even the rescaling is important here). Given that there is no benefit to fully support this feature, we decided to remove it completely. It comes also at the upside that users are not tempted to configure `preallocation="off"`, hoping that this would bypass the potentially compute-intense tree-based preallocation (the user only sees `Using tree-based preallocation for ..` which might take a while).
 
Resolves #873 and resolves #955

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
<del> [ ] I added a test to cover the proposed changes in our test suite. </del>
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
