### PR TITLE
Improve compile times of Testing.hpp and fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,6 @@ precice_validate_libxml2()
 
 # libfmt
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/fmt)
-precice_validate_fmtlib()
 
 #
 # Find Configurable Dependencies
@@ -414,7 +413,7 @@ target_compile_definitions(preciceCore PUBLIC "$<$<CONFIG:DEBUG>:EIGEN_INITIALIZ
 target_link_libraries(preciceCore PUBLIC LibXml2::LibXml2)
 
 # Setup FMT
-target_link_libraries(preciceCore PUBLIC fmt-header-only)
+target_link_libraries(preciceCore PUBLIC fmtlib-static)
 
 # Setup MPI
 if (PRECICE_FEATURE_MPI_COMMUNICATION)

--- a/cmake/Validation.cmake
+++ b/cmake/Validation.cmake
@@ -94,12 +94,3 @@ macro(precice_validate_eigen)
     NAME Eigen
     LINK_LIBRARIES Eigen3::Eigen)
 endmacro()
-
-
-# Validation for fmtlib
-macro(precice_validate_fmtlib)
-  precice_validate_lib(
-    "#include <fmt/format.h>\nint main() { return 0; } "
-    NAME fmtlib
-    LINK_LIBRARIES fmt-header-only)
-endmacro()

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -114,14 +114,14 @@ BOOST_AUTO_TEST_CASE(ParVectorOperations)
   utils::IntraComm::reduceSum(iaa, ires1);
 
   BOOST_TEST(testing::equals(res1, 10.));
-  BOOST_TEST(testing::equals(ires2, 10));
+  BOOST_TEST(ires2 == 10);
   BOOST_TEST(testing::equals(res2.at(0), 10.));
   BOOST_TEST(testing::equals(res2.at(1), 10.));
 
   if (utils::IntraComm::isPrimary()) {
     BOOST_TEST(testing::equals(res3.at(0), 10.));
     BOOST_TEST(testing::equals(res3.at(1), 10.));
-    BOOST_TEST(testing::equals(ires1, 10));
+    BOOST_TEST(ires1 == 10);
   }
   // ---------------------------------------------------------
 

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -104,10 +104,10 @@ void runCoupling(
         computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
+        BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
-        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
+        BOOST_TEST(iterationCount == *iterValidIterations);
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
           cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
@@ -140,7 +140,7 @@ void runCoupling(
     }
     cplScheme.finalize(); // Ends the coupling scheme
     BOOST_TEST(testing::equals(computedTime, 0.3));
-    BOOST_TEST(testing::equals(computedTimesteps, 3));
+    BOOST_TEST(computedTimesteps == 3);
   } else if (nameParticipant == nameParticipant1) {
     mesh->data(1)->setSampleAtTime(0, time::Sample{1, mesh->data(1)->values()});
     cplScheme.initialize(0.0, 1);
@@ -176,10 +176,10 @@ void runCoupling(
         computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
+        BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
         // The iterations are enforced by the controlled decrease of the
         // change of data written
-        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
+        BOOST_TEST(iterationCount == *iterValidIterations);
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
           cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
@@ -215,7 +215,7 @@ void runCoupling(
     }
     cplScheme.finalize(); // Ends the coupling scheme
     BOOST_TEST(testing::equals(computedTime, 0.3));
-    BOOST_TEST(testing::equals(computedTimesteps, 3));
+    BOOST_TEST(computedTimesteps == 3);
   }
 }
 
@@ -282,10 +282,10 @@ void runCouplingWithSubcycling(
         computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
+        BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
-        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
+        BOOST_TEST(iterationCount == *iterValidIterations);
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
           cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
@@ -302,7 +302,7 @@ void runCouplingWithSubcycling(
         // Reset data values, to simulate same convergence behavior of
         // interface values in next time step.
         stepsizeData0 = initialStepsizeData0;
-        BOOST_TEST(testing::equals(subcyclingStep, 1));
+        BOOST_TEST(subcyclingStep == 1);
         subcyclingStep = 0;
       } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
@@ -329,7 +329,7 @@ void runCouplingWithSubcycling(
     }
     cplScheme.finalize(); // Ends the coupling scheme
     BOOST_TEST(testing::equals(computedTime, 0.3));
-    BOOST_TEST(testing::equals(computedTimesteps, 3));
+    BOOST_TEST(computedTimesteps == 3);
     BOOST_TEST(stepsizeData0 == 5.0);
   }
 
