### PR TITLE
Remove time from performAction

### DIFF
--- a/src/action/Action.hpp
+++ b/src/action/Action.hpp
@@ -3,8 +3,7 @@
 #include "mapping/Mapping.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace action {
+namespace precice::action {
 
 /**
  * @brief Abstract base class for configurable actions on data and/or meshes.
@@ -41,14 +40,12 @@ public:
   Action &operator=(Action &&) = delete;
 
   /// Destructor, empty.
-  virtual ~Action() {}
+  virtual ~Action() = default;
 
   /**
    * @brief Performs the action, to be overwritten by subclasses.
-   *
-   * @param[in] time the current total simulation time.
    */
-  virtual void performAction(double time) = 0;
+  virtual void performAction() = 0;
 
   /// Returns the timing of the action.
   Timing getTiming() const
@@ -79,5 +76,4 @@ private:
   mapping::Mapping::MeshRequirement _meshRequirement = mapping::Mapping::MeshRequirement::UNDEFINED;
 };
 
-} // namespace action
-} // namespace precice
+} // namespace precice::action

--- a/src/action/PythonAction.hpp
+++ b/src/action/PythonAction.hpp
@@ -9,8 +9,7 @@
 struct _object;
 using PyObject = _object;
 
-namespace precice {
-namespace action {
+namespace precice::action {
 
 /// Action whose implementation is given in a Python file.
 class PythonAction : public Action {
@@ -25,7 +24,7 @@ public:
 
   virtual ~PythonAction();
 
-  virtual void performAction(double time) override;
+  virtual void performAction() final override;
 
 private:
   logging::Logger _log{"action::PythonAction"};
@@ -57,7 +56,6 @@ private:
   int makeNumPyArraysAvailable();
 };
 
-} // namespace action
-} // namespace precice
+} // namespace precice::action
 
 #endif

--- a/src/action/RecorderAction.cpp
+++ b/src/action/RecorderAction.cpp
@@ -10,10 +10,9 @@ RecorderAction::RecorderAction(
     const mesh::PtrMesh &mesh)
     : Action(timing, mesh) {}
 
-void RecorderAction::performAction(double time)
+void RecorderAction::performAction()
 {
-  records.push_back(Record{
-      getTiming(), time});
+  records.push_back(Record{getTiming()});
 }
 
 std::vector<RecorderAction::Record> RecorderAction::records{};

--- a/src/action/RecorderAction.hpp
+++ b/src/action/RecorderAction.hpp
@@ -4,8 +4,7 @@
 #include "action/Action.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace action {
+namespace precice::action {
 
 /// Action that records invocations for testing purposes
 class RecorderAction : public Action {
@@ -22,11 +21,10 @@ public:
       const mesh::PtrMesh &mesh);
 
   /// Records the invocation and appends it to the records
-  virtual void performAction(double time) override;
+  virtual void performAction() final override;
 
   struct Record {
     Timing timing;
-    double time;
   };
 
   /// resets the saved records.
@@ -35,5 +33,4 @@ public:
   static std::vector<Record> records;
 };
 
-} // namespace action
-} // namespace precice
+} // namespace precice::action

--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -23,7 +23,7 @@ ScaleByAreaAction::ScaleByAreaAction(
 {
 }
 
-void ScaleByAreaAction::performAction(double time)
+void ScaleByAreaAction::performAction()
 {
   PRECICE_TRACE();
   const int meshDimensions = getMesh()->getDimensions();

--- a/src/action/ScaleByAreaAction.hpp
+++ b/src/action/ScaleByAreaAction.hpp
@@ -5,15 +5,7 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace mesh {
-class Edge;
-class Triangle;
-} // namespace mesh
-} // namespace precice
-
-namespace precice {
-namespace action {
+namespace precice::action {
 
 class ScaleByAreaAction : public Action {
 public:
@@ -36,12 +28,10 @@ public:
       const mesh::PtrMesh &mesh,
       Scaling              scaling);
 
-  virtual ~ScaleByAreaAction() {}
-
   /**
    * @brief Scales data on mesh nodes according to selected scaling type.
    */
-  virtual void performAction(double time) override;
+  void performAction() final override;
 
 private:
   logging::Logger _log{"action::ScaleByAreaAction"};
@@ -51,5 +41,4 @@ private:
   Scaling _scaling;
 };
 
-} // namespace action
-} // namespace precice
+} // namespace precice::action

--- a/src/action/SummationAction.cpp
+++ b/src/action/SummationAction.cpp
@@ -27,7 +27,7 @@ SummationAction::SummationAction(
   }
 }
 
-void SummationAction::performAction(double time)
+void SummationAction::performAction()
 {
   PRECICE_TRACE();
 

--- a/src/action/SummationAction.hpp
+++ b/src/action/SummationAction.hpp
@@ -6,8 +6,7 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace action {
+namespace precice::action {
 
 /// Action that adds multiple source data into target data
 class SummationAction : public Action {
@@ -26,10 +25,8 @@ public:
       int                     targetDataID,
       const mesh::PtrMesh &   mesh);
 
-  virtual ~SummationAction() {}
-
   /// Adding data and applying them to target
-  virtual void performAction(double time) override;
+  void performAction() final override;
 
 private:
   logging::Logger _log{"action::SummationAction"};
@@ -38,5 +35,4 @@ private:
   std::vector<mesh::PtrData> _sourceDataVector;
 };
 
-} // namespace action
-} // namespace precice
+} // namespace precice::action

