### PR TITLE
Prevent unintended extrapolation in B-splines

### DIFF
--- a/src/math/bspline.cpp
+++ b/src/math/bspline.cpp
@@ -22,6 +22,8 @@ Eigen::VectorXd interpolateAt(Eigen::VectorXd ts, const Eigen::MatrixXd &xs, int
   const int ndofs = xs.rows(); // number of dofs. Each dof needs it's own interpolant.
 
   // transform all times to the relative interval [0; 1]
+  PRECICE_ASSERT(ts(0) != ts(ts.size() - 1));
+  PRECICE_ASSERT((t >= ts(0)) && (t <= ts(ts.size() - 1)), "t lies outside of ts!", t, ts); // Only allowed to use BSpline for interpolation, not extrapolation.
   auto         relativeTime = [tsMin = ts(0), tsMax = ts(ts.size() - 1)](double t) -> double { return (t - tsMin) / (tsMax - tsMin); };
   const double tRelative    = relativeTime(t);
   ts                        = ts.unaryExpr(relativeTime);

--- a/src/math/bspline.cpp
+++ b/src/math/bspline.cpp
@@ -1,9 +1,12 @@
 #include "math/bspline.hpp"
+#include "math/differences.hpp"
 #include "utils/assertion.hpp"
 
 #include <Eigen/Core>
 #include <algorithm>
 #include <cstdlib>
+#include <functional>
+#include <iterator>
 #include <unsupported/Eigen/Splines>
 
 namespace precice::math::bspline {
@@ -11,19 +14,21 @@ namespace precice::math::bspline {
 Eigen::VectorXd interpolateAt(Eigen::VectorXd ts, const Eigen::MatrixXd &xs, int splineDegree, double t)
 {
   PRECICE_ASSERT(ts.size() >= 2, "Interpolation requires at least 2 samples");
-#if EIGEN_VERSION_AT_LEAST(3, 4, 0)
-  PRECICE_ASSERT(std::is_sorted(ts.begin(), ts.end()), "Timestamps must be sorted");
-#else
-  PRECICE_ASSERT(std::is_sorted(ts.data(), ts.data() + ts.size()), "Timestamps must be sorted");
-#endif
+
+  PRECICE_ASSERT(std::inner_product(
+                     ts.data(), std::next(ts.data(), ts.size() - 1),
+                     std::next(ts.data()), true,
+                     std::logical_and<bool>{},
+                     [](double l, double r) { return math::smaller(l, r); }),
+                 "Timestamps must be strictly increasting", ts);
 
   // organize data in columns. Each column represents one sample in time.
   PRECICE_ASSERT(xs.cols() == ts.size());
   const int ndofs = xs.rows(); // number of dofs. Each dof needs it's own interpolant.
 
   // transform all times to the relative interval [0; 1]
-  PRECICE_ASSERT(ts(0) != ts(ts.size() - 1));
-  PRECICE_ASSERT((t >= ts(0)) && (t <= ts(ts.size() - 1)), "t lies outside of ts!", t, ts); // Only allowed to use BSpline for interpolation, not extrapolation.
+  PRECICE_ASSERT(math::greaterEquals(t, ts(0)), "t is before the first sample!", t, ts(0), ts);                       // Only allowed to use BSpline for interpolation, not extrapolation.
+  PRECICE_ASSERT(math::smallerEquals(t, ts(ts.size() - 1)), "t is after the last sample!", t, ts(ts.size() - 1), ts); // Only allowed to use BSpline for interpolation, not extrapolation.
   auto         relativeTime = [tsMin = ts(0), tsMax = ts(ts.size() - 1)](double t) -> double { return (t - tsMin) / (tsMax - tsMin); };
   const double tRelative    = relativeTime(t);
   ts                        = ts.unaryExpr(relativeTime);


### PR DESCRIPTION
## Main changes of this PR

Adds assertion to prevent unintended extrapolation.

## Motivation and additional information

Additional security check to prevent unintended B-spline extrapolation. This might happen, if the storage is not cleared properly due to an incorrect implementation.

Some tests fail due to this new assertion (e.g. `Integration/Serial/Whitebox`). This is a hint for a possible bug in the implementation.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