@@ -376,10 +376,10 @@ void runCouplingWithSubcycling(
         computedTime += maxTimeStepSize;
         computedTimesteps++;
         BOOST_TEST(testing::equals(computedTime, cplScheme.getTime()));
-        BOOST_TEST(testing::equals(computedTimesteps, cplScheme.getTimeWindows() - 1));
+        BOOST_TEST(computedTimesteps == cplScheme.getTimeWindows() - 1);
         // The iteration number is enforced by the controlled decrease of the
         // change of data written
-        BOOST_TEST(testing::equals(iterationCount, *iterValidIterations));
+        BOOST_TEST(iterationCount == *iterValidIterations);
         if (cplScheme.isCouplingOngoing()) {
           BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
           cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
@@ -396,7 +396,7 @@ void runCouplingWithSubcycling(
         // Reset data values, to simulate same convergence behavior of
         // interface values in next time step.
         stepsizeData1 = initialStepsizeData1;
-        BOOST_TEST(testing::equals(subcyclingStep, 2));
+        BOOST_TEST(subcyclingStep == 2);
         subcyclingStep = 0;
       } else { // coupling timestep is not yet complete
         BOOST_TEST(cplScheme.isCouplingOngoing());
@@ -423,7 +423,7 @@ void runCouplingWithSubcycling(
     }
     cplScheme.finalize(); // Ends the coupling scheme
     BOOST_TEST(testing::equals(computedTime, 0.3));
-    BOOST_TEST(testing::equals(computedTimesteps, 3));
+    BOOST_TEST(computedTimesteps == 3);
   }
 }
 

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -61,11 +61,11 @@ boost::log::record precice_feature<BaseT>::open_record_unlocked(ArgsT const &arg
     PRECICE_ASSERT(res.second);
   }
   {
-    [[maybe_unused]] auto res = BaseT::add_attribute_unlocked("File", constant<std::string>(file_value));
+    [[maybe_unused]] auto res = BaseT::add_attribute_unlocked("File", constant<std::string>(std::move(file_value)));
     PRECICE_ASSERT(res.second);
   }
   {
-    [[maybe_unused]] auto res = BaseT::add_attribute_unlocked("Function", constant<std::string>(func_value));
+    [[maybe_unused]] auto res = BaseT::add_attribute_unlocked("Function", constant<std::string>(std::move(func_value)));
     PRECICE_ASSERT(res.second);
   }
 
@@ -103,11 +103,11 @@ public:
   /** Creates a Boost logger for the said module.
    * @param[in] module the name of the module.
    */
-  explicit LoggerImpl(const std::string &module);
+  explicit LoggerImpl(std::string_view module);
 };
 
 /// Registers attributes that don't depend on the \ref LogLocation
-Logger::LoggerImpl::LoggerImpl(const std::string &module)
+Logger::LoggerImpl::LoggerImpl(std::string_view module)
 {
   namespace attrs = boost::log::attributes;
 
@@ -117,7 +117,7 @@ Logger::LoggerImpl::LoggerImpl(const std::string &module)
   add_attribute("Rank", attrs::make_function<int>([] { return getGlobalLoggingConfig().rank; }));
 
   // Constant attributes
-  add_attribute("Module", attrs::constant<std::string>(module));
+  add_attribute("Module", attrs::constant<std::string>(std::string{module}));
 
   // Ensure, boost-provided attributes are present
   add_attribute("TimeStamp", attrs::local_clock());
@@ -125,8 +125,8 @@ Logger::LoggerImpl::LoggerImpl(const std::string &module)
   add_attribute("Scope", attrs::named_scope());
 }
 
-Logger::Logger(std::string module)
-    : _impl(new LoggerImpl{std::move(module)}) {}
+Logger::Logger(std::string_view module)
+    : _impl(new LoggerImpl{module}) {}
 
 /// This is required for the std::unique_ptr.
 Logger::~Logger() = default;
@@ -154,7 +154,7 @@ void Logger::swap(Logger &other) noexcept
 #define PRECICE_LOG_IMPL(lg, sev, loc) \
   BOOST_LOG_STREAM_WITH_PARAMS((lg), (boost::log::keywords::severity = (sev))(keywords::line = (loc.line))(keywords::file = (loc.file))(keywords::func = (loc.func)))
 
-void Logger::error(LogLocation loc, const std::string &mess) noexcept
+void Logger::error(LogLocation loc, std::string_view mess) noexcept
 {
   try {
     PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::error, loc) << mess;
@@ -162,7 +162,7 @@ void Logger::error(LogLocation loc, const std::string &mess) noexcept
   }
 }
 
-void Logger::warning(LogLocation loc, const std::string &mess) noexcept
+void Logger::warning(LogLocation loc, std::string_view mess) noexcept
 {
   try {
     PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::warning, loc) << mess;
@@ -170,7 +170,7 @@ void Logger::warning(LogLocation loc, const std::string &mess) noexcept
   }
 }
 