--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -37,14 +37,14 @@ BOOST_AUTO_TEST_CASE(PerformActionWithGlobalIterationsCounter)
   mesh->data(sourceID)->setSampleAtTime(1, time::Sample{1, v});
   mesh->data(targetID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->vertices().size())});
 
-  action.performAction(0.0);
+  action.performAction();
 
   Eigen::VectorXd result(3);
   result << 1.1, 1.2, 1.3;
   BOOST_TEST(testing::equals(mesh->data(targetID)->values(), result));
   mesh->data(sourceID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->vertices().size())});
 
-  action.performAction(0.0);
+  action.performAction();
 
   result << 2.0, 2.0, 2.0;
   BOOST_TEST(testing::equals(mesh->data(targetID)->values(), result));

--- a/src/action/tests/ScaleActionTest.cpp
+++ b/src/action/tests/ScaleActionTest.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(DivideByArea2D)
       action::ScaleByAreaAction::WRITE_MAPPING_POST, dataID, mesh,
       action::ScaleByAreaAction::SCALING_DIVIDE_BY_AREA);
 
-  scale.performAction(0.0);
+  scale.performAction();
 
   BOOST_TEST(values(0) == 4.0);
   BOOST_TEST(values(1) == 3.0);
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(DivideByArea3D)
       action::ScaleByAreaAction::WRITE_MAPPING_POST, dataID, mesh,
       action::ScaleByAreaAction::SCALING_DIVIDE_BY_AREA);
 
-  scale.performAction(0.0);
+  scale.performAction();
 
   BOOST_TEST(values(0) == 0.5);
   BOOST_TEST(values(1) == 1.5);

--- a/src/action/tests/SummationActionTest.cpp
+++ b/src/action/tests/SummationActionTest.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(SummationOneDimensional)
   action::SummationAction sum(
       action::SummationAction::WRITE_MAPPING_POST, sourceDataIDs, targetDataID, mesh);
 
-  sum.performAction(0.0);
+  sum.performAction();
 
   const auto &sourceValues1 = sourceData1->values();
   const auto &sourceValues2 = sourceData2->values();
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(SummationThreeDimensional)
   action::SummationAction sum(
       action::SummationAction::WRITE_MAPPING_POST, sourceDataIDs, targetDataID, mesh);
 
-  sum.performAction(0.0);
+  sum.performAction();
 
   const auto &sourceValues1 = sourceData1->values();
   const auto &sourceValues2 = sourceData2->values();
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(SummationThreeDimensionalSubcycling)
   action::SummationAction sum(
       action::SummationAction::WRITE_MAPPING_POST, sourceDataIDs, targetDataID, mesh);
 
-  sum.performAction(0.0);
+  sum.performAction();
 
   const auto &sourceValues1 = sourceData1->values();
   const auto &sourceValues2 = sourceData2->values();

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -322,13 +322,13 @@ void ParticipantImpl::initialize()
   }
 
   mapWrittenData();
-  performDataActions({action::Action::WRITE_MAPPING_POST}, 0.0);
+  performDataActions({action::Action::WRITE_MAPPING_POST});
 
   PRECICE_DEBUG("Initialize coupling schemes");
   _couplingScheme->initialize(time, timeWindow);
 
   mapReadData();
-  performDataActions({action::Action::READ_MAPPING_POST}, 0.0);
+  performDataActions({action::Action::READ_MAPPING_POST});
 
   PRECICE_DEBUG("Plot output");
   _accessor->exportInitial();
@@ -401,7 +401,7 @@ void ParticipantImpl::handleDataBeforeAdvance(bool reachedTimeWindowEnd, double 
 
   if (reachedTimeWindowEnd) {
     mapWrittenData();
-    performDataActions({action::Action::WRITE_MAPPING_POST}, timeSteppedTo);
+    performDataActions({action::Action::WRITE_MAPPING_POST});
   }
 }
 
@@ -415,7 +415,7 @@ void ParticipantImpl::handleDataAfterAdvance(bool reachedTimeWindowEnd, bool isT
   if (reachedTimeWindowEnd) {
     mapReadData();
     // FIXME: the actions timing for read mappings doesn't make sense after
-    performDataActions({action::Action::READ_MAPPING_POST}, timeAfterAdvance);
+    performDataActions({action::Action::READ_MAPPING_POST});
   }
 
   if (isTimeWindowComplete) {
@@ -1399,14 +1399,12 @@ void ParticipantImpl::mapReadData()
   }
 }
 
-void ParticipantImpl::performDataActions(
-    const std::set<action::Action::Timing> &timings,
-    double                                  time)
+void ParticipantImpl::performDataActions(const std::set<action::Action::Timing> &timings)
 {
   PRECICE_TRACE();
   for (action::PtrAction &action : _accessor->actions()) {
     if (timings.find(action->getTiming()) != timings.end()) {
-      action->performAction(time);
+      action->performAction();
     }
   }
 }

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -373,11 +373,8 @@ private:
    * @brief Performs all data actions with given timing.
    *
    * @param[in] timings the timings of the action.
-   * @param[in] time the current total simulation time.
    */
-  void performDataActions(
-      const std::set<action::Action::Timing> &timings,
-      double                                  time);
+  void performDataActions(const std::set<action::Action::Timing> &timings);
 
   /**
    * @brief Resets written data.


### PR DESCRIPTION
## Main changes of this PR

This PR removes time from `Action::performAction()` as the time is now given by the processed Stample.

## Motivation and additional information

Closes #1864

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.
