### PR TITLE
Improve test logging and CI output

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -119,7 +119,7 @@ jobs:
           Ginkgo: ${{ contains(matrix.CONFIG, 'Ginkgo') }}
         run: |
           cmake --version
-          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DPRECICE_FEATURE_GINKGO_MAPPING=${{ env.Ginkgo }} -DPRECICE_FEATURE_LIBBACKTRACE_STACKTRACES=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.COVFLAGS }}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DPRECICE_FEATURE_GINKGO_MAPPING=${{ env.Ginkgo }} -DPRECICE_FEATURE_LIBBACKTRACE_STACKTRACES=ON -DMPIEXEC_POSTFLAGS="--logger=HRF,error,error.log" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.COVFLAGS }}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -167,6 +167,9 @@ jobs:
         run: |
           cpack
           lintian -i --suppress-tags control-file-has-bad-permissions *.deb
+      - name: Print error reports
+        working-directory: build
+        run: find . -name 'error.log' -exec cat {} \;
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -275,7 +275,7 @@ std::string TestContext::describe() const
   } else {
     os << " represents \"" << name << '"';
   }
-  os << " and runs on rank " << rank << " out of " << size << '.';
+  os << " and runs test \"" << testing::getTestName() << "\" on rank " << rank << " out of " << size << '.';
 
   if (_initIntraComm || _events || _petsc) {
     os << " Initialized: {";


### PR DESCRIPTION
## Main changes of this PR

Adds the test name to the context description and adds dedicated error reports into the CI pipeline.

## Motivation and additional information

Tracing down bugs/errors in our CI is somewhat intricate. The current `context` description simply reveals the mode (serial vs parallel) and the rank the test is being performed on. In addition, we get now the test name, which is helpful if preCICE crashed (not the test fails), becaue the test context will give the context description before failing (so at least the failing test is known). As of know, the trace-like test-logging was ambiguous: it might happen that another test was already reported as 'entered' although the actual fail was related to another test.

In addition, our BOOST_TEST_LOG_LEVEL=all is very clumsy to read. However, we can create a dedicated error logger for the test suits which will create a nice error report for each test suite in a HRF. I added a printer for the error logs, such that inspecting the logs should be much easier.