### PR TITLE
Replace `_computedTimeWindowPart` with `_time`

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -345,7 +345,7 @@ void BaseCouplingScheme::secondExchange()
         // The computed time window part equals the time window size, since the
         // time window remainder is zero. Subtract the time window size and do another
         // coupling iteration.
-        PRECICE_ASSERT(math::greater(_time - _timeWindowStartTime, 0.0));
+        PRECICE_ASSERT(math::greater(_time, _timeWindowStartTime));
         _timeWindows -= 1;
         _isTimeWindowComplete = false;
       } else { // write output, prepare for next window
@@ -758,7 +758,7 @@ void BaseCouplingScheme::advanceTXTWriters()
 
 bool BaseCouplingScheme::reachedEndOfTimeWindow() const
 {
-  return math::equals(_timeWindowStartTime + _timeWindowSize - _time, 0.0) || not hasTimeWindowSize();
+  return math::equals(_timeWindowStartTime + _timeWindowSize, _time) || not hasTimeWindowSize();
 }
 
 void BaseCouplingScheme::storeIteration()

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -446,11 +446,6 @@ bool BaseCouplingScheme::hasDataBeenReceived() const
   return _hasDataBeenReceived;
 }
 
-double BaseCouplingScheme::getComputedTimeWindowPart() const
-{
-  return _time - _timeWindowStartTime;
-}
-
 void BaseCouplingScheme::setDoesFirstStep(bool doesFirstStep)
 {
   _doesFirstStep = doesFirstStep;

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -197,24 +197,21 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
         PRECICE_ASSERT(data->hasGradient());
         m2n->receive(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
       }
-      data->setSampleAtTime(getTime(), data->sample());
+      data->setSampleAtTime(_time, data->sample());
     }
   }
 }
 
 void BaseCouplingScheme::receiveDataForWindowEnd(const m2n::PtrM2N &m2n, const DataMap &receiveData)
 {
-  // buffer current time state
-  const double oldComputedTimeWindowPart = _computedTimeWindowPart;
-  const double oldTimeWindowStartTime    = _timeWindowStartTime;
-  // set time state to point to end of this window such that getTime() in receiveData returns time at end of window
-  _timeWindowStartTime    = getTime() + _nextTimeWindowSize;
-  _computedTimeWindowPart = 0;
+  // buffer current time
+  const double oldTime = _time;
+  // set _time state to point to end of this window such that _time in receiveData is at end of window
+  _time += _nextTimeWindowSize;
   // receive data for end of window
   this->receiveData(m2n, receiveData);
   // reset time state;
-  _computedTimeWindowPart = oldComputedTimeWindowPart;
-  _timeWindowStartTime    = oldTimeWindowStartTime;
+  _time = oldTime;
 }
 
 void BaseCouplingScheme::initializeWithZeroInitialData(const DataMap &receiveData)
@@ -222,7 +219,7 @@ void BaseCouplingScheme::initializeWithZeroInitialData(const DataMap &receiveDat
   for (const auto &data : receiveData | boost::adaptors::map_values) {
     PRECICE_DEBUG("Initialize {} as zero.", data->getDataName());
     // just store already initialized zero sample to storage.
-    data->setSampleAtTime(getTime(), data->sample());
+    data->setSampleAtTime(_time, data->sample());
   }
 }
 
@@ -329,7 +326,7 @@ CouplingScheme::ChangedMeshes BaseCouplingScheme::secondSynchronization()
 
 void BaseCouplingScheme::secondExchange()
 {
-  PRECICE_TRACE(_timeWindows, getTime());
+  PRECICE_TRACE(_timeWindows, _time);
   checkCompletenessRequiredActions();
   PRECICE_ASSERT(_isInitialized, "Before calling advance() coupling scheme has to be initialized via initialize().");
   PRECICE_ASSERT(_couplingMode != Undefined);
@@ -348,7 +345,7 @@ void BaseCouplingScheme::secondExchange()
         // The computed time window part equals the time window size, since the
         // time window remainder is zero. Subtract the time window size and do another
         // coupling iteration.
-        PRECICE_ASSERT(math::greater(_computedTimeWindowPart, 0.0));
+        PRECICE_ASSERT(math::greater(_time - _timeWindowStartTime, 0.0));
         _timeWindows -= 1;
         _isTimeWindowComplete = false;
       } else { // write output, prepare for next window
@@ -381,8 +378,8 @@ void BaseCouplingScheme::secondExchange()
     if (_isTimeWindowComplete) {
       _timeWindowStartTime += _timeWindowSize;
     }
-    _computedTimeWindowPart = 0.0; // reset window
-    _timeWindowSize         = _nextTimeWindowSize;
+    _time           = _timeWindowStartTime;
+    _timeWindowSize = _nextTimeWindowSize;
   }
 }
 
