### PR TITLE
Compute bounding box for pum clustering locally

### DIFF
--- a/docs/changelog/1805.md
+++ b/docs/changelog/1805.md
@@ -1,0 +1,1 @@
+- Replaced calls to `computeBoundingBox` by manual implementation in partition of unity mapping for better cluster radius computations in parallel.

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -314,11 +314,16 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
   // Note that we don't use the corresponding bounding box functions from
   // precice::mesh (e.g. ::getBoundingBox), as the stored bounding box might
   // have the wrong size (e.g. direct access)
-  precice::mesh::BoundingBox bb(filterMesh->getDimensions());
-  for (const mesh::Vertex &vertex : filterMesh->vertices()) {
-    bb.expandBy(vertex);
-  }
+  precice::mesh::BoundingBox bb = filterMesh->index().getRtreeBounds();
 
+#ifndef NDEBUG
+  // Safety check
+  precice::mesh::BoundingBox bb_check(filterMesh->getDimensions());
+  for (const mesh::Vertex &vertex : filterMesh->vertices()) {
+    bb_check.expandBy(vertex);
+  }
+  PRECICE_ASSERT(bb_check == bb);
+#endif
   // @TODO: This assert is not completely right, as it checks all dimensions for non-emptyness (which might not be the case).
   // However, with the current BB implementation, the expandBy function will just do nothing.
   PRECICE_ASSERT(!bb.empty());

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -311,8 +311,13 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
   // In order to construct the local partitions, we need all vertices with a distance of 2 x radius,
   // as the relevant partitions centers have a maximum distance of radius, and the proper construction of the
   // interpolant requires all vertices with a distance of radius from the center.
-  filterMesh->computeBoundingBox();
-  auto bb = filterMesh->getBoundingBox();
+  // Note that we don't use the corresponding bounding box functions from
+  // precice::mesh (e.g. ::getBoundingBox), as the stored bounding box might
+  // have the wrong size (e.g. direct access)
+  precice::mesh::BoundingBox bb(filterMesh->getDimensions());
+  for (const mesh::Vertex &vertex : filterMesh->vertices()) {
+    bb.expandBy(vertex);
+  }
 
   // @TODO: This assert is not completely right, as it checks all dimensions for non-emptyness (which might not be the case).
   // However, with the current BB implementation, the expandBy function will just do nothing.

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -332,7 +332,13 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   // pro outMesh: we want perfectly fitting clusters around our output vertices
   // however, this makes the cluster distribution/mapping dependent on the output
   inMesh->computeBoundingBox();
-  auto localBB = inMesh->getBoundingBox();
+
+  precice::mesh::BoundingBox localBB(inMesh->getDimensions());
+  for (const mesh::Vertex &vertex : inMesh->vertices()) {
+    localBB.expandBy(vertex);
+  }
+
+  // auto localBB = inMesh->getBoundingBox();
 
   // If we have less vertices in the whole domain than our target cluster size,
   // we just use a single cluster. The clustering result of the algorithm further

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -327,18 +327,18 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   PRECICE_DEBUG("Relative overlap: {}", relativeOverlap);
   PRECICE_DEBUG("Vertices per cluster: {}", verticesPerCluster);
 
-  // Step 1: Get the (global) bounding box of the input mesh
+  // Step 1: Compute the local bounding box of the input mesh manually
+  // Note that we don't use the corresponding bounding box functions from
+  // precice::mesh (e.g. ::getBoundingBox), as the stored bounding box might
+  // have the wrong size (e.g. direct access)
   // @todo: Which mesh should be used in order to determine the cluster centers:
   // pro outMesh: we want perfectly fitting clusters around our output vertices
   // however, this makes the cluster distribution/mapping dependent on the output
-  inMesh->computeBoundingBox();
 
   precice::mesh::BoundingBox localBB(inMesh->getDimensions());
   for (const mesh::Vertex &vertex : inMesh->vertices()) {
     localBB.expandBy(vertex);
   }
-
-  // auto localBB = inMesh->getBoundingBox();
 
   // If we have less vertices in the whole domain than our target cluster size,
   // we just use a single cluster. The clustering result of the algorithm further

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -334,11 +334,16 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   // @todo: Which mesh should be used in order to determine the cluster centers:
   // pro outMesh: we want perfectly fitting clusters around our output vertices
   // however, this makes the cluster distribution/mapping dependent on the output
