### PR TITLE
Fix const relax acceleration

### DIFF
--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -59,24 +59,3 @@ void Acceleration::concatenateCouplingData(
   }
 }
 } // namespace precice::acceleration
-//
-//
-
-#if 0
-
-  for (auto &pair : cplData) {
-    auto &couplingData = *(pair.second);
-
-    for (auto &stample : couplingData.timeStepsStorage().stamples()) {
-      auto &values    = stample.sample.values;
-      auto  oldValues = couplingData.getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
-      values          = values * omega + oldValues * (1.0 - omega);
-
-      if (couplingData.hasGradient()) {
-        auto &gradients    = stample.sample.gradients;
-        auto  oldGradients = couplingData.getPreviousGradientsAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
-        gradients          = gradients * omega + oldGradients * (1.0 - omega);
-      }
-    }
-  }
-#endif

--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -14,26 +14,30 @@ void Acceleration::checkDataIDs(const DataMap &cplData) const
 #endif
 }
 
-void Acceleration::applyRelaxation(double omega, const DataMap &cplData) const
+void Acceleration::applyRelaxation(double omega, DataMap &cplData)
 {
-  for (const DataMap::value_type &pair : cplData) {
-    const auto couplingData = pair.second;
+  for (auto &pair : cplData) {
+    auto &couplingData = *(pair.second);
 
-    for (auto &stample : couplingData->stamples()) {
-      auto values            = stample.sample.values;
-      auto oldValues         = couplingData->getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
-      couplingData->values() = values * omega;
-      couplingData->values() += oldValues * (1 - omega);
-
-      if (couplingData->hasGradient()) {
-        auto       gradients      = stample.sample.gradients;
-        const auto oldGradients   = couplingData->getPreviousGradientsAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
-        couplingData->gradients() = gradients * omega;
-        couplingData->gradients() += oldGradients * (1 - omega);
-      }
-
-      couplingData->setSampleAtTime(stample.timestamp, couplingData->sample());
+    if (couplingData.timeStepsStorage().empty()) {
+      continue;
     }
+
+    for (auto &stample : couplingData.timeStepsStorage().stamples()) {
+      auto &values    = stample.sample.values;
+      auto  oldValues = couplingData.getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
+      values          = values * omega + oldValues * (1.0 - omega);
+
+      if (couplingData.hasGradient()) {
+        auto &gradients    = stample.sample.gradients;
+        auto  oldGradients = couplingData.getPreviousGradientsAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
+        gradients          = gradients * omega + oldGradients * (1.0 - omega);
+      }
+    }
+
+    // @todo remove
+    // update the "sample"
+    couplingData.sample() = couplingData.timeStepsStorage().last().sample;
   }
 }
 
@@ -55,3 +59,24 @@ void Acceleration::concatenateCouplingData(
   }
 }
 } // namespace precice::acceleration
+//
+//
+
+#if 0
+
+  for (auto &pair : cplData) {
+    auto &couplingData = *(pair.second);
+
+    for (auto &stample : couplingData.timeStepsStorage().stamples()) {
+      auto &values    = stample.sample.values;
+      auto  oldValues = couplingData.getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
+      values          = values * omega + oldValues * (1.0 - omega);
+
+      if (couplingData.hasGradient()) {
+        auto &gradients    = stample.sample.gradients;
+        auto  oldGradients = couplingData.getPreviousGradientsAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
+        gradients          = gradients * omega + oldGradients * (1.0 - omega);
+      }
+    }
+  }
+#endif

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -34,7 +34,7 @@ public:
 
   virtual void initialize(const DataMap &cpldata) = 0;
 
-  virtual void performAcceleration(const DataMap &cpldata) = 0;
+  virtual void performAcceleration(DataMap &cpldata) = 0;
 
   virtual void iterationsConverged(const DataMap &cpldata) = 0;
 
