### PR TITLE
Fix `acceleration:constant` for waveforms

### DIFF
--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -17,16 +17,22 @@ void Acceleration::checkDataIDs(const DataMap &cplData) const
 void Acceleration::applyRelaxation(double omega, const DataMap &cplData) const
 {
   for (const DataMap::value_type &pair : cplData) {
-    const auto  couplingData = pair.second;
-    auto &      values       = couplingData->values();
-    const auto &oldValues    = couplingData->previousIteration();
-    values *= omega;
-    values += oldValues * (1 - omega);
-    if (couplingData->hasGradient()) {
-      auto &      gradients    = couplingData->gradients();
-      const auto &oldGradients = couplingData->previousIterationGradients();
-      gradients *= omega;
-      gradients += oldGradients * (1 - omega);
+    const auto couplingData = pair.second;
+
+    for (auto &stample : couplingData->stamples()) {
+      auto values            = stample.sample.values;
+      auto oldValues         = couplingData->getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
+      couplingData->values() = values * omega;
+      couplingData->values() += oldValues * (1 - omega);
+
+      if (couplingData->hasGradient()) {
+        auto       gradients      = stample.sample.gradients;
+        const auto oldGradients   = couplingData->getPreviousGradientsAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
+        couplingData->gradients() = gradients * omega;
+        couplingData->gradients() += oldGradients * (1 - omega);
+      }
+
+      couplingData->setSampleAtTime(stample.timestamp, couplingData->sample());
     }
   }
 }

--- a/src/acceleration/test/AccelerationIntraCommTest.cpp
+++ b/src/acceleration/test/AccelerationIntraCommTest.cpp
@@ -605,11 +605,11 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp)
 
     // init displacements
     dpcd.reset(new CouplingData(displacements, dummyMesh, false, exchangeSubsteps));
-    dpcd->setSampleAtTime(time::Storage::WINDOW_END, dpcd->sample());
+    dpcd->setSampleAtTime(time::Storage::WINDOW_START, dpcd->sample());
 
     // init forces
     fpcd.reset(new CouplingData(forces, dummyMesh, false, exchangeSubsteps));
-    fpcd->setSampleAtTime(time::Storage::WINDOW_END, fpcd->sample());
+    fpcd->setSampleAtTime(time::Storage::WINDOW_START, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -630,9 +630,9 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp)
     forces->values() << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
 
     dpcd.reset(new CouplingData(displacements, dummyMesh, false, exchangeSubsteps));
-    dpcd->setSampleAtTime(time::Storage::WINDOW_END, dpcd->sample());
+    dpcd->setSampleAtTime(time::Storage::WINDOW_START, dpcd->sample());
     fpcd.reset(new CouplingData(forces, dummyMesh, false, exchangeSubsteps));
-    fpcd->setSampleAtTime(time::Storage::WINDOW_END, fpcd->sample());
+    fpcd->setSampleAtTime(time::Storage::WINDOW_START, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -655,9 +655,9 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp)
     forces->values() << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
 
     dpcd.reset(new CouplingData(displacements, dummyMesh, false, exchangeSubsteps));
-    dpcd->setSampleAtTime(time::Storage::WINDOW_END, dpcd->sample());
+    dpcd->setSampleAtTime(time::Storage::WINDOW_START, dpcd->sample());
     fpcd.reset(new CouplingData(forces, dummyMesh, false, exchangeSubsteps));
-    fpcd->setSampleAtTime(time::Storage::WINDOW_END, fpcd->sample());
+    fpcd->setSampleAtTime(time::Storage::WINDOW_START, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -677,9 +677,9 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_pp)
     forces->values().resize(0);
 
     dpcd.reset(new CouplingData(displacements, dummyMesh, false, exchangeSubsteps));
-    dpcd->setSampleAtTime(time::Storage::WINDOW_END, dpcd->sample());
+    dpcd->setSampleAtTime(time::Storage::WINDOW_START, dpcd->sample());
     fpcd.reset(new CouplingData(forces, dummyMesh, false, exchangeSubsteps));
-    fpcd->setSampleAtTime(time::Storage::WINDOW_END, fpcd->sample());
+    fpcd->setSampleAtTime(time::Storage::WINDOW_START, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -1080,7 +1080,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLogging)
 
   PtrCouplingData dpcd(new CouplingData(displacements, dummyMesh, false, exchangeSubsteps));
   data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
