### PR TITLE
Link developer tooling from CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,18 +10,17 @@ In order to get your contributions into the code base as smoothly as possible, p
   * Make sure you fill in the earliest version that you know has the issue.
 * Fork the repository on GitHub.
 * Create a feature branch, based on `develop`, from where you want to base your work. For simplicity, prefix the branch name either with `add-` or `fix-`.
-* Make commits of logical units.  
+* Make commits of logical units.
   Write [good commit messages][commit].
   Check for unnecessary whitespace with `git diff --check` before committing.
-* Write tests to assure your feature works as expected and prevent it from getting broken in the future.  
+* Write tests to assure your feature works as expected and prevent it from getting broken in the future.
   See our example tests in `src/testing/tests/ExampleTests.cpp` and the [documentation of boost.test][boosttest] for more information.
 * Run _all_ the tests to assure nothing else accidentally broke.
-* Follow our [style guide][style].
-  Install `clang-format-8` and run `tools/formatting/format-all` to format your code.
-* Submit a pull request to the repository in the preCICE organization.  
-  See [Collaboration workflow with pull requests and issues][workflow] and [Creating a pull request][pullrequest]
+* Use the available [tools to format and check your contribution](https://precice.org/dev-docs-dev-tooling.html), in particular the pre-commit hook that will format the code following our [style guide][style].
+* Submit a pull request to the repository in the preCICE organization and fill the provided template.
+  See [Collaboration workflow with pull requests and issues][workflow] and [Creating a pull request][pullrequest] to get started.
 * If applicable, add an entry for our `CHANGELOG.md` as a file `docs/changelog/123.md`, where `123` your Pull Request number.
-  If you have [GitHub CLI](https://cli.github.com/) installed, you can use the script `createChangelog` in `tools/building` to create the file for you.
+  If you have [GitHub CLI](https://cli.github.com/) installed, you can use the script `createChangelog` in `tools/building`, or run `make changelog` to create the file.
   The content of the file is a markdown list of the entries using `*` as marker. Write 1 entry per line to simplify the merging process. Each entry should start with a verb in the past tense such as `Added`, `Fixed`, `Updated`, `Simplified`, `Improved`. This simplifies sorting the changelog and finding interesting content in it.
 
 ## Taking code from other projects

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,11 +16,11 @@ In order to get your contributions into the code base as smoothly as possible, p
 * Write tests to assure your feature works as expected and prevent it from getting broken in the future.
   See our example tests in `src/testing/tests/ExampleTests.cpp` and the [documentation of boost.test][boosttest] for more information.
 * Run _all_ the tests to assure nothing else accidentally broke.
-* Use the available [tools to format and check your contribution](https://precice.org/dev-docs-dev-tooling.html), in particular the pre-commit hook that will format the code following our [style guide][style].
+* Use the available [tools to format and check your contribution][devtools], in particular the pre-commit hook that will format the code following our [style guide][style].
 * Submit a pull request to the repository in the preCICE organization and fill the provided template.
   See [Collaboration workflow with pull requests and issues][workflow] and [Creating a pull request][pullrequest] to get started.
 * If applicable, add an entry for our `CHANGELOG.md` as a file `docs/changelog/123.md`, where `123` your Pull Request number.
-  If you have [GitHub CLI](https://cli.github.com/) installed, you can use the script `createChangelog` in `tools/building`, or run `make changelog` to create the file.
+  If you have [GitHub CLI][githubcli] installed, you can use the script `createChangelog` in `tools/building`, or run `make changelog` to create the file.
   The content of the file is a markdown list of the entries using `*` as marker. Write 1 entry per line to simplify the merging process. Each entry should start with a verb in the past tense such as `Added`, `Fixed`, `Updated`, `Simplified`, `Improved`. This simplifies sorting the changelog and finding interesting content in it.
 
 ## Taking code from other projects
@@ -34,3 +34,5 @@ Please contact the maintainers before integrating non-trivial amount of code fro
 [pullrequest]: https://help.github.com/articles/creating-a-pull-request
 [style]: https://precice.org/dev-docs-dev-conventions.html
 [workflow]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests
+[devtools]: https://precice.org/dev-docs-dev-tooling.html
+[githubcli]: https://cli.github.com/


### PR DESCRIPTION
Closes #1481.

The links are already fine, main remaining issue was linking to the pre-commit hook description: https://precice.org/dev-docs-dev-tooling.html

It also removes the duplication regarding formatting.

