### PR TITLE
Fix roundoff problem if close to window boundary in `math::Bspline`

### DIFF
--- a/src/math/Bspline.cpp
+++ b/src/math/Bspline.cpp
@@ -57,6 +57,12 @@ Bspline::Bspline(Eigen::VectorXd ts, const Eigen::MatrixXd &xs, int splineDegree
 
 Eigen::VectorXd Bspline::interpolateAt(double t) const
 {
+  if (math::equals(t, _tsMax)) {
+    t = _tsMax; // set t exactly to _tsMax, to avoid artifacts originating from floating-point arithmetic
+  } else if (math::equals(t, _tsMin)) {
+    t = _tsMin; // set t exactly to _tsMin, to avoid artifacts originating from floating-point arithmetic
+  }
+
   // transform t to the relative interval [0; 1]
   const double tRelative = (t - _tsMin) / (_tsMax - _tsMin);
   PRECICE_ASSERT(math::greaterEquals(tRelative, 0.0), "t is before the first sample!", tRelative, 0.0, _tsMin); // Only allowed to use BSpline for interpolation, not extrapolation.

--- a/src/math/tests/BSplineTest.cpp
+++ b/src/math/tests/BSplineTest.cpp
@@ -30,6 +30,23 @@ BOOST_AUTO_TEST_CASE(TwoPointsLinear)
   BOOST_TEST(equals(bspline.interpolateAt(1.75), Eigen::Vector3d(1.75, 17.5, 175)));
 }
 
+BOOST_AUTO_TEST_CASE(TwoPointsLinearRoundoff)
+{
+  PRECICE_TEST(1_rank);
+  Eigen::Vector2d ts;
+  ts << 1e-6, 2e-6;
+  Eigen::MatrixXd xs(3, 2);
+  xs << 1, 2, 10, 20, 100, 200;
+
+  BOOST_ASSERT(equals(ts[0], 1e-6 - std::numeric_limits<double>::epsilon()));
+  BOOST_ASSERT(equals(ts[1], 2e-6 + std::numeric_limits<double>::epsilon()));
+
+  precice::math::Bspline bspline(ts, xs, 1);
+  // Limits
+  BOOST_TEST(equals(bspline.interpolateAt(1e-6 - std::numeric_limits<double>::epsilon()), Eigen::Vector3d(1, 10, 100)));
+  BOOST_TEST(equals(bspline.interpolateAt(2e-6 + std::numeric_limits<double>::epsilon()), Eigen::Vector3d(2, 20, 200)));
+}
+
 BOOST_AUTO_TEST_CASE(ThreePointsLinear)
 {
   PRECICE_TEST(1_rank);

--- a/src/math/tests/BSplineTest.cpp
+++ b/src/math/tests/BSplineTest.cpp
@@ -35,16 +35,21 @@ BOOST_AUTO_TEST_CASE(TwoPointsLinearRoundoff)
   PRECICE_TEST(1_rank);
   Eigen::Vector2d ts;
   ts << 1e-6, 2e-6;
+
+  // Evaluate Bspline slightly outside of borders of time window.
+  Eigen::Vector2d teval;
+  teval << 1e-6 - std::numeric_limits<double>::epsilon(), 2e-6 + std::numeric_limits<double>::epsilon();
+  // However, cannot distinguish between ts and teval
+  BOOST_ASSERT(equals(ts[0], teval[0]));
+  BOOST_ASSERT(equals(ts[1], teval[1]));
+
   Eigen::MatrixXd xs(3, 2);
   xs << 1, 2, 10, 20, 100, 200;
 
-  BOOST_ASSERT(equals(ts[0], 1e-6 - std::numeric_limits<double>::epsilon()));
-  BOOST_ASSERT(equals(ts[1], 2e-6 + std::numeric_limits<double>::epsilon()));
-
   precice::math::Bspline bspline(ts, xs, 1);
-  // Limits
-  BOOST_TEST(equals(bspline.interpolateAt(1e-6 - std::numeric_limits<double>::epsilon()), Eigen::Vector3d(1, 10, 100)));
-  BOOST_TEST(equals(bspline.interpolateAt(2e-6 + std::numeric_limits<double>::epsilon()), Eigen::Vector3d(2, 20, 200)));
+  // Make sure that evaluating at borders of window (again: with some floating point error within eps) does not introduce observable errors
+  BOOST_TEST(equals(bspline.interpolateAt(teval[0]), Eigen::Vector3d(1, 10, 100)));
+  BOOST_TEST(equals(bspline.interpolateAt(teval[1]), Eigen::Vector3d(2, 20, 200)));
 }
 
 BOOST_AUTO_TEST_CASE(ThreePointsLinear)

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSmallSteps.cpp
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSmallSteps.cpp
@@ -44,6 +44,7 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSmallSteps)
 
   while (precice.isCouplingOngoing()) {
     double dt = precice.getMaxTimeStepSize();
+    precice.readData(meshName, readDataName, {&vertexID, 1}, 0, {&value, 1});
     precice.readData(meshName, readDataName, {&vertexID, 1}, dt, {&value, 1});
     precice.advance(dt);
   }

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSmallSteps.cpp
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSmallSteps.cpp
@@ -1,0 +1,61 @@
+#include <string>
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Explicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief Test to run a simple serial coupling.
+ *
+ * Performs many, small time steps to test for floating point inaccuracies.
+ */
+BOOST_AUTO_TEST_CASE(DoNothingWithSmallSteps)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  double value = 1; // actual value does not matter, but we need to call readData to test for assertions in the bspline class.
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName     = "MeshOne";
+    readDataName = "DataTwo";
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName     = "MeshTwo";
+    readDataName = "DataOne";
+  }
+
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
+  precice.initialize();
+  double dt = precice.getMaxTimeStepSize();
+
+  while (precice.isCouplingOngoing()) {
+    double dt = precice.getMaxTimeStepSize();
+    precice.readData(meshName, readDataName, {&vertexID, 1}, dt, {&value, 1});
+    precice.advance(dt);
+  }
+
+  BOOST_TEST(not precice.isCouplingOngoing());
+  precice.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Explicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/explicit/serial-coupling/DoNothingWithSmallSteps.xml
+++ b/tests/serial/time/explicit/serial-coupling/DoNothingWithSmallSteps.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time value="1e-3" />
+    <time-window-size value="1e-6" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -181,6 +181,7 @@ target_sources(testprecice
     tests/serial/time/explicit/compositional/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
     tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+    tests/serial/time/explicit/serial-coupling/DoNothingWithSmallSteps.cpp
     tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp


### PR DESCRIPTION
## Main changes of this PR

Compare `t` to `_tsMin` and `_tsMax` within floating-point accuracy. If `t` equals `_tsMin` or `_tsMax`, set `t` to this value. This avoids round-off errors in later steps that can trigger assertions.

## Motivation and additional information

See #1838. Especially important for adaptive time stepping where time window sizes might become small. @NiklasKotarsky 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