@@ -422,7 +419,7 @@ bool BaseCouplingScheme::addComputedTime(
   PRECICE_ASSERT(isCouplingOngoing(), "Invalid call of addComputedTime() after simulation end.");
 
   // add time interval that has been computed in the solver to get the correct time remainder
-  _computedTimeWindowPart += timeToAdd;
+  _time += timeToAdd;
 
   // Check validness
   bool valid = math::greaterEquals(getNextTimeStepMaxSize(), 0.0);
@@ -431,7 +428,7 @@ bool BaseCouplingScheme::addComputedTime(
                 "in the remaining of this time window. "
                 "Did you restrict your time step size, \"dt = min(preciceDt, solverDt)\"? "
                 "For more information, consult the adapter example in the preCICE documentation.",
-                timeToAdd, _timeWindowSize - _computedTimeWindowPart + timeToAdd);
+                timeToAdd, _timeWindowStartTime + _timeWindowSize - _time + timeToAdd);
 
   return reachedEndOfTimeWindow();
 }
@@ -451,7 +448,7 @@ bool BaseCouplingScheme::hasDataBeenReceived() const
 
 double BaseCouplingScheme::getComputedTimeWindowPart() const
 {
-  return _computedTimeWindowPart;
+  return _time - _timeWindowStartTime;
 }
 
 void BaseCouplingScheme::setDoesFirstStep(bool doesFirstStep)
@@ -477,7 +474,7 @@ void BaseCouplingScheme::setTimeWindows(int timeWindows)
 
 double BaseCouplingScheme::getTime() const
 {
-  return _timeWindowStartTime + _computedTimeWindowPart;
+  return _time;
 }
 
 double BaseCouplingScheme::getTimeWindowStart() const
@@ -493,19 +490,19 @@ int BaseCouplingScheme::getTimeWindows() const
 double BaseCouplingScheme::getNextTimeStepMaxSize() const
 {
   if (hasTimeWindowSize()) {
-    return _timeWindowSize - _computedTimeWindowPart;
+    return _timeWindowStartTime + _timeWindowSize - _time;
   } else {
     if (math::equals(_maxTime, UNDEFINED_MAX_TIME)) {
       return std::numeric_limits<double>::max();
     } else {
-      return _maxTime - getTime();
+      return _maxTime - _time;
     }
   }
 }
 
 bool BaseCouplingScheme::isCouplingOngoing() const
 {
-  bool timeLeft      = math::greater(_maxTime, getTime()) || math::equals(_maxTime, UNDEFINED_MAX_TIME);
+  bool timeLeft      = math::greater(_maxTime, _time) || math::equals(_maxTime, UNDEFINED_MAX_TIME);
   bool timestepsLeft = (_maxTimeWindows >= _timeWindows) || (_maxTimeWindows == UNDEFINED_TIME_WINDOWS);
   return timeLeft && timestepsLeft;
 }
@@ -550,7 +547,7 @@ std::string BaseCouplingScheme::printCouplingState() const
   if (_minIterations != UNDEFINED_MIN_ITERATIONS) {
     os << " (min " << _minIterations << ")";
   }
-  os << ", " << printBasicState(_timeWindows, getTime()) << ", " << printActionsState();
+  os << ", " << printBasicState(_timeWindows, _time) << ", " << printActionsState();
   return os.str();
 }
 
@@ -766,7 +763,7 @@ void BaseCouplingScheme::advanceTXTWriters()
 
 bool BaseCouplingScheme::reachedEndOfTimeWindow() const
 {
-  return math::equals(_timeWindowSize - _computedTimeWindowPart, 0.0) || not hasTimeWindowSize();
+  return math::equals(_timeWindowStartTime + _timeWindowSize - _time, 0.0) || not hasTimeWindowSize();
 }
 
 void BaseCouplingScheme::storeIteration()

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -322,8 +322,8 @@ protected:
   void setNextTimeWindowSize(double timeWindowSize);
 
   /**
-   * @brief Getter for _computedTimeWindowPart
-   * @returns _computedTimeWindowPart
+   * @brief Getter for time computed in the current window
+   * @returns time difference between window start and current time
    */
   double getComputedTimeWindowPart() const;
 
