### PR TITLE
Fix zero write data bug

### DIFF
--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1427,7 +1427,7 @@ void ParticipantImpl::resetWrittenData()
 {
   PRECICE_TRACE();
   for (auto &context : _accessor->writeDataContexts()) {
-    context.resetData();
+    context.resetBuffer();
   }
 }
 

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -13,12 +13,8 @@ WriteDataContext::WriteDataContext(mesh::PtrData data,
 {
 }
 
-void WriteDataContext::resetData()
+void WriteDataContext::resetBuffer()
 {
-  // See also https://github.com/precice/precice/issues/1156.
-  _providedData->toZero();
-
-  // reset writeDataBuffer
   _writeDataBuffer.values.setZero();
   _writeDataBuffer.gradients.setZero();
 }

--- a/src/precice/impl/WriteDataContext.hpp
+++ b/src/precice/impl/WriteDataContext.hpp
@@ -26,8 +26,8 @@ public:
       mesh::PtrData data,
       mesh::PtrMesh mesh);
 
-  /// Resets provided data and writeDataBuffer
-  void resetData();
+  /// Resets writeDataBuffer
+  void resetBuffer();
 
   /**
    * @brief Removes stample before \ref time and (if mapping exists) fromData or toData


### PR DESCRIPTION
## Main changes of this PR

Fixed a regression introduced by #1705.

After converting the written data to a sample, I zeroed the write buffer and mistakenly zeroed the `values()`.

## Motivation and additional information

Shame

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
