### PR TITLE
Fix PETSc collective load and store for empty partitions

### DIFF
--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -359,29 +359,37 @@ void Vector::fillWithRandoms()
 
 Vector &Vector::copyFrom(precice::span<const double> source)
 {
-  if (source.empty()) {
+  // This is collective, so we can only skip if the global size is 0
+  if (getSize() == 0) {
     return *this;
   }
-  PRECICE_ASSERT(source.size() == getLocalSize());
-  PetscScalar *data;
-  VecGetArray(vector, &data);
+  PRECICE_ASSERT(static_cast<PetscInt>(source.size()) == getLocalSize());
+  PetscScalar *  data;
+  PetscErrorCode ierr = 0;
+  ierr                = VecGetArray(vector, &data);
+  PRECICE_ASSERT(ierr == 0);
   std::copy(source.begin(), source.end(), data);
-  VecRestoreArray(vector, &data);
+  ierr = VecRestoreArray(vector, &data);
+  PRECICE_ASSERT(ierr == 0);
   return *this;
 }
 
 Vector &Vector::copyTo(precice::span<double> destination)
 {
-  if (destination.empty()) {
+  // This is collective, so we can only skip if the global size is 0
+  if (getSize() == 0) {
     return *this;
   }
   auto localSize = getLocalSize();
-  PRECICE_ASSERT(destination.size() == localSize);
-  PetscScalar *data;
-  VecGetArray(vector, &data);
+  PRECICE_ASSERT(static_cast<PetscInt>(destination.size()) == localSize);
+  PetscScalar *  data;
+  PetscErrorCode ierr = 0;
+  ierr                = VecGetArray(vector, &data);
+  PRECICE_ASSERT(ierr == 0);
   auto dataEnd = std::next(data, localSize);
   std::copy(data, dataEnd, destination.begin());
-  VecRestoreArray(vector, &data);
+  ierr = VecRestoreArray(vector, &data);
+  PRECICE_ASSERT(ierr == 0);
   return *this;
 }
 

--- a/tools/linting/run_clang_tidy.sh
+++ b/tools/linting/run_clang_tidy.sh
@@ -31,7 +31,7 @@ echo "SRC-DIR=$SRC"
 # -BUILD_TESTING: we don't want to analyze the test targets
 # -PRECICE_BINDINGS_C: naming conventions are different from the code base
 # -PRECICE_BINDINGS_FORTRAN: naming conventions are different from the code base
-ARGS=("-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "BUILD_TESTING=OFF" "-D" "BUILD_SHARED_LIBS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "-D" "PRECICE_BINDINGS_C=OFF" "-D" "PRECICE_BINDINGS_FORTRAN=OFF" "-D" "PRECICE_MPICommunication=ON" "-D" "PRECICE_PETScMapping=ON" "-D" "PRECICE_PythonActions=ON" "-D" "PRECICE_CONFIGURE_PACKAGE_GENERATION=OFF" "$@")
+ARGS=("-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "BUILD_TESTING=OFF" "-D" "BUILD_SHARED_LIBS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "-D" "PRECICE_BINDINGS_C=OFF" "-D" "PRECICE_BINDINGS_FORTRAN=OFF" "-D" "PRECICE_FEATURE_MPI_COMMUNICATION=ON" "-D" "PRECICE_FEATURE_PETSC_MAPPING=ON" "-D" "PRECICE_FEATURE_PYTHON_ACTIONS=ON" "-D" "PRECICE_CONFIGURE_PACKAGE_GENERATION=OFF" "$@")
 
 
 if ! [ -x "$(command -v run-clang-tidy)" ] || ! [ -x "$(command -v clang++)" ]; then


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a problem with PETSc RBF mappings, only loading and storing initial guesses when the local rank contains entries.
The used PETSc methods are collectives over all ranks though.
The proposed solution only skips the load/store of vectors that are globally empty.

## Motivation and additional information

Closes #1842 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

