### PR TITLE
More explicit time management in BaseCouplingScheme

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -359,14 +359,12 @@ void BaseCouplingScheme::secondExchange()
         // coupling iteration.
         PRECICE_ASSERT(math::greater(_computedTimeWindowPart, 0.0));
         _timeWindows -= 1;
-        _computedTimeWindowPart = 0.0; // reset window
-      } else {                         // write output, prepare for next window
+        _isTimeWindowComplete = false;
+      } else { // write output, prepare for next window
         PRECICE_DEBUG("Convergence achieved");
         advanceTXTWriters();
         PRECICE_INFO("Time window completed");
         _isTimeWindowComplete = true;
-        _timeWindowStartTime += _timeWindowSize;
-        _computedTimeWindowPart = 0.0; // reset window
         if (isCouplingOngoing()) {
           PRECICE_DEBUG("Setting require create checkpoint");
           requireAction(CouplingScheme::Action::WriteCheckpoint);
@@ -380,15 +378,20 @@ void BaseCouplingScheme::secondExchange()
         _iterations = 1;
       }
     } else {
+      PRECICE_ASSERT(isExplicitCouplingScheme());
       PRECICE_INFO("Time window completed");
       _isTimeWindowComplete = true;
-      _timeWindowStartTime += _timeWindowSize;
-      _computedTimeWindowPart = 0.0; // reset window
     }
     if (isCouplingOngoing()) {
       PRECICE_ASSERT(_hasDataBeenReceived);
     }
-    _timeWindowSize = _nextTimeWindowSize;
+
+    // Update internal time tracking
+    if (_isTimeWindowComplete) {
+      _timeWindowStartTime += _timeWindowSize;
+    }
+    _computedTimeWindowPart = 0.0; // reset window
+    _timeWindowSize         = _nextTimeWindowSize;
   }
 }
 

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -370,7 +370,6 @@ void BaseCouplingScheme::secondExchange()
         if (isCouplingOngoing()) {
           PRECICE_DEBUG("Setting require create checkpoint");
           requireAction(CouplingScheme::Action::WriteCheckpoint);
-          _timeWindowSize = _nextTimeWindowSize;
         }
       }
       //update iterations
@@ -388,8 +387,8 @@ void BaseCouplingScheme::secondExchange()
     }
     if (isCouplingOngoing()) {
       PRECICE_ASSERT(_hasDataBeenReceived);
-      _timeWindowSize = _nextTimeWindowSize;
     }
+    _timeWindowSize = _nextTimeWindowSize;
   }
 }
 

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -311,6 +311,12 @@ protected:
   void setTimeWindowSize(double timeWindowSize);
 
   /**
+   * @brief Setter for _nextTimeWindowSize
+   * @param timeWindowSize
+   */
+  void setNextTimeWindowSize(double timeWindowSize);
+
+  /**
    * @brief Getter for _computedTimeWindowPart
    * @returns _computedTimeWindowPart
    */
@@ -410,7 +416,10 @@ private:
   int _timeWindows = 0;
 
   /// size of time window; _timeWindowSize <= _maxTime
-  double _timeWindowSize;
+  double _timeWindowSize = UNDEFINED_TIME_WINDOW_SIZE;
+
+  /// time window size of next window (acts as buffer for time windows size provided by first participant, if using first participant method)
+  double _nextTimeWindowSize = UNDEFINED_TIME_WINDOW_SIZE;
 
   /// Part of the window that is already computed; _computedTimeWindowPart <= _timeWindowSize
   double _computedTimeWindowPart = 0;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -311,6 +311,12 @@ protected:
   void setTimeWindowSize(double timeWindowSize);
 
   /**
+   * @brief Getter for _nextTimeWindowSize
+   * @param timeWindowSize
+   */
+  double getNextTimeWindowSize() const;
+
+  /**
    * @brief Setter for _nextTimeWindowSize
    * @param timeWindowSize
    */

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -58,11 +58,6 @@ SerialCouplingScheme::SerialCouplingScheme(
     CouplingMode                  cplMode)
     : SerialCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, minTimeStepSize, firstParticipant, secondParticipant, localParticipant, std::move(m2n), dtMethod, cplMode, UNDEFINED_MAX_ITERATIONS, UNDEFINED_MAX_ITERATIONS){};
 
