### PR TITLE
Remove final export, fix initial export

### DIFF
--- a/docs/changelog/1796.md
+++ b/docs/changelog/1796.md
@@ -1,0 +1,2 @@
+- Removed *final* export written in `finalize`.
+- Fixed *init* export written at the end of `initialize`.

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -329,9 +329,11 @@ void ParticipantImpl::initialize()
   mapReadData();
   performDataActions({action::Action::READ_MAPPING_POST}, 0.0);
 
-  resetWrittenData(false, false);
   PRECICE_DEBUG("Plot output");
-  _accessor->exportFinal();
+  _accessor->exportInitial();
+
+  resetWrittenData(false, false);
+
   e.stop();
   sep.pop();
 
@@ -429,8 +431,6 @@ void ParticipantImpl::finalize()
     PRECICE_DEBUG("Finalize coupling scheme");
     _couplingScheme->finalize();
 
-    PRECICE_DEBUG("Handle exports");
-    _accessor->exportFinal();
     closeCommunicationChannels(CloseChannels::All);
   }
 

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -350,21 +350,6 @@ void ParticipantState::exportInitial()
   }
 }
 
-void ParticipantState::exportFinal()
-{
-  for (const io::ExportContext &context : exportContexts()) {
-    if (context.everyNTimeWindows < 1) {
-      continue;
-    }
-
-    for (const MeshContext *meshContext : usedMeshContexts()) {
-      auto &mesh = *meshContext->mesh;
-      PRECICE_DEBUG("Exporting final mesh {} to location \"{}\"", mesh.getName(), context.location);
-      context.exporter->doExport(fmt::format("{}-{}.final", mesh.getName(), getName()), context.location, mesh);
-    }
-  }
-}
-
 void ParticipantState::exportIntermediate(IntermediateExport exp)
 {
   for (const io::ExportContext &context : exportContexts()) {

--- a/src/precice/impl/ParticipantState.hpp
+++ b/src/precice/impl/ParticipantState.hpp
@@ -261,9 +261,6 @@ public:
   /// Exports the initial state of meshes
   void exportInitial();
 
-  /// Exports the final state of meshes
-  void exportFinal();
-
   struct IntermediateExport {
     size_t timewindow;
     size_t iteration;


### PR DESCRIPTION
## Main changes of this PR

Closes #1563 

- Removes final export
- Fix wrong location of `resetWrittenData(...)` in `initialize()` (has to come after the export)
- Fix missing initial export (previously "final" export was written in `initialize()`)

I played a bit around with the solverdummy and initial exports. All worked as expected. I cannot reproduce the problem mentioned in the issue. 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
