### PR TITLE
Fix PETSc deprecation warning

### DIFF
--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -29,7 +29,7 @@ inline PetscErrorCode PRECICE_VecFilter(Vec v, PetscReal tol)
 #if ((PETSC_MAJOR > 3) || (PETSC_MAJOR == 3 && PETSC_MINOR >= 20))
   return VecFilter(v, tol);
 #else
-  return VecFilter(v, tol);
+  return VecChop(v, tol);
 #endif
 }
 } // namespace


### PR DESCRIPTION
## Main changes of this PR

PETSc VecChop was deprecated and is to be replaced by VecFilter


## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
