### PR TITLE
Always perform mapping when entering new window.

### DIFF
--- a/docs/changelog/1791.md
+++ b/docs/changelog/1791.md
@@ -1,0 +1,1 @@
+- Perform additional mappings to simplify implementation. Can lead to slight performance degradation for serial coupling schemes.

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -386,7 +386,7 @@ void ParticipantImpl::advance(
 
   advanceCouplingScheme();
 
-  if (_couplingScheme->hasDataBeenReceived()) {
+  if (_couplingScheme->hasDataBeenReceived() || _couplingScheme->isTimeWindowComplete()) {
     mapReadData();
     performDataActions({action::Action::READ_MAPPING_POST}, time);
   }

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -386,7 +386,7 @@ void ParticipantImpl::advance(
 
   advanceCouplingScheme();
 
-  if (_couplingScheme->hasDataBeenReceived() || _couplingScheme->isTimeWindowComplete()) {
+  if (_couplingScheme->hasDataBeenReceived() || _couplingScheme->isTimeWindowComplete()) { // @todo potential to avoid unnecessary mappings here.
     mapReadData();
     performDataActions({action::Action::READ_MAPPING_POST}, time);
   }

--- a/tests/serial/action-timings/ActionTimingsSerialExplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsSerialExplicit.cpp
@@ -68,14 +68,11 @@ BOOST_AUTO_TEST_CASE(ActionTimingsSerialExplicit)
     double dt = interface.getMaxTimeStepSize();
     BOOST_TEST(interface.isTimeWindowComplete());
     iteration++;
-    if (context.isNamed("SolverOne") || iteration < 10) {
-      BOOST_TEST(action::RecorderAction::records.size() == 2);
-      BOOST_TEST(action::RecorderAction::records.at(0).timing == action::Action::WRITE_MAPPING_POST);
-      BOOST_TEST(action::RecorderAction::records.at(1).timing == action::Action::READ_MAPPING_POST);
-    } else { // SolverTwo only writes in very last iteration, does not read.
-      BOOST_TEST(action::RecorderAction::records.size() == 1);
-      BOOST_TEST(action::RecorderAction::records.at(0).timing == action::Action::WRITE_MAPPING_POST);
-    }
+
+    BOOST_TEST(action::RecorderAction::records.size() == 2);
+    BOOST_TEST(action::RecorderAction::records.at(0).timing == action::Action::WRITE_MAPPING_POST);
+    BOOST_TEST(action::RecorderAction::records.at(1).timing == action::Action::READ_MAPPING_POST);
+
     action::RecorderAction::reset();
   }
   interface.finalize();

--- a/tests/serial/action-timings/ActionTimingsSerialImplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsSerialImplicit.cpp
@@ -74,14 +74,11 @@ BOOST_AUTO_TEST_CASE(ActionTimingsSerialImplicit)
     if (interface.isTimeWindowComplete()) {
       iteration++;
     }
-    if (context.isNamed("SolverOne") || iteration < 10) {
-      BOOST_TEST(action::RecorderAction::records.size() == 2);
-      BOOST_TEST(action::RecorderAction::records.at(0).timing == action::Action::WRITE_MAPPING_POST);
-      BOOST_TEST(action::RecorderAction::records.at(1).timing == action::Action::READ_MAPPING_POST);
-    } else { // SolverTwo only writes in very last iteration, does not read.
-      BOOST_TEST(action::RecorderAction::records.size() == 1);
-      BOOST_TEST(action::RecorderAction::records.at(0).timing == action::Action::WRITE_MAPPING_POST);
-    }
+
+    BOOST_TEST(action::RecorderAction::records.size() == 2);
+    BOOST_TEST(action::RecorderAction::records.at(0).timing == action::Action::WRITE_MAPPING_POST);
+    BOOST_TEST(action::RecorderAction::records.at(1).timing == action::Action::READ_MAPPING_POST);
+
     action::RecorderAction::reset();
   }
   interface.finalize();


### PR DESCRIPTION
## Main changes of this PR

`ParticipantImpl` now always performs a read mapping, if we enter a new window. This in the end only affects serial coupling schemes.

## Motivation and additional information

This change is motivated by #1746, where we need to always perform a mapping, if we enter a new window.

This change is conflicting with #1707, but it also simplifies the overall implementation from my perspective.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] ~~For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).~~ not breaking
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
