### PR TITLE
Prevent bad optional access in events

### DIFF
--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -124,6 +124,7 @@ void EventRegistry::startBackend()
   _output.open(filename);
   PRECICE_CHECK(_output, "Unable to open the events-file: \"{}\"", filename);
   _globalId = nameToID("_GLOBAL");
+  PRECICE_ASSERT(_globalId.has_value());
   _writeQueue.emplace_back(StartEntry{_globalId.value(), _initClock});
 
   // write header
@@ -155,7 +156,9 @@ void EventRegistry::stopBackend()
   }
   // create end of global event
   auto now = Event::Clock::now();
-  put(StopEntry{_globalId.value(), now});
+  if (_globalId) {
+    put(StopEntry{_globalId.value(), now});
+  }
   // flush the queue
   flush();
   _output << "]}";


### PR DESCRIPTION
## Main changes of this PR

Closes https://github.com/precice/precice/issues/1896

Which is triggered during the configuration stage as the events are not initialized yet.
