### PR TITLE
Detect polars instead of installing it

### DIFF
--- a/tools/profiling/CMakeLists.txt
+++ b/tools/profiling/CMakeLists.txt
@@ -18,23 +18,14 @@ set(_precice_profiling "${CMAKE_CURRENT_LIST_DIR}/precice-profiling")
 set(_test_script "${CMAKE_CURRENT_LIST_DIR}/tests/simple-test.cmake")
 set(_test_root "${PROJECT_BINARY_DIR}/TestOutput")
 
-# Install polars in a venv if available
-if(NOT PRECICE_TEST_VENV)
-  execute_process(COMMAND ${Python3_EXECUTABLE} -c "import venv, ensurepip" RESULTS_VARIABLE _precice_has_venv ERROR_QUIET)
-  if("${_precice_has_venv}" EQUAL 0)
-    message("Installing polars in a python venv to allow for full profiling tests.")
-    execute_process(COMMAND ${Python3_EXECUTABLE} -m venv --clear venv WORKING_DIRECTORY ${_test_root} OUTPUT_QUIET)
-    execute_process(COMMAND ${_test_root}/venv/bin/pip install --upgrade pip polars OUTPUT_QUIET)
-
-    execute_process(COMMAND ${_test_root}/venv/bin/python -c "import polars" RESULTS_VARIABLE _precice_has_polars OUTPUT_QUIET)
-    if ("${_precice_has_polars}" EQUAL 0)
-      set(PRECICE_TEST_VENV "${_test_root}/venv" CACHE INTERNAL "Location of venv for preCICE tests")
-    else()
-      message(WARNING "Installing polars in a venv failed.")
-    endif()
-  else()
-    message("Python venv not found. Please install python-venv or python3-venv for full profiling tests.")
-  endif()
+# Check if polars is installed
+set(_test_message_suffix "")
+execute_process(COMMAND ${Python3_EXECUTABLE} -c "import polars"
+  RESULTS_VARIABLE PRECICE_PYTHON_POLARS_CHECK
+  OUTPUT_QUIET ERROR_QUIET)
+if(NOT "${PRECICE_PYTHON_POLARS_CHECK}" EQUAL "0")
+  message(STATUS "The python package polars is not installed. Profiling tests will be limited. Install polars using your package manager or \"pip install polars\" to enable all profiling tests.")
+  set(_test_message_suffix " - limited")
 endif()
 
 foreach(test IN LISTS _tests)
@@ -42,15 +33,11 @@ foreach(test IN LISTS _tests)
   set(_test_location "${CMAKE_CURRENT_LIST_DIR}/tests/${test}")
   set(_test_wd "${_test_root}/tools.profiling.${test}")
   file(MAKE_DIRECTORY ${_test_wd})
-  message(STATUS "Test ${_test_name}")
+  message(STATUS "Test ${_test_name}${_test_message_suffix}")
   add_test(NAME ${_test_name}
     COMMAND ${CMAKE_COMMAND} -DPROFILING_SCRIPT=${_precice_profiling} -DTEST_FOLDER=${_test_location} -DFOLDER_ARG=${_test_location} -P ${_test_script}
     WORKING_DIRECTORY ${_test_wd}
     )
-  # Pass the venv to the script
-  if (PRECICE_TEST_VENV)
-    set_tests_properties(${_test_name} PROPERTIES ENVIRONMENT "VIRTUAL_ENV=${PRECICE_TEST_VENV}")
-  endif()
 endforeach(test)
 
 # Multi directory tests
@@ -60,14 +47,16 @@ set(_test_name precice.tools.profiling.${test})
 set(_test_location "${CMAKE_CURRENT_LIST_DIR}/tests/${test}")
 set(_test_wd "${PROJECT_BINARY_DIR}/TestOutput/tools.profiling.${test}")
 file(MAKE_DIRECTORY ${_test_wd})
-message(STATUS "Test ${_test_name}")
+message(STATUS "Test ${_test_name}${_test_message_suffix}")
 add_test(NAME ${_test_name}
   COMMAND ${CMAKE_COMMAND} -DPROFILING_SCRIPT=${_precice_profiling} -DTEST_FOLDER=${_test_location} -DFOLDER_ARG=${_test_location}/A\;${_test_location}/B -P ${_test_script}
   WORKING_DIRECTORY ${_test_wd}
   )
-if (PRECICE_TEST_VENV)
-  set_tests_properties(${_test_name} PROPERTIES ENVIRONMENT "VIRTUAL_ENV=${PRECICE_TEST_VENV}")
-endif()
-
 
 unset(_precice_profiling)
+unset(_test_location)
+unset(_test_message_suffix)
+unset(_test_name)
+unset(_test_root)
+unset(_test_script)
+unset(_test_wd)

--- a/tools/profiling/tests/simple-test.cmake
+++ b/tools/profiling/tests/simple-test.cmake
@@ -45,8 +45,10 @@ if(NOT EXISTS "profiling.csv")
 endif()
 
 execute_process(COMMAND ${Python3_EXECUTABLE} -c "import polars"
-  RESULTS_VARIABLE PYTHON_NO_POLARS)
-if(NOT ${PYTHON_NO_POLARS})
+  RESULTS_VARIABLE PRECICE_PYTHON_POLARS_CHECK)
+if(NOT "${PRECICE_PYTHON_POLARS_CHECK}" EQUAL "0")
+  message("Skipping analysis as polars is missing")
+else()
   file(STRINGS "${TEST_FOLDER}/.test" _participants)
   foreach(_participant IN LISTS _participants)
     message(STATUS "Testing: analyze ${_participant}")


### PR DESCRIPTION
## Main changes of this PR

This PR detects python polars instead of installing it.

## Motivation and additional information

Repeated issues with the auto installation in a venv

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