-void Logger::info(LogLocation loc, const std::string &mess) noexcept
+void Logger::info(LogLocation loc, std::string_view mess) noexcept
 {
   try {
     PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::info, loc) << mess;
@@ -178,7 +178,7 @@ void Logger::info(LogLocation loc, const std::string &mess) noexcept
   }
 }
 
-void Logger::debug(LogLocation loc, const std::string &mess) noexcept
+void Logger::debug(LogLocation loc, std::string_view mess) noexcept
 {
   try {
     PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::debug, loc) << mess;
@@ -186,7 +186,7 @@ void Logger::debug(LogLocation loc, const std::string &mess) noexcept
   }
 }
 
-void Logger::trace(LogLocation loc, const std::string &mess) noexcept
+void Logger::trace(LogLocation loc, std::string_view mess) noexcept
 {
   try {
     PRECICE_LOG_IMPL(*_impl, boost::log::trivial::severity_level::trace, loc) << mess;

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <string>
+#include <string_view>
 
 namespace precice::logging {
 
@@ -18,7 +18,7 @@ public:
   /** Creates a logger for a given module.
    * @param[in] the name of the module
    */
-  explicit Logger(std::string module);
+  explicit Logger(std::string_view module);
 
   Logger(const Logger &other);
   Logger(Logger &&other) noexcept;
@@ -29,11 +29,11 @@ public:
 
   ///@name Logging operations
   ///@{
-  void error(LogLocation loc, const std::string &mess) noexcept;
-  void warning(LogLocation loc, const std::string &mess) noexcept;
-  void info(LogLocation loc, const std::string &mess) noexcept;
-  void debug(LogLocation loc, const std::string &mess) noexcept;
-  void trace(LogLocation loc, const std::string &mess) noexcept;
+  void error(LogLocation loc, std::string_view mess) noexcept;
+  void warning(LogLocation loc, std::string_view mess) noexcept;
+  void info(LogLocation loc, std::string_view mess) noexcept;
+  void debug(LogLocation loc, std::string_view mess) noexcept;
+  void trace(LogLocation loc, std::string_view mess) noexcept;
   ///@}
 
 private:

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -4,15 +4,23 @@
 #include <boost/test/framework.hpp>
 #include <boost/test/tree/test_unit.hpp>
 #include <cstdlib>
+#include <limits>
 #include <string>
 
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
 #include "testing/SourceLocation.hpp"
 #include "testing/Testing.hpp"
+#include "utils/ManageUniqueIDs.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice::testing {
+
+DataID operator"" _dataID(unsigned long long n)
+{
+  PRECICE_ASSERT(n < std::numeric_limits<DataID>::max(), "DataID is too big");
+  return static_cast<DataID>(n);
+}
 
 std::string getPathToRepository()
 {
@@ -45,6 +53,57 @@ std::string getTestName()
   }
   auto parent = boost::unit_test::framework::current_test_case().p_parent_id;
   return boost::unit_test::framework::get<boost::unit_test::test_suite>(parent).p_name;
+}
+
+int nextMeshID()
+{
+  static utils::ManageUniqueIDs manager;
+  return manager.getFreeID();
+}
+
+/// equals to be used in tests. Compares two std::vectors using a given tolerance. Prints both operands on failure
+boost::test_tools::predicate_result equals(const std::vector<float> &VectorA,
+                                           const std::vector<float> &VectorB,
+                                           float                     tolerance)
+{
+  PRECICE_ASSERT(VectorA.size() == VectorB.size());
+  Eigen::MatrixXd MatrixA(VectorA.size(), 1);
+  std::copy(VectorA.begin(), VectorA.end(), MatrixA.data());
+  Eigen::MatrixXd MatrixB(VectorB.size(), 1);
+  std::copy(VectorB.begin(), VectorB.end(), MatrixB.data());
+  return equals(MatrixA, MatrixB, tolerance);
+}
+
+boost::test_tools::predicate_result equals(const std::vector<double> &VectorA,
+                                           const std::vector<double> &VectorB,
+                                           double                     tolerance)
+{
+  PRECICE_ASSERT(VectorA.size() == VectorB.size());
+  Eigen::MatrixXd MatrixA(VectorA.size(), 1);
+  std::copy(VectorA.begin(), VectorA.end(), MatrixA.data());
+  Eigen::MatrixXd MatrixB(VectorB.size(), 1);
+  std::copy(VectorB.begin(), VectorB.end(), MatrixB.data());
+  return equals(MatrixA, MatrixB, tolerance);
+}
+
+boost::test_tools::predicate_result equals(float a, float b, float tolerance)
+{
+  if (not math::equals(a, b, tolerance)) {
+    boost::test_tools::predicate_result res(false);
+    res.message() << "Not equal: " << a << "!=" << b;
+    return res;
+  }
+  return true;
+}
+
+boost::test_tools::predicate_result equals(double a, double b, double tolerance)
+{
+  if (not math::equals(a, b, tolerance)) {
+    boost::test_tools::predicate_result res(false);
+    res.message() << "Not equal: " << a << "!=" << b;
+    return res;
+  }
+  return true;
 }
 
 } // namespace precice::testing

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -33,20 +33,6 @@ using precice::testing::operator""_dataID;
   BOOST_TEST_MESSAGE(context.describe());             \
   boost::unit_test::framework::add_context(BOOST_TEST_LAZY_MSG(context.describe()), true);
 
-/// Boost.Test decorator that unconditionally deletes the test.
-class Deleted : public bt::decorator::base {
-private:
-  virtual void apply(bt::test_unit &tu)
-  {
-    bt::framework::get<bt::test_suite>(tu.p_parent_id).remove(tu.p_id);
-  }
-
-  virtual bt::decorator::base_ptr clone() const
-  {
-    return bt::decorator::base_ptr(new Deleted());
-  }
-};
-
 /// struct giving access to the impl of a befriended class or struct
 struct WhiteboxAccessor {
   /** Returns the impl of the obj by reference.

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -2,26 +2,19 @@
 
 #include <Eigen/Core>
 #include <boost/test/unit_test.hpp>
-#include <limits>
 #include <string>
 #include <type_traits>
+
 #include "math/differences.hpp"
 #include "math/math.hpp"
 #include "testing/TestContext.hpp"
 #include "utils/IntraComm.hpp"
-#include "utils/ManageUniqueIDs.hpp"
-#include "utils/assertion.hpp"
 
-namespace precice {
-namespace testing {
+namespace precice::testing {
 
 namespace bt = boost::unit_test;
 
-constexpr DataID operator"" _dataID(unsigned long long n)
-{
-  PRECICE_ASSERT(n < std::numeric_limits<DataID>::max(), "DataID is too big");
-  return static_cast<DataID>(n);
-}
+DataID operator"" _dataID(unsigned long long n);
 
 namespace inject {
 using precice::testing::Require;
@@ -104,30 +97,18 @@ boost::test_tools::predicate_result equals(const Eigen::MatrixBase<DerivedA> &A,
 }
 
 /// equals to be used in tests. Compares two std::vectors using a given tolerance. Prints both operands on failure
-template <typename NumberType>
-boost::test_tools::predicate_result equals(const std::vector<NumberType> &VectorA,
-                                           const std::vector<NumberType> &VectorB,
-                                           double                         tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
-{
-  PRECICE_ASSERT(VectorA.size() == VectorB.size());
-  Eigen::MatrixXd MatrixA(VectorA.size(), 1);
-  std::copy(VectorA.begin(), VectorA.end(), MatrixA.data());
-  Eigen::MatrixXd MatrixB(VectorB.size(), 1);
-  std::copy(VectorB.begin(), VectorB.end(), MatrixB.data());
-  return equals(MatrixA, MatrixB, tolerance);
-}
+boost::test_tools::predicate_result equals(const std::vector<float> &VectorA,
+                                           const std::vector<float> &VectorB,
+                                           float                     tolerance = math::NUMERICAL_ZERO_DIFFERENCE);
+
+boost::test_tools::predicate_result equals(const std::vector<double> &VectorA,
+                                           const std::vector<double> &VectorB,
+                                           double                     tolerance = math::NUMERICAL_ZERO_DIFFERENCE);
 
 /// equals to be used in tests. Compares two scalar numbers using a given tolerance. Prints both operands on failure
-template <class Scalar>
-typename std::enable_if<std::is_arithmetic<Scalar>::value, boost::test_tools::predicate_result>::type equals(const Scalar a, const Scalar b, const Scalar tolerance = math::NUMERICAL_ZERO_DIFFERENCE)
-{
-  if (not math::equals(a, b, tolerance)) {
-    boost::test_tools::predicate_result res(false);
-    res.message() << "Not equal: " << a << "!=" << b;
-    return res;
-  }
-  return true;
-}
+boost::test_tools::predicate_result equals(float a, float b, float tolerance = math::NUMERICAL_ZERO_DIFFERENCE);
+
+boost::test_tools::predicate_result equals(double a, double b, double tolerance = math::NUMERICAL_ZERO_DIFFERENCE);
 
 /// Returns the base path of the repo.
 std::string getPathToRepository();
@@ -148,11 +129,6 @@ std::string getTestPath();
  *
  * @returns a new unique mesh ID
  */
-inline int nextMeshID()
-{
-  static utils::ManageUniqueIDs manager;
-  return manager.getFreeID();
-}
+int nextMeshID();
 
-} // namespace testing
-} // namespace precice
+} // namespace precice::testing

