### PR TITLE
Fix deadlock in two-level initialization

### DIFF
--- a/docs/changelog/1847.md
+++ b/docs/changelog/1847.md
@@ -1,0 +1,1 @@
+- Fixed deadlock in two-level initialization, which occurs if ranks share vertices, but only one of the ranks actually needs the vertices (or any) to compute the mapping.

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -743,10 +743,8 @@ void ReceivedPartition::createOwnerInformation()
     }
 
     setOwnerInformation(tags);
-    auto filteredVertices = std::count(tags.begin(), tags.end(), 0);
-    if (filteredVertices)
-      PRECICE_WARN("{} of {} vertices of mesh {} have been filtered out since they have no influence on the mapping.",
-                   filteredVertices, _mesh->getGlobalNumberOfVertices(), _mesh->getName());
+    PRECICE_DEBUG("{} of {} vertices of mesh {} have been filtered out on rank {} since they have no influence on the mapping.",
+                  std::count(tags.begin(), tags.end(), 0), tags.size(), _mesh->getName(), utils::IntraComm::getRank());
     // end of two-level initialization section
   } else {
     if (utils::IntraComm::isSecondary()) {

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -607,6 +607,7 @@ void ReceivedPartition::createOwnerInformation()
     // when exchanging the vector sizes as vertices might be shared from the other
     // connected rank(s), although the actual size we request here is zero
     // i.e., we never tell the other ranks that we don't want any vertices
+    // See also test Integration/Parallel/TestBoundingBoxInitializationEmpty
     for (auto &neighborRank : localConnectedBBMap)
       sharedVerticesSendMap[neighborRank.first] = std::vector<VertexID>();
 

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -603,6 +603,13 @@ void ReceivedPartition::createOwnerInformation()
       }
     }
 
+    // First, insert all comm partnerts, otherwise we end up in a deadlock further down
+    // when exchanging the vector sizes as vertices might be shared from the other
+    // connected rank(s), although the actual size we request here is zero
+    // i.e., we never tell the other ranks that we don't want any vertices
+    for (auto &neighborRank : localConnectedBBMap)
+      sharedVerticesSendMap[neighborRank.first] = std::vector<VertexID>();
+
     // #3: check vertices and keep only those that fit into the current rank's bb
     const int numberOfVertices = _mesh->vertices().size();
     PRECICE_DEBUG("Tag vertices, number of vertices {}", numberOfVertices);

--- a/tests/parallel/TestBoundingBoxInitializationEmpty.cpp
+++ b/tests/parallel/TestBoundingBoxInitializationEmpty.cpp
@@ -7,7 +7,8 @@
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
-// Test to ensure that no exchange of shared vertices doesn't lead to a deadlock
+// Test to ensure that the exchange of shared vertices, which are only required
+// by one participant to actually compute the mapping, doesn't lead to a deadlock
 BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationEmpty)
 {
   PRECICE_TEST("Fluid"_on(2_ranks), "Structure"_on(2_ranks));

--- a/tests/parallel/TestBoundingBoxInitializationEmpty.cpp
+++ b/tests/parallel/TestBoundingBoxInitializationEmpty.cpp
@@ -1,0 +1,63 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationEmpty)
+{
+  PRECICE_TEST("Fluid"_on(2_ranks), "Structure"_on(2_ranks));
+
+  std::vector<double> positions;
+  std::vector<double> data;
+  std::vector<double> expectedData;
+
+  if (context.isNamed("Fluid")) {
+    if (context.isPrimary()) {
+      // init
+    } else {
+      // init
+    }
+  } else {
+    BOOST_TEST(context.isNamed("Structure"));
+    if (context.isPrimary()) {
+      // init
+    } else {
+      // init
+    }
+  }
+
+  precice::Participant interface(context.name, context.config(), context.rank, context.size);
+
+  auto meshName = context.name + "Mesh";
+  auto dataName = "Data";
+
+  std::vector<int> vertexIDs(positions.size() / interface.getMeshDimensions(meshName));
+  interface.setMeshVertices(meshName, positions, vertexIDs);
+
+  interface.initialize();
+
+  if (context.isNamed("Fluid")) {
+    interface.writeData(meshName, dataName, vertexIDs, data);
+  }
+
+  interface.advance(1.0);
+
+  if (context.isNamed("Structure")) {
+    double preciceDt = interface.getMaxTimeStepSize();
+    interface.readData(meshName, dataName, vertexIDs, preciceDt, data);
+    // for (size_t d = 0; d < 3; d++) {
+    //   BOOST_TEST(expectedData[i + i1][d] == data[i + i1][d]);
+    // }
+  }
+
+  interface.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/TestBoundingBoxInitializationEmpty.cpp
+++ b/tests/parallel/TestBoundingBoxInitializationEmpty.cpp
@@ -7,6 +7,7 @@
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
+// Test to ensure that no exchange of shared vertices doesn't lead to a deadlock
 BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationEmpty)
 {
   PRECICE_TEST("Fluid"_on(2_ranks), "Structure"_on(2_ranks));
@@ -16,17 +17,59 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationEmpty)
   std::vector<double> expectedData;
 
   if (context.isNamed("Fluid")) {
+    // Fluid 0 rank: create a grid from 0 to 3
     if (context.isPrimary()) {
-      // init
+      for (int x = 0; x < 4; ++x) {
+        for (int y = 0; y < 2; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          data.push_back(x + y * 7);
+        }
+      }
     } else {
-      // init
+      // Fluid 1 rank: create a grid from 10 to 13
+      for (int x = 12; x < 16; ++x) {
+        for (int y = 0; y < 2; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          data.push_back(x + y * 7);
+        }
+      }
     }
   } else {
     BOOST_TEST(context.isNamed("Structure"));
     if (context.isPrimary()) {
-      // init
+      // Structure 0 rank: create a grid from 8 to 12
+      // The BB box will have bounds from 6 to 14 with
+      // safety margins (0.5)
+      // see comment below
+      for (int x = 8; x < 13; ++x) {
+        for (int y = 0; y < 2; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          // all vertices map to the 'last column'
+          // of the primary fluid rank
+          expectedData.push_back(12 + y * 7);
+        }
+      }
+      data.resize(positions.size() / 2);
     } else {
-      // init
+      // Structure 1 rank: create a grid from 14 to 15
+      // The BB box will have bounds from 13.5 to 14.5
+      // with safety margins
+      // -> both bounding boxes on this rank are intersecting
+      // -> this rank considers (14, 0) and (14, 1) as shared
+      // as they are also tagged and used to compute the mapping
+      // however, the primary rank doesn't need any of the shared
+      // vertices to compute the mapping
+      for (int x = 14; x < 15; ++x) {
+        for (int y = 0; y < 2; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          expectedData.push_back(x + y * 7);
+        }
+      }
+      data.resize(positions.size() / 2);
     }
   }
 
