### PR TITLE
Fix more coverity complaints

### DIFF
--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -22,8 +22,8 @@ NearestNeighborBaseMapping::NearestNeighborBaseMapping(
     std::string mappingName,
     std::string mappingNameShort)
     : Mapping(constraint, dimensions, requiresGradientData, Mapping::InitialGuessRequirement::None),
-      mappingName(mappingName),
-      mappingNameShort(mappingNameShort)
+      mappingName(std::move(mappingName)),
+      mappingNameShort(std::move(mappingNameShort))
 {
 }
 

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -46,9 +46,9 @@ namespace mapping {
  *
  */
 struct RadialBasisParameters {
-  double parameter1;
-  double parameter2;
-  double parameter3;
+  double parameter1{};
+  double parameter2{};
+  double parameter3{};
 };
 
 /// Base class for RBF with compact support
@@ -248,14 +248,15 @@ public:
                   "Support radius for radial-basis-function gaussian has to be larger than zero. Please update the \"support-radius\" attribute.");
 #endif
 
-    if (supportRadius < std::numeric_limits<double>::infinity()) {
-      _deltaY = evaluate(supportRadius);
-    }
     double threshold   = std::sqrt(-std::log(cutoffThreshold)) / shape;
     _supportRadius     = std::min(supportRadius, threshold);
     _params.parameter1 = _shape;
     _params.parameter2 = _supportRadius;
     _params.parameter3 = _deltaY;
+    if (supportRadius < std::numeric_limits<double>::infinity()) {
+      _deltaY            = evaluate(supportRadius);
+      _params.parameter3 = _deltaY;
+    }
   }
 
   double getSupportRadius() const

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV1)
       {-1, 3, {3, 1}, {8}}};
 
   MeshSpecification in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
 
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV1)
       {3, -1, {3, 1}, {0}}};
 
   MeshSpecification out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification ref{// Tests for {0, 1} on the first rank, {1, 2} on the second, ...
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV1Vector)
                                                 {-1, 3, {3, 0}, {7, 10}},
                                                 {-1, 3, {3, 1}, {8, 11}}};
   MeshSpecification                in{// The outMesh is local, distributed among all ranks
-                       inVertexList,
+                       std::move(inVertexList),
                        meshDims2D,
                        "inMesh"};
 
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV1Vector)
                                                  {3, -1, {3, 0}, {0, 0}},
                                                  {3, -1, {3, 1}, {0, 0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification ref{// Tests for {0, 1} on the first rank, {1, 2} on the second, ...
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV2)
                                                 {-1, 3, {3, 1}, {8}}};
 
   MeshSpecification in = {
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is local, rank 1 is empty
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV2)
                                                  {3, -1, {3, 0}, {0}},
                                                  {3, -1, {3, 1}, {0}}};
   MeshSpecification                out = {
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification                                     ref{// Tests for {0, 1, 2} on the first rank,
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3)
       {3, 3, {3, 1}, {8}},
   };
   MeshSpecification in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is local, rank 1 is empty
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3)
                                                  {3, -1, {3, 0}, {0}},
                                                  {3, -1, {3, 1}, {0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification ref{// Tests for {0, 1, 2} on the first rank,
@@ -409,7 +409,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3Vector)
       {3, 3, {3, 1}, {8, 11}},
   };
   MeshSpecification in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is local, rank 1 is empty
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV3Vector)
                                                  {3, -1, {3, 0}, {0, 0}},
                                                  {3, -1, {3, 1}, {0, 0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
 
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
       // Rank 3 has no vertices
   };
   MeshSpecification in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is local, rank 0 and 3 are empty
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV4)
                                                  {2, -1, {3, 0}, {0}},
                                                  {2, -1, {3, 1}, {0}}};
   MeshSpecification out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification                                        ref{{1, {5}},
@@ -553,7 +553,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
       {3, 3, {3, 1}, {8}},
   };
   MeshSpecification in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is local, rank 0 and 3 are empty
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV5)
                                                  {2, -1, {3, 0}, {0}},
                                                  {2, -1, {3, 1}, {0}}};
   MeshSpecification out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification                                        ref{{1, {5}},
@@ -619,7 +619,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV6,
       // Rank 3 has no vertices
   };
   MeshSpecification in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is local, rank 0 and 3 are empty
@@ -634,7 +634,7 @@ BOOST_AUTO_TEST_CASE(DistributedConsistent2DV6,
                                                  {2, -1, {3, 0}, {0}},
                                                  {2, -1, {3, 1}, {0}}};
   MeshSpecification out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification                                        ref{{1, {5}},
@@ -670,7 +670,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV1)
                                                 {3, -1, {3, 0}, {7}},
                                                 {3, -1, {3, 1}, {8}}};
   MeshSpecification                in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is distributed