+  precice::mesh::BoundingBox localBB = inMesh->index().getRtreeBounds();
 
-  precice::mesh::BoundingBox localBB(inMesh->getDimensions());
+#ifndef NDEBUG
+  // Safety check
+  precice::mesh::BoundingBox bb_check(inMesh->getDimensions());
   for (const mesh::Vertex &vertex : inMesh->vertices()) {
-    localBB.expandBy(vertex);
+    bb_check.expandBy(vertex);
   }
+  PRECICE_ASSERT(bb_check == localBB);
+#endif
 
   // If we have less vertices in the whole domain than our target cluster size,
   // we just use a single cluster. The clustering result of the algorithm further

--- a/src/mesh/BoundingBox.cpp
+++ b/src/mesh/BoundingBox.cpp
@@ -17,7 +17,7 @@ BoundingBox::BoundingBox(Eigen::VectorXd boundMin, Eigen::VectorXd boundMax)
 {
   PRECICE_ASSERT((boundMin.rows() == 2 && boundMax.rows() == 2) || (boundMin.rows() == 3 && boundMax.rows() == 3),
                  "Dimension of min {} and max {} vertices should be the same and both 2 or 3.", boundMin.rows(), boundMax.rows());
-  PRECICE_ASSERT((boundMin - boundMax).maxCoeff() < 0, "Each component of min vertex {} must be <= max vertex {} in the same axis direction.", boundMin, boundMax);
+  PRECICE_ASSERT((boundMin - boundMax).maxCoeff() <= 0, "Each component of min vertex {} must be <= max vertex {} in the same axis direction.", boundMin, boundMax);
 
   _boundMin   = std::move(boundMin);
   _boundMax   = std::move(boundMax);

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -206,7 +206,7 @@ public:
   void computeBoundingBox();
 
   /**
-   * @brief Removes all mesh elements and data values (does not remove data).
+   * @brief Removes all mesh elements and data values (does not remove data or the bounding boxes).
    *
    * A mesh element is a
    * - vertex

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -280,6 +280,12 @@ public:
    * @brief Returns the bounding box of the mesh.
    *
    * BoundingBox is a vector of pairs (min, max), one pair for each dimension.
+   * Note that the bounding box does not necessarily need to match the bounding
+   * box of the contained vertices of the mesh. Examples are the direct mesh access
+   * or a computation of the bounding box before applying additional filtering
+   * during the repartitioning. Note that mesh::clear doesn't clear the underlying
+   * bounding box (which is potentially a user input when using and defining
+   * direct mesh access)
    */
   const BoundingBox &getBoundingBox() const;
 

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -349,6 +349,30 @@ ProjectionMatch Index::findTriangleProjection(const Eigen::VectorXd &location, i
   return *min;
 }
 
+mesh::BoundingBox Index::getRtreeBounds()
+{
+  PRECICE_TRACE();
+  // if the mesh is empty, we will most likely hit an assertion in the bounding box class
+  // therefore, we keep the assert here, but might want to return an empty bounding box in case
+  // we want to allow calling this function with empty meshes
+  PRECICE_ASSERT(_mesh->vertices().size() > 0);
+
+  auto            rtreeBox = _pimpl->getVertexRTree(*_mesh)->bounds();
+  int             dim      = _mesh->getDimensions();
+  Eigen::VectorXd min(dim), max(dim);
+
+  min[0] = rtreeBox.min_corner().get<0>();
+  min[1] = rtreeBox.min_corner().get<1>();
+  max[0] = rtreeBox.max_corner().get<0>();
+  max[1] = rtreeBox.max_corner().get<1>();
+
+  if (dim > 2) {
+    min[2] = rtreeBox.min_corner().get<2>();
+    max[2] = rtreeBox.max_corner().get<2>();
+  }
+  return mesh::BoundingBox{min, max};
+}
+
 void Index::clear()
 {
   _pimpl->clear();

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -103,6 +103,10 @@ public:
   ProjectionMatch findNearestProjection(const Eigen::VectorXd &location, int n);
 
   ProjectionMatch findCellOrProjection(const Eigen::VectorXd &location, int n);
+
+  // Index tree, bounds
+  mesh::BoundingBox getRtreeBounds();
+
   /// Clear the index
   void clear();
 

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -213,6 +213,49 @@ BOOST_AUTO_TEST_CASE(QueryWithBoxEverything)
   BOOST_TEST(results.size() == 8);
 }
 
+BOOST_AUTO_TEST_CASE(QueryRtreeBoundingBox2D)
+{
+  PRECICE_TEST(1_rank);
+  auto mesh   = edgeMesh2D();
+  auto result = mesh->index().getRtreeBounds();
+  mesh->computeBoundingBox();
+  auto comparison = mesh->getBoundingBox();
+
+  BOOST_TEST(result == comparison);
+  BOOST_TEST(result.minCorner() == Eigen::Vector2d(0, 0));
+  BOOST_TEST(result.maxCorner() == Eigen::Vector2d(1, 1));
+}
+
+BOOST_AUTO_TEST_CASE(QueryRtreeBoundingBox3D)
+{
+  PRECICE_TEST(1_rank);
+  auto mesh   = vertexMesh3D();
+  auto result = mesh->index().getRtreeBounds();
+  mesh->computeBoundingBox();
+  auto comparison = mesh->getBoundingBox();
+
+  BOOST_TEST(result == comparison);
+  BOOST_TEST(result.minCorner() == Eigen::Vector3d(0, 0, 0));
+  BOOST_TEST(result.maxCorner() == Eigen::Vector3d(1, 1, 1));
+}
+
+BOOST_AUTO_TEST_CASE(QueryRtreeBoundingBox3DComplex)
+{
+  PRECICE_TEST(1_rank);
+  PtrMesh mesh(new precice::mesh::Mesh("MyMesh", 3, precice::testing::nextMeshID()));
+  mesh->createVertex(Eigen::Vector3d(7, 4, 3.3));
+  mesh->createVertex(Eigen::Vector3d(26.4777, 5, 8));
+  mesh->createVertex(Eigen::Vector3d(-23.4, 100000.2, 7));
+  mesh->createVertex(Eigen::Vector3d(0.211, -21.37, 0.00003));
+  auto result = mesh->index().getRtreeBounds();
+  mesh->computeBoundingBox();
+  auto comparison = mesh->getBoundingBox();
+
+  BOOST_TEST(result == comparison);
+  BOOST_TEST(result.minCorner() == Eigen::Vector3d(-23.4, -21.37, 0.00003));
+  BOOST_TEST(result.maxCorner() == Eigen::Vector3d(26.4777, 100000.2, 8));
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Vertex
 
 BOOST_AUTO_TEST_SUITE(Edge)


### PR DESCRIPTION
## Main changes of this PR

Computes the bounding box used to estimate the cluster radius locally instead of using the pre-computed bounding box of the meshes.

## Motivation and additional information

While investigating parallel performance of the implementation I notices quite some load imbalances. Reason: the cluster-radius estimates are poor, leading to large clusters on some ranks, which are consequently more expensive to compute.

The miserable radius computation puzzled me a bit and after digging a bit deeper, it turned out that calling `mesh->getBoundingBox()` in `computeMapping` returns the global bounding box (of the sender) instead of the bounding box of the local partition (which was what I assumed). 

Example in the image: looking at the yellow colorized partition (on the `to` participant), I received the bounding box (indicated by the outline) and the clustering algorithm generated the samples (indicated in blue) out of it as shown. However, what's actually required for the algorithm to work properly is the bounding box of the local yellow partition. In the example, I used a single rank for the `from` participant and four ranks for the `to` participant.

![image](https://github.com/precice/precice/assets/33414590/72fb03c6-bf31-48ea-a50a-4ba26b039b5f)

I don't understand in the first place, where the `to` participant receives information about the global bounding box of the `from` participant. Also, I'm not sure whether this indicates an actual bug in the interplay of `BoundingBox` as used in our `Mesh` data structure. IIRC, we can't simply clear and recompute the bounding box in the mesh due to the direct mesh access, where the bounding box might be defined by a user. In any case: if the behavior is intended this way, we should probably rename the function to `mesh::getGlobalBoundingBox()`.

I will try to come up with a unit test to prevent future confusion in this regard, at least in the pum mapping.  


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
