### PR TITLE
Improve error message in PUM

### DIFF
--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -232,7 +232,10 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     const auto localNumberOfClusters = clusterIDs.size();
     // Consider the case where we didn't find any cluster (meshes don't match very well)
     if (localNumberOfClusters == 0) {
-      PRECICE_ERROR("Output vertex {} could not be assigned to any cluster. This means that the meshes probably do not match well geometry-wise or the target number of vertices per cluster is too small.", vertex.getCoords());
+      PRECICE_ERROR("Output vertex {} of mesh \"{}\" could not be assigned to any cluster in the rbf-pum mapping. This means that the meshes probably do not match well geometry-wise."
+                    " If you want to keep your meshes, you can try to increase the number of \"vertices-per-cluster\" (default is 100), the \"relative-overlap\" (default is 0.3)"
+                    " or disable the option \"project-to-input\".",
+                    vertex.getCoords(), outMesh->getName());
       // In principle, we could assign the vertex to the closest cluster using clusterIDs.emplace_back(clusterIndex.getClosestVertex(vertex.getCoords()).index);
       // However, this leads to a conflict with weights already set in the corresponding cluster, since we insert the ID and, later on, map the ID to a local weight index
       // Of course, we could rearrange the weights, but we want to avoid the case here anyway, i.e., prefer to abort.

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -232,9 +232,10 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
     const auto localNumberOfClusters = clusterIDs.size();
     // Consider the case where we didn't find any cluster (meshes don't match very well)
     if (localNumberOfClusters == 0) {
-      PRECICE_ERROR("Output vertex {} of mesh \"{}\" could not be assigned to any cluster in the rbf-pum mapping. This means that the meshes probably do not match well geometry-wise."
-                    " If you want to keep your meshes, you can try to increase the number of \"vertices-per-cluster\" (default is 100), the \"relative-overlap\" (default is 0.3)"
-                    " or disable the option \"project-to-input\".",
+      PRECICE_ERROR("Output vertex {} of mesh \"{}\" could not be assigned to any cluster in the rbf-pum mapping. This probably means that the meshes do not match well geometry-wise: Visualize the exported preCICE meshes to confirm."
+                    " If the meshes are fine geometry-wise, you can try to increase the number of \"vertices-per-cluster\" (default is 100), the \"relative-overlap\" (default is 0.3),"
+                    " or disable the option \"project-to-input\"."
+                    "These options are only valid for the <mapping:rbf-pum-direct/> tag.",
                     vertex.getCoords(), outMesh->getName());
       // In principle, we could assign the vertex to the closest cluster using clusterIDs.emplace_back(clusterIndex.getClosestVertex(vertex.getCoords()).index);
       // However, this leads to a conflict with weights already set in the corresponding cluster, since we insert the ID and, later on, map the ID to a local weight index


### PR DESCRIPTION
## Main changes of this PR

Give more instructive options if the mapping fails

This might be an error message the user will face more frequently, guessing that geometries might not match very well for complex shapes. The pitfall here is a bit that the error also occurs when using our config alias `<mapping:rbf ...>` (of course it does, as the alias resolves to the actual method), which doesn't offer the described options in the first place. So, in some sense our alias tag uses reasonable defaults, but in case they don't work, one has to switch from `<mapping:rbf...` to `<mapping:rbf-pum-direct OPTIONS>`. To prevent a flood of discourse requests, I would try to put some effort in a descriptive message here.

What I don't like so much about the large error message here (and the error message in general) is that it is currently located in a hot loop.
