### PR TITLE
Cleanup Parallel class

### DIFF
--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -51,7 +51,7 @@ void checkConfiguration(const std::string &filename, const std::string &particip
   logging::setMPIRank(0);
   const auto wasInitialized = utils::Parallel::isMPIInitialized();
   if (!wasInitialized) {
-    utils::Parallel::initializeMPI(nullptr, nullptr);
+    utils::Parallel::initializeTestingMPI(nullptr, nullptr);
   }
   xml::ConfigurationContext context{
       participant,
@@ -61,7 +61,7 @@ void checkConfiguration(const std::string &filename, const std::string &particip
   fmt::print(fmt::emphasis::bold | fg(fmt::color::green), "No major issues detected\n", filename);
   if (!wasInitialized) {
     utils::Petsc::finalize();
-    utils::Parallel::finalizeMPI();
+    utils::Parallel::finalizeTestingMPI();
   }
 }
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -112,7 +112,9 @@ ParticipantImpl::ParticipantImpl(
 #ifndef PRECICE_NO_MPI
   if (communicator.has_value()) {
     auto commptr = static_cast<utils::Parallel::Communicator *>(communicator.value());
-    utils::Parallel::registerUserProvidedComm(*commptr);
+    utils::Parallel::initializeOrDetectMPI(*commptr);
+  } else {
+    utils::Parallel::initializeOrDetectMPI();
   }
 #endif
 
@@ -168,7 +170,6 @@ void ParticipantImpl::configure(
 {
 
   config::Configuration config;
-  utils::Parallel::initializeManagedMPI(nullptr, nullptr);
   logging::setMPIRank(utils::Parallel::current()->rank());
   xml::ConfigurationContext context{
       _accessorName,
@@ -511,7 +512,7 @@ void ParticipantImpl::finalize()
   profiling::EventRegistry::instance().finalize();
 
   // Finally clear events and finalize MPI
-  utils::Parallel::finalizeManagedMPI();
+  utils::Parallel::finalizeOrCleanupMPI();
   _state = State::Finalized;
 }
 

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
   using namespace precice;
 
   precice::syncMode = false;
-  utils::Parallel::initializeMPI(&argc, &argv);
+  utils::Parallel::initializeTestingMPI(&argc, &argv);
   const auto rank = utils::Parallel::current()->rank();
   const auto size = utils::Parallel::current()->size();
   logging::setMPIRank(rank);
@@ -81,6 +81,6 @@ int main(int argc, char *argv[])
   }
 
   utils::IntraComm::getCommunication() = nullptr;
-  utils::Parallel::finalizeMPI();
+  utils::Parallel::finalizeTestingMPI();
   return retCode;
 }

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -15,9 +15,10 @@ namespace precice::utils {
 
 logging::Logger Parallel::_log("utils::Parallel");
 
-bool                   Parallel::_isInitialized           = false;
 Parallel::CommStatePtr Parallel::_currentState            = nullptr;
 bool                   Parallel::_mpiInitializedByPrecice = false;
+
+Parallel::InitializationState Parallel::_initState = Parallel::InitializationState::Uninitialized;
 
 /// BEGIN CommState
 
@@ -162,7 +163,7 @@ void Parallel::resetCommState()
 void Parallel::resetManagedMPI()
 {
   _mpiInitializedByPrecice = false;
-  _isInitialized           = false;
+  _initState               = Parallel::InitializationState::Uninitialized;
 }
 
 void Parallel::pushState(CommStatePtr newState)
@@ -177,15 +178,6 @@ void Parallel::pushState(CommStatePtr newState)
   _currentState    = std::move(newState);
 }
 
-// Parallel::Communicator Parallel::getCommunicatorWorld()
-// {
-// #ifndef PRECICE_NO_MPI
-//   return MPI_COMM_WORLD;
-// #else
-//   return nullptr;
-// #endif
-// }
-
 bool Parallel::isMPIInitialized()
 {
 #ifndef PRECICE_NO_MPI
@@ -197,78 +189,87 @@ bool Parallel::isMPIInitialized()
 #endif // not PRECICE_NO_MPI
 }
 
-void Parallel::initializeManagedMPI(
-    int *   argc,
-    char ***argv)
+void Parallel::initializeOrDetectMPI(std::optional<Communicator> userProvided)
 {
 #ifndef PRECICE_NO_MPI
-  PRECICE_TRACE();
-  PRECICE_ASSERT(!_isInitialized, "A managed MPI session already exists.");
-  PRECICE_ASSERT(!_mpiInitializedByPrecice);
-  int isMPIInitialized{-1};
-  MPI_Initialized(&isMPIInitialized);
-  if (isMPIInitialized) {
-    PRECICE_DEBUG("Initializing unmanaged MPI.");
-    _mpiInitializedByPrecice = false;
-  } else {
-    PRECICE_DEBUG("Initializing managed MPI");
-    _mpiInitializedByPrecice = true;
-    initializeMPI(argc, argv);
+  PRECICE_ASSERT(!_mpiInitializedByPrecice,
+                 "MPI cannot be initialized twice. You need to handle the MPI lifetime yourself.");
+
+  bool isInit = isMPIInitialized();
+
+  // Handle user-provided Communicator first
+  if (userProvided.has_value()) {
+    PRECICE_ASSERT(isInit, "A user-provided comm can only exist if MPI has been initialized.");
+    pushState(Parallel::CommState::fromExtern(*userProvided));
+    _initState = InitializationState::Provided;
+    return;
   }
-  _isInitialized = true;
+
+  // preCICE needs to initialize MPI itself
+  if (!isInit) {
+    MPI_Init(nullptr, nullptr);
+    _currentState            = CommState::world();
+    _initState               = InitializationState::Managed;
+    _mpiInitializedByPrecice = true;
+    return;
+  }
+
+  // preCICE is constructed in testing mode
+  if (_currentState == nullptr) {
+    // User initialized MPI but didn't pass a communicator
+    // We need to use MPI_COMM_WORLD
+    _currentState = CommState::world();
+    _initState    = InitializationState::Unmanaged;
+    return;
+  }
+
+  // We are in testing mode as \ref _currentState has been altered.
+  _initState = InitializationState::Testing;
+  return;
+#endif
+}
+
+void Parallel::finalizeOrCleanupMPI()
+{
+#ifndef PRECICE_NO_MPI
+  // Make sure all com states are freed at this point in time
+  if (_initState == InitializationState::Testing) {
+    resetCommState();
+  } else {
+    _currentState = nullptr;
+  }
+
+  if (_initState == InitializationState::Managed) {
+    MPI_Finalize();
+    PRECICE_ASSERT(_mpiInitializedByPrecice, "Something changed this state!");
+  }
+
+  _initState = InitializationState::Uninitialized;
 #endif // not PRECICE_NO_MPI
 }
 
-void Parallel::initializeMPI(
+void Parallel::initializeTestingMPI(
     int *   argc,
     char ***argv)
 {
 #ifndef PRECICE_NO_MPI
-  int isMPIInitialized{-1};
-  MPI_Initialized(&isMPIInitialized);
-  PRECICE_ASSERT(!isMPIInitialized, "MPI was already initialized.");
-  PRECICE_DEBUG("Initialize MPI");
+  PRECICE_ASSERT(!isMPIInitialized(), "MPI was already initialized.");
   MPI_Init(argc, argv);
+  // By altering the commstate, preCICE will know that it is testing mode
+  _currentState = CommState::world();
 #endif // not PRECICE_NO_MPI
 }
 
-void Parallel::finalizeManagedMPI()
+void Parallel::finalizeTestingMPI()
 {
-  PRECICE_TRACE();
-  // Make sure all com states were freed at this point in time
+  // Make sure all com states are freed at this point in time
   resetCommState();
 #ifndef PRECICE_NO_MPI
-  PRECICE_ASSERT(_isInitialized, "There is no managed MPI session.");
-  if (_mpiInitializedByPrecice) {
-    PRECICE_DEBUG("Finalizing managed MPI.");
-    finalizeMPI();
-  } else {
-    PRECICE_DEBUG("Finalizing unmanaged MPI");
-  }
-  _mpiInitializedByPrecice = false;
-  _isInitialized           = false;
-#endif // not PRECICE_NO_MPI
-}
-
-void Parallel::finalizeMPI()
-{
-#ifndef PRECICE_NO_MPI
-  PRECICE_TRACE();
-  int isMPIInitialized;
-  MPI_Initialized(&isMPIInitialized);
-  PRECICE_ASSERT(isMPIInitialized, "MPI was not initialized.");
-  PRECICE_DEBUG("Finalize MPI");
   MPI_Finalize();
 #endif // not PRECICE_NO_MPI
 }
 
-void Parallel::registerUserProvidedComm(Communicator comm)
-{
-#ifndef PRECICE_NO_MPI
-  PRECICE_TRACE();
-  pushState(Parallel::CommState::fromExtern(comm));
-#endif // not PRECICE_NO_MPI
-}
+// State altering
 
 void Parallel::splitCommunicator(const std::string &groupName)
 {
@@ -390,100 +391,15 @@ void Parallel::popState()
   }
 }
 
-// void Parallel::clearGroups()
-// {
-//   _accessorGroups.clear();
-//   _isSplit = false;
-// }
-
 int Parallel::getProcessRank()
 {
   // Do not use TRACE or DEBUG here!
 #ifndef PRECICE_NO_MPI
-  if (!_isInitialized)
-    return 0;
-
-  return getGlobalCommState()->rank();
-#else
-  return 0;
+  if (_currentState) {
+    return _currentState->rank();
+  }
 #endif // not PRECICE_NO_MPI
-}
-
-int Parallel::getLocalProcessRank()
-{
-#ifndef PRECICE_NO_MPI
-  if (!_isInitialized)
-    return 0;
-
-  return getLocalCommState()->rank();
-#else
   return 0;
-#endif // not PRECICE_NO_MPI
-}
-
-// inline int Parallel::getCommunicatorSize()
-// {
-//   return getCommunicatorSize(_globalCommunicator);
-// }
-
-// int Parallel::getCommunicatorSize(Communicator comm)
-// {
-//   PRECICE_TRACE();
-//   int communicatorSize = 1;
-// #ifndef PRECICE_NO_MPI
-//   if (_isInitialized) {
-//     MPI_Comm_size(comm, &communicatorSize);
-//   }
-// #endif // not PRECICE_NO_MPI
-//   return communicatorSize;
-// }
-
-// void Parallel::synchronizeProcesses()
-// {
-// #ifndef PRECICE_NO_MPI
-//   PRECICE_TRACE();
-//   PRECICE_ASSERT(_isInitialized);
-//   MPI_Barrier(_globalCommunicator);
-// #endif // not PRECICE_NO_MPI
-// }
-//
-// void Parallel::synchronizeLocalProcesses()
-// {
-// #ifndef PRECICE_NO_MPI
-//   PRECICE_TRACE();
-//   PRECICE_ASSERT(_isInitialized && _isSplit);
-//   MPI_Barrier(_localCommunicator);
-// #endif // not PRECICE_NO_MPI
-// }
-
-// // @TODO The freeing and cleaning behaviour is weird and needs fixing
-// void Parallel::setGlobalCommunicator(
-//     Parallel::Communicator defaultCommunicator,
-//     bool                   free)
-// {
-// #ifndef PRECICE_NO_MPI
-//   PRECICE_TRACE();
-//   if (free && _globalCommunicator != getCommunicatorWorld() && _globalCommunicator != MPI_COMM_SELF && _globalCommunicator != MPI_COMM_NULL) {
-//     MPI_Comm_free(&_globalCommunicator);
-//   }
-//   _globalCommunicator = defaultCommunicator;
-//   _localCommunicator  = _globalCommunicator;
-//   if (free)
-//     _accessorGroups.clear();
-// #endif // not PRECICE_NO_MPI
-// }
-
-const Parallel::CommStatePtr Parallel::getGlobalCommState()
-{
-  PRECICE_TRACE();
-  auto local = current();
-  return local->parent ? local->parent : CommState::world();
-}
-
-const Parallel::CommStatePtr Parallel::getLocalCommState()
-{
-  PRECICE_TRACE();
-  return current();
 }
 
 void Parallel::restrictCommunicator(int newSize)
@@ -561,13 +477,6 @@ void Parallel::restrictCommunicator(int newSize)
   pushState(CommState::fromComm(restrictedCommunicator));
 #endif // not PRECICE_NO_MPI
 }
-
-// const std::vector<Parallel::AccessorGroup> &Parallel::getAccessorGroups()
-// {
-//   PRECICE_TRACE();
-//   PRECICE_ASSERT(_isInitialized);
-//   return _accessorGroups;
-// }
 
 std::ostream &operator<<(std::ostream &out, const Parallel::CommState &value)
 {

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -304,9 +304,9 @@ void Parallel::splitCommunicator(const std::string &groupName)
       std::string name;
       com.receive(name, i); // Receive group name from all ranks
       if (groupMap.find(name) == groupMap.end()) {
-        groupMap[name] = accessorGroups.size();
+        groupMap[name] = static_cast<int>(accessorGroups.size());
         AccessorGroup newGroup;
-        newGroup.id         = accessorGroups.size();
+        newGroup.id         = static_cast<int>(accessorGroups.size());
         newGroup.size       = 1;
         newGroup.leaderRank = i;
         newGroup.name       = name;
@@ -450,7 +450,7 @@ void Parallel::restrictCommunicator(int newSize)
   // Create subgroup, containing processes contained in ranks
   PRECICE_DEBUG("Create restricted group");
   MPI_Group restrictedGroup;
-  MPI_Group_incl(currentGroup, ranks.size(), ranks.data(), &restrictedGroup);
+  MPI_Group_incl(currentGroup, static_cast<int>(ranks.size()), ranks.data(), &restrictedGroup);
 
   // @todo check if it has to go back down to the other group free
   MPI_Group_free(&currentGroup);

--- a/src/utils/Parallel.hpp
+++ b/src/utils/Parallel.hpp
@@ -2,6 +2,7 @@
 
 #include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -133,46 +134,47 @@ public:
   /// Return true if MPI is initialized
   static bool isMPIInitialized();
 
-  /**
-   * @brief Initializes the MPI environment and manages it.
+  /** Initializes or detects an existing MPI environment
    *
-   * This keeps track of the state when called by setting _isInitialized and _mpiInitializedByPrecice
-   * To finalize the managed MPI call @ref finalizeManagedMPI().
+   * If a custom MPI Communicator is provided via \ref userProvided then this registers a user-provided MPI session.
+   *
+   * If MPI has already been initialized, then preCICE uses MPI_COMM_WORLD as communicator
+   * and registers a unmanaged MPI session.
+   * If \ref _currentState isn't nullptr, then this signals launch inside a test.
+   *
+   * If MPI hasn't been initialized yet, then preCICE takes ownership.
+   * It initializes the environment and will later destroy it.
+   * As MPI forbids reinitialization, this prevents reconstruction.
+   *
+   * @param[in] userProvided an optional user-provided Communicator
+   *
+   * @see finalizeOrCleanupMPI()
+   */
+  static void initializeOrDetectMPI(std::optional<Communicator> userProvided = std::nullopt);
+
+  /**
+   * @brief Finalized a managed MPI environment or cleans up after an non-managed session.
+   *
+   * To initialize the managed MPI call @ref initializeOrDetectMPI().
+   * This finalizes MPI only if the preCICE initialized the MPI session itself.
+   *
+   * @see initializeOrDetectMPI()
+   */
+  static void finalizeOrCleanupMPI();
+
+  /** Unconditionally initializes the MPI environment.
+   *
+   * Alters the \ref _currentState, which indicates a testing session.
    *
    * @param[in] argc Parameter count
    * @param[in] argv Parameter values, is passed to MPI_Init
-   *
-   * @see finalizeManagedMPI
    */
-  static void initializeManagedMPI(
+  static void initializeTestingMPI(
       int *   argc,
       char ***argv);
-
-  /**
-   * @brief Unconditionally initializes the MPI environment.
-   *
-   * @param[in] argc Parameter count
-   * @param[in] argv Parameter values, is passed to MPI_Init
-   */
-  static void initializeMPI(
-      int *   argc,
-      char ***argv);
-
-  /**
-   * @brief Finalized a managed MPI environment.
-   *
-   * To initialize the managed MPI call @ref initializeManagedMPI().
-   * This finalizes MPI only if it was not initialized before the call to @ref initializeManagedMPI()
-   *
-   * @see InitializeManagedMPI
-   */
-  static void finalizeManagedMPI();
 
   /// Unconditionally finalizes MPI environment.
-  static void finalizeMPI();
-
-  /// Registers a user-provided communicator
-  static void registerUserProvidedComm(Communicator comm);
+  static void finalizeTestingMPI();
 
   /// @}
 
@@ -222,83 +224,13 @@ public:
   static void popState();
   /// @}
 
-  /// @name State Access
-  /// @{
-
-  /// clears groups for communicator splitting
-  // @todo remove
-  // static void clearGroups(){};
-
-  /// Returns the global process rank.
-  //@todo remove
-  static Rank getProcessRank();
-
-  /**
-   * @brief Returns the local process rank.
-   *
-   * If only one accessor group is present, returns getProcessRank().
-   */
-  //@todo remove
-  static Rank getLocalProcessRank();
-
-  /// Returns the number of processes in the global communicator.
-  //@todo remove
-  // static int getCommunicatorSize();
-
-  /// Returns the number of processes in the given communicator.
-  //@todo remove
-  // static int getCommunicatorSize(Communicator comm);
-
-  /// Synchronizes all processes.
-  //@todo remove
-  // static void synchronizeProcesses();
-
-  /**
-   * @brief Synchronizes all local processes.
-   *
-   * If only one accessor group is present, calls synchcronizeProcesses().
-   */
-  //@todo remove
-  // static void synchronizeLocalProcesses();
-
-  /**
-   * @brief Switches precice communication away from global space to given one.
-   *
-   * The switch has only effects on communication means created after the
-   * switch. The ones before stay in their old communication universe.
-   * Standard communication space is MPI_COMM_WORLD. The local process rank
-   * and communicator size is recomputed, relative to the new default
-   * communicator.
-   *
-   * @param[in] defaultCommunicator The new global/default Communicator
-   * @param[in] free free the old communicator?
-   *
-   * @attention Will result in an error, if called by a process not in the new
-   *            default communicator!
-   */
-  //static void setGlobalCommunicator(Communicator defaultCommunicator, bool free = true);
-
-  /// @}
-
   /// @name Misc
   /// @{
 
-  /** Returns an owning pointer to the global CommState, being the parent of the current CommState
-   *
-   * @note Calling this on World returns World.
-   *
-   * @see getLocalCommunicator()
+  /** Returns the global process rank or 0
+   * used in assertions.
    */
-  static const CommStatePtr getGlobalCommState();
-
-  /**
-   * @brief Returns an owning pointer to the local CommState, being the current CommState
-   *
-   * @note equivalent to calling current()
-   *
-   * @see getGlobalCommunicator()
-   */
-  static const CommStatePtr getLocalCommState();
+  static Rank getProcessRank();
 
   /// Returns an owning pointer to the current CommState.
   static CommStatePtr current();
@@ -310,9 +242,19 @@ private:
 
   static CommStatePtr _currentState;
 
-  static bool _isInitialized;
-
+  /// Flag to saveguard against reinitializing MPI, which is forbidden
   static bool _mpiInitializedByPrecice;
+
+  /// Kind of initialization that took place
+  enum struct InitializationState {
+    Uninitialized, /// Not initialized
+    Provided,      /// Communicator was provided by the user
+    Managed,       /// preCICE manages the lifetime of the MPI environment
+    Unmanaged,     /// preCICE was initialized in an existing MPI environment
+    Testing        /// preCICE was initialized in a testing environment initialized with \ref initializeTestingMPI()
+  };
+
+  static InitializationState _initState;
 
   /** Pushes a new state on the state stack
    *


### PR DESCRIPTION
## Main changes of this PR

This PR cleans up the Parallel utility-class.

It is now more strict when detection reconstruction of the Participant which would require reinitalization of MPI, which is forbidden by the standard.

It also allows to reconstruct a Participant sessions, where MPI was initialized outside of preCICE, but no communicator was passed to the Participant constructor.
This direclty resolves https://github.com/precice/precice/issues/828 , assuming that mpi4py initializes MPI before the Participant is initialized.

## Motivation and additional information

Closes #828

Removes code kept for backwards compatibility with the "old" test system.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