-  dpcd->setSampleAtTime(time::Storage::WINDOW_END, dpcd->sample());
+  dpcd->setSampleAtTime(time::Storage::WINDOW_START, dpcd->sample());
   dpcd->storeIteration();
 
   acc.initialize(data);

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -65,12 +65,12 @@ BOOST_AUTO_TEST_CASE(testIQNIMVJPP)
   // init displacements
   displacements->values().resize(4);
   displacements->values() << 1.0, 1.0, 1.0, 1.0;
-  displacements->setSampleAtTime(time::Storage::WINDOW_END, displacements->sample());
+  displacements->setSampleAtTime(time::Storage::WINDOW_START, displacements->sample());
 
   // init forces
   forces->values().resize(4);
   forces->values() << 0.2, 0.2, 0.2, 0.2;
-  forces->setSampleAtTime(time::Storage::WINDOW_END, forces->sample());
+  forces->setSampleAtTime(time::Storage::WINDOW_START, forces->sample());
 
   bool exchangeSubsteps = true;
 
@@ -147,12 +147,12 @@ BOOST_AUTO_TEST_CASE(testVIQNPP)
   // init displacements
   displacements->values().resize(4);
   displacements->values() << 1.0, 1.0, 1.0, 1.0;
-  displacements->setSampleAtTime(time::Storage::WINDOW_END, displacements->sample());
+  displacements->setSampleAtTime(time::Storage::WINDOW_START, displacements->sample());
 
   // init forces
   forces->values().resize(4);
   forces->values() << 0.2, 0.2, 0.2, 0.2;
-  forces->setSampleAtTime(time::Storage::WINDOW_END, forces->sample());
+  forces->setSampleAtTime(time::Storage::WINDOW_START, forces->sample());
 
   bool exchangeSubsteps = true;
 

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -20,7 +20,7 @@ CouplingData::CouplingData(
       _timeStepsStoragePrevious()
 {
   PRECICE_ASSERT(_data != nullptr);
-  _timeStepsStoragePrevious.setInterpolationOrder(3); // @todo hard-coded for now, but we need to somehow link this to <read-data waveform-order="ORDER" />
+  _timeStepsStoragePrevious.setInterpolationDegree(3); // @todo hard-coded for now, but we need to somehow link this to <read-data waveform-order="ORDER" />
   _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_START, time::Sample{getDimensions(), Eigen::VectorXd::Zero(getSize())});
   _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_END, time::Sample{getDimensions(), Eigen::VectorXd::Zero(getSize())});
 
@@ -73,12 +73,12 @@ const time::Storage &CouplingData::timeStepsStorage() const
 
 Eigen::VectorXd CouplingData::getPreviousValuesAtTime(double relativeDt)
 {
-  return _timeStepsStoragePrevious.sampleAt(relativeDt);
+  return _timeStepsStoragePrevious.sample(relativeDt);
 }
 
 Eigen::MatrixXd CouplingData::getPreviousGradientsAtTime(double relativeDt)
 {
-  return _timeStepsStoragePrevious.sampleGradientsAt(relativeDt);
+  return _timeStepsStoragePrevious.sampleGradients(relativeDt);
 }
 
 void CouplingData::setSampleAtTime(double time, time::Sample sample)

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -16,10 +16,14 @@ CouplingData::CouplingData(
     : requiresInitialization(requiresInitialization),
       _mesh(std::move(mesh)),
       _data(std::move(data)),
-      _previousIteration(_data->getDimensions(), Eigen::VectorXd::Zero(getSize())),
-      _exchangeSubsteps(exchangeSubsteps)
+      _exchangeSubsteps(exchangeSubsteps),
+      _timeStepsStoragePrevious()
 {
   PRECICE_ASSERT(_data != nullptr);
+  _timeStepsStoragePrevious.setInterpolationOrder(3); // @todo hard-coded for now, but we need to somehow link this to <read-data waveform-order="ORDER" />
+  _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_START, time::Sample{getDimensions(), Eigen::VectorXd::Zero(getSize())});
+  _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_END, time::Sample{getDimensions(), Eigen::VectorXd::Zero(getSize())});
+
   PRECICE_ASSERT(_mesh != nullptr);
   PRECICE_ASSERT(_mesh.use_count() > 0);
 }
