### PR TITLE
Removing mpi-single and mpi-singleports tags

### DIFF
--- a/src/com/config/CommunicationConfiguration.cpp
+++ b/src/com/config/CommunicationConfiguration.cpp
@@ -33,13 +33,6 @@ PtrCommunication CommunicationConfiguration::createCommunication(
 #else
     com = std::make_shared<com::MPIPortsCommunication>(dir);
 #endif
-  } else if (tag.getName() == "mpi-single") {
-#ifdef PRECICE_NO_MPI
-    PRECICE_ERROR("Communication type \"mpi-single\" can only be used if preCICE was compiled with MPI support enabled. "
-                  "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
-#else
-    com = std::make_shared<com::MPIDirectCommunication>();
-#endif
   }
   PRECICE_ASSERT(com != nullptr);
   return com;

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -84,20 +84,6 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
     tag.addAttribute(attrExchangeDirectory);
     tags.push_back(tag);
   }
-  {
-    /// @TODO Remove in Version 3.0, see https://github.com/precice/precice/issues/1650
-    XMLTag tag(*this, "mpi-singleports", occ, TAG);
-    doc = "Communication via MPI with startup in separated communication spaces, using a single communicator";
-    tag.setDocumentation(doc);
-
-    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
-                                     .setDocumentation(
-                                         "Directory where connection information is exchanged. By default, the "
-                                         "directory of startup is chosen, and both solvers have to be started "
-                                         "in the same directory.");
-    tag.addAttribute(attrExchangeDirectory);
-    tags.push_back(tag);
-  }
 
   XMLAttribute<bool> attrEnforce(ATTR_ENFORCE_GATHER_SCATTER, false);
   attrEnforce.setDocumentation("Enforce the distributed communication to a gather-scatter scheme. "
@@ -185,10 +171,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
       comFactory = std::make_shared<com::MPIPortsCommunicationFactory>(dir);
       com        = comFactory->newCommunication();
 #endif
-    } else if (tagName == "mpi" || tagName == "mpi-singleports") {
-      if (tagName == "mpi-singleports") {
-        PRECICE_WARN("You used <m2n:mpi-singleports />, which is deprecated. Please use <m2n:mpi /> instead.");
-      }
+    } else if (tagName == "mpi") {
       std::string dir = tag.getStringAttributeValue(ATTR_EXCHANGE_DIRECTORY);
 #ifdef PRECICE_NO_MPI
       PRECICE_ERROR("Communication type \"{}\" can only be used if preCICE was compiled with MPI support enabled. "

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -226,7 +226,7 @@ ParticipantConfiguration::ParticipantConfiguration(
 
     intraCommTags.push_back(tagIntraComm);
   }
-  
+
   for (XMLTag &tagIntraComm : intraCommTags) {
     tag.addSubtag(tagIntraComm);
   }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -226,15 +226,7 @@ ParticipantConfiguration::ParticipantConfiguration(
 
     intraCommTags.push_back(tagIntraComm);
   }
-  {
-    XMLTag tagIntraComm(*this, "mpi-single", intraCommOcc, TAG_INTRA_COMM);
-    doc = "A solver in parallel needs a communication between its ranks. ";
-    doc += "By default (which is this option), the participant's MPI_COM_WORLD is reused.";
-    doc += "This tag is only used to ensure backwards compatibility.";
-    tagIntraComm.setDocumentation(doc);
-
-    intraCommTags.push_back(tagIntraComm);
-  }
+  
   for (XMLTag &tagIntraComm : intraCommTags) {
     tag.addSubtag(tagIntraComm);
   }

--- a/tests/parallel/GlobalRBFPartitioning.xml
+++ b/tests/parallel/GlobalRBFPartitioning.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/GlobalRBFPartitioning.xml
+++ b/tests/parallel/GlobalRBFPartitioning.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/GlobalRBFPartitioning.xml
+++ b/tests/parallel/GlobalRBFPartitioning.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/GlobalRBFPartitioningPETSc.xml
+++ b/tests/parallel/GlobalRBFPartitioningPETSc.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/GlobalRBFPartitioningPETSc.xml
+++ b/tests/parallel/GlobalRBFPartitioningPETSc.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/GlobalRBFPartitioningPETSc.xml
+++ b/tests/parallel/GlobalRBFPartitioningPETSc.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/LocalRBFPartitioning.xml
+++ b/tests/parallel/LocalRBFPartitioning.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/LocalRBFPartitioning.xml
+++ b/tests/parallel/LocalRBFPartitioning.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/LocalRBFPartitioning.xml
+++ b/tests/parallel/LocalRBFPartitioning.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/LocalRBFPartitioningPETSc.xml
+++ b/tests/parallel/LocalRBFPartitioningPETSc.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/LocalRBFPartitioningPETSc.xml
+++ b/tests/parallel/LocalRBFPartitioningPETSc.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/LocalRBFPartitioningPETSc.xml
+++ b/tests/parallel/LocalRBFPartitioningPETSc.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/NearestProjectionRePartitioning.xml
+++ b/tests/parallel/NearestProjectionRePartitioning.xml
@@ -11,7 +11,7 @@
   </mesh>
 
   <participant name="FluidSolver">
-    <intra-comm:mpi />
+    
     <provide-mesh name="CellCenters" />
     <receive-mesh name="Nodes" from="SolidSolver" safety-factor="0.5" />
     <mapping:nearest-projection

--- a/tests/parallel/NearestProjectionRePartitioning.xml
+++ b/tests/parallel/NearestProjectionRePartitioning.xml
@@ -11,7 +11,6 @@
   </mesh>
 
   <participant name="FluidSolver">
-    
     <provide-mesh name="CellCenters" />
     <receive-mesh name="Nodes" from="SolidSolver" safety-factor="0.5" />
     <mapping:nearest-projection

--- a/tests/parallel/NearestProjectionRePartitioning.xml
+++ b/tests/parallel/NearestProjectionRePartitioning.xml
@@ -11,7 +11,7 @@
   </mesh>
 
   <participant name="FluidSolver">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <provide-mesh name="CellCenters" />
     <receive-mesh name="Nodes" from="SolidSolver" safety-factor="0.5" />
     <mapping:nearest-projection

--- a/tests/parallel/TestFinalize.xml
+++ b/tests/parallel/TestFinalize.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi/>
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi />
+    
     <provide-mesh name="MeshTwo" />
     <write-data name="Data2" mesh="MeshTwo" />
     <read-data name="Data1" mesh="MeshTwo" />

--- a/tests/parallel/TestFinalize.xml
+++ b/tests/parallel/TestFinalize.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor
@@ -32,7 +31,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <provide-mesh name="MeshTwo" />
     <write-data name="Data2" mesh="MeshTwo" />
     <read-data name="Data1" mesh="MeshTwo" />

--- a/tests/parallel/TestFinalize.xml
+++ b/tests/parallel/TestFinalize.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi/>
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <provide-mesh name="MeshTwo" />
     <write-data name="Data2" mesh="MeshTwo" />
     <read-data name="Data1" mesh="MeshTwo" />

--- a/tests/parallel/UserDefinedMPICommunicator.xml
+++ b/tests/parallel/UserDefinedMPICommunicator.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/UserDefinedMPICommunicator.xml
+++ b/tests/parallel/UserDefinedMPICommunicator.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/UserDefinedMPICommunicator.xml
+++ b/tests/parallel/UserDefinedMPICommunicator.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:rbf-global-iterative

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:rbf-global-iterative

--- a/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
+++ b/tests/parallel/UserDefinedMPICommunicatorPetRBF.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:rbf-global-iterative

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="Fluid">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="Structure">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="Fluid">
-    <intra-comm:mpi />
+    
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="Structure">
-    <intra-comm:mpi />
+    
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="Fluid">
-    
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +31,6 @@
   </participant>
 
   <participant name="Structure">
-    
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="Fluid">
-    <intra-comm:mpi/>
+    
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="Structure">
-    <intra-comm:mpi />
+    
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="Fluid">
-    
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +31,6 @@
   </participant>
 
   <participant name="Structure">
-    
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="Fluid">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi/>
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="Structure">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="Fluid">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="Structure">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="Fluid">
-    <intra-comm:mpi />
+    
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +32,7 @@
   </participant>
 
   <participant name="Structure">
-    <intra-comm:mpi />
+    
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="Fluid">
-    
     <provide-mesh name="FluidMesh" />
     <receive-mesh name="StructureMesh" from="Structure" />
     <write-data name="Forces" mesh="FluidMesh" />
@@ -32,7 +31,6 @@
   </participant>
 
   <participant name="Structure">
-    
     <provide-mesh name="StructureMesh" />
     <write-data name="Velocities" mesh="StructureMesh" />
     <read-data name="Forces" mesh="StructureMesh" />

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
@@ -14,7 +14,7 @@
   </mesh>
 
   <participant name="SolverOne">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
+++ b/tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.xml
@@ -14,7 +14,6 @@
   </mesh>
 
   <participant name="SolverOne">
-    
     <receive-mesh name="MeshTwo" from="SolverTwo" />
     <provide-mesh name="MeshOne" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -20,7 +20,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN1EmptyPartition.xml
@@ -20,7 +20,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -20,7 +20,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN2EmptyPartition.xml
@@ -20,7 +20,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -20,7 +20,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi-single />
+    <intra-comm:mpi />
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:mpi />
+    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
+++ b/tests/quasi-newton/parallel/TestQN3EmptyPartition.xml
@@ -20,7 +20,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
@@ -20,7 +20,7 @@
   </participant>
 
   <participant name="SolverTwo">
-    <!-- <intra-comm:mpi-single /> -->
+    
     <receive-mesh name="MeshOne" from="SolverOne" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor

--- a/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
+++ b/tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.xml
@@ -20,7 +20,6 @@
   </participant>
 
   <participant name="SolverTwo">
-    
     <receive-mesh name="MeshOne" from="SolverOne" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor


### PR DESCRIPTION
## Main changes of this PR

Removed `mpi-single` and `mpi-singleports` tags from m2n/intracomm source files and test configuration XML files.

## Motivation and additional information

See #1772 
Closes #1650 (detailed information)

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
