### PR TITLE
Replaced deprecated master/slave with primary/secondary

### DIFF
--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -550,7 +550,7 @@ void TestSendAndReceiveRanges(TestContext const &context)
   using precice::com::AsVectorTag;
 
   if (context.isPrimary()) {
-    com.acceptConnection("Master", "Slave", "", 0, 1);
+    com.acceptConnection("Primary", "Secondary", "", 0, 1);
     {
       std::vector<int> recv{1, 2, 3};
       std::vector<int> msg = com.receiveRange(1, AsVectorTag<int>{});
@@ -564,7 +564,7 @@ void TestSendAndReceiveRanges(TestContext const &context)
     }
     com.closeConnection();
   } else {
-    com.requestConnection("Master", "Slave", "", 0, 1);
+    com.requestConnection("Primary", "Secondary", "", 0, 1);
     {
       std::vector<int> msg{1, 2, 3};
       com.sendRange(msg, 0);

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -219,7 +219,7 @@ void ReceivedPartition::compute()
       vertexDistribution[0] = std::move(vertexIDs);
 
       for (int secondaryRank : utils::IntraComm::allSecondaryRanks()) {
-        PRECICE_DEBUG("Receive partition feedback from slave rank {}", secondaryRank);
+        PRECICE_DEBUG("Receive partition feedback from the secondary rank {}", secondaryRank);
         vertexDistribution[secondaryRank] = utils::IntraComm::getCommunication()->receiveRange(secondaryRank, com::AsVectorTag<VertexID>{});
       }
       PRECICE_ASSERT(_mesh->getVertexDistribution().empty());
@@ -287,7 +287,7 @@ void ReceivedPartition::filterByBoundingBox()
   if (m2n().usesTwoLevelInitialization()) {
     std::string msg = "The received mesh " + _mesh->getName() +
                       " cannot solely be filtered on the primary rank "
-                      "(option \"filter-on-master\") if it is communicated by an m2n communication that uses "
+                      "(option \"filter-on-primary-rank\") if it is communicated by an m2n communication that uses "
                       "two-level initialization. Use \"filter-on-secondary-rank\" or \"no-filter\" instead.";
     PRECICE_CHECK(_geometricFilter != ON_PRIMARY_RANK, msg);
   }


### PR DESCRIPTION
## Main changes of this PR
 
This PR replaces deprecated master/slave tags with primary/secondary for filter options.

## Motivation and additional information

See closes #1772 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
