### PR TITLE
Optimize building the communication map

### DIFF
--- a/docs/changelog/1830.md
+++ b/docs/changelog/1830.md
@@ -1,0 +1,1 @@
+- Optimized communication map creation for parallel single-level initialization significantly.

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -253,22 +253,21 @@ namespace {
    * @param first1 The begin of the second range we want to compute the intersection with
    * @param last1 The end of the second range we want to compute the intersection with
    * @param d_first Beginning of the output range
-   * @return OutputIt Iterator past the end of the constructed range.
    */
 template <class InputIt1, class InputIt2, class OutputIt>
-OutputIt set_intersection_indices(InputIt1 ref1, InputIt1 first1, InputIt1 last1,
-                                  InputIt2 first2, InputIt2 last2, OutputIt d_first)
+void set_intersection_indices(InputIt1 ref1, InputIt1 first1, InputIt1 last1,
+                              InputIt2 first2, InputIt2 last2, OutputIt d_first)
 {
   while (first1 != last1 && first2 != last2) {
-    if (*first1 < *first2)
+    if (*first1 < *first2) {
       ++first1;
-    else {
-      if (!(*first2 < *first1))
+    } else {
+      if (!(*first2 < *first1)) {
         *d_first++ = std::distance(ref1, first1++); // *first1 and *first2 are equivalent.
+      }
       ++first2;
     }
   }
-  return d_first;
 }
 } // namespace
 
@@ -303,11 +302,11 @@ std::map<int, std::vector<int>> buildCommunicationMap(
     int                             thisRank = utils::IntraComm::getRank())
 {
   auto iterator = thisVertexDistribution.find(thisRank);
-  if (iterator == thisVertexDistribution.end())
+  if (iterator == thisVertexDistribution.end()) {
     return {};
+  }
 
   std::map<int, std::vector<int>> communicationMap;
-
   // take advantage that these data structures are in most cases sorted by construction,
   // i.e., we perform here mostly a safety check and don't perform an actual sorting
   if (!std::is_sorted(iterator->second.begin(), iterator->second.end())) {
@@ -329,17 +328,17 @@ std::map<int, std::vector<int>> buildCommunicationMap(
     if (iterator->second.empty() || other.second.empty() || (other.second.back() < iterator->second.at(0)) || (other.second.at(0) > iterator->second.back())) {
       // in this case there is nothing to be done
       continue;
-    } else {
-      // we have an intersection, let's compute it
-      std::vector<int> inters;
-      // the actual worker function, which gives us the indices of intersecting elements
-      // have a look at the documentation of the function for more details
-      precice::m2n::set_intersection_indices(iterator->second.begin(), iterator->second.begin(), iterator->second.end(),
-                                             other.second.begin(), other.second.end(),
-                                             std::back_inserter(inters));
-      // we have the results, now commit it into the final map
-      if (!inters.empty())
-        communicationMap.insert({other.first, std::move(inters)});
+    }
+    // we have an intersection, let's compute it
+    std::vector<int> inters;
+    // the actual worker function, which gives us the indices of intersecting elements
+    // have a look at the documentation of the function for more details
+    precice::m2n::set_intersection_indices(iterator->second.begin(), iterator->second.begin(), iterator->second.end(),
+                                           other.second.begin(), other.second.end(),
+                                           std::back_inserter(inters));
+    // we have the results, now commit it into the final map
+    if (!inters.empty()) {
+      communicationMap.insert({other.first, std::move(inters)});
     }
   }
   return communicationMap;

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -236,6 +236,23 @@ void printLocalIndexCountStats(std::map<int, std::vector<int>> const &m)
   }
 }
 
+template<class InputIt1, class InputIt2, class OutputIt>
+OutputIt set_intersection(InputIt1 ref, InputIt1 first1, InputIt1 last1,
+                          InputIt2 first2, InputIt2 last2, OutputIt d_first)
+{
+    while (first1 != last1 && first2 != last2)
+    {
+        if (*first1 < *first2)
+            ++first1;
+        else
+        {
+            if (!(*first2 < *first1))
+                *d_first++ = std::distance(ref, first1++); // *first1 and *first2 are equivalent.
+            ++first2;
+        }
+    }
+    return d_first;
+}
 /** builds the communication map for a local distribution given the global distribution.
  *
  *
@@ -254,35 +271,51 @@ void printLocalIndexCountStats(std::map<int, std::vector<int>> const &m)
  */
 std::map<int, std::vector<int>> buildCommunicationMap(
     // `thisVertexDistribution' is input vertex distribution from this participant.
-    mesh::Mesh::VertexDistribution const &thisVertexDistribution,
+    mesh::Mesh::VertexDistribution  &thisVertexDistribution,
     // `otherVertexDistribution' is input vertex distribution from other participant.
-    mesh::Mesh::VertexDistribution const &otherVertexDistribution,
+    mesh::Mesh::VertexDistribution  &otherVertexDistribution,
     int                                   thisRank = utils::IntraComm::getRank())
 {
   auto iterator = thisVertexDistribution.find(thisRank);
   if (iterator == thisVertexDistribution.end())
     return {};
-
-  // Build lookup table from otherIndex -> rank for the otherVertexDistribution
-  const auto lookupIndexRank = [&otherVertexDistribution] {
-    boost::container::flat_multimap<int, int> lookupIndexRank;
-    for (const auto &other : otherVertexDistribution) {
-      for (const auto &otherIndex : other.second) {
-        lookupIndexRank.emplace(otherIndex, other.first);
-      }
-    }
-    return lookupIndexRank;
-  }();
-
-  auto const &indices = iterator->second;
-
+    Event e0("m2n.copyMap");
   std::map<int, std::vector<int>> communicationMap;
-  for (size_t index = 0lu; index < indices.size(); ++index) {
-    auto range = lookupIndexRank.equal_range(indices[index]);
-    for (auto iter = range.first; iter != range.second; ++iter) {
-      communicationMap[iter->second].push_back(index);
+  // creating the map is very expensive O (n log n) for large data sets and the performance becomes
+  // only worse if we add more ranks as data-locality of the source map deteriorates
+  // hence we first look, whether there are any relevant indices in the map and only add entries in case
+  // they are relevant
+  logging::Logger _log{"m2n::buildMap"};
+  // take advantage that these data structures are in most cases sorted by construction
+   if(!std::is_sorted(iterator->second.begin(), iterator->second.end())){
+       PRECICE_CHECK(false, "APPLYING  SORTING ");
+      std::sort(iterator->second.begin(), iterator->second.end());
+   }
+
+  for (auto &other : otherVertexDistribution) {
+    // first a safety check, that we are actually sorted
+    if(!std::is_sorted(other.second.begin(), other.second.end())) {
+       PRECICE_CHECK(false, "APPLYING  SORTING ");
+       std::sort(other.second.begin(), other.second.end());
+    }
+    // now we start inserting elements
+    // first check if elements can possibly be in there
+    if(iterator->second.empty() ||  other.second.empty() || (other.second.back() < iterator->second.at(0)) || (other.second.at(0) > iterator->second.back())){
+      // in this case there is nothing to be done
+      continue;
+    }
+    else {
+    // we have an intersection, let's compute it
+    std::vector<int> inters;
+    precice::m2n::set_intersection(iterator->second.begin(), iterator->second.begin(), iterator->second.end(),
+                         other.second.begin(), other.second.end(),
+			 std::back_inserter(inters));
+    // we have the results, now commit it into the final map
+     if(!inters.empty())
+       	communicationMap.insert({other.first, std::move(inters)});
     }
   }
+
   return communicationMap;
 }
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -220,6 +220,7 @@ public:
 
   void setVertexDistribution(VertexDistribution vd)
   {
+    PRECICE_ASSERT(std::all_of(vd.begin(), vd.end(), [](const auto &p) { return std::is_sorted(p.second.begin(), p.second.end()); }));
     _vertexDistribution = std::move(vd);
   }
 


### PR DESCRIPTION
## Main changes of this PR

Optimizes the function [`buildCommunicationMap`](https://github.com/precice/precice/blob/7bdf93d6e060bad08cbef26946ea0536478251cd/src/m2n/PointToPointCommunication.cpp#L255) significantly.

## Motivation and additional information

While investigating PUM mappings, running larger cases on more cores became infeasible. After digging a bit deeper into the reason, it turned out that creating the 'lookup table' in `buildCommunicationMap` takes 99% of the time. So, I spent some effort to optimize the current way we compute the communication map. I'm not 100% sure that the proposed changes here are actually legal, as it performs a sorting on the vertex indices. However, I _could_ recover less, but still significant speed-up without doing so.

The changes are mostly relevant for a large number of global vertices. Here are some relevant performance measurements for one of the aste standard cases (one time-step, one mapping, serial-explicit schemes) on a 600k vertices input mesh and corresponding speedups on SuperMUC-NG

On 2 x 2 cores (input x output)

|   | `buildCommMap` | global run time |
| ------------- | ------------- | ------------- |
| `develop` | 2,081,519 |16,892,952 (~17secs) |
| `opt-bbmap` | 3,360  | 14,845,686 (~15secs) |
| speed up | 619 | 1.14 |

On 24 x 24 cores (input x output)

|   | `buildCommMap` | global run time |
| ------------- | ------------- | ------------- |
| `develop` |  839,366,952 |858,955,792 (~14min) |
| `opt-bbmap` | 2,358  | 4,554,192 (~4.5secs)|
| speed up | 355,965  | 188 |


On 240 x 240 cores (input x output)

|   | `buildCommMap` | global run time |
| ------------- | ------------- | ------------- |
| `develop` | 4,645,940,719 |4,688,943,494 (~77min)|
| `opt-bbmap` |  2,235 | 10,057,928 (~10 secs) |
| speed up |  2,078,720 | 466 |

Note that the issue is a general preCICE issue. However, using a NN mapping (as opposed to the PUM mapping used here) with a filter on the primary rank reduces the vertex count relevant for the function significantly (mapping fine to coarse), such that the issue would be observable only later. Also note that the global run time is now dominated by other events instead of the BB map creation. The larger the input mesh gets, the more significant the changes here would be (and vice versa).

EDIT: With the first version of this PR, cases with 1.35mio (bbMap in 3,300us) ran on 240 cores in <1min as well.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] I sticked to C++17 features.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
