### PR TITLE
Provide initial values in `tests/serial/mapping-volume/helpers.cpp`

### DIFF
--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -40,12 +40,13 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
     BOOST_TEST(equals(mesh.triangles()[0].getArea(), 0.5), "Triangle area must be 0.5");
 
     // Initialize, write data, advance and finalize
+    std::vector<double> values{1.0, 100.0, 10.0};
+    participant.writeData(meshName, dataName, vertexIDs, values);
     participant.initialize();
     double dt = participant.getMaxTimeStepSize();
     BOOST_TEST(!mesh.triangles().empty(), "Triangle must still be stored");
     BOOST_TEST(participant.isCouplingOngoing(), "Sending participant must advance once.");
 
-    std::vector<double> values{1.0, 100.0, 10.0};
     participant.writeData(meshName, dataName, vertexIDs, values);
 
     participant.advance(dt);
@@ -113,11 +114,12 @@ void testMappingVolumeOneTriangleConservative(const std::string configFile, cons
     BOOST_CHECK(participant.getMeshVertexSize(meshName) == 1);
 
     // Initialize, write data, advance and finalize
+    std::vector<double> values{1.0};
+    participant.writeData(meshName, dataName, vertexIDs, values);
     participant.initialize();
     double dt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Sending participant must advance once.");
 
-    std::vector<double> values{1.0};
     participant.writeData(meshName, dataName, vertexIDs, values);
 
     participant.advance(dt);
@@ -198,6 +200,9 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
     BOOST_TEST(equals(mesh.tetrahedra()[0].getVolume(), 1.0 / 6), "Tetrahedron volume must be 1/6");
 
     // Initialize, write data, advance and finalize
+    // Send 1 + 5x - 3y + 9z
+    std::vector<double> values{1.0, 6.0, -2.0, 8.0};
+    participant.writeData(meshName, dataName, vertexIDs, values);
     participant.initialize();
     double dt = participant.getMaxTimeStepSize();
     BOOST_REQUIRE(mesh.edges().size() == 6);
@@ -206,8 +211,6 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
     BOOST_TEST(!mesh.tetrahedra().empty(), "Tetrahedra must still be stored");
     BOOST_TEST(participant.isCouplingOngoing(), "Sending participant must advance once.");
 
-    // Send 1 + 5x - 3y + 9z
-    std::vector<double> values{1.0, 6.0, -2.0, 8.0};
     participant.writeData(meshName, dataName, vertexIDs, values);
 
     participant.advance(dt);
@@ -277,11 +280,12 @@ void testMappingVolumeOneTetraConservative(const std::string configFile, const T
     BOOST_CHECK(participant.getMeshVertexSize(meshName) == 1);
 
     // Initialize, write data, advance and finalize
+    std::vector<double> values{1.0};
+    participant.writeData(meshName, dataName, vertexIDs, values);
     participant.initialize();
     double dt = participant.getMaxTimeStepSize();
     BOOST_TEST(participant.isCouplingOngoing(), "Sending participant must advance once.");
 
-    std::vector<double> values{1.0};
     participant.writeData(meshName, dataName, vertexIDs, values);
 
     participant.advance(dt);


### PR DESCRIPTION
## Main changes of this PR

Provides initial values in `tests/serial/mapping-volume/helpers.cpp` to make sure that constant function is used.

## Motivation and additional information

Without this fix test fails in #1746 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