@@ -426,8 +426,8 @@ private:
   /// time window size of next window (acts as buffer for time windows size provided by first participant, if using first participant method)
   double _nextTimeWindowSize = UNDEFINED_TIME_WINDOW_SIZE;
 
-  /// Part of the window that is already computed; _computedTimeWindowPart <= _timeWindowSize
-  double _computedTimeWindowPart = 0;
+  /// Current time
+  double _time = 0;
 
   /// Lower limit of iterations during one time window. Prevents convergence if _iterations < _minIterations.
   int _minIterations = -1;
@@ -444,7 +444,7 @@ private:
   /// True, if local participant is the one starting the explicit scheme.
   bool _doesFirstStep = false;
 
-  /// True, if _computedTimeWindowPart == _timeWindowSize and (coupling has converged or _iterations == _maxIterations)
+  /// True, if _time == _timeWindowStartTime + _timeWindowSize and (coupling has converged or _iterations == _maxIterations)
   bool _isTimeWindowComplete = false;
 
   /// True, if this participant has to send initialized data.

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -322,12 +322,6 @@ protected:
   void setNextTimeWindowSize(double timeWindowSize);
 
   /**
-   * @brief Getter for time computed in the current window
-   * @returns time difference between window start and current time
-   */
-  double getComputedTimeWindowPart() const;
-
-  /**
    * @brief Setter for _doesFirstStep
    */
   void setDoesFirstStep(bool doesFirstStep);

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -60,7 +60,7 @@ void SerialCouplingScheme::sendTimeWindowSize()
 {
   PRECICE_TRACE();
   if (_participantSetsTimeWindowSize) {
-    setTimeWindowSize(getComputedTimeWindowPart());
+    setTimeWindowSize(getTime() - getTimeWindowStart());
     setNextTimeWindowSize(UNDEFINED_TIME_WINDOW_SIZE);
     PRECICE_DEBUG("sending time window size of {}", getTimeWindowSize());
     getM2N()->send(getTimeWindowSize());

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1042,7 +1042,7 @@ void ParticipantImpl::readData(
 {
   PRECICE_TRACE(meshName, dataName, vertices.size(), relativeReadTime);
   PRECICE_CHECK(_state != State::Finalized, "readData(...) cannot be called after finalize().");
-  PRECICE_CHECK(relativeReadTime <= _couplingScheme->getNextTimeStepMaxSize(), "readData(...) cannot sample data outside of current time window.");
+  PRECICE_CHECK(math::smallerEquals(relativeReadTime, _couplingScheme->getNextTimeStepMaxSize()), "readData(...) cannot sample data outside of current time window.");
   PRECICE_CHECK(relativeReadTime >= 0, "readData(...) cannot sample data before the current time.");
 
   PRECICE_REQUIRE_DATA_READ(meshName, dataName);

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -210,20 +210,8 @@ Eigen::MatrixXd Storage::sampleGradients(double time) const
 
 int Storage::computeUsedDegree(int requestedDegree, int numberOfAvailableSamples) const
 {
-  int usedDegree = -1;
   PRECICE_ASSERT(requestedDegree <= Time::MAX_WAVEFORM_DEGREE);
-  if (requestedDegree == 0 || numberOfAvailableSamples < 2) {
-    usedDegree = 0;
-  } else if (requestedDegree == 1 || numberOfAvailableSamples < 3) {
-    usedDegree = 1;
-  } else if (requestedDegree == 2 || numberOfAvailableSamples < 4) {
-    usedDegree = 2;
-  } else if (requestedDegree == 3 || numberOfAvailableSamples < 5) {
-    usedDegree = 3;
-  } else {
-    PRECICE_ASSERT(false); // not supported
-  }
-  return usedDegree;
+  return std::min(requestedDegree, numberOfAvailableSamples - 1);
 }
 
 time::Sample Storage::getSampleAtBeginning()

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingDifferentDts)
     precice.advance(currentDt);
     double maxDt = precice.getMaxTimeStepSize();
     currentDt    = dt > maxDt ? maxDt : dt;
-    BOOST_CHECK(currentDt == windowDt / nSubsteps); // no subcycling.
+    BOOST_CHECK(math::equals(currentDt, windowDt / nSubsteps)); // no subcycling.
     timestep++;
     if (precice.requiresReadingCheckpoint()) { // at end of window and we have to repeat it.
       iterations++;


### PR DESCRIPTION
## Main changes of this PR

Use absolute `_time` instead of `_computedTimeWindowPart` for time tracking.

## Motivation and additional information

Improves readability.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

**not relevant, because of refactoring**

* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
