### PR TITLE
Update badges and URLs in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,12 @@
 # preCICE #
 
-**Communication**  
-<a style="text-decoration: none" href="https://matrix.to/#/#precice_lobby:gitter.im?web-instance[element.io]=app.gitter.im" target="_blank">
-    <img src="https://matrix.to/img/matrix-badge.svg" alt="Chat on Matrix">
-</a>
-<a style="text-decoration: none" href="https://precice.discourse.group" target="_blank">
-    <img alt="Discourse posts" src="https://img.shields.io/discourse/posts?label=discourse%20QA&server=https%3A%2F%2Fprecice.discourse.group">
-</a>
-<a style="text-decoration: none" href="https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice" target="_blank">
-    <img src="https://img.shields.io/badge/mailing%20list-subscribe-blue.svg" alt="Mailing list">
-</a>
-<a style="text-decoration: none" href="https://twitter.com/preCICE_org" target="_blank">
-    <img src="https://img.shields.io/badge/twitter-%40preCICE__org-1da1f2.svg" alt="Twitter">
-</a>
-<a style="text-decoration: none" href="https://www.precice.org/" target="_blank">
-    <img src="https://img.shields.io/website-up-down-green-red/https/precice.org.svg?label=website" alt="preCICE website status">
-</a>
-
 **Project Status**  
-<a style="text-decoration: none" href="https://github.com/precice/precice/releases/latest" target="_blank">
-    <img src="https://img.shields.io/github/release/precice/precice.svg" alt="Release">
-</a>
-<a style="text-decoration: none" href="https://doi.org/10.18419/darus-2613" target="_blank">
-    <img src="https://img.shields.io/badge/doi-10.18419%2Fdarus--2613-d45815.svg" alt="preCICE distribution">
-</a>
-<a style="text-decoration: none" href="https://github.com/precice/precice/actions?query=workflow%3A%22Build+and+Test%22+branch%3Adevelop" target="_blank">
-    <img src="https://github.com/precice/precice/workflows/Build%20and%20Test/badge.svg" alt="Build status">
-</a>
+[![preCICE website status](https://img.shields.io/website-up-down-green-red/https/precice.org.svg?label=website)](https://twitter.com/preCICE_org)
+[![Release](https://img.shields.io/github/release/precice/precice.svg)](https://github.com/precice/precice/releases/latest)
+[![Cite](https://img.shields.io/badge/cite-literature_guide-d45815)](https://precice.org/fundamentals-literature-guide.html)
+[![preCICE distribution](https://img.shields.io/badge/preCICE_Distribution-10.18419%2Fdarus--2613-d45815.svg)](https://doi.org/10.18419/darus-2613)
+[![Build status](https://github.com/precice/precice/workflows/Build%20and%20Test/badge.svg)](https://github.com/precice/precice/actions?query=workflow%3A%22Build+and+Test%22+branch%3Adevelop)
+[![System tests](https://img.shields.io/badge/system_tests-trigger_manually-blue)](https://github.com/precice/tutorials/actions/workflows/run_testsuite_manual.yml)
 
 **Project Quality**  
 [![xSDK Policy Compatibility](https://img.shields.io/badge/xSDK-member-brightgreen)](https://github.com/xsdk-project/xsdk-policy-compatibility/blob/master/precice-policy-compatibility.md)
@@ -36,6 +16,12 @@
 [![codecov](https://codecov.io/gh/precice/precice/branch/develop/graph/badge.svg?token=ixXCTXAZMU)](https://codecov.io/gh/precice/precice)
 [![Coverity](https://scan.coverity.com/projects/19312/badge.svg)](https://scan.coverity.com/projects/precice-precice)
 
+**Community**  
+[![Join the forum](https://img.shields.io/badge/discourse-news_and_forum-orange?link=https%3A%2F%2Fprecice.discourse.group%2F)](https://precice.discourse.group/)
+[![Chat on Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#precice_lobby:gitter.im?web-instance[element.io]=app.gitter.im)
+[![Twitter](https://img.shields.io/badge/twitter-%40preCICE__org-1da1f2)](https://twitter.com/preCICE_org)
+[![Mastodon](https://img.shields.io/badge/mastodon-%40preCICE-6364ff)](https://fosstodon.org/@precice)
+[![YouTube](https://img.shields.io/badge/youtube-%40preCICECoupling-ff0000)](https://www.youtube.com/c/preCICECoupling/)
 
 preCICE stands for Precise Code Interaction Coupling Environment. Its main component is a library that can be used by simulation programs to be coupled together in a partitioned way, enabling multi-physics simulations, such as fluid-structure interaction.
 
@@ -45,4 +31,4 @@ If you are new to preCICE, please have a look at our [documentation](https://www
 <img src="https://github.com/precice/precice.github.io/blob/master/material/overview/precice-overview.png" alt="preCICE overview" style="max-height: 100%; max-width: 100%">
 </div>
 
-preCICE is an academic project, developed at the [Technical University of Munich](https://www.in.tum.de/i05/startseite/) and at the [University of Stuttgart](https://www.ipvs.uni-stuttgart.de). If you use preCICE, please [cite us](https://www.precice.org/publications/).
+preCICE is an academic project, developed at the [Technical University of Munich](https://www.cs.cit.tum.de/en/sccs/home/) and at the [University of Stuttgart](https://www.ipvs.uni-stuttgart.de). If you use preCICE, please [cite us](https://www.precice.org/fundamentals-literature-guide.html).


### PR DESCRIPTION
## Main changes of this PR

- Removes the mailing list badge, since we want to phase it out
- Replaces the dynamic Discourse badge with a static one, since it is currently failing to render
- Adds badges for Mastodon, YouTube, Literature Guide, and System Tests (manual trigger)
- Changes the "Communication" to "Community" and moves it to the bottom
- Updates the SCCS URL
- Replaces all remaining HTML variants with Markdown. This fixes some strange rendering issues (underlining of everything).

Current rendering:

![Screenshot from 2023-11-22 13-00-30](https://github.com/precice/precice/assets/4943683/5022efa0-5896-45ea-9895-a0fcd1171b97)


## Motivation and additional information

Badges are nice, but should be up-to-date.

## Author's checklist

(docs only - does not apply)

## Reviewers' checklist

* [ ] Anything else we should add?
* [x] Should we keep the system tests badge? It mainly serves as a shortcut for developers, and shows that we have system tests.
