### PR TITLE
Add a warning for empty IQN matrix, but keep going

### DIFF
--- a/docs/changelog/1895.md
+++ b/docs/changelog/1895.md
@@ -1,0 +1,1 @@
+- Added a warning for empty IQN matrix, but keep the simulation going. This allows to start from a zero initial state that only later changes (e.g., an opening valve in a flow simulation)

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -235,6 +235,7 @@ void IQNILSAcceleration::specializedIterationsConverged(
     const DataMap &cplData)
 {
   PRECICE_TRACE();
+  PRECICE_ASSERT(_matrixCols.size() > 0, "The IQN matrix has no columns.");
   if (_matrixCols.front() == 0) { // Did only one iteration
     _matrixCols.pop_front();
   }

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -235,7 +235,9 @@ void IQNILSAcceleration::specializedIterationsConverged(
     const DataMap &cplData)
 {
   PRECICE_TRACE();
-  if (_matrixCols.size() > 0) {
+  if (_matrixCols.empty()) {
+    PRECICE_WARN("The IQN matrix has no columns.");
+  } else {
     if (_matrixCols.front() == 0) { // Did only one iteration
       _matrixCols.pop_front();
     }
@@ -262,8 +264,6 @@ void IQNILSAcceleration::specializedIterationsConverged(
         }
       }
     }
-  } else {
-    PRECICE_WARN("The IQN matrix has no columns.");
   }
 }
 


### PR DESCRIPTION
## Main changes of this PR

Closes #1894.

Adds a preCICE warning when the IQN matrix has zero columns, but keeps going.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> N/A
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