@@ -49,9 +92,9 @@ BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationEmpty)
   if (context.isNamed("Structure")) {
     double preciceDt = interface.getMaxTimeStepSize();
     interface.readData(meshName, dataName, vertexIDs, preciceDt, data);
-    // for (size_t d = 0; d < 3; d++) {
-    //   BOOST_TEST(expectedData[i + i1][d] == data[i + i1][d]);
-    // }
+    for (size_t i = 0; i < expectedData.size(); ++i) {
+      BOOST_TEST(expectedData[i] == data[i]);
+    }
   }
 
   interface.finalize();

--- a/tests/parallel/TestBoundingBoxInitializationEmpty.xml
+++ b/tests/parallel/TestBoundingBoxInitializationEmpty.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="FluidMesh" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="StructureMesh" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="Fluid">
+    <provide-mesh name="FluidMesh" />
+    <write-data name="Data" mesh="FluidMesh" />
+  </participant>
+
+  <participant name="Structure">
+    <provide-mesh name="StructureMesh" />
+    <receive-mesh name="FluidMesh" from="Fluid" />
+    <read-data name="Data" mesh="StructureMesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="FluidMesh"
+      to="StructureMesh"
+      constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="Fluid" connector="Structure" use-two-level-initialization="true" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Fluid" second="Structure" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="FluidMesh" from="Fluid" to="Structure" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -12,6 +12,7 @@ target_sources(testprecice
     tests/parallel/NearestProjectionRePartitioning.cpp
     tests/parallel/PrimaryRankSockets.cpp
     tests/parallel/TestBoundingBoxInitialization.cpp
+    tests/parallel/TestBoundingBoxInitializationEmpty.cpp
     tests/parallel/TestBoundingBoxInitializationTwoWay.cpp
     tests/parallel/TestFinalize.cpp
     tests/parallel/UserDefinedMPICommunicator.cpp


### PR DESCRIPTION
## Main changes of this PR
Fixes a deadlock in the two-level initialization, which occurs if ranks share vertices (or vertices are considered 'shared' when creating the owner information), but only one of the ranks actually needs the vertices to compute the mapping. In such a case, the rank which does not need the vertex never tells the partner rank the empty size. By initializing all coupling partner pairs with a zero vector, we can ensure that zero sized vectors are exchanged in any case.

## Motivation and additional information
It's somewhat surprising to me, that this error has never shown up before. However, I added an integration test to reproduce, showcase and safeguard against it for future references. 

I also converted the (somewhat erroneous) warning about filtered vertices into a debug log and changed the referenced number of filtered vertices from global to local. Raising a warning here doesn't make sense in my opinion and users would only be able to see information (by default of course) from the primary rank, which is again misleading.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
