### PR TITLE
Add support for configurable wait in finalize

### DIFF
--- a/docs/changelog/1840.md
+++ b/docs/changelog/1840.md
@@ -1,0 +1,1 @@
+- Added configuration option for participants waiting for each other in finalize: `<precice-configuration wait-in-finalize="1"/>`.

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -38,6 +38,10 @@ Configuration::Configuration()
                               .setDocumentation("Enable experimental features.");
   _tag.addAttribute(attrExperimental);
 
+  auto attrWaitInFinalize = xml::makeXMLAttribute("wait-in-finalize", false)
+                                .setDocumentation("Connected participants wait for each other in finalize, which can be helpful in SLURM sessions.");
+  _tag.addAttribute(attrWaitInFinalize);
+
   _dataConfiguration = std::make_shared<mesh::DataConfiguration>(
       _tag);
   _meshConfiguration = std::make_shared<mesh::MeshConfiguration>(
@@ -61,6 +65,7 @@ void Configuration::xmlTagCallback(const xml::ConfigurationContext &context, xml
   if (tag.getName() == "precice-configuration") {
     _experimental = tag.getBooleanAttributeValue("experimental");
     _participantConfiguration->setExperimental(_experimental);
+    _waitInFinalize = tag.getBooleanAttributeValue("wait-in-finalize");
   } else {
     PRECICE_UNREACHABLE("Received callback from unknown tag '{}'.", tag.getName());
   }

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -56,6 +56,12 @@ public:
     return _experimental;
   }
 
+  /// @brief Returns whether participants wait for each other in finalize
+  bool waitInFinalize() const
+  {
+    return _waitInFinalize;
+  }
+
   const mesh::PtrDataConfiguration getDataConfiguration() const
   {
     return _dataConfiguration;
@@ -107,6 +113,9 @@ private:
 
   /// Allow the use of experimental features
   bool _experimental = false;
+
+  /// Synchronize participants in finalize
+  bool _waitInFinalize;
 
   // @brief Root tag of preCICE configuration.
   xml::XMLTag _tag;

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -314,6 +314,9 @@ private:
   /// Are experimental API calls allowed?
   bool _allowsExperimental = false;
 
+  /// Are participants waiting for each other in finalize?
+  bool _waitInFinalize = false;
+
   /// setMeshAccessRegion may only be called once
   mutable bool _accessRegionDefined = false;
 

--- a/tests/serial/lifecycle/ConstructOnlyWait.cpp
+++ b/tests/serial/lifecycle/ConstructOnlyWait.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+// Test representing the minimal lifecylce, which consists out of construction only.
+// The destructor has to cleanup correctly.
+BOOST_AUTO_TEST_CASE(ConstructOnlyWait)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  precice::Participant interface(context.name, context.config(), context.rank, context.size);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/ConstructOnlyWait.xml
+++ b/tests/serial/lifecycle/ConstructOnlyWait.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration wait-in-finalize="yes">
+  <data:vector name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/lifecycle/FullWait.cpp
+++ b/tests/serial/lifecycle/FullWait.cpp
@@ -1,0 +1,43 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+// Test representing the full explicit lifecycle of a Participant
+BOOST_AUTO_TEST_CASE(FullWait)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  precice::Participant interface(context.name, context.config(), context.rank, context.size);
+
+  if (context.isNamed("SolverOne")) {
+    auto   meshName = "MeshOne";
+    double coords[] = {0.1, 1.2, 2.3};
+    auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+    auto   dataName = "DataOne";
+    double data[]   = {3.4, 4.5, 5.6};
+    interface.writeData(meshName, dataName, {&vertexid, 1}, data);
+  } else {
+    auto   meshName = "MeshTwo";
+    double coords[] = {0.12, 1.21, 2.2};
+    auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+    auto   dataName = "DataTwo";
+    double data[]   = {7.8};
+    interface.writeData(meshName, dataName, {&vertexid, 1}, data);
+  }
+  interface.initialize();
+  BOOST_TEST(interface.isCouplingOngoing());
+  interface.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/FullWait.xml
+++ b/tests/serial/lifecycle/FullWait.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration wait-in-finalize="yes">
+  <data:vector name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -107,7 +107,9 @@ target_sources(testprecice
     tests/serial/initialize-data/helpers.hpp
     tests/serial/lifecycle/ConstructAndExplicitFinalize.cpp
     tests/serial/lifecycle/ConstructOnly.cpp
+    tests/serial/lifecycle/ConstructOnlyWait.cpp
     tests/serial/lifecycle/Full.cpp
+    tests/serial/lifecycle/FullWait.cpp
     tests/serial/lifecycle/ImplicitFinalize.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds support for configurable inter-participant synchronization in finalize.
Main change is that this defaults to `off`.


## Motivation and additional information

Closes #1600

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
