### PR TITLE
Add Fortran to macOS CI

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -58,7 +58,7 @@ jobs:
         PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_Fortran_COMPILER=$(which gfortran) -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
     - uses: actions/upload-artifact@v3
       if: failure()
       with:

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install numpy
       run: pip3 install numpy
     - name: Install preCICE dependencies
-      run: brew install cmake eigen libxml2 boost petsc openmpi pkg-config
+      run: brew install gfortran cmake eigen libxml2 boost petsc openmpi pkg-config
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -47,6 +47,10 @@ jobs:
       run: pip3 install numpy
     - name: Install preCICE dependencies
       run: brew install gfortran cmake eigen libxml2 boost petsc openmpi pkg-config
+    - name: gfortran
+      run: |
+        gfortran --version
+        which gfortran
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure


### PR DESCRIPTION
## Main changes of this PR

This PR installs gfortran (gcc) in the macOS CI. This should enable tests of the fortran solverdummies.

## Motivation and additional information

There are currently no tests of the Fortran interface on macOS.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.