### PR TITLE
Installs the precice-profiling script as a program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,7 +601,7 @@ if(PRECICE_BUILD_TOOLS)
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
-    install(FILES ${preCICE_SOURCE_DIR}/tools/profiling/precice-profiling
+  install(PROGRAMS ${preCICE_SOURCE_DIR}/tools/profiling/precice-profiling
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 


### PR DESCRIPTION
## Main changes of this PR

This PR fixes CMake to install the python script precice-profiling with executable flags set


