### PR TITLE
Speed-up two-level initialization owner decision for shared vertices

### DIFF
--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -722,46 +722,6 @@ void ReceivedPartition::createOwnerInformation()
       }
     }
 
-    // The commented code is an old implementatiton of the few lines above, only significantly slower
-    // for (size_t i = 0; i < sharedVerticesGlobalIDs.size(); i++) {
-    //   bool owned = true;
-
-    //   for (auto &sharingRank : sharedVerticesReceiveMap) {
-    //     std::vector<int> vec = sharingRank.second;
-    //     if (std::find(vec.begin(), vec.end(), sharedVerticesGlobalIDs[i]) != vec.end()) {
-    //       if ((ownedVerticesCount > neighborRanksVertexCount[sharingRank.first]) ||
-    //           (ownedVerticesCount == neighborRanksVertexCount[sharingRank.first] && utils::IntraComm::getRank() > sharingRank.first)) {
-    //         owned = false;
-
-    // // Decide upon owners,
-    // PRECICE_DEBUG("Decide owners, first round by rough load balancing");
-    // // Provide a more descriptive error message if direct access was enabled
-    // PRECICE_CHECK(!(ranksAtInterface == 0 && _allowDirectAccess),
-    //               "After repartitioning of mesh \"{}\" all ranks are empty. "
-    //               "Please check the dimensions of the provided bounding box "
-    //               "(in \"setMeshAccessRegion\") and verify that it covers vertices "
-    //               "in the mesh or check the definition of the provided meshes.",
-    //               _mesh->getName());
-    // PRECICE_ASSERT(ranksAtInterface != 0);
-    // int localGuess = _mesh->getGlobalNumberOfVertices() / ranksAtInterface; // Guess for a decent load balancing
-    // // First round: every secondary rank gets localGuess vertices
-    // for (Rank rank : utils::IntraComm::allRanks()) {
-    //   int counter = 0;
-    //   for (size_t i = 0; i < secondaryOwnerVecs[rank].size(); i++) {
-    //     // Vertex has no owner yet and rank could be owner
-    //     if (globalOwnerVec[secondaryGlobalIDs[rank][i]] == 0 && secondaryTags[rank][i] == 1) {
-    //       secondaryOwnerVecs[rank][i]                 = 1; // Now rank is owner
-    //       globalOwnerVec[secondaryGlobalIDs[rank][i]] = 1; // Vertex now has owner
-    //       counter++;
-    //       if (counter == localGuess)
-
-    //         break;
-    //       }
-    //     }
-    //   }
-    //   tags[sharedVerticesLocalIDs[i]] = static_cast<int>(owned);
-    // }
-
     setOwnerInformation(tags);
     PRECICE_DEBUG("{} of {} vertices of mesh {} have been filtered out on rank {} since they have no influence on the mapping.",
                   std::count(tags.begin(), tags.end(), 0), tags.size(), _mesh->getName(), utils::IntraComm::getRank());

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -21,6 +21,7 @@
 #include "precice/impl/Types.hpp"
 #include "profiling/Event.hpp"
 #include "utils/IntraComm.hpp"
+#include "utils/algorithm.hpp"
 #include "utils/assertion.hpp"
 #include "utils/fmt.hpp"
 
@@ -520,23 +521,6 @@ void ReceivedPartition::prepareBoundingBox()
     _boundingBoxPrepared = true;
   }
 }
-namespace {
-template <class InputIt1, class InputIt2, class OutputIt>
-void set_intersection_indices(InputIt1 ref1, InputIt1 first1, InputIt1 last1,
-                              InputIt2 first2, InputIt2 last2, OutputIt d_first)
-{
-  while (first1 != last1 && first2 != last2) {
-    if (*first1 < *first2) {
-      ++first1;
-    } else {
-      if (!(*first2 < *first1)) {
-        *d_first++ = std::distance(ref1, first1++); // *first1 and *first2 are equivalent.
-      }
-      ++first2;
-    }
-  }
-}
-} // namespace
 
 void ReceivedPartition::createOwnerInformation()
 {
@@ -731,8 +715,8 @@ void ReceivedPartition::createOwnerInformation()
         // The set_intersection_indices gives us the indices in the sharedVerticesGlobalIDs, which we
         // can use in the sharedVerticesLocalIDs to get the actual index in the 'tags' vector.
         std::vector<int> res;
-        set_intersection_indices(sharedVerticesGlobalIDs.begin(), sharedVerticesGlobalIDs.begin(), sharedVerticesGlobalIDs.end(),
-                                 sharingRank.second.begin(), sharingRank.second.end(), std::back_inserter(res));
+        precice::utils::set_intersection_indices(sharedVerticesGlobalIDs.begin(), sharedVerticesGlobalIDs.begin(), sharedVerticesGlobalIDs.end(),
+                                                 sharingRank.second.begin(), sharingRank.second.end(), std::back_inserter(res));
         for (auto r : res)
           tags[sharedVerticesLocalIDs[r]] = static_cast<int>(false);
       }

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -520,6 +520,23 @@ void ReceivedPartition::prepareBoundingBox()
     _boundingBoxPrepared = true;
   }
 }
