### PR TITLE
Require at least two samples for `Storage::move()`

### DIFF
--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -208,7 +208,7 @@ double CompositionalCouplingScheme::getTimeWindowSize() const
 double CompositionalCouplingScheme::getNormalizedWindowTime() const
 {
   PRECICE_TRACE();
-  auto   schemes      = allSchemes();
+  auto   schemes      = schemesToRun();
   double normalizedDt = std::transform_reduce(
       schemes.begin(), schemes.end(), std::numeric_limits<double>::max(),
       ::min<double>,

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -104,7 +104,9 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         mesh->data(0)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{1, mesh->data(0)->values()});
+        BOOST_TEST(cplScheme->getNormalizedWindowTime() == time::Storage::WINDOW_START);
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
+        BOOST_TEST(cplScheme->getNormalizedWindowTime() == time::Storage::WINDOW_END); // ensure that time is correctly updated, even if iterating. See https://github.com/precice/precice/pull/1792.
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
@@ -139,7 +141,9 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         mesh->data(1)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{ddims, mesh->data(1)->values()});
+        BOOST_TEST(cplScheme->getNormalizedWindowTime() == time::Storage::WINDOW_START);
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
+        BOOST_TEST(cplScheme->getNormalizedWindowTime() == time::Storage::WINDOW_END); // ensure that time is correctly updated, even if iterating. See https://github.com/precice/precice/pull/1792.
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();
@@ -175,7 +179,9 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         mesh->data(2)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{ddims, mesh->data(2)->values()});
+        BOOST_TEST(cplScheme->getNormalizedWindowTime() == time::Storage::WINDOW_START);
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
+        BOOST_TEST(cplScheme->getNormalizedWindowTime() == time::Storage::WINDOW_END); // ensure that time is correctly updated, even if iterating. See https://github.com/precice/precice/pull/1792.
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
         cplScheme->secondSynchronization();

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -103,7 +103,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        mesh->data(0)->setSampleAtTime(time::Storage::WINDOW_START, time::Sample{1, mesh->data(0)->values()});
+        mesh->data(0)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{1, mesh->data(0)->values()});
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
@@ -138,7 +138,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        mesh->data(1)->setSampleAtTime(time::Storage::WINDOW_START, time::Sample{ddims, mesh->data(1)->values()});
+        mesh->data(1)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{ddims, mesh->data(1)->values()});
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();
@@ -174,7 +174,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
         if (cplScheme->isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
-        mesh->data(2)->setSampleAtTime(time::Storage::WINDOW_START, time::Sample{ddims, mesh->data(2)->values()});
+        mesh->data(2)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{ddims, mesh->data(2)->values()});
         cplScheme->addComputedTime(cplScheme->getNextTimeStepMaxSize());
         cplScheme->firstSynchronization({});
         cplScheme->firstExchange();

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -432,6 +432,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
       dt        = std::min({solverDt, preciceDt});
       computedTime += dt;
       computedTimesteps++;
+      mesh->data(0)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
       cplScheme.addComputedTime(dt);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
@@ -459,6 +460,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
     while (cplScheme.isCouplingOngoing()) {
       computedTime += cplScheme.getTimeWindowSize();
       computedTimesteps++;
+      mesh->data(1)->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
       cplScheme.addComputedTime(cplScheme.getTimeWindowSize());
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -155,15 +155,16 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
-      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
-        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
-      }
+      sendCouplingData->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{1, Eigen::VectorXd::Constant(1, 4.0)});
       cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
       cplScheme.secondExchange();
       BOOST_TEST(cplScheme.hasDataBeenReceived());
+      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
+      }
     }
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
@@ -190,6 +191,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
+      sendCouplingData->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{3, v});
       cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -786,20 +786,20 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(testing::equals(sendCouplingData->previousIteration()(0), 0.0));
     BOOST_TEST(sendCouplingData->getPreviousIterationSize() == 1);
     // set write data
-    sendCouplingData->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{1, Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0)});
     while (cplScheme.isCouplingOngoing()) {
       if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
-      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
-        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
-      }
+      sendCouplingData->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{1, Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0)});
       cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
       cplScheme.secondExchange();
       BOOST_TEST(cplScheme.hasDataBeenReceived());
+      if (cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint)) {
+        cplScheme.markActionFulfilled(CouplingScheme::Action::ReadCheckpoint);
+      }
     }
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
@@ -830,6 +830,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
       if (cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint)) {
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
+      sendCouplingData->setSampleAtTime(time::Storage::WINDOW_END, time::Sample{1, v});
       cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -65,7 +65,10 @@ int Storage::nDofs() const
 
 void Storage::move()
 {
-  PRECICE_ASSERT(nTimes() > 0);
+  PRECICE_ASSERT(nTimes() >= 2, "Calling Storage::move() is only allowed, if there is a sample at the beginning and at the end. This ensures that this function is only called at the end of the window.", getTimes());
+  PRECICE_ASSERT(math::equals(_stampleStorage.front().timestamp, time::Storage::WINDOW_START), _stampleStorage.front().timestamp);
+  PRECICE_ASSERT(math::equals(_stampleStorage.back().timestamp, time::Storage::WINDOW_END), _stampleStorage.back().timestamp);
+
   auto sampleAtBeginning = getSampleAtEnd();
   auto sampleAtEnd       = getSampleAtEnd();
   _stampleStorage.clear();


### PR DESCRIPTION
## Main changes of this PR

Introduces the strict requirement for two samples to allow `Storage::move()` and updates tests correspondingly.

## Motivation and additional information

In some tests `Storage::move()` is called even, if only a single sample exists. This does not reflect the intended use case of the function: call `move()` to make the sample at the **end** of the window the sample at the beginning of the next window. This can lead to errors and unintended usage of the API. Main motivation is to help with the debugging and implementation of #1729 and improve the readability of the diff with respect to the develop branch.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
