### PR TITLE
Add sample duplication tests to bspline tests

### DIFF
--- a/src/math/tests/BSplineTest.cpp
+++ b/src/math/tests/BSplineTest.cpp
@@ -3,21 +3,38 @@
 #include "testing/Testing.hpp"
 
 #include <Eigen/Core>
+#include <boost/test/data/test_case.hpp>
 
 using namespace precice::testing;
 
 BOOST_AUTO_TEST_SUITE(MathTests)
 BOOST_AUTO_TEST_SUITE(BSpline)
 
-BOOST_AUTO_TEST_CASE(TwoPointsLinear)
+void duplicateEndSample(Eigen::VectorXd &ts, Eigen::MatrixXd &xs, double epsilon = 1e-13)
+{
+  auto ntimestamps = ts.size();
+  ts.conservativeResize(ntimestamps + 1);
+  ts(ntimestamps) = ts(ntimestamps - 1);
+  ts(ntimestamps - 1) -= epsilon;
+
+  auto ndata = xs.rows();
+  xs.conservativeResize(ndata, ntimestamps + 1);
+  xs.col(ntimestamps) = xs.col(ntimestamps - 1);
+}
+
+BOOST_DATA_TEST_CASE(TwoPointsLinear,
+                     boost::unit_test::data::make({false, true}),
+                     duplicate)
 {
   PRECICE_TEST(1_rank);
-  Eigen::Vector2d ts;
-  ts << 1, 2;
+  Eigen::VectorXd ts = Eigen::Vector2d(1, 2);
   Eigen::MatrixXd xs(3, 2);
   xs << 1, 2, 10, 20, 100, 200;
 
+  if (duplicate)
+    duplicateEndSample(ts, xs);
   precice::math::Bspline bspline(ts, xs, 1);
+
   // Limits
   BOOST_TEST(equals(bspline.interpolateAt(1.0), Eigen::Vector3d(1, 10, 100)));
   BOOST_TEST(equals(bspline.interpolateAt(2.0), Eigen::Vector3d(2, 20, 200)));
@@ -30,14 +47,19 @@ BOOST_AUTO_TEST_CASE(TwoPointsLinear)
   BOOST_TEST(equals(bspline.interpolateAt(1.75), Eigen::Vector3d(1.75, 17.5, 175)));
 }
 
-BOOST_AUTO_TEST_CASE(ThreePointsLinear)
+BOOST_DATA_TEST_CASE(ThreePointsLinear,
+                     boost::unit_test::data::make({false, true}),
+                     duplicate)
 {
   PRECICE_TEST(1_rank);
-  Eigen::Vector3d ts;
-  ts << 0, 1, 2;
+  Eigen::VectorXd ts = Eigen::Vector3d(0, 1, 2);
   Eigen::MatrixXd xs(3, 3);
   xs << 1, 2, 3, 10, 20, 30, 100, 200, 300;
+
+  if (duplicate)
+    duplicateEndSample(ts, xs);
   precice::math::Bspline bspline(ts, xs, 1);
+
   // Points
   BOOST_TEST(equals(bspline.interpolateAt(0.0), Eigen::Vector3d(1, 10, 100)));
   BOOST_TEST(equals(bspline.interpolateAt(1.0), Eigen::Vector3d(2, 20, 200)));
@@ -48,12 +70,16 @@ BOOST_AUTO_TEST_CASE(ThreePointsLinear)
   BOOST_TEST(equals(bspline.interpolateAt(1.5), Eigen::Vector3d(2.5, 25, 250)));
 }
 
-BOOST_AUTO_TEST_CASE(ThreePointsLinearNonEquidistant)
+BOOST_DATA_TEST_CASE(ThreePointsLinearNonEquidistant,
+                     boost::unit_test::data::make({false, true}),
+                     duplicate)
 {
-  Eigen::Vector3d ts;
-  ts << 0, 1, 3;
+  Eigen::VectorXd ts = Eigen::Vector3d(0, 1, 3);
   Eigen::MatrixXd xs(3, 3);
   xs << 1, 2, 3, 10, 20, 30, 100, 200, 300;
+
+  if (duplicate)
+    duplicateEndSample(ts, xs);
   precice::math::Bspline bspline(ts, xs, 1);
   // Points
   BOOST_TEST(equals(bspline.interpolateAt(0.0), Eigen::Vector3d(1, 10, 100)));
@@ -65,13 +91,17 @@ BOOST_AUTO_TEST_CASE(ThreePointsLinearNonEquidistant)
   BOOST_TEST(equals(bspline.interpolateAt(2.0), Eigen::Vector3d(2.5, 25, 250), 1e-13));
 }
 
-BOOST_AUTO_TEST_CASE(ThreePointsQuadratic)
+BOOST_DATA_TEST_CASE(ThreePointsQuadratic,
+                     boost::unit_test::data::make({false, true}),
+                     duplicate)
 {
   PRECICE_TEST(1_rank);
-  Eigen::Vector3d ts;
-  ts << 0, 1, 2;
+  Eigen::VectorXd ts = Eigen::Vector3d(0, 1, 2);
   Eigen::MatrixXd xs(3, 3);
   xs << 1, 2, 3, 10, 20, 30, 100, 200, 300;
+
+  if (duplicate)
+    duplicateEndSample(ts, xs);
   precice::math::Bspline bspline(ts, xs, 2);
   // Points
   BOOST_TEST(equals(bspline.interpolateAt(0.0), Eigen::Vector3d(1, 10, 100), 1e-13));
@@ -83,13 +113,17 @@ BOOST_AUTO_TEST_CASE(ThreePointsQuadratic)
   BOOST_TEST(equals(bspline.interpolateAt(1.5), Eigen::Vector3d(2.5, 25, 250)));
 }
 
-BOOST_AUTO_TEST_CASE(ThreePointsQuadraticNonEquidistant)
+BOOST_DATA_TEST_CASE(ThreePointsQuadraticNonEquidistant,
+                     boost::unit_test::data::make({false, true}),
+                     duplicate)
 {
   PRECICE_TEST(1_rank);
-  Eigen::Vector3d ts;
-  ts << 0, 1, 3;
+  Eigen::VectorXd ts = Eigen::Vector3d(0, 1, 3);
   Eigen::MatrixXd xs(3, 3);
   xs << 1, 2, 3, 10, 20, 30, 100, 200, 300;
+
+  if (duplicate)
+    duplicateEndSample(ts, xs);
   precice::math::Bspline bspline(ts, xs, 2);
   // Points
   BOOST_TEST(equals(bspline.interpolateAt(0.0), Eigen::Vector3d(1, 10, 100), 1e-13));


### PR DESCRIPTION
## Main changes of this PR

This PR adds sample duplication tests to the BSpline tests to help deciding how to proceed in #1788

## Motivation and additional information

See #1788

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
