### PR TITLE
Fix git detection not working in worktrees

### DIFF
--- a/cmake/cmake_refresh_git_revision.cmake
+++ b/cmake/cmake_refresh_git_revision.cmake
@@ -13,32 +13,17 @@
 find_package(Git REQUIRED)
 
 execute_process(
-  COMMAND ${GIT_EXECUTABLE} rev-parse --show-toplevel
-  RESULT_VARIABLE PRECICE_REPO_RET
-  OUTPUT_VARIABLE PRECICE_REPO_OUT
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
-  )
-
-execute_process(
   COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
   RESULT_VARIABLE PRECICE_REVISION_RET
   OUTPUT_VARIABLE PRECICE_REVISION_OUT
   OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
   )
 
 set(preCICE_REVISION "no-info [git failed to run]")
 
-if(("${PRECICE_REVISION_RET}" EQUAL "0") AND ("${PRECICE_REPO_RET}" EQUAL "0"))
-  file(TO_CMAKE_PATH "${PRECICE_REPO_OUT}" _detected_path)
-  if("${PROJECT_SOURCE_DIR}" STREQUAL "${_detected_path}")
-    set(preCICE_REVISION "${PRECICE_REVISION_OUT}")
-    message(STATUS "Revision status: ${preCICE_REVISION}")
-  else()
-    message(STATUS "Revision status: directory is not a git repository")
-    set(preCICE_REVISION "no-info [not a repository]")
-  endif()
+if("${PRECICE_REVISION_RET}" EQUAL "0")
+  set(preCICE_REVISION "${PRECICE_REVISION_OUT}")
+  message(STATUS "Revision status: ${preCICE_REVISION}")
 else()
   message(STATUS "Revision status: Detection failed")
 endif()


### PR DESCRIPTION
## Main changes of this PR

This PR disables the directory check of the git revision detection as it is not reliable.


## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