@@ -67,6 +71,16 @@ const time::Storage &CouplingData::timeStepsStorage() const
   return _data->timeStepsStorage();
 }
 
+Eigen::VectorXd CouplingData::getPreviousValuesAtTime(double relativeDt)
+{
+  return _timeStepsStoragePrevious.sampleAt(relativeDt);
+}
+
+Eigen::MatrixXd CouplingData::getPreviousGradientsAtTime(double relativeDt)
+{
+  return _timeStepsStoragePrevious.sampleGradientsAt(relativeDt);
+}
+
 void CouplingData::setSampleAtTime(double time, time::Sample sample)
 {
   PRECICE_ASSERT(not sample.values.hasNaN());
@@ -89,23 +103,36 @@ void CouplingData::storeIteration()
 {
   const auto &stamples = this->stamples();
   PRECICE_ASSERT(stamples.size() > 0);
-  this->sample()     = stamples.back().sample;
-  _previousIteration = this->sample();
+  this->sample() = stamples.back().sample;
+
+  _timeStepsStoragePrevious.trim();
+  if (stamples.size() == 1) { // special treatment during initialization
+    const auto &stample = this->stamples().back();
+    PRECICE_ASSERT(math::equals(stample.timestamp, time::Storage::WINDOW_START), "stample.timestamp must be WINDOW_START", stample.timestamp);
+    _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_START, stample.sample);
+    _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_END, stample.sample);
+  } else {
+    // @todo add function to copy from this->timeStepsStorage() to _timeStepsStoragePrevious to avoid duplication
+    PRECICE_ASSERT(math::equals(this->stamples().back().timestamp, time::Storage::WINDOW_END), "Only allowed to storeIteration, if at window end");
+    for (const auto &stample : this->stamples()) {
+      _timeStepsStoragePrevious.setSampleAtTime(stample.timestamp, stample.sample);
+    }
+  }
 }
 
 const Eigen::VectorXd CouplingData::previousIteration() const
 {
-  return _previousIteration.values;
+  return _timeStepsStoragePrevious.stamples().back().sample.values;
 }
 
 const Eigen::MatrixXd &CouplingData::previousIterationGradients() const
 {
-  return _previousIteration.gradients;
+  return _timeStepsStoragePrevious.stamples().back().sample.gradients;
 }
 
 int CouplingData::getPreviousIterationSize() const
 {
-  return _previousIteration.values.size();
+  return _timeStepsStoragePrevious.stamples().back().sample.values.size();
 }
 
 int CouplingData::getMeshID()
@@ -131,6 +158,15 @@ std::vector<int> CouplingData::getVertexOffsets()
 void CouplingData::moveToNextWindow()
 {
   _data->moveToNextWindow();
+  // @todo put everything into _data->moveToNextWindow().
+  if (this->stamples().size() > 0) {
+    // @todo add function to copy from this->timeStepsStorage() to _timeStepsStoragePrevious to avoid duplication
+    this->_timeStepsStoragePrevious.move();
+    PRECICE_ASSERT(math::equals(this->stamples().back().timestamp, time::Storage::WINDOW_END), "this->stamples() needs to be initialized properly for WINDOW_START and WINDOW_END");
+    for (const auto &stample : this->stamples()) {
+      _timeStepsStoragePrevious.setSampleAtTime(stample.timestamp, stample.sample);
+    }
+  }
 }
 
 time::Sample &CouplingData::sample()

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -112,11 +112,8 @@ void CouplingData::storeIteration()
     _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_START, stample.sample);
     _timeStepsStoragePrevious.setSampleAtTime(time::Storage::WINDOW_END, stample.sample);
   } else {
-    // @todo add function to copy from this->timeStepsStorage() to _timeStepsStoragePrevious to avoid duplication
     PRECICE_ASSERT(math::equals(this->stamples().back().timestamp, time::Storage::WINDOW_END), "Only allowed to storeIteration, if at window end");
-    for (const auto &stample : this->stamples()) {
-      _timeStepsStoragePrevious.setSampleAtTime(stample.timestamp, stample.sample);
-    }
+    _timeStepsStoragePrevious = _data->timeStepsStorage();
   }
 }
 
