### PR TITLE
Add compiler detection for IntelLLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,23 @@ if(PRECICE_FEATURE_LIBBACKTRACE_STACKTRACES)
   target_link_libraries(preciceCore PRIVATE internal::libbacktrace)
 endif()
 
+# Force Intel to honor nan and infinite in every floating point mode
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+  # Compiler ID is supported after CMake 3.20
+  target_compile_options(preciceCore PUBLIC $<$<CXX_COMPILER_ID:IntelLLVM>:-fhonor-infinities -fhonor-nans>)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # Compiler ID is supported after CMake 3.20 and IntelLLVM shows up as LLVM
+  # We need to inspect the version
+  execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} --version
+      OUTPUT_VARIABLE PRECICE_CXX_COMPILER_VERSION
+  )
+  mark_as_advanced(PRECICE_CXX_COMPILER_VERSION)
+  if(PRECICE_CXX_COMPILER_VERSION MATCHES "Intel.+oneAPI DPC")
+    target_compile_options(preciceCore PUBLIC -fhonor-infinities -fhonor-nans)
+  endif()
+endif()
+
 # Setup Eigen3
 target_link_libraries(preciceCore PUBLIC Eigen3::Eigen)
 target_compile_definitions(preciceCore PUBLIC "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZE_MATRICES_BY_NAN>")


### PR DESCRIPTION
## Main changes of this PR

This PR adds compiler detection for the new LLVM-based Intel compilers and tells it to honor nan and inf independent of floating point mode.

## Motivation and additional information

Part of getting #1826 to work

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
