### PR TITLE
Fix Archlinux CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,22 +70,22 @@ jobs:
             CONFIG: MPIPETScGinkgo
             CXX: 'g++'
             TYPE: Debug
-            #- IMAGE: 'archlinux'
-            #  CONFIG: MPIPETSc
-            #  CXX: 'g++'
-            #  TYPE: Debug
-            #- IMAGE: 'archlinux'
-            #  CONFIG: MPIPETSc
-            #  CXX: 'g++'
-            #  TYPE: Release
-            #- IMAGE: 'archlinux'
-            #  CONFIG: MPIPETSc
-            #  CXX: 'clang++'
-            #  TYPE: Debug
-            #- IMAGE: 'archlinux'
-            #  CONFIG: MPIPETSc
-            #  CXX: 'clang++'
-            #  TYPE: Release
+          - IMAGE: 'archlinux'
+            CONFIG: MPIPETSc
+            CXX: 'g++'
+            TYPE: Debug
+          - IMAGE: 'archlinux'
+            CONFIG: MPIPETSc
+            CXX: 'g++'
+            TYPE: Release
+          - IMAGE: 'archlinux'
+            CONFIG: MPIPETSc
+            CXX: 'clang++'
+            TYPE: Debug
+          - IMAGE: 'archlinux'
+            CONFIG: MPIPETSc
+            CXX: 'clang++'
+            TYPE: Release
           - IMAGE: 'fedora'
             CONFIG: MPIPETSc
             CXX: 'g++'
@@ -148,6 +148,7 @@ jobs:
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
           BOOST_TEST_LOG_LEVEL: all
+          OMPI_MCA_btl_tcp_include_if: "${{ contains(matrix.IMAGE, 'archlinux') && 'lo' || '' }}"
         working-directory: build
         run: su -c "ctest" $PRECICE_USER
       - name: Coverage Report

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -148,7 +148,7 @@ jobs:
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
           BOOST_TEST_LOG_LEVEL: all
-          OMPI_MCA_btl_tcp_include_if: "${{ contains(matrix.IMAGE, 'archlinux') && 'lo' || '' }}"
+          OMPI_MCA_btl_tcp_if_include: "${{ contains(matrix.IMAGE, 'archlinux') && 'lo' || '' }}"
         working-directory: build
         run: su -c "ctest" $PRECICE_USER
       - name: Coverage Report


### PR DESCRIPTION
## Main changes of this PR

This PR forces Open MPI to use the lo interface on archlinux.
It also re-enables the CI.

## Motivation and additional information

Followup of #1762

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