-void SerialCouplingScheme::setNextTimeWindowSize(double timeWindowSize)
-{
-  BaseCouplingScheme::setNextTimeWindowSize(timeWindowSize);
-}
-
 void SerialCouplingScheme::sendTimeWindowSize()
 {
   PRECICE_TRACE();

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -111,6 +111,7 @@ void SerialCouplingScheme::exchangeInitialData()
     // similar to SerialCouplingScheme::exchangeSecondData()
     PRECICE_DEBUG("Receiving data...");
     receiveAndSetTimeWindowSize();
+    setTimeWindowSize(getNextTimeWindowSize()); // Needed, because second participant just received _timeWindowSize from first participant, if serial coupling scheme using first participant method.
     receiveDataForWindowEnd(getM2N(), getReceiveData());
     notifyDataHasBeenReceived();
   }

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -58,18 +58,19 @@ SerialCouplingScheme::SerialCouplingScheme(
     CouplingMode                  cplMode)
     : SerialCouplingScheme(maxTime, maxTimeWindows, timeWindowSize, minTimeStepSize, firstParticipant, secondParticipant, localParticipant, std::move(m2n), dtMethod, cplMode, UNDEFINED_MAX_ITERATIONS, UNDEFINED_MAX_ITERATIONS){};
 
-void SerialCouplingScheme::setTimeWindowSize(double timeWindowSize)
+void SerialCouplingScheme::setNextTimeWindowSize(double timeWindowSize)
 {
-  PRECICE_ASSERT(not _participantSetsTimeWindowSize);
-  BaseCouplingScheme::setTimeWindowSize(timeWindowSize);
+  BaseCouplingScheme::setNextTimeWindowSize(timeWindowSize);
 }
 
 void SerialCouplingScheme::sendTimeWindowSize()
 {
   PRECICE_TRACE();
   if (_participantSetsTimeWindowSize) {
-    PRECICE_DEBUG("sending time window size of {}", getComputedTimeWindowPart());
-    getM2N()->send(getComputedTimeWindowPart());
+    setTimeWindowSize(getComputedTimeWindowPart());
+    setNextTimeWindowSize(UNDEFINED_TIME_WINDOW_SIZE);
+    PRECICE_DEBUG("sending time window size of {}", getTimeWindowSize());
+    getM2N()->send(getTimeWindowSize());
   }
 }
 
@@ -88,7 +89,7 @@ void SerialCouplingScheme::receiveAndSetTimeWindowSize()
       PRECICE_CHECK(dt == getTimeWindowSize(), "May only use a larger time window size in the first iteration of the window. Otherwise old time window size must equal new time window size.");
     }
 
-    setTimeWindowSize(dt);
+    setNextTimeWindowSize(dt);
   }
 }
 

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -67,10 +67,10 @@ public:
 
 protected:
   /**
-   * @brief Setter for _timeWindowSize
+   * @brief Setter for _nextTimeWindowSize
    * @param timeWindowSize
    */
-  void setTimeWindowSize(double timeWindowSize);
+  void setNextTimeWindowSize(double timeWindowSize);
 
 private:
   logging::Logger _log{"cplschemes::SerialCouplingSchemes"};

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -65,13 +65,6 @@ public:
       constants::TimesteppingMethod dtMethod,
       CouplingMode                  cplMode);
 
-protected:
-  /**
-   * @brief Setter for _nextTimeWindowSize
-   * @param timeWindowSize
-   */
-  void setNextTimeWindowSize(double timeWindowSize);
-
 private:
   logging::Logger _log{"cplschemes::SerialCouplingSchemes"};
 

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipant)
           timeInWindow = 0;
         }
 
-        if (context.isNamed("SolverOne")) {
+        if (context.isNamed("SolverOne") && precice.isCouplingOngoing()) {
           // Check remainder of simulation time
           BOOST_TEST(precice.getMaxTimeStepSize() == totalTime - startOfWindowTime - timeInWindow);
         }

--- a/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
+++ b/tests/serial/time/implicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipant)
           timeInWindow = 0;
         }
 
-        if (context.isNamed("SolverOne") && precice.isCouplingOngoing()) {
+        if (context.isNamed("SolverOne")) {
           // Check remainder of simulation time
           BOOST_TEST(precice.getMaxTimeStepSize() == totalTime - startOfWindowTime - timeInWindow);
         }


### PR DESCRIPTION
## Main changes of this PR

* Introduce `_nextTimeWindowSize` as a buffer for time window size received in the participant first method
* Explicitly set `_timeWindowSize = _nextTimeWindowSize` when at end of `advance`
* Use `_computedTimeWindowPart` only to track current point in time, not to move `_timeWindowStartTime` to next window.

## Motivation and additional information

The way how preCICE tracks participant and its internal time is complicated. I'm trying to simplify things with this refactoring.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] ~~I added a changelog file with `make changelog` if there are user-observable changes since the last release.~~ Not relevant, only refactoring
* [x] ~~I added a test to cover the proposed changes in our test suite.~~ Not relevant, only refactoring
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
