### PR TITLE
Fix type mismatch in Config Parser

### DIFF
--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -85,7 +85,7 @@ void OnCharacters(void *ctx, const xmlChar *ch, int len)
   pParser->OnTextSection(std::string(reinterpret_cast<const char *>(ch), len));
 }
 
-void OnStructuredErrorFunc(void *userData, xmlError *error)
+void OnStructuredErrorFunc(void *userData, const xmlError *error)
 {
   const std::string message{error->message};
 

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -97,6 +97,12 @@ void OnStructuredErrorFunc(void *userData, const xmlError *error)
   ConfigParser::MessageProxy(error->level, message);
 }
 
+// Required for versions before 2.12.0 of libxml
+void OnStructuredErrorFunc(void *userData, xmlError *error)
+{
+  OnStructuredErrorFunc(userData, static_cast<const xmlError *>(error));
+}
+
 void OnErrorFunc(void *userData, const char *error, ...)
 {
   ConfigParser::MessageProxy(XML_ERR_ERROR, error);


### PR DESCRIPTION
## Main changes of this PR

This fixes a type mismatch due to a changed function signature in libxml 2.12.0.

## Motivation and additional information

~~Still unclear if this is backwards compatible.~~

I used an overload set instead.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
