### PR TITLE
Coverity fixes

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -253,7 +253,7 @@ add_precice_test(
 add_precice_test(
   NAME mapping.petrbf
   ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_NORMAL}
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
   LABELS petsc
   PETSC
   )

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -20,13 +20,13 @@ namespace precice::com {
 
 namespace {
 
-std::string preciceFancyHash(const std::string &s)
+std::string preciceFancyHash(std::string_view s)
 try {
   boost::uuids::string_generator ns_gen;
   auto                           ns = ns_gen("af7ce8f2-a9ee-46cb-38ee-71c318aa3580"); // md5 hash of precice.org as namespace
 
   boost::uuids::name_generator gen{ns};
-  return boost::uuids::to_string(gen(s));
+  return boost::uuids::to_string(gen(s.data(), s.size()));
 
 } catch (const std::runtime_error &e) {
   PRECICE_UNREACHABLE("preCICE hashing failed", e.what());
@@ -34,10 +34,10 @@ try {
 }
 } // namespace
 
-std::string impl::hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &tag, Rank rank)
+std::string impl::hashedFilePath(std::string_view acceptorName, std::string_view requesterName, std::string_view tag, Rank rank)
 {
   constexpr int     firstLevelLen = 2;
-  std::string const s             = acceptorName + tag + requesterName + std::to_string(rank);
+  std::string const s             = std::string(acceptorName).append(tag).append(requesterName).append(std::to_string(rank));
   std::string       hash          = preciceFancyHash(s);
   hash.erase(std::remove(hash.begin(), hash.end(), '-'), hash.end());
 
@@ -46,9 +46,9 @@ std::string impl::hashedFilePath(const std::string &acceptorName, const std::str
   return p.string();
 }
 
-std::string impl::localDirectory(const std::string &acceptorName, const std::string &requesterName, const std::string &addressDirectory)
+std::string impl::localDirectory(std::string_view acceptorName, std::string_view requesterName, std::string_view addressDirectory)
 {
-  std::string directional = acceptorName + "-" + requesterName;
+  std::string directional = std::string(acceptorName).append("-").append(requesterName);
 
   auto p = bfs::path(addressDirectory) / "precice-run" / directional;
 
@@ -119,7 +119,7 @@ ConnectionInfoWriter::~ConnectionInfoWriter()
   }
 }
 
-void ConnectionInfoWriter::write(std::string const &info) const
+void ConnectionInfoWriter::write(std::string_view info) const
 {
   auto path = getFilename();
   auto tmp  = bfs::path(path + "~");

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -50,7 +50,7 @@ std::string impl::localDirectory(std::string_view acceptorName, std::string_view
 {
   std::string directional = std::string(acceptorName).append("-").append(requesterName);
 
-  auto p = bfs::path(addressDirectory) / "precice-run" / directional;
+  auto p = bfs::path(addressDirectory.begin(), addressDirectory.end()) / "precice-run" / directional;
 
   return p.string();
 }

--- a/src/com/ConnectionInfoPublisher.hpp
+++ b/src/com/ConnectionInfoPublisher.hpp
@@ -1,12 +1,12 @@
 #pragma once
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "logging/Logger.hpp"
 #include "precice/types.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 
 namespace impl {
 /// Returns the file name for the connection information.
@@ -14,37 +14,37 @@ namespace impl {
    * It has the form first two letters from hash of
    * (acceptorName, requesterName, mesh, rank)/rest of hash.
    */
-std::string hashedFilePath(const std::string &acceptorName, const std::string &requesterName, const std::string &meshName, Rank rank);
+std::string hashedFilePath(std::string_view acceptorName, std::string_view requesterName, std::string_view meshName, Rank rank);
 
 /** Returns the local directory which is the root for storing connection information.
    * It has the form addressDirectory/precice-run/acceptorName-requesterName
    */
-std::string localDirectory(const std::string &acceptorName, const std::string &requesterName, const std::string &addressDirectory);
+std::string localDirectory(std::string_view acceptorName, std::string_view requesterName, std::string_view addressDirectory);
 } // namespace impl
 
 class ConnectionInfoPublisher {
 public:
-  ConnectionInfoPublisher(std::string acceptorName,
-                          std::string requesterName,
-                          std::string tag,
-                          int         rank,
-                          std::string addressDirectory) noexcept
-      : acceptorName(std::move(acceptorName)),
-        requesterName(std::move(requesterName)),
-        tag(std::move(tag)),
+  ConnectionInfoPublisher(std::string_view acceptorName,
+                          std::string_view requesterName,
+                          std::string_view tag,
+                          int              rank,
+                          std::string_view addressDirectory) noexcept
+      : acceptorName(acceptorName),
+        requesterName(requesterName),
+        tag(tag),
         rank(rank),
-        addressDirectory(std::move(addressDirectory))
+        addressDirectory(addressDirectory)
   {
   }
 
-  ConnectionInfoPublisher(std::string acceptorName,
-                          std::string requesterName,
-                          std::string tag,
-                          std::string addressDirectory) noexcept
-      : acceptorName(std::move(acceptorName)),
-        requesterName(std::move(requesterName)),
-        tag(std::move(tag)),
-        addressDirectory(std::move(addressDirectory))
+  ConnectionInfoPublisher(std::string_view acceptorName,
+                          std::string_view requesterName,
+                          std::string_view tag,
+                          std::string_view addressDirectory) noexcept
+      : acceptorName(acceptorName),
+        requesterName(requesterName),
+        tag(tag),
+        addressDirectory(addressDirectory)
   {
   }
 
@@ -67,19 +67,19 @@ protected:
 /// Reads the connection info for the given participant/rank information
 class ConnectionInfoReader : public ConnectionInfoPublisher {
 public:
-  ConnectionInfoReader(std::string acceptorName,
-                       std::string requesterName,
-                       std::string tag,
-                       int         rank,
-                       std::string addressDirectory) noexcept
+  ConnectionInfoReader(std::string_view acceptorName,
+                       std::string_view requesterName,
+                       std::string_view tag,
+                       int              rank,
+                       std::string_view addressDirectory) noexcept
       : ConnectionInfoPublisher(acceptorName, requesterName, tag, rank, addressDirectory)
   {
   }
 
-  ConnectionInfoReader(std::string acceptorName,
-                       std::string requesterName,
-                       std::string tag,
-                       std::string addressDirectory) noexcept
+  ConnectionInfoReader(std::string_view acceptorName,
+                       std::string_view requesterName,
+                       std::string_view tag,
+                       std::string_view addressDirectory) noexcept
       : ConnectionInfoPublisher(acceptorName, requesterName, tag, addressDirectory)
   {
   }
@@ -94,19 +94,19 @@ public:
  */
 class ConnectionInfoWriter : public ConnectionInfoPublisher {
 public:
-  ConnectionInfoWriter(std::string acceptorName,
-                       std::string requesterName,
-                       std::string tag,
-                       int         rank,
-                       std::string addressDirectory) noexcept
+  ConnectionInfoWriter(std::string_view acceptorName,
+                       std::string_view requesterName,
+                       std::string_view tag,
+                       int              rank,
+                       std::string_view addressDirectory) noexcept
       : ConnectionInfoPublisher(acceptorName, requesterName, tag, rank, addressDirectory)
   {
   }
 
-  ConnectionInfoWriter(std::string acceptorName,
-                       std::string requesterName,
-                       std::string tag,
-                       std::string addressDirectory) noexcept
+  ConnectionInfoWriter(std::string_view acceptorName,
+                       std::string_view requesterName,
+                       std::string_view tag,
+                       std::string_view addressDirectory) noexcept
       : ConnectionInfoPublisher(acceptorName, requesterName, tag, addressDirectory)
   {
   }
@@ -119,8 +119,7 @@ public:
    * which is determined by acceptorName, requesterName, rank, addressDirectory
    * set at construction.
    */
-  void write(std::string const &info) const;
+  void write(std::string_view info) const;
 };
 
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -330,10 +330,10 @@ void SocketCommunication::closeConnection()
 
     try {
       socket.second->shutdown(Socket::shutdown_send);
+      socket.second->close();
     } catch (std::exception &e) {
       PRECICE_WARN("Socket shutdown failed with system error: {}", e.what());
     }
-    socket.second->close();
   }
 
   _isConnected = false;

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -287,7 +287,7 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
         tcp::resolver             resolver(*_ioService);
         tcp::resolver::iterator   endpoint_iterator = resolver.resolve(query);
         boost::system::error_code error             = asio::error::host_not_found;
-        boost::asio::connect(*socket, endpoint_iterator, error);
+        boost::asio::connect(*socket, std::move(endpoint_iterator), error);
 
         _isConnected = not error;
 

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -34,7 +34,7 @@ ParallelCouplingScheme::ParallelCouplingScheme(
     m2n::PtrM2N                   m2n,
     constants::TimesteppingMethod dtMethod,
     CouplingMode                  cplMode)
-    : ParallelCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, minTimeStepSize, firstParticipant, secondParticipant, localParticipant, m2n, dtMethod, cplMode, UNDEFINED_MAX_ITERATIONS, UNDEFINED_MAX_ITERATIONS){};
+    : ParallelCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, minTimeStepSize, firstParticipant, secondParticipant, localParticipant, std::move(m2n), dtMethod, cplMode, UNDEFINED_MAX_ITERATIONS, UNDEFINED_MAX_ITERATIONS){};
 
 void ParallelCouplingScheme::exchangeInitialData()
 {

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -124,7 +124,7 @@ private:
   double _minTimeStepSize = math::NUMERICAL_ZERO_DIFFERENCE;
 
   /// Synchronize participants in finalize
-  bool _waitInFinalize;
+  bool _waitInFinalize = false;
 
   // @brief Root tag of preCICE configuration.
   xml::XMLTag _tag;

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -318,8 +318,7 @@ void ParticipantConfiguration::xmlTagCallback(
     _watchIntegralConfigs.push_back(config);
   } else if (tag.getNamespace() == TAG_INTRA_COMM) {
     com::CommunicationConfiguration comConfig;
-    com::PtrCommunication           com  = comConfig.createCommunication(tag);
-    utils::IntraComm::getCommunication() = com;
+    utils::IntraComm::getCommunication() = comConfig.createCommunication(tag);
     _isIntraCommDefined                  = true;
     _participants.back()->setUsePrimaryRank(true);
   }

--- a/src/profiling/Event.cpp
+++ b/src/profiling/Event.cpp
@@ -5,11 +5,11 @@
 
 namespace precice::profiling {
 
-Event::Event(std::string eventName, Options options)
+Event::Event(std::string_view eventName, Options options)
     : _fundamental(options.fundamental), _synchronize(options.synchronized)
 {
   auto &er = EventRegistry::instance();
-  _eid     = er.nameToID(EventRegistry::instance().prefix + eventName);
+  _eid     = er.nameToID(std::string(EventRegistry::instance().prefix).append(eventName));
   start();
 }
 
@@ -45,7 +45,7 @@ void Event::stop()
   }
 }
 
-void Event::addData(const std::string &key, int value)
+void Event::addData(std::string_view key, int value)
 {
   auto timestamp = Clock::now();
   PRECICE_ASSERT(_state == State::RUNNING, _eid);
@@ -59,7 +59,7 @@ void Event::addData(const std::string &key, int value)
 
 // -----------------------------------------------------------------------
 
-ScopedEventPrefix::ScopedEventPrefix(std::string const &name)
+ScopedEventPrefix::ScopedEventPrefix(std::string_view name)
 {
   previousName = EventRegistry::instance().prefix;
   EventRegistry::instance().prefix += name;

--- a/src/profiling/Event.hpp
+++ b/src/profiling/Event.hpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 namespace precice::profiling {
@@ -66,12 +67,12 @@ public:
   }
 
   template <typename... Args>
-  Event(std::string eventName, Args... args)
-      : Event(std::move(eventName), optionsFromTags(args...))
+  Event(std::string_view eventName, Args... args)
+      : Event(eventName, optionsFromTags(args...))
   {
   }
 
-  Event(std::string eventName, Options options);
+  Event(std::string_view eventName, Options options);
 
   Event(Event &&) = default;
   Event &operator=(Event &&) = default;
@@ -90,7 +91,7 @@ public:
   void stop();
 
   /// Adds named integer data, associated to an event.
-  void addData(const std::string &key, int value);
+  void addData(std::string_view key, int value);
 
 private:
   int   _eid;
@@ -102,7 +103,7 @@ private:
 /// Class that changes the prefix in its scope
 class ScopedEventPrefix {
 public:
-  ScopedEventPrefix(const std::string &name);
+  ScopedEventPrefix(std::string_view name);
 
   ~ScopedEventPrefix();
 

--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <ratio>
 #include <string>
+#include <string_view>
 #include <sys/types.h>
 #include <tuple>
 #include <utility>
@@ -51,7 +52,7 @@ EventRegistry &EventRegistry::instance()
   return instance;
 }
 
-void EventRegistry::initialize(std::string applicationName, int rank, int size)
+void EventRegistry::initialize(std::string_view applicationName, int rank, int size)
 {
   auto initClock = Event::Clock::now();
   auto initTime  = std::chrono::system_clock::now();
@@ -75,7 +76,7 @@ void EventRegistry::setWriteQueueMax(std::size_t size)
   _writeQueueMax = size;
 }
 
-void EventRegistry::setDirectory(std::string directory)
+void EventRegistry::setDirectory(std::string_view directory)
 {
   _directory = directory;
 }
@@ -253,13 +254,13 @@ try {
   PRECICE_UNREACHABLE(e.what());
 }
 
-int EventRegistry::nameToID(const std::string &name)
+int EventRegistry::nameToID(std::string_view name)
 {
   if (auto iter = _nameDict.find(name);
       iter == _nameDict.end()) {
     int id = _nameDict.size();
-    _nameDict.insert(iter, {name, id});
-    _writeQueue.emplace_back(NameEntry{name, id});
+    _nameDict.insert(iter, {std::string(name), id});
+    _writeQueue.emplace_back(NameEntry{std::string(name), id});
     return id;
   } else {
     return iter->second;

--- a/src/profiling/EventUtils.hpp
+++ b/src/profiling/EventUtils.hpp
@@ -6,6 +6,7 @@
 #include <iosfwd>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -95,13 +96,13 @@ public:
    * @param[in] rank the current number of the parallel instance
    * @param[in] size the total number of a parallel instances
    */
-  void initialize(std::string applicationName, int rank = 0, int size = 1);
+  void initialize(std::string_view applicationName, int rank = 0, int size = 1);
 
   /// Sets the maximum size of the writequeue before calling flush(). Use 0 to flush on destruction.
   void setWriteQueueMax(std::size_t size);
 
   /// Sets the directory where to write the event files to
-  void setDirectory(std::string directory);
+  void setDirectory(std::string_view directory);
 
   /// Sets the operational mode of the registry.
   void setMode(Mode mode);
@@ -127,7 +128,7 @@ public:
     return _mode == Mode::All || (ec == EventClass::Fundamental && _mode == Mode::Fundamental);
   }
 
-  int nameToID(const std::string &name);
+  int nameToID(std::string_view name);
 
   /// Currently active prefix. Changing that applies only to newly created events.
   std::string prefix;
@@ -156,7 +157,7 @@ private:
   /// Private, empty constructor for singleton pattern
   EventRegistry() = default;
 
-  std::map<std::string, int> _nameDict;
+  std::map<std::string, int, std::less<>> _nameDict;
 
   std::vector<PendingEntry> _writeQueue;
   std::size_t               _writeQueueMax = 0;


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a bunch of coverity warnings.
I changed many string-related "move instead of copy" to using string_view instead.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
