### PR TITLE
Do not interpolate data for existing timestamps

### DIFF
--- a/docs/changelog/1837.md
+++ b/docs/changelog/1837.md
@@ -1,0 +1,1 @@
+- Changed storage so that it does not interpolate data for existing timestamps

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -163,17 +163,15 @@ Eigen::VectorXd Storage::sample(double time) const
 
   PRECICE_ASSERT(usedDegree >= 1);
 
-  auto [times, values] = getTimesAndValues();
-
   //Return the sample corresponding to time if it exists
-  for (int i = 0; i < times.size(); i++) {
-    if (math::equals(times[i], time)) {
-      return values.col(i);
-    }
+  const int i = findTimeId(time);
+  if (i > -1) {                              // _stampleStorage contains sample at given time
+    return _stampleStorage[i].sample.values; // don't use getTimesAndValues, because this would iterate over the complete _stampleStorage.
   }
 
   //Create a new bspline if _bspline does not already contain a spline
   if (!_bspline.has_value()) {
+    auto [times, values] = getTimesAndValues();
     _bspline.emplace(times, values, usedDegree);
   }
 
@@ -218,6 +216,18 @@ time::Sample Storage::getSampleAtBeginning()
 time::Sample Storage::getSampleAtEnd()
 {
   return _stampleStorage.back().sample;
+}
+
+int Storage::findTimeId(double time) const
+{
+  int i = 0;
+  while (math::smallerEquals(_stampleStorage[i].timestamp, time)) {
+    if (math::equals(_stampleStorage[i].timestamp, time)) {
+      return i;
+    }
+    i++;
+  }
+  return -1; // time not found in times
 }
 
 } // namespace precice::time

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -163,10 +163,7 @@ Eigen::VectorXd Storage::sample(double time) const
 
   PRECICE_ASSERT(usedDegree >= 1);
 
-  auto data = getTimesAndValues();
-
-  auto times  = data.first;
-  auto values = data.second;
+  auto [times, values] = getTimesAndValues();
 
   //Return the sample corresponding to time if it exists
   for (int i = 0; i < times.size(); i++) {

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -164,9 +164,20 @@ Eigen::VectorXd Storage::sample(double time) const
   PRECICE_ASSERT(usedDegree >= 1);
 
   auto data = getTimesAndValues();
+
+  auto times  = data.first;
+  auto values = data.second;
+
+  //Return the sample corresponding to time if it exists
+  for (int i = 0; i < times.size(); i++) {
+    if (math::equals(times[i], time)) {
+      return values.col(i);
+    }
+  }
+
   //Create a new bspline if _bspline does not already contain a spline
   if (!_bspline.has_value()) {
-    _bspline.emplace(data.first, data.second, usedDegree);
+    _bspline.emplace(times, values, usedDegree);
   }
 
   return _bspline.value().interpolateAt(time);

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -148,6 +148,8 @@ private:
   time::Sample getSampleAtBeginning();
 
   time::Sample getSampleAtEnd();
+
+  int findTimeId(double time) const;
 };
 
 } // namespace precice::time


### PR DESCRIPTION
## Main changes of this PR
Changes storage so that it returns the existing values instead of interpolating them. 

## Motivation and additional information
Fixes  #1752

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
