### PR TITLE
Deactivate archlinux until OpenMPI 4.1.6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,22 +70,22 @@ jobs:
             CONFIG: MPIPETScGinkgo
             CXX: 'g++'
             TYPE: Debug
-          - IMAGE: 'archlinux'
-            CONFIG: MPIPETSc
-            CXX: 'g++'
-            TYPE: Debug
-          - IMAGE: 'archlinux'
-            CONFIG: MPIPETSc
-            CXX: 'g++'
-            TYPE: Release
-          - IMAGE: 'archlinux'
-            CONFIG: MPIPETSc
-            CXX: 'clang++'
-            TYPE: Debug
-          - IMAGE: 'archlinux'
-            CONFIG: MPIPETSc
-            CXX: 'clang++'
-            TYPE: Release
+            #- IMAGE: 'archlinux'
+            #  CONFIG: MPIPETSc
+            #  CXX: 'g++'
+            #  TYPE: Debug
+            #- IMAGE: 'archlinux'
+            #  CONFIG: MPIPETSc
+            #  CXX: 'g++'
+            #  TYPE: Release
+            #- IMAGE: 'archlinux'
+            #  CONFIG: MPIPETSc
+            #  CXX: 'clang++'
+            #  TYPE: Debug
+            #- IMAGE: 'archlinux'
+            #  CONFIG: MPIPETSc
+            #  CXX: 'clang++'
+            #  TYPE: Release
           - IMAGE: 'fedora'
             CONFIG: MPIPETSc
             CXX: 'g++'


### PR DESCRIPTION
Problem is an incompatibility with OpenPMIX

## Main changes of this PR

Disables arch in CI

## Motivation and additional information

OpenMPI currently broken and we need to wait for release 4.1.6

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