@@ -158,14 +155,9 @@ std::vector<int> CouplingData::getVertexOffsets()
 void CouplingData::moveToNextWindow()
 {
   _data->moveToNextWindow();
-  // @todo put everything into _data->moveToNextWindow().
   if (this->stamples().size() > 0) {
-    // @todo add function to copy from this->timeStepsStorage() to _timeStepsStoragePrevious to avoid duplication
-    this->_timeStepsStoragePrevious.move();
     PRECICE_ASSERT(math::equals(this->stamples().back().timestamp, time::Storage::WINDOW_END), "this->stamples() needs to be initialized properly for WINDOW_START and WINDOW_END");
-    for (const auto &stample : this->stamples()) {
-      _timeStepsStoragePrevious.setSampleAtTime(stample.timestamp, stample.sample);
-    }
+    _timeStepsStoragePrevious = _data->timeStepsStorage();
   }
 }
 

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -43,6 +43,11 @@ public:
   /// Returns a reference to the time step storage of the data.
   time::Storage &timeStepsStorage();
 
+  /// returns previous data interpolated to the relativeDt time
+  Eigen::VectorXd getPreviousValuesAtTime(double relativeDt);
+
+  Eigen::MatrixXd getPreviousGradientsAtTime(double relativeDt);
+
   /// Returns a const reference to the time step storage of the data.
   const time::Storage &timeStepsStorage() const;
 
@@ -103,7 +108,7 @@ private:
   mesh::PtrData _data;
 
   /// Sample values of previous iteration (end of time window).
-  time::Sample _previousIteration;
+  time::Storage _timeStepsStoragePrevious; // @todo move this inside _data?
 
   /// If true, all substeps will be sent / received for this coupling data
   bool _exchangeSubsteps;

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -108,7 +108,7 @@ private:
   mesh::PtrData _data;
 
   /// Sample values of previous iteration (end of time window).
-  time::Storage _timeStepsStoragePrevious; // @todo move this inside _data?
+  time::Storage _timeStepsStoragePrevious;
 
   /// If true, all substeps will be sent / received for this coupling data
   bool _exchangeSubsteps;

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -108,7 +108,7 @@ private:
   mesh::PtrData _data;
 
   /// Sample values of previous iteration (end of time window).
-  time::Storage _timeStepsStoragePrevious;
+  time::Storage _previousTimeStepsStorage;
 
   /// If true, all substeps will be sent / received for this coupling data
   bool _exchangeSubsteps;

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -42,7 +42,7 @@ public:
    */
   void setSampleAtTime(double time, Sample sample);
 
-  void setInterpolationOrder(int interpolationOrder);
+  void setInterpolationDegree(int interpolationDegree);
 
   /**
    * @brief Get maximum normalized dt that is stored in this Storage.
@@ -117,9 +117,9 @@ public:
    * @param normalizedDt a double, where we want to sample the waveform
    * @return Eigen::VectorXd values in this Storage at or directly after "before"
   */
-  Eigen::VectorXd sampleAt(double normalizedDt); // @todo try to solve this differently. Currently duplicates a lot of code from Waveform::sample. Maybe even move Waveform inside Storage, if every Storage needs to interpolate anyway?
+  Eigen::VectorXd sample(double normalizedDt) const; // @todo try to solve this differently. Currently duplicates a lot of code from Waveform::sample. Maybe even move Waveform inside Storage, if every Storage needs to interpolate anyway?
 
-  Eigen::MatrixXd sampleGradientsAt(double normalizedDt); // @todo try to solve this differently. Currently duplicates a lot of code from Waveform::sample. Maybe even move Waveform inside Storage, if every Storage needs to interpolate anyway?
+  Eigen::MatrixXd sampleGradients(double normalizedDt) const; // @todo try to solve this differently. Currently duplicates a lot of code from Waveform::sample. Maybe even move Waveform inside Storage, if every Storage needs to interpolate anyway?
 
 private:
   /// Stores Stamples on the current window
@@ -127,11 +127,19 @@ private:
 
   mutable logging::Logger _log{"time::Storage"};
 
-  int _interpolationOrder;
+  int _degree;
 
