### PR TITLE
Use UNREACHABLE instead of relying on UB

### DIFF
--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -123,8 +123,7 @@ double XMLTag::getDoubleAttributeValue(const std::string &name, std::optional<do
   if (default_value) {
     return default_value.value();
   }
-  PRECICE_ASSERT(default_value, "The XMLAttribute doesn't exist, check its default.");
-  return default_value.value();
+  PRECICE_UNREACHABLE("The XMLAttribute doesn't exist, check its default.");
 }
 
 int XMLTag::getIntAttributeValue(const std::string &name, std::optional<int> default_value) const
@@ -137,8 +136,7 @@ int XMLTag::getIntAttributeValue(const std::string &name, std::optional<int> def
   if (default_value) {
     return default_value.value();
   }
-  PRECICE_ASSERT(default_value, "The XMLAttribute doesn't exist, check its default.");
-  return default_value.value();
+  PRECICE_UNREACHABLE("The XMLAttribute doesn't exist, check its default.");
 }
 
 std::string XMLTag::getStringAttributeValue(const std::string &name, std::optional<std::string> default_value) const
@@ -151,8 +149,7 @@ std::string XMLTag::getStringAttributeValue(const std::string &name, std::option
   if (default_value) {
     return default_value.value();
   }
-  PRECICE_ASSERT(default_value, "The XMLAttribute doesn't exist, check its default.");
-  return default_value.value();
+  PRECICE_UNREACHABLE("The XMLAttribute doesn't exist, check its default.");
 }
 
 bool XMLTag::getBooleanAttributeValue(const std::string &name, std::optional<bool> default_value) const
@@ -165,8 +162,7 @@ bool XMLTag::getBooleanAttributeValue(const std::string &name, std::optional<boo
   if (default_value) {
     return default_value.value();
   }
-  PRECICE_ASSERT(default_value, "The XMLAttribute doesn't exist, check its default.");
-  return default_value.value();
+  PRECICE_UNREACHABLE("The XMLAttribute doesn't exist, check its default.");
 }
 
 Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name, int dimensions) const


### PR DESCRIPTION
## Main changes of this PR

This PR fixes potential UB in the XMLTag, which is picked up by the intel compiler in #1826 


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