--- a/src/testing/tests/ExampleTests.cpp
+++ b/src/testing/tests/ExampleTests.cpp
@@ -51,14 +51,6 @@ BOOST_AUTO_TEST_CASE(NumericalTolerance,
   BOOST_TEST(1.0 == 1.01, boost::test_tools::tolerance(0.1));
 }
 
-/// Use testing::Deleted to unconditionally delete the test
-BOOST_AUTO_TEST_CASE(Deleted,
-                     *testing::Deleted())
-{
-  PRECICE_TEST(1_rank);
-  BOOST_TEST(false);
-}
-
 /// Test that requires 4 processors.
 /*
  * If less than 4 procs are available the test will fail.

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -2,6 +2,8 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <string_view>
+
 #include "utils/fmt.hpp"
 
 // Assertions are disabled in release (NDEBUG) builds by default.
@@ -32,7 +34,7 @@
 namespace precice {
 namespace utils {
 
-static constexpr char const *ASSERT_FMT =
+static constexpr std::string_view ASSERT_FMT =
     "ASSERTION FAILED\n"
     "Location:   {}\n"
     "File:       {}:{}\n"
@@ -87,8 +89,8 @@ static constexpr char const *ASSERT_FMT =
 
 /// Displays an error message and aborts the program independent of the build type.
 /// Use to mark unreachable statements under switch or if blocks.
-#define PRECICE_UNREACHABLE(...)                        \
-  {                                                     \
-    std::cerr << fmt::format(__VA_ARGS__) << std::endl; \
-    std::abort();                                       \
+#define PRECICE_UNREACHABLE(...)                                              \
+  {                                                                           \
+    std::cerr << ::precice::utils::format_or_error(__VA_ARGS__) << std::endl; \
+    std::abort();                                                             \
   }

--- a/src/utils/fmt.hpp
+++ b/src/utils/fmt.hpp
@@ -6,24 +6,29 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include "fmt/format.h"
 #include "fmt/ostream.h"
 #include "utils/fmtEigen.hpp"
 #include "utils/fmtSTL.hpp"
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
+
+// pass through for string only
+inline std::string format_or_error(std::string_view str)
+{
+  return std::string{str};
+}
 
 template <class... A>
-std::string format_or_error(A &&... args)
+std::string format_or_error(std::string_view fmt, A &&... args)
 {
   try {
-    return fmt::format(std::forward<A>(args)...);
+    return fmt::vformat(fmt, fmt::make_format_args(args...));
   } catch (const fmt::format_error &e) {
     return std::string{"fmt_error: "} + e.what();
   }
 }
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/thirdparty/fmt/CMakeLists.txt
+++ b/thirdparty/fmt/CMakeLists.txt
@@ -1,5 +1,9 @@
-add_library(fmt-header-only INTERFACE IMPORTED GLOBAL)
-set_target_properties(fmt-header-only
+add_library(fmtlib-static STATIC src/format.cc src/os.cc)
+target_include_directories(fmtlib-static PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include")
+set_target_properties(fmtlib-static
   PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/include"
-  INTERFACE_COMPILE_DEFINITIONS FMT_HEADER_ONLY=1)
+  POSITION_INDEPENDENT_CODE ON
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED YES
+  CXX_EXTENSIONS NO
+  )


### PR DESCRIPTION
## Main changes of this PR

This PR attempts to reduce compile times of components that are used a lot in the code-base.
* It links fmtlib as a static library and links it against the preciceCore
* It adjusts parameter types in formatting tools to avoid conversions etc. This includes `Logger.hpp` and `assertions.hpp`.
* It reduces templates and inline functions in `Testing.hpp` by making them explicit and moving them to `Testing.cpp`. This eliminates a row of transitive headers.
* It removes unused features from Testing

## Motivation and additional information

This reduces the total compile time (excluding linkage) from 1696 to 1320 seconds.

Replacing iostream in assertions with `fmt::printf(stderr, ...)` leads to a higher compile time.

Going forward, Eigen seems to be the next major burden. It's expensive to include and used in every test. The most likely next step would be to build testprecice as a unity build, which requires disambiguation across cpp files.

Thankfully this is super easy to setup with CMake and was introduced in 3.16.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.
