### PR TITLE
Use python interpreter from env

### DIFF
--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#! /usr/bin/env python3
 
 # Import the fastest jsons library available
 try:


### PR DESCRIPTION
## Main changes of this PR

..which should be more robust. Especially for HPC clusters, where python might be loaded via modules, using the hard-coded python path is very likely to give the wrong interpreter. Using env should result in the correct one used by the OS.