+namespace {
+template <class InputIt1, class InputIt2, class OutputIt>
+void set_intersection_indices(InputIt1 ref1, InputIt1 first1, InputIt1 last1,
+                              InputIt2 first2, InputIt2 last2, OutputIt d_first)
+{
+  while (first1 != last1 && first2 != last2) {
+    if (*first1 < *first2) {
+      ++first1;
+    } else {
+      if (!(*first2 < *first1)) {
+        *d_first++ = std::distance(ref1, first1++); // *first1 and *first2 are equivalent.
+      }
+      ++first2;
+    }
+  }
+}
+} // namespace
 
 void ReceivedPartition::createOwnerInformation()
 {
@@ -614,7 +631,7 @@ void ReceivedPartition::createOwnerInformation()
     // #3: check vertices and keep only those that fit into the current rank's bb
     const int numberOfVertices = _mesh->vertices().size();
     PRECICE_DEBUG("Tag vertices, number of vertices {}", numberOfVertices);
-    std::vector<int>      tags(numberOfVertices, -1);
+    std::vector<int>      tags(numberOfVertices, 1);
     std::vector<VertexID> globalIDs(numberOfVertices, -1);
     int                   ownedVerticesCount = 0; // number of vertices owned by this rank
     for (int i = 0; i < numberOfVertices; i++) {
@@ -625,18 +642,17 @@ void ReceivedPartition::createOwnerInformation()
           if (neighborRank.second.contains(_mesh->vertices()[i])) {
             vertexIsShared = true;
             sharedVerticesSendMap[neighborRank.first].push_back(globalIDs[i]);
-            sharedVerticesGlobalIDs.push_back(globalIDs[i]);
-            sharedVerticesLocalIDs.push_back(i);
           }
         }
 
         if (not vertexIsShared) {
           tags[i] = 1;
           ownedVerticesCount++;
+        } else {
+          sharedVerticesGlobalIDs.push_back(globalIDs[i]);
+          sharedVerticesLocalIDs.push_back(i);
         }
-      }
-
-      else {
+      } else {
         tags[i] = 0;
       }
     }
@@ -698,50 +714,69 @@ void ReceivedPartition::createOwnerInformation()
     }
 
     // #5: Second round assignment according to the number of owned vertices
+    // In case that a vertex can be shared between two ranks, the rank with lower
+    // vertex count will own the vertex.
+    // If both ranks have same vertex count, the lower rank will own the vertex.
 
