### PR TITLE
Rewrite error message in RBF solver

### DIFF
--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -246,8 +246,8 @@ RadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::RadialBasisFctSolver(RADIAL_BASIS
   PRECICE_CHECK(decompositionSuccessful,
                 "The interpolation matrix of the RBF mapping from mesh \"{}\" to mesh \"{}\" is not invertable. "
                 "This means that the mapping problem is not well-posed. "
-                "Please check if your coupling meshes are correct. Maybe you need to fix axis-aligned mapping setups "
-                "by marking perpendicular axes as dead?",
+                "Please check if your coupling meshes are correct (e.g. no vertices are duplicated) or reconfigure "
+                "your basis-function (e.g. reduce the support-radius).",
                 inputMesh.getName(), outputMesh.getName());
 
   // Second, assemble evaluation matrix


### PR DESCRIPTION
## Main changes of this PR

Rewrite error message in RBF solver.

## Motivation and additional information

The current error message is misleading. dead-axis can only be a reason for divergence if somebody configures `polynomial=on` in the rbf mapping by hand, which nobody does. In most of the cases, there are either duplicated nodes in the mesh (I would say that's most likely the case) or people configured the RBF function too flat such that the meshes are fine but the resulting matrix is not. Not sure how understandable the latter point is, but this would be the other error message user might face in the context of PUM (or RBFs more in general), so loosely related to #1869 . 