@@ -683,7 +683,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV1)
                                                  {-1, 3, {3, 0}, {0}},
                                                  {-1, 3, {3, 1}, {0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification ref{// Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
@@ -744,7 +744,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV1Vector)
                                                 {3, -1, {3, 0}, {7, 10}},
                                                 {3, -1, {3, 1}, {8, 11}}};
   MeshSpecification                in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is distributed
@@ -757,7 +757,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV1Vector)
                                                  {-1, 3, {3, 0}, {0, 0}},
                                                  {-1, 3, {3, 1}, {0, 0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification                                     ref{// Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
@@ -820,7 +820,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV2)
                                                 {3, -1, {3, 0}, {7}},
                                                 {3, -1, {3, 1}, {8}}};
   MeshSpecification                in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is distributed, rank 0 owns no vertex
@@ -833,7 +833,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV2)
                                                  {-1, 3, {3, 0}, {0}},
                                                  {-1, 3, {3, 1}, {0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification ref{// Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
@@ -895,7 +895,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV3)
                                                 {3, -1, {3, 0}, {7}},
                                                 {3, -1, {3, 1}, {8}}}; // Sum of all vertices is 34
   MeshSpecification                in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is distributed, rank 0 owns no vertex
@@ -908,7 +908,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV3)
                                                  {-1, 3, {3, 0}, {0}},
                                                  {-1, 3, {3, 1}, {0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification ref{// Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
@@ -972,7 +972,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV4,
                                                 {3, -1, {3, 0}, {7}},
                                                 {3, -1, {3, 1}, {8}}}; // Sum is 36
   MeshSpecification                in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is distributed, rank 0 has no vertex at all
@@ -984,7 +984,7 @@ BOOST_AUTO_TEST_CASE(DistributedConservative2DV4,
                                                  {-1, 3, {3, 0}, {0}},
                                                  {-1, 3, {3, 1}, {0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification                                        ref{// Tests for {0, 0, 0, 0, 0, 0, 0, 0} on the first rank,
@@ -1037,7 +1037,7 @@ BOOST_AUTO_TEST_CASE(testDistributedConservative2DV5)
                                                 {3, -1, {3, 0}, {7}},
                                                 {3, -1, {3, 1}, {8}}};
   MeshSpecification                in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is distributed and non-contigous
@@ -1050,7 +1050,7 @@ BOOST_AUTO_TEST_CASE(testDistributedConservative2DV5)
                                                  {-1, 3, {3, 0}, {0}},
                                                  {-1, 3, {3, 1}, {0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification ref{// Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
@@ -1112,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(testDistributedConservative2DV5Vector)
                                                 {3, -1, {3, 0}, {7, 10}},
                                                 {3, -1, {3, 1}, {8, 11}}};
   MeshSpecification                in{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> outVertexList{// The outMesh is distributed and non-contigous
@@ -1125,7 +1125,7 @@ BOOST_AUTO_TEST_CASE(testDistributedConservative2DV5Vector)
                                                  {-1, 3, {3, 0}, {0, 0}},
                                                  {-1, 3, {3, 1}, {0, 0}}};
   MeshSpecification                out{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   ReferenceSpecification                                     ref{// Tests for {0, 1, 0, 0, 0, 0, 0, 0} on the first rank,
@@ -1239,7 +1239,7 @@ BOOST_AUTO_TEST_CASE(testTagFirstRound)
   std::vector<VertexSpecification> outVertexList{
       {0, -1, {0, 0}, {0}}};
   MeshSpecification outMeshSpec{
-      outVertexList,
+      std::move(outVertexList),
       meshDims2D,
       "outMesh"};
   std::vector<VertexSpecification> inVertexList{
@@ -1253,7 +1253,7 @@ BOOST_AUTO_TEST_CASE(testTagFirstRound)
       {0, -1, {0, 2}, {1}}   // outside
   };
   MeshSpecification inMeshSpec{
-      inVertexList,
+      std::move(inVertexList),
       meshDims2D,
       "inMesh"};
   std::vector<VertexSpecification> firstRoundVertices = {

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -245,7 +245,8 @@ bool Index::isAnyVertexInsideBox(const mesh::Vertex &centerVertex, double radius
 
   const auto &rtree = _pimpl->getVertexRTree(*_mesh);
 
-  for (auto it = rtree->qbegin(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertices()[i]) < radius; })); it != rtree->qend(); ++it) {
+  // We can skip the iterator increment in the loop signature, as it is never executed
+  for (auto it = rtree->qbegin(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertices()[i]) < radius; })); it != rtree->qend();) {
     return true;
   }
 


### PR DESCRIPTION
## Main changes of this PR

More of a complement to #1859

If possible, we should maybe disable efficiency concerns in our test suite. I fixed the easy ones as well to clear out the clutter in the coverity overview page.


## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
