### PR TITLE
Add reconstruction tests

### DIFF
--- a/src/testing/TestContext.hpp
+++ b/src/testing/TestContext.hpp
@@ -253,6 +253,12 @@ public:
   /// Check whether this context has a given rank inside the Participant
   bool isRank(Rank rank) const;
 
+  /// Returns a pointer to the MPI communicator of this context
+  auto comm()
+  {
+    return &(_contextComm->comm);
+  }
+
   /** Check whether this context is the primary rank of a participant
    * @note This is equivalent to `isRank(0)`
    */

--- a/tests/serial/lifecycle/reconstruction/ConstructOnly.cpp
+++ b/tests/serial/lifecycle/reconstruction/ConstructOnly.cpp
@@ -1,0 +1,27 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+BOOST_AUTO_TEST_SUITE(Reconstruction)
+BOOST_AUTO_TEST_CASE(ConstructOnly)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  for (auto n : {1, 2, 3})
+    BOOST_TEST_CONTEXT("construction #" << n)
+    {
+      precice::Participant interface(context.name, context.config(), context.rank, context.size, context.comm());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Reconstruction
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/reconstruction/ConstructOnly.xml
+++ b/tests/serial/lifecycle/reconstruction/ConstructOnly.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/lifecycle/reconstruction/Full.cpp
+++ b/tests/serial/lifecycle/reconstruction/Full.cpp
@@ -1,0 +1,50 @@
+/* Test body goes here */
+// ORIGINAL START
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+BOOST_AUTO_TEST_SUITE(Reconstruction)
+BOOST_AUTO_TEST_CASE(Full)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  for (auto n : {1, 2, 3})
+    BOOST_TEST_CONTEXT("construction #" << n)
+    {
+      precice::Participant interface(context.name, context.config(), context.rank, context.size, context.comm());
+
+      if (context.isNamed("SolverOne")) {
+        auto   meshName = "MeshOne";
+        double coords[] = {0.1, 1.2, 2.3};
+        auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+        auto   dataName = "DataOne";
+        double data[]   = {3.4, 4.5, 5.6};
+        interface.writeData(meshName, dataName, {&vertexid, 1}, data);
+      } else {
+        auto   meshName = "MeshTwo";
+        double coords[] = {0.12, 1.21, 2.2};
+        auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+        auto   dataName = "DataTwo";
+        double data[]   = {7.8};
+        interface.writeData(meshName, dataName, {&vertexid, 1}, data);
+      }
+      interface.initialize();
+      BOOST_TEST(interface.isCouplingOngoing());
+      interface.finalize();
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Reconstruction
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/reconstruction/Full.xml
+++ b/tests/serial/lifecycle/reconstruction/Full.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/lifecycle/reconstruction/ImplicitFinalize.cpp
+++ b/tests/serial/lifecycle/reconstruction/ImplicitFinalize.cpp
@@ -1,0 +1,47 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+BOOST_AUTO_TEST_SUITE(Reconstruction)
+BOOST_AUTO_TEST_CASE(ImplicitFinalize)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  for (auto n : {1, 2, 3})
+    BOOST_TEST_CONTEXT("construction #" << n)
+    {
+      precice::Participant interface(context.name, context.config(), context.rank, context.size, context.comm());
+
+      if (context.isNamed("SolverOne")) {
+        auto   meshName = "MeshOne";
+        double coords[] = {0.1, 1.2, 2.3};
+        auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+        auto   dataName = "DataOne";
+        double data[]   = {3.4, 4.5, 5.6};
+        interface.writeData(meshName, dataName, {&vertexid, 1}, data);
+      } else {
+        auto   meshName = "MeshTwo";
+        double coords[] = {0.12, 1.21, 2.2};
+        auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+        auto   dataName = "DataTwo";
+        double data[]   = {7.8};
+        interface.writeData(meshName, dataName, {&vertexid, 1}, data);
+      }
+      interface.initialize();
+      BOOST_TEST(interface.isCouplingOngoing());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Reconstruction
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/reconstruction/ImplicitFinalize.xml
+++ b/tests/serial/lifecycle/reconstruction/ImplicitFinalize.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -113,6 +113,9 @@ target_sources(testprecice
     tests/serial/lifecycle/Full.cpp
     tests/serial/lifecycle/FullWait.cpp
     tests/serial/lifecycle/ImplicitFinalize.cpp
+    tests/serial/lifecycle/reconstruction/ConstructOnly.cpp
+    tests/serial/lifecycle/reconstruction/Full.cpp
+    tests/serial/lifecycle/reconstruction/ImplicitFinalize.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds some simple tests to test reconstruction of the Participant.

This is possible since #1419

## Motivation and additional information

Related to #655
Replaces #1191

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