-  Eigen::VectorXd bSplineInterpolationAt(double t, Eigen::VectorXd ts, Eigen::MatrixXd xs, int splineDegree);
-
-  int computeUsedOrder(int requestedOrder, int numberOfAvailableSamples);
+  /**
+   * @brief Computes which degree may be used for interpolation.
+   *
+   * Actual degree of interpolating B-spline is determined by number of stored samples and maximum degree defined by the user.
+   * Example: If only two samples are available, the maximum degree we may use is 1, even if the user demands degree 2.
+   *
+   * @param requestedDegree B-spline degree requested by the user.
+   * @param numberOfAvailableSamples Samples available for interpolation.
+   * @return B-spline degree that may be used.
+   */
+  int computeUsedDegree(int requestedDegree, int numberOfAvailableSamples) const;
 
   time::Sample getSampleAtBeginning();
 

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -42,6 +42,8 @@ public:
    */
   void setSampleAtTime(double time, Sample sample);
 
+  void setInterpolationOrder(int interpolationOrder);
+
   /**
    * @brief Get maximum normalized dt that is stored in this Storage.
    *
@@ -58,6 +60,8 @@ public:
    * @return Eigen::VectorXd values in this Storage at or directly after "before"
    */
   Eigen::VectorXd getValuesAtOrAfter(double before) const;
+
+  Eigen::MatrixXd getGradientsAtOrAfter(double before) const;
 
   /**
    * @brief Get all normalized dts stored in this Storage sorted ascending.
@@ -107,11 +111,27 @@ public:
    */
   void trim();
 
+  /**
+   * @brief Need to use interpolation for the case with changing time grids
+   *
+   * @param normalizedDt a double, where we want to sample the waveform
+   * @return Eigen::VectorXd values in this Storage at or directly after "before"
+  */
+  Eigen::VectorXd sampleAt(double normalizedDt); // @todo try to solve this differently. Currently duplicates a lot of code from Waveform::sample. Maybe even move Waveform inside Storage, if every Storage needs to interpolate anyway?
+
+  Eigen::MatrixXd sampleGradientsAt(double normalizedDt); // @todo try to solve this differently. Currently duplicates a lot of code from Waveform::sample. Maybe even move Waveform inside Storage, if every Storage needs to interpolate anyway?
+
 private:
   /// Stores Stamples on the current window
   std::vector<Stample> _stampleStorage;
 
   mutable logging::Logger _log{"time::Storage"};
+
+  int _interpolationOrder;
+
+  Eigen::VectorXd bSplineInterpolationAt(double t, Eigen::VectorXd ts, Eigen::MatrixXd xs, int splineDegree);
+
+  int computeUsedOrder(int requestedOrder, int numberOfAvailableSamples);
 
   time::Sample getSampleAtBeginning();
 

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -26,6 +26,14 @@ public:
   Storage();
 
   /**
+   * @brief Copy assignment operator to assign Storage to this Storage
+   *
+   * @param other Storage
+   * @return Storage&
+   */
+  Storage &operator=(const Storage &other);
+
+  /**
    * @brief Initialize storage by storing given sample at time 0.0 and 1.0.
    *
    * @param sample initial sample
@@ -52,16 +60,14 @@ public:
   double maxStoredNormalizedDt() const;
 
   /**
-   * @brief Returns the values at time following "before" contained in this Storage.
+   * @brief Returns the Sample at time following "before" contained in this Storage.
    *
-   * The stored normalized dt is larger or equal than "before". If "before" is a normalized dt stored in this Storage, this function returns the values at "before"
+   * The stored normalized dt is larger or equal than "before". If "before" is a normalized dt stored in this Storage, this function returns the Sample at "before"
    *
    * @param before a double, where we want to find a normalized dt that comes directly after this one
-   * @return Eigen::VectorXd values in this Storage at or directly after "before"
+   * @return Sample in this Storage at or directly after "before"
    */
