### PR TITLE
Fix profiling tests checking for pandas instead of polars

### DIFF
--- a/tools/profiling/CMakeLists.txt
+++ b/tools/profiling/CMakeLists.txt
@@ -65,6 +65,9 @@ add_test(NAME ${_test_name}
   COMMAND ${CMAKE_COMMAND} -DEVENTS_SCRIPT=${_precice_events} -DTEST_FOLDER=${_test_location} -DFOLDER_ARG=${_test_location}/A\;${_test_location}/B -P ${_test_script}
   WORKING_DIRECTORY ${_test_wd}
   )
+if (PRECICE_TEST_VENV)
+  set_tests_properties(${_test_name} PROPERTIES ENVIRONMENT "VIRTUAL_ENV=${PRECICE_TEST_VENV}")
+endif()
 
 
 unset(_precice_events)

--- a/tools/profiling/CMakeLists.txt
+++ b/tools/profiling/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT PRECICE_TEST_VENV)
     execute_process(COMMAND ${Python3_EXECUTABLE} -m venv --clear venv WORKING_DIRECTORY ${_test_root} OUTPUT_QUIET)
     execute_process(COMMAND ${_test_root}/venv/bin/pip install --upgrade pip polars OUTPUT_QUIET)
 
-    execute_process(COMMAND ${_test_root}/venv/bin/python -c "import polars" RESULTS_VARIABLE _precice_has_polars ERROR_QUIET OUTPUT_QUIET)
+    execute_process(COMMAND ${_test_root}/venv/bin/python -c "import polars" RESULTS_VARIABLE _precice_has_polars OUTPUT_QUIET)
     if ("${_precice_has_polars}" EQUAL 0)
       set(PRECICE_TEST_VENV "${_test_root}/venv" CACHE INTERNAL "Location of venv for preCICE tests")
     else()

--- a/tools/profiling/CMakeLists.txt
+++ b/tools/profiling/CMakeLists.txt
@@ -20,7 +20,7 @@ set(_test_root "${PROJECT_BINARY_DIR}/TestOutput")
 
 # Install polars in a venv if available
 if(NOT PRECICE_TEST_VENV)
-  execute_process(COMMAND ${Python3_EXECUTABLE} -c "import venv" RESULTS_VARIABLE _precice_has_venv ERROR_QUIET)
+  execute_process(COMMAND ${Python3_EXECUTABLE} -c "import venv, ensurepip" RESULTS_VARIABLE _precice_has_venv ERROR_QUIET)
   if("${_precice_has_venv}" EQUAL 0)
     message("Installing polars in a python venv to allow for full profiling tests.")
     execute_process(COMMAND ${Python3_EXECUTABLE} -m venv --clear venv WORKING_DIRECTORY ${_test_root} OUTPUT_QUIET)

--- a/tools/profiling/precice-events
+++ b/tools/profiling/precice-events
@@ -443,7 +443,12 @@ def analyzeCommand(eventfile, participant, outfile=None, unit='us'):
         rankAdvance = ldf.filter((pl.col("eid") == "advance") & (pl.col("rank") > 0)).groupby("rank").agg(pl.col("dur").sum()).sort("dur").collect()
         minSecRank = rankAdvance.select(pl.first("rank")).item()
         maxSecRank = rankAdvance.select(pl.last("rank")).item()
-        print(f"Selection contains the primary rank 0, the cheapest secondary rank {minSecRank}, and the most expensive secondary rank {maxSecRank}.")
+
+        ranksToPrint = (0, minSecRank) if minSecRank == maxSecRank else (0, minSecRank, maxSecRank)
+        if len(ranksToPrint) == 2:
+            print(f"Selection contains the primary rank 0 and secondary rank {minSecRank}.")
+        else:
+            print(f"Selection contains the primary rank 0, the cheapest secondary rank {minSecRank}, and the most expensive secondary rank {maxSecRank}.")
 
         ldf = df.lazy()
         joined = pl.concat([
@@ -456,7 +461,7 @@ def analyzeCommand(eventfile, participant, outfile=None, unit='us'):
                   pl.min("dur").alias(f"R{rank}:min"),
                   pl.max("dur").alias(f"R{rank}:max")
               ))
-            for rank in (0, minSecRank, maxSecRank)
+            for rank in ranksToPrint
         ], how="align").collect()
 
     printWide(joined)

--- a/tools/profiling/tests/simple-test.cmake
+++ b/tools/profiling/tests/simple-test.cmake
@@ -11,6 +11,7 @@
 # Force using a virtual env if it is set in the environment
 if(DEFINED ENV{VIRTUAL_ENV})
   set(Python3_FIND_VIRTUALENV ONLY)
+  message(STATUS "Running in the python venv $ENV{VIRTUAL_ENV}")
 endif()
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 

--- a/tools/profiling/tests/simple-test.cmake
+++ b/tools/profiling/tests/simple-test.cmake
@@ -43,9 +43,9 @@ if(NOT EXISTS "events.csv")
   message(FATAL_ERROR "No events.csv file found")
 endif()
 
-execute_process(COMMAND ${Python3_EXECUTABLE} -c "import pandas"
-                RESULTS_VARIABLE PYTHON_NO_PANDAS)
-if(NOT ${PYTHON_NO_PANDAS})
+execute_process(COMMAND ${Python3_EXECUTABLE} -c "import polars"
+  RESULTS_VARIABLE PYTHON_NO_POLARS)
+if(NOT ${PYTHON_NO_POLARS})
   file(STRINGS "${TEST_FOLDER}/.test" _participants)
   foreach(_participant IN LISTS _participants)
     message(STATUS "Testing: analyze ${_participant}")


### PR DESCRIPTION
## Main changes of this PR

This PR changes the profiling tests to
* check for polars instead of pandas in simple tests
* set the venv correctly for the one multi directory test
* add more debug output in the tests and while installing polars
* correctly analyse 2 rank runs.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