-    /* In case that a vertex can be shared between two ranks, the rank with lower
-       vertex count will own the vertex.
-       If both ranks have same vertex count, the lower rank will own the vertex.
-    */
-
-    for (size_t i = 0; i < sharedVerticesGlobalIDs.size(); i++) {
-      bool owned = true;
-
-      for (auto &sharingRank : sharedVerticesReceiveMap) {
-        std::vector<int> vec = sharingRank.second;
-        if (std::find(vec.begin(), vec.end(), sharedVerticesGlobalIDs[i]) != vec.end()) {
-          if ((ownedVerticesCount > neighborRanksVertexCount[sharingRank.first]) ||
-              (ownedVerticesCount == neighborRanksVertexCount[sharingRank.first] && utils::IntraComm::getRank() > sharingRank.first)) {
-            owned = false;
-
-            // // Decide upon owners,
-            // PRECICE_DEBUG("Decide owners, first round by rough load balancing");
-            // // Provide a more descriptive error message if direct access was enabled
-            // PRECICE_CHECK(!(ranksAtInterface == 0 && _allowDirectAccess),
-            //               "After repartitioning of mesh \"{}\" all ranks are empty. "
-            //               "Please check the dimensions of the provided bounding box "
-            //               "(in \"setMeshAccessRegion\") and verify that it covers vertices "
-            //               "in the mesh or check the definition of the provided meshes.",
-            //               _mesh->getName());
-            // PRECICE_ASSERT(ranksAtInterface != 0);
-            // int localGuess = _mesh->getGlobalNumberOfVertices() / ranksAtInterface; // Guess for a decent load balancing
-            // // First round: every secondary rank gets localGuess vertices
-            // for (Rank rank : utils::IntraComm::allRanks()) {
-            //   int counter = 0;
-            //   for (size_t i = 0; i < secondaryOwnerVecs[rank].size(); i++) {
-            //     // Vertex has no owner yet and rank could be owner
-            //     if (globalOwnerVec[secondaryGlobalIDs[rank][i]] == 0 && secondaryTags[rank][i] == 1) {
-            //       secondaryOwnerVecs[rank][i]                 = 1; // Now rank is owner
-            //       globalOwnerVec[secondaryGlobalIDs[rank][i]] = 1; // Vertex now has owner
-            //       counter++;
-            //       if (counter == localGuess)
-
-            break;
-          }
-        }
+    // To do so, we look at all vertices shared with all neighbors
+    for (auto &sharingRank : sharedVerticesReceiveMap) {
+      // First, check if we would change the ownership at all (by default initialization
+      // above, we would be considered as owner of the shared vertices)
+      // If this is fulfilled, we need to set the ownership to false
+      if ((ownedVerticesCount > neighborRanksVertexCount[sharingRank.first]) ||
+          (ownedVerticesCount == neighborRanksVertexCount[sharingRank.first] && utils::IntraComm::getRank() > sharingRank.first)) {
+        // In such a case, we need to find out the tags we need to switch to 'false', as we don't want
+        // to own them any longer. We compute the intersection of all globalIDs this rank shares with
+        // others and the globalIDs of the neighbor rank we are just considering.
+        // The set_intersection_indices gives us the indices in the sharedVerticesGlobalIDs, which we
+        // can use in the sharedVerticesLocalIDs to get the actual index in the 'tags' vector.
+        std::vector<int> res;
+        set_intersection_indices(sharedVerticesGlobalIDs.begin(), sharedVerticesGlobalIDs.begin(), sharedVerticesGlobalIDs.end(),
+                                 sharingRank.second.begin(), sharingRank.second.end(), std::back_inserter(res));
+        for (auto r : res)
+          tags[sharedVerticesLocalIDs[r]] = static_cast<int>(false);
       }
-      tags[sharedVerticesLocalIDs[i]] = owned ? 1 : 0;
     }
+
+    // The commented code is an old implementatiton of the few lines above, only significantly slower
+    // for (size_t i = 0; i < sharedVerticesGlobalIDs.size(); i++) {
+    //   bool owned = true;
+
+    //   for (auto &sharingRank : sharedVerticesReceiveMap) {
+    //     std::vector<int> vec = sharingRank.second;
+    //     if (std::find(vec.begin(), vec.end(), sharedVerticesGlobalIDs[i]) != vec.end()) {
+    //       if ((ownedVerticesCount > neighborRanksVertexCount[sharingRank.first]) ||
+    //           (ownedVerticesCount == neighborRanksVertexCount[sharingRank.first] && utils::IntraComm::getRank() > sharingRank.first)) {
+    //         owned = false;
+
+    // // Decide upon owners,
+    // PRECICE_DEBUG("Decide owners, first round by rough load balancing");
+    // // Provide a more descriptive error message if direct access was enabled
+    // PRECICE_CHECK(!(ranksAtInterface == 0 && _allowDirectAccess),
+    //               "After repartitioning of mesh \"{}\" all ranks are empty. "
+    //               "Please check the dimensions of the provided bounding box "
+    //               "(in \"setMeshAccessRegion\") and verify that it covers vertices "
+    //               "in the mesh or check the definition of the provided meshes.",
+    //               _mesh->getName());
+    // PRECICE_ASSERT(ranksAtInterface != 0);
+    // int localGuess = _mesh->getGlobalNumberOfVertices() / ranksAtInterface; // Guess for a decent load balancing
+    // // First round: every secondary rank gets localGuess vertices
+    // for (Rank rank : utils::IntraComm::allRanks()) {
+    //   int counter = 0;
+    //   for (size_t i = 0; i < secondaryOwnerVecs[rank].size(); i++) {
+    //     // Vertex has no owner yet and rank could be owner
+    //     if (globalOwnerVec[secondaryGlobalIDs[rank][i]] == 0 && secondaryTags[rank][i] == 1) {
+    //       secondaryOwnerVecs[rank][i]                 = 1; // Now rank is owner
+    //       globalOwnerVec[secondaryGlobalIDs[rank][i]] = 1; // Vertex now has owner
+    //       counter++;
+    //       if (counter == localGuess)
+
+    //         break;
+    //       }
+    //     }
+    //   }
+    //   tags[sharedVerticesLocalIDs[i]] = static_cast<int>(owned);
+    // }
 
     setOwnerInformation(tags);
     PRECICE_DEBUG("{} of {} vertices of mesh {} have been filtered out on rank {} since they have no influence on the mapping.",

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -12,6 +12,40 @@
 namespace precice {
 namespace utils {
 
+/**
+   * @brief This function is by and large the same as std::set_intersection().
+   * The only difference is that we don't return the intersection set itself, but
+   * we return the indices of elements in \p InputIt1, which appear in both sets
+   * ( \p InputIt1 and \p InputIt2 )
+   * The implementation was taken from
+   * https://en.cppreference.com/w/cpp/algorithm/set_intersection#Version_1 with the
+   * only difference that we compute and store std::distance() (i.e. the indices)
+   * in the output iterator. Similar to the std function, this function operates
+   * on sorted ranges.
+   *
+   * @param ref1 The reference iterator, to which we compute the distance/indices.
+   * @param first1 The begin of the first range we want to compute the intersection with
+   * @param last1 The end of the first range we want to compute the intersection with
+   * @param first1 The begin of the second range we want to compute the intersection with
+   * @param last1 The end of the second range we want to compute the intersection with
+   * @param d_first Beginning of the output range
+   */
+template <class InputIt1, class InputIt2, class OutputIt>
+void set_intersection_indices(InputIt1 ref1, InputIt1 first1, InputIt1 last1,
+                              InputIt2 first2, InputIt2 last2, OutputIt d_first)
+{
+  while (first1 != last1 && first2 != last2) {
+    if (*first1 < *first2) {
+      ++first1;
+    } else {
+      if (!(*first2 < *first1)) {
+        *d_first++ = std::distance(ref1, first1++); // *first1 and *first2 are equivalent.
+      }
+      ++first2;
+    }
+  }
+}
+
 /// Function that generates an array from given elements.
 template <typename... Elements>
 auto make_array(Elements &&... elements) -> std::array<typename std::common_type<Elements...>::type, sizeof...(Elements)>

--- a/tests/parallel/TestBoundingBoxInitializationPUM.cpp
+++ b/tests/parallel/TestBoundingBoxInitializationPUM.cpp
@@ -1,0 +1,93 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+// Integration test for 2LI with PUM mapping
+BOOST_AUTO_TEST_CASE(TestBoundingBoxInitializationPUM)
+{
+  PRECICE_TEST("Fluid"_on(2_ranks), "Structure"_on(2_ranks));
+
+  std::vector<double> positions;
+  std::vector<double> data;
+  std::vector<double> expectedData;
+
+  if (context.isNamed("Fluid")) {
+    // Fluid 0 rank: create a grid from 0 to 20
+    if (context.isPrimary()) {
+      for (int x = 0; x < 20; ++x) {
+        for (int y = 0; y < 20; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          data.push_back(x + y * 7);
+        }
+      }
+    } else {
+      // Fluid 1 rank: create a grid from 21 to 41
+      for (int x = 21; x < 41; ++x) {
+        for (int y = 0; y < 20; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          data.push_back(x + y * 7);
+        }
+      }
+    }
+  } else {
+    BOOST_TEST(context.isNamed("Structure"));
+    if (context.isPrimary()) {
+      for (int x = 0; x < 20; ++x) {
+        for (int y = 0.5; y < 20.5; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          // method should be exact when using the polynomial
+          expectedData.push_back(x + y * 7);
+        }
+      }
+      data.resize(positions.size() / 2);
+    } else {
+      for (int x = 21; x < 41; ++x) {
+        for (int y = 0.5; y < 20.5; ++y) {
+          positions.push_back(x);
+          positions.push_back(y);
+          expectedData.push_back(x + y * 7);
+        }
+      }
+      data.resize(positions.size() / 2);
+    }
+  }
+
+  precice::Participant interface(context.name, context.config(), context.rank, context.size);
+
+  auto meshName = context.name + "Mesh";
+  auto dataName = "Data";
+
+  std::vector<int> vertexIDs(positions.size() / interface.getMeshDimensions(meshName));
+  interface.setMeshVertices(meshName, positions, vertexIDs);
+
+  interface.initialize();
+
+  if (context.isNamed("Fluid")) {
+    interface.writeData(meshName, dataName, vertexIDs, data);
+  }
+
+  interface.advance(1.0);
+
+  if (context.isNamed("Structure")) {
+    double preciceDt = interface.getMaxTimeStepSize();
+    interface.readData(meshName, dataName, vertexIDs, preciceDt, data);
+    for (size_t i = 0; i < expectedData.size(); ++i) {
+      BOOST_TEST(expectedData[i] == data[i]);
+    }
+  }
+
+  interface.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/TestBoundingBoxInitializationPUM.xml
+++ b/tests/parallel/TestBoundingBoxInitializationPUM.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="FluidMesh" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="StructureMesh" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="Fluid">
+    <provide-mesh name="FluidMesh" />
+    <write-data name="Data" mesh="FluidMesh" />
+  </participant>
+
+  <participant name="Structure">
+    <provide-mesh name="StructureMesh" />
+    <receive-mesh name="FluidMesh" from="Fluid" />
+    <read-data name="Data" mesh="StructureMesh" />
+    <mapping:rbf-pum-direct
+      direction="read"
+      from="FluidMesh"
+      to="StructureMesh"
+      constraint="consistent"
+      vertices-per-cluster="40"
+      relative-overlap="0.2"
+      project-to-input="false"
+      polynomial="separate">
+      <basis-function:compact-polynomial-c0 support-radius="1" />
+    </mapping:rbf-pum-direct>
+  </participant>
+
+  <m2n:sockets acceptor="Fluid" connector="Structure" use-two-level-initialization="true" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Fluid" second="Structure" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="FluidMesh" from="Fluid" to="Structure" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -13,6 +13,7 @@ target_sources(testprecice
     tests/parallel/PrimaryRankSockets.cpp
     tests/parallel/TestBoundingBoxInitialization.cpp
     tests/parallel/TestBoundingBoxInitializationEmpty.cpp
+    tests/parallel/TestBoundingBoxInitializationPUM.cpp
     tests/parallel/TestBoundingBoxInitializationTwoWay.cpp
     tests/parallel/TestFinalize.cpp
     tests/parallel/UserDefinedMPICommunicator.cpp


### PR DESCRIPTION
## Main changes of this PR
More of a performance bug. Speeds-up the computation of the owner rank for two-level initialization for shared vertices between ranks.

## Motivation and additional information

The `48x48` PUM mapping run on ca 8mio vertices took the two-level initialization more than 3 hours due to the implementation touched here. With the performance fixes here, we can run the same in $\mathcal{O}(10\text{ms})$. I don't want to investigate the exact speed-up for more cases, but the speed-up is significant.

The changes I made in #1830 are nice and run fast, but for larger cases, I was not able to bypass the memory bottlenecks, i.e., typically ran out of RAM on the primary rank.

Open points here:

- I used the nice set intersection function again. In principle, I like to keep it in an anonymous namespace, but duplicating it seems like a bad idea. Any idea where to put it (it is now used in different packages. maybe a new utils file @fsimonis  ?)
- what to do with the commented code? It was already there before

I am a bit afraid of the test coverage in the whole two-level initialization, but I ran a PETSc case, which succeeded. I would assume that the ownership is for PETSc important and errors in the ownership would lead to errors in the PETSc mapping.

For now, I only ran the (2LI) cases on a moderate number of cores and I really hope that the somewhat mediocre looking computation of the bounding box intersection in the beginning of the two-level initialization doesn't pose an issue for larger core counts. 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