-  Eigen::VectorXd getValuesAtOrAfter(double before) const;
-
-  Eigen::MatrixXd getGradientsAtOrAfter(double before) const;
+  Sample getSampleAtOrAfter(double before) const;
 
   /**
    * @brief Get all normalized dts stored in this Storage sorted ascending.

--- a/src/time/Waveform.cpp
+++ b/src/time/Waveform.cpp
@@ -38,7 +38,7 @@ Eigen::VectorXd Waveform::sample(double normalizedDt) const
   PRECICE_ASSERT(math::equals(this->_timeStepsStorage.maxStoredNormalizedDt(), time::Storage::WINDOW_END), this->_timeStepsStorage.maxStoredNormalizedDt()); // sampling is only allowed, if a window is complete.
 
   if (_degree == 0) {
-    return this->_timeStepsStorage.getValuesAtOrAfter(normalizedDt);
+    return this->_timeStepsStorage.getSampleAtOrAfter(normalizedDt).values;
   }
 
   PRECICE_ASSERT(usedDegree >= 1);

--- a/src/time/tests/StorageTest.cpp
+++ b/src/time/tests/StorageTest.cpp
@@ -20,9 +20,9 @@ BOOST_AUTO_TEST_CASE(testInitialize)
   BOOST_TEST(storage.nDofs() == nValues);
   BOOST_TEST(storage.nTimes() == 2);
   for (int i = 0; i < nValues; i++) {
-    BOOST_TEST(storage.getValuesAtOrAfter(0)(i) == 1);
-    BOOST_TEST(storage.getValuesAtOrAfter(0.5)(i) == 1);
-    BOOST_TEST(storage.getValuesAtOrAfter(1)(i) == 1);
+    BOOST_TEST(storage.getSampleAtOrAfter(0).values(i) == 1);
+    BOOST_TEST(storage.getSampleAtOrAfter(0.5).values(i) == 1);
+    BOOST_TEST(storage.getSampleAtOrAfter(1).values(i) == 1);
   }
 }
 
@@ -63,17 +63,17 @@ BOOST_AUTO_TEST_CASE(testMove)
   BOOST_TEST(storage.nTimes() == 3);
   BOOST_TEST(storage.maxStoredNormalizedDt() == 1.0);
   for (int i = 0; i < nValues; i++) {
-    BOOST_TEST(storage.getValuesAtOrAfter(0)(i) == 1);
-    BOOST_TEST(storage.getValuesAtOrAfter(0.5)(i) == 1);
-    BOOST_TEST(storage.getValuesAtOrAfter(1)(i) == 0);
+    BOOST_TEST(storage.getSampleAtOrAfter(0).values(i) == 1);
+    BOOST_TEST(storage.getSampleAtOrAfter(0.5).values(i) == 1);
+    BOOST_TEST(storage.getSampleAtOrAfter(1).values(i) == 0);
   }
   storage.move();
   BOOST_TEST(storage.nDofs() == nValues);
   BOOST_TEST(storage.nTimes() == 2);
   BOOST_TEST(storage.maxStoredNormalizedDt() == 1.0);
   for (int i = 0; i < nValues; i++) {
-    BOOST_TEST(storage.getValuesAtOrAfter(0)(i) == 0);
-    BOOST_TEST(storage.getValuesAtOrAfter(1)(i) == 0);
+    BOOST_TEST(storage.getSampleAtOrAfter(0).values(i) == 0);
+    BOOST_TEST(storage.getSampleAtOrAfter(1).values(i) == 0);
   }
 }
 

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
@@ -1,0 +1,135 @@
+#ifndef PRECICE_NO_MPI
+
+#include <math.h>
+#include <precice/precice.hpp>
+#include <vector>
+#include "testing/Testing.hpp"
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief Simple test to ensure that underrelaxation is applied to every  timestep.
+ */
+BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAcceleration)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  MeshID meshID;
+  DataID writeDataID;
+  DataID readDataID;
+
+  typedef double (*DataFunction)(double);
+
+  DataFunction dataOneFunction = [](double t) -> double {
+    return (double) (2 * t);
+  };
+  DataFunction dataTwoFunction = [](double t) -> double {
+    return (double) (3 * t);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "DataOne";
+    writeFunction = dataOneFunction;
+    readDataName  = "DataTwo";
+    readFunction  = dataTwoFunction;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "DataTwo";
+    writeFunction = dataTwoFunction;
+    readDataName  = "DataOne";
+    readFunction  = dataOneFunction;
+  }
+
+  double   writeData = 0;
+  double   readData  = 0;
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID;
+  vertexID = precice.setMeshVertex(meshName, v0);
+
+  int    nSubsteps          = 7; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows           = 5; // perform 5 windows.
+  int    timestep           = 0;
+  double time               = 0;
+  int    timestepCheckpoint = timestep;
+  double timeCheckpoint     = time;
+  int    iterations         = 0;
+
+  if (precice.requiresInitialData()) {
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+  }
+
+  precice.initialize();
+  double maxDt     = precice.getMaxTimeStepSize();
+  double windowDt  = maxDt;
+  double dt        = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 7 steps  with size 1/7
+  double currentDt = dt;                   // Timestep length used by solver
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.requiresWritingCheckpoint()) {
+      timeCheckpoint     = time;
+      timestepCheckpoint = timestep;
+      iterations         = 0;
+    }
+
+    double factor = 1 - pow((1 - 0.1), iterations); // The total relaxation factor over all iterations
+    precice.readData(meshName, readDataName, {&vertexID, 1}, maxDt, {&readData, 1});
+    if (context.isNamed("SolverOne")) { // in the first iteration of each window, use data from previous window.
+      if (iterations == 0) {
+        BOOST_TEST(readData == readFunction(timeCheckpoint));
+      } else {
+        BOOST_TEST(readData == factor * readFunction(time + maxDt));
+      }
+    } else { // in the following iterations, use data at the end of window.
+      BOOST_TEST(readData == readFunction(time + maxDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, currentDt, {&readData, 1});
+    if (context.isNamed("SolverOne")) { // in the first iteration of each window, use data from previous window.
+      if (iterations == 0) {
+        BOOST_TEST(readData == readFunction(timeCheckpoint));
+      } else {
+        BOOST_TEST(readData == factor * readFunction(time + currentDt));
+      }
+    } else { // in the following iterations, use data at the end of window.
+      BOOST_TEST(readData == readFunction(time + currentDt));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    time += currentDt;
+    timestep++;
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+    precice.advance(currentDt);
+    maxDt = precice.getMaxTimeStepSize();
+    if (precice.requiresReadingCheckpoint()) {
+      time     = timeCheckpoint;
+      timestep = timestepCheckpoint;
+      iterations++;
+    }
+    currentDt = dt > maxDt ? maxDt : dt;
+  }
+
+  precice.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Explicit
+BOOST_AUTO_TEST_SUITE_END() // ParallelCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAcceleration)
 BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Time
-BOOST_AUTO_TEST_SUITE_END() // Explicit
-BOOST_AUTO_TEST_SUITE_END() // ParallelCoupling
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.xml
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1" />
+    <max-iterations value="4" />
+    <min-iteration-convergence-measure min-iterations="4" data="DataOne" mesh="MeshOne" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" initialize="on" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" initialize="on" />
+    <acceleration:constant>
+      <relaxation value="0.1" />
+    </acceleration:constant>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAccelerationNoInit)
 BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // Serial
 BOOST_AUTO_TEST_SUITE_END() // Time
-BOOST_AUTO_TEST_SUITE_END() // Explicit
-BOOST_AUTO_TEST_SUITE_END() // ParallelCoupling
+BOOST_AUTO_TEST_SUITE_END() // Implicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
 
 #endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
@@ -1,0 +1,135 @@
+#ifndef PRECICE_NO_MPI
+
+#include <math.h>
+#include <precice/precice.hpp>
+#include <vector>
+#include "testing/Testing.hpp"
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Implicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief Simple test to ensure that underrelaxation is applied to every  timestep.
+ */
+BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAccelerationNoInit)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  MeshID meshID;
+  DataID writeDataID;
+  DataID readDataID;
+
+  typedef double (*DataFunction)(double);
+
+  DataFunction dataOneFunction = [](double t) -> double {
+    return (double) (2 * t);
+  };
+  DataFunction dataTwoFunction = [](double t) -> double {
+    return (double) (3 * t);
+  };
+  DataFunction writeFunction;
+  DataFunction readFunction;
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "DataOne";
+    writeFunction = dataOneFunction;
+    readDataName  = "DataTwo";
+    readFunction  = dataTwoFunction;
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "DataTwo";
+    writeFunction = dataTwoFunction;
+    readDataName  = "DataOne";
+    readFunction  = dataOneFunction;
+  }
+
+  double   writeData = 0;
+  double   readData  = 0;
+  double   v0[]      = {0, 0, 0};
+  VertexID vertexID;
+  vertexID = precice.setMeshVertex(meshName, v0);
+
+  int    nSubsteps          = 7; // perform subcycling on solvers. 4 steps happen in each window.
+  int    nWindows           = 5; // perform 5 windows.
+  int    timestep           = 0;
+  double time               = 0;
+  int    timestepCheckpoint = timestep;
+  double timeCheckpoint     = time;
+  int    iterations         = 0;
+
+  if (precice.requiresInitialData()) {
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+  }
+
+  precice.initialize();
+  double maxDt     = precice.getMaxTimeStepSize();
+  double windowDt  = maxDt;
+  double dt        = windowDt / nSubsteps; // Timestep length desired by solver. E.g. 7 steps  with size 1/7
+  double currentDt = dt;                   // Timestep length used by solver
+
+  while (precice.isCouplingOngoing()) {
+    if (precice.requiresWritingCheckpoint()) {
+      timeCheckpoint     = time;
+      timestepCheckpoint = timestep;
+      iterations         = 0;
+    }
+
+    double factor = 1 - pow((1 - 0.1), iterations); // The total relaxation factor over all iterations
+    precice.readData(meshName, readDataName, {&vertexID, 1}, maxDt, {&readData, 1});
+    if (context.isNamed("SolverOne")) { // in the first iteration of each window, use data from previous window.
+      if (iterations == 0) {
+        BOOST_TEST(readData == readFunction(timeCheckpoint));
+      } else {
+        BOOST_TEST(readData == factor * readFunction(time + maxDt));
+      }
+    } else { // in the following iterations, use data at the end of window.
+      BOOST_TEST(readData == readFunction(time + maxDt));
+    }
+
+    precice.readData(meshName, readDataName, {&vertexID, 1}, currentDt, {&readData, 1});
+    if (context.isNamed("SolverOne")) { // in the first iteration of each window, use data from previous window.
+      if (iterations == 0) {
+        BOOST_TEST(readData == readFunction(timeCheckpoint));
+      } else {
+        BOOST_TEST(readData == factor * readFunction(time + currentDt));
+      }
+    } else { // in the following iterations, use data at the end of window.
+      BOOST_TEST(readData == readFunction(time + currentDt));
+    }
+
+    // solve usually goes here. Dummy solve: Just sampling the writeFunction.
+    time += currentDt;
+    timestep++;
+    writeData = writeFunction(time);
+    precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
+    precice.advance(currentDt);
+    maxDt = precice.getMaxTimeStepSize();
+    if (precice.requiresReadingCheckpoint()) {
+      time     = timeCheckpoint;
+      timestep = timestepCheckpoint;
+      iterations++;
+    }
+    currentDt = dt > maxDt ? maxDt : dt;
+  }
+
+  precice.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Explicit
+BOOST_AUTO_TEST_SUITE_END() // ParallelCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.xml
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1" />
+    <max-iterations value="4" />
+    <min-iteration-convergence-measure min-iterations="4" data="DataOne" mesh="MeshOne" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <acceleration:constant>
+      <relaxation value="0.1" />
+    </acceleration:constant>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -200,6 +200,8 @@ target_sources(testprecice
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingFirst.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingMixed.cpp
     tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataWithWaveformSubcyclingThird.cpp
+    tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
+    tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
     tests/serial/watch-integral/WatchIntegralScaleAndNoScale.cpp
     tests/serial/watch-integral/helpers.cpp
     tests/serial/watch-integral/helpers.hpp


### PR DESCRIPTION
## Main changes of this PR

* Provides proper implementation of constant underrelaxation when using subcycling.

## Motivation and additional information

Similar to mapping and actions, we need also a proper implementation for acceleration that supports waveforms (see also https://github.com/precice/precice/issues/1645).

Some todos:

- [x] Plan this for 3.0.0 or 3.x.x ? Technically the changes are not breaking. However, performance of Quasi-Newton acceleration will currently suffer if waveform relaxation is used. We still need to do some testing here.
- [x] Need to take care of previous iterations in an appropriate way (already deal with time grid changes from one iteration to the next here? Related to https://github.com/precice/precice/issues/1658)
- [x] Implement tests for all acceleration schemes (decided to only start with `acceleration:constant` for now)
- [x] Which variants of Quasi-Newton schemes do we want to implement for waveform relaxation? (decided to only start with `acceleration:constant` for now)

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