@@ -68,7 +68,7 @@ protected:
   void concatenateCouplingData(const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const;
 
   /// performs a relaxation given a relaxation factor omega
-  void applyRelaxation(double omega, const DataMap &cplData) const;
+  static void applyRelaxation(double omega, DataMap &cplData);
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -60,7 +60,7 @@ void AitkenAcceleration::initialize(const DataMap &cplData)
 }
 
 void AitkenAcceleration::performAcceleration(
-    const DataMap &cplData)
+    DataMap &cplData)
 {
   PRECICE_TRACE();
 

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -31,7 +31,7 @@ public:
       const DataMap &cpldata);
 
   virtual void performAcceleration(
-      const DataMap &cpldata);
+      DataMap &cpldata);
 
   virtual void iterationsConverged(
       const DataMap &cpldata);

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -273,7 +273,7 @@ void BaseQNAcceleration::updateDifferenceMatrices(
  *  ---------------------------------------------------------------------------------------------
  */
 void BaseQNAcceleration::performAcceleration(
-    const DataMap &cplData)
+    DataMap &cplData)
 {
   PRECICE_TRACE(_dataIDs.size(), cplData.size());
 

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -103,7 +103,7 @@ public:
    *
    * Has to be called after every implicit coupling iteration.
    */
-  virtual void performAcceleration(const DataMap &cplData);
+  virtual void performAcceleration(DataMap &cplData);
 
   /**
    * @brief Marks a iteration sequence as converged.

--- a/src/acceleration/ConstantRelaxationAcceleration.cpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.cpp
@@ -29,7 +29,7 @@ void ConstantRelaxationAcceleration::initialize(const DataMap &cplData)
   checkDataIDs(cplData);
 }
 
-void ConstantRelaxationAcceleration::performAcceleration(const DataMap &cplData)
+void ConstantRelaxationAcceleration::performAcceleration(DataMap &cplData)
 {
   PRECICE_TRACE();
   applyRelaxation(_relaxation, cplData);

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -23,7 +23,7 @@ public:
 
   virtual void initialize(const DataMap &cplData) override;
 
-  virtual void performAcceleration(const DataMap &cplData) override;
+  virtual void performAcceleration(DataMap &cplData) override;
 
   virtual void iterationsConverged(const DataMap &cplData) override
   {

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -515,6 +515,8 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
 
   acc.performAcceleration(data);
 
+  // 0.2 * 0.6 + 0.1 * 0.4 = 0.12 + 0.04 = 0.16
+
   BOOST_TEST(data.at(0)->values()(0) == 2);
   BOOST_TEST(data.at(0)->values()(1) == 2);
   BOOST_TEST(data.at(0)->values()(2) == 2.6);
@@ -523,6 +525,8 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
   BOOST_TEST(data.at(1)->values()(1) == 0.16);
   BOOST_TEST(data.at(1)->values()(2) == 0.16);
   BOOST_TEST(data.at(1)->values()(3) == 0.16);
+
+#if 0
 
   displacements->values() << 10, 10, 10, 10;
   displacements->setSampleAtTime(1.0, displacements->sample());
@@ -538,6 +542,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
   BOOST_TEST(data.at(1)->values()(1) == 0.184);
   BOOST_TEST(data.at(1)->values()(2) == 0.184);
   BOOST_TEST(data.at(1)->values()(3) == 0.184);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithoutSubsteps)

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -515,8 +515,6 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
 
   acc.performAcceleration(data);
 
-  // 0.2 * 0.6 + 0.1 * 0.4 = 0.12 + 0.04 = 0.16
-
   BOOST_TEST(data.at(0)->values()(0) == 2);
   BOOST_TEST(data.at(0)->values()(1) == 2);
   BOOST_TEST(data.at(0)->values()(2) == 2.6);
@@ -525,8 +523,6 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
   BOOST_TEST(data.at(1)->values()(1) == 0.16);
   BOOST_TEST(data.at(1)->values()(2) == 0.16);
   BOOST_TEST(data.at(1)->values()(3) == 0.16);
-
-#if 0
 
   displacements->values() << 10, 10, 10, 10;
   displacements->setSampleAtTime(1.0, displacements->sample());
@@ -542,7 +538,6 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
   BOOST_TEST(data.at(1)->values()(1) == 0.184);
   BOOST_TEST(data.at(1)->values()(2) == 0.184);
   BOOST_TEST(data.at(1)->values()(3) == 0.184);
-#endif
 }
 
 BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithoutSubsteps)

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -529,7 +529,7 @@ private:
    * @brief interface to provide accelerated data, depending on coupling scheme being used
    * @return data being accelerated
    */
-  virtual const DataMap &getAccelerationData() = 0;
+  virtual DataMap &getAccelerationData() = 0;
 
   /**
    * @brief If any required actions are open, an error message is issued.

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -153,9 +153,11 @@ CouplingData::Direction CouplingData::getDirection() const
 void CouplingData::moveToNextWindow()
 {
   if (_direction == Direction::Receive) {
-    _data->moveToNextWindow();
-    _previousTimeStepsStorage = _data->timeStepsStorage();
+    //_data->moveToNextWindow();
+    // _previousTimeStepsStorage = _data->timeStepsStorage();
   }
+  _data->moveToNextWindow();
+  _previousTimeStepsStorage = _data->timeStepsStorage();
 }
 
 time::Sample &CouplingData::sample()

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -64,7 +64,7 @@ bool MultiCouplingScheme::hasAnySendData()
   return std::any_of(_sendDataVector.cbegin(), _sendDataVector.cend(), [](const auto &sendExchange) { return not sendExchange.second.empty(); });
 }
 
-const DataMap &MultiCouplingScheme::getAccelerationData()
+DataMap &MultiCouplingScheme::getAccelerationData()
 {
   // MultiCouplingScheme applies acceleration to all CouplingData
   return _allData;

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -91,7 +91,7 @@ private:
 
   void exchangeSecondData() override final;
 
-  const DataMap &getAccelerationData() override final;
+  DataMap &getAccelerationData() override final;
 
   /// @copydoc cplscheme::BaseCouplingScheme::initializeReceiveDataStorage()
   void initializeReceiveDataStorage() override final;

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -110,7 +110,7 @@ void ParallelCouplingScheme::exchangeSecondData()
   }
 }
 
-const DataMap &ParallelCouplingScheme::getAccelerationData()
+DataMap &ParallelCouplingScheme::getAccelerationData()
 {
   // ParallelCouplingScheme applies acceleration to all CouplingData
   PRECICE_ASSERT(!doesFirstStep(), "Only the second participant should do the acceleration.");

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -74,7 +74,7 @@ private:
 
   void exchangeSecondData() override final;
 
-  const DataMap &getAccelerationData() override final;
+  DataMap &getAccelerationData() override final;
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -197,7 +197,7 @@ void SerialCouplingScheme::exchangeSecondData()
   }
 }
 
-const DataMap &SerialCouplingScheme::getAccelerationData()
+DataMap &SerialCouplingScheme::getAccelerationData()
 {
   // SerialCouplingSchemes applies acceleration to send data
   return getSendData();

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -84,7 +84,7 @@ private:
 
   void exchangeSecondData() override final;
 
-  const DataMap &getAccelerationData() override final;
+  DataMap &getAccelerationData() override final;
 };
 
 } // namespace cplscheme

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -160,6 +160,17 @@ Eigen::VectorXd Storage::getTimes() const
   return times;
 }
 
+bool Storage::empty() const
+{
+  return _stampleStorage.empty();
+}
+
+const time::Stample &Storage::last() const
+{
+  PRECICE_ASSERT(!_stampleStorage.empty());
+  return _stampleStorage[_stampleStorage.size() - 1];
+}
+
 std::pair<Eigen::VectorXd, Eigen::MatrixXd> Storage::getTimesAndValues() const
 {
   auto times  = Eigen::VectorXd(nTimes());

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -77,6 +77,15 @@ public:
     return boost::make_iterator_range(_stampleStorage);
   }
 
+  auto stamples()
+  {
+    return boost::make_iterator_range(_stampleStorage);
+  }
+
+  bool empty() const;
+
+  const time::Stample &last() const;
+
   /**
    * @brief Get all normalized dts and values in ascending order (with respect to normalized dts)
    *


### PR DESCRIPTION
## Main changes of this PR

This PR attempts to solve the problem discovered by https://github.com/precice/tutorials/pull/406

Problem is that we still need to update `Data::values()` alongside the time storage.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
