### PR TITLE
Allow tests to run in parallel

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -190,8 +190,7 @@ function(add_precice_test_run_solverdummies PAT_LANG_A PAT_LANG_B)
     PROPERTIES
     RUN_SERIAL TRUE # Do not run this test in parallel with others
     WORKING_DIRECTORY "${PAT_RUN_DIR}"
-    FIXTURES_REQUIRED "${PAT_LANG_A}-solverdummy"
-    FIXTURES_REQUIRED "${PAT_LANG_B}-solverdummy"
+    FIXTURES_REQUIRED "${PAT_LANG_A}-solverdummy;${PAT_LANG_B}-solverdummy"
     LABELS "Solverdummy"
     TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
     )

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -3,6 +3,7 @@
 #
 
 set(PRECICE_TEST_TIMEOUT_LONG 180 CACHE STRING "The timeout in seconds for longer tests.")
+set(PRECICE_TEST_TIMEOUT_NORMAL 40 CACHE STRING "The timeout in seconds for normal tests.")
 set(PRECICE_TEST_TIMEOUT_SHORT 20 CACHE STRING "The timeout in seconds for shorter tests.")
 
 set(PRECICE_TEST_DIR "${preCICE_BINARY_DIR}/TestOutput")
@@ -228,7 +229,7 @@ add_precice_test(
 add_precice_test(
   NAME cplscheme
   ARGUMENTS "--run_test=CplSchemeTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_NORMAL}
   )
 add_precice_test(
   NAME io
@@ -250,12 +251,12 @@ add_precice_test(
 add_precice_test(
   NAME mapping
   ARGUMENTS "--run_test=MappingTests:\!MappingTests/PetRadialBasisFunctionMapping:\!MappingTests/GinkgoRadialBasisFunctionSolver"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_NORMAL}
   )
 add_precice_test(
   NAME mapping.petrbf
   ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_NORMAL}
   LABELS petsc
   PETSC
   )

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -62,7 +62,6 @@ function(add_precice_test)
   # Setting properties
   set_tests_properties(${PAT_FULL_NAME}
     PROPERTIES
-    RUN_SERIAL TRUE # Do not run this test in parallel with others
     WORKING_DIRECTORY "${PAT_WDIR}"
     ENVIRONMENT "OMPI_MCA_rmaps_base_oversubscribe=1;OMP_NUM_THREADS=2"
     )
@@ -115,7 +114,6 @@ function(add_precice_test_build_solverdummy PAT_LANG)
   # Setting properties
   set_tests_properties(${PAT_FULL_NAME}
     PROPERTIES
-    RUN_SERIAL TRUE # Do not run this test in parallel with others
     WORKING_DIRECTORY "${PAT_BIN_DIR}"
     FIXTURES_SETUP "${PAT_LANG}-solverdummy"
     LABELS "Solverdummy"
@@ -189,7 +187,6 @@ function(add_precice_test_run_solverdummies PAT_LANG_A PAT_LANG_B)
   # Setting properties
   set_tests_properties(${PAT_FULL_NAME}
     PROPERTIES
-    RUN_SERIAL TRUE # Do not run this test in parallel with others
     WORKING_DIRECTORY "${PAT_RUN_DIR}"
     FIXTURES_REQUIRED "${PAT_LANG_A}-solverdummy;${PAT_LANG_B}-solverdummy"
     LABELS "Solverdummy"

--- a/cmake/runsolverdummies.cmake
+++ b/cmake/runsolverdummies.cmake
@@ -7,7 +7,7 @@ if(NOT EXISTS ${DUMMY_A})
 endif()
 
 if(NOT EXISTS ${DUMMY_B})
-  message(FATAL_ERROR "CMake was unable to locate solverdummy A at ${DUMMY_B}!")
+  message(FATAL_ERROR "CMake was unable to locate solverdummy B at ${DUMMY_B}!")
 endif()
 
 if(NOT EXISTS ${DUMMY_RUN_DIR})


### PR DESCRIPTION
## Main changes of this PR

This experimental PR allows tests to run in parallel and fixes some problems with solverdummy test dependencies. 

~~Furthermore, the workflow now runs tests in parallel.~~

For linux runners, the two VCores cannot deal with the high load of some tests.
For macOS runners, I wasn't able to get them to run reliably.

This PR makes running tests locally a way better experience though. For this purpose, I defined the `alias ctestn='ctest -j12'` in my bashrc.

## Motivation and additional information

~~Reduce the time taken by CI in exchange for less readable test output.
This will however fully utilise the available compute.
Test output may be interleaved, but is prefixed by the test Nr. So a grep or sort will help.~~

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
